### PR TITLE
Add new dependency to building guide

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -45,7 +45,7 @@ satisfied with the following:
 ```
 sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev \
      libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
-     python3-pip unzip libgirepository1.0-dev libcairo2-dev
+     python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
 ```
 
 ### Installing prerequisites on macOS


### PR DESCRIPTION
#### Problem
Recent changes to [InteractiveCommands.cpp](https://github.com/project-chip/connectedhomeip/blob/master/examples/chip-tool/commands/interactive/InteractiveCommands.cpp) have introduced a new dependency libreadline-dev, but it wasn't mentioned in the [BUILDING.md](https://github.com/project-chip/connectedhomeip/blob/master/docs/guides/BUILDING.md) guide, which causes confusions to first-time users like myself.

#### Change overview
Updated the apt-get command to install libreadline-dev. 

#### Testing
How was this tested? (at least one bullet point required)
* It's just a one-liner in the docs, hence no testing required. I have run the updated command locally, and it works. 
