### PR TITLE
Allow empty events in report

### DIFF
--- a/src/app/MessageDef/AttributeReportIBs.cpp
+++ b/src/app/MessageDef/AttributeReportIBs.cpp
@@ -35,8 +35,7 @@ namespace app {
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR AttributeReportIBs::Parser::CheckSchemaValidity() const
 {
-    CHIP_ERROR err               = CHIP_NO_ERROR;
-    size_t numAttributeReportIBs = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("AttributeReportIBs =");
@@ -55,8 +54,6 @@ CHIP_ERROR AttributeReportIBs::Parser::CheckSchemaValidity() const
             ReturnErrorOnFailure(AttributeReport.CheckSchemaValidity());
             PRETTY_PRINT_DECDEPTH();
         }
-
-        ++numAttributeReportIBs;
     }
 
     PRETTY_PRINT("],");
@@ -65,16 +62,7 @@ CHIP_ERROR AttributeReportIBs::Parser::CheckSchemaValidity() const
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        // if we have at least one Attribute report
-        if (numAttributeReportIBs > 0)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        else
-        {
-            ChipLogError(DataManagement, "PROTOCOL ERROR: Empty Attribute reports");
-            err = CHIP_NO_ERROR;
-        }
+        err = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
     ReturnErrorOnFailure(reader.ExitContainer(mOuterContainerType));

--- a/src/app/MessageDef/EventReportIBs.cpp
+++ b/src/app/MessageDef/EventReportIBs.cpp
@@ -35,7 +35,7 @@ namespace app {
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
 {
-    CHIP_ERROR err         = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("EventReportIBs =");

--- a/src/app/MessageDef/EventReportIBs.cpp
+++ b/src/app/MessageDef/EventReportIBs.cpp
@@ -36,7 +36,6 @@ namespace app {
 CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
 {
     CHIP_ERROR err         = CHIP_NO_ERROR;
-    size_t numEventReports = 0;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("EventReportIBs =");
@@ -55,8 +54,6 @@ CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
             ReturnErrorOnFailure(eventReport.CheckSchemaValidity());
             PRETTY_PRINT_DECDEPTH();
         }
-
-        ++numEventReports;
     }
 
     PRETTY_PRINT("],");
@@ -65,16 +62,7 @@ CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        // if we have at least one event report
-        if (numEventReports > 0)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        else
-        {
-            ChipLogError(DataManagement, "PROTOCOL ERROR: Empty event reports");
-            err = CHIP_NO_ERROR;
-        }
+        err = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
     ReturnErrorOnFailure(reader.ExitContainer(mOuterContainerType));

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -545,7 +545,6 @@ void BuildEventReports(nlTestSuite * apSuite, EventReportIBs::Builder & aEventRe
     EventReportIB::Builder & eventReportIBBuilder = aEventReportsBuilder.CreateEventReport();
     NL_TEST_ASSERT(apSuite, aEventReportsBuilder.GetError() == CHIP_NO_ERROR);
     BuildEventReportIB(apSuite, eventReportIBBuilder);
-
     aEventReportsBuilder.EndOfEventReports();
     NL_TEST_ASSERT(apSuite, aEventReportsBuilder.GetError() == CHIP_NO_ERROR);
 }
@@ -1708,6 +1707,28 @@ void EventReportsTest(nlTestSuite * apSuite, void * apContext)
     ParseEventReports(apSuite, reader);
 }
 
+void EmptyEventReportsTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
+    EventReportIBs::Builder eventReportsBuilder;
+    writer.Init(chip::System::PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize));
+    eventReportsBuilder.Init(&writer);
+    eventReportsBuilder.EndOfEventReports();
+    NL_TEST_ASSERT(apSuite, eventReportsBuilder.GetError() == CHIP_NO_ERROR);
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    DebugPrettyPrint(buf);
+
+    reader.Init(std::move(buf));
+    err = reader.Next();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    ParseEventReports(apSuite, reader);
+}
+
 void AttributeReportIBTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2285,6 +2306,7 @@ const nlTest sTests[] =
                 NL_TEST_DEF("EventDataIBTest", EventDataIBTest),
                 NL_TEST_DEF("EventReportIBTest", EventReportIBTest),
                 NL_TEST_DEF("EventReportsTest", EventReportsTest),
+                NL_TEST_DEF("EmptyEventReportsTest", EmptyEventReportsTest),
                 NL_TEST_DEF("StatusIBTest", StatusIBTest),
                 NL_TEST_DEF("EventStatusIBTest", EventStatusIBTest),
                 NL_TEST_DEF("CommandPathIBTest", CommandPathIBTest),

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -1774,6 +1774,28 @@ void AttributeReportIBsTest(nlTestSuite * apSuite, void * apContext)
     ParseAttributeReportIBs(apSuite, reader);
 }
 
+void EmptyAttributeReportIBsTest(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::System::PacketBufferTLVWriter writer;
+    chip::System::PacketBufferTLVReader reader;
+    AttributeReportIBs::Builder attributeReportIBsBuilder;
+    writer.Init(chip::System::PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize));
+    attributeReportIBsBuilder.Init(&writer);
+    attributeReportIBsBuilder.EndOfAttributeReportIBs();
+    NL_TEST_ASSERT(apSuite, attributeReportIBsBuilder.GetError() == CHIP_NO_ERROR);
+    chip::System::PacketBufferHandle buf;
+    err = writer.Finalize(&buf);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    DebugPrettyPrint(buf);
+
+    reader.Init(std::move(buf));
+    err = reader.Next();
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    ParseAttributeReportIBs(apSuite, reader);
+}
+
 void StatusIBTest(nlTestSuite * apSuite, void * apContext)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -2301,6 +2323,7 @@ const nlTest sTests[] =
                 NL_TEST_DEF("AttributeDataIBsTest", AttributeDataIBsTest),
                 NL_TEST_DEF("AttributeReportIBTest", AttributeReportIBTest),
                 NL_TEST_DEF("AttributeReportIBsTest", AttributeReportIBsTest),
+                NL_TEST_DEF("EmptyAttributeReportIBsTest", EmptyAttributeReportIBsTest),
                 NL_TEST_DEF("EventPathTest", EventPathTest),
                 NL_TEST_DEF("EventPathsTest", EventPathsTest),
                 NL_TEST_DEF("EventDataIBTest", EventDataIBTest),


### PR DESCRIPTION
#### Problem
spec says that empty event report list is allowed, but currently parser see it as protocol error

#### Change overview
Allow parser to process empty event list with no error.

#### Testing
Add unit test for the empty event event report list
