### PR TITLE
[docs] Improve docs on chip-tool tests. Add example. Fix broken links.

### DIFF
--- a/docs/guides/chip_tool_guide.md
+++ b/docs/guides/chip_tool_guide.md
@@ -657,6 +657,27 @@ In this command:
 
 -   _<test_name\>_ is the name of the particular test.
 
+#### Example: running TestClusters test
+
+As an example of running one test suite test:
+
+```
+# Clean initialization of state.
+rm -fr /tmp/chip_*
+
+# In a shell window, start the DUT device.
+./out/debug/standalone/chip-all-clusters-app
+
+# In a second shell window, pair the DUT with chip-tool.
+./out/debug/standalone/chip-tool pairing onnetwork 1 20202021
+
+# Now run the test
+./out/debug/standalone/chip-tool tests TestCluster --nodeId 1
+```
+
+Developer details on how the test suite is structured can be found
+[here](../../src/app/tests/suites/README.md).
+
 ### Parsing the setup payload
 
 The CHIP Tool offers a utility for parsing the Matter onboarding setup payload

--- a/docs/guides/chip_tool_guide.md
+++ b/docs/guides/chip_tool_guide.md
@@ -657,7 +657,7 @@ In this command:
 
 -   _<test_name\>_ is the name of the particular test.
 
-#### Example: running TestClusters test
+#### Example: running `TestClusters` test
 
 As an example of running one test suite test:
 
@@ -669,10 +669,10 @@ rm -fr /tmp/chip_*
 ./out/debug/standalone/chip-all-clusters-app
 
 # In a second shell window, pair the DUT with chip-tool.
-./out/debug/standalone/chip-tool pairing onnetwork 1 20202021
+./out/debug/standalone/chip-tool pairing onnetwork 333221 20202021
 
 # Now run the test
-./out/debug/standalone/chip-tool tests TestCluster --nodeId 1
+./out/debug/standalone/chip-tool tests TestCluster --nodeId 333221
 ```
 
 Developer details on how the test suite is structured can be found

--- a/src/app/tests/suites/README.md
+++ b/src/app/tests/suites/README.md
@@ -246,10 +246,10 @@ Top level key to define a YAML test: [test](#property-test)
     [tests.js](../../../../examples/placeholder/linux/apps/app1/tests.js)
 
 -   chip-tool(darwin) tests:
-    [tests.js](../../../../examples/chip-tool-darwin/templates/tests.js)
+    [tests.js](../../../../examples/chip-tool-darwin/templates/tests/tests.js)
 
 -   chip-tool tests:
-    [tests.js](../../../../examples/chip-tool/templates/tests.js)
+    [tests.js](../../../../examples/chip-tool/templates/tests/tests.js)
 
     ```javascript
     // Manual test definitions. Does not run in CI.


### PR DESCRIPTION
#### Problem
* Some links in test suite docs were broken
* `chip-tool tests` has no documented example of how to setup and run a 2 node test manually

#### Testing
Documentation only