### PR TITLE
Add GetNewSessionHandlingPolicy callback

### DIFF
--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -31,7 +31,6 @@ CHIP_ERROR CASEClient::EstablishSession(PeerId peer, const Transport::PeerAddres
                                         SessionEstablishmentDelegate * delegate)
 {
     // Create a UnauthenticatedSession for CASE pairing.
-    // Don't use mSecureSession here, because mSecureSession is for encrypted communication.
     Optional<SessionHandle> session = mInitParams.sessionManager->CreateUnauthenticatedSession(peerAddress, remoteMRPConfig);
     VerifyOrReturnError(session.HasValue(), CHIP_ERROR_NO_MEMORY);
 

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -85,7 +85,7 @@ typedef void (*OnDeviceConnectionFailure)(void * context, PeerId peerId, CHIP_ER
  *    - Expose to consumers the secure session for talking to the device.
  */
 class DLL_EXPORT OperationalDeviceProxy : public DeviceProxy,
-                                          public SessionReleaseDelegate,
+                                          public SessionDelegate,
                                           public SessionEstablishmentDelegate,
                                           public AddressResolve::NodeListener
 {

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -55,7 +55,7 @@ struct ControllerDeviceInitParams
     Messaging::ExchangeManager * exchangeMgr = nullptr;
 };
 
-class CommissioneeDeviceProxy : public DeviceProxy, public SessionReleaseDelegate
+class CommissioneeDeviceProxy : public DeviceProxy, public SessionDelegate
 {
 public:
     ~CommissioneeDeviceProxy() override;

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -82,7 +82,7 @@ public:
     bool IsGroupExchangeContext() const { return mSession && mSession->IsGroupSession(); }
 
     // Implement SessionDelegate
-    SessionUpdated OnSessionUpdated(const SessionHandle & newSession) override { return SessionUpdated::DoNotMigrate; }
+    NewSessionHandlingPolicy GetNewSessionHandlingPolicy() override { return NewSessionHandlingPolicy::kStayAtOldSession; }
     void OnSessionReleased() override;
 
     /**

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -57,7 +57,7 @@ public:
  */
 class DLL_EXPORT ExchangeContext : public ReliableMessageContext,
                                    public ReferenceCounted<ExchangeContext, ExchangeContextDeletor>,
-                                   public SessionReleaseDelegate
+                                   public SessionDelegate
 {
     friend class ExchangeManager;
     friend class ExchangeContextDeletor;
@@ -81,7 +81,8 @@ public:
 
     bool IsGroupExchangeContext() const { return mSession && mSession->IsGroupSession(); }
 
-    // Implement SessionReleaseDelegate
+    // Implement SessionDelegate
+    SessionUpdated OnSessionUpdated(const SessionHandle & newSession) override { return SessionUpdated::DoNotMigrate; }
     void OnSessionReleased() override;
 
     /**

--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -154,7 +154,7 @@ public:
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
     Messaging::ExchangeMessageDispatch & GetMessageDispatch() override { return SessionEstablishmentExchangeDispatch::Instance(); }
 
-    //// SessionReleaseDelegate ////
+    //// SessionDelegate ////
     void OnSessionReleased() override;
 
     FabricIndex GetFabricIndex() const { return mFabricInfo != nullptr ? mFabricInfo->GetFabricIndex() : kUndefinedFabricIndex; }

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -178,7 +178,7 @@ public:
 
     Messaging::ExchangeMessageDispatch & GetMessageDispatch() override { return SessionEstablishmentExchangeDispatch::Instance(); }
 
-    //// SessionReleaseDelegate ////
+    //// SessionDelegate ////
     void OnSessionReleased() override;
 
 private:

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -38,7 +38,7 @@ namespace chip {
 
 class SessionManager;
 
-class DLL_EXPORT PairingSession : public SessionReleaseDelegate
+class DLL_EXPORT PairingSession : public SessionDelegate
 {
 public:
     PairingSession() : mSecureSessionHolder(*this) {}
@@ -48,6 +48,9 @@ public:
     virtual ScopedNodeId GetPeer() const                                = 0;
     virtual ScopedNodeId GetLocalScopedNodeId() const                   = 0;
     virtual CATValues GetPeerCATs() const                               = 0;
+
+    // Implement SessionDelegate
+    SessionUpdated OnSessionUpdated(const SessionHandle & newSession) override { return SessionUpdated::DoNotMigrate; }
 
     Optional<uint16_t> GetLocalSessionId() const
     {

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -50,7 +50,7 @@ public:
     virtual CATValues GetPeerCATs() const                               = 0;
 
     // Implement SessionDelegate
-    SessionUpdated OnSessionUpdated(const SessionHandle & newSession) override { return SessionUpdated::DoNotMigrate; }
+    NewSessionHandlingPolicy GetNewSessionHandlingPolicy() override { return NewSessionHandlingPolicy::kStayAtOldSession; }
 
     Optional<uint16_t> GetLocalSessionId() const
     {

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -25,21 +25,21 @@ class DLL_EXPORT SessionDelegate
 public:
     virtual ~SessionDelegate() {}
 
-    enum class SessionUpdated : uint8_t
+    enum class NewSessionHandlingPolicy : uint8_t
     {
-        Migrate,
-        DoNotMigrate,
+        kShiftToNewSession,
+        kStayAtOldSession,
     };
 
     /**
      * @brief
-     *   Called when a new secure session to the same peer is established, and it is suggested to migrate to the newly created
-     * session.
+     *   Called when a new secure session to the same peer is established, over the delegate of SessionHolderWithDelegate object. It
+     *   is suggested to shift to the newly created session.
      *
-     * Note: the default implementation move to the new sessoin, it should be fine for all users, unless the SessionHolder object is
-     * expected to be sticky to a specified session.
+     * Note: the default implementation orders shifting to the new session, it should be fine for all users, unless the
+     * SessionHolder object is expected to be sticky to a specified session.
      */
-    virtual SessionUpdated OnSessionUpdated(const SessionHandle & newSession) { return SessionUpdated::Migrate; }
+    virtual NewSessionHandlingPolicy GetNewSessionHandlingPolicy() { return NewSessionHandlingPolicy::kShiftToNewSession; }
 
     /**
      * @brief

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -20,10 +20,26 @@
 
 namespace chip {
 
-class DLL_EXPORT SessionReleaseDelegate
+class DLL_EXPORT SessionDelegate
 {
 public:
-    virtual ~SessionReleaseDelegate() {}
+    virtual ~SessionDelegate() {}
+
+    enum class SessionUpdated : uint8_t
+    {
+        Migrate,
+        DoNotMigrate,
+    };
+
+    /**
+     * @brief
+     *   Called when a new secure session to the same peer is established, and it is suggested to migrate to the newly created
+     * session.
+     *
+     * Note: the default implementation move to the new sessoin, it should be fine for all users, unless the SessionHolder object is
+     * expected to be sticky to a specified session.
+     */
+    virtual SessionUpdated OnSessionUpdated(const SessionHandle & newSession) { return SessionUpdated::Migrate; }
 
     /**
      * @brief

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -28,7 +28,7 @@ namespace chip {
  *    released when the underlying session is released. One must verify it is available before use. The object can be
  *    created using SessionHandle.Grab()
  */
-class SessionHolder : public SessionReleaseDelegate, public IntrusiveListNodeBase
+class SessionHolder : public SessionDelegate, public IntrusiveListNodeBase
 {
 public:
     SessionHolder() {}
@@ -39,7 +39,7 @@ public:
     SessionHolder & operator=(const SessionHolder &);
     SessionHolder & operator=(SessionHolder && that);
 
-    // Implement SessionReleaseDelegate
+    // Implement SessionDelegate
     void OnSessionReleased() override { Release(); }
 
     bool Contains(const SessionHandle & session) const
@@ -67,11 +67,8 @@ private:
 class SessionHolderWithDelegate : public SessionHolder
 {
 public:
-    SessionHolderWithDelegate(SessionReleaseDelegate & delegate) : mDelegate(delegate) {}
-    SessionHolderWithDelegate(const SessionHandle & handle, SessionReleaseDelegate & delegate) : mDelegate(delegate)
-    {
-        Grab(handle);
-    }
+    SessionHolderWithDelegate(SessionDelegate & delegate) : mDelegate(delegate) {}
+    SessionHolderWithDelegate(const SessionHandle & handle, SessionDelegate & delegate) : mDelegate(delegate) { Grab(handle); }
     operator bool() const { return SessionHolder::operator bool(); }
 
     void OnSessionReleased() override
@@ -83,7 +80,7 @@ public:
     }
 
 private:
-    SessionReleaseDelegate & mDelegate;
+    SessionDelegate & mDelegate;
 };
 
 } // namespace chip

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -59,7 +59,7 @@ const char PAYLOAD[] = "Hello!";
 
 const char LARGE_PAYLOAD[kMaxAppMessageLen + 1] = "test message";
 
-class TestSessionReleaseCallback : public SessionReleaseDelegate
+class TestSessionReleaseCallback : public SessionDelegate
 {
 public:
     void OnSessionReleased() override { mOldConnectionDropped = true; }


### PR DESCRIPTION
#### Problem
Path to implement #17569

#### Change overview
* Rename `SessionReleaseDelegate` => `SessionDelegate`
* Add `GetNewSessionHandlingPolicy` callback to `SessionDelegate`
* Audited all holder usage, There are 2 holders which are not eligible for auto-shifting
  * ExchangeContext
  * PairingSession

This PR depends on #17881 which makes `PairingSession` implement `SessionReleaseDelegate` 

#### Testing
Passed unit-tests