### PR TITLE
[esp32] add configurable external platform include directory

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -130,7 +130,7 @@ endif()
 
 if (CONFIG_CHIP_ENABLE_EXTERNAL_PLATFORM)
     chip_gn_arg_append("chip_device_platform"   "\"external\"")
-    chip_gn_arg_append("chip_platform_target"   "\"${CONFIG_CHIP_EXTERNAL_PLATFORM_TARGET}\"")
+    chip_gn_arg_append("chip_platform_target"   "\"//${CONFIG_CHIP_EXTERNAL_PLATFORM_DIR}\"")
 endif()
 
 if (CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER)
@@ -226,6 +226,8 @@ target_include_directories(${COMPONENT_LIB} INTERFACE
     "${CMAKE_CURRENT_BINARY_DIR}/src/include"
     "${CMAKE_CURRENT_BINARY_DIR}/include"
     "${CMAKE_CURRENT_BINARY_DIR}/gen/include"
+    "${CHIP_ROOT}/config/esp32/${CONFIG_CHIP_EXTERNAL_PLATFORM_DIR}"
+    "${CHIP_ROOT}/config/esp32/${CONFIG_CHIP_EXTERNAL_PLATFORM_DIR}/../../"
 )
 
 idf_component_get_property(esp32_mbedtls_lib esp32_mbedtls COMPONENT_LIB)

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -793,11 +793,12 @@ menu "CHIP Device Layer"
             help
                 Use external platform layer to override the default ESP32 platform in Matter SDK.
 
-        config CHIP_EXTERNAL_PLATFORM_TARGET
-            string "The external platform target"
+        config CHIP_EXTERNAL_PLATFORM_DIR
+            string "The external platform directory"
             depends on CHIP_ENABLE_EXTERNAL_PLATFORM
             help
-                The gn target of the external platform.
+                The directory of the external platform.
+
     endmenu
 
     menu "Matter Manufacturing Options"


### PR DESCRIPTION

#### Problem

The ESP32 components depending on CHIP must manually modify their include directories if they are to use the external platform.

#### Change overview

Add a Kconfig option for users to config the  external platform include directory.

#### Testing

* Platform changes, tested in internal repositories.
