### PR TITLE
[chip-tool] Get TestGroupMessaging to work under darwin when the fire…

### DIFF
--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -17,6 +17,7 @@ import("//build_overrides/chip.gni")
 import("${build_root}/config/compiler/compiler.gni")
 
 import("${chip_root}/src/lib/lib.gni")
+import("${chip_root}/src/platform/device.gni")
 
 source_set("chip-all-clusters-common") {
   sources = [
@@ -79,6 +80,23 @@ if (is_libfuzzer) {
         [ "${chip_root}/examples/all-clusters-app/all-clusters-common/include" ]
 
     output_dir = root_out_dir
+  }
+
+  if (chip_device_platform == "darwin") {
+    action("codesign") {
+      script = "entitlements/codesign.py"
+      public_deps = [ ":chip-all-clusters-app" ]
+
+      args = [
+        "--target_path",
+        rebase_path("${root_build_dir}/chip-all-clusters-app", root_build_dir),
+        "--log_path",
+        rebase_path("${root_build_dir}/codesign_log.txt", root_build_dir),
+      ]
+
+      output_name = "codesign_log.txt"
+      outputs = [ "${root_build_dir}/${output_name}" ]
+    }
   }
 }
 

--- a/examples/all-clusters-app/linux/entitlements/codesign.py
+++ b/examples/all-clusters-app/linux/entitlements/codesign.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env -S python3 -B
+
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+import subprocess
+import re
+
+
+def run_command(command):
+    print("Running {}".format(command))
+    return str(subprocess.check_output(command.split()))
+
+
+def get_identity():
+    command = "/usr/bin/security find-identity -v -p codesigning"
+    command_result = run_command(command)
+
+    failure_str = "Error: 0 valid identities found"
+    if failure_str in command_result:
+        print(
+            "No valid identity has been found. Application will run without entitlements.")
+        exit(0)
+
+    identity = re.search(r'\b[0-9a-fA-F]{40}\b', command_result)
+    if identity is None:
+        print(
+            "No valid identity has been found. Application will run without entitlements.")
+        exit(0)
+
+    return identity.group()
+
+
+def codesign(args):
+    command = "codesign --force -d --sign {identity} {target}".format(
+        identity=get_identity(),
+        target=args.target_path)
+    command_result = run_command(command)
+
+    print("Codesign Result: {}".format(command_result))
+    with open(args.log_path, "w") as f:
+        f.write(command_result)
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(
+        description='Codesign the binary')
+    parser.add_argument(
+        '--log_path', help='Output log file destination', required=True)
+    parser.add_argument('--target_path', help='Binary to sign', required=True)
+
+    args = parser.parse_args()
+    codesign(args)


### PR DESCRIPTION
…wall is active

#### Problem

On darwin, when the firewall is active, `TestGroupMessaging` triggers a popup since `chip-all-clusters-app` is trying to listen to a multicast address. That is unpractical, especially if you can not / do not want to disable the firewall.

#### Change overview
 * Sign the all-clusters-app without any entitlement, so the firewall setting to allow locally built app to listen is enough

#### Testing
`./scripts/tests/run_test_suite.py --chip-tool out/debug/standalone/chip-tool --target TestGroupMessaging --log-level debug run --iterations 1 --all-clusters-app out/debug/standalone/chip-all-clusters-app --lock-app out/debug/standalone/chip-lock-app --tv-app out/debug/standalone/chip-tv-app`
