### PR TITLE
Add ability to select controller name in chip-tool-darwin

### DIFF
--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.h
@@ -25,12 +25,14 @@
 
 #pragma once
 
+constexpr const char kIdentityAlpha[] = "alpha";
+constexpr const char kIdentityBeta[]  = "beta";
+constexpr const char kIdentityGamma[] = "gamma";
+
 class CHIPCommandBridge : public Command
 {
 public:
-    CHIPCommandBridge(const char * commandName) : Command(commandName) {}
-
-    CHIPCommandBridge(const char * commandName, CredentialIssuerCommands * credIssuerCmds) : CHIPCommandBridge(commandName) {}
+    CHIPCommandBridge(const char * commandName) : Command(commandName) { AddArgument("commissioner-name", &mCommissionerName); }
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
@@ -58,7 +60,7 @@ protected:
     // loop has been stopped.
     virtual void Shutdown() {}
 
-    void SetIdentity(const char * name);
+    void SetIdentity(const char * identity);
 
     // This method returns the commissioner instance to be used for running the command.
     CHIPDeviceController * CurrentCommissioner();
@@ -82,5 +84,6 @@ private:
 
     std::condition_variable cvWaitingForResponse;
     std::mutex cvWaitingForResponseMutex;
+    chip::Optional<char *> mCommissionerName;
     bool mWaitingForResponse{ true };
 };

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.mm
@@ -53,7 +53,7 @@ CHIP_ERROR CHIPCommandBridge::Run()
 
     ipk = [nocSigner getIPK];
 
-    constexpr const char * identities[] = { "alpha", "beta", "gamma" };
+    constexpr const char * identities[] = { kIdentityAlpha, kIdentityBeta, kIdentityGamma };
     for (size_t i = 0; i < ArraySize(identities); ++i) {
         auto controllerParams = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nocSigner];
         controllerParams.vendorId = chip::VendorId::TestVendor1;
@@ -75,8 +75,8 @@ CHIP_ERROR CHIPCommandBridge::Run()
         mControllers[identities[i]] = controller;
     }
 
-    // Default to alpha.
-    SetIdentity("alpha");
+    // If no commissioner name passed in, default to alpha.
+    SetIdentity(mCommissionerName.HasValue() ? mCommissionerName.Value() : kIdentityAlpha);
 
     ReturnLogErrorOnFailure(RunCommand());
     ReturnLogErrorOnFailure(StartWaiting(GetWaitDuration()));
@@ -84,7 +84,16 @@ CHIP_ERROR CHIPCommandBridge::Run()
     return CHIP_NO_ERROR;
 }
 
-void CHIPCommandBridge::SetIdentity(const char * name) { mCurrentController = mControllers[name]; }
+void CHIPCommandBridge::SetIdentity(const char * identity)
+{
+    std::string name = std::string(identity);
+    if (name.compare(kIdentityAlpha) != 0 && name.compare(kIdentityBeta) != 0 && name.compare(kIdentityGamma) != 0) {
+        ChipLogError(chipTool, "Unknown commissioner name: %s. Supported names are [%s, %s, %s]", name.c_str(), kIdentityAlpha,
+            kIdentityBeta, kIdentityGamma);
+        chipDie();
+    }
+    mCurrentController = mControllers[name];
+}
 
 CHIPDeviceController * CHIPCommandBridge::CurrentCommissioner() { return mCurrentController; }
 


### PR DESCRIPTION
#### Problem
Currently there is not a way to select which commissioner to use in chip-tool-darwin. 
* Fixes #18126 

#### Change overview
- Add ability to select commissioner in chip-tool-darwin.

#### Testing
- Tested different controllers
- Tested invalid controller name
