### PR TITLE
Moved door-lock app from chip-all-clusters-common to chip-all-clusters-app

### DIFF
--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -23,9 +23,6 @@ source_set("chip-all-clusters-common") {
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp",
-    "${chip_root}/examples/lock-app/linux/src/LockEndpoint.cpp",
-    "${chip_root}/examples/lock-app/linux/src/LockManager.cpp",
-    "${chip_root}/examples/lock-app/linux/src/ZCLDoorLockCallbacks.cpp",
     "AppOptions.cpp",
     "include/tv-callbacks.cpp",
     "include/tv-callbacks.h",
@@ -39,10 +36,8 @@ source_set("chip-all-clusters-common") {
     "${chip_root}/src/lib",
   ]
 
-  include_dirs = [
-    "${chip_root}/examples/all-clusters-app/all-clusters-common/include",
-    "${chip_root}/examples/lock-app/linux/include",
-  ]
+  include_dirs =
+      [ "${chip_root}/examples/all-clusters-app/all-clusters-common/include" ]
 
   cflags = [ "-Wconversion" ]
 
@@ -51,12 +46,27 @@ source_set("chip-all-clusters-common") {
   }
 }
 
+source_set("chip-lock-app-common") {
+  sources = [
+    "${chip_root}/examples/lock-app/linux/src/LockEndpoint.cpp",
+    "${chip_root}/examples/lock-app/linux/src/LockManager.cpp",
+    "${chip_root}/examples/lock-app/linux/src/ZCLDoorLockCallbacks.cpp",
+  ]
+
+  deps = [ "${chip_root}/examples/all-clusters-app/all-clusters-common" ]
+
+  include_dirs = [ "${chip_root}/examples/lock-app/linux/include" ]
+
+  cflags = [ "-Wconversion" ]
+}
+
 if (is_libfuzzer) {
   executable("chip-all-clusters-app-fuzzing") {
     sources = [ "fuzzing-main.cpp" ]
 
     deps = [
       ":chip-all-clusters-common",
+      ":chip-lock-app-common",
       "${chip_root}/examples/platform/linux:app-main",
     ]
 
@@ -70,6 +80,7 @@ if (is_libfuzzer) {
 
     deps = [
       ":chip-all-clusters-common",
+      ":chip-lock-app-common",
       "${chip_root}/examples/platform/linux:app-main",
     ]
 


### PR DESCRIPTION
#### Problem
* Linux all-clusters-app build environment uses a common source-set that includes example-specific code/callbacks for door-lock applications. This should not be part of the common source-set, because it overrides weak methods that could be used for customer-specific demonstration/test applications (that use the all-clusters-app common source-set).

#### Change overview
* Move door-lock app dependencies from the chip-all-clusters-common source-set into the executable targets of the example chip-all-clusters-app.

#### Testing
* Matter Unit Tests
* Tested Commissioning flow (chip-tool vs chip-all-clusters-app)
