### PR TITLE
[chip-tool] Implement framework for adding and displaying command line argument descriptions

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -528,11 +528,11 @@ public:
         ReportCommand("subscribe-event", credsIssuerConfig),
         mClusterIds(1, clusterId), mEventIds(1, eventId)
     {
-        AddArgument("attr-name", eventName, 0, "attr-name desc");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, 0, "min-interval desc");
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, 0, "max-interval desc");
-        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions, "keepSubscriptions desc");
-        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber, "event-min desc");
+        AddArgument("attr-name", eventName, 0, "Event name.");
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, 0, "The requested minimum interval boundary floor in seconds.");
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, 0, "The requested maximum interval boundary ceiling in seconds.");
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions, "0 - Terminate existing subscriptions from initiator.\n  1 - Otherwise.");
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }
 

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -528,11 +528,11 @@ public:
         ReportCommand("subscribe-event", credsIssuerConfig),
         mClusterIds(1, clusterId), mEventIds(1, eventId)
     {
-        AddArgument("attr-name", eventName);
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions);
-        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
+        AddArgument("attr-name", eventName, 0, "attr-name desc");
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, 0, "min-interval desc");
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, 0, "max-interval desc");
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions, "keepSubscriptions desc");
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber, "event-min desc");
         ReportCommand::AddArguments();
     }
 

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -528,9 +528,11 @@ public:
         ReportCommand("subscribe-event", credsIssuerConfig),
         mClusterIds(1, clusterId), mEventIds(1, eventId)
     {
-        AddArgument("attr-name", eventName, 0, "Event name.");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, 0, "The requested minimum interval boundary floor in seconds.");
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, 0, "The requested maximum interval boundary ceiling in seconds.");
+        AddArgument("event-name", eventName, 0, "Event name.");
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, 0,
+                    "The requested minimum interval between reports. Sets MinIntervalFloor in the Subscribe Request.");
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, 0,
+                    "The requested maximum interval between reports. Sets MaxIntervalCeiling in the Subscribe Request.");
         AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
                     "0 - Terminate existing subscriptions from initiator.\n  1 - Otherwise.");
         AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -531,7 +531,8 @@ public:
         AddArgument("attr-name", eventName, 0, "Event name.");
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, 0, "The requested minimum interval boundary floor in seconds.");
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, 0, "The requested maximum interval boundary ceiling in seconds.");
-        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions, "0 - Terminate existing subscriptions from initiator.\n  1 - Otherwise.");
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
+                    "0 - Terminate existing subscriptions from initiator.\n  1 - Otherwise.");
         AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -486,62 +486,67 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
     return isValidArgument;
 }
 
-size_t Command::AddArgument(const char * name, const char * value, uint8_t flags)
+size_t Command::AddArgument(const char * name, const char * value, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Attribute;
     arg.name  = name;
     arg.value = const_cast<void *>(reinterpret_cast<const void *>(value));
     arg.flags = flags;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, char ** value, uint8_t flags)
+size_t Command::AddArgument(const char * name, char ** value, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::String;
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(value);
     arg.flags = flags;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, chip::CharSpan * value, uint8_t flags)
+size_t Command::AddArgument(const char * name, chip::CharSpan * value, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::CharString;
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(value);
     arg.flags = flags;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, chip::ByteSpan * value, uint8_t flags)
+size_t Command::AddArgument(const char * name, chip::ByteSpan * value, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::OctetString;
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(value);
     arg.flags = flags;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, AddressWithInterface * out, uint8_t flags)
+size_t Command::AddArgument(const char * name, AddressWithInterface * out, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Address;
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(out);
     arg.flags = flags;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint16_t> * value)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint16_t> * value, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Vector16;
@@ -550,11 +555,12 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::v
     arg.min   = min;
     arg.max   = max;
     arg.flags = 0;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint32_t> * value)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint32_t> * value, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Vector32;
@@ -563,11 +569,12 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::v
     arg.min   = min;
     arg.max   = max;
     arg.flags = 0;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Vector32;
@@ -576,57 +583,62 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, chip::
     arg.min   = min;
     arg.max   = max;
     arg.flags = Argument::kOptional;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, ComplexArgument * value)
+size_t Command::AddArgument(const char * name, ComplexArgument * value, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Complex;
     arg.name  = name;
     arg.value = static_cast<void *>(value);
     arg.flags = 0;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, CustomArgument * value)
+size_t Command::AddArgument(const char * name, CustomArgument * value, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Custom;
     arg.name  = name;
     arg.value = const_cast<void *>(reinterpret_cast<const void *>(value));
     arg.flags = 0;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, float min, float max, float * out, uint8_t flags)
+size_t Command::AddArgument(const char * name, float min, float max, float * out, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Float;
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(out);
     arg.flags = flags;
+    arg.desc = desc;
     // Ignore min/max for now; they're always +-Infinity anyway.
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, double min, double max, double * out, uint8_t flags)
+size_t Command::AddArgument(const char * name, double min, double max, double * out, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Double;
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(out);
     arg.flags = flags;
+    arg.desc = desc;
     // Ignore min/max for now; they're always +-Infinity anyway.
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = type;
@@ -635,11 +647,12 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void *
     arg.min   = min;
     arg.max   = max;
     arg.flags = flags;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, uint8_t flags)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, uint8_t flags, const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Number_uint8;
@@ -648,6 +661,7 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void *
     arg.min   = min;
     arg.max   = max;
     arg.flags = flags;
+    arg.desc = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -657,6 +671,16 @@ const char * Command::GetArgumentName(size_t index) const
     if (index < mArgs.size())
     {
         return mArgs.at(index).name;
+    }
+
+    return nullptr;
+}
+
+const char * Command::GetArgumentDescription(size_t index) const
+{
+    if (index < mArgs.size())
+    {
+        return mArgs.at(index).desc;
     }
 
     return nullptr;

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -493,7 +493,7 @@ size_t Command::AddArgument(const char * name, const char * value, uint8_t flags
     arg.name  = name;
     arg.value = const_cast<void *>(reinterpret_cast<const void *>(value));
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -505,7 +505,7 @@ size_t Command::AddArgument(const char * name, char ** value, uint8_t flags, con
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(value);
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -517,7 +517,7 @@ size_t Command::AddArgument(const char * name, chip::CharSpan * value, uint8_t f
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(value);
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -529,7 +529,7 @@ size_t Command::AddArgument(const char * name, chip::ByteSpan * value, uint8_t f
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(value);
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -541,7 +541,7 @@ size_t Command::AddArgument(const char * name, AddressWithInterface * out, uint8
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(out);
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -555,7 +555,7 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::v
     arg.min   = min;
     arg.max   = max;
     arg.flags = 0;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -569,12 +569,13 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, std::v
     arg.min   = min;
     arg.max   = max;
     arg.flags = 0;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value, const char * desc)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value,
+                            const char * desc)
 {
     Argument arg;
     arg.type  = ArgumentType::Vector32;
@@ -583,7 +584,7 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, chip::
     arg.min   = min;
     arg.max   = max;
     arg.flags = Argument::kOptional;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -595,7 +596,7 @@ size_t Command::AddArgument(const char * name, ComplexArgument * value, const ch
     arg.name  = name;
     arg.value = static_cast<void *>(value);
     arg.flags = 0;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -607,7 +608,7 @@ size_t Command::AddArgument(const char * name, CustomArgument * value, const cha
     arg.name  = name;
     arg.value = const_cast<void *>(reinterpret_cast<const void *>(value));
     arg.flags = 0;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -619,7 +620,7 @@ size_t Command::AddArgument(const char * name, float min, float max, float * out
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(out);
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
     // Ignore min/max for now; they're always +-Infinity anyway.
 
     return AddArgumentToList(std::move(arg));
@@ -632,13 +633,14 @@ size_t Command::AddArgument(const char * name, double min, double max, double * 
     arg.name  = name;
     arg.value = reinterpret_cast<void *>(out);
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
     // Ignore min/max for now; they're always +-Infinity anyway.
 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags,
+                            const char * desc)
 {
     Argument arg;
     arg.type  = type;
@@ -647,7 +649,7 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void *
     arg.min   = min;
     arg.max   = max;
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }
@@ -661,7 +663,7 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void *
     arg.min   = min;
     arg.max   = max;
     arg.flags = flags;
-    arg.desc = desc;
+    arg.desc  = desc;
 
     return AddArgumentToList(std::move(arg));
 }

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -82,6 +82,7 @@ struct Argument
     uint64_t max;
     void * value;
     uint8_t flags;
+    const char * desc;
 
     enum
     {
@@ -109,119 +110,122 @@ public:
     const char * GetAttribute(void) const;
     const char * GetEvent(void) const;
     const char * GetArgumentName(size_t index) const;
+    const char * GetArgumentDescription(size_t index) const;
     bool GetArgumentIsOptional(size_t index) const { return mArgs[index].isOptional(); }
     size_t GetArgumentsCount(void) const { return mArgs.size(); }
 
     bool InitArguments(int argc, char ** argv);
-    size_t AddArgument(const char * name, const char * value, uint8_t flags = 0);
+    size_t AddArgument(const char * name, const char * value, uint8_t flags = 0, const char * desc = "");
     /**
      * @brief
      *   Add a char string command argument
      *
      * @param name  The name that will be displayed in the command help
      * @param value A pointer to a `char *` where the argv value will be stored
+     * @param flags
+     * @param desc The description of the argument that will be displayed in the command help
      * @returns The number of arguments currently added to the command
      */
-    size_t AddArgument(const char * name, char ** value, uint8_t flags = 0);
+    size_t AddArgument(const char * name, char ** value, uint8_t flags = 0, const char * desc = "");
 
     /**
      * Add an octet string command argument
      */
-    size_t AddArgument(const char * name, chip::ByteSpan * value, uint8_t flags = 0);
-    size_t AddArgument(const char * name, chip::Span<const char> * value, uint8_t flags = 0);
-    size_t AddArgument(const char * name, AddressWithInterface * out, uint8_t flags = 0);
-    size_t AddArgument(const char * name, ComplexArgument * value);
-    size_t AddArgument(const char * name, CustomArgument * value);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, chip::ByteSpan * value, uint8_t flags = 0, const char * desc = "");
+    size_t AddArgument(const char * name, chip::Span<const char> * value, uint8_t flags = 0, const char * desc = "");
+    size_t AddArgument(const char * name, AddressWithInterface * out, uint8_t flags = 0, const char * desc = "");
+    size_t AddArgument(const char * name, ComplexArgument * value, const char * desc = "");
+    size_t AddArgument(const char * name, CustomArgument * value, const char * desc = "");
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Bool, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Bool, flags, desc);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8, flags, desc);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16, flags, desc);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32, flags, desc);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64, flags, desc);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8, flags, desc);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16, flags, desc);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32, flags, desc);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64, flags);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64, flags, desc);
     }
 
-    size_t AddArgument(const char * name, float min, float max, float * out, uint8_t flags = 0);
-    size_t AddArgument(const char * name, double min, double max, double * out, uint8_t flags = 0);
+    size_t AddArgument(const char * name, float min, float max, float * out, uint8_t flags = 0, const char * desc = "");
+    size_t AddArgument(const char * name, double min, double max, double * out, uint8_t flags = 0, const char * desc = "");
 
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint16_t> * value);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint32_t> * value);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint16_t> * value, const char * desc = "");
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint32_t> * value, const char * desc = "");
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value, const char * desc = "");
 
     template <typename T, typename = std::enable_if_t<std::is_enum<T>::value>>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out), flags);
+        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out), flags, desc);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::BitFlags<T> * out, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::BitFlags<T> * out, uint8_t flags = 0, const char * desc = "")
     {
         // This is a terrible hack that relies on BitFlags only having the one
         // mValue member.
-        return AddArgument(name, min, max, reinterpret_cast<T *>(out), flags);
+        return AddArgument(name, min, max, reinterpret_cast<T *>(out), flags, desc);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, chip::Optional<T> * value)
+    size_t AddArgument(const char * name, chip::Optional<T> * value, const char * desc = "")
     {
-        return AddArgument(name, reinterpret_cast<T *>(value), Argument::kOptional);
+        return AddArgument(name, reinterpret_cast<T *>(value), Argument::kOptional, desc);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<T> * value)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<T> * value, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<T *>(value), Argument::kOptional);
+        return AddArgument(name, min, max, reinterpret_cast<T *>(value), Argument::kOptional, desc);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0)
+    size_t AddArgument(const char * name, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, reinterpret_cast<T *>(value), flags | Argument::kNullable);
+        return AddArgument(name, reinterpret_cast<T *>(value), flags | Argument::kNullable, desc);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0)
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<T *>(value), flags | Argument::kNullable);
+        return AddArgument(name, min, max, reinterpret_cast<T *>(value), flags | Argument::kNullable, desc);
     }
 
-    size_t AddArgument(const char * name, float min, float max, chip::app::DataModel::Nullable<float> * value, uint8_t flags = 0)
+    size_t AddArgument(const char * name, float min, float max, chip::app::DataModel::Nullable<float> * value, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<float *>(value), flags | Argument::kNullable);
+        return AddArgument(name, min, max, reinterpret_cast<float *>(value), flags | Argument::kNullable, desc);
     }
 
-    size_t AddArgument(const char * name, double min, double max, chip::app::DataModel::Nullable<double> * value, uint8_t flags = 0)
+    size_t AddArgument(const char * name, double min, double max, chip::app::DataModel::Nullable<double> * value, uint8_t flags = 0, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<double *>(value), flags | Argument::kNullable);
+        return AddArgument(name, min, max, reinterpret_cast<double *>(value), flags | Argument::kNullable, desc);
     }
 
     void ResetArguments();
@@ -238,8 +242,8 @@ public:
 
 private:
     bool InitArgument(size_t argIndex, char * argValue);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, uint8_t flags);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags, const char * desc = "");
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, uint8_t flags, const char * desc = "");
 
     /**
      * Add the Argument to our list.  This preserves the property that all

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -178,7 +178,8 @@ public:
 
     size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint16_t> * value, const char * desc = "");
     size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint32_t> * value, const char * desc = "");
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value, const char * desc = "");
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value,
+                       const char * desc = "");
 
     template <typename T, typename = std::enable_if_t<std::is_enum<T>::value>>
     size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, uint8_t flags = 0, const char * desc = "")
@@ -187,7 +188,8 @@ public:
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::BitFlags<T> * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::BitFlags<T> * out, uint8_t flags = 0,
+                       const char * desc = "")
     {
         // This is a terrible hack that relies on BitFlags only having the one
         // mValue member.
@@ -213,17 +215,20 @@ public:
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0,
+                       const char * desc = "")
     {
         return AddArgument(name, min, max, reinterpret_cast<T *>(value), flags | Argument::kNullable, desc);
     }
 
-    size_t AddArgument(const char * name, float min, float max, chip::app::DataModel::Nullable<float> * value, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, float min, float max, chip::app::DataModel::Nullable<float> * value, uint8_t flags = 0,
+                       const char * desc = "")
     {
         return AddArgument(name, min, max, reinterpret_cast<float *>(value), flags | Argument::kNullable, desc);
     }
 
-    size_t AddArgument(const char * name, double min, double max, chip::app::DataModel::Nullable<double> * value, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, double min, double max, chip::app::DataModel::Nullable<double> * value, uint8_t flags = 0,
+                       const char * desc = "")
     {
         return AddArgument(name, min, max, reinterpret_cast<double *>(value), flags | Argument::kNullable, desc);
     }
@@ -242,7 +247,8 @@ public:
 
 private:
     bool InitArgument(size_t argIndex, char * argValue);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags, const char * desc = "");
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags,
+                       const char * desc = "");
     size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, uint8_t flags, const char * desc = "");
 
     /**

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -310,7 +310,6 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
 {
     fprintf(stderr, "Usage:\n");
 
-    std::string arg;
     std::string arguments;
     std::string description;
     arguments += command->GetName();
@@ -318,7 +317,7 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
     size_t argumentsCount = command->GetArgumentsCount();
     for (size_t i = 0; i < argumentsCount; i++)
     {
-        arg             = "";
+        std::string arg;
         bool isOptional = command->GetArgumentIsOptional(i);
         if (isOptional)
         {
@@ -332,12 +331,13 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
         arguments += " ";
         arguments += arg;
 
-        if (strlen(command->GetArgumentDescription(i)) > 0)
+        const char * argDescription = command->GetArgumentDescription(i);
+        if ((argDescription != nullptr) && (strlen(argDescription) > 0))
         {
             description += "\n";
             description += arg;
             description += ":\n  ";
-            description += command->GetArgumentDescription(i);
+            description += argDescription;
             description += "\n";
         }
     }

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -318,7 +318,7 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
     size_t argumentsCount = command->GetArgumentsCount();
     for (size_t i = 0; i < argumentsCount; i++)
     {
-        arg = "";
+        arg             = "";
         bool isOptional = command->GetArgumentIsOptional(i);
         if (isOptional)
         {
@@ -332,7 +332,7 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
         arguments += " ";
         arguments += arg;
 
-        if(strlen(command->GetArgumentDescription(i)) > 0)
+        if (strlen(command->GetArgumentDescription(i)) > 0)
         {
             description += "\n";
             description += arg;
@@ -343,7 +343,7 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
     }
     fprintf(stderr, "  %s %s %s\n", executable.c_str(), clusterName.c_str(), arguments.c_str());
 
-    if(description.size() > 0)
+    if (description.size() > 0)
     {
         fprintf(stderr, "%s\n", description.c_str());
     }

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -310,23 +310,41 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
 {
     fprintf(stderr, "Usage:\n");
 
+    std::string arg;
     std::string arguments;
+    std::string description;
     arguments += command->GetName();
 
     size_t argumentsCount = command->GetArgumentsCount();
     for (size_t i = 0; i < argumentsCount; i++)
     {
-        arguments += " ";
+        arg = "";
         bool isOptional = command->GetArgumentIsOptional(i);
         if (isOptional)
         {
-            arguments += "[--";
+            arg += "[--";
         }
-        arguments += command->GetArgumentName(i);
+        arg += command->GetArgumentName(i);
         if (isOptional)
         {
-            arguments += "]";
+            arg += "]";
+        }
+        arguments += " ";
+        arguments += arg;
+
+        if(strlen(command->GetArgumentDescription(i)) > 0)
+        {
+            description += "\n";
+            description += arg;
+            description += ":\n  ";
+            description += command->GetArgumentDescription(i);
+            description += "\n";
         }
     }
     fprintf(stderr, "  %s %s %s\n", executable.c_str(), clusterName.c_str(), arguments.c_str());
+
+    if(description.size() > 0)
+    {
+        fprintf(stderr, "%s\n", description.c_str());
+    }
 }


### PR DESCRIPTION
#### Problem

Chip-tool command line arguments lack user-friendly documentation.  For example, the usage blurb for a particular command lists all the required and optional arguments with no description for any arguments.

```
irenesiu@Irenes-MacBook-Pro connectedhomeip % out/apps/chip-tool/chip-tool otasoftwareupdaterequestor subscribe-event state-transition
*[1651253302463] [2020:56832] CHIP: [TOO] InitArgs: Wrong arguments number: 1 instead of 5*
Usage:
 out/apps/chip-tool/chip-tool otasoftwareupdaterequestor subscribe-event attr-name min-interval max-interval node-id/group-id endpoint-id-ignored-for-group-commands [--paa-trust-store-path] [--commissioner-name] [--commissioner-nodeid] [--commissioner-fabricid] [--trace_file] [--trace_log] [--ble-adapter] [--keepSubscriptions] [--event-min] [--timeout]
```

Fixes: https://github.com/project-chip/connectedhomeip/issues/17926

#### Change overview

Added optional argument to `Command::AddArgument()` to take in the description for each argument to be displayed in a user-friendly format in the usage blurb.

#### Testing

Verified chip-tool usage blurb for commands with and without descriptions added.

```
irenesiu@Irenes-MacBook-Pro connectedhomeip % out/apps/chip-tool/chip-tool otasoftwareupdaterequestor subscribe-event state-transition
[1651767490342] [45759:983590] CHIP: [TOO] InitArgs: Wrong arguments number: 1 instead of 5
Usage:
  out/apps/chip-tool/chip-tool otasoftwareupdaterequestor subscribe-event event-name min-interval max-interval node-id/group-id endpoint-id-ignored-for-group-commands [--paa-trust-store-path] [--commissioner-name] [--commissioner-nodeid] [--trace_file] [--trace_log] [--ble-adapter] [--keepSubscriptions] [--event-min] [--timeout]

event-name:
  Event name.

min-interval:
  The requested minimum interval between reports. Sets MinIntervalFloor in the Subscribe Request.

max-interval:
  The requested maximum interval between reports. Sets MaxIntervalCeiling in the Subscribe Request.

[--keepSubscriptions]:
  0 - Terminate existing subscriptions from initiator.
  1 - Otherwise.
```
