### PR TITLE
Stop having darwin tests depend on in-framework key generation.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,4 +5,3 @@
 # And some specific generated files
 src/controller/python/chip/clusters/CHIPClusters.py linguist-generated
 src/controller/python/chip/clusters/Objects.py linguist-generated
-src/darwin/Framework/CHIPTests/CHIPClustersTests.m linguist-generated

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		51B22C222740CB1D008D5055 /* CHIPCommandPayloadsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C212740CB1D008D5055 /* CHIPCommandPayloadsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C262740CB32008D5055 /* CHIPStructsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C252740CB32008D5055 /* CHIPStructsObjc.mm */; };
 		51B22C2A2740CB47008D5055 /* CHIPCommandPayloadsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C292740CB47008D5055 /* CHIPCommandPayloadsObjc.mm */; };
+		51C8E3F82825CDB600D47D00 /* CHIPTestKeys.m in Sources */ = {isa = PBXBuildFile; fileRef = 51C8E3F72825CDB600D47D00 /* CHIPTestKeys.m */; };
 		51D10D2E2808E2CA00E8CA3D /* CHIPTestStorage.m in Sources */ = {isa = PBXBuildFile; fileRef = 51D10D2D2808E2CA00E8CA3D /* CHIPTestStorage.m */; };
 		51E0310027EA20D20083DC9C /* CHIPControllerAccessControl.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E030FE27EA20D20083DC9C /* CHIPControllerAccessControl.h */; };
 		51E0310127EA20D20083DC9C /* CHIPControllerAccessControl.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E030FF27EA20D20083DC9C /* CHIPControllerAccessControl.mm */; };
@@ -148,6 +149,7 @@
 		51B22C212740CB1D008D5055 /* CHIPCommandPayloadsObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = CHIPCommandPayloadsObjc.h; path = "zap-generated/CHIPCommandPayloadsObjc.h"; sourceTree = "<group>"; };
 		51B22C252740CB32008D5055 /* CHIPStructsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPStructsObjc.mm; path = "zap-generated/CHIPStructsObjc.mm"; sourceTree = "<group>"; };
 		51B22C292740CB47008D5055 /* CHIPCommandPayloadsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPCommandPayloadsObjc.mm; path = "zap-generated/CHIPCommandPayloadsObjc.mm"; sourceTree = "<group>"; };
+		51C8E3F72825CDB600D47D00 /* CHIPTestKeys.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHIPTestKeys.m; sourceTree = "<group>"; };
 		51D10D2D2808E2CA00E8CA3D /* CHIPTestStorage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = CHIPTestStorage.m; sourceTree = "<group>"; };
 		51E030FE27EA20D20083DC9C /* CHIPControllerAccessControl.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPControllerAccessControl.h; sourceTree = "<group>"; };
 		51E030FF27EA20D20083DC9C /* CHIPControllerAccessControl.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPControllerAccessControl.mm; sourceTree = "<group>"; };
@@ -353,6 +355,7 @@
 			isa = PBXGroup;
 			children = (
 				51E24E72274E0DAC007CCF6E /* CHIPErrorTestUtils.mm */,
+				51C8E3F72825CDB600D47D00 /* CHIPTestKeys.m */,
 				51D10D2D2808E2CA00E8CA3D /* CHIPTestStorage.m */,
 				1EB41B7A263C4CC60048E4C1 /* CHIPClustersTests.m */,
 				99C65E0F267282F1003402F6 /* CHIPControllerTests.m */,
@@ -593,6 +596,7 @@
 				51D10D2E2808E2CA00E8CA3D /* CHIPTestStorage.m in Sources */,
 				1EB41B7B263C4CC60048E4C1 /* CHIPClustersTests.m in Sources */,
 				997DED1A26955D0200975E97 /* CHIPThreadOperationalDatasetTests.mm in Sources */,
+				51C8E3F82825CDB600D47D00 /* CHIPTestKeys.m in Sources */,
 				99C65E10267282F1003402F6 /* CHIPControllerTests.m in Sources */,
 				5A6FEC9D27B5E48900F25F42 /* CHIPXPCProtocolTests.m in Sources */,
 				5AE6D4E427A99041001F2493 /* CHIPDeviceTests.m in Sources */,

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -24,6 +24,7 @@
 #import <CHIP/CHIP.h>
 
 #import "CHIPErrorTestUtils.h"
+#import "CHIPTestKeys.h"
 #import "CHIPTestStorage.h"
 
 #import <app/util/af-enums.h>
@@ -121,12 +122,15 @@ CHIPDevice * GetConnectedDevice(void)
     BOOL ok = [factory startup:factoryParams];
     XCTAssertTrue(ok);
 
-    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nil];
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
     params.vendorId = kTestVendorId;
     params.fabricId = 1;
+    params.ipk = testKeys.ipk;
 
-    // TODO: Once we have a non-nil keypair, use startControllerOnNewFabric.
-    CHIPDeviceController * controller = [factory startControllerOnExistingFabric:params];
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
 
     sController = controller;

--- a/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPControllerTests.m
@@ -23,6 +23,7 @@
 // system dependencies
 #import <XCTest/XCTest.h>
 
+#import "CHIPTestKeys.h"
 #import "CHIPTestStorage.h"
 
 static uint16_t kTestVendorId = 0xFFF1u;
@@ -65,12 +66,15 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertTrue([factory startup:factoryParams]);
     XCTAssertTrue([factory isRunning]);
 
-    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nil];
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
     params.vendorId = kTestVendorId;
     params.fabricId = 1;
+    params.ipk = testKeys.ipk;
 
-    // TODO: Once we have a non-nil keypair, use startControllerOnNewFabric.
-    CHIPDeviceController * controller = [factory startControllerOnExistingFabric:params];
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -99,12 +103,15 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertTrue([factory startup:factoryParams]);
     XCTAssertTrue([factory isRunning]);
 
-    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nil];
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
     params.vendorId = kTestVendorId;
     params.fabricId = 1;
+    params.ipk = testKeys.ipk;
 
-    // TODO: Once we have a non-nil keypair, use startControllerOnNewFabric.
-    CHIPDeviceController * controller = [factory startControllerOnExistingFabric:params];
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -123,12 +130,15 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertTrue([factory startup:factoryParams]);
     XCTAssertTrue([factory isRunning]);
 
-    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nil];
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
     params.vendorId = kTestVendorId;
     params.fabricId = 1;
+    params.ipk = testKeys.ipk;
 
-    // TODO: Once we have a non-nil keypair, use startControllerOnNewFabric.
-    CHIPDeviceController * controller = [factory startControllerOnExistingFabric:params];
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertTrue([controller isRunning]);
     for (int i = 0; i < 5; i++) {
         [controller shutdown];
@@ -149,12 +159,15 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertTrue([factory startup:factoryParams]);
     XCTAssertTrue([factory isRunning]);
 
-    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nil];
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
     params.vendorId = kTestVendorId;
     params.fabricId = 1;
+    params.ipk = testKeys.ipk;
 
-    // TODO: Once we have a non-nil keypair, use startControllerOnNewFabric.
-    CHIPDeviceController * controller = [factory startControllerOnExistingFabric:params];
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertTrue([controller isRunning]);
     [controller shutdown];
 
@@ -179,11 +192,15 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertTrue([factory startup:factoryParams]);
     XCTAssertTrue([factory isRunning]);
 
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
     __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nil];
     params.vendorId = kTestVendorId;
     params.fabricId = 1;
 
-    // TODO: Once we have a non-nil keypair, use startControllerOnNewFabric.
+    // TODO: Once we require a non-nil keypair, this test will stop
+    // making sense and need to go away.
     CHIPDeviceController * controller1 = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller1);
     XCTAssertTrue([controller1 isRunning]);
@@ -199,6 +216,117 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     [controller1 shutdown];
     XCTAssertFalse([controller1 isRunning]);
+
+    [factory shutdown];
+    XCTAssertFalse([factory isRunning]);
+}
+
+- (void)testControllerNewFabricMatchesOldFabric
+{
+    __auto_type * factory = [MatterControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+
+    __auto_type * storage = [[CHIPTestStorage alloc] init];
+    __auto_type * factoryParams = [[MatterControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startup:factoryParams]);
+    XCTAssertTrue([factory isRunning]);
+
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
+    params.vendorId = kTestVendorId;
+    params.fabricId = 1;
+    params.ipk = testKeys.ipk;
+
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
+    XCTAssertNotNil(controller);
+    XCTAssertTrue([controller isRunning]);
+
+    [controller shutdown];
+    XCTAssertFalse([controller isRunning]);
+
+    // now try to start a new controller on a new fabric but using the
+    // same params; this should fail.
+    XCTAssertNil([factory startControllerOnNewFabric:params]);
+
+    XCTAssertFalse([controller isRunning]);
+
+    [factory shutdown];
+    XCTAssertFalse([factory isRunning]);
+}
+
+- (void)testControllerExistingFabricMatchesRunningController
+{
+    __auto_type * factory = [MatterControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+
+    __auto_type * storage = [[CHIPTestStorage alloc] init];
+    __auto_type * factoryParams = [[MatterControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startup:factoryParams]);
+    XCTAssertTrue([factory isRunning]);
+
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
+    params.vendorId = kTestVendorId;
+    params.fabricId = 1;
+    params.ipk = testKeys.ipk;
+
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
+    XCTAssertNotNil(controller);
+    XCTAssertTrue([controller isRunning]);
+
+    // Now try to start a new controller on the same fabric.  This should fail.
+    XCTAssertNil([factory startControllerOnExistingFabric:params]);
+
+    XCTAssertTrue([controller isRunning]);
+
+    [controller shutdown];
+    XCTAssertFalse([controller isRunning]);
+
+    [factory shutdown];
+    XCTAssertFalse([factory isRunning]);
+}
+
+- (void)testControllerStartControllersOnTwoFabricIds
+{
+    __auto_type * factory = [MatterControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+
+    __auto_type * storage = [[CHIPTestStorage alloc] init];
+    __auto_type * factoryParams = [[MatterControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startup:factoryParams]);
+    XCTAssertTrue([factory isRunning]);
+
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
+    params.vendorId = kTestVendorId;
+    params.fabricId = 1;
+    params.ipk = testKeys.ipk;
+
+    CHIPDeviceController * controller1 = [factory startControllerOnNewFabric:params];
+    XCTAssertNotNil(controller1);
+    XCTAssertTrue([controller1 isRunning]);
+
+    // Now try to start a new controller with the same root but a
+    // different fabric id.
+    params.fabricId = 2;
+
+    CHIPDeviceController * controller2 = [factory startControllerOnNewFabric:params];
+    XCTAssertNotNil(controller2);
+    XCTAssertTrue([controller2 isRunning]);
+
+    XCTAssertNil([factory startControllerOnExistingFabric:params]);
+
+    [controller1 shutdown];
+    XCTAssertFalse([controller1 isRunning]);
+
+    [controller2 shutdown];
+    XCTAssertFalse([controller2 isRunning]);
 
     [factory shutdown];
     XCTAssertFalse([factory isRunning]);

--- a/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPDeviceTests.m
@@ -25,6 +25,7 @@
 #import <CHIP/CHIPDevice.h>
 
 #import "CHIPErrorTestUtils.h"
+#import "CHIPTestKeys.h"
 #import "CHIPTestStorage.h"
 
 #import <app/util/af-enums.h>
@@ -153,12 +154,15 @@ static CHIPDevice * GetConnectedDevice(void)
     BOOL ok = [factory startup:factoryParams];
     XCTAssertTrue(ok);
 
-    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nil];
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
     params.vendorId = kTestVendorId;
     params.fabricId = 1;
+    params.ipk = testKeys.ipk;
 
-    // TODO: Once we have a non-nil keypair, use startControllerOnNewFabric.
-    CHIPDeviceController * controller = [factory startControllerOnExistingFabric:params];
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
 
     sController = controller;

--- a/src/darwin/Framework/CHIPTests/CHIPTestKeys.h
+++ b/src/darwin/Framework/CHIPTests/CHIPTestKeys.h
@@ -1,0 +1,29 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <CHIP/CHIP.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface CHIPTestKeys : NSObject <CHIPKeypair>
+
+@property (readonly, nonatomic, strong) NSData * ipk;
+
+- (instancetype)init;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/CHIPTestKeys.m
+++ b/src/darwin/Framework/CHIPTests/CHIPTestKeys.m
@@ -1,0 +1,95 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "CHIPTestKeys.h"
+#import <Security/SecKey.h>
+
+@interface CHIPTestKeys ()
+@property (readonly) SecKeyRef privateKey;
+@property (readonly) SecKeyRef publicKey;
+@end
+
+@implementation CHIPTestKeys
+
+- (instancetype)init
+{
+    if (!(self = [super init])) {
+        return nil;
+    }
+
+    // Generate an IPK.  For now, hardcoded to 16 bytes until the
+    // framework exposes this constant.
+    const size_t ipk_size = 16;
+    NSMutableData * ipkData = [NSMutableData dataWithLength:ipk_size];
+    if (ipkData == nil) {
+        return nil;
+    }
+
+    int status = SecRandomCopyBytes(kSecRandomDefault, ipk_size, [ipkData mutableBytes]);
+    if (status != errSecSuccess) {
+        NSLog(@"Failed to generate IPK");
+        return nil;
+    }
+    _ipk = ipkData;
+
+    // Generate a keypair.  For now harcoded to 256 bits until the framework exposes this constant.
+    const size_t keySizeInBits = 256;
+    CFErrorRef error = NULL;
+    const NSDictionary * keygenParams = @{
+        (__bridge NSString *) kSecAttrKeyClass : (__bridge NSString *) kSecAttrKeyClassPrivate,
+        (__bridge NSString *) kSecAttrKeyType : (__bridge NSNumber *) kSecAttrKeyTypeECSECPrimeRandom,
+        (__bridge NSString *) kSecAttrKeySizeInBits : @(keySizeInBits),
+        (__bridge NSString *) kSecAttrIsPermanent : @(NO)
+    };
+
+    _privateKey = SecKeyCreateRandomKey((__bridge CFDictionaryRef) keygenParams, &error);
+    if (error) {
+        NSLog(@"Failed to generate private key");
+        return nil;
+    }
+    _publicKey = SecKeyCopyPublicKey(_privateKey);
+
+    return self;
+}
+
+- (NSData *)ECDSA_sign_hash:(NSData *)hash
+{
+    CFErrorRef error = NULL;
+    CFDataRef outData
+        = SecKeyCreateSignature(_privateKey, kSecKeyAlgorithmECDSASignatureRFC4754, (__bridge CFDataRef) hash, &error);
+
+    if (error != noErr) {
+        NSLog(@"Failed to sign cert: %@", (__bridge NSError *) error);
+    }
+    return (__bridge_transfer NSData *) outData;
+}
+
+- (SecKeyRef)pubkey
+{
+    return self.publicKey;
+}
+
+- (void)dealloc
+{
+    if (_publicKey) {
+        CFRelease(_publicKey);
+    }
+
+    if (_privateKey) {
+        CFRelease(_privateKey);
+    }
+}
+@end

--- a/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPXPCListenerSampleTests.m
@@ -23,6 +23,7 @@
 #import <CHIP/CHIPDevice.h>
 
 #import "CHIPErrorTestUtils.h"
+#import "CHIPTestKeys.h"
 #import "CHIPTestStorage.h"
 
 #import <app/util/af-enums.h>
@@ -520,12 +521,15 @@ static CHIPDevice * GetConnectedDevice(void)
     BOOL ok = [factory startup:factoryParams];
     XCTAssertTrue(ok);
 
-    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:nil];
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[CHIPDeviceControllerStartupParams alloc] initWithKeypair:testKeys];
     params.vendorId = kTestVendorId;
     params.fabricId = 1;
+    params.ipk = testKeys.ipk;
 
-    // TODO: Once we have a non-nil keypair, use startControllerOnNewFabric.
-    CHIPDeviceController * controller = [factory startControllerOnExistingFabric:params];
+    CHIPDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
 
     sController = controller;


### PR DESCRIPTION
Adds a key generator that the test files can share.

#### Problem
XCTests are relying on us generating keys inside the Matter framework.

#### Change overview
Start generating the keys outside the API boundary.

#### Testing
Ran the tests and ensured they passed.

Ran them with the internal key generation disabled, and ensured all except `testControllerStartTwoControllersNoKeypair` failed.