### PR TITLE
Added Content Launcher to android tv-casting-app

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissionerDiscoveryFragment.java
@@ -94,7 +94,7 @@ public class CommissionerDiscoveryFragment extends Fragment {
 
   /** Interface for notifying the host. */
   public interface Callback {
-    /** Notifies listener of Skip to manual Commissioning Button click. */
+    /** Notifies listener of Commissioning Button click. */
     void handleCommissioningButtonClicked(DiscoveredNodeData selectedCommissioner);
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ContentLauncherFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ContentLauncherFragment.java
@@ -1,0 +1,65 @@
+package com.chip.casting.app;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.EditText;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.chip.casting.TvCastingApp;
+
+/** A {@link Fragment} to send Content Launcher commands from the TV Casting App. */
+public class ContentLauncherFragment extends Fragment {
+  private static final String TAG = ContentLauncherFragment.class.getSimpleName();
+
+  private final TvCastingApp tvCastingApp;
+
+  private View.OnClickListener launchUrlButtonClickListener;
+
+  public ContentLauncherFragment(TvCastingApp tvCastingApp) {
+    this.tvCastingApp = tvCastingApp;
+  }
+
+  /**
+   * Use this factory method to create a new instance of this fragment using the provided
+   * parameters.
+   *
+   * @param tvCastingApp TV Casting App (JNI)
+   * @return A new instance of fragment ContentLauncherFragment.
+   */
+  public static ContentLauncherFragment newInstance(TvCastingApp tvCastingApp) {
+    return new ContentLauncherFragment(tvCastingApp);
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    this.launchUrlButtonClickListener =
+        new View.OnClickListener() {
+          @Override
+          public void onClick(View v) {
+            EditText contentUrl = getView().findViewById(R.id.contentUrlEditText);
+            EditText contentDisplayString =
+                getView().findViewById(R.id.contentDisplayStringEditText);
+            tvCastingApp.contentLauncherLaunchURL(
+                contentUrl.getText().toString(), contentDisplayString.getText().toString());
+          }
+        };
+
+    return inflater.inflate(R.layout.fragment_content_launcher, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    Log.d(TAG, "ContentLauncherFragment.onViewCreated called");
+    getView().findViewById(R.id.launchUrlButton).setOnClickListener(launchUrlButtonClickListener);
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -19,7 +19,7 @@ import com.chip.casting.dnssd.DiscoveredNodeData;
 import com.chip.casting.util.GlobalCastingConstants;
 
 public class MainActivity extends AppCompatActivity
-    implements CommissionerDiscoveryFragment.Callback {
+    implements CommissionerDiscoveryFragment.Callback, CommissioningFragment.Callback {
 
   private ChipAppServer chipAppServer;
   private TvCastingApp tvCastingApp;
@@ -41,6 +41,11 @@ public class MainActivity extends AppCompatActivity
   @Override
   public void handleCommissioningButtonClicked(DiscoveredNodeData commissioner) {
     showFragment(CommissioningFragment.newInstance(tvCastingApp, commissioner));
+  }
+
+  @Override
+  public void handleCommissioningComplete() {
+    showFragment(ContentLauncherFragment.newInstance(tvCastingApp));
   }
 
   private void initJni() {

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/platform/MatterCallbackHandler.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/platform/MatterCallbackHandler.java
@@ -1,0 +1,5 @@
+package com.chip.casting.platform;
+
+public interface MatterCallbackHandler {
+  boolean handle(boolean success);
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -45,7 +45,9 @@ public class TvCastingApp {
 
   public native boolean discoverCommissioners();
 
-  public native void initServer();
+  public native boolean initServer(Object commissioningCompleteHandler);
+
+  public native void contentLauncherLaunchURL(String contentUrl, String contentDisplayStr);
 
   static {
     System.loadLibrary("TvCastingApp");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/CallbackHelper.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/CallbackHelper.cpp
@@ -1,0 +1,73 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "CallbackHelper.h"
+
+#include <lib/support/JniReferences.h>
+
+using namespace chip;
+
+struct MatterCallbackHandler gCommissioningCompleteHandler;
+
+CHIP_ERROR SetUpMatterCallbackHandler(JNIEnv * env, jobject inHandler, MatterCallbackHandler & callback)
+{
+    ChipLogProgress(AppServer, "SetUpMatterCallbackHandler called");
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    callback.object = env->NewGlobalRef(inHandler);
+    VerifyOrExit(callback.object != nullptr, ChipLogError(AppServer, "Failed to NewGlobalRef for handler object"));
+
+    callback.clazz = env->GetObjectClass(callback.object);
+    VerifyOrExit(callback.clazz != nullptr, ChipLogError(AppServer, "Failed to get handler Java class"));
+
+    callback.method = env->GetMethodID(callback.clazz, "handle", "(Z)Z");
+    if (callback.method == nullptr)
+    {
+        ChipLogError(AppServer, "Failed to access 'handle' method");
+        env->ExceptionClear();
+    }
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "SetUpMatterCallbackHandler error: %s", err.AsString());
+        return err;
+    }
+
+    return err;
+}
+
+CHIP_ERROR CommissioningCompleteHandler()
+{
+    ChipLogProgress(AppServer, "CommissioningCompleteHandler called");
+
+    JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    VerifyOrExit(gCommissioningCompleteHandler.object != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(gCommissioningCompleteHandler.method != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(env->CallBooleanMethod(gCommissioningCompleteHandler.object, gCommissioningCompleteHandler.method,
+                                        static_cast<jboolean>(true)) != JNI_FALSE,
+                 err = CHIP_ERROR_INCORRECT_STATE);
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(AppServer, "CommissioningCompleteHandler status error: %s", err.AsString());
+    }
+
+    return err;
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/CallbackHelper.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/CallbackHelper.h
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <jni.h>
+#include <lib/core/CHIPError.h>
+
+struct MatterCallbackHandler
+{
+    jobject object   = nullptr;
+    jclass clazz     = nullptr;
+    jmethodID method = nullptr;
+};
+
+extern struct MatterCallbackHandler gCommissioningCompleteHandler;
+
+CHIP_ERROR SetUpMatterCallbackHandler(JNIEnv * env, jobject inHandler, MatterCallbackHandler & callback);
+
+CHIP_ERROR CommissioningCompleteHandler();

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_content_launcher.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_content_launcher.xml
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".ContentLauncherFragment">
+
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="10sp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/content_launcher_fragment_title"
+            android:textAppearance="@style/TextAppearance.AppCompat.Display2" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/launch_url_command_title"
+            android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/content_url_prompt_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:layout_marginRight="10sp"/>
+
+            <EditText
+                android:id="@+id/contentUrlEditText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/default_content_url"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/content_display_string_prompt_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:layout_marginRight="10sp"/>
+
+            <EditText
+                android:id="@+id/contentDisplayStringEditText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/default_content_display_string"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/launchUrlButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/launch_url_button_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:layout_marginRight="10sp" />
+
+            <TextView
+                android:id="@+id/launchUrlStatus"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+        </LinearLayout>
+
+    </LinearLayout>
+</FrameLayout>

--- a/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
@@ -1,3 +1,10 @@
 <resources>
     <string name="app_name">CHIPTVCastingApp</string>
+    <string name="content_launcher_fragment_title">Content Launcher</string>
+    <string name="launch_url_command_title">Launch URL</string>
+    <string name="launch_url_button_text">Launch URL</string>
+    <string name="default_content_url">https://www.test.com/videoid</string>
+    <string name="default_content_display_string">Test video</string>
+    <string name="content_url_prompt_text">URL</string>
+    <string name="content_display_string_prompt_text">Display string</string>
 </resources>

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -24,6 +24,8 @@ shared_library("jni") {
 
   sources = [
     "${chip_root}/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h",
+    "App/app/src/main/jni/cpp/CallbackHelper.cpp",
+    "App/app/src/main/jni/cpp/CallbackHelper.h",
     "App/app/src/main/jni/cpp/JNIDACProvider.cpp",
     "App/app/src/main/jni/cpp/JNIDACProvider.h",
     "App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp",

--- a/examples/tv-casting-app/linux/CastingShellCommands.cpp
+++ b/examples/tv-casting-app/linux/CastingShellCommands.cpp
@@ -79,7 +79,7 @@ static CHIP_ERROR CastingHandler(int argc, char ** argv)
         char * eptr;
         chip::NodeId nodeId           = (chip::NodeId) strtoull(argv[1], &eptr, 10);
         chip::FabricIndex fabricIndex = (chip::FabricIndex) strtol(argv[2], &eptr, 10);
-        return CastingServer::GetInstance()->TargetVideoPlayerInfoInit(nodeId, fabricIndex);
+        return CastingServer::GetInstance()->TargetVideoPlayerInfoInit(nodeId, fabricIndex, HandleCommissioningCompleteCallback);
     }
     if (strcmp(argv[0], "discover") == 0)
     {
@@ -160,7 +160,7 @@ static CHIP_ERROR CastingHandler(int argc, char ** argv)
             streamer_printf(streamer_get(), "ERROR - invalid fabric or video player nodeId not found\r\n");
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        return CastingServer::GetInstance()->TargetVideoPlayerInfoInit(nodeId, fabricIndex);
+        return CastingServer::GetInstance()->TargetVideoPlayerInfoInit(nodeId, fabricIndex, HandleCommissioningCompleteCallback);
     }
     if (strcmp(argv[0], "cluster") == 0)
     {

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -23,6 +23,10 @@ using namespace chip::System;
 using namespace chip::DeviceLayer;
 using namespace chip::Dnssd;
 
+// TODO: Accept these values over CLI
+const char * kContentUrl        = "https://www.test.com/videoid";
+const char * kContentDisplayStr = "Test video";
+
 CHIP_ERROR DiscoverCommissioners()
 {
     // Send discover commissioners request
@@ -53,7 +57,7 @@ CHIP_ERROR RequestCommissioning(int index)
  */
 void PrepareForCommissioning(const Dnssd::DiscoveredNodeData * selectedCommissioner)
 {
-    CastingServer::GetInstance()->InitServer();
+    CastingServer::GetInstance()->InitServer(HandleCommissioningCompleteCallback);
 
     CastingServer::GetInstance()->OpenBasicCommissioningWindow();
 
@@ -103,6 +107,12 @@ void InitCommissioningFlow(intptr_t commandArg)
         ChipLogError(AppServer, "No commissioner discovered, commissioning must be initiated manually!");
         PrepareForCommissioning();
     }
+}
+
+CHIP_ERROR HandleCommissioningCompleteCallback()
+{
+    ChipLogProgress(AppServer, "HandleCommissioningCompleteCallback calling ContentLauncherLaunchURL");
+    return CastingServer::GetInstance()->ContentLauncherLaunchURL(kContentUrl, kContentDisplayStr);
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT

--- a/examples/tv-casting-app/linux/CastingUtils.h
+++ b/examples/tv-casting-app/linux/CastingUtils.h
@@ -38,6 +38,8 @@ void PrepareForCommissioning(const chip::Dnssd::DiscoveredNodeData * selectedCom
 
 void InitCommissioningFlow(intptr_t commandArg);
 
+CHIP_ERROR HandleCommissioningCompleteCallback();
+
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 void HandleUDCSendExpiration(chip::System::Layer * aSystemLayer, void * context);
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -99,7 +99,7 @@ CHIP_ERROR ProcessClusterCommand(int argc, char ** argv)
 {
     if (!CastingServer::GetInstance()->GetTargetVideoPlayerInfo()->IsInitialized())
     {
-        CastingServer::GetInstance()->SetDefaultFabricIndex();
+        CastingServer::GetInstance()->SetDefaultFabricIndex(HandleCommissioningCompleteCallback);
     }
     gCommands.Run(argc, argv);
     return CHIP_NO_ERROR;

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -20,6 +20,7 @@
 
 #include <app/server/Server.h>
 #include <controller/CHIPCommissionableNodeController.h>
+#include <functional>
 #include <zap-generated/CHIPClusters.h>
 
 #include "TargetEndpointInfo.h"
@@ -40,7 +41,7 @@ public:
     void operator=(const CastingServer &) = delete;
     static CastingServer * GetInstance();
 
-    void InitServer();
+    void InitServer(std::function<CHIP_ERROR()> commissioningCompleteCallback);
 
     CHIP_ERROR DiscoverCommissioners();
     const chip::Dnssd::DiscoveredNodeData * GetDiscoveredCommissioner(int index);
@@ -51,9 +52,11 @@ public:
 
     CHIP_ERROR InitBindingHandlers();
     TargetVideoPlayerInfo * GetTargetVideoPlayerInfo() { return &mTargetVideoPlayerInfo; }
-    CHIP_ERROR TargetVideoPlayerInfoInit(chip::NodeId nodeId, chip::FabricIndex fabricIndex);
+    CHIP_ERROR TargetVideoPlayerInfoInit(chip::NodeId nodeId, chip::FabricIndex fabricIndex,
+                                         std::function<CHIP_ERROR()> commissioningCompleteCallback);
     void ReadServerClusters(chip::EndpointId endpointId);
     void ReadServerClustersForNode(chip::NodeId nodeId);
+
     static void OnDescriptorReadSuccessResponse(void * context,
                                                 const chip::app::DataModel::DecodableList<chip::ClusterId> & responseList);
     static void OnDescriptorReadFailureResponse(void * context, CHIP_ERROR error);
@@ -67,7 +70,7 @@ public:
     chip::FabricIndex GetVideoPlayerFabricIndexForNode(chip::NodeId nodeId);
     void PrintBindings();
     chip::FabricIndex CurrentFabricIndex() { return mTargetVideoPlayerInfo.GetFabricIndex(); }
-    void SetDefaultFabricIndex();
+    void SetDefaultFabricIndex(std::function<CHIP_ERROR()> commissioningCompleteCallback);
 
 private:
     static CastingServer * castingServer_;
@@ -76,4 +79,5 @@ private:
     bool mInited = false;
     TargetVideoPlayerInfo mTargetVideoPlayerInfo;
     chip::Controller::CommissionableNodeController mCommissionableNodeController;
+    std::function<CHIP_ERROR()> mCommissioningCompleteCallback;
 };

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -25,10 +25,6 @@ using namespace chip::app::Clusters::ContentLauncher::Commands;
 
 CastingServer * CastingServer::castingServer_ = nullptr;
 
-// TODO: Accept these values over CLI
-const char * kContentUrl        = "https://www.test.com/videoid";
-const char * kContentDisplayStr = "Test video";
-
 CastingServer * CastingServer::GetInstance()
 {
     if (castingServer_ == nullptr)
@@ -38,12 +34,14 @@ CastingServer * CastingServer::GetInstance()
     return castingServer_;
 }
 
-void CastingServer::InitServer()
+void CastingServer::InitServer(std::function<CHIP_ERROR()> commissioningCompleteCallback)
 {
     if (mInited)
     {
         return;
     }
+
+    mCommissioningCompleteCallback = commissioningCompleteCallback;
 
     // Enter commissioning mode, open commissioning window
     static chip::CommonCaseDeviceServerInitParams initParams;
@@ -67,9 +65,10 @@ CHIP_ERROR CastingServer::InitBindingHandlers()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CastingServer::TargetVideoPlayerInfoInit(NodeId nodeId, FabricIndex fabricIndex)
+CHIP_ERROR CastingServer::TargetVideoPlayerInfoInit(NodeId nodeId, FabricIndex fabricIndex,
+                                                    std::function<CHIP_ERROR()> commissioningCompleteCallback)
 {
-    InitServer();
+    InitServer(mCommissioningCompleteCallback);
     return mTargetVideoPlayerInfo.Initialize(nodeId, fabricIndex);
 }
 
@@ -227,7 +226,7 @@ void CastingServer::DeviceEventCallback(const DeviceLayer::ChipDeviceEvent * eve
         ReturnOnFailure(CastingServer::GetInstance()->GetTargetVideoPlayerInfo()->Initialize(
             event->CommissioningComplete.PeerNodeId, event->CommissioningComplete.PeerFabricIndex));
 
-        CastingServer::GetInstance()->ContentLauncherLaunchURL(kContentUrl, kContentDisplayStr);
+        CastingServer::GetInstance()->mCommissioningCompleteCallback();
     }
 }
 
@@ -287,9 +286,9 @@ void CastingServer::PrintBindings()
     return;
 }
 
-void CastingServer::SetDefaultFabricIndex()
+void CastingServer::SetDefaultFabricIndex(std::function<CHIP_ERROR()> commissioningCompleteCallback)
 {
-    InitServer();
+    InitServer(commissioningCompleteCallback);
 
     // set fabric to be the first in the list
     for (const auto & fb : chip::Server::GetInstance().GetFabricTable())


### PR DESCRIPTION
#### Problem
Android tv-casting-app did not have an implementation for sending the ContentLauncher:LaunchURL matter command. See https://github.com/project-chip/connectedhomeip/issues/14558

#### Change overview

1.Added ContentLauncherFragment and Content Launch page
2. Added JNI layer method for ContentLauncherLaunchURL.
3. Added Callback mechanism in the CastingServer to call linux/android/iOS tv-casting-apps when commissioning completes (similar mechanism will be used for other callbacks in the future).
4. Implemented handlers for the above callback in the Linux and Android tv-casting-apps. 
5. In Linux, the handler simply calls CastingServer.ContentLauncherLaunchURL(). On Android, the app transitions to the next screen i.e. the Content Launch page which lets the user enter a Video URL/display title before calling CastingServer.ContentLauncherLaunchURL().

#### Testing
Built and deployed the Android tv-casting-app on an Android phone.

<img src="https://user-images.githubusercontent.com/31142146/167980477-4f27b6cb-7df4-4ad9-96dd-940fb1e22620.jpg" width="281" height="500">