### PR TITLE
Skip SetCurrentHeapHighWatermark if GetCurrentHeapUsed is not impleme…

### DIFF
--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -156,23 +156,11 @@ bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(app::CommandHandle
 {
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
 
-    uint64_t currentHeapUsed;
-    CHIP_ERROR err = DeviceLayer::GetDiagnosticDataProvider().GetCurrentHeapUsed(currentHeapUsed);
-
-    // Skip SetCurrentHeapHighWatermark if GetCurrentHeapUsed is not implemented
-    if (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE && err != CHIP_ERROR_NOT_IMPLEMENTED)
+    // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the
+    // value of the CurrentHeapUsed.
+    if (DeviceLayer::GetDiagnosticDataProvider().ResetWatermarks() != CHIP_NO_ERROR)
     {
-        if (err == CHIP_NO_ERROR)
-        {
-            if (CHIP_NO_ERROR != DeviceLayer::GetDiagnosticDataProvider().SetCurrentHeapHighWatermark(currentHeapUsed))
-            {
-                status = EMBER_ZCL_STATUS_FAILURE;
-            }
-        }
-        else
-        {
-            status = EMBER_ZCL_STATUS_FAILURE;
-        }
+        status = EMBER_ZCL_STATUS_FAILURE;
     }
 
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -158,12 +158,23 @@ bool emberAfSoftwareDiagnosticsClusterResetWatermarksCallback(app::CommandHandle
 
     uint64_t currentHeapUsed;
     CHIP_ERROR err = DeviceLayer::GetDiagnosticDataProvider().GetCurrentHeapUsed(currentHeapUsed);
-    VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
 
-    err = DeviceLayer::GetDiagnosticDataProvider().SetCurrentHeapHighWatermark(currentHeapUsed);
-    VerifyOrExit(err == CHIP_NO_ERROR, status = EMBER_ZCL_STATUS_FAILURE);
+    // Skip SetCurrentHeapHighWatermark if GetCurrentHeapUsed is not implemented
+    if (err != CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE && err != CHIP_ERROR_NOT_IMPLEMENTED)
+    {
+        if (err == CHIP_NO_ERROR)
+        {
+            if (CHIP_NO_ERROR != DeviceLayer::GetDiagnosticDataProvider().SetCurrentHeapHighWatermark(currentHeapUsed))
+            {
+                status = EMBER_ZCL_STATUS_FAILURE;
+            }
+        }
+        else
+        {
+            status = EMBER_ZCL_STATUS_FAILURE;
+        }
+    }
 
-exit:
     emberAfSendImmediateDefaultResponse(status);
 
     return true;

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -180,6 +180,7 @@ public:
     virtual CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed);
     virtual CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark);
     virtual CHIP_ERROR SetCurrentHeapHighWatermark(uint64_t heapHighWatermark);
+    virtual CHIP_ERROR ResetWatermarks();
 
     /*
      * Get the linked list of thread metrics of the current plaform. After usage, each caller of GetThreadMetrics
@@ -268,6 +269,11 @@ inline CHIP_ERROR DiagnosticDataProvider::GetCurrentHeapHighWatermark(uint64_t &
 }
 
 inline CHIP_ERROR DiagnosticDataProvider::SetCurrentHeapHighWatermark(uint64_t heapHighWatermark)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+inline CHIP_ERROR DiagnosticDataProvider::ResetWatermarks()
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
@@ -68,5 +68,14 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     return CHIP_ERROR_INVALID_TIME;
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
+{
+    // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the
+    // value of the CurrentHeapUsed.
+    // On Darwin, overide with non-op to pass CI.
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
@@ -68,32 +68,5 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     return CHIP_ERROR_INVALID_TIME;
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeapFree)
-{
-    // Overide with dummy value to pass CI
-    currentHeapFree = 0;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapUsed(uint64_t & currentHeapUsed)
-{
-    // Overide with dummy value to pass CI
-    currentHeapUsed = 0;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
-{
-    // Overide with dummy value to pass CI
-    currentHeapHighWatermark = 0;
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR DiagnosticDataProviderImpl::SetCurrentHeapHighWatermark(uint64_t heapHighWatermark)
-{
-    // Overide to pass CI
-    return CHIP_NO_ERROR;
-}
-
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.h
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.h
@@ -38,6 +38,9 @@ public:
     // ===== Methods that implement the PlatformManager abstract interface.
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
+
+    // ===== Methods that implement the DiagnosticDataProvider abstract interface.
+    CHIP_ERROR ResetWatermarks() override;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.h
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.h
@@ -38,12 +38,6 @@ public:
     // ===== Methods that implement the PlatformManager abstract interface.
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
-
-    // ===== Methods that implement the DiagnosticDataProvider abstract interface.
-    CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
-    CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
-    CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
-    CHIP_ERROR SetCurrentHeapHighWatermark(uint64_t heapHighWatermark) override;
 };
 
 } // namespace DeviceLayer

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -274,6 +274,17 @@ CHIP_ERROR DiagnosticDataProviderImpl::SetCurrentHeapHighWatermark(uint64_t heap
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
+{
+    // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the
+    // value of the CurrentHeapUsed.
+
+    // On Linux, the write operation is non-op since we always rely on the mallinfo system
+    // function to get the current heap memory.
+
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadMetricsOut)
 {
     CHIP_ERROR err = CHIP_ERROR_READ_FAILED;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -44,6 +44,7 @@ public:
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
     CHIP_ERROR GetThreadMetrics(ThreadMetrics ** threadMetricsOut) override;
     CHIP_ERROR SetCurrentHeapHighWatermark(uint64_t heapHighWatermark) override;
+    CHIP_ERROR ResetWatermarks() override;
     void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
 
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;


### PR DESCRIPTION
…nted

#### Problem
What is being fixed?  Examples:
* Current implementation need a device to implement GetCurrentHeapUsed attribute to support ResetWatermarks command. But it's valid for a node to have WTRMRK feature enabled without GetCurrentHeapUsed attribute implemented.

#### Change overview
Skip SetCurrentHeapHighWatermark if GetCurrentHeapUsed is not implemented.

#### Testing
How was this tested? (at least one bullet point required)
* This is covered by Darwin CI which have GetCurrentHeapUsed support removed

