### PR TITLE
[nrfconnect] Changed settings partition size from 32k to 16k.

### DIFF
--- a/examples/all-clusters-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
+++ b/examples/all-clusters-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
@@ -7,32 +7,32 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0x7000
-    size: 0xf1000
+    size: 0xf5000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_secondary:
     address: 0x0
-    size: 0xf1000
+    size: 0xf5000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0xf1000
-    size: 0x70f000
+    address: 0xf5000
+    size: 0x70b000
     device: MX25R64
     region: external_flash

--- a/examples/all-clusters-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/all-clusters-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -7,24 +7,24 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0xC000
-    size: 0xec000
+    size: 0xf0000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_primary_1:
     address: 0x0
@@ -33,17 +33,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xec000
+    size: 0xf0000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xec000
+    address: 0xf0000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12C000
-    size: 0x6D4000
+    address: 0x130000
+    size: 0x6D0000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/light-switch-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
+++ b/examples/light-switch-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
@@ -7,32 +7,32 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0x7000
-    size: 0xf1000
+    size: 0xf5000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_secondary:
     address: 0x0
-    size: 0xf1000
+    size: 0xf5000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0xf1000
-    size: 0x70f000
+    address: 0xf5000
+    size: 0x70b000
     device: MX25R64
     region: external_flash

--- a/examples/light-switch-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/light-switch-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -7,24 +7,24 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0xC000
-    size: 0xec000
+    size: 0xf0000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_primary_1:
     address: 0x0
@@ -33,17 +33,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xec000
+    size: 0xf0000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xec000
+    address: 0xf0000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12C000
-    size: 0x6D4000
+    address: 0x130000
+    size: 0x6D0000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/lighting-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
+++ b/examples/lighting-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
@@ -7,32 +7,32 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0x7000
-    size: 0xf1000
+    size: 0xf5000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_secondary:
     address: 0x0
-    size: 0xf1000
+    size: 0xf5000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0xf1000
-    size: 0x70f000
+    address: 0xf5000
+    size: 0x70b000
     device: MX25R64
     region: external_flash

--- a/examples/lighting-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/lighting-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -7,24 +7,24 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0xC000
-    size: 0xec000
+    size: 0xf0000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_primary_1:
     address: 0x0
@@ -33,17 +33,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xec000
+    size: 0xf0000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xec000
+    address: 0xf0000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12C000
-    size: 0x6D4000
+    address: 0x130000
+    size: 0x6D0000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/lock-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
+++ b/examples/lock-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
@@ -7,32 +7,32 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0x7000
-    size: 0xf1000
+    size: 0xf5000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_secondary:
     address: 0x0
-    size: 0xf1000
+    size: 0xf5000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0xf1000
-    size: 0x70f000
+    address: 0xf5000
+    size: 0x70b000
     device: MX25R64
     region: external_flash

--- a/examples/lock-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/lock-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -7,24 +7,24 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0xC000
-    size: 0xec000
+    size: 0xf0000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_primary_1:
     address: 0x0
@@ -33,17 +33,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xec000
+    size: 0xf0000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xec000
+    address: 0xf0000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12C000
-    size: 0x6D4000
+    address: 0x130000
+    size: 0x6D0000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/pump-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
+++ b/examples/pump-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
@@ -7,32 +7,32 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0x7000
-    size: 0xf1000
+    size: 0xf5000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_secondary:
     address: 0x0
-    size: 0xf1000
+    size: 0xf5000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0xf1000
-    size: 0x70f000
+    address: 0xf5000
+    size: 0x70b000
     device: MX25R64
     region: external_flash

--- a/examples/pump-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/pump-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -7,24 +7,24 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0xC000
-    size: 0xec000
+    size: 0xf0000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_primary_1:
     address: 0x0
@@ -33,17 +33,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xec000
+    size: 0xf0000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xec000
+    address: 0xf0000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12C000
-    size: 0x6D4000
+    address: 0x130000
+    size: 0x6D0000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/pump-controller-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
+++ b/examples/pump-controller-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
@@ -7,32 +7,32 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0x7000
-    size: 0xf1000
+    size: 0xf5000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_secondary:
     address: 0x0
-    size: 0xf1000
+    size: 0xf5000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0xf1000
-    size: 0x70f000
+    address: 0xf5000
+    size: 0x70b000
     device: MX25R64
     region: external_flash

--- a/examples/pump-controller-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/pump-controller-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -7,24 +7,24 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0xC000
-    size: 0xec000
+    size: 0xf0000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_primary_1:
     address: 0x0
@@ -33,17 +33,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xec000
+    size: 0xf0000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xec000
+    address: 0xf0000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12C000
-    size: 0x6D4000
+    address: 0x130000
+    size: 0x6D0000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/window-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
+++ b/examples/window-app/nrfconnect/configuration/nrf52840dk_nrf52840/pm_static_dfu.yml
@@ -7,32 +7,32 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0x7000
-    size: 0xf1000
+    size: 0xf5000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0x7200
-    size: 0xf0e00
+    size: 0xf4e00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_secondary:
     address: 0x0
-    size: 0xf1000
+    size: 0xf5000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0xf1000
-    size: 0x70f000
+    address: 0xf5000
+    size: 0x70b000
     device: MX25R64
     region: external_flash

--- a/examples/window-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/window-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -7,24 +7,24 @@ mcuboot_pad:
     size: 0x200
 app:
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
     address: 0xC000
-    size: 0xec000
+    size: 0xf0000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
     address: 0xC200
-    size: 0xebe00
+    size: 0xefe00
 settings_storage:
-    address: 0xf8000
-    size: 0x8000
+    address: 0xfc000
+    size: 0x4000
     region: flash_primary
 mcuboot_primary_1:
     address: 0x0
@@ -33,17 +33,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xec000
+    size: 0xf0000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xec000
+    address: 0xf0000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12C000
-    size: 0x6D4000
+    address: 0x130000
+    size: 0x6D0000
     device: MX25R64
     region: external_flash
 pcd_sram:


### PR DESCRIPTION
#### Problem
Settings partition size has 32k that is unnecessarily big.

#### Change overview
Reduced settings size to 16k, what gained 16k of flash for application.

#### Testing
Only building tests were done.