### PR TITLE
[chip-tool][yaml] Unify the interaction model backend

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -18,16 +18,16 @@
 
 #pragma once
 
-#include <app/CommandSender.h>
-#include <lib/support/UnitTestUtils.h>
+#include <app/tests/suites/commands/interaction_model/InteractionModel.h>
 
 #include "DataModelLogger.h"
 #include "ModelCommand.h"
 
-class ClusterCommand : public ModelCommand, public chip::app::CommandSender::Callback
+class ClusterCommand : public InteractionModelCommands, public ModelCommand, public chip::app::CommandSender::Callback
 {
 public:
-    ClusterCommand(CredentialIssuerCommands * credsIssuerConfig) : ModelCommand("command-by-id", credsIssuerConfig)
+    ClusterCommand(CredentialIssuerCommands * credsIssuerConfig) :
+        InteractionModelCommands(this), ModelCommand("command-by-id", credsIssuerConfig)
     {
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
         AddArgument("command-id", 0, UINT32_MAX, &mCommandId);
@@ -40,7 +40,7 @@ public:
     }
 
     ClusterCommand(chip::ClusterId clusterId, CredentialIssuerCommands * credsIssuerConfig) :
-        ModelCommand("command-by-id", credsIssuerConfig), mClusterId(clusterId)
+        InteractionModelCommands(this), ModelCommand("command-by-id", credsIssuerConfig), mClusterId(clusterId)
     {
         AddArgument("command-id", 0, UINT32_MAX, &mCommandId);
         AddArgument("payload", &mPayload);
@@ -52,7 +52,7 @@ public:
     }
 
     ClusterCommand(const char * commandName, CredentialIssuerCommands * credsIssuerConfig) :
-        ModelCommand(commandName, credsIssuerConfig)
+        InteractionModelCommands(this), ModelCommand(commandName, credsIssuerConfig)
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
@@ -64,12 +64,28 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ClusterCommand::SendCommand(device, endpointIds.at(0), mClusterId, mCommandId, mPayload);
+        return InteractionModelCommands::SendCommand(device, endpointIds.at(0), mClusterId, mCommandId, mPayload,
+                                                     mTimedInteractionTimeoutMs, mRepeatCount, mRepeatDelayInMs, mSuppressResponse);
+    }
+
+    template <class T>
+    CHIP_ERROR SendCommand(chip::DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                           chip::CommandId commandId, const T & value)
+    {
+        return InteractionModelCommands::SendCommand(device, endpointId, clusterId, commandId, value, mTimedInteractionTimeoutMs,
+                                                     mRepeatCount, mRepeatDelayInMs, mSuppressResponse);
     }
 
     CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
     {
-        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, mClusterId, mCommandId, mPayload);
+        return InteractionModelCommands::SendGroupCommand(groupId, fabricIndex, mClusterId, mCommandId, mPayload);
+    }
+
+    template <class T>
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::ClusterId clusterId,
+                                chip::CommandId commandId, const T & value)
+    {
+        return InteractionModelCommands::SendGroupCommand(groupId, fabricIndex, clusterId, commandId, value);
     }
 
     /////////// CommandSender Callback Interface /////////
@@ -125,54 +141,6 @@ public:
         }
     }
 
-    template <class T>
-    CHIP_ERROR SendCommand(chip::DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId,
-                           chip::CommandId commandId, const T & value)
-    {
-        uint16_t repeatCount = mRepeatCount.ValueOr(1);
-        while (repeatCount--)
-        {
-            chip::app::CommandPathParams commandPath = { endpointId, 0 /* groupId */, clusterId, commandId,
-                                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
-
-            auto commandSender = std::make_unique<chip::app::CommandSender>(this, device->GetExchangeManager(),
-                                                                            mTimedInteractionTimeoutMs.HasValue());
-            VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
-            ReturnErrorOnFailure(commandSender->AddRequestDataNoTimedCheck(commandPath, value, mTimedInteractionTimeoutMs,
-                                                                           mSuppressResponse.ValueOr(false)));
-
-            ReturnErrorOnFailure(commandSender->SendCommandRequest(device->GetSecureSession().Value()));
-            mCommandSender.push_back(std::move(commandSender));
-
-            if (mRepeatDelayInMs.HasValue())
-            {
-                chip::test_utils::SleepMillis(mRepeatDelayInMs.Value());
-            }
-        }
-        return CHIP_NO_ERROR;
-    }
-
-    template <class T>
-    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::ClusterId clusterId,
-                                chip::CommandId commandId, const T & value)
-    {
-        chip::app::CommandPathParams commandPath = { 0 /* endpoint */, groupId, clusterId, commandId,
-                                                     (chip::app::CommandPathFlags::kGroupIdValid) };
-
-        chip::Messaging::ExchangeManager * exchangeManager = chip::app::InteractionModelEngine::GetInstance()->GetExchangeManager();
-
-        auto commandSender =
-            chip::Platform::MakeUnique<chip::app::CommandSender>(this, exchangeManager, mTimedInteractionTimeoutMs.HasValue());
-        VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
-        ReturnErrorOnFailure(commandSender->AddRequestDataNoTimedCheck(commandPath, value, mTimedInteractionTimeoutMs));
-
-        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
-        ReturnErrorOnFailure(commandSender->SendGroupCommandRequest(chip::SessionHandle(session)));
-        commandSender.release();
-
-        return CHIP_NO_ERROR;
-    }
-
 private:
     chip::ClusterId mClusterId;
     chip::CommandId mCommandId;
@@ -183,5 +151,4 @@ private:
 
     CHIP_ERROR mError = CHIP_NO_ERROR;
     CustomArgument mPayload;
-    std::vector<std::unique_ptr<chip::app::CommandSender>> mCommandSender;
 };

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -18,18 +18,16 @@
 
 #pragma once
 
-#include <app/ReadClient.h>
+#include <app/tests/suites/commands/interaction_model/InteractionModel.h>
 
 #include "DataModelLogger.h"
 #include "ModelCommand.h"
 
-constexpr uint8_t kMaxAllowedPaths = 10;
-
-class ReportCommand : public ModelCommand, public chip::app::ReadClient::Callback
+class ReportCommand : public InteractionModelReports, public ModelCommand, public chip::app::ReadClient::Callback
 {
 public:
     ReportCommand(const char * commandName, CredentialIssuerCommands * credsIssuerConfig) :
-        ModelCommand(commandName, credsIssuerConfig), mBufferedReadAdapter(*this)
+        InteractionModelReports(this), ModelCommand(commandName, credsIssuerConfig)
     {}
 
     virtual void OnSubscription(){};
@@ -100,237 +98,19 @@ public:
 
     void OnDone() override
     {
-        mReadClient.reset();
+        InteractionModelReports::Shutdown();
         SetCommandExitStatus(mError);
     }
 
     void OnSubscriptionEstablished(uint64_t subscriptionId) override { OnSubscription(); }
 
 protected:
-    CHIP_ERROR ReportAttribute(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
-                               std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
-                               chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval = 0,
-                               uint16_t maxInterval                                                = 0,
-                               const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional)
-    {
-        const size_t clusterCount      = clusterIds.size();
-        const size_t attributeCount    = attributeIds.size();
-        const size_t endpointCount     = endpointIds.size();
-        const size_t dataVersionsCount = dataVersions.HasValue() ? dataVersions.Value().size() : 0;
-
-        VerifyOrReturnError(clusterCount > 0 && clusterCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(attributeCount > 0 && attributeCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(endpointCount > 0 && endpointCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(dataVersionsCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
-
-        const bool hasSameIdsCount = (clusterCount == attributeCount) && (clusterCount == endpointCount) &&
-            (dataVersionsCount == 0 || clusterCount == dataVersionsCount);
-        const bool multipleClusters =
-            clusterCount > 1 && attributeCount == 1 && endpointCount == 1 && (dataVersionsCount == 0 || dataVersionsCount == 1);
-        const bool multipleAttributes =
-            attributeCount > 1 && clusterCount == 1 && endpointCount == 1 && (dataVersionsCount == 0 || dataVersionsCount == 1);
-        const bool multipleEndpoints =
-            endpointCount > 1 && clusterCount == 1 && attributeCount == 1 && (dataVersionsCount == 0 || dataVersionsCount == 1);
-        const bool multipleDataVersions = dataVersionsCount > 1 && clusterCount == 1 && attributeCount == 1 && endpointCount == 1;
-
-        size_t pathsCount = 0;
-        if (hasSameIdsCount)
-        {
-            pathsCount = clusterCount;
-        }
-        else if (multipleClusters)
-        {
-            pathsCount = clusterCount;
-        }
-        else if (multipleAttributes)
-        {
-            pathsCount = attributeCount;
-        }
-        else if (multipleEndpoints)
-        {
-            pathsCount = endpointCount;
-        }
-        else if (multipleDataVersions)
-        {
-            pathsCount = dataVersionsCount;
-        }
-        else
-        {
-            ChipLogError(
-                chipTool,
-                "\n%sAttribute commands targetting multiple paths needs to have: \n \t * One element with multiple ids (for "
-                "example 1 cluster id, 1 attribute id, 2 endpoint ids)\n\t * Or the same "
-                "number of ids (for examples 2 cluster ids, 2 attribute ids and 2 endpoint ids).\n The current command has %u "
-                "cluster ids, %u attribute ids, %u endpoint ids.",
-                interactionType == chip::app::ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read",
-                static_cast<unsigned int>(clusterCount), static_cast<unsigned int>(attributeCount),
-                static_cast<unsigned int>(endpointCount));
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-
-        ChipLogProgress(chipTool, "Sending %sAttribute to:",
-                        interactionType == chip::app::ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read");
-
-        chip::app::AttributePathParams attributePathParams[kMaxAllowedPaths];
-        chip::app::DataVersionFilter dataVersionFilter[kMaxAllowedPaths];
-        for (size_t i = 0; i < pathsCount; i++)
-        {
-            chip::ClusterId clusterId     = clusterIds.at((hasSameIdsCount || multipleClusters) ? i : 0);
-            chip::AttributeId attributeId = attributeIds.at((hasSameIdsCount || multipleAttributes) ? i : 0);
-            chip::EndpointId endpointId   = endpointIds.at((hasSameIdsCount || multipleEndpoints) ? i : 0);
-
-            ChipLogProgress(chipTool, "\tcluster " ChipLogFormatMEI ", attribute: " ChipLogFormatMEI ", endpoint %u",
-                            ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId), endpointId);
-            attributePathParams[i].mClusterId   = clusterId;
-            attributePathParams[i].mAttributeId = attributeId;
-            attributePathParams[i].mEndpointId  = endpointId;
-
-            if (dataVersions.HasValue())
-            {
-                chip::DataVersion dataVersion    = dataVersions.Value().at((hasSameIdsCount || multipleDataVersions) ? i : 0);
-                dataVersionFilter[i].mEndpointId = endpointId;
-                dataVersionFilter[i].mClusterId  = clusterId;
-                dataVersionFilter[i].mDataVersion.SetValue(dataVersion);
-            }
-        }
-
-        chip::app::ReadPrepareParams params(device->GetSecureSession().Value());
-        params.mpEventPathParamsList        = nullptr;
-        params.mEventPathParamsListSize     = 0;
-        params.mpAttributePathParamsList    = attributePathParams;
-        params.mAttributePathParamsListSize = pathsCount;
-
-        if (mFabricFiltered.HasValue())
-        {
-            params.mIsFabricFiltered = mFabricFiltered.Value();
-        }
-
-        if (dataVersions.HasValue())
-        {
-            params.mpDataVersionFilterList    = dataVersionFilter;
-            params.mDataVersionFilterListSize = pathsCount;
-        }
-
-        if (interactionType == chip::app::ReadClient::InteractionType::Subscribe)
-        {
-            params.mMinIntervalFloorSeconds   = minInterval;
-            params.mMaxIntervalCeilingSeconds = maxInterval;
-            if (mKeepSubscriptions.HasValue())
-            {
-                params.mKeepSubscriptions = mKeepSubscriptions.Value();
-            }
-        }
-
-        mReadClient = std::make_unique<chip::app::ReadClient>(chip::app::InteractionModelEngine::GetInstance(),
-                                                              device->GetExchangeManager(), mBufferedReadAdapter, interactionType);
-        return mReadClient->SendRequest(params);
-    }
-
-    CHIP_ERROR ReportEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
-                           std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds,
-                           chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval = 0,
-                           uint16_t maxInterval = 0)
-    {
-        const size_t clusterCount  = clusterIds.size();
-        const size_t eventCount    = eventIds.size();
-        const size_t endpointCount = endpointIds.size();
-
-        VerifyOrReturnError(clusterCount > 0 && clusterCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(eventCount > 0 && eventCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
-        VerifyOrReturnError(endpointCount > 0 && endpointCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
-
-        const bool hasSameIdsCount   = (clusterCount == eventCount) && (clusterCount == endpointCount);
-        const bool multipleClusters  = clusterCount > 1 && eventCount == 1 && endpointCount == 1;
-        const bool multipleEvents    = eventCount > 1 && clusterCount == 1 && endpointCount == 1;
-        const bool multipleEndpoints = endpointCount > 1 && clusterCount == 1 && eventCount == 1;
-
-        size_t pathsCount = 0;
-        if (hasSameIdsCount)
-        {
-            pathsCount = clusterCount;
-        }
-        else if (multipleClusters)
-        {
-            pathsCount = clusterCount;
-        }
-        else if (multipleEvents)
-        {
-            pathsCount = eventCount;
-        }
-        else if (multipleEndpoints)
-        {
-            pathsCount = endpointCount;
-        }
-        else
-        {
-            ChipLogError(chipTool,
-                         "\n%sEvent command targetting multiple paths needs to have: \n \t * One element with multiple ids (for "
-                         "example 1 cluster id, 1 event id, 2 endpoint ids)\n\t * Or the same "
-                         "number of ids (for examples 2 cluster ids, 2 event ids and 2 endpoint ids).\n The current command has %u "
-                         "cluster ids, %u event ids, %u endpoint ids.",
-                         interactionType == chip::app::ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read",
-                         static_cast<unsigned int>(clusterCount), static_cast<unsigned int>(eventCount),
-                         static_cast<unsigned int>(endpointCount));
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
-
-        chip::app::EventPathParams eventPathParams[kMaxAllowedPaths];
-
-        ChipLogProgress(chipTool, "Sending %sEvent to:",
-                        interactionType == chip::app::ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read");
-        for (size_t i = 0; i < pathsCount; i++)
-        {
-            chip::ClusterId clusterId   = clusterIds.at((hasSameIdsCount || multipleClusters) ? i : 0);
-            chip::EventId eventId       = eventIds.at((hasSameIdsCount || multipleEvents) ? i : 0);
-            chip::EndpointId endpointId = endpointIds.at((hasSameIdsCount || multipleEndpoints) ? i : 0);
-
-            ChipLogProgress(chipTool, "\tcluster " ChipLogFormatMEI ", event: " ChipLogFormatMEI ", endpoint %u",
-                            ChipLogValueMEI(clusterId), ChipLogValueMEI(eventId), endpointId);
-            eventPathParams[i].mClusterId  = clusterId;
-            eventPathParams[i].mEventId    = eventId;
-            eventPathParams[i].mEndpointId = endpointId;
-        }
-
-        chip::app::ReadPrepareParams params(device->GetSecureSession().Value());
-        params.mpEventPathParamsList        = eventPathParams;
-        params.mEventPathParamsListSize     = pathsCount;
-        params.mEventNumber                 = mEventNumber;
-        params.mpAttributePathParamsList    = nullptr;
-        params.mAttributePathParamsListSize = 0;
-
-        if (interactionType == chip::app::ReadClient::InteractionType::Subscribe)
-        {
-            params.mMinIntervalFloorSeconds   = minInterval;
-            params.mMaxIntervalCeilingSeconds = maxInterval;
-            if (mKeepSubscriptions.HasValue())
-            {
-                params.mKeepSubscriptions = mKeepSubscriptions.Value();
-            }
-        }
-
-        mReadClient = std::make_unique<chip::app::ReadClient>(chip::app::InteractionModelEngine::GetInstance(),
-                                                              device->GetExchangeManager(), mBufferedReadAdapter, interactionType);
-        return mReadClient->SendRequest(params);
-    }
-
     // Use a 3x-longer-than-default timeout because wildcard reads can take a
     // while.
     chip::System::Clock::Timeout GetWaitDuration() const override
     {
         return mTimeout.HasValue() ? chip::System::Clock::Seconds16(mTimeout.Value()) : (ModelCommand::GetWaitDuration() * 3);
     }
-
-    std::unique_ptr<chip::app::ReadClient> mReadClient;
-    chip::app::BufferedReadCallback mBufferedReadAdapter;
-
-    // mFabricFiltered is really only used by the attribute commands, but we end
-    // up needing it in our class's shared code.
-    chip::Optional<bool> mFabricFiltered;
-
-    // mKeepSubscriptions is really only used by the subscribe commands, but we end
-    // up needing it in our class's shared code.
-    chip::Optional<bool> mKeepSubscriptions;
-    chip::Optional<chip::EventNumber> mEventNumber;
 
     CHIP_ERROR mError = CHIP_NO_ERROR;
 };
@@ -371,13 +151,13 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ReportCommand::ReportAttribute(device, endpointIds, mClusterIds, mAttributeIds,
-                                              chip::app::ReadClient::InteractionType::Read, 0, 0, mDataVersion);
+        return ReportCommand::ReadAttribute(device, endpointIds, mClusterIds, mAttributeIds, mFabricFiltered, mDataVersion);
     }
 
 private:
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::AttributeId> mAttributeIds;
+    chip::Optional<bool> mFabricFiltered;
     chip::Optional<std::vector<chip::DataVersion>> mDataVersion;
 };
 
@@ -426,9 +206,8 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ReportCommand::ReportAttribute(device, endpointIds, mClusterIds, mAttributeIds,
-                                              chip::app::ReadClient::InteractionType::Subscribe, mMinInterval, mMaxInterval,
-                                              mDataVersion);
+        return ReportCommand::SubscribeAttribute(device, endpointIds, mClusterIds, mAttributeIds, mMinInterval, mMaxInterval,
+                                                 mFabricFiltered, mDataVersion, mKeepSubscriptions);
     }
 
     void OnSubscription() override
@@ -441,7 +220,7 @@ public:
                 auto * command = reinterpret_cast<SubscribeAttribute *>(arg);
                 if (!command->IsInteractive())
                 {
-                    command->mReadClient.reset();
+                    command->InteractionModelReports::Shutdown();
                 }
                 command->SetCommandExitStatus(CHIP_NO_ERROR);
             },
@@ -454,7 +233,9 @@ private:
 
     uint16_t mMinInterval;
     uint16_t mMaxInterval;
+    chip::Optional<bool> mFabricFiltered;
     chip::Optional<std::vector<chip::DataVersion>> mDataVersion;
+    chip::Optional<bool> mKeepSubscriptions;
 };
 
 class ReadEvent : public ReportCommand
@@ -490,13 +271,13 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ReportCommand::ReportEvent(device, endpointIds, mClusterIds, mEventIds,
-                                          chip::app::ReadClient::InteractionType::Read);
+        return ReportCommand::ReadEvent(device, endpointIds, mClusterIds, mEventIds, mEventNumber);
     }
 
 private:
     std::vector<chip::ClusterId> mClusterIds;
     std::vector<chip::EventId> mEventIds;
+    chip::Optional<chip::EventNumber> mEventNumber;
 };
 
 class SubscribeEvent : public ReportCommand
@@ -544,8 +325,8 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ReportCommand::ReportEvent(device, endpointIds, mClusterIds, mEventIds,
-                                          chip::app::ReadClient::InteractionType::Subscribe, mMinInterval, mMaxInterval);
+        return ReportCommand::SubscribeEvent(device, endpointIds, mClusterIds, mEventIds, mMinInterval, mMaxInterval, mEventNumber,
+                                             mKeepSubscriptions);
     }
 
     void OnSubscription() override
@@ -558,7 +339,7 @@ public:
                 auto * command = reinterpret_cast<SubscribeEvent *>(arg);
                 if (!command->IsInteractive())
                 {
-                    command->mReadClient.reset();
+                    command->InteractionModelReports::Shutdown();
                 }
                 command->SetCommandExitStatus(CHIP_NO_ERROR);
             },
@@ -571,4 +352,6 @@ private:
 
     uint16_t mMinInterval;
     uint16_t mMaxInterval;
+    chip::Optional<bool> mKeepSubscriptions;
+    chip::Optional<chip::EventNumber> mEventNumber;
 };

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -18,15 +18,16 @@
 
 #pragma once
 
-#include <app/WriteClient.h>
+#include <app/tests/suites/commands/interaction_model/InteractionModel.h>
 
 #include "DataModelLogger.h"
 #include "ModelCommand.h"
 
-class WriteAttribute : public ModelCommand, public chip::app::WriteClient::Callback
+class WriteAttribute : public InteractionModelWriter, public ModelCommand, public chip::app::WriteClient::Callback
 {
 public:
-    WriteAttribute(CredentialIssuerCommands * credsIssuerConfig) : ModelCommand("write-by-id", credsIssuerConfig)
+    WriteAttribute(CredentialIssuerCommands * credsIssuerConfig) :
+        InteractionModelWriter(this), ModelCommand("write-by-id", credsIssuerConfig)
     {
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterId);
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
@@ -38,7 +39,7 @@ public:
     }
 
     WriteAttribute(chip::ClusterId clusterId, CredentialIssuerCommands * credsIssuerConfig) :
-        ModelCommand("write-by-id", credsIssuerConfig), mClusterId(clusterId)
+        InteractionModelWriter(this), ModelCommand("write-by-id", credsIssuerConfig), mClusterId(clusterId)
     {
         AddArgument("attribute-id", 0, UINT32_MAX, &mAttributeId);
         AddArgument("attribute-value", &mAttributeValue);
@@ -49,7 +50,7 @@ public:
     }
 
     WriteAttribute(const char * attributeName, CredentialIssuerCommands * credsIssuerConfig) :
-        ModelCommand("write", credsIssuerConfig)
+        InteractionModelWriter(this), ModelCommand("write", credsIssuerConfig)
     {
         AddArgument("timedInteractionTimeoutMs", 0, UINT16_MAX, &mTimedInteractionTimeoutMs);
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
@@ -88,7 +89,7 @@ public:
 
     void OnDone(chip::app::WriteClient * client) override
     {
-        mWriteClient.reset();
+        InteractionModelWriter::Shutdown();
         SetCommandExitStatus(mError);
     }
 
@@ -98,45 +99,17 @@ public:
     {
         ChipLogProgress(chipTool, "Sending WriteAttribute to cluster " ChipLogFormatMEI " on endpoint %u",
                         ChipLogValueMEI(clusterId), endpointId);
-        chip::app::AttributePathParams attributePathParams;
-        if (!device->GetSecureSession().Value()->IsGroupSession())
-        {
-            attributePathParams.mEndpointId = endpointId;
-        }
-        attributePathParams.mClusterId   = clusterId;
-        attributePathParams.mAttributeId = attributeId;
-
-        mWriteClient = std::make_unique<chip::app::WriteClient>(device->GetExchangeManager(), this, mTimedInteractionTimeoutMs,
-                                                                mSuppressResponse.ValueOr(false));
-
-        ReturnErrorOnFailure(mWriteClient->EncodeAttribute(attributePathParams, value, mDataVersion));
-
-        return mWriteClient->SendWriteRequest(device->GetSecureSession().Value());
+        return InteractionModelWriter::WriteAttribute(device, endpointId, clusterId, attributeId, value, mTimedInteractionTimeoutMs,
+                                                      mSuppressResponse, mDataVersion);
     }
 
     template <class T>
     CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::ClusterId clusterId,
                                 chip::AttributeId attributeId, const T & value)
     {
-
-        chip::app::AttributePathParams attributePathParams;
-        attributePathParams.mClusterId   = clusterId;
-        attributePathParams.mAttributeId = attributeId;
-
-        chip::Messaging::ExchangeManager * exchangeManager = chip::app::InteractionModelEngine::GetInstance()->GetExchangeManager();
-
         ChipLogDetail(chipTool, "Sending Write Attribute to Group %u, on Fabric %x, for cluster %u with attributeId %u", groupId,
                       fabricIndex, clusterId, attributeId);
-
-        auto writeClient = chip::Platform::MakeUnique<chip::app::WriteClient>(exchangeManager, this, mTimedInteractionTimeoutMs);
-        VerifyOrReturnError(writeClient != nullptr, CHIP_ERROR_NO_MEMORY);
-        ReturnErrorOnFailure(writeClient->EncodeAttribute(attributePathParams, value, mDataVersion));
-
-        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
-        ReturnErrorOnFailure(writeClient->SendWriteRequest(chip::SessionHandle(session)));
-        writeClient.release();
-
-        return CHIP_NO_ERROR;
+        return InteractionModelWriter::WriteGroupAttribute(groupId, fabricIndex, clusterId, attributeId, value, mDataVersion);
     }
 
 private:
@@ -147,5 +120,4 @@ private:
     chip::Optional<chip::DataVersion> mDataVersion = chip::NullOptional;
     chip::Optional<bool> mSuppressResponse;
     CustomArgument mAttributeValue;
-    std::unique_ptr<chip::app::WriteClient> mWriteClient;
 };

--- a/examples/chip-tool/templates/tests/partials/test_step.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_step.zapt
@@ -77,8 +77,8 @@
 {{else if isSubscribeAttribute}}   {{>attributeArguments}}, {{minInterval}}, {{maxInterval}}{{>maybeFabricFiltered~}}
 {{else if isWriteGroupAttribute}}  {{>groupAttributeArguments}}, value{{>maybeTimedInteractionTimeout~}}
 {{else if isWriteAttribute}}       {{>attributeArguments}}, value{{>maybeTimedInteractionTimeout~}}
-{{else if isReadEvent}}            {{>eventArguments}}{{>maybeFabricFiltered}}
-{{else if isSubscribeEvent}}       {{>eventArguments}}, {{minInterval}}, {{maxInterval}}{{>maybeFabricFiltered~}}
+{{else if isReadEvent}}            {{>eventArguments~}}
+{{else if isSubscribeEvent}}       {{>eventArguments}}, {{minInterval}}, {{maxInterval~}}
 {{else if isGroupCommand}}         {{>groupCommandArguments}}, value{{>maybeTimedInteractionTimeout~}}
 {{else if isCommand}}              {{>commandArguments}}, value{{>maybeTimedInteractionTimeout~}}
 {{/if}}

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -27,69 +27,22 @@ CHIP_ERROR InteractionModel::ReadAttribute(const char * identity, EndpointId end
     DeviceProxy * device = GetDevice(identity);
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    AttributePathParams attributePathParams[1];
-    if (endpointId != kInvalidEndpointId)
-    {
-        attributePathParams[0].mEndpointId = endpointId;
-    }
-
-    if (clusterId != kInvalidClusterId)
-    {
-        attributePathParams[0].mClusterId = clusterId;
-    }
-
-    if (attributeId != kInvalidAttributeId)
-    {
-        attributePathParams[0].mAttributeId = attributeId;
-    }
-
-    ReadPrepareParams params(device->GetSecureSession().Value());
-    params.mpEventPathParamsList        = nullptr;
-    params.mEventPathParamsListSize     = 0;
-    params.mpAttributePathParamsList    = attributePathParams;
-    params.mAttributePathParamsListSize = 1;
-    params.mIsFabricFiltered            = fabricFiltered;
-
-    mReadClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                               mBufferedReadAdapter, ReadClient::InteractionType::Read);
-    return mReadClient->SendRequest(params);
+    std::vector<EndpointId> endpointIds   = { endpointId };
+    std::vector<ClusterId> clusterIds     = { clusterId };
+    std::vector<AttributeId> attributeIds = { attributeId };
+    return InteractionModelReports::ReadAttribute(device, endpointIds, clusterIds, attributeIds, Optional<bool>(fabricFiltered));
 }
 
 CHIP_ERROR InteractionModel::ReadEvent(const char * identity, EndpointId endpointId, ClusterId clusterId, EventId eventId,
-                                       bool fabricFiltered)
+                                       const Optional<EventNumber> & eventNumber)
 {
     DeviceProxy * device = GetDevice(identity);
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    EventPathParams eventPathParams[1];
-    if (endpointId != kInvalidEndpointId)
-    {
-        eventPathParams[0].mEndpointId = endpointId;
-    }
-
-    if (clusterId != kInvalidClusterId)
-    {
-        eventPathParams[0].mClusterId = clusterId;
-    }
-
-    if (eventId != kInvalidEventId)
-    {
-        eventPathParams[0].mEventId = eventId;
-    }
-
-    ReadPrepareParams params(device->GetSecureSession().Value());
-    params.mpEventPathParamsList        = eventPathParams;
-    params.mEventPathParamsListSize     = 1;
-    params.mpAttributePathParamsList    = nullptr;
-    params.mAttributePathParamsListSize = 0;
-    params.mIsFabricFiltered            = fabricFiltered;
-
-    // TODO: Add data version supports
-    mReadClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                               mBufferedReadAdapter, ReadClient::InteractionType::Read);
-    VerifyOrReturnError(mReadClient != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    return mReadClient->SendRequest(params);
+    std::vector<EndpointId> endpointIds = { endpointId };
+    std::vector<ClusterId> clusterIds   = { clusterId };
+    std::vector<EventId> eventIds       = { eventId };
+    return InteractionModelReports::ReadEvent(device, endpointIds, clusterIds, eventIds, eventNumber);
 }
 
 CHIP_ERROR InteractionModel::SubscribeAttribute(const char * identity, EndpointId endpointId, ClusterId clusterId,
@@ -99,83 +52,31 @@ CHIP_ERROR InteractionModel::SubscribeAttribute(const char * identity, EndpointI
     DeviceProxy * device = GetDevice(identity);
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    AttributePathParams attributePathParams[1];
-    if (endpointId != kInvalidEndpointId)
-    {
-        attributePathParams[0].mEndpointId = endpointId;
-    }
-
-    if (clusterId != kInvalidClusterId)
-    {
-        attributePathParams[0].mClusterId = clusterId;
-    }
-
-    if (attributeId != kInvalidAttributeId)
-    {
-        attributePathParams[0].mAttributeId = attributeId;
-    }
-
-    ReadPrepareParams params(device->GetSecureSession().Value());
-    params.mpEventPathParamsList        = nullptr;
-    params.mEventPathParamsListSize     = 0;
-    params.mpAttributePathParamsList    = attributePathParams;
-    params.mAttributePathParamsListSize = 1;
-    params.mMinIntervalFloorSeconds     = minInterval;
-    params.mMaxIntervalCeilingSeconds   = maxInterval;
-    params.mIsFabricFiltered            = fabricFiltered;
-
-    mSubscribeClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                                    mBufferedReadAdapter, ReadClient::InteractionType::Subscribe);
-    VerifyOrReturnError(mSubscribeClient != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    return mSubscribeClient->SendRequest(params);
+    std::vector<EndpointId> endpointIds   = { endpointId };
+    std::vector<ClusterId> clusterIds     = { clusterId };
+    std::vector<AttributeId> attributeIds = { attributeId };
+    return InteractionModelReports::SubscribeAttribute(device, endpointIds, clusterIds, attributeIds, minInterval, maxInterval,
+                                                       Optional<bool>(fabricFiltered));
 }
 
 CHIP_ERROR InteractionModel::SubscribeEvent(const char * identity, EndpointId endpointId, ClusterId clusterId, EventId eventId,
-                                            uint16_t minInterval, uint16_t maxInterval, bool fabricFiltered)
+                                            uint16_t minInterval, uint16_t maxInterval, const Optional<EventNumber> & eventNumber)
 {
     DeviceProxy * device = GetDevice(identity);
     VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    EventPathParams eventPathParams[1];
-
-    if (endpointId != kInvalidEndpointId)
-    {
-        eventPathParams[0].mEndpointId = endpointId;
-    }
-
-    if (clusterId != kInvalidClusterId)
-    {
-        eventPathParams[0].mClusterId = clusterId;
-    }
-
-    if (eventId != kInvalidEventId)
-    {
-        eventPathParams[0].mEventId = eventId;
-    }
-
-    ReadPrepareParams params(device->GetSecureSession().Value());
-    params.mpEventPathParamsList        = eventPathParams;
-    params.mEventPathParamsListSize     = 1;
-    params.mpAttributePathParamsList    = nullptr;
-    params.mAttributePathParamsListSize = 0;
-    params.mMinIntervalFloorSeconds     = minInterval;
-    params.mMaxIntervalCeilingSeconds   = maxInterval;
-    params.mIsFabricFiltered            = fabricFiltered;
-
-    mSubscribeClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                                    mBufferedReadAdapter, ReadClient::InteractionType::Subscribe);
-    VerifyOrReturnError(mSubscribeClient != nullptr, CHIP_ERROR_NO_MEMORY);
-
-    return mSubscribeClient->SendRequest(params);
+    std::vector<EndpointId> endpointIds = { endpointId };
+    std::vector<ClusterId> clusterIds   = { clusterId };
+    std::vector<EventId> eventIds       = { eventId };
+    return InteractionModelReports::SubscribeEvent(device, endpointIds, clusterIds, eventIds, minInterval, maxInterval,
+                                                   eventNumber);
 }
 
 void InteractionModel::Shutdown()
 {
-    mReadClient.reset();
-    mSubscribeClient.reset();
-    mWriteClient.reset();
-    mCommandSender.reset();
+    InteractionModelReports::Shutdown();
+    InteractionModelWriter::Shutdown();
+    InteractionModelCommands::Shutdown();
 }
 
 /////////// ReadClient Callback Interface /////////
@@ -198,7 +99,6 @@ void InteractionModel::OnError(CHIP_ERROR error)
 void InteractionModel::OnDone()
 {
     mReadClient.reset();
-    // TODO: Close the subscribe client
     ContinueOnChipMainThread(CHIP_NO_ERROR);
 }
 
@@ -240,6 +140,249 @@ void InteractionModel::OnError(const CommandSender * client, CHIP_ERROR error)
 
 void InteractionModel::OnDone(CommandSender * client)
 {
-    mCommandSender.reset();
-    ContinueOnChipMainThread(CHIP_NO_ERROR);
+    if (mCommandSender.size())
+    {
+        mCommandSender.front().reset();
+        mCommandSender.erase(mCommandSender.begin());
+    }
+
+    // If the command is repeated N times, wait for all the responses to comes in
+    // before exiting.
+    if (!mCommandSender.size())
+    {
+        ContinueOnChipMainThread(CHIP_NO_ERROR);
+    }
+}
+
+CHIP_ERROR InteractionModelReports::ReportAttribute(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                                                    std::vector<chip::ClusterId> clusterIds,
+                                                    std::vector<chip::AttributeId> attributeIds,
+                                                    chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval,
+                                                    uint16_t maxInterval, const chip::Optional<bool> & fabricFiltered,
+                                                    const chip::Optional<std::vector<chip::DataVersion>> & dataVersions,
+                                                    const chip::Optional<bool> & keepSubscriptions)
+{
+    const size_t clusterCount      = clusterIds.size();
+    const size_t attributeCount    = attributeIds.size();
+    const size_t endpointCount     = endpointIds.size();
+    const size_t dataVersionsCount = dataVersions.HasValue() ? dataVersions.Value().size() : 0;
+
+    VerifyOrReturnError(clusterCount > 0 && clusterCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(attributeCount > 0 && attributeCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(endpointCount > 0 && endpointCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(dataVersionsCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
+
+    const bool hasSameIdsCount = (clusterCount == attributeCount) && (clusterCount == endpointCount) &&
+        (dataVersionsCount == 0 || clusterCount == dataVersionsCount);
+    const bool multipleClusters =
+        clusterCount > 1 && attributeCount == 1 && endpointCount == 1 && (dataVersionsCount == 0 || dataVersionsCount == 1);
+    const bool multipleAttributes =
+        attributeCount > 1 && clusterCount == 1 && endpointCount == 1 && (dataVersionsCount == 0 || dataVersionsCount == 1);
+    const bool multipleEndpoints =
+        endpointCount > 1 && clusterCount == 1 && attributeCount == 1 && (dataVersionsCount == 0 || dataVersionsCount == 1);
+    const bool multipleDataVersions = dataVersionsCount > 1 && clusterCount == 1 && attributeCount == 1 && endpointCount == 1;
+
+    size_t pathsCount = 0;
+    if (hasSameIdsCount)
+    {
+        pathsCount = clusterCount;
+    }
+    else if (multipleClusters)
+    {
+        pathsCount = clusterCount;
+    }
+    else if (multipleAttributes)
+    {
+        pathsCount = attributeCount;
+    }
+    else if (multipleEndpoints)
+    {
+        pathsCount = endpointCount;
+    }
+    else if (multipleDataVersions)
+    {
+        pathsCount = dataVersionsCount;
+    }
+    else
+    {
+        ChipLogError(chipTool,
+                     "\n%sAttribute commands targetting multiple paths needs to have: \n \t * One element with multiple ids (for "
+                     "example 1 cluster id, 1 attribute id, 2 endpoint ids)\n\t * Or the same "
+                     "number of ids (for examples 2 cluster ids, 2 attribute ids and 2 endpoint ids).\n The current command has %u "
+                     "cluster ids, %u attribute ids, %u endpoint ids.",
+                     interactionType == chip::app::ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read",
+                     static_cast<unsigned int>(clusterCount), static_cast<unsigned int>(attributeCount),
+                     static_cast<unsigned int>(endpointCount));
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    ChipLogProgress(chipTool, "Sending %sAttribute to:",
+                    interactionType == chip::app::ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read");
+
+    chip::app::AttributePathParams attributePathParams[kMaxAllowedPaths];
+    chip::app::DataVersionFilter dataVersionFilter[kMaxAllowedPaths];
+    for (size_t i = 0; i < pathsCount; i++)
+    {
+        chip::ClusterId clusterId     = clusterIds.at((hasSameIdsCount || multipleClusters) ? i : 0);
+        chip::AttributeId attributeId = attributeIds.at((hasSameIdsCount || multipleAttributes) ? i : 0);
+        chip::EndpointId endpointId   = endpointIds.at((hasSameIdsCount || multipleEndpoints) ? i : 0);
+
+        ChipLogProgress(chipTool, "\tcluster " ChipLogFormatMEI ", attribute: " ChipLogFormatMEI ", endpoint %u",
+                        ChipLogValueMEI(clusterId), ChipLogValueMEI(attributeId), endpointId);
+
+        if (clusterId != kInvalidClusterId)
+        {
+            attributePathParams[i].mClusterId = clusterId;
+        }
+
+        if (attributeId != kInvalidAttributeId)
+        {
+            attributePathParams[i].mAttributeId = attributeId;
+        }
+
+        if (endpointId != kInvalidEndpointId)
+        {
+            attributePathParams[i].mEndpointId = endpointId;
+        }
+
+        if (dataVersions.HasValue())
+        {
+            chip::DataVersion dataVersion    = dataVersions.Value().at((hasSameIdsCount || multipleDataVersions) ? i : 0);
+            dataVersionFilter[i].mEndpointId = endpointId;
+            dataVersionFilter[i].mClusterId  = clusterId;
+            dataVersionFilter[i].mDataVersion.SetValue(dataVersion);
+        }
+    }
+
+    chip::app::ReadPrepareParams params(device->GetSecureSession().Value());
+    params.mpEventPathParamsList        = nullptr;
+    params.mEventPathParamsListSize     = 0;
+    params.mpAttributePathParamsList    = attributePathParams;
+    params.mAttributePathParamsListSize = pathsCount;
+
+    if (fabricFiltered.HasValue())
+    {
+        params.mIsFabricFiltered = fabricFiltered.Value();
+    }
+
+    if (dataVersions.HasValue())
+    {
+        params.mpDataVersionFilterList    = dataVersionFilter;
+        params.mDataVersionFilterListSize = pathsCount;
+    }
+
+    if (interactionType == chip::app::ReadClient::InteractionType::Subscribe)
+    {
+        params.mMinIntervalFloorSeconds   = minInterval;
+        params.mMaxIntervalCeilingSeconds = maxInterval;
+        if (keepSubscriptions.HasValue())
+        {
+            params.mKeepSubscriptions = keepSubscriptions.Value();
+        }
+    }
+
+    auto & client = interactionType == chip::app::ReadClient::InteractionType::Subscribe ? mSubscribeClient : mReadClient;
+    client = std::make_unique<chip::app::ReadClient>(chip::app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+                                                     mBufferedReadAdapter, interactionType);
+    return client->SendRequest(params);
+}
+
+CHIP_ERROR InteractionModelReports::ReportEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                                                std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds,
+                                                chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval,
+                                                uint16_t maxInterval, const chip::Optional<chip::EventNumber> & eventNumber,
+                                                const chip::Optional<bool> & keepSubscriptions)
+{
+    const size_t clusterCount  = clusterIds.size();
+    const size_t eventCount    = eventIds.size();
+    const size_t endpointCount = endpointIds.size();
+
+    VerifyOrReturnError(clusterCount > 0 && clusterCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(eventCount > 0 && eventCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(endpointCount > 0 && endpointCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
+
+    const bool hasSameIdsCount   = (clusterCount == eventCount) && (clusterCount == endpointCount);
+    const bool multipleClusters  = clusterCount > 1 && eventCount == 1 && endpointCount == 1;
+    const bool multipleEvents    = eventCount > 1 && clusterCount == 1 && endpointCount == 1;
+    const bool multipleEndpoints = endpointCount > 1 && clusterCount == 1 && eventCount == 1;
+
+    size_t pathsCount = 0;
+    if (hasSameIdsCount)
+    {
+        pathsCount = clusterCount;
+    }
+    else if (multipleClusters)
+    {
+        pathsCount = clusterCount;
+    }
+    else if (multipleEvents)
+    {
+        pathsCount = eventCount;
+    }
+    else if (multipleEndpoints)
+    {
+        pathsCount = endpointCount;
+    }
+    else
+    {
+        ChipLogError(chipTool,
+                     "\n%sEvent command targetting multiple paths needs to have: \n \t * One element with multiple ids (for "
+                     "example 1 cluster id, 1 event id, 2 endpoint ids)\n\t * Or the same "
+                     "number of ids (for examples 2 cluster ids, 2 event ids and 2 endpoint ids).\n The current command has %u "
+                     "cluster ids, %u event ids, %u endpoint ids.",
+                     interactionType == chip::app::ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read",
+                     static_cast<unsigned int>(clusterCount), static_cast<unsigned int>(eventCount),
+                     static_cast<unsigned int>(endpointCount));
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    chip::app::EventPathParams eventPathParams[kMaxAllowedPaths];
+
+    ChipLogProgress(chipTool, "Sending %sEvent to:",
+                    interactionType == chip::app::ReadClient::InteractionType::Subscribe ? "Subscribe" : "Read");
+    for (size_t i = 0; i < pathsCount; i++)
+    {
+        chip::ClusterId clusterId   = clusterIds.at((hasSameIdsCount || multipleClusters) ? i : 0);
+        chip::EventId eventId       = eventIds.at((hasSameIdsCount || multipleEvents) ? i : 0);
+        chip::EndpointId endpointId = endpointIds.at((hasSameIdsCount || multipleEndpoints) ? i : 0);
+
+        ChipLogProgress(chipTool, "\tcluster " ChipLogFormatMEI ", event: " ChipLogFormatMEI ", endpoint %u",
+                        ChipLogValueMEI(clusterId), ChipLogValueMEI(eventId), endpointId);
+        if (clusterId != chip::kInvalidClusterId)
+        {
+            eventPathParams[i].mClusterId = clusterId;
+        }
+
+        if (eventId != chip::kInvalidEventId)
+        {
+            eventPathParams[i].mEventId = eventId;
+        }
+
+        if (endpointId != chip::kInvalidEndpointId)
+        {
+            eventPathParams[i].mEndpointId = endpointId;
+        }
+    }
+
+    chip::app::ReadPrepareParams params(device->GetSecureSession().Value());
+    params.mpEventPathParamsList        = eventPathParams;
+    params.mEventPathParamsListSize     = pathsCount;
+    params.mEventNumber                 = eventNumber;
+    params.mpAttributePathParamsList    = nullptr;
+    params.mAttributePathParamsListSize = 0;
+
+    if (interactionType == chip::app::ReadClient::InteractionType::Subscribe)
+    {
+        params.mMinIntervalFloorSeconds   = minInterval;
+        params.mMaxIntervalCeilingSeconds = maxInterval;
+        if (keepSubscriptions.HasValue())
+        {
+            params.mKeepSubscriptions = keepSubscriptions.Value();
+        }
+    }
+
+    auto & client = interactionType == chip::app::ReadClient::InteractionType::Subscribe ? mSubscribeClient : mReadClient;
+    client = std::make_unique<chip::app::ReadClient>(chip::app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+                                                     mBufferedReadAdapter, interactionType);
+    return client->SendRequest(params);
 }

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -25,42 +25,162 @@
 #include <app/ReadClient.h>
 #include <app/WriteClient.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/UnitTestUtils.h>
 
-class InteractionModel : public chip::app::ReadClient::Callback,
-                         public chip::app::WriteClient::Callback,
-                         public chip::app::CommandSender::Callback
+constexpr uint8_t kMaxAllowedPaths = 10;
+
+class InteractionModelReports
 {
 public:
-    InteractionModel() : mBufferedReadAdapter(*this), mChunkedWriteCallback(this){};
-    virtual ~InteractionModel(){};
+    InteractionModelReports(chip::app::ReadClient::Callback * callback) : mBufferedReadAdapter(*callback) {}
 
-    virtual void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) = 0;
-    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err)                              = 0;
-    virtual chip::DeviceProxy * GetDevice(const char * identity)                             = 0;
+protected:
+    CHIP_ERROR ReadAttribute(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                             std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
+                             const chip::Optional<bool> & fabricFiltered                         = chip::Optional<bool>(true),
+                             const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional)
+    {
+        return ReportAttribute(device, endpointIds, clusterIds, attributeIds, chip::app::ReadClient::InteractionType::Read, 0, 0,
+                               fabricFiltered, dataVersions);
+    }
 
-    CHIP_ERROR ReadAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
-                             chip::AttributeId attributeId, bool fabricFiltered = true);
+    CHIP_ERROR SubscribeAttribute(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                                  std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
+                                  uint16_t minInterval = 0, uint16_t maxInterval = 0,
+                                  const chip::Optional<bool> & fabricFiltered                         = chip::Optional<bool>(true),
+                                  const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional,
+                                  const chip::Optional<bool> & keepSubscriptions                      = chip::NullOptional)
+    {
+        return ReportAttribute(device, endpointIds, clusterIds, attributeIds, chip::app::ReadClient::InteractionType::Subscribe,
+                               minInterval, maxInterval, fabricFiltered, dataVersions, keepSubscriptions);
+    }
 
-    CHIP_ERROR SubscribeAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
-                                  chip::AttributeId attributeId, uint16_t minInterval, uint16_t maxInterval,
-                                  bool fabricFiltered = true);
+    CHIP_ERROR ReportAttribute(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                               std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
+                               chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval = 0,
+                               uint16_t maxInterval = 0, const chip::Optional<bool> & fabricFiltered = chip::Optional<bool>(true),
+                               const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional,
+                               const chip::Optional<bool> & keepSubscriptions                      = chip::NullOptional);
 
-    CHIP_ERROR ReadEvent(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::EventId eventId,
-                         bool fabricFiltered = true);
+    CHIP_ERROR ReadEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                         std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds,
+                         const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional)
+    {
+        return ReportEvent(device, endpointIds, clusterIds, eventIds, chip::app::ReadClient::InteractionType::Read, 0, 0,
+                           eventNumber);
+    }
 
-    CHIP_ERROR SubscribeEvent(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::EventId eventId,
-                              uint16_t minInterval, uint16_t maxInterval, bool fabricFiltered = true);
+    CHIP_ERROR SubscribeEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                              std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds,
+                              uint16_t minInterval = 0, uint16_t maxInterval = 0,
+                              const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional,
+                              const chip::Optional<bool> & keepSubscriptions        = chip::NullOptional)
+    {
+        return ReportEvent(device, endpointIds, clusterIds, eventIds, chip::app::ReadClient::InteractionType::Subscribe,
+                           minInterval, maxInterval, eventNumber, keepSubscriptions);
+    }
 
-    CHIP_ERROR WaitForReport() { return CHIP_NO_ERROR; }
+    CHIP_ERROR ReportEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                           std::vector<chip::ClusterId> clusterIds, std::vector<chip::EventId> eventIds,
+                           chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval = 0,
+                           uint16_t maxInterval = 0, const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional,
+                           const chip::Optional<bool> & keepSubscriptions = chip::NullOptional);
+
+    void Shutdown()
+    {
+        mSubscribeClient.reset();
+        mReadClient.reset();
+    }
+
+    std::unique_ptr<chip::app::ReadClient> mReadClient;
+    std::unique_ptr<chip::app::ReadClient> mSubscribeClient;
+    chip::app::BufferedReadCallback mBufferedReadAdapter;
+};
+
+class InteractionModelCommands
+{
+public:
+    InteractionModelCommands(chip::app::CommandSender::Callback * callback) : mCallback(callback) {}
+
+protected:
+    template <class T>
+    CHIP_ERROR SendCommand(chip::DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                           chip::CommandId commandId, const T & value,
+                           chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional,
+                           chip::Optional<uint16_t> repeatCount               = chip::NullOptional,
+                           chip::Optional<uint16_t> repeatDelayInMs           = chip::NullOptional,
+                           chip::Optional<bool> suppressResponse              = chip::NullOptional)
+    {
+        uint16_t repeat = repeatCount.ValueOr(1);
+        while (repeat--)
+        {
+
+            chip::app::CommandPathParams commandPath = { endpointId, clusterId, commandId,
+                                                         (chip::app::CommandPathFlags::kEndpointIdValid) };
+            auto commandSender = std::make_unique<chip::app::CommandSender>(mCallback, device->GetExchangeManager(),
+                                                                            timedInteractionTimeoutMs.HasValue());
+            VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
+
+            ReturnErrorOnFailure(commandSender->AddRequestDataNoTimedCheck(commandPath, value, timedInteractionTimeoutMs,
+                                                                           suppressResponse.ValueOr(false)));
+            ReturnErrorOnFailure(commandSender->SendCommandRequest(device->GetSecureSession().Value()));
+            mCommandSender.push_back(std::move(commandSender));
+
+            if (repeatDelayInMs.HasValue())
+            {
+                chip::test_utils::SleepMillis(repeatDelayInMs.Value());
+            }
+        }
+        return CHIP_NO_ERROR;
+    }
 
     template <class T>
-    CHIP_ERROR WriteAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
-                              chip::AttributeId attributeId, const T & value,
-                              chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional)
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::ClusterId clusterId,
+                                chip::CommandId commandId, const T & value)
     {
-        chip::DeviceProxy * device = GetDevice(identity);
-        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        chip::app::CommandPathParams commandPath = { groupId, clusterId, commandId, (chip::app::CommandPathFlags::kGroupIdValid) };
 
+        chip::Messaging::ExchangeManager * exchangeManager = chip::app::InteractionModelEngine::GetInstance()->GetExchangeManager();
+        VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        auto commandSender = chip::Platform::MakeUnique<chip::app::CommandSender>(mCallback, exchangeManager, false);
+        VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
+
+        ReturnErrorOnFailure(commandSender->AddRequestDataNoTimedCheck(commandPath, value, chip::NullOptional));
+
+        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
+        ReturnErrorOnFailure(commandSender->SendGroupCommandRequest(chip::SessionHandle(session)));
+        commandSender.release();
+
+        return CHIP_NO_ERROR;
+    }
+
+    void Shutdown()
+    {
+        for (auto & commandSender : mCommandSender)
+        {
+            commandSender.reset();
+        }
+        mCommandSender.clear();
+    }
+
+    std::vector<std::unique_ptr<chip::app::CommandSender>> mCommandSender;
+    chip::app::CommandSender::Callback * mCallback;
+};
+
+class InteractionModelWriter
+{
+public:
+    InteractionModelWriter(chip::app::WriteClient::Callback * callback) : mChunkedWriteCallback(callback) {}
+
+protected:
+    template <class T>
+    CHIP_ERROR WriteAttribute(chip::DeviceProxy * device, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                              chip::AttributeId attributeId, const T & value,
+                              const chip::Optional<uint16_t> & timedInteractionTimeoutMs = chip::NullOptional,
+                              const chip::Optional<bool> & suppressResponse              = chip::NullOptional,
+                              const chip::Optional<chip::DataVersion> & dataVersion      = chip::NullOptional)
+    {
         chip::app::AttributePathParams attributePathParams;
         if (endpointId != chip::kInvalidEndpointId)
         {
@@ -78,23 +198,18 @@ public:
         }
 
         mWriteClient = std::make_unique<chip::app::WriteClient>(device->GetExchangeManager(), &mChunkedWriteCallback,
-                                                                timedInteractionTimeoutMs);
+                                                                timedInteractionTimeoutMs, suppressResponse.ValueOr(false));
         VerifyOrReturnError(mWriteClient != nullptr, CHIP_ERROR_NO_MEMORY);
 
-        // TODO: Add data version supports
-        chip::Optional<chip::DataVersion> dataVersion = chip::NullOptional;
         ReturnErrorOnFailure(mWriteClient->EncodeAttribute(attributePathParams, value, dataVersion));
         return mWriteClient->SendWriteRequest(device->GetSecureSession().Value());
     }
 
     template <class T>
-    CHIP_ERROR WriteGroupAttribute(const char * identity, chip::GroupId groupId, chip::ClusterId clusterId,
+    CHIP_ERROR WriteGroupAttribute(chip::GroupId groupId, chip::FabricIndex fabricIndex, chip::ClusterId clusterId,
                                    chip::AttributeId attributeId, const T & value,
-                                   chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional)
+                                   const chip::Optional<chip::DataVersion> & dataVersion = chip::NullOptional)
     {
-        chip::DeviceProxy * device = GetDevice(identity);
-        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
-
         chip::app::AttributePathParams attributePathParams;
 
         if (clusterId != chip::kInvalidClusterId)
@@ -107,17 +222,78 @@ public:
             attributePathParams.mAttributeId = attributeId;
         }
 
-        mWriteClient = std::make_unique<chip::app::WriteClient>(device->GetExchangeManager(), &mChunkedWriteCallback,
-                                                                timedInteractionTimeoutMs);
-        VerifyOrReturnError(mWriteClient != nullptr, CHIP_ERROR_NO_MEMORY);
+        chip::Messaging::ExchangeManager * exchangeManager = chip::app::InteractionModelEngine::GetInstance()->GetExchangeManager();
+        VerifyOrReturnError(exchangeManager != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-        // TODO: Add data version supports
-        chip::Optional<chip::DataVersion> dataVersion = chip::NullOptional;
-        ReturnErrorOnFailure(mWriteClient->EncodeAttribute(attributePathParams, value, dataVersion));
+        auto writeClient =
+            chip::Platform::MakeUnique<chip::app::WriteClient>(exchangeManager, &mChunkedWriteCallback, chip::NullOptional);
+        VerifyOrReturnError(writeClient != nullptr, CHIP_ERROR_NO_MEMORY);
+        ReturnErrorOnFailure(writeClient->EncodeAttribute(attributePathParams, value, dataVersion));
+
+        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
+        ReturnErrorOnFailure(writeClient->SendWriteRequest(chip::SessionHandle(session)));
+        writeClient.release();
+
+        return CHIP_NO_ERROR;
+    }
+
+    void Shutdown() { mWriteClient.reset(); }
+
+    std::unique_ptr<chip::app::WriteClient> mWriteClient;
+    chip::app::ChunkedWriteCallback mChunkedWriteCallback;
+};
+
+class InteractionModel : public InteractionModelReports,
+                         public InteractionModelCommands,
+                         public InteractionModelWriter,
+                         public chip::app::ReadClient::Callback,
+                         public chip::app::WriteClient::Callback,
+                         public chip::app::CommandSender::Callback
+{
+public:
+    InteractionModel() : InteractionModelReports(this), InteractionModelCommands(this), InteractionModelWriter(this){};
+    virtual ~InteractionModel(){};
+
+    virtual void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) = 0;
+    virtual CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err)                              = 0;
+    virtual chip::DeviceProxy * GetDevice(const char * identity)                             = 0;
+
+    CHIP_ERROR ReadAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                             chip::AttributeId attributeId, bool fabricFiltered = true);
+
+    CHIP_ERROR SubscribeAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                                  chip::AttributeId attributeId, uint16_t minInterval, uint16_t maxInterval,
+                                  bool fabricFiltered = true);
+
+    CHIP_ERROR ReadEvent(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::EventId eventId,
+                         const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional);
+
+    CHIP_ERROR SubscribeEvent(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId, chip::EventId eventId,
+                              uint16_t minInterval, uint16_t maxInterval,
+                              const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional);
+
+    CHIP_ERROR WaitForReport() { return CHIP_NO_ERROR; }
+
+    template <class T>
+    CHIP_ERROR WriteAttribute(const char * identity, chip::EndpointId endpointId, chip::ClusterId clusterId,
+                              chip::AttributeId attributeId, const T & value,
+                              chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional)
+    {
+        chip::DeviceProxy * device = GetDevice(identity);
+        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        return InteractionModelWriter::WriteAttribute(device, endpointId, clusterId, attributeId, value, timedInteractionTimeoutMs);
+    }
+
+    template <class T>
+    CHIP_ERROR WriteGroupAttribute(const char * identity, chip::GroupId groupId, chip::ClusterId clusterId,
+                                   chip::AttributeId attributeId, const T & value)
+    {
+        chip::DeviceProxy * device = GetDevice(identity);
+        VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
         chip::FabricIndex fabricIndex = device->GetSecureSession().Value()->GetFabricIndex();
-        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
-        return mWriteClient->SendWriteRequest(chip::SessionHandle(session));
+        return InteractionModelWriter::WriteGroupAttribute(groupId, fabricIndex, clusterId, attributeId, value);
     }
 
     template <class T>
@@ -127,34 +303,18 @@ public:
         chip::DeviceProxy * device = GetDevice(identity);
         VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-        chip::app::CommandPathParams commandPath = { endpointId, 0 /* groupId */, clusterId, commandId,
-                                                     (chip::app::CommandPathFlags::kEndpointIdValid) };
-        mCommandSender =
-            std::make_unique<chip::app::CommandSender>(this, device->GetExchangeManager(), timedInteractionTimeoutMs.HasValue());
-        VerifyOrReturnError(mCommandSender != nullptr, CHIP_ERROR_NO_MEMORY);
-
-        ReturnErrorOnFailure(mCommandSender->AddRequestDataNoTimedCheck(commandPath, value, timedInteractionTimeoutMs));
-        return mCommandSender->SendCommandRequest(device->GetSecureSession().Value());
+        return InteractionModelCommands::SendCommand(device, endpointId, clusterId, commandId, value, timedInteractionTimeoutMs);
     }
 
     template <class T>
     CHIP_ERROR SendGroupCommand(const char * identity, chip::GroupId groupId, chip::ClusterId clusterId, chip::CommandId commandId,
-                                const T & value, chip::Optional<uint16_t> timedInteractionTimeoutMs = chip::NullOptional)
+                                const T & value)
     {
         chip::DeviceProxy * device = GetDevice(identity);
         VerifyOrReturnError(device != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-        chip::app::CommandPathParams commandPath = { 0 /* endpoint */, groupId, clusterId, commandId,
-                                                     (chip::app::CommandPathFlags::kGroupIdValid) };
-
-        mCommandSender =
-            std::make_unique<chip::app::CommandSender>(this, device->GetExchangeManager(), timedInteractionTimeoutMs.HasValue());
-        VerifyOrReturnError(mCommandSender != nullptr, CHIP_ERROR_NO_MEMORY);
-
         chip::FabricIndex fabricIndex = device->GetSecureSession().Value()->GetFabricIndex();
-        chip::Transport::OutgoingGroupSession session(groupId, fabricIndex);
-        ReturnErrorOnFailure(mCommandSender->AddRequestDataNoTimedCheck(commandPath, value, timedInteractionTimeoutMs));
-        return mCommandSender->SendGroupCommandRequest(chip::SessionHandle(session));
+        return InteractionModelCommands::SendGroupCommand(groupId, fabricIndex, clusterId, commandId, value);
     }
 
     void Shutdown();
@@ -179,14 +339,4 @@ public:
                     const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override;
     void OnError(const chip::app::CommandSender * client, CHIP_ERROR error) override;
     void OnDone(chip::app::CommandSender * client) override;
-
-protected:
-    std::unique_ptr<chip::app::ReadClient> mReadClient;
-    // TODO: Add multiple subscriptions at the same time supports
-    std::unique_ptr<chip::app::ReadClient> mSubscribeClient;
-    std::unique_ptr<chip::app::WriteClient> mWriteClient;
-    std::unique_ptr<chip::app::CommandSender> mCommandSender;
-
-    chip::app::BufferedReadCallback mBufferedReadAdapter;
-    chip::app::ChunkedWriteCallback mChunkedWriteCallback;
 };

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -45181,15 +45181,11 @@ private:
         }
         case 1: {
             LogStep(1, "Check there is no event on the target endpoint");
-            return ReadEvent(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Events::TestEvent::Id, false
-
-            );
+            return ReadEvent(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Events::TestEvent::Id);
         }
         case 2: {
             LogStep(2, "Check reading events from an invalid endpoint");
-            return ReadEvent(kIdentityAlpha, GetEndpoint(0), TestCluster::Id, TestCluster::Events::TestEvent::Id, false
-
-            );
+            return ReadEvent(kIdentityAlpha, GetEndpoint(0), TestCluster::Id, TestCluster::Events::TestEvent::Id);
         }
         case 3: {
             LogStep(3, "Generate an event on the accessory");
@@ -45202,9 +45198,7 @@ private:
         }
         case 4: {
             LogStep(4, "Read the event back");
-            return ReadEvent(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Events::TestEvent::Id, false
-
-            );
+            return ReadEvent(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Events::TestEvent::Id);
         }
         case 5: {
             LogStep(5, "Generate a second event on the accessory");
@@ -45218,14 +45212,12 @@ private:
         case 6: {
             LogStep(6, "Read the event back");
             mTestSubStepCount = 2;
-            return ReadEvent(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Events::TestEvent::Id, false
-
-            );
+            return ReadEvent(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Events::TestEvent::Id);
         }
         case 7: {
             LogStep(7, "Subscribe to the event");
             mTestSubStepCount = 2;
-            return SubscribeEvent(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Events::TestEvent::Id, 3, 5, false);
+            return SubscribeEvent(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Events::TestEvent::Id, 3, 5);
         }
         case 8: {
             LogStep(8, "Generate a third event on the accessory");


### PR DESCRIPTION
#### Problem

`chip-tool` and the `YAML` test suites uses a different backend for accessing the interaction model APIs. It generates additional maintenance work, and the yaml backend is behind the `chip-tool` backend at the moment.

For example the yaml backend does not support setting `suppressResponse`, `data version`,  `event number` or multiple endpoint/cluster/attribute/event ids.

This is a step forward to support that for YAML.

#### Change overview 
 * Unify both backend
 * Update tests codegen