### PR TITLE
Be more strict with constness of argv variable

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -197,7 +197,7 @@ static bool EnsureWiFiIsStarted()
 }
 #endif
 
-int ChipLinuxAppInit(int argc, char ** argv, OptionSet * customOptions)
+int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 #if CONFIG_NETWORK_LAYER_BLE

--- a/examples/platform/linux/AppMain.h
+++ b/examples/platform/linux/AppMain.h
@@ -27,7 +27,7 @@
 
 #include "Options.h"
 
-int ChipLinuxAppInit(int argc, char ** argv, chip::ArgParser::OptionSet * customOptions = nullptr);
+int ChipLinuxAppInit(int argc, char * const argv[], chip::ArgParser::OptionSet * customOptions = nullptr);
 void ChipLinuxAppMainLoop();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -390,7 +390,7 @@ OptionSet sDeviceOptions = { HandleOption, sDeviceOptionDefs, "GENERAL OPTIONS",
 OptionSet * sLinuxDeviceOptionSets[] = { &sDeviceOptions, nullptr, nullptr, nullptr };
 } // namespace
 
-CHIP_ERROR ParseArguments(int argc, char * argv[], OptionSet * customOptions)
+CHIP_ERROR ParseArguments(int argc, char * const argv[], OptionSet * customOptions)
 {
     // Index 0 is for the general Linux options
     uint8_t optionSetIndex = 1;

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -60,4 +60,4 @@ struct LinuxDeviceOptions
     static LinuxDeviceOptions & GetInstance();
 };
 
-CHIP_ERROR ParseArguments(int argc, char * argv[], chip::ArgParser::OptionSet * customOptions = nullptr);
+CHIP_ERROR ParseArguments(int argc, char * const argv[], chip::ArgParser::OptionSet * customOptions = nullptr);

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -80,7 +80,7 @@ struct TestState
 
 static void HandleSignal(int aSignal);
 static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, const char * aName, const char * aValue);
-static bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[]);
+static bool HandleNonOptionArgs(const char * aProgram, int argc, char * const argv[]);
 
 static void StartTest();
 static void CleanupTest();
@@ -429,7 +429,7 @@ static bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdent
     return (retval);
 }
 
-bool HandleNonOptionArgs(const char * aProgram, int argc, char * argv[])
+bool HandleNonOptionArgs(const char * aProgram, int argc, char * const argv[])
 {
     if (Common::IsSender())
     {

--- a/src/inet/tests/TestLwIPDNS.cpp
+++ b/src/inet/tests/TestLwIPDNS.cpp
@@ -50,7 +50,7 @@ using namespace chip::Inet;
 
 #define TOOL_NAME "TestLwIPDNS"
 
-static bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+static bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
 
 // Globals
 
@@ -239,7 +239,7 @@ int main(int argc, char * argv[])
     return (EXIT_SUCCESS);
 }
 
-static bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+static bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
 {
     if (argc < 2)
     {

--- a/src/lib/support/CHIPArgParser.cpp
+++ b/src/lib/support/CHIPArgParser.cpp
@@ -107,8 +107,8 @@ OptionSet ** gActiveOptionSets = nullptr;
 void (*PrintArgError)(const char * msg, ...) = DefaultPrintArgError;
 
 /**
- * @fn bool ParseArgs(const char *progName, int argc, char *argv[], OptionSet *optSets[], NonOptionArgHandlerFunct nonOptArgHandler,
- * bool ignoreUnknown)
+ * @fn bool ParseArgs(const char *progName, int argc, char * const argv[], OptionSet *optSets[],
+ * NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown)
  *
  * @brief
  * Parse a set of command line-style arguments, calling handling functions to process each
@@ -119,8 +119,9 @@ void (*PrintArgError)(const char * msg, ...) = DefaultPrintArgError;
  *                                  messages and warnings.
  * @param[in]  argc                 The number of arguments to be parsed, plus 1.
  * @param[in]  argv                 An array of argument strings to be parsed.  The array length must
- * 									be 1 greater than the value specified for argc, and
- * argv[argc] must be set to NULL.  Argument parsing begins with the *second* array element (argv[1]); element 0 is ignored.
+ *                                  be 1 greater than the value specified for argc, and
+ *                                  argv[argc] must be set to NULL.  Argument parsing begins with the
+ *                                  *second* array element (argv[1]); element 0 is ignored.
  * @param[in]  optSets              A list of pointers to `OptionSet` structures that define the legal
  *                                  options.  The supplied list must be terminated with a NULL.
  * @param[in]  nonOptArgHandler     A pointer to a function that will be called once option parsing
@@ -280,8 +281,8 @@ void (*PrintArgError)(const char * msg, ...) = DefaultPrintArgError;
  * a common section title.
  *
  */
-bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[], NonOptionArgHandlerFunct nonOptArgHandler,
-               bool ignoreUnknown)
+bool ParseArgs(const char * progName, int argc, char * const argv[], OptionSet * optSets[],
+               NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown)
 {
     bool res = false;
     char optName[64];
@@ -433,12 +434,13 @@ done:
     return res;
 }
 
-bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[], NonOptionArgHandlerFunct nonOptArgHandler)
+bool ParseArgs(const char * progName, int argc, char * const argv[], OptionSet * optSets[],
+               NonOptionArgHandlerFunct nonOptArgHandler)
 {
     return ParseArgs(progName, argc, argv, optSets, nonOptArgHandler, false);
 }
 
-bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[])
+bool ParseArgs(const char * progName, int argc, char * const argv[], OptionSet * optSets[])
 {
     return ParseArgs(progName, argc, argv, optSets, nullptr, false);
 }

--- a/src/lib/support/CHIPArgParser.hpp
+++ b/src/lib/support/CHIPArgParser.hpp
@@ -45,7 +45,7 @@ typedef bool (*OptionHandlerFunct)(const char * progName, OptionSet * optSet, in
 /**
  * A function that can be called to handle any remaining, non-option command line arguments.
  */
-typedef bool (*NonOptionArgHandlerFunct)(const char * progName, int argc, char * argv[]);
+typedef bool (*NonOptionArgHandlerFunct)(const char * progName, int argc, char * const argv[]);
 
 /**
  * Defines the argument requirements for a command line option.
@@ -94,10 +94,11 @@ private:
     static bool CallHandleFunct(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
 };
 
-bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[]);
-bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[], NonOptionArgHandlerFunct nonOptArgHandler);
-bool ParseArgs(const char * progName, int argc, char * argv[], OptionSet * optSets[], NonOptionArgHandlerFunct nonOptArgHandler,
-               bool ignoreUnknown);
+bool ParseArgs(const char * progName, int argc, char * const argv[], OptionSet * optSets[]);
+bool ParseArgs(const char * progName, int argc, char * const argv[], OptionSet * optSets[],
+               NonOptionArgHandlerFunct nonOptArgHandler);
+bool ParseArgs(const char * progName, int argc, char * const argv[], OptionSet * optSets[],
+               NonOptionArgHandlerFunct nonOptArgHandler, bool ignoreUnknown);
 
 bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[]);
 bool ParseArgsFromString(const char * progName, const char * argStr, OptionSet * optSets[],

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -36,7 +36,7 @@
 using namespace chip::ArgParser;
 
 static bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
-static bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+static bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
 static void HandleArgError(const char * msg, ...);
 static void ClearCallbackRecords();
 
@@ -701,7 +701,7 @@ static bool HandleOption(const char * progName, OptionSet * optSet, int id, cons
     return true;
 }
 
-static bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+static bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
 {
 #if DEBUG_TESTS
     // clang-format off

--- a/src/tools/chip-cert/Cmd_ConvertCert.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertCert.cpp
@@ -35,7 +35,7 @@ using namespace chip::Credentials;
 #define CMD_NAME "chip-cert convert-cert"
 
 bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
-bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
 
 // clang-format off
 OptionDef gCmdOptionDefs[] =
@@ -131,7 +131,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
     return true;
 }
 
-bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
 {
     if (argc == 0)
     {

--- a/src/tools/chip-cert/Cmd_ConvertKey.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertKey.cpp
@@ -35,7 +35,7 @@ using namespace chip::Credentials;
 #define CMD_NAME "chip-cert convert-key"
 
 bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
-bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
 
 // clang-format off
 OptionDef gCmdOptionDefs[] =
@@ -132,7 +132,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
     return true;
 }
 
-bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
 {
     if (argc == 0)
     {

--- a/src/tools/chip-cert/Cmd_PrintCert.cpp
+++ b/src/tools/chip-cert/Cmd_PrintCert.cpp
@@ -36,7 +36,7 @@ using namespace chip::ASN1;
 #define CMD_NAME "chip-cert print-cert"
 
 bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
-bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
 
 // clang-format off
 OptionDef gCmdOptionDefs[] =
@@ -101,7 +101,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
     return true;
 }
 
-bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
 {
     if (argc == 0)
     {

--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -38,7 +38,7 @@ using namespace chip::ASN1;
 #define CMD_NAME "chip-cert validate-cert"
 
 bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg);
-bool HandleNonOptionArgs(const char * progName, int argc, char * argv[]);
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
 
 // clang-format off
 OptionDef gCmdOptionDefs[] =
@@ -118,7 +118,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
     return true;
 }
 
-bool HandleNonOptionArgs(const char * progName, int argc, char * argv[])
+bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[])
 {
     if (argc == 0)
     {


### PR DESCRIPTION
#### Problem

If function does not modify its arguments it should be declared with const modifiers. Later, it's easier to use such function, e.g. with RO-data memory.
Theoretically, we could use here "const char * const argv[]", however, functions `getopt()`/`getopt_long()` expect char to be non-const.

#### Change overview

- added `const` to argv arguments

#### Testing

CI will check for any potential build breaks.