### PR TITLE
[Ameba] NotifyUpdateApplied sent after rebooting into new OTA image

### DIFF
--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -409,7 +409,7 @@ void AmebaOTAImageProcessor::HandleApply(intptr_t context)
     chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(2 * 1000), HandleRestart, nullptr);
 }
 
-void AmebaOTAImageProcessor::HandleRestart(chip::System::Layer *systemLayer, void *appState)
+void AmebaOTAImageProcessor::HandleRestart(chip::System::Layer * systemLayer, void * appState)
 {
     ota_platform_reset();
 }

--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -79,6 +79,38 @@ CHIP_ERROR AmebaOTAImageProcessor::ProcessBlock(ByteSpan & block)
     return CHIP_NO_ERROR;
 }
 
+bool AmebaOTAImageProcessor::IsFirstImageRun()
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor == nullptr)
+    {
+        return false;
+    }
+
+    return requestor->GetCurrentUpdateState() == OTARequestorInterface::OTAUpdateStateEnum::kApplying;
+}
+
+CHIP_ERROR AmebaOTAImageProcessor::ConfirmCurrentImage()
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor == nullptr)
+    {
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    uint32_t currentVersion;
+    uint32_t targetVersion = requestor->GetTargetVersion();
+    ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(currentVersion));
+    if (currentVersion != targetVersion)
+    {
+        ChipLogError(SoftwareUpdate, "Current software version = %" PRIu32 ", expected software version = %" PRIu32, currentVersion,
+                     targetVersion);
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
 void AmebaOTAImageProcessor::HandlePrepareDownload(intptr_t context)
 {
     auto * imageProcessor = reinterpret_cast<AmebaOTAImageProcessor *>(context);
@@ -371,15 +403,14 @@ void AmebaOTAImageProcessor::HandleApply(intptr_t context)
         return;
     }
 
-    OTARequestorInterface * requestor = chip::GetRequestorInstance();
-    if (requestor != nullptr)
-    {
-        // TODO: Implement restarting into new image instead of changing the version
-        DeviceLayer::ConfigurationMgr().StoreSoftwareVersion(imageProcessor->mSoftwareVersion);
-        requestor->NotifyUpdateApplied();
-    }
+    ChipLogProgress(SoftwareUpdate, "Rebooting in 2 seconds...");
 
-    // Reboot
+    // Delay action time before calling HandleRestart
+    chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(2 * 1000), HandleRestart, nullptr);
+}
+
+void AmebaOTAImageProcessor::HandleRestart(chip::System::Layer *systemLayer, void *appState)
+{
     ota_platform_reset();
 }
 

--- a/src/platform/Ameba/AmebaOTAImageProcessor.h
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.h
@@ -44,8 +44,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
-    bool IsFirstImageRun() override { return false; }
-    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
+    bool IsFirstImageRun() override;
+    CHIP_ERROR ConfirmCurrentImage() override;
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 
 private:
@@ -55,6 +55,7 @@ private:
     static void HandleAbort(intptr_t context);
     static void HandleProcessBlock(intptr_t context);
     static void HandleApply(intptr_t context);
+    static void HandleRestart(chip::System::Layer *systemLayer, void *appState);
 
     CHIP_ERROR ProcessHeader(ByteSpan & block);
 

--- a/src/platform/Ameba/AmebaOTAImageProcessor.h
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.h
@@ -55,7 +55,7 @@ private:
     static void HandleAbort(intptr_t context);
     static void HandleProcessBlock(intptr_t context);
     static void HandleApply(intptr_t context);
-    static void HandleRestart(chip::System::Layer *systemLayer, void *appState);
+    static void HandleRestart(chip::System::Layer * systemLayer, void * appState);
 
     CHIP_ERROR ProcessHeader(ByteSpan & block);
 

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -39,6 +39,12 @@ class ConfigurationManagerImpl : public Internal::GenericConfigurationManagerImp
 public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
+    CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
+    CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
+    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
+    CHIP_ERROR GetBootReason(uint32_t & bootReason) override;
+    CHIP_ERROR StoreBootReason(uint32_t bootReason) override;
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.
@@ -49,12 +55,6 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
-    CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
-    CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
-    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
-    CHIP_ERROR GetBootReason(uint32_t & bootReason) override;
-    CHIP_ERROR StoreBootReason(uint32_t bootReason) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 


### PR DESCRIPTION
#### Problem
- Current implementation of Ameba OTA will send notifyupdateapplied to the provider before it reboots into new image

#### Change overview
- Added IsFirstImageRun and ConfirmCurrentImage checks
- Remove notifyupdateapplied in HandleApply
- Added 2sec countdown before rebooting into new image after successful OTA transfer

#### Testing
- Tested with linux ota-provider-app
- NotifyUpdateApplied received by provider after ameba reboots into new image

