### PR TITLE
[chip-tool-darwin] AddressSanitizer: heap-use-after-free in printf_co…

### DIFF
--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.h
@@ -39,7 +39,15 @@ public:
 
     void SetCommandExitStatus(CHIP_ERROR status)
     {
+#if CHIP_CONFIG_ERROR_SOURCE
+        // If there is a filename in the status makes a copy of the filename as the pointer may be released
+        // when the autorelease pool is drained.
+        strncpy(mCommandExitStatusFilename, status.GetFile(), sizeof(mCommandExitStatusFilename));
+        mCommandExitStatusFilename[sizeof(mCommandExitStatusFilename) - 1] = '\0';
+        mCommandExitStatus = chip::ChipError(status.AsInteger(), mCommandExitStatusFilename, status.GetLine());
+#else
         mCommandExitStatus = status;
+#endif // CHIP_CONFIG_ERROR_SOURCE
         ShutdownCommissioner();
         StopWaiting();
     }
@@ -71,6 +79,9 @@ private:
     CHIP_ERROR ShutdownCommissioner();
     uint16_t CurrentCommissionerIndex();
 
+#if CHIP_CONFIG_ERROR_SOURCE
+    char mCommandExitStatusFilename[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
+#endif // CHIP_CONFIG_ERROR_SOURCE
     CHIP_ERROR mCommandExitStatus = CHIP_ERROR_INTERNAL;
 
     CHIP_ERROR StartWaiting(chip::System::Clock::Timeout seconds);


### PR DESCRIPTION
…mmon

#### Problem

When an error with a file name is converted by https://github.com/project-chip/connectedhomeip/blob/master/src/darwin/Framework/CHIP/CHIPError.mm#L268 the underlying string may be drained by the autorelease pool before the error is logged.
It ends up in a `use-after-free` as `chip::ErrorStr` is trying to read the filename at https://github.com/project-chip/connectedhomeip/blob/53dd5833f08e5a6e4f19ed26442b5fb3510cf7ec/src/lib/support/ErrorStr.cpp#L64  

#### Change overview
 * Makes a copy of the filename before it is drained by the pool

#### Testing
It was tested on a buggy version of `chip-tool-darwin` that was failing `TestGeneralCommissioning` all the times. Without the patch there is a `use-after-free` and none with it.