### PR TITLE
Stop logging "Error:" in chip-tool-darwin when there is no error.

### DIFF
--- a/examples/chip-tool-darwin/templates/commands.zapt
+++ b/examples/chip-tool-darwin/templates/commands.zapt
@@ -68,7 +68,9 @@ public:
             ^(NSError * _Nullable error) {
         {{/if}}
             chipError = [CHIPError errorToCHIPErrorCode:error];
-            ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(chipError));
+            if (error != nil) {
+              ChipLogProgress(chipTool, "Error: %s", chip::ErrorStr(chipError));
+            }
             SetCommandExitStatus(chipError);
             }];
         return chipError;
@@ -133,7 +135,9 @@ public:
         NSLog(@"{{asUpperCamelCase parent.name}}.{{asUpperCamelCase name}} response %@", [value description]);
         err = [CHIPError errorToCHIPErrorCode:error];
 
-        ChipLogError(chipTool, "{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} Error: %s", chip::ErrorStr(err));
+        if (error != nil) {
+          ChipLogError(chipTool, "{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} read Error: %s", chip::ErrorStr(err));
+        }
         SetCommandExitStatus(err);
          }];
         return err;
@@ -188,7 +192,9 @@ public:
 
         [cluster writeAttribute{{asUpperCamelCase name}}WithValue:value params:params completionHandler:^(NSError * _Nullable error) {
             chipError = [CHIPError errorToCHIPErrorCode:error];
-            ChipLogError(chipTool, "{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} Error: %s", chip::ErrorStr(chipError));
+            if (error != nil) {
+              ChipLogError(chipTool, "{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} write Error: %s", chip::ErrorStr(chipError));
+            }
             SetCommandExitStatus(chipError);
             }];
         return chipError;


### PR DESCRIPTION
Running something like:
```
  chip-tool-darwin operationalcredentials read fabrics NODE_ID 0
```
ends up logging:
```
  [1651763766864] [75364:41306780] CHIP: [TOO] OperationalCredentials Fabrics Error: ../../../examples/chip-tool-darwin/third_party/connectedhomeip/src/darwin/Framework/CHIP/CHIPError.mm:214: Success
```
as an error-level log, which is pretty confusing.  This change skips logging the "Error: ..." bits if there is in fact no error.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran a data model command that succeeded; made sure it did not log the Error: bits.