### PR TITLE
android tv-casting-app: Send UDC request via JNI/CastingServer

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CastingContext.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CastingContext.java
@@ -16,6 +16,10 @@ public class CastingContext {
     return fragmentActivity.getApplicationContext();
   }
 
+  public FragmentActivity getFragmentActivity() {
+    return fragmentActivity;
+  }
+
   public NsdManager getNsdManager() {
     return (NsdManager)
         fragmentActivity.getApplicationContext().getSystemService(Context.NSD_SERVICE);

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.net.nsd.NsdManager;
 import android.net.wifi.WifiManager;
 import android.os.Bundle;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -11,12 +12,14 @@ import android.widget.Button;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.chip.casting.dnssd.CommissionerDiscoveryListener;
+import com.chip.casting.dnssd.DiscoveredNodeData;
 import com.chip.casting.util.GlobalCastingConstants;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 
 /** A {@link Fragment} to discover commissioners on the network */
 public class CommissionerDiscoveryFragment extends Fragment {
+  private static final String TAG = CommissionerDiscoveryFragment.class.getSimpleName();
 
   public CommissionerDiscoveryFragment() {}
 
@@ -52,12 +55,13 @@ public class CommissionerDiscoveryFragment extends Fragment {
         new View.OnClickListener() {
           @Override
           public void onClick(View v) {
-            callback.handleManualCommissioningButtonClicked();
+            callback.handleCommissioningButtonClicked(null);
           }
         });
   }
 
   private void startCommissionerDiscovery() {
+    Log.d(TAG, "CommissionerDiscoveryFragment.startCommissionerDiscovery called");
     WifiManager wifi = (WifiManager) this.getContext().getSystemService(Context.WIFI_SERVICE);
     WifiManager.MulticastLock multicastLock = wifi.createMulticastLock("multicastLock");
     multicastLock.setReferenceCounted(true);
@@ -85,11 +89,12 @@ public class CommissionerDiscoveryFragment extends Fragment {
             },
             10,
             TimeUnit.SECONDS);
+    Log.d(TAG, "CommissionerDiscoveryFragment.startCommissionerDiscovery ended");
   }
 
   /** Interface for notifying the host. */
-  interface Callback {
+  public interface Callback {
     /** Notifies listener of Skip to manual Commissioning Button click. */
-    void handleManualCommissioningButtonClicked();
+    void handleCommissioningButtonClicked(DiscoveredNodeData selectedCommissioner);
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissioningFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissioningFragment.java
@@ -9,29 +9,30 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.chip.casting.TvCastingApp;
-import com.chip.casting.dnssd.CommissionerDiscoveryListener;
+import com.chip.casting.dnssd.DiscoveredNodeData;
 import com.chip.casting.util.GlobalCastingConstants;
 
 /** A {@link Fragment} to get the TV Casting App commissioned. */
 public class CommissioningFragment extends Fragment {
-  private static final String TAG = CommissionerDiscoveryListener.class.getSimpleName();
+  private static final String TAG = CommissioningFragment.class.getSimpleName();
 
   private final TvCastingApp tvCastingApp;
+  private final DiscoveredNodeData selectedCommissioner;
 
-  public CommissioningFragment(TvCastingApp tvCastingApp) {
+  public CommissioningFragment(TvCastingApp tvCastingApp, DiscoveredNodeData selectedCommissioner) {
     this.tvCastingApp = tvCastingApp;
+    this.selectedCommissioner = selectedCommissioner;
   }
 
   /**
    * Use this factory method to create a new instance of this fragment using the provided
    * parameters.
    *
-   * @param tvCastingApp TV Casting App (JNI)
    * @return A new instance of fragment CommissioningFragment.
    */
-  // TODO: Rename and change types and number of parameters
-  public static CommissioningFragment newInstance(TvCastingApp tvCastingApp) {
-    return new CommissioningFragment(tvCastingApp);
+  public static CommissioningFragment newInstance(
+      TvCastingApp tvCastingApp, DiscoveredNodeData selectedCommissioner) {
+    return new CommissioningFragment(tvCastingApp, selectedCommissioner);
   }
 
   @Override
@@ -49,20 +50,33 @@ public class CommissioningFragment extends Fragment {
   @Override
   public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
     super.onViewCreated(view, savedInstanceState);
-    boolean status =
-        tvCastingApp.openBasicCommissioningWindow(
-            GlobalCastingConstants.CommissioningWindowDurationSecs);
-    Log.d(
-        TAG,
-        "CommissioningFragment.onViewCreated tvCastingApp.openBasicCommissioningWindow returned "
-            + status);
-    TextView commissioningWindowStatusView = getView().findViewById(R.id.commissioningWindowStatus);
-    TextView onboardingPayloadView = getView().findViewById(R.id.onboardingPayload);
-    if (status == true) {
-      commissioningWindowStatusView.setText("Commissioning window opened!");
-      onboardingPayloadView.setText("Onboarding Pin: " + GlobalCastingConstants.SetupPasscode);
-    } else {
-      commissioningWindowStatusView.setText("Commissioning window could not be opened!");
+
+    tvCastingApp.initServer();
+
+    String commissioningWindowStatus = "Failed to open commissioning window";
+    if (tvCastingApp.openBasicCommissioningWindow(
+        GlobalCastingConstants.CommissioningWindowDurationSecs)) {
+      commissioningWindowStatus = "Commissioning window has been opened. Commission manually.";
+      if (selectedCommissioner != null && selectedCommissioner.getNumIPs() > 0) {
+        String ipAddress = selectedCommissioner.getIpAddresses().get(0).getHostAddress();
+        Log.d(
+            TAG,
+            "CommissioningFragment calling tvCastingApp.sendUserDirectedCommissioningRequest with IP: "
+                + ipAddress
+                + " port: "
+                + selectedCommissioner.getPort());
+
+        if (tvCastingApp.sendUserDirectedCommissioningRequest(
+            ipAddress, selectedCommissioner.getPort())) {
+          commissioningWindowStatus =
+              "Commissioning window has been opened. Commissioning requested from "
+                  + selectedCommissioner.getDeviceName();
+        }
+      }
+      TextView onboardingPayloadView = getView().findViewById(R.id.onboardingPayload);
+      onboardingPayloadView.setText("Onboarding PIN: " + GlobalCastingConstants.SetupPasscode);
     }
+    TextView commissioningWindowStatusView = getView().findViewById(R.id.commissioningWindowStatus);
+    commissioningWindowStatusView.setText(commissioningWindowStatus);
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -15,6 +15,7 @@ import chip.platform.PreferencesConfigurationManager;
 import chip.platform.PreferencesKeyValueStoreManager;
 import com.chip.casting.DACProviderStub;
 import com.chip.casting.TvCastingApp;
+import com.chip.casting.dnssd.DiscoveredNodeData;
 import com.chip.casting.util.GlobalCastingConstants;
 
 public class MainActivity extends AppCompatActivity
@@ -38,8 +39,8 @@ public class MainActivity extends AppCompatActivity
   }
 
   @Override
-  public void handleManualCommissioningButtonClicked() {
-    showFragment(CommissioningFragment.newInstance(tvCastingApp));
+  public void handleCommissioningButtonClicked(DiscoveredNodeData commissioner) {
+    showFragment(CommissioningFragment.newInstance(tvCastingApp, commissioner));
   }
 
   private void initJni() {

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/dnssd/CommissionerResolveListener.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/dnssd/CommissionerResolveListener.java
@@ -5,9 +5,11 @@ import android.net.nsd.NsdServiceInfo;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import android.view.View;
 import android.widget.Button;
 import androidx.annotation.VisibleForTesting;
 import com.chip.casting.app.CastingContext;
+import com.chip.casting.app.CommissionerDiscoveryFragment;
 import java.util.List;
 
 public class CommissionerResolveListener implements NsdManager.ResolveListener {
@@ -32,6 +34,19 @@ public class CommissionerResolveListener implements NsdManager.ResolveListener {
     if (!buttonText.isEmpty()) {
       Button commissionerButton = new Button(castingContext.getApplicationContext());
       commissionerButton.setText(buttonText);
+      CommissionerDiscoveryFragment.Callback callback =
+          (CommissionerDiscoveryFragment.Callback) castingContext.getFragmentActivity();
+      commissionerButton.setOnClickListener(
+          new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+              Log.d(
+                  TAG,
+                  "CommissionerResolveListener.onServiceResolved.OnClickListener.onClick called for "
+                      + commissioner);
+              callback.handleCommissioningButtonClicked(commissioner);
+            }
+          });
       new Handler(Looper.getMainLooper())
           .post(() -> castingContext.getCommissionersLayout().addView(commissionerButton));
     } else Log.e(TAG, "Skipped displaying " + commissioner);

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/dnssd/DiscoveredNodeData.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/dnssd/DiscoveredNodeData.java
@@ -26,7 +26,7 @@ public class DiscoveredNodeData {
   private int rotatingIdLen;
   private short pairingHint;
   private String pairingInstruction;
-  private short port;
+  private int port;
   private int numIPs;
   private List<InetAddress> ipAddresses;
 
@@ -46,6 +46,10 @@ public class DiscoveredNodeData {
         }
       }
     }
+
+    this.port = serviceInfo.getPort();
+    this.ipAddresses = Arrays.asList(serviceInfo.getHost());
+    this.numIPs = 1;
   }
 
   public String getHostName() {
@@ -144,11 +148,11 @@ public class DiscoveredNodeData {
     this.pairingInstruction = pairingInstruction;
   }
 
-  public short getPort() {
+  public int getPort() {
     return port;
   }
 
-  public void setPort(short port) {
+  public void setPort(int port) {
     this.port = port;
   }
 

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -39,8 +39,13 @@ public class TvCastingApp {
 
   public native void setDACProvider(DACProvider provider);
 
-  /** TBD: Temp dummy function for testing */
   public native boolean openBasicCommissioningWindow(int duration);
+
+  public native boolean sendUserDirectedCommissioningRequest(String address, int port);
+
+  public native boolean discoverCommissioners();
+
+  public native void initServer();
 
   static {
     System.loadLibrary("TvCastingApp");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -17,15 +17,19 @@
  */
 
 #include "TvCastingApp-JNI.h"
+#include "CastingServer.h"
 #include "JNIDACProvider.h"
+
 #include <app/server/Server.h>
 #include <app/server/java/AndroidAppServerWrapper.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <inet/InetInterface.h>
 #include <jni.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPJNIError.h>
 #include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
 
 using namespace chip;
 
@@ -96,14 +100,54 @@ JNI_METHOD(jboolean, openBasicCommissioningWindow)(JNIEnv *, jobject, jint durat
 {
     ChipLogProgress(AppServer, "JNI_METHOD openBasicCommissioningWindow called with duration %d", duration);
 
-    Server::GetInstance().GetFabricTable().DeleteAllFabrics();
-    CHIP_ERROR err =
-        Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow(System::Clock::Seconds16(duration));
+    CHIP_ERROR err = CastingServer::GetInstance()->OpenBasicCommissioningWindow();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "GetCommissioningWindowManager failed: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(AppServer, "CastingServer::OpenBasicCommissioningWindow failed: %" CHIP_ERROR_FORMAT, err.Format());
         return false;
     }
 
     return true;
+}
+
+JNI_METHOD(jboolean, sendUserDirectedCommissioningRequest)(JNIEnv * env, jobject, jstring addressJStr, jint port)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD sendUserDirectedCommissioningRequest called with port %d", port);
+    Inet::IPAddress addressInet;
+    JniUtfString addressJniString(env, addressJStr);
+    if (Inet::IPAddress::FromString(addressJniString.c_str(), addressInet) == false)
+    {
+        ChipLogError(AppServer, "Failed to parse IP address");
+        return false;
+    }
+
+    chip::Inet::InterfaceId interfaceId = chip::Inet::InterfaceId::FromIPAddress(addressInet);
+    chip::Transport::PeerAddress peerAddress =
+        chip::Transport::PeerAddress::UDP(addressInet, static_cast<uint16_t>(port), interfaceId);
+    CHIP_ERROR err = CastingServer::GetInstance()->SendUserDirectedCommissioningRequest(peerAddress);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CastingServer::SendUserDirectedCommissioningRequest failed: %" CHIP_ERROR_FORMAT, err.Format());
+        return false;
+    }
+    return true;
+}
+
+JNI_METHOD(jboolean, discoverCommissioners)(JNIEnv *, jobject)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD discoverCommissioners called");
+    CHIP_ERROR err = CastingServer::GetInstance()->DiscoverCommissioners();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CastingServer::DiscoverCommissioners failed: %" CHIP_ERROR_FORMAT, err.Format());
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(void, initServer)(JNIEnv *, jobject)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD initServer called");
+    CastingServer::GetInstance()->InitServer();
 }


### PR DESCRIPTION
#### Problem
The android tv-casting-app did not have user directed commissioning implemented

#### Change overview
1. Added JNI implementation in the TVCastingApp-JNI.cpp that leverages the tv-casting-common's CastingServer
2. Added call to sendUserDirectedCommissioningRequest in the CommissioningFragment and updated implementation to show UI status accordingly

#### Testing
Tested by deploying the android tv-casting-app on an Android phone. Screenshots from the app below:

| <img src="https://user-images.githubusercontent.com/31142146/167480813-10a53163-5cde-44a3-9d41-bf7bf1244b3e.jpg" width="281" height="500"> | <img src="https://user-images.githubusercontent.com/31142146/167480820-875dc95f-58bd-4c60-a908-46aef7e9f70d.jpg" width="281" height="500"> |

UDC related logs from the android-tv-casting-app:

> 2022-05-09 12:38:11.215 17721-17721/com.chip.casting D/CommissioningFragment: CommissioningFragment calling tvCastingApp.sendUserDirectedCommissioningRequest with IP: 10.0.0.196port: 5550
2022-05-09 12:38:11.216 17721-17721/com.chip.casting D/SVR: JNI_METHOD sendUserDirectedCommissioningRequest called with port 5550
2022-05-09 12:38:11.216 17721-17721/com.chip.casting D/SVR: SendUserDirectedCommissioningRequest2
2022-05-09 12:38:11.216 17721-17721/com.chip.casting D/SVR: instanceName=616A296876AA770C
2022-05-09 12:38:11.216 17721-17721/com.chip.casting D/IN: Sending UDC msg
2022-05-09 12:38:11.920 17721-17775/com.chip.casting I/NsdManagerServiceResolver: service 616A296876AA770C(chip.platform.NsdManagerServiceResolver$3@310ddac) onServiceRegistered
2022-05-09 12:38:16.230 17721-17721/com.chip.casting D/IN: UDC msg send status ../../examples/tv-casting-app/android/third_party/connectedhomeip/src/inet/UDPEndPoint.cpp:121: Success
2022-05-09 12:38:16.230 17721-17721/com.chip.casting D/SVR: Send UDC request success