### PR TITLE
Ignore what things are enabled (or not) in controller-clusters.zap when doing YAML generation.

### DIFF
--- a/src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
+++ b/src/app/zap-templates/common/simulated-clusters/SimulatedClusters.js
@@ -60,7 +60,7 @@ function getSimulatedCluster(clusterName)
 
 function getClusters(context)
 {
-  return ensureClusters(context).getClusters().then(clusters => clusters.concat(SimulatedClusters).flat(1));
+  return ensureClusters(context, true).getClusters().then(clusters => clusters.concat(SimulatedClusters).flat(1));
 }
 
 function getCommands(context, clusterName)


### PR DESCRIPTION
The YAML codegen was only allowing attributes/commands that were
enabled in controller-clusters.zap.  It should just allow all known
attributes/commands.

#### Problem
YAML generation depends on what's selected in controller-clusters.zap, leading various tests to be disabled.

#### Change overview
Stop depending on controller-clusters.zap.

#### Testing
On a revision before #18189 tried enabling some of the disabled tests in src/app/tests/suites/certification/Test_TC_PRS_2_1.yaml and verified that I get generation errors without this PR and generate successfully with it.