### PR TITLE
[EFR32] Remove ota generation

### DIFF
--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -161,18 +161,4 @@ else
     #print stats
     arm-none-eabi-size -A "$BUILD_DIR"/*.out
 
-    # Generate bootloader file
-    if [ "${BUILD_DIR:0:2}" == "./" ]; then
-        BUILD_DIR_TRIMMED="${BUILD_DIR:2}"
-        S37_PATH=$(find "$BUILD_DIR_TRIMMED" -type f -name "*.s37")
-        if [ -z "$S37_PATH" ]; then
-            echo "Bootloader could not be built"
-        else
-            TARGET_PATH=${S37_PATH%????}
-            OTA_PATH="$TARGET_PATH".ota
-            commander gbl create "$TARGET_PATH".gbl --app "$S37_PATH"
-            GBL_PATH="$TARGET_PATH".gbl
-            ./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8005 -vn 1 -vs "1.0" -da sha256 "$GBL_PATH" "$OTA_PATH"
-        fi
-    fi
 fi


### PR DESCRIPTION
#### Problem
OTA Image problems : 
- Hard coded parameter to configure OTA image since nested in a build scripts
- Dependency on third_party application which is not available through standard package.

Build scripts for EFR32 has a direct dependency on commander used to generate OTA file automatically. This is problematic because most of the arguments 

#### Change overview
As discussed with @selissia remove the problematic section in the build scripts.

#### Testing
Tested on efr32
