### PR TITLE
[chip-tool-darwin] Enable TestConfigVariables

### DIFF
--- a/examples/chip-tool-darwin/templates/tests/partials/check_test_value.zapt
+++ b/examples/chip-tool-darwin/templates/tests/partials/check_test_value.zapt
@@ -40,6 +40,7 @@
       {{~#if (chip_tests_variables_has expected)}}{{expected}}
       {{~else if (isOctetString type)}}[[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral expected}}" length:{{expected.length}}]
       {{~else if (isCharString type)}}@"{{expected}}"
+      {{else if (chip_tests_config_has expected)}}m{{asUpperCamelCase expected}}.HasValue() ? m{{asUpperCamelCase expected}}.Value() : {{asTypedLiteral (chip_tests_config_get_default_value expected) (chip_tests_config_get_type expected)}}
       {{~else}}{{asTypedExpressionFromObjectiveC expected type}}
       {{~/if}}));
   {{/if_is_struct}}

--- a/examples/chip-tool-darwin/templates/tests/partials/test_value.zapt
+++ b/examples/chip-tool-darwin/templates/tests/partials/test_value.zapt
@@ -1,7 +1,4 @@
-{{#if (chip_tests_config_has definedValue)}}
-  {{! Just replace the value's name with the actual value in the rest of the processing~}}
-  {{>test_value target=target definedValue=(chip_tests_config_get_default_value definedValue) cluster=cluster depth=depth}}
-{{else if isOptional}}
+{{#if isOptional}}
   {{! Just go ahead and assign to the value, stripping the optionality bit off.  }}
   {{>test_value target=target definedValue=definedValue cluster=cluster isOptional=false depth=(incrementDepth depth)}}
 {{else if isNullable}}
@@ -31,13 +28,28 @@
       {{/if_include_struct_item_value}}
     {{/zcl_struct_items_by_struct_name}}
 
-  {{else if (chip_tests_variables_has definedValue)}}
-    {{target}} = [{{definedValue}} copy];
-  {{else if (isCharString type)}}
-    {{target}} = @"{{definedValue}}";
-  {{else if (isOctetString type)}}
-    {{target}} = [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral definedValue}}" length:{{definedValue.length}}];
   {{else}}
-    {{target}} = [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{asTypedExpressionFromObjectiveC definedValue type}}];
+    {{target}} =
+    {{#if (chip_tests_variables_has definedValue)}}
+      [{{definedValue}} copy];
+    {{else if (chip_tests_config_has definedValue)}}
+      m{{asUpperCamelCase definedValue}}.HasValue() ?
+      {{#if (isCharString type)}}
+        m{{asUpperCamelCase definedValue}}.Value() : @"{{chip_tests_config_get_default_value definedValue}}";
+      {{else if (isOctetString type)}}
+        {{!-- TODO Extract the length of the default value for ByteSpan--}}
+      {{else}}
+        [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:m{{asUpperCamelCase definedValue}}.Value()] :
+        [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{asTypedExpressionFromObjectiveC (chip_tests_config_get_default_value definedValue) type}}];
+      {{/if}}
+    {{else}}
+      {{#if (isCharString type)}}
+        @"{{definedValue}}";
+      {{else if (isOctetString type)}}
+        [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral definedValue}}" length:{{definedValue.length}}];
+      {{else}}
+        [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{asTypedExpressionFromObjectiveC definedValue type}}];
+      {{/if}}
+    {{/if}}
   {{/if_is_struct}}
 {{/if}}

--- a/examples/chip-tool-darwin/templates/tests/tests.js
+++ b/examples/chip-tool-darwin/templates/tests/tests.js
@@ -42,9 +42,6 @@ function getTests() {
   // TODO: TestDiscovery needs FindCommissionable
   tests.disable('TestDiscovery');
 
-  // TODO: TestConfigVariables not supported properly in codegen yet.
-  tests.disable('TestConfigVariables');
-
   // TODO: TestGroupMessaging does not work on Darwin for now.
   tests.disable('TestGroupMessaging');
 


### PR DESCRIPTION
#### Problem

`TestConfigVariables` is not enabled under `chip-tool-darwin`.

#### Change overview
 * Enable it
 * Upate codegen

#### Testing
The command `./out/debug/standalone/chip-tool-darwin tests TestConfigVariables --arg1 0 --returnValueWithArg1 20` was not working before.