### PR TITLE
Fix "ethernet" pairing for chip-tool-darwin.

### DIFF
--- a/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.mm
@@ -37,6 +37,11 @@ void PairingCommandBridge::SetUpPairingDelegate()
     CHIPCommissioningParameters * params = [[CHIPCommissioningParameters alloc] init];
 
     [pairing setDeviceID:mNodeId];
+
+    // For Ethernet pairing, commissioning will be handled automatically by the
+    // CHIPDeviceController.
+    [pairing setCommissionAfterPairingComplete:(mNetworkType != PairingNetworkType::Ethernet)];
+
     switch (mNetworkType) {
     case PairingNetworkType::None:
     case PairingNetworkType::Ethernet:

--- a/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.h
+++ b/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.h
@@ -23,6 +23,7 @@
 @property chip::NodeId deviceID;
 @property CHIPDeviceController * commissioner;
 @property CHIPCommissioningParameters * params;
+@property bool commissionAfterPairingComplete;
 
 - (void)onPairingComplete:(NSError *)error;
 - (void)onPairingDeleted:(NSError *)error;

--- a/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.mm
+++ b/examples/chip-tool-darwin/commands/pairing/PairingDelegateBridge.mm
@@ -49,6 +49,9 @@
         return;
     }
     ChipLogProgress(chipTool, "Pairing Complete: %s", chip::ErrorStr(err));
+    if (!_commissionAfterPairingComplete) {
+        return;
+    }
     [_commissioner commissionDevice:_deviceID commissioningParams:_params error:&commissionError];
     err = [CHIPError errorToCHIPErrorCode:commissionError];
     if (err != CHIP_NO_ERROR) {


### PR DESCRIPTION
The Matter framework pairDevice API will actually go ahead and
commission the device if it's provided with the IP/port (as opposed to
the versions that just take an onboarding payload, which will set up
PASE but not commission).  The pairing delegate in chip-tool-darwin
was _also_ trying to commission, and then we failed out because we had
two commissioning attempts at the same time.

The fix is to not try to commission in the delegate if we are doing
"ethernet" pairing.

#### Problem
See above.  "ethernet" pairing does not work with chip-tool-darwin.

#### Change overview
Make it work.

#### Testing
Used "ethernet" pairing to pair an all-clusters-app running on localhost.