### PR TITLE
Remove build variant from repl linux tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -222,12 +222,7 @@ jobs:
         name: REPL Tests - Linux
         timeout-minutes: 120
 
-        strategy:
-            matrix:
-                build_variant: [no-ble-no-wifi-tsan-clang]
-
         env:
-            BUILD_VARIANT: ${{matrix.build_variant}}
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
 
         if: github.actor != 'restyled-io[bot]'
@@ -269,7 +264,7 @@ jobs:
                     scripts/run_in_build_env.sh './scripts/build_python.sh --install_wheel build-env'
                     ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target linux-x64-all-clusters-${BUILD_VARIANT}-test \
+                        --target linux-x64-all-clusters-no-ble-no-wifi-tsan-clang-test \
                         --target linux-x64-python-bindings \
                         build \
                         --copy-artifacts-to objdir-clone \


### PR DESCRIPTION
#### Problem
Usage of a build variant and matrix makes the REPL tests unnecessarely complex and hard to copy & paste commands to reproduce locally.

#### Change overview
Replace build matrix and variant with direct string. no need for a matrix and direct string was already hard-coded for execution.

#### Testing
CI will validate the build.