### PR TITLE
Enable TV_* tests in darwin CI

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -89,6 +89,7 @@ jobs:
                         --target darwin-x64-chip-tool-darwin-${BUILD_VARIANT} \
                         --target darwin-x64-all-clusters-${BUILD_VARIANT} \
                         --target darwin-x64-lock-${BUILD_VARIANT} \
+                        --target darwin-x64-tv-app-${BUILD_VARIANT} \
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
@@ -98,11 +99,12 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                   "./scripts/tests/run_test_suite.py \
                      --chip-tool ./out/darwin-x64-chip-tool-darwin-${BUILD_VARIANT}/chip-tool-darwin \
-                     --target-skip-glob '{TestGroupMessaging,TV_*}' \
+                     --target-skip-glob '{TestGroupMessaging}' \
                      run \
                      --iterations 1 \
                      --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
                      --lock-app ./out/darwin-x64-lock-${BUILD_VARIANT}/chip-lock-app \
+                     --tv-app ./out/darwin-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
                   "
             - name: Uploading core files
               uses: actions/upload-artifact@v2


### PR DESCRIPTION
#### Problem

The `TV_*` tests are not running in CI with `chip-tool-darwin`. Not sure why.

#### Change overview
 * Enable them
