### PR TITLE
[OTA-R] OTA watchdog timer should not expire when device is in idle state.

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -361,10 +361,10 @@
             "name": "OTA Requestor App (Linux)",
             "type": "lldb",
             "request": "launch",
-            "program": "${workspaceFolder}/out/ota-requestor/chip-ota-requestor-app",
+            "program": "${workspaceFolder}/out/apps/ota-requestor/chip-ota-requestor-app",
             "args": [
                 "--discriminator",
-                "18",
+                "30",
                 "--secured-device-port",
                 "5560",
                 "--KVS",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -361,10 +361,10 @@
             "name": "OTA Requestor App (Linux)",
             "type": "lldb",
             "request": "launch",
-            "program": "${workspaceFolder}/out/apps/ota-requestor/chip-ota-requestor-app",
+            "program": "${workspaceFolder}/out/ota-requestor/chip-ota-requestor-app",
             "args": [
                 "--discriminator",
-                "30",
+                "18",
                 "--secured-device-port",
                 "5560",
                 "--KVS",

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -49,12 +49,6 @@ constexpr uint32_t kDelayQueryUponCommissioningSec = 30; // Delay before sending
 constexpr uint32_t kImmediateStartDelaySec         = 1;  // Delay before sending a query in response to UrgentUpdateAvailable
 constexpr System::Clock::Seconds32 kDefaultDelayedActionTime = System::Clock::Seconds32(120);
 
-//is:
-uint32_t debug_watchdog_start_cnt = 0;
-uint32_t debug_watchdog_stop_cnt = 0;
-uint32_t debug_periodic_start_cnt = 0;
-uint32_t debug_periodic_stop_cnt = 0;
-
 DefaultOTARequestorDriver * ToDriver(void * context)
 {
     return static_cast<DefaultOTARequestorDriver *>(context);
@@ -347,22 +341,12 @@ void DefaultOTARequestorDriver::StartPeriodicQueryTimer()
                     (unsigned int) mPeriodicQueryTimeInterval);
     ScheduleDelayedAction(
         System::Clock::Seconds32(mPeriodicQueryTimeInterval), PeriodicQueryTimerHandler, this);
-
-    debug_periodic_start_cnt++;
-    ChipLogProgress(SoftwareUpdate, "//is: periodic_start_cnt=%u, periodic_stop_cnt=%u, watchdog_start_cnt=%u, watchdog_stop_cnt=%u",
-                    (unsigned int)debug_periodic_start_cnt, (unsigned int)debug_periodic_stop_cnt, 
-                    (unsigned int)debug_watchdog_start_cnt, (unsigned int)debug_watchdog_stop_cnt);
 }
 
 void DefaultOTARequestorDriver::StopPeriodicQueryTimer()
 {
     ChipLogProgress(SoftwareUpdate, "Stopping the Periodic Query timer");
     CancelDelayedAction(PeriodicQueryTimerHandler, this);
-        
-    debug_periodic_stop_cnt++;
-    ChipLogProgress(SoftwareUpdate, "//is: periodic_start_cnt=%u, periodic_stop_cnt=%u, watchdog_start_cnt=%u, watchdog_stop_cnt=%u",
-                    (unsigned int)debug_periodic_start_cnt, (unsigned int)debug_periodic_stop_cnt, 
-                    (unsigned int)debug_watchdog_start_cnt, (unsigned int)debug_watchdog_stop_cnt);
 }
 
 void DefaultOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer, void * appState)
@@ -376,11 +360,6 @@ void DefaultOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer
     // Let's just cancel download, reset state, and re-start periodic query timer.
     driver->UpdateDiscontinued();
     driver->mRequestor->CancelImageUpdate();
-
-    ChipLogProgress(SoftwareUpdate, "//is: periodic_start_cnt=%u, periodic_stop_cnt=%u, watchdog_start_cnt=%u, watchdog_stop_cnt=%u",
-                    (unsigned int)debug_periodic_start_cnt, (unsigned int)debug_periodic_stop_cnt, 
-                    (unsigned int)debug_watchdog_start_cnt, (unsigned int)debug_watchdog_stop_cnt);
-
     driver->StartPeriodicQueryTimer();    
 }
 
@@ -389,22 +368,12 @@ void DefaultOTARequestorDriver::StartWatchdogTimer()
     ChipLogProgress(SoftwareUpdate, "Starting the watchdog timer, timeout: %u seconds", (unsigned int) mWatchdogTimeInterval);
     ScheduleDelayedAction(
         System::Clock::Seconds32(mWatchdogTimeInterval), WatchdogTimerHandler, this);
-
-    debug_watchdog_start_cnt++;
-    ChipLogProgress(SoftwareUpdate, "//is: periodic_start_cnt=%u, periodic_stop_cnt=%u, watchdog_start_cnt=%u, watchdog_stop_cnt=%u",
-                    (unsigned int)debug_periodic_start_cnt, (unsigned int)debug_periodic_stop_cnt, 
-                    (unsigned int)debug_watchdog_start_cnt, (unsigned int)debug_watchdog_stop_cnt);
 }
 
 void DefaultOTARequestorDriver::StopWatchdogTimer()
 {
     ChipLogProgress(SoftwareUpdate, "Stopping the watchdog timer");
     CancelDelayedAction(WatchdogTimerHandler, this);
-
-    debug_watchdog_stop_cnt++;
-    ChipLogProgress(SoftwareUpdate, "//is: periodic_start_cnt=%u, periodic_stop_cnt=%u, watchdog_start_cnt=%u, watchdog_stop_cnt=%u",
-                    (unsigned int)debug_periodic_start_cnt, (unsigned int)debug_periodic_stop_cnt, 
-                    (unsigned int)debug_watchdog_start_cnt, (unsigned int)debug_watchdog_stop_cnt);
 }
 
 void DefaultOTARequestorDriver::StartSelectedTimer(SelectedTimer timer)
@@ -420,9 +389,6 @@ void DefaultOTARequestorDriver::StartSelectedTimer(SelectedTimer timer)
         StartWatchdogTimer();
         break;
     }
-    ChipLogProgress(SoftwareUpdate, "//is: StartSelectedTimer periodic_start_cnt=%u, periodic_stop_cnt=%u, watchdog_start_cnt=%u, watchdog_stop_cnt=%u",
-                    (unsigned int)debug_periodic_start_cnt, (unsigned int)debug_periodic_stop_cnt, 
-                    (unsigned int)debug_watchdog_start_cnt, (unsigned int)debug_watchdog_stop_cnt);
 }
 
 /**

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -319,7 +319,7 @@ void DefaultOTARequestorDriver::PeriodicQueryTimerHandler(System::Layer * system
 {
     ChipLogProgress(SoftwareUpdate, "Default Provider timer handler is invoked");
 
-    DefaultOTARequestorDriver * driver = reinterpret_cast<DefaultOTARequestorDriver *>(appState);
+    DefaultOTARequestorDriver * driver = ToDriver(appState);
 
     // Determine which provider to query next
     ProviderLocationType providerLocation;
@@ -350,7 +350,7 @@ void DefaultOTARequestorDriver::StopPeriodicQueryTimer()
 
 void DefaultOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer, void * appState)
 {
-    DefaultOTARequestorDriver * driver = reinterpret_cast<DefaultOTARequestorDriver *>(appState);
+    DefaultOTARequestorDriver * driver = ToDriver(appState);
 
     ChipLogError(SoftwareUpdate, "Watchdog timer detects state stuck at %u. Cancelling download and resetting state.",
                  to_underlying(driver->mRequestor->GetCurrentUpdateState()));

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -339,8 +339,7 @@ void DefaultOTARequestorDriver::StartPeriodicQueryTimer()
 {
     ChipLogProgress(SoftwareUpdate, "Starting the periodic query timer, timeout: %u seconds",
                     (unsigned int) mPeriodicQueryTimeInterval);
-    ScheduleDelayedAction(
-        System::Clock::Seconds32(mPeriodicQueryTimeInterval), PeriodicQueryTimerHandler, this);
+    ScheduleDelayedAction(System::Clock::Seconds32(mPeriodicQueryTimeInterval), PeriodicQueryTimerHandler, this);
 }
 
 void DefaultOTARequestorDriver::StopPeriodicQueryTimer()
@@ -360,14 +359,13 @@ void DefaultOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer
     // Let's just cancel download, reset state, and re-start periodic query timer.
     driver->UpdateDiscontinued();
     driver->mRequestor->CancelImageUpdate();
-    driver->StartPeriodicQueryTimer();    
+    driver->StartPeriodicQueryTimer();
 }
 
 void DefaultOTARequestorDriver::StartWatchdogTimer()
 {
     ChipLogProgress(SoftwareUpdate, "Starting the watchdog timer, timeout: %u seconds", (unsigned int) mWatchdogTimeInterval);
-    ScheduleDelayedAction(
-        System::Clock::Seconds32(mWatchdogTimeInterval), WatchdogTimerHandler, this);
+    ScheduleDelayedAction(System::Clock::Seconds32(mWatchdogTimeInterval), WatchdogTimerHandler, this);
 }
 
 void DefaultOTARequestorDriver::StopWatchdogTimer()

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -99,9 +99,9 @@ protected:
     OTAImageProcessorInterface * mImageProcessor = nullptr;
     uint32_t mOtaStartDelaySec                   = 0;
     // Timeout (in seconds) for querying providers from the default OTA provider list
-    uint32_t mPeriodicQueryTimeInterval = (2 * 60); //is: (24 * 60 * 60);
+    uint32_t mPeriodicQueryTimeInterval = (24 * 60 * 60);
     // Timeout (in seconds) for checking if current OTA download is stuck and requires a reset
-    uint32_t mWatchdogTimeInterval = (2 * 60); //is: (6 * 60 * 60);
+    uint32_t mWatchdogTimeInterval = (6 * 60 * 60);
     uint16_t maxDownloadBlockSize  = 1024;
     // Maximum number of times to retry a BUSY OTA provider before moving to the next available one
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -82,12 +82,13 @@ public:
     bool GetNextProviderLocation(ProviderLocationType & providerLocation, bool & listExhausted) override;
 
 protected:
+    static void PeriodicQueryTimerHandler(System::Layer * systemLayer, void * appState);
+    static void WatchdogTimerHandler(System::Layer * systemLayer, void * appState);
+
     void StartPeriodicQueryTimer();
     void StopPeriodicQueryTimer();
-    static void PeriodicQueryTimerHandler(System::Layer * systemLayer, void * appState);
     void StartWatchdogTimer();
     void StopWatchdogTimer();
-    static void WatchdogTimerHandler(System::Layer * systemLayer, void * appState);
     void StartSelectedTimer(SelectedTimer timer);
     void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
     void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -84,10 +84,10 @@ public:
 protected:
     void StartPeriodicQueryTimer();
     void StopPeriodicQueryTimer();
-    void PeriodicQueryTimerHandler(System::Layer * systemLayer, void * appState);
+    static void PeriodicQueryTimerHandler(System::Layer * systemLayer, void * appState);
     void StartWatchdogTimer();
     void StopWatchdogTimer();
-    void WatchdogTimerHandler(System::Layer * systemLayer, void * appState);
+    static void WatchdogTimerHandler(System::Layer * systemLayer, void * appState);
     void StartSelectedTimer(SelectedTimer timer);
     void ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action, void * aAppState);
     void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);
@@ -99,9 +99,9 @@ protected:
     OTAImageProcessorInterface * mImageProcessor = nullptr;
     uint32_t mOtaStartDelaySec                   = 0;
     // Timeout (in seconds) for querying providers from the default OTA provider list
-    uint32_t mPeriodicQueryTimeInterval = (24 * 60 * 60);
+    uint32_t mPeriodicQueryTimeInterval = (2 * 60); //is: (24 * 60 * 60);
     // Timeout (in seconds) for checking if current OTA download is stuck and requires a reset
-    uint32_t mWatchdogTimeInterval = (6 * 60 * 60);
+    uint32_t mWatchdogTimeInterval = (2 * 60); //is: (6 * 60 * 60);
     uint16_t maxDownloadBlockSize  = 1024;
     // Maximum number of times to retry a BUSY OTA provider before moving to the next available one
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;


### PR DESCRIPTION
#### Problem

OTA watchdog timer should not expire when device is in idle state.  

```
[1651703424056] [22377:597089] CHIP: [SWU] Stopping the watchdog timer
[1651703424056] [22377:597089] CHIP: [SWU] Starting the periodic query timer, timeout: 86400 seconds
[1651703424059] [22377:597089] CHIP: [DMG] All ReadHandler-s are clean, clear GlobalDirtySet
[1651703424060] [22377:597089] CHIP: [SWU] OTA image downloaded to /tmp/test.bin
[1651703424258] [22377:597089] CHIP: [EM] Received message of type 0x10 with protocolId (0, 0) and MessageCounter:10947771 on exchange 39081i
[1651703424258] [22377:597089] CHIP: [EM] Found matching exchange: 39081i, Delegate: 0x0
[1651703424258] [22377:597089] CHIP: [EM] Rxd Ack; Removing MessageCounter:7473674 from Retrans Table on exchange 39081i
[1651703424258] [22377:597089] CHIP: [EM] Removed CHIP MessageCounter:7473674 from RetransTable on exchange 39081i
[1651704294908] [22377:607983] CHIP: [DIS] OnExpiration callback for cleared session
[1651704294908] [22377:607983] CHIP: [DIS] OnDiscoveryExpiration callback for cleared session
*[1651726325897] [22377:760473] CHIP: [SWU] Watchdog timer detects state stuck at 1. Cancelling download and resetting state.*
*[1651726325899] [22377:760473] CHIP: [BDX] No download in progress*
*[1651726325899] [22377:760473] CHIP: [ZCL] Previous state and new state are the same (1), no event to log*
[1651726326268] [22377:760473] CHIP: [SWU] Starting the periodic query timer, timeout: 86400 seconds
```

In `DefaultOTARequestorDriver::StopPeriodicQueryTimer()` and `DefaultOTARequestorDriver::StopWatchdogTimer()`, need to update the `CancelDelayedAction()` call to pass in the correct `TimerCompleteCallback` for the timer to be cancelled.  Upon further debugging of this issue, found that both watchdog and periodic timers are not being cancelled when their respective `StopWatchdogTimer()` and `StopPeriodicQueryTimer()` functions are being called.  This is due to `TimerCompleteCallback aOnComplete` mismatch in the `TimerList::Remove()` call.

`TimerList::Node * TimerList::Remove(TimerCompleteCallback aOnComplete, void * aAppState)`

Fixes: https://github.com/project-chip/connectedhomeip/issues/18222

#### Change overview

Pass in correct watchdog and periodic timer handler functions as `TimerCompleteCallback` when starting and cancelling the respective timers.

#### Testing

- Set breakpoints in `DefaultOTARequestorDriver::StopWatchdogTimer()` and `DefaultOTARequestorDriver::StopPeriodicQueryTimer()` and ensured the timers were properly removed in `TimerList::Remove()`.
- Verified Query image works.
- Verified watchdog timer and periodic timer works.
- Verified watchdog timer and periodic timer are no longer running at the same time.
