### PR TITLE
Use true/false for keepSubscriptions documentation.

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -534,7 +534,7 @@ public:
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, 0,
                     "The requested maximum interval between reports. Sets MaxIntervalCeiling in the Subscribe Request.");
         AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
-                    "0 - Terminate existing subscriptions from initiator.\n  1 - Otherwise.");
+                    "false - Terminate existing subscriptions from initiator.\n  true - Leave existing subscriptions in place.");
         AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReportCommand::AddArguments();
     }


### PR DESCRIPTION
Now that we support using true and false for booleans on the chip-tool
command line, the docs should suggest that.

#### Problem
Docs say to use 0/1 when false/true would be clearer.

#### Change overview
Adjust the docs.

#### Testing
No behavior changes.