### PR TITLE
Removed some methods that are unused from af-events.cpp

### DIFF
--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -120,8 +120,6 @@ void EventControlHandler(chip::System::Layer * systemLayer, void * appState)
     }
 }
 
-const char emAfStackEventString[] = "Stack";
-
 // *****************************************************************************
 // Functions
 

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -194,16 +194,6 @@ EmberStatus emberAfEventControlSetDelayQS(EmberEventControl * control, uint32_t 
     return EMBER_BAD_ARGUMENT;
 }
 
-EmberStatus emberAfEventControlSetDelayMinutes(EmberEventControl * control, uint16_t delayM)
-{
-    if (delayM <= EMBER_MAX_EVENT_CONTROL_DELAY_MINUTES)
-    {
-        return emberEventControlSetDelayMS(control, static_cast<uint32_t>(delayM) << 16);
-    }
-
-    return EMBER_BAD_ARGUMENT;
-}
-
 EmberStatus emberAfScheduleTickExtended(EndpointId endpoint, ClusterId clusterId, bool isClient, uint32_t delayMs,
                                         EmberAfEventPollControl pollControl, EmberAfEventSleepControl sleepControl)
 {

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -184,16 +184,6 @@ void emberEventControlSetActive(EmberEventControl * control)
 #endif
 }
 
-EmberStatus emberAfEventControlSetDelayQS(EmberEventControl * control, uint32_t delayQs)
-{
-    if (delayQs <= EMBER_MAX_EVENT_CONTROL_DELAY_QS)
-    {
-        return emberEventControlSetDelayMS(control, delayQs << 8);
-    }
-
-    return EMBER_BAD_ARGUMENT;
-}
-
 EmberStatus emberAfScheduleTickExtended(EndpointId endpoint, ClusterId clusterId, bool isClient, uint32_t delayMs,
                                         EmberAfEventPollControl pollControl, EmberAfEventSleepControl sleepControl)
 {

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -128,11 +128,6 @@ const char emAfStackEventString[] = "Stack";
 // A function used to initialize events for idling
 void emAfInitEvents(void) {}
 
-const char * emberAfGetEventString(uint8_t index)
-{
-    return (index == 0XFF ? emAfStackEventString : emAfEventStrings[index]);
-}
-
 static EmberAfEventContext * findEventContext(EndpointId endpoint, ClusterId clusterId, bool isClient)
 {
 #if defined(EMBER_AF_GENERATED_EVENT_CONTEXT)
@@ -294,38 +289,12 @@ void emAfGetTimerDurationAndUnitFromMS(uint32_t durationMs, uint16_t * duration,
     }
     else if (MS_TO_QS(durationMs) <= MAX_TIMER_UNITS_HOST)
     {
-        *duration = (uint16_t)(MS_TO_QS(durationMs));
+        *duration = (uint16_t) (MS_TO_QS(durationMs));
         *units    = EMBER_EVENT_QS_TIME;
     }
     else
     {
-        *duration = (MS_TO_MIN(durationMs) <= MAX_TIMER_UNITS_HOST ? (uint16_t)(MS_TO_MIN(durationMs)) : MAX_TIMER_UNITS_HOST);
+        *duration = (MS_TO_MIN(durationMs) <= MAX_TIMER_UNITS_HOST ? (uint16_t) (MS_TO_MIN(durationMs)) : MAX_TIMER_UNITS_HOST);
         *units    = EMBER_EVENT_MINUTE_TIME;
     }
-}
-
-uint32_t emAfGetMSFromTimerDurationAndUnit(uint16_t duration, EmberEventUnits units)
-{
-    uint32_t ms;
-    if (units == EMBER_EVENT_MS_TIME)
-    {
-        ms = duration;
-    }
-    else if (units == EMBER_EVENT_QS_TIME)
-    {
-        ms = QS_TO_MS(static_cast<uint32_t>(duration));
-    }
-    else if (units == EMBER_EVENT_MINUTE_TIME)
-    {
-        ms = MIN_TO_MS(static_cast<uint32_t>(duration));
-    }
-    else if (units == EMBER_EVENT_ZERO_DELAY)
-    {
-        ms = 0;
-    }
-    else
-    {
-        ms = UINT32_MAX;
-    }
-    return ms;
 }

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -273,28 +273,3 @@ EmberStatus emberAfDeactivateServerTick(EndpointId endpoint, ClusterId clusterId
 {
     return emberAfDeactivateClusterTick(endpoint, clusterId, EMBER_AF_SERVER_CLUSTER_TICK);
 }
-
-#define MS_TO_QS(ms) ((ms) >> 8)
-#define MS_TO_MIN(ms) ((ms) >> 16)
-#define QS_TO_MS(qs) ((qs) << 8)
-#define MIN_TO_MS(min) ((min) << 16)
-
-// Used to calculate the duration and unit used by the host to set the sleep timer
-void emAfGetTimerDurationAndUnitFromMS(uint32_t durationMs, uint16_t * duration, EmberEventUnits * units)
-{
-    if (durationMs <= MAX_TIMER_UNITS_HOST)
-    {
-        *duration = (uint16_t) durationMs;
-        *units    = EMBER_EVENT_MS_TIME;
-    }
-    else if (MS_TO_QS(durationMs) <= MAX_TIMER_UNITS_HOST)
-    {
-        *duration = (uint16_t) (MS_TO_QS(durationMs));
-        *units    = EMBER_EVENT_QS_TIME;
-    }
-    else
-    {
-        *duration = (MS_TO_MIN(durationMs) <= MAX_TIMER_UNITS_HOST ? (uint16_t) (MS_TO_MIN(durationMs)) : MAX_TIMER_UNITS_HOST);
-        *units    = EMBER_EVENT_MINUTE_TIME;
-    }
-}

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -125,9 +125,6 @@ const char emAfStackEventString[] = "Stack";
 // *****************************************************************************
 // Functions
 
-// A function used to initialize events for idling
-void emAfInitEvents(void) {}
-
 static EmberAfEventContext * findEventContext(EndpointId endpoint, ClusterId clusterId, bool isClient)
 {
 #if defined(EMBER_AF_GENERATED_EVENT_CONTEXT)

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -53,8 +53,6 @@
  */
 typedef struct EmberEventData EmberEventData;
 
-void emAfInitEvents(void);
-
 /** @brief Sets this ::EmberEventControl as inactive (no pending event).
  */
 void emberEventControlSetInactive(EmberEventControl * control);

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -53,10 +53,6 @@
  */
 typedef struct EmberEventData EmberEventData;
 
-// A function used to retrieve the proper NCP timer duration and unit based on a given
-// passed number of milliseconds.
-void emAfGetTimerDurationAndUnitFromMS(uint32_t durationMs, uint16_t * duration, EmberEventUnits * units);
-
 void emAfInitEvents(void);
 
 /** @brief Sets this ::EmberEventControl as inactive (no pending event).

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -57,12 +57,6 @@ typedef struct EmberEventData EmberEventData;
 // passed number of milliseconds.
 void emAfGetTimerDurationAndUnitFromMS(uint32_t durationMs, uint16_t * duration, EmberEventUnits * units);
 
-// A function (inverse of the above) to retrieve the number of milliseconds
-// represented by a given timer duration and unit.
-uint32_t emAfGetMSFromTimerDurationAndUnit(uint16_t duration, EmberEventUnits units);
-
-const char * emberAfGetEventString(uint8_t index);
-
 void emAfInitEvents(void);
 
 /** @brief Sets this ::EmberEventControl as inactive (no pending event).

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -842,12 +842,6 @@ EmberStatus emberAfNetworkEventControlSetDelay(EmberEventControl * controls, uin
 #endif
 /**
  * @brief Sets the ::EmberEventControl for the current network, and only the
- * current network, to run "delayQs" quarter seconds in the future.  See
- * ::emberAfEventControlSetDelayQS.
- */
-EmberStatus emberAfNetworkEventControlSetDelayQS(EmberEventControl * controls, uint32_t delayQs);
-/**
- * @brief Sets the ::EmberEventControl for the current network, and only the
  * current network, to run "delayM" minutes in the future.  See
  * ::emberAfEventControlSetDelayMinutes.
  */

--- a/src/app/util/af.h
+++ b/src/app/util/af.h
@@ -809,22 +809,6 @@ EmberStatus emberEventControlSetDelayMS(EmberEventControl * control, uint32_t de
 EmberStatus emberAfEventControlSetDelayQS(EmberEventControl * control, uint32_t delayQs);
 
 /**
- * @brief Sets the ::EmberEventControl to run "delayM" minutes in the future.
- * The 'minutes' are actually 65536 (0x10000) milliseconds long.  This function
- * first verifies that the delay is within the acceptable range before
- * scheduling the event.
- *
- * @param control a pointer to the event control.
- * @param delayM the number of minutes until the next event.
- *
- * @return If delayM is less than or equal to
-           ::EMBER_MAX_EVENT_CONTROL_DELAY_MINUTES, this function will schedule
-           the event and return ::EMBER_SUCCESS.  Otherwise it will return
-           ::EMBER_BAD_ARGUMENT.
- */
-EmberStatus emberAfEventControlSetDelayMinutes(EmberEventControl * control, uint16_t delayM);
-
-/**
  * @brief Sets the ::EmberEventControl for the current network, and only
  * the current network, as inactive.  See ::emberEventControlSetInactive.
  */

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -434,23 +434,23 @@ EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberA
 
 void emberAfCopyInt16u(uint8_t * data, uint16_t index, uint16_t x)
 {
-    data[index]     = (uint8_t) (((x)) & 0xFF);
-    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
+    data[index]     = (uint8_t)(((x)) & 0xFF);
+    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
 }
 
 void emberAfCopyInt24u(uint8_t * data, uint16_t index, uint32_t x)
 {
-    data[index]     = (uint8_t) (((x)) & 0xFF);
-    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
-    data[index + 2] = (uint8_t) (((x) >> 16) & 0xFF);
+    data[index]     = (uint8_t)(((x)) & 0xFF);
+    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
+    data[index + 2] = (uint8_t)(((x) >> 16) & 0xFF);
 }
 
 void emberAfCopyInt32u(uint8_t * data, uint16_t index, uint32_t x)
 {
-    data[index]     = (uint8_t) (((x)) & 0xFF);
-    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
-    data[index + 2] = (uint8_t) (((x) >> 16) & 0xFF);
-    data[index + 3] = (uint8_t) (((x) >> 24) & 0xFF);
+    data[index]     = (uint8_t)(((x)) & 0xFF);
+    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
+    data[index + 2] = (uint8_t)(((x) >> 16) & 0xFF);
+    data[index + 3] = (uint8_t)(((x) >> 24) & 0xFF);
 }
 
 void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size)

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -213,9 +213,6 @@ void emberAfInit(chip::Messaging::ExchangeManager * exchangeMgr)
     // Set up client API buffer.
     emberAfSetExternalBuffer(appResponseData, EMBER_AF_RESPONSE_BUFFER_LEN, &appResponseLength, &emberAfResponseApsFrame);
 
-    // initialize event management system
-    emAfInitEvents();
-
     MATTER_PLUGINS_INIT
 
     emAfCallInits();
@@ -437,23 +434,23 @@ EmberStatus emberAfSendDefaultResponse(const EmberAfClusterCommand * cmd, EmberA
 
 void emberAfCopyInt16u(uint8_t * data, uint16_t index, uint16_t x)
 {
-    data[index]     = (uint8_t)(((x)) & 0xFF);
-    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
+    data[index]     = (uint8_t) (((x)) & 0xFF);
+    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
 }
 
 void emberAfCopyInt24u(uint8_t * data, uint16_t index, uint32_t x)
 {
-    data[index]     = (uint8_t)(((x)) & 0xFF);
-    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
-    data[index + 2] = (uint8_t)(((x) >> 16) & 0xFF);
+    data[index]     = (uint8_t) (((x)) & 0xFF);
+    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
+    data[index + 2] = (uint8_t) (((x) >> 16) & 0xFF);
 }
 
 void emberAfCopyInt32u(uint8_t * data, uint16_t index, uint32_t x)
 {
-    data[index]     = (uint8_t)(((x)) & 0xFF);
-    data[index + 1] = (uint8_t)(((x) >> 8) & 0xFF);
-    data[index + 2] = (uint8_t)(((x) >> 16) & 0xFF);
-    data[index + 3] = (uint8_t)(((x) >> 24) & 0xFF);
+    data[index]     = (uint8_t) (((x)) & 0xFF);
+    data[index + 1] = (uint8_t) (((x) >> 8) & 0xFF);
+    data[index + 2] = (uint8_t) (((x) >> 16) & 0xFF);
+    data[index + 3] = (uint8_t) (((x) >> 24) & 0xFF);
 }
 
 void emberAfCopyString(uint8_t * dest, const uint8_t * src, size_t size)


### PR DESCRIPTION
#### Problem
Unused code. Af-events usage is unclear since `af-gen-events.h` currently is not generated yet it seems a required include sometimes generated as empty by our build infra.

#### Change overview
Remove some unused code in the repo, trying to simplify the amount of code we have to review and maintain.

#### Testing
Grepping said that this code is unused. CI will validate that things still build.