### PR TITLE
[Fix] Change event number counter key

### DIFF
--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -108,7 +108,7 @@ public:
     static const char * OTATargetVersion() { return "g/o/tv"; }
 
     // Event number counter.
-    const char * IMEventNumber() { return Format("g/im/e"); }
+    const char * IMEventNumber() { return Format("g/im/ec"); }
 
 private:
     // The ENFORCE_FORMAT args are "off by one" because this is a class method,

--- a/src/lib/support/PersistedCounter.h
+++ b/src/lib/support/PersistedCounter.h
@@ -197,7 +197,7 @@ private:
             ReturnErrorOnFailure(err);
         }
 
-        if (size > sizeof(valueLE))
+        if (size != sizeof(valueLE))
         {
             // TODO: Again, figure out whether this could lead to bootloops.
             return CHIP_ERROR_INCORRECT_STATE;


### PR DESCRIPTION
#### Problem
* reverts #18045 since the check was not the underlying issue
* event number counter size was changed without changing the key. This caused mismatch sizes when flashing a new app when they key was already written in non-volatile memory. Mismatch caused the server init to fail and exit without completing initialization. Not completing initialization causes undefined behaviours.

#### Change overview
* Changes the key to avoid any mismatchs when they already exists with the previous test

#### Testing
* Manual tests with efr32 to validate read / write
