### PR TITLE
Add data version to framework and chip-tool-darwin.

### DIFF
--- a/examples/chip-tool-darwin/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/clusters/WriteAttributeCommandBridge.h
@@ -47,6 +47,7 @@ public:
     WriteAttribute(const char * _Nonnull attributeName)
         : ModelCommand("write")
     {
+        AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
     }
 
@@ -104,6 +105,7 @@ public:
 
 protected:
     chip::Optional<uint16_t> mTimedInteractionTimeoutMs;
+    chip::Optional<uint32_t> mDataVersion;
 
 private:
     chip::ClusterId mClusterId;

--- a/examples/chip-tool-darwin/templates/commands.zapt
+++ b/examples/chip-tool-darwin/templates/commands.zapt
@@ -200,6 +200,7 @@ public:
         CHIP_ERROR __block chipError = CHIP_NO_ERROR;
         CHIPWriteParams * params = [[CHIPWriteParams alloc] init];
         params.timedWriteTimeoutMs = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
+        params.dataVersion = mDataVersion.HasValue() ? [NSNumber numberWithUnsignedInt:mDataVersion.Value()] : nil;
         {{#if_chip_complex}}
         {{asObjectiveCType type parent.name}} value;
         {{>decodable_value target="value" source="mValue" cluster=parent.name errorCode="return err;" depth=0}}

--- a/src/darwin/Framework/CHIP/CHIPCluster.h
+++ b/src/darwin/Framework/CHIP/CHIPCluster.h
@@ -57,6 +57,14 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (strong, nonatomic, nullable) NSNumber * timedWriteTimeoutMs;
 
+/**
+ * Sets the data version for the Write Request for the interaction.
+ *
+ * If not nil, the write will only succeed if the current data version of
+ * the cluster matches the provided data version.
+ */
+@property (strong, nonatomic, nullable) NSNumber * dataVersion;
+
 - (instancetype)init;
 @end
 


### PR DESCRIPTION
#### Problem
CHIP.framework has no way of setting the data version in read and write. We need a way to set this in the framework and in chip-tool-darwin.
* Fixes #16136 

#### Change overview
- Updates CHIP.framework Read APIs to include params and retains legacy API.
- Updates CHIP.framework ReadParams to have dataVersion and sets it.
- Updates CHIP.framework WriteParams to have dataVersion and sets it.
- Updates chip-tool-darwin to accept data version as an argument and sets it.

#### Testing
- Tested legacy read
- Tested new data version read and write with accessory.