### PR TITLE
[CI] Add a test for successful OTA transfer

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -89,6 +89,8 @@ jobs:
                         --target darwin-x64-chip-tool-darwin-${BUILD_VARIANT} \
                         --target darwin-x64-all-clusters-${BUILD_VARIANT} \
                         --target darwin-x64-lock-${BUILD_VARIANT} \
+                        --target darwin-x64-ota-provider-${BUILD_VARIANT} \
+                        --target darwin-x64-ota-requestor-${BUILD_VARIANT} \
                         --target darwin-x64-tv-app-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
@@ -104,6 +106,8 @@ jobs:
                      --iterations 1 \
                      --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
                      --lock-app ./out/darwin-x64-lock-${BUILD_VARIANT}/chip-lock-app \
+                     --ota-provider-app ./out/darwin-x64-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
+                     --ota-requestor-app ./out/darwin-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
                      --tv-app ./out/darwin-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
                   "
             - name: Uploading core files

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
     test_suites_linux:
         name: Test Suites - Linux
-        timeout-minutes: 120
+        timeout-minutes: 130
 
         strategy:
             matrix:
@@ -76,13 +76,15 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Apps
-              timeout-minutes: 30
+              timeout-minutes: 40
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
                         --target linux-x64-all-clusters-${BUILD_VARIANT} \
                         --target linux-x64-lock-${BUILD_VARIANT} \
+                        --target linux-x64-ota-provider-${BUILD_VARIANT} \
+                        --target linux-x64-ota-requestor-${BUILD_VARIANT} \
                         --target linux-x64-tv-app-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
@@ -97,6 +99,8 @@ jobs:
                      --iterations 1 \
                      --all-clusters-app ./out/linux-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
                      --lock-app ./out/linux-x64-lock-${BUILD_VARIANT}/chip-lock-app \
+                     --ota-provider-app ./out/linux-x64-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
+                     --ota-requestor-app ./out/linux-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
                      --tv-app ./out/linux-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
                   "
             - name: Uploading core files
@@ -117,7 +121,7 @@ jobs:
                   retention-days: 5
     test_suites_darwin:
         name: Test Suites - Darwin
-        timeout-minutes: 120
+        timeout-minutes: 130
 
         strategy:
             matrix:
@@ -172,13 +176,15 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Apps
-              timeout-minutes: 30
+              timeout-minutes: 40
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target darwin-x64-chip-tool${CHIP_TOOL_VARIANT}-${BUILD_VARIANT} \
                         --target darwin-x64-all-clusters-${BUILD_VARIANT} \
                         --target darwin-x64-lock-${BUILD_VARIANT} \
+                        --target darwin-x64-ota-provider-${BUILD_VARIANT} \
+                        --target darwin-x64-ota-requestor-${BUILD_VARIANT} \
                         --target darwin-x64-tv-app-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
@@ -194,6 +200,8 @@ jobs:
                      --iterations 1 \
                      --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
                      --lock-app ./out/darwin-x64-lock-${BUILD_VARIANT}/chip-lock-app \
+                     --ota-provider-app ./out/darwin-x64-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
+                     --ota-requestor-app ./out/darwin-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
                      --tv-app ./out/darwin-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
                   "
             - name: Uploading core files

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -28,7 +28,7 @@ concurrency:
 jobs:
     test_suites_linux:
         name: Test Suites - Linux
-        timeout-minutes: 130
+        timeout-minutes: 120
 
         strategy:
             matrix:
@@ -76,7 +76,7 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Apps
-              timeout-minutes: 40
+              timeout-minutes: 30
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
@@ -121,7 +121,7 @@ jobs:
                   retention-days: 5
     test_suites_darwin:
         name: Test Suites - Darwin
-        timeout-minutes: 130
+        timeout-minutes: 120
 
         strategy:
             matrix:
@@ -176,7 +176,7 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Apps
-              timeout-minutes: 40
+              timeout-minutes: 30
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \

--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -34,6 +34,8 @@ def AllTests(chip_tool: str):
             target = TestTarget.TV
         elif name.startswith('DL_'):
             target = TestTarget.LOCK
+        elif name.startswith('OTA_'):
+            target = TestTarget.OTA
         else:
             target = TestTarget.ALL_CLUSTERS
 

--- a/scripts/tests/chiptest/accessories.py
+++ b/scripts/tests/chiptest/accessories.py
@@ -64,7 +64,7 @@ class AppsRegister:
     def start(self, name, args):
         accessory = self.__accessories[name]
         if accessory:
-            # The args param comes directly from the sys.argv[1:] of Start.py and should contain a list of strings in
+            # The args param comes directly from the sys.argv[2:] of Start.py and should contain a list of strings in
             # key-value pair, e.g. [option1, value1, option2, value2, ...]
             options = self.__createCommandLineOptions(args)
             return accessory.start(options)
@@ -104,6 +104,14 @@ class AppsRegister:
             return accessory.waitForOperationalAdvertisement()
         return False
 
+    def waitForMessage(self, name, message):
+        accessory = self.__accessories[name]
+        if accessory:
+            # The message param comes directly from the sys.argv[2:] of WaitForMessage.py and should contain a list of strings that
+            # comprise the entire message to wait for
+            return accessory.waitForMessage(' '.join(message))
+        return False
+
     def __startXMLRPCServer(self):
         self.server = SimpleXMLRPCServer((IP, PORT))
 
@@ -117,6 +125,9 @@ class AppsRegister:
         self.server.register_function(
             self.waitForOperationalAdvertisement,
             'waitForOperationalAdvertisement')
+        self.server.register_function(
+            self.waitForMessage,
+            'waitForMessage')
 
         self.server_thread = threading.Thread(target=self.server.serve_forever)
         self.server_thread.start()

--- a/scripts/tests/chiptest/linux.py
+++ b/scripts/tests/chiptest/linux.py
@@ -145,5 +145,7 @@ def PathsWithNetworkNamespaces(paths: ApplicationPaths) -> ApplicationPaths:
         chip_tool='ip netns exec tool'.split() + paths.chip_tool,
         all_clusters_app='ip netns exec app'.split() + paths.all_clusters_app,
         lock_app='ip netns exec app'.split() + paths.lock_app,
+        ota_provider_app='ip netns exec app'.split() + paths.ota_provider_app,
+        ota_requestor_app='ip netns exec app'.split() + paths.ota_requestor_app,
         tv_app='ip netns exec app'.split() + paths.tv_app,
     )

--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -89,6 +89,10 @@ class App:
                        self.process, self.outpipe)
         return True
 
+    def waitForMessage(self, message):
+        self.__waitFor(message, self.process, self.outpipe)
+        return True
+
     def kill(self):
         if self.process:
             self.process.kill()
@@ -154,6 +158,7 @@ class TestTarget(Enum):
     ALL_CLUSTERS = auto()
     TV = auto()
     LOCK = auto()
+    OTA = auto()
 
 
 @dataclass
@@ -161,10 +166,12 @@ class ApplicationPaths:
     chip_tool: typing.List[str]
     all_clusters_app: typing.List[str]
     lock_app: typing.List[str]
+    ota_provider_app: typing.List[str]
+    ota_requestor_app: typing.List[str]
     tv_app: typing.List[str]
 
     def items(self):
-        return [self.chip_tool, self.all_clusters_app, self.lock_app, self.tv_app]
+        return [self.chip_tool, self.all_clusters_app, self.lock_app, self.ota_provider_app, self.ota_requestor_app, self.tv_app]
 
 
 @dataclass
@@ -225,6 +232,8 @@ class TestDefinition:
                 target_app = paths.tv_app
             elif self.target == TestTarget.LOCK:
                 target_app = paths.lock_app
+            elif self.target == TestTarget.OTA:
+                target_app = paths.ota_requestor_app
             else:
                 raise Exception("Unknown test target - "
                                 "don't know which application to run")

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -172,6 +172,12 @@ def cmd_list(context):
     '--lock-app',
     help='what lock app to use')
 @click.option(
+    '--ota-provider-app',
+    help='what ota provider app to use')
+@click.option(
+    '--ota-requestor-app',
+    help='what ota requestor app to use')
+@click.option(
     '--tv-app',
     help='what tv app to use')
 @click.option(
@@ -180,7 +186,7 @@ def cmd_list(context):
     default="src/app/tests/suites/certification/ci-pics-values",
     help='PICS file to use for test runs.')
 @click.pass_context
-def cmd_run(context, iterations, all_clusters_app, lock_app, tv_app, pics_file):
+def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, ota_requestor_app, tv_app, pics_file):
     runner = chiptest.runner.Runner()
 
     if all_clusters_app is None:
@@ -188,6 +194,12 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, tv_app, pics_file):
 
     if lock_app is None:
         lock_app = FindBinaryPath('chip-lock-app')
+
+    if ota_provider_app is None:
+        ota_provider_app = FindBinaryPath('chip-ota-provider-app')
+
+    if ota_requestor_app is None:
+        ota_requestor_app = FindBinaryPath('chip-ota-requestor-app')
 
     if tv_app is None:
         tv_app = FindBinaryPath('chip-tv-app')
@@ -197,6 +209,8 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, tv_app, pics_file):
         chip_tool=[context.obj.chip_tool],
         all_clusters_app=[all_clusters_app],
         lock_app=[lock_app],
+        ota_provider_app=[ota_provider_app],
+        ota_requestor_app=[ota_requestor_app],
         tv_app=[tv_app]
     )
 

--- a/src/app/tests/suites/OTA_SuccessfulTransfer.yaml
+++ b/src/app/tests/suites/OTA_SuccessfulTransfer.yaml
@@ -1,0 +1,177 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Test OTA Software Update Successful Transfer
+
+config:
+    endpoint: 0
+    requestorNodeId:
+        type: NODE_ID
+        defaultValue: 0x12344321
+    providerNodeId:
+        type: NODE_ID
+        defaultValue: 0xC0FFEE
+    providerPayload:
+        type: CHAR_STRING
+        defaultValue: "MT:-24J0IX4122-.548G00" # This value needs to be generated
+    providerDiscriminator:
+        type: INT16U
+        defaultValue: 50
+    providerPort:
+        type: INT16U
+        defaultValue: 5560
+    providerKvs:
+        type: CHAR_STRING
+        defaultValue: "/tmp/chip_kvs_provider"
+    otaImageFilePath:
+        type: CHAR_STRING
+        defaultValue: "/tmp/otaImage"
+    rawImageFilePath:
+        type: CHAR_STRING
+        defaultValue: "/tmp/rawImage"
+    rawImageContent:
+        type: CHAR_STRING
+        defaultValue: "Have a hootenanny!"
+    downloadImageFilePath:
+        type: CHAR_STRING
+        defaultValue: "/tmp/downloadedImage"
+
+tests:
+    - label: "Create OTA image"
+      cluster: "SystemCommands"
+      command: "CreateOtaImage"
+      arguments:
+          values:
+              - name: "otaImageFilePath"
+                value: otaImageFilePath
+              - name: "rawImageFilePath"
+                value: rawImageFilePath
+              - name: "rawImageContent"
+                value: rawImageContent
+
+    - label: "Start the provider with an image"
+      cluster: "SystemCommands"
+      command: "Start"
+      arguments:
+          values:
+              - name: "registerKey"
+                value: "chip-ota-provider-app"
+              - name: "discriminator"
+                value: providerDiscriminator
+              - name: "port"
+                value: providerPort
+              - name: "kvs"
+                value: providerKvs
+              - name: "filepath"
+                value: otaImageFilePath
+
+    - label: "Commission the provider from alpha"
+      identity: "alpha"
+      cluster: "CommissionerCommands"
+      command: "PairWithQRCode"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: providerNodeId
+              - name: "payload"
+                value: providerPayload
+
+    - label: "Wait for the commissioned provider to be retrieved for alpha"
+      identity: "alpha"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: providerNodeId
+
+    - label: "Install ACL for QueryImage"
+      cluster: "Access Control"
+      command: "writeAttribute"
+      attribute: "ACL"
+      arguments:
+          value: [
+                  # Grant administer privilege to the default controller node ID 112233
+                  {
+                      FabricIndex: 1,
+                      Privilege: 5,
+                      AuthMode: 2,
+                      Subjects: [112233],
+                      Targets: null,
+                  },
+                  # Grant operate privileges to all nodes for the OTA Provider cluster on every endpoint
+                  {
+                      FabricIndex: 1,
+                      Privilege: 3,
+                      AuthMode: 2,
+                      Subjects: null,
+                      Targets: null,
+                      [{ Cluster: 41, Endpoint: null, DeviceType: null }],
+                  },
+              ]
+
+    - label: "Stop the requestor"
+      cluster: "SystemCommands"
+      command: "Stop"
+
+    - label: "Start the requestor with an OTA download path"
+      cluster: "SystemCommands"
+      command: "Start"
+      arguments:
+          values:
+              - name: "otaDownloadPath"
+                value: downloadImageFilePath
+
+    - label: "Wait for the commissioned requestor to be retrieved for alpha"
+      identity: "alpha"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: requestorNodeId
+
+    - label: "Send an announce OTA provider command to the requestor"
+      cluster: "OTA Software Update Requestor"
+      command: "AnnounceOtaProvider"
+      arguments:
+          values:
+              - name: "providerNodeId"
+                value: providerNodeId
+              - name: "vendorId"
+                value: 0
+              - name: "announcementReason"
+                value: 0
+              - name: "endpoint"
+                value: endpoint
+
+    - label: "Wait for transfer complete message"
+      cluster: "DelayCommands"
+      command: "WaitForMessage"
+      arguments:
+          values:
+              - name: "registerKey"
+                value: "default"
+              - name: "message"
+                value: "OTA image downloaded"
+
+    - label: "Compare original file to downloaded file"
+      cluster: "SystemCommands"
+      command: "CompareFiles"
+      arguments:
+          values:
+              - name: "file1"
+                value: rawImageFilePath
+              - name: "file2"
+                value: downloadImageFilePath

--- a/src/app/tests/suites/commands/delay/DelayCommands.cpp
+++ b/src/app/tests/suites/commands/delay/DelayCommands.cpp
@@ -26,6 +26,8 @@ const char * getScriptsFolder()
 }
 } // namespace
 
+constexpr const char * kDefaultKey = "default";
+
 CHIP_ERROR DelayCommands::WaitForMs(const char * identity,
                                     const chip::app::Clusters::DelayCommands::Commands::WaitForMs::Type & value)
 {
@@ -58,6 +60,24 @@ CHIP_ERROR DelayCommands::WaitForOperationalAdvertisement(
 
     char command[128];
     VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s", scriptDir, scriptName) >= 0, CHIP_ERROR_INTERNAL);
+    return RunInternal(command);
+}
+
+CHIP_ERROR DelayCommands::WaitForMessage(const char * identity,
+                                         const chip::app::Clusters::DelayCommands::Commands::WaitForMessage::Type & value)
+{
+    VerifyOrReturnError(!value.message.empty(), CHIP_ERROR_INVALID_ARGUMENT);
+
+    const char * scriptDir            = getScriptsFolder();
+    constexpr const char * scriptName = "WaitForMessage.py";
+    const char * registerKeyValue     = value.registerKey.HasValue() ? value.registerKey.Value().data() : kDefaultKey;
+    const size_t registerKeyLen       = value.registerKey.HasValue() ? value.registerKey.Value().size() : strlen(kDefaultKey);
+
+    char command[128];
+    VerifyOrReturnError(snprintf(command, sizeof(command), "%s%s %.*s %.*s", scriptDir, scriptName,
+                                 static_cast<int>(registerKeyLen), registerKeyValue, static_cast<int>(value.message.size()),
+                                 value.message.data()) >= 0,
+                        CHIP_ERROR_INTERNAL);
     return RunInternal(command);
 }
 

--- a/src/app/tests/suites/commands/delay/DelayCommands.h
+++ b/src/app/tests/suites/commands/delay/DelayCommands.h
@@ -49,6 +49,8 @@ public:
         const chip::app::Clusters::DelayCommands::Commands::WaitForCommissionableAdvertisement::Type & value);
     CHIP_ERROR WaitForOperationalAdvertisement(
         const char * identity, const chip::app::Clusters::DelayCommands::Commands::WaitForOperationalAdvertisement::Type & value);
+    // Wait for any message specified by value.message for the application specified by value.registerKey
+    // If the message is never seen, a timeout would occur
     CHIP_ERROR WaitForMessage(const char * identity,
                               const chip::app::Clusters::DelayCommands::Commands::WaitForMessage::Type & value);
 

--- a/src/app/tests/suites/commands/delay/DelayCommands.h
+++ b/src/app/tests/suites/commands/delay/DelayCommands.h
@@ -49,6 +49,8 @@ public:
         const chip::app::Clusters::DelayCommands::Commands::WaitForCommissionableAdvertisement::Type & value);
     CHIP_ERROR WaitForOperationalAdvertisement(
         const char * identity, const chip::app::Clusters::DelayCommands::Commands::WaitForOperationalAdvertisement::Type & value);
+    CHIP_ERROR WaitForMessage(const char * identity,
+                              const chip::app::Clusters::DelayCommands::Commands::WaitForMessage::Type & value);
 
     // Busy-wait for a given duration in milliseconds
     CHIP_ERROR BusyWaitFor(chip::System::Clock::Milliseconds32 durationInMs);

--- a/src/app/tests/suites/commands/delay/scripts/WaitForMessage.py
+++ b/src/app/tests/suites/commands/delay/scripts/WaitForMessage.py
@@ -23,5 +23,11 @@ PORT = 9000
 if sys.platform == 'linux':
     IP = '10.10.10.5'
 
-with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
-    proxy.waitForMessage(sys.argv[1], sys.argv[2:])
+
+def main():
+    with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
+        proxy.waitForMessage(sys.argv[1], sys.argv[2:])
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/tests/suites/commands/delay/scripts/WaitForMessage.py
+++ b/src/app/tests/suites/commands/delay/scripts/WaitForMessage.py
@@ -1,0 +1,27 @@
+#!/usr/bin/env -S python3 -B
+
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import sys
+import xmlrpc.client
+
+IP = '127.0.0.1'
+PORT = 9000
+
+if sys.platform == 'linux':
+    IP = '10.10.10.5'
+
+with xmlrpc.client.ServerProxy('http://' + IP + ':' + str(PORT) + '/', allow_none=True) as proxy:
+    proxy.waitForMessage(sys.argv[1], sys.argv[2:])

--- a/src/app/tests/suites/commands/system/SystemCommands.h
+++ b/src/app/tests/suites/commands/system/SystemCommands.h
@@ -35,8 +35,12 @@ public:
     CHIP_ERROR Stop(const char * identity, const chip::app::Clusters::SystemCommands::Commands::Stop::Type & value);
     CHIP_ERROR Reboot(const char * identity, const chip::app::Clusters::SystemCommands::Commands::Reboot::Type & value);
     CHIP_ERROR FactoryReset(const char * identity, const chip::app::Clusters::SystemCommands::Commands::FactoryReset::Type & value);
+    CHIP_ERROR CreateOtaImage(const char * identity,
+                              const chip::app::Clusters::SystemCommands::Commands::CreateOtaImage::Type & value);
+    CHIP_ERROR CompareFiles(const char * identity, const chip::app::Clusters::SystemCommands::Commands::CompareFiles::Type & value);
 
 private:
     CHIP_ERROR RunInternal(const char * scriptName, const chip::Optional<chip::CharSpan> registerKey);
     CHIP_ERROR RunInternal(const char * command);
+    CHIP_ERROR AddSystemCommandArgument(chip::StringBuilderBase & builder, const char * argName, const chip::CharSpan & argValue);
 };

--- a/src/app/tests/suites/commands/system/scripts/CompareFiles.py
+++ b/src/app/tests/suites/commands/system/scripts/CompareFiles.py
@@ -20,5 +20,11 @@ import sys
 file1 = sys.argv[1]
 file2 = sys.argv[2]
 
-if filecmp.cmp(file1, file2, shallow=False) is False:
-    raise Exception('Files %s and %s do not match' % (file1, file2))
+
+def main():
+    if filecmp.cmp(file1, file2, shallow=False) is False:
+        raise Exception('Files %s and %s do not match' % (file1, file2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/tests/suites/commands/system/scripts/CompareFiles.py
+++ b/src/app/tests/suites/commands/system/scripts/CompareFiles.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env -S python3 -B
+
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import filecmp
+import sys
+
+file1 = sys.argv[1]
+file2 = sys.argv[2]
+
+if filecmp.cmp(file1, file2, shallow=False) is False:
+    raise Exception('Files %s and %s do not match' % (file1, file2))

--- a/src/app/tests/suites/commands/system/scripts/CreateOtaImage.py
+++ b/src/app/tests/suites/commands/system/scripts/CreateOtaImage.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env -S python3 -B
+
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import subprocess
+import sys
+
+DEFAULT_CHIP_ROOT = os.path.abspath(
+    os.path.join(os.path.dirname(__file__), '..', '..', '..', '..', '..', '..', '..'))
+
+otaImageFilePath = sys.argv[1]
+rawImageFilePath = sys.argv[2]
+rawImageContent = ' '.join(sys.argv[3:])
+
+# Write the raw image content
+with open(rawImageFilePath, 'w') as rawFile:
+    rawFile.write(rawImageContent)
+
+# Add an OTA header to the raw file
+otaImageTool = DEFAULT_CHIP_ROOT + '/src/app/ota_image_tool.py'
+cmd = [otaImageTool, 'create', '-v', '0xDEAD', '-p', '0xBEEF', '-vn', '2',
+       '-vs', "2.0", '-da', 'sha256', rawImageFilePath, otaImageFilePath]
+s = subprocess.Popen(cmd)
+s.wait()
+if s.returncode != 0:
+    raise Exception('Cannot create OTA image file')

--- a/src/app/tests/suites/commands/system/scripts/CreateOtaImage.py
+++ b/src/app/tests/suites/commands/system/scripts/CreateOtaImage.py
@@ -25,15 +25,21 @@ otaImageFilePath = sys.argv[1]
 rawImageFilePath = sys.argv[2]
 rawImageContent = ' '.join(sys.argv[3:])
 
-# Write the raw image content
-with open(rawImageFilePath, 'w') as rawFile:
-    rawFile.write(rawImageContent)
 
-# Add an OTA header to the raw file
-otaImageTool = DEFAULT_CHIP_ROOT + '/src/app/ota_image_tool.py'
-cmd = [otaImageTool, 'create', '-v', '0xDEAD', '-p', '0xBEEF', '-vn', '2',
-       '-vs', "2.0", '-da', 'sha256', rawImageFilePath, otaImageFilePath]
-s = subprocess.Popen(cmd)
-s.wait()
-if s.returncode != 0:
-    raise Exception('Cannot create OTA image file')
+def main():
+    # Write the raw image content
+    with open(rawImageFilePath, 'w') as rawFile:
+        rawFile.write(rawImageContent)
+
+    # Add an OTA header to the raw file
+    otaImageTool = DEFAULT_CHIP_ROOT + '/src/app/ota_image_tool.py'
+    cmd = [otaImageTool, 'create', '-v', '0xDEAD', '-p', '0xBEEF', '-vn', '2',
+           '-vs', "2.0", '-da', 'sha256', rawImageFilePath, otaImageFilePath]
+    s = subprocess.Popen(cmd)
+    s.wait()
+    if s.returncode != 0:
+        raise Exception('Cannot create OTA image file')
+
+
+if __name__ == "__main__":
+    main()

--- a/src/app/tests/suites/tests.js
+++ b/src/app/tests/suites/tests.js
@@ -28,8 +28,7 @@ function disable(testName)
 
 // clang-format off
 
-function getManualTests()
-{
+function getManualTests() {
   const DeviceDiscovery = [
     'Test_TC_DD_1_5',
     'Test_TC_DD_1_6',
@@ -451,8 +450,7 @@ function getManualTests()
   return tests;
 }
 
-function getTests()
-{
+function getTests() {
   const AccessControl = [
     'TestAccessControlCluster',
   ];
@@ -604,6 +602,10 @@ function getTests()
     'Test_TC_MF_1_5',
     'Test_TC_MF_1_6',
     'Test_TC_MF_1_15',
+  ];
+
+  const OTASoftwareUpdate = [
+    'OTA_SuccessfulTransfer',
   ];
 
   const OnOff = [
@@ -785,6 +787,7 @@ function getTests()
     MediaControl,
     ModeSelect,
     MultipleFabrics,
+    OTASoftwareUpdate,
     OccupancySensing,
     OnOff,
     PowerSource,

--- a/src/app/zap-templates/common/simulated-clusters/clusters/DelayCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/DelayCommands.js
@@ -46,9 +46,16 @@ const WaitForOperationalAdvertisement = {
   name : 'WaitForOperationalAdvertisement',
 };
 
-const name = 'DelayCommands';
-const commands =
-    [ WaitForMs, WaitForCommissioning, WaitForCommissionee, WaitForCommissionableAdvertisement, WaitForOperationalAdvertisement ];
+const WaitForMessage = {
+  name : 'WaitForMessage',
+  arguments : [ { type : 'CHAR_STRING', name : 'registerKey', isOptional : true }, { type : 'CHAR_STRING', name : 'message' } ],
+};
+
+const name     = 'DelayCommands';
+const commands = [
+  WaitForMs, WaitForCommissioning, WaitForCommissionee, WaitForCommissionableAdvertisement, WaitForOperationalAdvertisement,
+  WaitForMessage
+];
 
 const DelayCommands = {
   name,

--- a/src/app/zap-templates/common/simulated-clusters/clusters/SystemCommands.js
+++ b/src/app/zap-templates/common/simulated-clusters/clusters/SystemCommands.js
@@ -27,10 +27,14 @@
 const Start = {
   name : 'Start',
   arguments : [
+    { 'name' : 'registerKey', type : 'CHAR_STRING', isOptional : true },
     { 'name' : 'discriminator', type : 'INT16U', isOptional : true }, { 'name' : 'port', type : 'INT16U', isOptional : true },
     { 'name' : 'kvs', type : 'CHAR_STRING', isOptional : true },
     { 'name' : 'minCommissioningTimeout', type : 'INT16U', isOptional : true },
-    { 'name' : 'registerKey', type : 'CHAR_STRING', isOptional : true }
+    // OTA provider specific arguments
+    { 'name' : 'filepath', type : 'CHAR_STRING', isOptional : true },
+    // OTA requestor specific arguments
+    { 'name' : 'otaDownloadPath', type : 'CHAR_STRING', isOptional : true }
   ],
 };
 
@@ -49,9 +53,22 @@ const FactoryReset = {
   arguments : [ { 'name' : 'registerKey', type : 'CHAR_STRING', isOptional : true } ],
 };
 
+const CreateOtaImage = {
+  name : 'CreateOtaImage',
+  arguments : [
+    { 'name' : 'otaImageFilePath', type : 'CHAR_STRING' }, { 'name' : 'rawImageFilePath', type : 'CHAR_STRING' },
+    { 'name' : 'rawImageContent', type : 'CHAR_STRING' }
+  ],
+};
+
+const CompareFiles = {
+  name : 'CompareFiles',
+  arguments : [ { 'name' : 'file1', type : 'CHAR_STRING' }, { 'name' : 'file2', type : 'CHAR_STRING' } ],
+};
+
 const SystemCommands = {
   name : 'SystemCommands',
-  commands : [ Start, Stop, Reboot, FactoryReset ],
+  commands : [ Start, Stop, Reboot, FactoryReset, CreateOtaImage, CompareFiles ],
 };
 
 //

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -129,6 +129,7 @@ public:
         printf("Test_TC_MF_1_5\n");
         printf("Test_TC_MF_1_6\n");
         printf("Test_TC_MF_1_15\n");
+        printf("OTA_SuccessfulTransfer\n");
         printf("Test_TC_OCC_1_1\n");
         printf("Test_TC_OCC_2_1\n");
         printf("Test_TC_OCC_2_2\n");
@@ -22785,6 +22786,241 @@ private:
             return SendCommand(kIdentityBeta, GetEndpoint(0), AdministratorCommissioning::Id,
                                AdministratorCommissioning::Commands::OpenCommissioningWindow::Id, value,
                                chip::Optional<uint16_t>(10000));
+        }
+        }
+        return CHIP_NO_ERROR;
+    }
+};
+
+class OTA_SuccessfulTransferSuite : public TestCommand
+{
+public:
+    OTA_SuccessfulTransferSuite(CredentialIssuerCommands * credsIssuerConfig) :
+        TestCommand("OTA_SuccessfulTransfer", 11, credsIssuerConfig)
+    {
+        AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
+        AddArgument("requestorNodeId", 0, UINT64_MAX, &mRequestorNodeId);
+        AddArgument("providerNodeId", 0, UINT64_MAX, &mProviderNodeId);
+        AddArgument("providerPayload", &mProviderPayload);
+        AddArgument("providerDiscriminator", 0, UINT16_MAX, &mProviderDiscriminator);
+        AddArgument("providerPort", 0, UINT16_MAX, &mProviderPort);
+        AddArgument("providerKvs", &mProviderKvs);
+        AddArgument("otaImageFilePath", &mOtaImageFilePath);
+        AddArgument("rawImageFilePath", &mRawImageFilePath);
+        AddArgument("rawImageContent", &mRawImageContent);
+        AddArgument("downloadImageFilePath", &mDownloadImageFilePath);
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
+    }
+
+    ~OTA_SuccessfulTransferSuite() {}
+
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mTimeout.ValueOr(kTimeoutInSeconds));
+    }
+
+private:
+    chip::Optional<chip::EndpointId> mEndpoint;
+    chip::Optional<chip::NodeId> mRequestorNodeId;
+    chip::Optional<chip::NodeId> mProviderNodeId;
+    chip::Optional<chip::CharSpan> mProviderPayload;
+    chip::Optional<uint16_t> mProviderDiscriminator;
+    chip::Optional<uint16_t> mProviderPort;
+    chip::Optional<chip::CharSpan> mProviderKvs;
+    chip::Optional<chip::CharSpan> mOtaImageFilePath;
+    chip::Optional<chip::CharSpan> mRawImageFilePath;
+    chip::Optional<chip::CharSpan> mRawImageContent;
+    chip::Optional<chip::CharSpan> mDownloadImageFilePath;
+    chip::Optional<uint16_t> mTimeout;
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
+
+    //
+    // Tests methods
+    //
+
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
+    {
+        bool shouldContinue = false;
+
+        switch (mTestIndex - 1)
+        {
+        case 0:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 1:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 2:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 3:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 4:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 5:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 6:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 7:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 8:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 9:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 10:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
+    }
+
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
+    {
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        case 0: {
+            LogStep(0, "Create OTA image");
+            chip::app::Clusters::SystemCommands::Commands::CreateOtaImage::Type value;
+            value.otaImageFilePath =
+                mOtaImageFilePath.HasValue() ? mOtaImageFilePath.Value() : chip::Span<const char>("/tmp/otaImage", 13);
+            value.rawImageFilePath =
+                mRawImageFilePath.HasValue() ? mRawImageFilePath.Value() : chip::Span<const char>("/tmp/rawImage", 13);
+            value.rawImageContent =
+                mRawImageContent.HasValue() ? mRawImageContent.Value() : chip::Span<const char>("Have a hootenanny!", 18);
+            return CreateOtaImage(kIdentityAlpha, value);
+        }
+        case 1: {
+            LogStep(1, "Start the provider with an image");
+            chip::app::Clusters::SystemCommands::Commands::Start::Type value;
+            value.registerKey.Emplace();
+            value.registerKey.Value() = chip::Span<const char>("chip-ota-provider-appgarbage: not in length on purpose", 21);
+            value.discriminator.Emplace();
+            value.discriminator.Value() = mProviderDiscriminator.HasValue() ? mProviderDiscriminator.Value() : 50U;
+            value.port.Emplace();
+            value.port.Value() = mProviderPort.HasValue() ? mProviderPort.Value() : 5560U;
+            value.kvs.Emplace();
+            value.kvs.Value() =
+                mProviderKvs.HasValue() ? mProviderKvs.Value() : chip::Span<const char>("/tmp/chip_kvs_provider", 22);
+            value.filepath.Emplace();
+            value.filepath.Value() =
+                mOtaImageFilePath.HasValue() ? mOtaImageFilePath.Value() : chip::Span<const char>("/tmp/otaImage", 13);
+            return Start(kIdentityAlpha, value);
+        }
+        case 2: {
+            LogStep(2, "Commission the provider from alpha");
+            chip::app::Clusters::CommissionerCommands::Commands::PairWithQRCode::Type value;
+            value.nodeId = mProviderNodeId.HasValue() ? mProviderNodeId.Value() : 12648430ULL;
+            value.payload =
+                mProviderPayload.HasValue() ? mProviderPayload.Value() : chip::Span<const char>("MT:-24J0IX4122-.548G00", 22);
+            return PairWithQRCode(kIdentityAlpha, value);
+        }
+        case 3: {
+            LogStep(3, "Wait for the commissioned provider to be retrieved for alpha");
+            chip::app::Clusters::DelayCommands::Commands::WaitForCommissionee::Type value;
+            value.nodeId = mProviderNodeId.HasValue() ? mProviderNodeId.Value() : 12648430ULL;
+            return WaitForCommissionee(kIdentityAlpha, value);
+        }
+        case 4: {
+            LogStep(4, "Install ACL for QueryImage");
+            ListFreer listFreer;
+            chip::app::DataModel::List<const chip::app::Clusters::AccessControl::Structs::AccessControlEntry::Type> value;
+
+            {
+                auto * listHolder_0 = new ListHolder<chip::app::Clusters::AccessControl::Structs::AccessControlEntry::Type>(2);
+                listFreer.add(listHolder_0);
+
+                listHolder_0->mList[0].privilege = static_cast<chip::app::Clusters::AccessControl::Privilege>(5);
+                listHolder_0->mList[0].authMode  = static_cast<chip::app::Clusters::AccessControl::AuthMode>(2);
+                listHolder_0->mList[0].subjects.SetNonNull();
+
+                {
+                    auto * listHolder_3 = new ListHolder<uint64_t>(1);
+                    listFreer.add(listHolder_3);
+                    listHolder_3->mList[0]                  = 112233ULL;
+                    listHolder_0->mList[0].subjects.Value() = chip::app::DataModel::List<uint64_t>(listHolder_3->mList, 1);
+                }
+                listHolder_0->mList[0].targets.SetNull();
+                listHolder_0->mList[0].fabricIndex = 1;
+
+                listHolder_0->mList[1].privilege = static_cast<chip::app::Clusters::AccessControl::Privilege>(3);
+                listHolder_0->mList[1].authMode  = static_cast<chip::app::Clusters::AccessControl::AuthMode>(2);
+                listHolder_0->mList[1].subjects.SetNull();
+                listHolder_0->mList[1].targets.SetNull();
+                listHolder_0->mList[1].fabricIndex = 1;
+
+                value = chip::app::DataModel::List<chip::app::Clusters::AccessControl::Structs::AccessControlEntry::Type>(
+                    listHolder_0->mList, 2);
+            }
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(0), AccessControl::Id, AccessControl::Attributes::Acl::Id, value);
+        }
+        case 5: {
+            LogStep(5, "Stop the requestor");
+            chip::app::Clusters::SystemCommands::Commands::Stop::Type value;
+            return Stop(kIdentityAlpha, value);
+        }
+        case 6: {
+            LogStep(6, "Start the requestor with an OTA download path");
+            chip::app::Clusters::SystemCommands::Commands::Start::Type value;
+            value.otaDownloadPath.Emplace();
+            value.otaDownloadPath.Value() = mDownloadImageFilePath.HasValue() ? mDownloadImageFilePath.Value()
+                                                                              : chip::Span<const char>("/tmp/downloadedImage", 20);
+            return Start(kIdentityAlpha, value);
+        }
+        case 7: {
+            LogStep(7, "Wait for the commissioned requestor to be retrieved for alpha");
+            chip::app::Clusters::DelayCommands::Commands::WaitForCommissionee::Type value;
+            value.nodeId = mRequestorNodeId.HasValue() ? mRequestorNodeId.Value() : 305414945ULL;
+            return WaitForCommissionee(kIdentityAlpha, value);
+        }
+        case 8: {
+            LogStep(8, "Send an announce OTA provider command to the requestor");
+            chip::app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Type value;
+            value.providerNodeId     = mProviderNodeId.HasValue() ? mProviderNodeId.Value() : 12648430ULL;
+            value.vendorId           = static_cast<chip::VendorId>(0);
+            value.announcementReason = static_cast<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason>(0);
+            value.endpoint           = mEndpoint.HasValue() ? mEndpoint.Value() : 0U;
+            return SendCommand(kIdentityAlpha, GetEndpoint(0), OtaSoftwareUpdateRequestor::Id,
+                               OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::Id, value);
+        }
+        case 9: {
+            LogStep(9, "Wait for transfer complete message");
+            chip::app::Clusters::DelayCommands::Commands::WaitForMessage::Type value;
+            value.registerKey.Emplace();
+            value.registerKey.Value() = chip::Span<const char>("defaultgarbage: not in length on purpose", 7);
+            value.message             = chip::Span<const char>("OTA image downloadedgarbage: not in length on purpose", 20);
+            return WaitForMessage(kIdentityAlpha, value);
+        }
+        case 10: {
+            LogStep(10, "Compare original file to downloaded file");
+            chip::app::Clusters::SystemCommands::Commands::CompareFiles::Type value;
+            value.file1 = mRawImageFilePath.HasValue() ? mRawImageFilePath.Value() : chip::Span<const char>("/tmp/rawImage", 13);
+            value.file2 = mDownloadImageFilePath.HasValue() ? mDownloadImageFilePath.Value()
+                                                            : chip::Span<const char>("/tmp/downloadedImage", 20);
+            return CompareFiles(kIdentityAlpha, value);
         }
         }
         return CHIP_NO_ERROR;
@@ -50323,6 +50559,8 @@ private:
         case 10: {
             LogStep(10, "Start the default accessory by key with all command line options");
             chip::app::Clusters::SystemCommands::Commands::Start::Type value;
+            value.registerKey.Emplace();
+            value.registerKey.Value() = chip::Span<const char>("defaultgarbage: not in length on purpose", 7);
             value.discriminator.Emplace();
             value.discriminator.Value() = 1111U;
             value.port.Emplace();
@@ -50331,21 +50569,19 @@ private:
             value.kvs.Value() = chip::Span<const char>("/tmp/chip_kvs_defaultgarbage: not in length on purpose", 21);
             value.minCommissioningTimeout.Emplace();
             value.minCommissioningTimeout.Value() = 10U;
-            value.registerKey.Emplace();
-            value.registerKey.Value() = chip::Span<const char>("defaultgarbage: not in length on purpose", 7);
             return Start(kIdentityAlpha, value);
         }
         case 11: {
             LogStep(11, "Start a second accessory with all command line options");
             chip::app::Clusters::SystemCommands::Commands::Start::Type value;
+            value.registerKey.Emplace();
+            value.registerKey.Value() = chip::Span<const char>("chip-lock-appgarbage: not in length on purpose", 13);
             value.discriminator.Emplace();
             value.discriminator.Value() = 50U;
             value.port.Emplace();
             value.port.Value() = 5561U;
             value.kvs.Emplace();
             value.kvs.Value() = chip::Span<const char>("/tmp/chip_kvs_lockgarbage: not in length on purpose", 18);
-            value.registerKey.Emplace();
-            value.registerKey.Value() = chip::Span<const char>("chip-lock-appgarbage: not in length on purpose", 13);
             return Start(kIdentityAlpha, value);
         }
         case 12: {
@@ -50371,14 +50607,14 @@ private:
         case 15: {
             LogStep(15, "Start a second accessory with different KVS");
             chip::app::Clusters::SystemCommands::Commands::Start::Type value;
+            value.registerKey.Emplace();
+            value.registerKey.Value() = chip::Span<const char>("chip-lock-appgarbage: not in length on purpose", 13);
             value.discriminator.Emplace();
             value.discriminator.Value() = 50U;
             value.port.Emplace();
             value.port.Value() = 5561U;
             value.kvs.Emplace();
             value.kvs.Value() = chip::Span<const char>("/tmp/chip_kvs_lock2garbage: not in length on purpose", 19);
-            value.registerKey.Emplace();
-            value.registerKey.Value() = chip::Span<const char>("chip-lock-appgarbage: not in length on purpose", 13);
             return Start(kIdentityAlpha, value);
         }
         case 16: {
@@ -72845,6 +73081,7 @@ void registerCommandsTests(Commands & commands, CredentialIssuerCommands * creds
         make_unique<Test_TC_MF_1_5Suite>(credsIssuerConfig),
         make_unique<Test_TC_MF_1_6Suite>(credsIssuerConfig),
         make_unique<Test_TC_MF_1_15Suite>(credsIssuerConfig),
+        make_unique<OTA_SuccessfulTransferSuite>(credsIssuerConfig),
         make_unique<Test_TC_OCC_1_1Suite>(credsIssuerConfig),
         make_unique<Test_TC_OCC_2_1Suite>(credsIssuerConfig),
         make_unique<Test_TC_OCC_2_2Suite>(credsIssuerConfig),


### PR DESCRIPTION
#### Problem
There is currently no CI test for a basic successful OTA transfer

#### Change overview
- Add a simple test for successful OTA transfer
- Requires ota-provider-app and ota-requestor-app to be built and passed into `run_test_suite.py`
- Map the default app to launch in this test to be ota-requestor-app
- Add ability to pass in OTA-specific arguments to `SystemCommands:Start`
- Add helper script to create an OTA image
- Add helper script to compare to files for verification purpose
- Add a generic function to wait for a particular message for verification purpose

#### Testing
- Ran this locally and verified that the test passes:
```
./scripts/tests/run_test_suite.py --target OTA_SuccessfulTransfer --chip-tool out/chip-tool/chip-tool --log-level debug run --iterations 1 --all-clusters-app out/all-clusters/chip-all-clusters-app --lock-app out/lock/chip-lock-app --ota-provider-app out/ota-provider/chip-ota-provider-app --ota-requestor-app out/ota-requestor/chip-ota-requestor-app --tv-app out/tv/chip-tv-app
```
