### PR TITLE
[chip-tool-darwin] Enable TestSystemCommands

### DIFF
--- a/examples/chip-tool-darwin/templates/tests/tests.js
+++ b/examples/chip-tool-darwin/templates/tests/tests.js
@@ -45,10 +45,6 @@ function getTests() {
   // TODO: TestConfigVariables not supported properly in codegen yet.
   tests.disable('TestConfigVariables');
 
-  // TODO: TestSystemCommands needs codegen changes or changes to the system
-  // command implementation.
-  tests.disable('TestSystemCommands');
-
   // TODO: TestGroupMessaging does not work on Darwin for now.
   tests.disable('TestGroupMessaging');
 


### PR DESCRIPTION
#### Problem

`TestSystemCommands` is disabled in `chip-tool-darwin`.

#### Change overview
 * Remove the disabling line
 * Update codegen

#### Testing
`./scripts/tests/run_test_suite.py --chip-tool out/debug/standalone/chip-tool-darwin --target TestSystemCommands --log-level debug run --iterations 1 --all-clusters-app out/debug/standalone/chip-all-clusters-app --lock-app out/debug/standalone/chip-lock-app --tv-app out/debug/standalone/chip-tv-app`