### PR TITLE
Optional/Mandatory attributes in Level Control Cluster

### DIFF
--- a/src/app/zap-templates/zcl/data-model/silabs/general.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general.xml
@@ -285,11 +285,11 @@ limitations under the License.
     <attribute side="server" code="0x0006" define="MAX_FREQUENCY" type="INT16U" min="0x0000" max="0xFFFF" writable="false" default="0x0000" optional="true">max frequency</attribute>
     
     <attribute side="server" code="0x0010" define="ON_OFF_TRANSITION_TIME" type="INT16U" writable="true" default="0x0000" optional="true">on off transition time</attribute>
-    <attribute side="server" code="0x0011" define="ON_LEVEL" type="INT8U" isNullable="true" writable="true" optional="true">on level</attribute>
+    <attribute side="server" code="0x0011" define="ON_LEVEL" type="INT8U" isNullable="true" writable="true" optional="false">on level</attribute>
     <attribute side="server" code="0x0012" define="ON_TRANSITION_TIME" type="INT16U" isNullable="true" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">on transition time</attribute>
     <attribute side="server" code="0x0013" define="OFF_TRANSITION_TIME" type="INT16U" isNullable="true" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">off transition time</attribute>
     <attribute side="server" code="0x0014" define="DEFAULT_MOVE_RATE" type="INT8U" isNullable="true" writable="true" optional="true" introducedIn="ha-1.2-05-3520-29">default move rate</attribute>
-    <attribute side="server" code="0x000F" define="OPTIONS" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">options</attribute>
+    <attribute side="server" code="0x000F" define="OPTIONS" type="BITMAP8" min="0x00" max="0x03" writable="true" default="0x00" optional="false" introducedIn="l&amp;o-1.0-15-0014-04">options</attribute>
     <attribute side="server" code="0x4000" define="START_UP_CURRENT_LEVEL" type="INT8U" isNullable="true" writable="true" optional="true" introducedIn="l&amp;o-1.0-15-0014-04">
       <description>start up current level</description>
       <access op="read" role="view"/>

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -3021,9 +3021,9 @@ class LevelControl(Cluster):
                 ClusterObjectFieldDescriptor(Label="currentFrequency", Tag=0x00000004, Type=typing.Optional[uint]),
                 ClusterObjectFieldDescriptor(Label="minFrequency", Tag=0x00000005, Type=typing.Optional[uint]),
                 ClusterObjectFieldDescriptor(Label="maxFrequency", Tag=0x00000006, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="options", Tag=0x0000000F, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="options", Tag=0x0000000F, Type=uint),
                 ClusterObjectFieldDescriptor(Label="onOffTransitionTime", Tag=0x00000010, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="onLevel", Tag=0x00000011, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="onLevel", Tag=0x00000011, Type=typing.Union[Nullable, uint]),
                 ClusterObjectFieldDescriptor(Label="onTransitionTime", Tag=0x00000012, Type=typing.Union[None, Nullable, uint]),
                 ClusterObjectFieldDescriptor(Label="offTransitionTime", Tag=0x00000013, Type=typing.Union[None, Nullable, uint]),
                 ClusterObjectFieldDescriptor(Label="defaultMoveRate", Tag=0x00000014, Type=typing.Union[None, Nullable, uint]),
@@ -3042,9 +3042,9 @@ class LevelControl(Cluster):
     currentFrequency: 'typing.Optional[uint]' = None
     minFrequency: 'typing.Optional[uint]' = None
     maxFrequency: 'typing.Optional[uint]' = None
-    options: 'typing.Optional[uint]' = None
+    options: 'uint' = None
     onOffTransitionTime: 'typing.Optional[uint]' = None
-    onLevel: 'typing.Union[None, Nullable, uint]' = None
+    onLevel: 'typing.Union[Nullable, uint]' = None
     onTransitionTime: 'typing.Union[None, Nullable, uint]' = None
     offTransitionTime: 'typing.Union[None, Nullable, uint]' = None
     defaultMoveRate: 'typing.Union[None, Nullable, uint]' = None
@@ -3341,9 +3341,9 @@ class LevelControl(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class OnOffTransitionTime(ClusterAttributeDescriptor):
@@ -3373,9 +3373,9 @@ class LevelControl(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class OnTransitionTime(ClusterAttributeDescriptor):


### PR DESCRIPTION
#### Problem

ZAP is showing wrong mandatoriness on level control cluster.

#### Change overview

Set optional=false for Conformance M for attributes `OnLevel` and `Options`.

Is there an agreed way of setting optional for certain PICS values? Many attributes are marked optional in XML, but are mandatory for e.g. LT/FQ Features.

#### Testing

No testing: Simple XML change.
