### PR TITLE
[config] Error out when Spake2+ passcode is changed alone

### DIFF
--- a/examples/lighting-app/cyw30739/BUILD.gn
+++ b/examples/lighting-app/cyw30739/BUILD.gn
@@ -22,8 +22,8 @@ import("${cyw30739_sdk_build_root}/cyw30739_sdk.gni")
 cyw30739_project_dir = "${chip_root}/examples/lighting-app/cyw30739"
 
 declare_args() {
-  setupPinCode = 0
-  setupDiscriminator = 0
+  setupPinCode = 20202021
+  setupDiscriminator = 3840
 }
 
 cyw30739_sdk("sdk") {

--- a/examples/lock-app/cyw30739/BUILD.gn
+++ b/examples/lock-app/cyw30739/BUILD.gn
@@ -22,8 +22,8 @@ import("${cyw30739_sdk_build_root}/cyw30739_sdk.gni")
 cyw30739_project_dir = "${chip_root}/examples/lock-app/cyw30739"
 
 declare_args() {
-  setupPinCode = 0
-  setupDiscriminator = 0
+  setupPinCode = 20202021
+  setupDiscriminator = 3840
 }
 
 cyw30739_sdk("sdk") {

--- a/examples/ota-requestor-app/cyw30739/BUILD.gn
+++ b/examples/ota-requestor-app/cyw30739/BUILD.gn
@@ -22,8 +22,8 @@ import("${cyw30739_sdk_build_root}/cyw30739_sdk.gni")
 cyw30739_project_dir = "${chip_root}/examples/ota-requestor-app/cyw30739"
 
 declare_args() {
-  setupPinCode = 0
-  setupDiscriminator = 0
+  setupPinCode = 20202021
+  setupDiscriminator = 3840
 }
 
 cyw30739_sdk("sdk") {

--- a/src/include/platform/CHIPDeviceConfig.h
+++ b/src/include/platform/CHIPDeviceConfig.h
@@ -944,6 +944,7 @@
  */
 #ifndef CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_SALT
 #define CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_SALT "U1BBS0UyUCBLZXkgU2FsdA=="
+#define CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_SALT_DEFAULT
 #endif
 
 /**
@@ -955,6 +956,20 @@
  *   The value is base-64 encoded string.
  */
 #ifndef CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_VERIFIER
+
+#if CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE != 20202021
+#error "Non-default Spake2+ passcode configured but verifier left unchanged"
+#endif
+
+#if CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_ITERATION_COUNT != 1000
+#error "Non-default Spake2+ iteration count configured but verifier left unchanged"
+#endif
+
+#ifndef CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_SALT_DEFAULT
+#error "Non-default Spake2+ salt configured but verifier left unchanged"
+#endif
+
+// Generated with: spake2p gen-verifier -o - -i 1000 -s "SPAKE2P Key Salt" -p 20202021
 #define CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_VERIFIER                                                                               \
     "uWFwqugDNGiEck/po7KHwwMwwqZgN10XuyBajPGuyzUEV/iree4lOrao5GuwnlQ65CJzbeUB49s31EH+NEkg0JVI5MGCQGMMT/SRPFNRODm3wH/MBiehuFc6FJ/"  \
     "NH6Rmzw=="


### PR DESCRIPTION
#### Problem
If one changes the test Spake2+ passcode and leaves the verifier unchanged, PASE stops working which causes confusion among people who are not aware that we already use a pre-generated verifier in the code.

#### Change overview
Add an informative error message when only the passcode is changed to help people realize what needs to be done.

#### Testing
CI only.
