### PR TITLE
Add InitializeTracing for custom trace

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -141,7 +141,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
 
 #if defined(MATTER_CUSTOM_TRACE) && MATTER_CUSTOM_TRACE
     chip::InitializeTracing();
-#endif  // defined(MATTER_CUSTOM_TRACE) && MATTER_CUSTOM_TRACE
+#endif // defined(MATTER_CUSTOM_TRACE) && MATTER_CUSTOM_TRACE
 
     mSystemState = params.systemState->Retain();
     mState       = State::Initialized;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -139,6 +139,10 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
         }
     }
 
+#if defined(MATTER_CUSTOM_TRACE) && MATTER_CUSTOM_TRACE
+    chip::InitializeTracing();
+#endif  // defined(MATTER_CUSTOM_TRACE) && MATTER_CUSTOM_TRACE
+
     mSystemState = params.systemState->Retain();
     mState       = State::Initialized;
     return CHIP_NO_ERROR;

--- a/src/trace/trace.h
+++ b/src/trace/trace.h
@@ -21,6 +21,12 @@
 
 #include "trace/MatterCustomTrace.h"
 
+namespace chip {
+
+void InitializeTracing();
+
+}
+
 #else // MATTER_CUSTOM_TRACE
 
 #if defined(PW_TRACE_BACKEND_SET) && PW_TRACE_BACKEND_SET


### PR DESCRIPTION
#### Change overview
MATTER_CUSTOM_TRACE was added to enable user using customized tracing service. Add InitializeTracing method to the header.
Also initialize custom tracing system in controller initialization so that commissioner can get trace data.

