### PR TITLE
MinMdns - do not reset hasIP/hasHostPort on partial failure

### DIFF
--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -238,6 +238,10 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
             {
                 OnOperationalSrvRecord(data.GetName(), srv);
             }
+            else
+            {
+                ChipLogError(Discovery, "Invalid operational srv name: no '%s' part found.", kOperationalServiceName);
+            }
         }
         else if (mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode)
         {
@@ -245,6 +249,11 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
             if (HasQNamePart(data.GetName(), kCommissionableServiceName) || HasQNamePart(data.GetName(), kCommissionerServiceName))
             {
                 OnCommissionableNodeSrvRecord(data.GetName(), srv);
+            }
+            else
+            {
+                ChipLogError(Discovery, "Invalid commision srv name: no '%s' or '%s' part found.", kCommissionableServiceName,
+                             kCommissionerServiceName);
             }
         }
         break;
@@ -348,6 +357,7 @@ void PacketDataReporter::OnComplete(ActiveResolveAttempts & activeAttempts)
             ChipLogError(Discovery, "Operational discovery has no valid node/port. Resolve not complete.");
             return;
         }
+
         activeAttempts.Complete(mNodeData.mPeerId);
         mNodeData.LogNodeIdResolved();
 

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -318,9 +318,13 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
 
 void PacketDataReporter::OnComplete(ActiveResolveAttempts & activeAttempts)
 {
-    if ((mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode) &&
-        mDiscoveredNodeData.IsValid())
+    if (mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode)
     {
+        if (!mDiscoveredNodeData.IsValid())
+        {
+            ChipLogError(Discovery, "Discovered not data is not valid. Commissioning discovery not complete.");
+        }
+
         activeAttempts.Complete(mDiscoveredNodeData);
         if (mCommissioningDelegate != nullptr)
         {
@@ -331,8 +335,19 @@ void PacketDataReporter::OnComplete(ActiveResolveAttempts & activeAttempts)
             ChipLogError(Discovery, "No delegate to report commissioning node discovery");
         }
     }
-    else if (mDiscoveryType == DiscoveryType::kOperational && mHasIP && mHasNodePort)
+    else if (mDiscoveryType == DiscoveryType::kOperational)
     {
+        if (!mHasIP)
+        {
+            ChipLogError(Discovery, "Operational discovery has no valid ip address. Resolve not complete.");
+            return;
+        }
+
+        if (!mHasNodePort)
+        {
+            ChipLogError(Discovery, "Operational discovery has no valid node/port. Resolve not complete.");
+            return;
+        }
         activeAttempts.Complete(mNodeData.mPeerId);
         mNodeData.LogNodeIdResolved();
 

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -331,7 +331,8 @@ void PacketDataReporter::OnComplete(ActiveResolveAttempts & activeAttempts)
     {
         if (!mDiscoveredNodeData.IsValid())
         {
-            ChipLogError(Discovery, "Discovered not data is not valid. Commissioning discovery not complete.");
+            ChipLogError(Discovery, "Discovered node data is not valid. Commissioning discovery not complete.");
+            return;
         }
 
         activeAttempts.Complete(mDiscoveredNodeData);


### PR DESCRIPTION
MinMdns can receive several packets and if any of the packets are ok,
a single valid ip or host/port is sufficient.

In practice, this was failing on mdns on ipv6 only builds when both ipv6
and ipv4 were sent in order. Specifically:
  - MDNS packet contains AAAA followed by A
  - Resolver parses AAAA and sets a valid IP
  - Resolver sees A and fails to parse (no IPv4 support) and resets
    valid IP

As a result, dns resolution was never calling complete (because it
thinks no valid IPs).
