### PR TITLE
[Ameba] Update dockerfile to migrate mbedtls cmakefile to Matter sdk

### DIFF
--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -3,7 +3,7 @@ FROM connectedhomeip/chip-build:${VERSION}
 
 # Setup Ameba
 ARG AMEBA_DIR=/opt/ameba
-ARG TAG_NAME=ameba_update_2022_04_05
+ARG TAG_NAME=ameba_update_2022_05_10
 RUN set -x \
     && apt-get update \
     && mkdir ${AMEBA_DIR} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.71 Version bump reason: [Tizen] Fix permission bits for secret-tool
+0.5.72 Version bump reason: [Ameba] Migrate mbedtls cmake file to Matter SDK


### PR DESCRIPTION
#### Problem
Migrate mbedtls cmakefile to Matter SDK to save the effort updating docker when the third_party mbedtls module needs update.

#### Change overview
* Update chip-build-ameba/Dockerfile
* Update version

#### Testing
Tested docker build