### PR TITLE
Fix code in CHIPCryptoPALOpenSSL that could try to log nullptr

### DIFF
--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -104,10 +104,8 @@ static void _logSSLError()
         const char * err_str_reason  = ERR_reason_error_string(ssl_err_code);
         if (err_str_lib)
         {
-            ChipLogError(Crypto, " ssl err  %s %s %s\n",
-               StringOrNullMarker(err_str_lib),
-               StringOrNullMarker(err_str_routine),
-               StringOrNullMarker(err_str_reason));
+            ChipLogError(Crypto, " ssl err  %s %s %s\n", StringOrNullMarker(err_str_lib), StringOrNullMarker(err_str_routine),
+                         StringOrNullMarker(err_str_reason));
         }
 #endif // CHIP_ERROR_LOGGING
         ssl_err_code = ERR_get_error();

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -104,7 +104,10 @@ static void _logSSLError()
         const char * err_str_reason  = ERR_reason_error_string(ssl_err_code);
         if (err_str_lib)
         {
-            ChipLogError(Crypto, " ssl err  %s %s %s\n", err_str_lib, err_str_routine, err_str_reason);
+            ChipLogError(Crypto, " ssl err  %s %s %s\n",
+               StringOrNullMarker(err_str_lib),
+               StringOrNullMarker(err_str_routine),
+               StringOrNullMarker(err_str_reason));
         }
 #endif // CHIP_ERROR_LOGGING
         ssl_err_code = ERR_get_error();

--- a/src/lib/support/CodeUtils.h
+++ b/src/lib/support/CodeUtils.h
@@ -682,6 +682,29 @@ inline void chipDie(void)
  */
 #define ArraySize(a) (sizeof(a) / sizeof((a)[0]))
 
+/**
+ * @brief Ensures that if `str` is NULL, a non-null `default_str_value` is provided
+ *
+ * @param str - null-terminated string pointer or nullptr
+ * @param default_str_value - replacement value if `str` is nullptr
+ * @return `str` if not null, otherwise `default_str_value`
+ */
+inline const char * DefaultStringWhenNull(const char * str, const char * default_str_value)
+{
+    return (str != nullptr) ? str : default_str_value;
+}
+
+/**
+ * @brief Ensure that a string for a %s specifier is shown as "(null)" if null
+ *
+ * @param str - null-terminated string pointer or nullptr
+ * @return `str` if not null, otherwise literal "(null)"
+ */
+inline const char * StringOrNullMarker(const char * str)
+{
+    return DefaultStringWhenNull(str, "(null)");
+}
+
 namespace chip {
 
 /**


### PR DESCRIPTION
#### Problem
- Some `%s` specifiers did not have a guaranteed non-null string,
  in OpenSSL error reporting.
- Overall, we are missing a macro/function to make it easy to
  return a default string value when a string is null for a
  `%s` specifier, which is Undefined Behavior. Relying on
  standard libraries "catching it for us" is wrong and may
  fail on some platforms.

#### Change overview
This PR makes sure CHIPCryptoPALOpenSSL error reporting never
uses a null string argument. This is now valid by construction
without needing to validate the underlying implementations.

This PR also adds `DefaultStringWhenNull` and `StringOrNullMarker`
utilities to assist others in doing this safely

#### Testing
- Unit tests and cert tests all pass
