### PR TITLE
[nrfconnect] Fixed a logic with switching LED

### DIFF
--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -42,7 +42,14 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     else if (clusterId == LevelControl::Id && attributeId == LevelControl::Attributes::CurrentLevel::Id)
     {
         ChipLogProgress(Zcl, "Cluster LevelControl: attribute CurrentLevel set to %u", *value);
-        GetAppTask().GetLightingDevice().InitiateAction(PWMDevice::LEVEL_ACTION, AppEvent::kEventType_Lighting, value);
+        if (GetAppTask().GetLightingDevice().IsTurnedOn())
+        {
+            GetAppTask().GetLightingDevice().InitiateAction(PWMDevice::LEVEL_ACTION, AppEvent::kEventType_Lighting, value);
+        }
+        else
+        {
+            ChipLogDetail(Zcl, "LED is off. Try to use move-to-level-with-on-off instead of move-to-level");
+        }
     }
 }
 


### PR DESCRIPTION
#### Problem
The nRFconnect Lighting App example didn't work properly.
When received `onoff off` command it set the LED to an ON state.

Fixes: #18169 

#### Change overview
The issue has been fixed by adding additional logic in ZCL Callbacks.
Now LevelControl cluster Initiates a Lighting Action only when the LED state is `ON.`
A device reacts appropriately to `on,` `off,` and `toggle` commands.
A device changes a LED brightness after the LevelControl command receiving.

#### Testing
Tested locally on nRF52 and nRF53 using:
- chiptool 
- Light-Switch example
