### PR TITLE
Validate TIZEN environment variables at usage time only

### DIFF
--- a/scripts/build/builders/tizen.py
+++ b/scripts/build/builders/tizen.py
@@ -60,17 +60,6 @@ class TizenBuilder(GnBuilder):
             root=os.path.join(root, 'examples', app.ExampleName(), 'linux'),
             runner=runner)
 
-        # Make sure that required ENV variables are defined
-        for env in ('TIZEN_SDK_ROOT', 'TIZEN_SDK_SYSROOT'):
-            if env not in os.environ:
-                raise Exception(
-                    "Environment %s missing, cannot build Tizen target" % env)
-
-        self.tizen_sdk_root = os.environ['TIZEN_SDK_ROOT']
-        self.tizen_sdk_sysroot = os.environ['TIZEN_SDK_SYSROOT']
-        self.tizen_sdk_cli = os.path.join(
-            self.tizen_sdk_root, "tools/ide/bin/tizen")
-
         self.app = app
         self.board = board
         self.extra_gn_options = []
@@ -85,11 +74,17 @@ class TizenBuilder(GnBuilder):
             raise Exception("TSAN sanitizer not supported by Tizen toolchain")
 
     def GnBuildArgs(self):
+        # Make sure that required ENV variables are defined
+        for env in ('TIZEN_SDK_ROOT', 'TIZEN_SDK_SYSROOT'):
+            if env not in os.environ:
+                raise Exception(
+                    "Environment %s missing, cannot build Tizen target" % env)
+
         return self.extra_gn_options + [
             'target_os="tizen"',
             'target_cpu="%s"' % self.board.TargetCpuName(),
-            'tizen_sdk_root="%s"' % self.tizen_sdk_root,
-            'sysroot="%s"' % self.tizen_sdk_sysroot,
+            'tizen_sdk_root="%s"' % os.environ['TIZEN_SDK_ROOT'],
+            'sysroot="%s"' % os.environ['TIZEN_SDK_SYSROOT'],
         ]
 
     def build_outputs(self):


### PR DESCRIPTION
#### Problem

```
./scripts/build/build_examples.py --log-level fatal targets
```

breaks with

```
Exception: Environment TIZEN_SDK_SYSROOT missing, cannot build Tizen target
```

this is not ok as listing targets does not actually try to build anything.

#### Change overview

Move validation of arguments into generation/build instead of builder constructor.
Remove unused CLI path.

#### Testing

`./scripts/build/build_examples.py --log-level fatal targets` succeeds