### PR TITLE
Chef - Add RPC support for NRF

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -295,11 +295,12 @@ def main(argv: Sequence[str]) -> None:
             shell.run_cmd("idf.py build")
         elif options.build_target == "nrfconnect":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/nrfconnect")
+            nrf_build_cmds = ["west build -b nrf52840dk_nrf52840"]
             if options.do_clean:
-                # shell.run_cmd(f"rm -rf {paths['rootSampleFolder']}/nrfconnect/build")
-                shell.run_cmd("west build -b nrf52840dk_nrf52840")
-            else:
-                shell.run_cmd("west build -b nrf52840dk_nrf52840")
+                nrf_build_cmds.append("-p always")
+            if options.do_rpc:
+                nrf_build_cmds.append("-- -DOVERLAY_CONFIG=rpc.overlay")
+            shell.run_cmd(" ".join(nrf_build_cmds))
         elif options.build_target == "linux":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/linux")
             with open(f"{_CHEF_SCRIPT_PATH}/linux/args.gni", "w") as f:
@@ -341,7 +342,7 @@ def main(argv: Sequence[str]) -> None:
         elif options.build_target == "nrfconnect":
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}/nrfconnect")
             if options.do_erase:
-                shell.run_cmd("rm -rf build")
+                shell.run_cmd("west flash --erase")
             else:
                 shell.run_cmd("west flash")
 

--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -17,7 +17,6 @@ cmake_minimum_required(VERSION 3.13.1)
 
 get_filename_component(CHIP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/third_party/connectedhomeip REALPATH)
 get_filename_component(NRFCONNECT_COMMON ${CHIP_ROOT}/examples/platform/nrfconnect REALPATH)
-get_filename_component(APP_ROOT ${CMAKE_CURRENT_SOURCE_DIR}/.. REALPATH)
 get_filename_component(CHEF ${CMAKE_CURRENT_SOURCE_DIR}/../ REALPATH)
 
 include(${CHIP_ROOT}/config/nrfconnect/app/check-nrfconnect-version.cmake)
@@ -39,11 +38,12 @@ set(mcuboot_KCONFIG_ROOT ${CHIP_ROOT}/config/nrfconnect/chip-module/Kconfig.mcub
 set(multiprotocol_rpmsg_KCONFIG_ROOT ${CHIP_ROOT}/config/nrfconnect/chip-module/Kconfig.multiprotocol_rpmsg.root)
 
 list(APPEND ZEPHYR_EXTRA_MODULES ${CHIP_ROOT}/config/nrfconnect/chip-module)
-find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 if (EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/boards/${BOARD}.conf)
   list(APPEND CONF_FILE boards/${BOARD}.conf)
 endif()
+
+find_package(Zephyr HINTS $ENV{ZEPHYR_BASE})
 
 project(chip-nrfconnect-chef-example)
 
@@ -59,7 +59,6 @@ target_compile_options(app PRIVATE -Werror -Wno-error=maybe-uninitialized)
 target_include_directories(app PRIVATE
                            ${CMAKE_CURRENT_SOURCE_DIR}
                            ${CMAKE_CURRENT_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/app-common
-                           ${APP_ROOT}/shell_common/include
                            ${GEN_DIR}
                            ${CHEF}
                            ${GEN_DIR}/../
@@ -68,13 +67,22 @@ target_include_directories(app PRIVATE
                            ${NRFCONNECT_COMMON}/app/include
 )
 
+if (CONFIG_ENABLE_CHIP_SHELL)
+  target_sources(app PRIVATE
+    ${CHEF}/shell_common/globals.cpp
+    ${CHEF}/shell_common/cmd_misc.cpp
+    ${CHEF}/shell_common/cmd_otcli.cpp
+    ${CHEF}/shell_common/cmd_ping.cpp
+    ${CHEF}/shell_common/cmd_send.cpp
+  )
+
+  target_include_directories(app PRIVATE
+    ${CHEF}/shell_common/include
+  )
+endif (CONFIG_ENABLE_CHIP_SHELL)
+
 target_sources(app PRIVATE
-    ${APP_ROOT}/shell_common/globals.cpp
-    ${APP_ROOT}/shell_common/cmd_misc.cpp
-    ${APP_ROOT}/shell_common/cmd_otcli.cpp
-    ${APP_ROOT}/shell_common/cmd_ping.cpp
-    ${APP_ROOT}/shell_common/cmd_send.cpp
-    ${APP_ROOT}/nrfconnect/main.cpp
+    ${CHEF}/nrfconnect/main.cpp
     ${GEN_DIR}/callback-stub.cpp
     ${GEN_DIR}/IMClusterCommandHandler.cpp
     ${NRFCONNECT_COMMON}/util/ThreadUtil.cpp
@@ -84,6 +92,7 @@ message(STATUS ${CHEF}/devices/${SAMPLE_NAME}.zap)
 chip_configure_data_model(app
     INCLUDE_SERVER
     ZAP_FILE ${CHEF}/devices/${SAMPLE_NAME}.zap
+    GEN_DIR ${GEN_DIR}
 )
 
 
@@ -98,3 +107,137 @@ elseif(CONFIG_OPENTHREAD_MTD)
 endif()
 
 include(${CHIP_ROOT}/config/nrfconnect/app/flashing.cmake)
+
+
+if (CONFIG_ENABLE_PW_RPC)
+
+target_compile_options(app PRIVATE
+                       "-DCONFIG_ENABLE_PW_RPC=1"
+)
+
+# Make all targets created below depend on zephyr_interface to inherit MCU-related compilation flags
+link_libraries($<BUILD_INTERFACE:zephyr_interface>)
+
+set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
+include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
+include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
+
+pw_set_backend(pw_log pw_log_basic)
+pw_set_backend(pw_assert pw_assert_log)
+pw_set_backend(pw_sys_io pw_sys_io.nrfconnect)
+pw_set_backend(pw_trace pw_trace_tokenized)
+set(dir_pw_third_party_nanopb "${CHIP_ROOT}/third_party/nanopb/repo" CACHE STRING "" FORCE)
+
+add_subdirectory(third_party/connectedhomeip/examples/platform/nrfconnect/pw_sys_io)
+add_subdirectory(third_party/connectedhomeip/third_party/nanopb/repo)
+add_subdirectory(third_party/connectedhomeip/third_party/pigweed/repo)
+
+pw_proto_library(attributes_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/attributes_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/attributes_service.options
+  PREFIX
+    attributes_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(descriptor_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/descriptor_service.proto
+  PREFIX
+    descriptor_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(device_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/device_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/device_service.options
+  PREFIX
+    device_service
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(ot_cli_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/ot_cli_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/ot_cli_service.options
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  PREFIX
+    ot_cli_service
+  DEPS
+    pw_protobuf.common_protos
+)
+
+pw_proto_library(thread_service
+  SOURCES
+    ${CHIP_ROOT}/examples/common/pigweed/protos/thread_service.proto
+  INPUTS
+    ${CHIP_ROOT}/examples/common/pigweed/protos/thread_service.options
+  STRIP_PREFIX
+    ${CHIP_ROOT}/examples/common/pigweed/protos
+  PREFIX
+    thread_service
+  DEPS
+    pw_protobuf.common_protos
+)
+
+target_sources(app PRIVATE
+  ../../common/pigweed/RpcService.cpp
+  ../../common/pigweed/nrfconnect/PigweedLoggerMutex.cpp
+  ${NRFCONNECT_COMMON}/Rpc.cpp
+  ${NRFCONNECT_COMMON}/util/PigweedLogger.cpp
+)
+
+target_include_directories(app PRIVATE
+  ${PIGWEED_ROOT}/pw_sys_io/public
+  ${CHIP_ROOT}/src/lib/support
+  ${CHIP_ROOT}/src/system
+  ${NRFCONNECT_COMMON}
+  ${NRFCONNECT_COMMON}/util/include
+  ../../common
+  ../../common/pigweed
+  ../../common/pigweed/nrfconnect)
+
+target_compile_options(app PRIVATE
+                       "-DPW_RPC_ATTRIBUTE_SERVICE=1"
+                       "-DPW_RPC_DESCRIPTOR_SERVICE=1"
+                       "-DPW_RPC_DEVICE_SERVICE=1"
+                       "-DPW_RPC_THREAD_SERVICE=1"
+                       "-DPW_RPC_TRACING_SERVICE=1"
+)
+
+target_link_libraries(app PRIVATE
+  attributes_service.nanopb_rpc
+  descriptor_service.nanopb_rpc
+  device_service.nanopb_rpc
+  thread_service.nanopb_rpc
+  pw_checksum
+  pw_hdlc
+  pw_log
+  pw_rpc.server
+  pw_trace_tokenized
+  pw_trace_tokenized.trace_buffer
+  pw_trace_tokenized.rpc_service
+  pw_trace_tokenized.protos.nanopb_rpc
+)
+
+target_link_options(app
+  PUBLIC
+    "-T${PIGWEED_ROOT}/pw_tokenizer/pw_tokenizer_linker_sections.ld"
+)
+
+endif(CONFIG_ENABLE_PW_RPC)

--- a/examples/chef/nrfconnect/main.cpp
+++ b/examples/chef/nrfconnect/main.cpp
@@ -24,7 +24,6 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-#include <ChipShellCollection.h>
 #include <lib/support/CHIPMem.h>
 #include <platform/CHIPDeviceLayer.h>
 
@@ -33,6 +32,18 @@
 
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+
+#include <logging/log.h>
+
+#if CONFIG_ENABLE_CHIP_SHELL || CONFIG_CHIP_LIB_SHELL
+#include <ChipShellCollection.h>
+#endif
+
+#ifdef CONFIG_ENABLE_PW_RPC
+#include "Rpc.h"
+#endif
+
+LOG_MODULE_REGISTER(app, CONFIG_MATTER_LOG_LEVEL);
 
 using namespace chip;
 using namespace chip::Shell;
@@ -44,7 +55,13 @@ constexpr int kExtDiscoveryTimeoutSecs = 20;
 
 CHIP_ERROR main()
 {
-    CHIP_ERROR err = chip::Platform::MemoryInit();
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+#ifdef CONFIG_ENABLE_PW_RPC
+    rpc::Init();
+#endif
+
+    err = chip::Platform::MemoryInit();
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "Platform::MemoryInit() failed");

--- a/examples/chef/nrfconnect/rpc.overlay
+++ b/examples/chef/nrfconnect/rpc.overlay
@@ -1,0 +1,49 @@
+#
+#    Copyright (c) 2020 Project CHIP Authors
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This file should be used as a configuration overlay to build Pigweed RPCs to
+# lighting-app:
+#
+# west build -b nrf52840dk_nrf52840 -- -DOVERLAY_CONFIG=rpc.overlay
+
+# Enable Pigweed RPC
+CONFIG_CHIP_PW_RPC=y
+
+# Add support for C++17 to build Pigweed components
+CONFIG_STD_CPP14=n
+CONFIG_STD_CPP17=y
+
+# Add support for Zephyr console component to use it for Pigweed console purposes
+CONFIG_CONSOLE_SUBSYS=y
+CONFIG_CONSOLE_GETCHAR=y
+CONFIG_CONSOLE_PUTCHAR_BUFSIZE=256
+
+# Disable features which may interfere with Pigweed HDLC transport
+CONFIG_CHIP_LIB_SHELL=n
+CONFIG_SHELL=n
+CONFIG_OPENTHREAD_SHELL=n
+CONFIG_BOOT_BANNER=n
+
+# Configure Zephyr logger with defaults backends disabled as the app provides its own,
+# based on Pigweed HDLC.
+CONFIG_LOG=y
+CONFIG_LOG_MODE_MINIMAL=n
+CONFIG_LOG_MODE_IMMEDIATE=y
+CONFIG_LOG_BACKEND_UART=n
+CONFIG_LOG_BACKEND_RTT=n
+
+# Increase zephyr tty rx buffer
+CONFIG_CONSOLE_GETCHAR_BUFSIZE=128

--- a/examples/platform/nrfconnect/Rpc.cpp
+++ b/examples/platform/nrfconnect/Rpc.cpp
@@ -16,10 +16,13 @@
  *    limitations under the License.
  */
 
+#if defined(PW_RPC_BUTTON_SERVICE) && PW_RPC_BUTTON_SERVICE
 #include "AppTask.h"
+#endif // defined(PW_RPC_BUTTON_SERVICE) && PW_RPC_BUTTON_SERVICE
 #include "PigweedLoggerMutex.h"
 #include "pigweed/RpcService.h"
 #include "pw_sys_io_nrfconnect/init.h"
+#include <logging/log.h>
 
 #include <kernel.h>
 


### PR DESCRIPTION
Cherry picked from (#17774)

#### Problem
* NRF doesn't support RPC calls.

#### Change overview
* Include rpc.overlay file in Chef NRF RPC build
* Separate NRF shell dependencies into flag blocks
* Add RPC services to NRF build

#### Testing
Tested with
`./chef.py -bczer -d lighting-app -t nrfconnect`

Descriptor cluster was confirmed to provide a list of endpoints and the light endpoint functionality was tested.
