### PR TITLE
18158 Followup on fabricTable: DeviceController Setup after Shutdown

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -82,6 +82,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState()
         params.fabricIndependentStorage = mFabricIndependentStorage;
         params.enableServerInteractions = mEnableServerInteractions;
         params.groupDataProvider        = mSystemState->GetGroupDataProvider();
+        params.fabricTable              = mSystemState->Fabrics();
     }
 
     return InitSystemState(params);
@@ -414,6 +415,10 @@ CHIP_ERROR DeviceControllerSystemState::Shutdown()
     {
         chip::Platform::Delete(mTempFabricTable);
         mTempFabricTable = nullptr;
+        // if we created a temp fabric table, then mFabrics points to it.
+        // if we did not create a temp fabric table, then keep the reference
+        // so that SetupController/Commissioner can use it
+        mFabrics = nullptr;
     }
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
* If DeviceControllerFactory SetupController/Commissioner is called after Controller.Shutdown(), a new fabricTable will be created even when a specific fabric table was passed in to the original DeviceControllerFactory.InitSystemState method.

#### Change overview
* Keep track of whether to use a new fabricTable or an existing one in the DeviceControllerSystemState object

#### Testing
* Tested using tv-app, tv-casting-app and chip-tool