### PR TITLE
[EFR32] Remove fixed TODO and move BLE name adv to scan response

### DIFF
--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -399,8 +399,6 @@ CHIP_ERROR BLEManagerImpl::_GetDeviceName(char * buf, size_t bufSize)
 
 CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
 {
-    sl_status_t ret;
-    CHIP_ERROR err = CHIP_NO_ERROR;
     if (mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_NotSupported)
     {
         return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
@@ -413,20 +411,14 @@ CHIP_ERROR BLEManagerImpl::_SetDeviceName(const char * deviceName)
         }
         strcpy(mDeviceName, deviceName);
         mFlags.Set(Flags::kDeviceNameSet);
-        ChipLogProgress(DeviceLayer, "Setting device name to : \"%s\"", deviceName);
-        static_assert(kMaxDeviceNameLength <= UINT16_MAX, "deviceName length might not fit in a uint8_t");
-        ret = sl_bt_gatt_server_write_attribute_value(gattdb_device_name, 0, strlen(deviceName), (uint8_t *) deviceName);
-        if (ret != SL_STATUS_OK)
-        {
-            err = MapBLEError(ret);
-            ChipLogError(DeviceLayer, "sl_bt_gatt_server_write_attribute_value() failed: %s", ErrorStr(err));
-            return err;
-        }
+        mFlags.Set(Flags::kRestartAdvertising);
+        ChipLogProgress(DeviceLayer, "Setting device name to : \"%s\"", mDeviceName);
     }
     else
     {
         mDeviceName[0] = 0;
     }
+    PlatformMgr().ScheduleWork(DriveBLEState, 0);
     return CHIP_NO_ERROR;
 }
 
@@ -661,14 +653,6 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
         mDeviceNameLength                 = strlen(mDeviceName);
 
         VerifyOrExit(mDeviceNameLength < kMaxDeviceNameLength, err = CHIP_ERROR_INVALID_ARGUMENT);
-
-        ret = sl_bt_gatt_server_write_attribute_value(gattdb_device_name, 0, mDeviceNameLength, (uint8_t *) mDeviceName);
-        if (ret != SL_STATUS_OK)
-        {
-            err = MapBLEError(ret);
-            ChipLogError(DeviceLayer, "sl_bt_gatt_server_write_attribute_value() failed: %s", ErrorStr(err));
-            return err;
-        }
     }
 
     mDeviceNameLength = strlen(mDeviceName); // Device Name length + length field
@@ -688,11 +672,6 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     advData[index++] = ShortUUID_CHIPoBLEService[1];
     memcpy(&advData[index], (void *) &mDeviceIdInfo, mDeviceIdInfoLength); // AD value
     index += mDeviceIdInfoLength;
-
-    advData[index++] = static_cast<uint8_t>(mDeviceNameLength + 1); // length
-    advData[index++] = CHIP_ADV_DATA_TYPE_NAME;                     // AD type : name
-    memcpy(&advData[index], mDeviceName, mDeviceNameLength);        // AD value
-    index += mDeviceNameLength;
 
     if (0xff != advertising_set_handle)
     {
@@ -722,6 +701,11 @@ CHIP_ERROR BLEManagerImpl::ConfigureAdvertisingData(void)
     responseData[index++] = CHIP_ADV_DATA_TYPE_UUID;      // AD type : uuid
     responseData[index++] = ShortUUID_CHIPoBLEService[0]; // AD value
     responseData[index++] = ShortUUID_CHIPoBLEService[1];
+
+    responseData[index++] = static_cast<uint8_t>(mDeviceNameLength + 1); // length
+    responseData[index++] = CHIP_ADV_DATA_TYPE_NAME;                     // AD type : name
+    memcpy(&responseData[index], mDeviceName, mDeviceNameLength);        // AD value
+    index += mDeviceNameLength;
 
     ret = sl_bt_advertiser_set_data(advertising_set_handle, CHIP_ADV_SCAN_RESPONSE_DATA, index, (uint8_t *) responseData);
 
@@ -759,14 +743,10 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         ChipLogDetail(DeviceLayer, "Start BLE advertissement");
     }
 
-#ifndef EFR32MG24
-    // set_random_address call causes problems with MG24 family.
-    // Todo fix in GSDK.
     const uint8_t kResolvableRandomAddrType = 2; // Private resolvable random address type
     bd_addr unusedBdAddr;                        // We can ignore this field when setting random address.
     sl_bt_advertiser_set_random_address(advertising_set_handle, kResolvableRandomAddrType, unusedBdAddr, &unusedBdAddr);
     (void) unusedBdAddr;
-#endif
 
     err = ConfigureAdvertisingData();
     SuccessOrExit(err);


### PR DESCRIPTION
#### Problem
BLE name is advertised in the Device name GATT
MG24 is not setting a random BLE address due to a bug in the GSDK at the time of adding MG24 family support.

#### Change overview
Remove a #ifdef since the bug was fixed in GSDK for MG24 so we can set BLE with a random address 
Remove BLE name from GATT characteristic and ADV data and write it in the scan response data instead.

#### Testing
Ran on EFR32 MG12 and MG24 and validate BLE information.
