### PR TITLE
RPC support in the example tool chef linux build

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -333,7 +333,7 @@ def main(argv: Sequence[str]) -> None:
             with open(f"{_CHEF_SCRIPT_PATH}/linux/args.gni", "w") as f:
                 f.write(textwrap.dedent(f"""\
                         import("//build_overrides/chip.gni")
-                        import("\\${{chip_root}}/config/standalone/args.gni")
+                        import("${{chip_root}}/config/standalone/args.gni")
                         chip_shell_cmd_server = false
                         target_defines = ["CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID={options.vid}", "CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID={options.pid}", "CONFIG_ENABLE_PW_RPC={'1' if options.do_rpc else '0'}"]
                         """))
@@ -344,7 +344,10 @@ def main(argv: Sequence[str]) -> None:
                         """))
             if options.do_clean:
                 shell.run_cmd(f"rm -rf out")
-            shell.run_cmd("gn gen out")
+            if options.do_rpc:
+                shell.run_cmd("gn gen out --args='import(\"//with_pw_rpc.gni\")'")
+            else:
+                shell.run_cmd("gn gen out --args=''")
             shell.run_cmd("ninja -C out")
 
     #

--- a/examples/chef/linux/BUILD.gn
+++ b/examples/chef/linux/BUILD.gn
@@ -12,14 +12,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-import("//build_overrides/openthread.gni")
+
 import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/src/app/chip_data_model.gni")
-import("sample.gni")
+import("${chip_root}/src/app/common_flags.gni")
 
 assert(chip_build_tools)
+
+import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
+
+if (chip_enable_pw_rpc) {
+  import("//build_overrides/pigweed.gni")
+  import("$dir_pw_build/target_types.gni")
+}
+
+import("sample.gni")
 
 project_dir = "./.."
 
@@ -36,14 +44,60 @@ executable("${sample_name}") {
 
   deps = [
     ":chef-data-model",
-    "${chip_root}/src/controller",
-    "${chip_root}/src/credentials",
-    "${chip_root}/src/lib/shell",
-    "${chip_root}/src/platform",
+    "${chip_root}/examples/platform/linux:app-main",
+    "${chip_root}/src/lib",
     "${project_dir}/shell_common:shell_common",
   ]
 
-  cflags = [ "-Wconversion" ]
+  include_dirs = [ "include" ]
+
+  if (chip_enable_pw_rpc) {
+    defines = [
+      "PW_RPC_ENABLED",
+      "PW_RPC_ATTRIBUTE_SERVICE=1",
+      "PW_RPC_BUTTON_SERVICE=1",
+      "PW_RPC_DESCRIPTOR_SERVICE=1",
+      "PW_RPC_DEVICE_SERVICE=1",
+      "PW_RPC_LIGHTING_SERVICE=1",
+      "PW_RPC_TRACING_SERVICE=1",
+    ]
+
+    sources += [
+      "${chip_root}/examples/platform/linux/Rpc.cpp",
+      "${dir_pigweed}/targets/host/system_rpc_server.cc",
+    ]
+
+    deps += [
+      "$dir_pw_hdlc:pw_rpc",
+      "$dir_pw_hdlc:rpc_channel_output",
+      "$dir_pw_log",
+      "$dir_pw_rpc:server",
+      "$dir_pw_rpc/system_server:facade",
+      "$dir_pw_stream:socket_stream",
+      "$dir_pw_stream:sys_io_stream",
+      "$dir_pw_sync:mutex",
+      "$dir_pw_trace",
+      "$dir_pw_trace_tokenized",
+      "$dir_pw_trace_tokenized:trace_rpc_service",
+      "${chip_root}/config/linux/lib/pw_rpc:pw_rpc",
+      "${chip_root}/examples/common/pigweed:attributes_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:button_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:descriptor_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:device_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:lighting_service.nanopb_rpc",
+      "${chip_root}/examples/common/pigweed:rpc_services",
+    ]
+
+    deps += pw_build_LINK_DEPS
+
+    cflags = [ "-Wno-gnu-designator" ]
+
+    include_dirs += [ "${chip_root}/examples/common" ]
+  } else {
+    # The system_rpc_server.cc file is in pigweed and doesn't compile with
+    # -Wconversion, remove check for RPC build only.
+    cflags = [ "-Wconversion" ]
+  }
 
   output_dir = root_out_dir
 }
@@ -52,4 +106,6 @@ group("chef") {
   deps = [ ":${sample_name}" ]
 }
 
-import("//build_overrides/chip.gni")
+group("default") {
+  deps = [ ":chef" ]
+}

--- a/examples/chef/linux/main.cpp
+++ b/examples/chef/linux/main.cpp
@@ -1,6 +1,7 @@
 /*
  *
  *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -15,32 +16,29 @@
  *    limitations under the License.
  */
 
-#include <lib/shell/Engine.h>
+#include <AppMain.h>
 
-#include <lib/core/CHIPCore.h>
-#include <lib/support/Base64.h>
-#include <lib/support/CHIPArgParser.hpp>
-#include <lib/support/CodeUtils.h>
+#include <app-common/zap-generated/ids/Attributes.h>
+#include <app/ConcreteAttributePath.h>
 #include <lib/support/logging/CHIPLogging.h>
 
+#include <lib/shell/Engine.h>
+
 #include <ChipShellCollection.h>
-#include <lib/support/CHIPMem.h>
-#include <platform/CHIPDeviceLayer.h>
 
 using namespace chip;
 using namespace chip::Shell;
 
-int main()
+void ApplicationInit() {}
+
+int main(int argc, char * argv[])
 {
-    chip::Platform::MemoryInit();
-    chip::DeviceLayer::PlatformMgr().InitChipStack();
-    chip::DeviceLayer::PlatformMgr().StartEventLoopTask();
-#if CHIP_DEVICE_CONFIG_ENABLE_WPA
-    chip::DeviceLayer::ConnectivityManagerImpl().StartWiFiManagement();
-#endif
+    if (ChipLinuxAppInit(argc, argv) != 0)
+    {
+        return -1;
+    }
 
     const int rc = Engine::Root().Init();
-
     if (rc != 0)
     {
         ChipLogError(Shell, "Streamer initialization failed: %d", rc);
@@ -55,6 +53,7 @@ int main()
     cmd_app_server_init();
 #endif
 
-    Engine::Root().RunMainLoop();
+    ChipLinuxAppMainLoop();
+
     return 0;
 }

--- a/examples/chef/linux/with_pw_rpc.gni
+++ b/examples/chef/linux/with_pw_rpc.gni
@@ -1,0 +1,42 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# add this gni as import in your build args to use pigweed in the example
+# 'import("//with_pw_rpc.gni")'
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/config/standalone/args.gni")
+
+import("//build_overrides/pigweed.gni")
+
+cpp_standard = "gnu++17"
+
+pw_log_BACKEND = "$dir_pw_log_basic"
+pw_assert_BACKEND = "$dir_pw_assert_log"
+pw_sys_io_BACKEND = "$dir_pw_sys_io_stdio"
+pw_trace_BACKEND = "$dir_pw_trace_tokenized"
+pw_unit_test_MAIN = "$dir_pw_unit_test:logging_main"
+pw_rpc_system_server_BACKEND = "${chip_root}/config/linux/lib/pw_rpc:pw_rpc"
+dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
+pw_chrono_SYSTEM_CLOCK_BACKEND = "$dir_pw_chrono_stl:system_clock"
+pw_sync_MUTEX_BACKEND = "$dir_pw_sync_stl:mutex_backend"
+
+pw_build_LINK_DEPS = [
+  "$dir_pw_assert:impl",
+  "$dir_pw_log:impl",
+]
+
+chip_enable_pw_rpc = true
+chip_build_pw_trace_lib = true


### PR DESCRIPTION
Port RPC server enabled logic into example tool chef, and also all the
pre-configured zap file for different device types

the usage example:
  $ ./chef.py -zbr -t linux -d lighting --pid 0x8000

#### Problem
What is being fixed?  Examples:
* No RPC server support in the linux build of example tool chef

#### Change overview
* Add RPC server support in the linux build of example tool chef
* Add pre-configured zap files for different device types in the linux build of example tool chef

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how? 
  * follow the commands to build and run the virtual device on linux with RPC support
```
$ cd examples/chef
$ ./chef.py --bootstrap_zap
$ ./chef.py -zbr -t linux -d lighting-app --pid 0x8000
$ ./linux/out/lighting
```
* If no testing is required, why not?
