### PR TITLE
chip-cert/convert-key: fix writing CHIP TLV format key

### DIFF
--- a/src/tools/chip-cert/KeyUtils.cpp
+++ b/src/tools/chip-cert/KeyUtils.cpp
@@ -315,7 +315,7 @@ bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt)
         }
         else
         {
-            keyToWrite    = chipKey.get();
+            keyToWrite    = serializedKeypair.Bytes();
             keyToWriteLen = static_cast<uint32_t>(serializedKeypair.Length());
         }
 


### PR DESCRIPTION
#### Problem
`chip-cert convert-key` is not able to output a CHIP TLV format key

#### Change overview
Fix a minor mistake

#### Testing
Not needed