### PR TITLE
Fix "ethernet" pairing for chip-tool-darwin.

### DIFF
--- a/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.mm
@@ -96,7 +96,6 @@ void PairingCommandBridge::PairWithIPAddress(NSError * __autoreleasing * error)
     [CurrentCommissioner() pairDevice:mNodeId
                               address:[NSString stringWithUTF8String:ipAddress]
                                  port:mRemotePort
-                        discriminator:mDiscriminator
                          setupPINCode:mSetupPINCode
                                 error:error];
 }

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -35,18 +35,49 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
 
 @property (readonly, nonatomic) BOOL isRunning;
 
+/**
+ * Start pairing for a device with the given ID, using the provided setup PIN
+ * to establish a PASE connection.
+ *
+ * The IP and port for the device will be discovered automatically based on the
+ * provided discriminator.
+ *
+ * The pairing process will proceed until a PASE session is established or an
+ * error occurs, then notify onPairingComplete on the CHIPDevicePairingDelegate
+ * for this controller.  That delegate is expected to call commissionDevice
+ * after that point if it wants to commission the device.
+ */
 - (BOOL)pairDevice:(uint64_t)deviceID
      discriminator:(uint16_t)discriminator
       setupPINCode:(uint32_t)setupPINCode
              error:(NSError * __autoreleasing *)error;
 
+/**
+ * Start pairing for a device with the given ID, using the provided IP address
+ * and port to connect to the device and the provided setup PIN to establish a
+ * PASE connection.
+ *
+ * The pairing process will proceed until a PASE session is established or an
+ * error occurs, then notify onPairingComplete on the CHIPDevicePairingDelegate
+ * for this controller.  That delegate is expected to call commissionDevice
+ * after that point if it wants to commission the device.
+ */
 - (BOOL)pairDevice:(uint64_t)deviceID
            address:(NSString *)address
               port:(uint16_t)port
-     discriminator:(uint16_t)discriminator
       setupPINCode:(uint32_t)setupPINCode
              error:(NSError * __autoreleasing *)error;
 
+/**
+ * Start pairing for a device with the given ID and onboarding payload (QR code
+ * or manual setup code).  The payload will be used to discover the device and
+ * establish a PASE connection.
+ *
+ * The pairing process will proceed until a PASE session is established or an
+ * error occurs, then notify onPairingComplete on the CHIPDevicePairingDelegate
+ * for this controller.  That delegate is expected to call commissionDevice
+ * after that point if it wants to commission the device.
+ */
 - (BOOL)pairDevice:(uint64_t)deviceID onboardingPayload:(NSString *)onboardingPayload error:(NSError * __autoreleasing *)error;
 - (BOOL)commissionDevice:(uint64_t)deviceId
      commissioningParams:(CHIPCommissioningParameters *)commissioningParams

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -315,7 +315,6 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
 - (BOOL)pairDevice:(uint64_t)deviceID
            address:(NSString *)address
               port:(uint16_t)port
-     discriminator:(uint16_t)discriminator
       setupPINCode:(uint32_t)setupPINCode
              error:(NSError * __autoreleasing *)error
 {
@@ -330,13 +329,10 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
         chip::Inet::IPAddress::FromString([address UTF8String], addr);
         chip::Transport::PeerAddress peerAddress = chip::Transport::PeerAddress::UDP(addr, port);
 
-        chip::RendezvousParameters params = chip::RendezvousParameters()
-                                                .SetSetupPINCode(setupPINCode)
-                                                .SetDiscriminator(discriminator)
-                                                .SetPeerAddress(peerAddress);
+        chip::RendezvousParameters params = chip::RendezvousParameters().SetSetupPINCode(setupPINCode).SetPeerAddress(peerAddress);
         if ([self isRunning]) {
             _operationalCredentialsDelegate->SetDeviceID(deviceID);
-            errorCode = self.cppCommissioner->PairDevice(deviceID, params);
+            errorCode = self.cppCommissioner->EstablishPASEConnection(deviceID, params);
         }
         success = ![self checkForError:errorCode logMsg:kErrorPairDevice error:error];
     });

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -38,7 +38,6 @@ const uint16_t kAddressResolveTimeoutInSeconds = 10;
 const uint16_t kCASESetupTimeoutInSeconds = 30;
 const uint16_t kTimeoutInSeconds = 20;
 const uint64_t nodeId = 0x12344321;
-const uint16_t kDiscriminator = 3840;
 const uint32_t kSetupPINCode = 20202021;
 const uint16_t kRemotePort = 5540;
 const uint16_t kLocalPort = 5541;
@@ -75,6 +74,10 @@ CHIPDevice * GetConnectedDevice(void)
 - (void)onPairingComplete:(NSError *)error
 {
     XCTAssertEqual(error.code, 0);
+    NSError * commissionError = nil;
+    [sController commissionDevice:nodeId commissioningParams:[[CHIPCommissioningParameters alloc] init] error:&commissionError];
+    XCTAssertNil(commissionError);
+
     // Keep waiting for onCommissioningComplete
 }
 
@@ -134,12 +137,7 @@ CHIPDevice * GetConnectedDevice(void)
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
     NSError * error;
-    [controller pairDevice:nodeId
-                   address:kAddress
-                      port:kRemotePort
-             discriminator:kDiscriminator
-              setupPINCode:kSetupPINCode
-                     error:&error];
+    [controller pairDevice:nodeId address:kAddress port:kRemotePort setupPINCode:kSetupPINCode error:&error];
     XCTAssertEqual(error.code, 0);
 
     [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];

--- a/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
@@ -41,7 +41,6 @@ static const uint16_t kPairingTimeoutInSeconds = 10;
 static const uint16_t kCASESetupTimeoutInSeconds = 30;
 static const uint16_t kTimeoutInSeconds = 3;
 static const uint64_t kDeviceId = 0x12344321;
-static const uint16_t kDiscriminator = 3840;
 static const uint32_t kSetupPINCode = 20202021;
 static const uint16_t kRemotePort = 5540;
 static const uint16_t kLocalPort = 5541;
@@ -98,8 +97,12 @@ static CHIPDevice * GetConnectedDevice(void)
 - (void)onPairingComplete:(NSError *)error
 {
     XCTAssertEqual(error.code, 0);
-    [_expectation fulfill];
-    _expectation = nil;
+
+    NSError * commissionError = nil;
+    [sController commissionDevice:kDeviceId commissioningParams:[[CHIPCommissioningParameters alloc] init] error:&commissionError];
+    XCTAssertNil(commissionError);
+
+    // Keep waiting for onCommissioningComplete
 }
 
 - (void)onCommissioningComplete:(NSError *)error
@@ -166,12 +169,7 @@ static CHIPDevice * GetConnectedDevice(void)
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
     NSError * error;
-    [controller pairDevice:kDeviceId
-                   address:kAddress
-                      port:kRemotePort
-             discriminator:kDiscriminator
-              setupPINCode:kSetupPINCode
-                     error:&error];
+    [controller pairDevice:kDeviceId address:kAddress port:kRemotePort setupPINCode:kSetupPINCode error:&error];
     XCTAssertEqual(error.code, 0);
 
     [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];

--- a/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
@@ -430,7 +430,6 @@ static const uint16_t kPairingTimeoutInSeconds = 10;
 static const uint16_t kCASESetupTimeoutInSeconds = 30;
 static const uint16_t kTimeoutInSeconds = 3;
 static const uint64_t kDeviceId = 0x12344321;
-static const uint16_t kDiscriminator = 3840;
 static const uint32_t kSetupPINCode = 20202021;
 static const uint16_t kRemotePort = 5540;
 static const uint16_t kLocalPort = 5541;
@@ -465,8 +464,11 @@ static CHIPDevice * GetConnectedDevice(void)
 - (void)onPairingComplete:(NSError *)error
 {
     XCTAssertEqual(error.code, 0);
-    [_expectation fulfill];
-    _expectation = nil;
+    NSError * commissionError = nil;
+    [sController commissionDevice:kDeviceId commissioningParams:[[CHIPCommissioningParameters alloc] init] error:&commissionError];
+    XCTAssertNil(commissionError);
+
+    // Keep waiting for onCommissioningComplete
 }
 
 - (void)onCommissioningComplete:(NSError *)error
@@ -535,12 +537,7 @@ static CHIPDevice * GetConnectedDevice(void)
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
     NSError * error;
-    [controller pairDevice:kDeviceId
-                   address:kAddress
-                      port:kRemotePort
-             discriminator:kDiscriminator
-              setupPINCode:kSetupPINCode
-                     error:&error];
+    [controller pairDevice:kDeviceId address:kAddress port:kRemotePort setupPINCode:kSetupPINCode error:&error];
     XCTAssertEqual(error.code, 0);
 
     [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];


### PR DESCRIPTION
Makes the various pairDevice APIs on CHIPDeviceController have
identical behavior in terms of just establishing a PASE session and
waiting for the API consumer to call commissionDevice as desired.

Without this change, both the API implementation and
chip-tool-darwin's pairing delegate would try to commission the same
device, which would fail.

#### Problem
See above. "ethernet" pairing does not work with chip-tool-darwin.

#### Change overview
Make it work.

#### Testing
Used "ethernet" pairing to pair an all-clusters-app running on localhost.