### PR TITLE
Update FillNodeDataFromTxt to use the common & commission/operational…

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -80,7 +80,8 @@ static void HandleNodeResolve(void * context, DnssdService * result, const Span<
     {
         ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
         ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
-        FillNodeDataFromTxt(key, val, nodeData);
+        FillNodeDataFromTxt(key, val, nodeData.resolutionData);
+        FillNodeDataFromTxt(key, val, nodeData.commissionData);
     }
 
     proxy->OnNodeDiscovered(nodeData);
@@ -148,7 +149,7 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, const Spa
     {
         ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
         ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
-        FillNodeDataFromTxt(key, val, nodeData);
+        FillNodeDataFromTxt(key, val, nodeData.resolutionData);
     }
 
     nodeData.LogNodeIdResolved();

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -266,13 +266,16 @@ void PacketDataReporter::OnResource(ResourceType type, const ResourceData & data
     case QType::TXT:
         if (mDiscoveryType == DiscoveryType::kCommissionableNode || mDiscoveryType == DiscoveryType::kCommissionerNode)
         {
-            TxtRecordDelegateImpl<DiscoveredNodeData> textRecordDelegate(mDiscoveredNodeData);
-            ParseTxtRecord(data.GetData(), &textRecordDelegate);
+            TxtRecordDelegateImpl<CommonResolutionData> commonDelegate(mDiscoveredNodeData.resolutionData);
+            ParseTxtRecord(data.GetData(), &commonDelegate);
+
+            TxtRecordDelegateImpl<CommissionNodeData> commissionDelegate(mDiscoveredNodeData.commissionData);
+            ParseTxtRecord(data.GetData(), &commissionDelegate);
         }
         else if (mDiscoveryType == DiscoveryType::kOperational)
         {
-            TxtRecordDelegateImpl<ResolvedNodeData> textRecordDelegate(mNodeData);
-            ParseTxtRecord(data.GetData(), &textRecordDelegate);
+            TxtRecordDelegateImpl<CommonResolutionData> commonDelegate(mNodeData.resolutionData);
+            ParseTxtRecord(data.GetData(), &commonDelegate);
         }
         break;
     case QType::A: {

--- a/src/lib/dnssd/TxtFields.cpp
+++ b/src/lib/dnssd/TxtFields.cpp
@@ -195,62 +195,53 @@ TxtFieldKey GetTxtFieldKey(const ByteSpan & key)
 
 } // namespace Internal
 
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, DiscoveredNodeData & nodeData)
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & val, CommissionNodeData & nodeData)
 {
     TxtFieldKey keyType = Internal::GetTxtFieldKey(key);
     switch (keyType)
     {
     case TxtFieldKey::kLongDiscriminator:
-        nodeData.commissionData.longDiscriminator = Internal::GetLongDiscriminator(val);
+        nodeData.longDiscriminator = Internal::GetLongDiscriminator(val);
         break;
     case TxtFieldKey::kVendorProduct:
-        nodeData.commissionData.vendorId  = Internal::GetVendor(val);
-        nodeData.commissionData.productId = Internal::GetProduct(val);
+        nodeData.vendorId  = Internal::GetVendor(val);
+        nodeData.productId = Internal::GetProduct(val);
         break;
     case TxtFieldKey::kCommissioningMode:
-        nodeData.commissionData.commissioningMode = Internal::GetCommissioningMode(val);
+        nodeData.commissioningMode = Internal::GetCommissioningMode(val);
         break;
     case TxtFieldKey::kDeviceType:
-        nodeData.commissionData.deviceType = Internal::GetDeviceType(val);
+        nodeData.deviceType = Internal::GetDeviceType(val);
         break;
     case TxtFieldKey::kDeviceName:
-        Internal::GetDeviceName(val, nodeData.commissionData.deviceName);
+        Internal::GetDeviceName(val, nodeData.deviceName);
         break;
     case TxtFieldKey::kRotatingDeviceId:
-        Internal::GetRotatingDeviceId(val, nodeData.commissionData.rotatingId, &nodeData.commissionData.rotatingIdLen);
+        Internal::GetRotatingDeviceId(val, nodeData.rotatingId, &nodeData.rotatingIdLen);
         break;
     case TxtFieldKey::kPairingInstruction:
-        Internal::GetPairingInstruction(val, nodeData.commissionData.pairingInstruction);
+        Internal::GetPairingInstruction(val, nodeData.pairingInstruction);
         break;
     case TxtFieldKey::kPairingHint:
-        nodeData.commissionData.pairingHint = Internal::GetPairingHint(val);
-        break;
-    case TxtFieldKey::kSleepyIdleInterval:
-        nodeData.resolutionData.mrpRetryIntervalIdle = Internal::GetRetryInterval(val);
-        break;
-    case TxtFieldKey::kSleepyActiveInterval:
-        nodeData.resolutionData.mrpRetryIntervalActive = Internal::GetRetryInterval(val);
-        break;
-    case TxtFieldKey::kTcpSupported:
-        nodeData.resolutionData.supportsTcp = Internal::MakeBoolFromAsciiDecimal(val);
+        nodeData.pairingHint = Internal::GetPairingHint(val);
         break;
     default:
         break;
     }
 }
 
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, ResolvedNodeData & nodeData)
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommonResolutionData & nodeData)
 {
     switch (Internal::GetTxtFieldKey(key))
     {
     case TxtFieldKey::kSleepyIdleInterval:
-        nodeData.resolutionData.mrpRetryIntervalIdle = Internal::GetRetryInterval(value);
+        nodeData.mrpRetryIntervalIdle = Internal::GetRetryInterval(value);
         break;
     case TxtFieldKey::kSleepyActiveInterval:
-        nodeData.resolutionData.mrpRetryIntervalActive = Internal::GetRetryInterval(value);
+        nodeData.mrpRetryIntervalActive = Internal::GetRetryInterval(value);
         break;
     case TxtFieldKey::kTcpSupported:
-        nodeData.resolutionData.supportsTcp = Internal::MakeBoolFromAsciiDecimal(value);
+        nodeData.supportsTcp = Internal::MakeBoolFromAsciiDecimal(value);
         break;
     default:
         break;

--- a/src/lib/dnssd/TxtFields.h
+++ b/src/lib/dnssd/TxtFields.h
@@ -184,8 +184,8 @@ constexpr size_t ValSize(TxtFieldKey key)
     return Internal::txtFieldInfo[static_cast<int>(key)].valMaxSize;
 }
 
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, DiscoveredNodeData & nodeData);
-void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, ResolvedNodeData & nodeData);
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommonResolutionData & nodeData);
+void FillNodeDataFromTxt(const ByteSpan & key, const ByteSpan & value, CommissionNodeData & nodeData);
 
 } // namespace Dnssd
 } // namespace chip

--- a/src/lib/dnssd/tests/TestTxtFields.cpp
+++ b/src/lib/dnssd/tests/TestTxtFields.cpp
@@ -313,7 +313,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Long discriminator
     strcpy(key, "D");
     strcpy(val, "840");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
     NL_TEST_ASSERT(inSuite, filled.commissionData.longDiscriminator == 840);
     filled.commissionData.longDiscriminator = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -321,7 +321,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // vendor and product
     strcpy(key, "VP");
     strcpy(val, "123+456");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
     NL_TEST_ASSERT(inSuite, filled.commissionData.vendorId == 123);
     NL_TEST_ASSERT(inSuite, filled.commissionData.productId == 456);
     filled.commissionData.vendorId  = 0;
@@ -331,7 +331,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Commissioning mode
     strcpy(key, "CM");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
     NL_TEST_ASSERT(inSuite, filled.commissionData.commissioningMode == 1);
     filled.commissionData.commissioningMode = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -339,7 +339,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Device type
     strcpy(key, "DT");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
     NL_TEST_ASSERT(inSuite, filled.commissionData.deviceType == 1);
     filled.commissionData.deviceType = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -347,7 +347,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Device name
     strcpy(key, "DN");
     strcpy(val, "abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
     NL_TEST_ASSERT(inSuite, strcmp(filled.commissionData.deviceName, "abc") == 0);
     memset(filled.commissionData.deviceName, 0, sizeof(filled.commissionData.deviceName));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -355,7 +355,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Rotating device id
     strcpy(key, "RI");
     strcpy(val, "1A2B");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
     NL_TEST_ASSERT(inSuite, filled.commissionData.rotatingId[0] == 0x1A);
     NL_TEST_ASSERT(inSuite, filled.commissionData.rotatingId[1] == 0x2B);
     NL_TEST_ASSERT(inSuite, filled.commissionData.rotatingIdLen == 2);
@@ -366,7 +366,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Pairing instruction
     strcpy(key, "PI");
     strcpy(val, "hint");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
     NL_TEST_ASSERT(inSuite, strcmp(filled.commissionData.pairingInstruction, "hint") == 0);
     memset(filled.commissionData.pairingInstruction, 0, sizeof(filled.commissionData.pairingInstruction));
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -374,7 +374,7 @@ void TestFillDiscoveredNodeDataFromTxt(nlTestSuite * inSuite, void * inContext)
     // Pairing hint
     strcpy(key, "PH");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), filled.commissionData);
     NL_TEST_ASSERT(inSuite, filled.commissionData.pairingHint == 1);
     filled.commissionData.pairingHint = 0;
     NL_TEST_ASSERT(inSuite, NodeDataIsEmpty(filled));
@@ -418,14 +418,14 @@ void TxtFieldSleepyIdleInterval(nlTestSuite * inSuite, void * inContext)
     // Minimum
     strcpy(key, "SII");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryIntervalIdle().Value() == 1_ms32);
 
     // Maximum
     strcpy(key, "SII");
     strcpy(val, "3600000");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryIntervalIdle().Value() == 3600000_ms32);
 
@@ -436,37 +436,37 @@ void TxtFieldSleepyIdleInterval(nlTestSuite * inSuite, void * inContext)
     // Invalid SII - negative value
     strcpy(key, "SII");
     strcpy(val, "-1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - greater than maximum
     strcpy(key, "SII");
     strcpy(val, "3600001");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - much greater than maximum
     strcpy(key, "SII");
     strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - hexadecimal value
     strcpy(key, "SII");
     strcpy(val, "0x20");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - leading zeros
     strcpy(key, "SII");
     strcpy(val, "0700");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
 
     // Invalid SII - text at the end
     strcpy(key, "SII");
     strcpy(val, "123abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalIdle().HasValue());
 }
 
@@ -481,14 +481,14 @@ void TxtFieldSleepyActiveInterval(nlTestSuite * inSuite, void * inContext)
     // Minimum
     strcpy(key, "SAI");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryIntervalActive().Value() == 1_ms32);
 
     // Maximum
     strcpy(key, "SAI");
     strcpy(val, "3600000");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.GetMrpRetryIntervalActive().Value() == 3600000_ms32);
 
@@ -499,37 +499,37 @@ void TxtFieldSleepyActiveInterval(nlTestSuite * inSuite, void * inContext)
     // Invalid SAI - negative value
     strcpy(key, "SAI");
     strcpy(val, "-1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - greater than maximum
     strcpy(key, "SAI");
     strcpy(val, "3600001");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - much greater than maximum
     strcpy(key, "SAI");
     strcpy(val, "1095216660481"); // 0xFF00000001 == 1 (mod 2^32)
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - hexadecimal value
     strcpy(key, "SAI");
     strcpy(val, "0x20");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - leading zeros
     strcpy(key, "SAI");
     strcpy(val, "0700");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
 
     // Invalid SAI - text at the end
     strcpy(key, "SAI");
     strcpy(val, "123abc");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.GetMrpRetryIntervalActive().HasValue());
 }
 
@@ -544,7 +544,7 @@ void TxtFieldTcpSupport(nlTestSuite * inSuite, void * inContext)
     // True
     strcpy(key, "T");
     strcpy(val, "1");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.supportsTcp);
 
     // Test no other fields were populated
@@ -554,13 +554,13 @@ void TxtFieldTcpSupport(nlTestSuite * inSuite, void * inContext)
     // False
     strcpy(key, "T");
     strcpy(val, "0");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.supportsTcp == false);
 
     // Invalid value, stil false
     strcpy(key, "T");
     strcpy(val, "asdf");
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.supportsTcp == false);
 }
 
@@ -580,13 +580,13 @@ void TestIsDeviceSleepyIdle(nlTestSuite * inSuite, void * inContext)
     // If the interval is the default value, the device is not sleepy
     strcpy(key, "SII");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count()));
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     sprintf(key, "SII");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_DEFAULT_IDLE_RETRY_INTERVAL.count() + 1));
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 
@@ -606,13 +606,13 @@ void TestIsDeviceSleepyActive(nlTestSuite * inSuite, void * inContext)
     // If the interval is the default value, the device is not sleepy
     sprintf(key, "SAI");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL.count()));
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, !nodeData.resolutionData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 
     // If the interval is greater than the default value, the device is sleepy
     strcpy(key, "SAI");
     sprintf(val, "%d", static_cast<int>(CHIP_CONFIG_MRP_DEFAULT_ACTIVE_RETRY_INTERVAL.count() + 1));
-    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData);
+    FillNodeDataFromTxt(GetSpan(key), GetSpan(val), nodeData.resolutionData);
     NL_TEST_ASSERT(inSuite, nodeData.resolutionData.IsDeviceTreatedAsSleepy(&defaultMRPConfig));
 }
 


### PR DESCRIPTION
… split for discovery data

#### Problem
Filling text fields requires separate structures that include common code. This duplicates logic (same sleepy parsing occurs in two separate places) and makes the code more complex than it should.

This is part of working on #18256 - want to split txt record parsing so it can be used by common resolution logic.

#### Change overview
Use separate parsing for "common" and "commission" data parsing.

Mostly a NOOP except that commission parsing will do a 2-pass iteration in minmdns to fill up both common and commissioning parsing (this was previously done in one step).

#### Testing
Unit tests updated. CI will validate discovery and commissioning.
