### PR TITLE
Refactored OnboardingCodesUtil to decrease memory footprint.

### DIFF
--- a/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
+++ b/examples/all-clusters-app/esp32/main/DeviceWithDisplay.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "DeviceWithDisplay.h"
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 #if CONFIG_HAVE_DISPLAY
 using namespace ::chip;
@@ -651,8 +652,11 @@ esp_err_t InitM5Stack(std::string qrCodeText)
 
 void InitDeviceDisplay()
 {
-    std::string qrCodeText;
+    // Create buffer for QR code that can fit max size and null terminator.
+    char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan qrCodeText(qrCodeBuffer);
 
+    // Get QR Code and emulate its content using NFC tag
     GetQRCode(qrCodeText, chip::RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE));
 
     // Initialize the display device.
@@ -681,12 +685,12 @@ void InitDeviceDisplay()
 
 #if CONFIG_DEVICE_TYPE_M5STACK
 
-    InitM5Stack(qrCodeText);
+    InitM5Stack(qrCodeText.data());
 
 #elif CONFIG_DEVICE_TYPE_ESP32_WROVER_KIT
 
     // Display the QR Code
-    QRCodeScreen qrCodeScreen(qrCodeText);
+    QRCodeScreen qrCodeScreen(qrCodeText.data());
     qrCodeScreen.Display();
 
 #endif

--- a/examples/chef/esp32/main/main.cpp
+++ b/examples/chef/esp32/main/main.cpp
@@ -45,6 +45,7 @@
 #include <app/server/Dnssd.h>
 #include <app/util/af-event.h>
 #include <app/util/af.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 #include "Display.h"
 #include "QRCodeScreen.h"
@@ -137,7 +138,9 @@ const char * TAG = "chef-app";
 #if CONFIG_HAVE_DISPLAY
 void printQRCode()
 {
-    std::string qrCodeText;
+    // Create buffer for QR code that can fit max size and null terminator.
+    char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan qrCodeText(qrCodeBuffer);
 
     GetQRCode(qrCodeText, chip::RendezvousInformationFlags(CONFIG_RENDEZVOUS_MODE));
 
@@ -153,8 +156,8 @@ void printQRCode()
     ScreenManager::Init();
 
     ESP_LOGI(TAG, "Opening QR code screen");
-    ESP_LOGI(TAG, "QR CODE Text: '%s'", qrCodeText.c_str());
-    ScreenManager::PushScreen(chip::Platform::New<QRCodeScreen>(qrCodeText));
+    ESP_LOGI(TAG, "QR CODE Text: '%s'", qrCodeText.data());
+    ScreenManager::PushScreen(chip::Platform::New<QRCodeScreen>(qrCodeText.data()));
 }
 #endif // CONFIG_HAVE_DISPLAY
 

--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -28,6 +28,7 @@
 #include "platform/ConfigurationManager.h"
 #include "platform/DiagnosticDataProvider.h"
 #include "platform/PlatformManager.h"
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 namespace chip {
 namespace rpc {
@@ -146,10 +147,12 @@ public:
             snprintf(response.serial_number, sizeof(response.serial_number), CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER);
         }
 
-        std::string qrCodeText;
+        // Create buffer for QR code that can fit max size and null terminator.
+        char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+        chip::MutableCharSpan qrCodeText(qrCodeBuffer);
         if (GetQRCode(qrCodeText, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
         {
-            snprintf(response.pairing_info.qr_code, sizeof(response.pairing_info.qr_code), "%s", qrCodeText.c_str());
+            snprintf(response.pairing_info.qr_code, sizeof(response.pairing_info.qr_code), "%s", qrCodeText.data());
             GetQRCodeUrl(response.pairing_info.qr_code_url, sizeof(response.pairing_info.qr_code_url), qrCodeText);
             response.has_pairing_info = true;
         }

--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -239,11 +239,13 @@ CHIP_ERROR AppTask::Init()
 
 // Print setup info on LCD if available
 #ifdef DISPLAY_ENABLED
-    std::string QRCode;
+    // Create buffer for QR code that can fit max size and null terminator.
+    char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan QRCode(qrCodeBuffer);
 
     if (GetQRCode(QRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
     {
-        LCDWriteQRCode((uint8_t *) QRCode.c_str());
+        LCDWriteQRCode((uint8_t *) QRCode.data());
     }
     else
     {

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -283,11 +283,13 @@ CHIP_ERROR AppTask::Init()
 
 // Print setup info on LCD if available
 #ifdef DISPLAY_ENABLED
-    std::string QRCode;
+    // Create buffer for QR code that can fit max size and null terminator.
+    char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan QRCode(qrCodeBuffer);
 
     if (GetQRCode(QRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
     {
-        LCDWriteQRCode((uint8_t *) QRCode.c_str());
+        LCDWriteQRCode((uint8_t *) QRCode.data());
     }
     else
     {

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -264,11 +264,13 @@ CHIP_ERROR AppTask::Init()
 
 // Print setup info on LCD if available
 #ifdef DISPLAY_ENABLED
-    std::string QRCode;
+    // Create buffer for QR code that can fit max size and null terminator.
+    char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan QRCode(qrCodeBuffer);
 
     if (GetQRCode(QRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
     {
-        LCDWriteQRCode((uint8_t *) QRCode.c_str());
+        LCDWriteQRCode((uint8_t *) QRCode.data());
     }
     else
     {

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -170,11 +170,13 @@ CHIP_ERROR AppTask::Init()
 
 // Print setup info on LCD if available
 #ifdef DISPLAY_ENABLED
-    std::string QRCode;
+    // Create buffer for QR code that can fit max size and null terminator.
+    char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan QRCode(qrCodeBuffer);
 
     if (GetQRCode(QRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
     {
-        LCDWriteQRCode((uint8_t *) QRCode.c_str());
+        LCDWriteQRCode((uint8_t *) QRCode.data());
     }
     else
     {

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -237,7 +237,7 @@ int ChipLinuxAppInit(int argc, char ** argv, OptionSet * customOptions)
                                                    LinuxDeviceOptions::GetInstance());
     SuccessOrExit(err);
 
-    err = GetSetupPayload(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
+    err = GetPayloadContents(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
     SuccessOrExit(err);
 
     ConfigurationMgr().LogDeviceConfig();
@@ -250,7 +250,7 @@ int ChipLinuxAppInit(int argc, char ** argv, OptionSet * customOptions)
     {
         // For testing of manual pairing code with custom commissioning flow
         ChipLogProgress(NotSpecified, "==== Onboarding payload for Custom Commissioning Flows ====");
-        err = GetSetupPayload(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
+        err = GetPayloadContents(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
         SuccessOrExit(err);
 
         LinuxDeviceOptions::GetInstance().payload.commissioningFlow = chip::CommissioningFlow::kCustom;

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -38,7 +38,7 @@
 
 struct LinuxDeviceOptions
 {
-    chip::SetupPayload payload;
+    chip::PayloadContents payload;
     chip::Optional<uint16_t> discriminator;
     chip::Optional<std::vector<uint8_t>> spake2pVerifier;
     chip::Optional<std::vector<uint8_t>> spake2pSalt;

--- a/examples/window-app/efr32/include/WindowAppImpl.h
+++ b/examples/window-app/efr32/include/WindowAppImpl.h
@@ -81,7 +81,6 @@ private:
 
     // Get QR Code and emulate its content using NFC tag
     char mQRCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
-    chip::MutableCharSpan mQRCode(mQRCodeBuffer);
     Timer mIconTimer;
     LcdIcon mIcon = LcdIcon::None;
 };

--- a/examples/window-app/efr32/include/WindowAppImpl.h
+++ b/examples/window-app/efr32/include/WindowAppImpl.h
@@ -21,6 +21,7 @@
 #include <LEDWidget.h>
 #include <WindowApp.h>
 #include <queue.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <sl_simple_button_instances.h>
 #include <string>
 #include <task.h>
@@ -77,7 +78,10 @@ private:
     QueueHandle_t mQueue = nullptr;
     LEDWidget mStatusLED;
     LEDWidget mActionLED;
-    std::string mQRCode;
+
+    // Get QR Code and emulate its content using NFC tag
+    char mQRCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan mQRCode(mQRCodeBuffer);
     Timer mIconTimer;
     LcdIcon mIcon = LcdIcon::None;
 };

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -433,9 +433,10 @@ void WindowAppImpl::UpdateLCD()
 #ifdef QR_CODE_ENABLED
     else
     {
-        if (GetQRCode(mQRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
+        chip::MutableCharSpan qrCode(mQRCodeBuffer);
+        if (GetQRCode(qrCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
         {
-            LCDWriteQRCode((uint8_t *) mQRCode.data());
+            LCDWriteQRCode((uint8_t *) qrCode.data());
         }
     }
 #endif // QR_CODE_ENABLED

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -435,7 +435,7 @@ void WindowAppImpl::UpdateLCD()
     {
         if (GetQRCode(mQRCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)) == CHIP_NO_ERROR)
         {
-            LCDWriteQRCode((uint8_t *) mQRCode.c_str());
+            LCDWriteQRCode((uint8_t *) mQRCode.data());
         }
     }
 #endif // QR_CODE_ENABLED

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -50,7 +50,7 @@ void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
 
 void PrintOnboardingCodes(const chip::PayloadContents & payload)
 {
-    char payloadBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength];
+    char payloadBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
     chip::MutableCharSpan qrCode(payloadBuffer);
 
     if (GetQRCode(qrCode, payload) == CHIP_NO_ERROR)
@@ -86,7 +86,7 @@ void PrintOnboardingCodes(const chip::PayloadContents & payload)
 void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags)
 {
     // Get QR Code and emulate its content using NFC tag
-    char payloadBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength];
+    char payloadBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
     chip::MutableCharSpan qrCode(payloadBuffer);
 
     ReturnOnFailure(GetQRCode(qrCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)));
@@ -154,8 +154,6 @@ CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, chip::RendezvousInformatio
 
 CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, const chip::PayloadContents & payload)
 {
-    // TODO: Usage of STL will significantly increase the image size, this should be changed to more efficient method for
-    // generating payload
     CHIP_ERROR err = chip::QRCodeBasicSetupPayloadGenerator(payload).payloadBase38Representation(aQRCode);
     if (err != CHIP_NO_ERROR)
     {
@@ -166,7 +164,7 @@ CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, const chip::PayloadContent
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, chip::MutableCharSpan & aQRCode)
+CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const chip::CharSpan & aQRCode)
 {
     VerifyOrReturnError(aQRCodeUrl, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(aUrlMaxSize >= (strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + aQRCode.size() + 1),

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -37,21 +37,21 @@ using namespace ::chip::DeviceLayer;
 
 void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    chip::SetupPayload payload;
+    chip::PayloadContents payload;
 
-    CHIP_ERROR err = GetSetupPayload(payload, aRendezvousFlags);
+    CHIP_ERROR err = GetPayloadContents(payload, aRendezvousFlags);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetPayloadContents() failed: %s", chip::ErrorStr(err));
     }
 
     PrintOnboardingCodes(payload);
 }
 
-void PrintOnboardingCodes(const chip::SetupPayload & payload)
+void PrintOnboardingCodes(const chip::PayloadContents & payload)
 {
-    std::string qrCode;
-    std::string manualPairingCode;
+    char payloadBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength];
+    chip::MutableCharSpan qrCode(payloadBuffer);
 
     if (GetQRCode(qrCode, payload) == CHIP_NO_ERROR)
     {
@@ -59,7 +59,7 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
         const size_t qrCodeBufferMaxSize = strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + 3 * qrCode.size() + 1;
         qrCodeBuffer.Alloc(qrCodeBufferMaxSize);
 
-        ChipLogProgress(AppServer, "SetupQRCode: [%s]", qrCode.c_str());
+        ChipLogProgress(AppServer, "SetupQRCode: [%s]", qrCode.data());
         if (GetQRCodeUrl(qrCodeBuffer.Get(), qrCodeBufferMaxSize, qrCode) == CHIP_NO_ERROR)
         {
             ChipLogProgress(AppServer, "Copy/paste the below URL in a browser to see the QR Code:");
@@ -71,9 +71,10 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
         ChipLogError(AppServer, "Getting QR code failed!");
     }
 
+    chip::MutableCharSpan manualPairingCode(payloadBuffer);
     if (GetManualPairingCode(manualPairingCode, payload) == CHIP_NO_ERROR)
     {
-        ChipLogProgress(AppServer, "Manual pairing code: [%s]", manualPairingCode.c_str());
+        ChipLogProgress(AppServer, "Manual pairing code: [%s]", manualPairingCode.data());
     }
     else
     {
@@ -85,47 +86,49 @@ void PrintOnboardingCodes(const chip::SetupPayload & payload)
 void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags)
 {
     // Get QR Code and emulate its content using NFC tag
-    std::string qrCode;
+    char payloadBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength];
+    chip::MutableCharSpan qrCode(payloadBuffer);
+
     ReturnOnFailure(GetQRCode(qrCode, chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE)));
 
-    ReturnOnFailure(NFCMgr().StartTagEmulation(qrCode.c_str(), qrCode.size()));
+    ReturnOnFailure(NFCMgr().StartTagEmulation(qrCode.data(), qrCode.size()));
 }
 #endif
 
-CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousInformationFlags aRendezvousFlags)
+CHIP_ERROR GetPayloadContents(chip::PayloadContents & aPayload, chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    CHIP_ERROR err                      = CHIP_NO_ERROR;
-    aSetupPayload.version               = 0;
-    aSetupPayload.rendezvousInformation = aRendezvousFlags;
+    CHIP_ERROR err                 = CHIP_NO_ERROR;
+    aPayload.version               = 0;
+    aPayload.rendezvousInformation = aRendezvousFlags;
 
-    err = GetCommissionableDataProvider()->GetSetupPasscode(aSetupPayload.setUpPINCode);
+    err = GetCommissionableDataProvider()->GetSetupPasscode(aPayload.setUpPINCode);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "GetCommissionableDataProvider()->GetSetupPasscode() failed: %s", chip::ErrorStr(err));
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
         ChipLogProgress(AppServer, "*** Using default EXAMPLE passcode %u ***",
                         static_cast<unsigned>(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE));
-        aSetupPayload.setUpPINCode = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE;
+        aPayload.setUpPINCode = CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE;
 #else
         return err;
 #endif
     }
 
-    err = GetCommissionableDataProvider()->GetSetupDiscriminator(aSetupPayload.discriminator);
+    err = GetCommissionableDataProvider()->GetSetupDiscriminator(aPayload.discriminator);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "GetCommissionableDataProvider()->GetSetupDiscriminator() failed: %s", chip::ErrorStr(err));
         return err;
     }
 
-    err = ConfigurationMgr().GetVendorId(aSetupPayload.vendorID);
+    err = ConfigurationMgr().GetVendorId(aPayload.vendorID);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "ConfigurationMgr().GetVendorId() failed: %s", chip::ErrorStr(err));
         return err;
     }
 
-    err = ConfigurationMgr().GetProductId(aSetupPayload.productID);
+    err = ConfigurationMgr().GetProductId(aPayload.productID);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "ConfigurationMgr().GetProductId() failed: %s", chip::ErrorStr(err));
@@ -135,25 +138,25 @@ CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousI
     return err;
 }
 
-CHIP_ERROR GetQRCode(std::string & aQRCode, chip::RendezvousInformationFlags aRendezvousFlags)
+CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    chip::SetupPayload payload;
+    chip::PayloadContents payload;
 
-    CHIP_ERROR err = GetSetupPayload(payload, aRendezvousFlags);
+    CHIP_ERROR err = GetPayloadContents(payload, aRendezvousFlags);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetPayloadContents() failed: %s", chip::ErrorStr(err));
         return err;
     }
 
     return GetQRCode(aQRCode, payload);
 }
 
-CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload)
+CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, const chip::PayloadContents & payload)
 {
     // TODO: Usage of STL will significantly increase the image size, this should be changed to more efficient method for
     // generating payload
-    CHIP_ERROR err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(aQRCode);
+    CHIP_ERROR err = chip::QRCodeBasicSetupPayloadGenerator(payload).payloadBase38Representation(aQRCode);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "Generating QR Code failed: %s", chip::ErrorStr(err));
@@ -163,7 +166,7 @@ CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode)
+CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, chip::MutableCharSpan & aQRCode)
 {
     VerifyOrReturnError(aQRCodeUrl, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(aUrlMaxSize >= (strlen(kQrCodeBaseUrl) + strlen(kUrlDataAssignmentPhrase) + aQRCode.size() + 1),
@@ -173,24 +176,24 @@ CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string
     VerifyOrReturnError((writtenDataSize > 0) && (static_cast<size_t>(writtenDataSize) < aUrlMaxSize),
                         CHIP_ERROR_INVALID_STRING_LENGTH);
 
-    return EncodeQRCodeToUrl(aQRCode.c_str(), aQRCode.size(), aQRCodeUrl + writtenDataSize,
+    return EncodeQRCodeToUrl(aQRCode.data(), aQRCode.size(), aQRCodeUrl + writtenDataSize,
                              aUrlMaxSize - static_cast<size_t>(writtenDataSize));
 }
 
-CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags)
+CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    chip::SetupPayload payload;
+    chip::PayloadContents payload;
 
-    CHIP_ERROR err = GetSetupPayload(payload, aRendezvousFlags);
+    CHIP_ERROR err = GetPayloadContents(payload, aRendezvousFlags);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetSetupPayload() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetPayloadContents() failed: %s", chip::ErrorStr(err));
         return err;
     }
     return GetManualPairingCode(aManualPairingCode, payload);
 }
 
-CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload)
+CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, const chip::PayloadContents & payload)
 {
     CHIP_ERROR err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aManualPairingCode);
     if (err != CHIP_NO_ERROR)

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -17,17 +17,18 @@
 
 #pragma once
 
+#include <lib/support/Span.h>
 #include <setup_payload/SetupPayload.h>
 
 void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags);
-void PrintOnboardingCodes(const chip::SetupPayload & payload);
+void PrintOnboardingCodes(const chip::PayloadContents & payload);
 void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetQRCode(std::string & aQRCode, chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetQRCode(std::string & aQRCode, const chip::SetupPayload & payload);
-CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const std::string & aQRCode);
-CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
-CHIP_ERROR GetManualPairingCode(std::string & aManualPairingCode, const chip::SetupPayload & payload);
-CHIP_ERROR GetSetupPayload(chip::SetupPayload & aSetupPayload, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, const chip::PayloadContents & payload);
+CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, chip::MutableCharSpan & aQRCode);
+CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
+CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, const chip::PayloadContents & payload);
+CHIP_ERROR GetPayloadContents(chip::PayloadContents & aPayload, chip::RendezvousInformationFlags aRendezvousFlags);
 
 /**
  * Initialize DataModelHandler and start CHIP datamodel server, the server

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -23,11 +23,40 @@
 void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags);
 void PrintOnboardingCodes(const chip::PayloadContents & payload);
 void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags);
+
+/**
+ * Creates a null-terminated QR code from the payload created based on rendezvous flag information.
+ *
+ * The resulting size of the QR code span will not include the null terminator.
+ */
 CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, chip::RendezvousInformationFlags aRendezvousFlags);
+
+/**
+ * Creates a null-terminated QR code based on the provided payload.
+ *
+ * The resulting size of the QR code span will not include the null terminator.
+ */
 CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, const chip::PayloadContents & payload);
-CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, chip::MutableCharSpan & aQRCode);
+
+/**
+ * Creates a null-terminated QR code url.
+ */
+CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const chip::CharSpan & aQRCode);
+
+/**
+ * Creates a null-terminated manual pairing code from the payload created based on rendezvous flag information.
+ *
+ * The resulting size of the manual pairing code span will not include the null terminator.
+ */
 CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
+
+/**
+ * Creates a null-terminated manual pairing code based on the provided payload.
+ *
+ * The resulting size of the manual pairing code span will not include the null terminator.
+ */
 CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, const chip::PayloadContents & payload);
+
 CHIP_ERROR GetPayloadContents(chip::PayloadContents & aPayload, chip::RendezvousInformationFlags aRendezvousFlags);
 
 /**

--- a/src/app/server/OnboardingCodesUtil.h
+++ b/src/app/server/OnboardingCodesUtil.h
@@ -27,14 +27,14 @@ void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags);
 /**
  * Creates a null-terminated QR code from the payload created based on rendezvous flag information.
  *
- * The resulting size of the QR code span will not include the null terminator.
+ * The resulting size of the QR code span will be the size of data written and not including the null terminator.
  */
 CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, chip::RendezvousInformationFlags aRendezvousFlags);
 
 /**
  * Creates a null-terminated QR code based on the provided payload.
  *
- * The resulting size of the QR code span will not include the null terminator.
+ * The resulting size of the QR code span will be the size of data written and not including the null terminator.
  */
 CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, const chip::PayloadContents & payload);
 
@@ -46,14 +46,14 @@ CHIP_ERROR GetQRCodeUrl(char * aQRCodeUrl, size_t aUrlMaxSize, const chip::CharS
 /**
  * Creates a null-terminated manual pairing code from the payload created based on rendezvous flag information.
  *
- * The resulting size of the manual pairing code span will not include the null terminator.
+ * The resulting size of the manual pairing code span will be the size of data written and not including the null terminator.
  */
 CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, chip::RendezvousInformationFlags aRendezvousFlags);
 
 /**
  * Creates a null-terminated manual pairing code based on the provided payload.
  *
- * The resulting size of the manual pairing code span will not include the null terminator.
+ * The resulting size of the manual pairing code span will be the size of data written and not including the null terminator.
  */
 CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, const chip::PayloadContents & payload);
 

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -144,7 +144,7 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(Operationa
         ReturnErrorOnFailure(cluster.InvokeCommand(request, this, OnOpenCommissioningWindowSuccess,
                                                    OnOpenCommissioningWindowFailure, MakeOptional(kTimedInvokeTimeoutMs)));
 
-        char payloadBuffer[QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength];
+        char payloadBuffer[QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
 
         MutableCharSpan manualCode(payloadBuffer);
         ReturnErrorOnFailure(ManualSetupPayloadGenerator(mSetupPayload).payloadDecimalStringRepresentation(manualCode));

--- a/src/lib/shell/commands/OnboardingCodes.cpp
+++ b/src/lib/shell/commands/OnboardingCodes.cpp
@@ -25,6 +25,7 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <setup_payload/QRCodeSetupPayloadGenerator.h>
 
 #define CHIP_SHELL_MAX_BUFFER_SIZE 128
 
@@ -36,21 +37,27 @@ namespace Shell {
 static CHIP_ERROR GetOnboardingQRCode(bool printHeader, chip::RendezvousInformationFlags aRendezvousFlags)
 {
     streamer_t * sout = streamer_get();
-    std::string QRCode;
+
+    // Create buffer for QR code that can fit max size and null terminator.
+    char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan QRCode(qrCodeBuffer);
 
     if (printHeader)
     {
         streamer_printf(sout, "QRCode:            ");
     }
     ReturnErrorOnFailure(GetQRCode(QRCode, aRendezvousFlags));
-    streamer_printf(sout, "%s\r\n", QRCode.c_str());
+    streamer_printf(sout, "%s\r\n", QRCode.data());
     return CHIP_NO_ERROR;
 }
 
 static CHIP_ERROR GetOnboardingQRCodeUrl(bool printHeader, chip::RendezvousInformationFlags aRendezvousFlags)
 {
     streamer_t * sout = streamer_get();
-    std::string QRCode;
+
+    // Create buffer for QR code that can fit max size and null terminator.
+    char qrCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+    chip::MutableCharSpan QRCode(qrCodeBuffer);
 
     if (printHeader)
     {
@@ -58,24 +65,27 @@ static CHIP_ERROR GetOnboardingQRCodeUrl(bool printHeader, chip::RendezvousInfor
     }
     ReturnErrorOnFailure(GetQRCode(QRCode, aRendezvousFlags));
 
-    char qrCodeBuffer[CHIP_SHELL_MAX_BUFFER_SIZE];
+    char qrCodeUrlBuffer[CHIP_SHELL_MAX_BUFFER_SIZE];
 
-    ReturnErrorOnFailure(GetQRCodeUrl(qrCodeBuffer, sizeof(qrCodeBuffer), QRCode));
-    streamer_printf(sout, "%s\r\n", qrCodeBuffer);
+    ReturnErrorOnFailure(GetQRCodeUrl(qrCodeUrlBuffer, sizeof(qrCodeUrlBuffer), QRCode));
+    streamer_printf(sout, "%s\r\n", qrCodeUrlBuffer);
     return CHIP_NO_ERROR;
 }
 
 static CHIP_ERROR GetOnboardingManualPairingCode(bool printHeader, chip::RendezvousInformationFlags aRendezvousFlags)
 {
     streamer_t * sout = streamer_get();
-    std::string manualPairingCode;
+
+    // Create buffer for manual pariting code that can fit max size + check digit + null terminator.
+    char manualPairingCodeBuffer[chip::kManualSetupLongCodeCharLength + 1];
+    chip::MutableCharSpan manualPairingCode(manualPairingCodeBuffer);
 
     if (printHeader)
     {
         streamer_printf(sout, "ManualPairingCode: ");
     }
     ReturnErrorOnFailure(GetManualPairingCode(manualPairingCode, aRendezvousFlags));
-    streamer_printf(sout, "%s\r\n", manualPairingCode.c_str());
+    streamer_printf(sout, "%s\r\n", manualPairingCode.data());
     return CHIP_NO_ERROR;
 }
 

--- a/src/setup_payload/Base38Encode.cpp
+++ b/src/setup_payload/Base38Encode.cpp
@@ -81,6 +81,8 @@ CHIP_ERROR base38Encode(ByteSpan in_buf, MutableCharSpan & out_buf)
     if (out_idx < out_buf.size())
     {
         out_buf.data()[out_idx] = '\0';
+        // Reduce output span size to not include null-terminator.
+        out_buf.reduce_size(out_buf.size() - 1);
     }
     else
     {

--- a/src/setup_payload/Base38Encode.cpp
+++ b/src/setup_payload/Base38Encode.cpp
@@ -81,8 +81,8 @@ CHIP_ERROR base38Encode(ByteSpan in_buf, MutableCharSpan & out_buf)
     if (out_idx < out_buf.size())
     {
         out_buf.data()[out_idx] = '\0';
-        // Reduce output span size to not include null-terminator.
-        out_buf.reduce_size(out_buf.size() - 1);
+        // Reduce output span size to be the size of written data and to not include null-terminator.
+        out_buf.reduce_size(out_idx);
     }
     else
     {

--- a/src/setup_payload/Base38Encode.h
+++ b/src/setup_payload/Base38Encode.h
@@ -25,10 +25,16 @@
 
 namespace chip {
 
-// out_buf is null-terminated on success
+/*
+ * The out_buf is null-terminated on success.
+ *
+ * The resulting size of the out_buf span will not include the null terminator.
+ */
 CHIP_ERROR base38Encode(ByteSpan in_buf, MutableCharSpan & out_buf);
 
-// returns size needed to store encoded string given number of input bytes
+/*
+ * Returns size needed to store encoded string given number of input bytes including null terminator.
+ */
 size_t base38EncodedLength(size_t num_bytes);
 
 } // namespace chip

--- a/src/setup_payload/Base38Encode.h
+++ b/src/setup_payload/Base38Encode.h
@@ -28,7 +28,7 @@ namespace chip {
 /*
  * The out_buf is null-terminated on success.
  *
- * The resulting size of the out_buf span will not include the null terminator.
+ * The resulting size of the out_buf span will be the size of data written and not including the null terminator.
  */
 CHIP_ERROR base38Encode(ByteSpan in_buf, MutableCharSpan & out_buf);
 

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -151,9 +151,10 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(Mutab
 
     int checkDigit = Verhoeff10::CharToVal(Verhoeff10::ComputeCheckChar(outBuffer.data()));
     ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, 2), static_cast<uint32_t>(checkDigit)));
+    offset += 1;
 
-    // Reduce size of outBuffer by 1 to not include null terminator.
-    outBuffer.reduce_size(outBuffer.size() - 1);
+    // Reduce outBuffer span size to be the size of written data and to not include null-terminator.
+    outBuffer.reduce_size(offset);
 
     return CHIP_NO_ERROR;
 }

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -152,6 +152,9 @@ CHIP_ERROR ManualSetupPayloadGenerator::payloadDecimalStringRepresentation(Mutab
     int checkDigit = Verhoeff10::CharToVal(Verhoeff10::ComputeCheckChar(outBuffer.data()));
     ReturnErrorOnFailure(decimalStringWithPadding(outBuffer.SubSpan(offset, 2), static_cast<uint32_t>(checkDigit)));
 
+    // Reduce size of outBuffer by 1 to not include null terminator.
+    outBuffer.reduce_size(outBuffer.size() - 1);
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/setup_payload/ManualSetupPayloadGenerator.h
+++ b/src/setup_payload/ManualSetupPayloadGenerator.h
@@ -58,6 +58,8 @@ public:
      * This function is called to encode the binary data of a payload to a
      * decimal null-terminated string.
      *
+     * The resulting size of the outBuffer will be the size of data written and not including the null terminator.
+     *
      * @param[out] outBuffer
      *                  Output buffer to write the decimal string.
      *

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -112,6 +112,8 @@ public:
      * This function is called to encode the binary data of a payload to a
      * base38 null-terminated string.
      *
+     * The resulting size of the outBuffer span will not include the null terminator.
+     *
      * @param[out] outBuffer
      *                  The buffer to copy the base38 to.
      *

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.h
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.h
@@ -112,7 +112,7 @@ public:
      * This function is called to encode the binary data of a payload to a
      * base38 null-terminated string.
      *
-     * The resulting size of the outBuffer span will not include the null terminator.
+     * The resulting size of the out_buf span will be the size of data written and not including the null terminator.
      *
      * @param[out] outBuffer
      *                  The buffer to copy the base38 to.

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -126,14 +126,18 @@ void TestBase38(nlTestSuite * inSuite, void * inContext)
     // basic stuff
     base38Encode(inputSpan.SubSpan(0, 0), encodedSpan);
     NL_TEST_ASSERT(inSuite, strlen(encodedBuf) == 0);
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan.SubSpan(0, 1), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "A0") == 0);
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan.SubSpan(0, 2), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "OT10") == 0);
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan, encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "-N.B0") == 0);
 
     // test null termination of output buffer
+    encodedSpan             = MutableCharSpan(encodedBuf);
     MutableCharSpan subSpan = encodedSpan.SubSpan(0, 2);
     NL_TEST_ASSERT(inSuite, base38Encode(inputSpan.SubSpan(0, 1), subSpan) == CHIP_ERROR_BUFFER_TOO_SMALL);
     // Force no nulls in output buffer
@@ -146,60 +150,72 @@ void TestBase38(nlTestSuite * inSuite, void * inContext)
 
     // passing empty parameters
     MutableCharSpan emptySpan;
+    encodedSpan = MutableCharSpan(encodedBuf);
     NL_TEST_ASSERT(inSuite, base38Encode(inputSpan, emptySpan) == CHIP_ERROR_BUFFER_TOO_SMALL);
     base38Encode(MutableByteSpan(), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "") == 0);
     NL_TEST_ASSERT(inSuite, base38Encode(MutableByteSpan(), emptySpan) == CHIP_ERROR_BUFFER_TOO_SMALL);
 
     // test single odd byte corner conditions
-    input[2] = 0;
+    encodedSpan = MutableCharSpan(encodedBuf);
+    input[2]    = 0;
     base38Encode(inputSpan, encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "OT100") == 0);
-    input[2] = 40;
+    input[2]    = 40;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan, encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "Y6V91") == 0);
-    input[2] = 41;
+    input[2]    = 41;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan, encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "KL0B1") == 0);
-    input[2] = 255;
+    input[2]    = 255;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan, encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "Q-M08") == 0);
 
     // verify chunks of 1,2 and 3 bytes result in fixed-length strings padded with '0'
     // for 1 byte we need always 2 characters
-    input[0] = 35;
+    input[0]    = 35;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan.SubSpan(0, 1), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "Z0") == 0);
     // for 2 bytes we need always 4 characters
-    input[0] = 255;
-    input[1] = 0;
+    input[0]    = 255;
+    input[1]    = 0;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan.SubSpan(0, 2), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "R600") == 0);
     // for 3 bytes we need always 5 characters
-    input[0] = 46;
-    input[1] = 0;
-    input[2] = 0;
+    input[0]    = 46;
+    input[1]    = 0;
+    input[2]    = 0;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan, encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "81000") == 0);
 
     // verify maximum available values for each chunk size to check selecting proper characters number
     // for 1 byte we need 2 characters
-    input[0] = 255;
+    input[0]    = 255;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan.SubSpan(0, 1), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "R6") == 0);
     // for 2 bytes we need 4 characters
-    input[0] = 255;
-    input[1] = 255;
+    input[0]    = 255;
+    input[1]    = 255;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan.SubSpan(0, 2), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "NE71") == 0);
     // for 3 bytes we need 5 characters
-    input[0] = 255;
-    input[1] = 255;
-    input[2] = 255;
+    input[0]    = 255;
+    input[1]    = 255;
+    input[2]    = 255;
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(inputSpan, encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "PLS18") == 0);
 
     // fun with strings
+    encodedSpan = MutableCharSpan(encodedBuf);
     base38Encode(ByteSpan((uint8_t *) "Hello World!", sizeof("Hello World!") - 1), encodedSpan);
     NL_TEST_ASSERT(inSuite, strcmp(encodedBuf, "KKHF3W2S013OPM3EJX11") == 0);
 

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -119,7 +119,7 @@ void TestPayloadBase38Rep(nlTestSuite * inSuite, void * inContext)
 void TestBase38(nlTestSuite * inSuite, void * inContext)
 {
     uint8_t input[3] = { 10, 10, 10 };
-    char encodedBuf[32];
+    char encodedBuf[64];
     MutableByteSpan inputSpan(input);
     MutableCharSpan encodedSpan(encodedBuf);
 


### PR DESCRIPTION
#### Problem
OnboardingCodesUtil uses SetupPayload object that contains a lot unnecessary data and takes a lot of flash.

#### Change overview
Replaced using `SetupPayload` with `PayloadContents` and `QRCodeSetupPayloadGenerator` with `QRCodeBasicSetupPayloadGenerator`.
It allowed to save about 3.28 k of flash for nrfconnect platform.

#### Testing
Verified that generated QR code and manual pairing code is the same before and after the change.
