### PR TITLE
[chip-tool-darwin] Use DelayCommands in examples/chip-tool-darwin/commands/tests/TestCommandBridge.h

### DIFF
--- a/examples/chip-tool-darwin/commands/tests/TestCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/tests/TestCommandBridge.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "../common/CHIPCommandBridge.h"
+#include <app/tests/suites/commands/delay/DelayCommands.h>
 #include <app/tests/suites/commands/system/SystemCommands.h>
 #include <app/tests/suites/include/ConstraintsChecker.h>
 #include <app/tests/suites/include/PICSChecker.h>
@@ -58,6 +59,7 @@ class TestCommandBridge : public CHIPCommandBridge,
                           public ValueChecker,
                           public ConstraintsChecker,
                           public PICSChecker,
+                          public DelayCommands,
                           public SystemCommands {
 public:
     TestCommandBridge(const char * _Nonnull commandName)
@@ -104,31 +106,24 @@ public:
         NextTest();
     }
 
-    /////////// DelayCommands-like Interface /////////
-    void WaitForMs(unsigned int ms)
-    {
-        chip::app::Clusters::DelayCommands::Commands::WaitForMs::Type value;
-        value.ms = ms;
-        WaitForMs(nil, value);
-    }
-
-    void WaitForMs(const char * _Nullable identity, const chip::app::Clusters::DelayCommands::Commands::WaitForMs::Type & value)
-    {
-        dispatch_after(dispatch_time(DISPATCH_TIME_NOW, value.ms * NSEC_PER_MSEC), mCallbackQueue, ^{
-            NextTest();
-        });
-    }
-
     void UserPrompt(const char * _Nullable identity, const chip::app::Clusters::LogCommands::Commands::UserPrompt::Type & value)
     {
         NextTest();
     }
 
-    void WaitForCommissionee(
-        const char * _Nullable identity, const chip::app::Clusters::DelayCommands::Commands::WaitForCommissionee::Type & value)
+    /////////// DelayCommands Interface /////////
+    void OnWaitForMs() override
+    {
+        dispatch_async(mCallbackQueue, ^{
+            NextTest();
+        });
+    }
+
+    CHIP_ERROR WaitForCommissionee(const char * _Nullable identity,
+        const chip::app::Clusters::DelayCommands::Commands::WaitForCommissionee::Type & value) override
     {
         CHIPDeviceController * controller = GetCommissioner(identity);
-        VerifyOrReturn(controller != nil, SetCommandExitStatus(CHIP_ERROR_INCORRECT_STATE));
+        VerifyOrReturnError(controller != nil, CHIP_ERROR_INCORRECT_STATE);
 
         SetIdentity(identity);
 
@@ -152,6 +147,7 @@ public:
                          mConnectedDevices[identity] = device;
                          NextTest();
                      }];
+        return CHIP_NO_ERROR;
     }
 
     /////////// CommissionerCommands-like Interface /////////
@@ -183,8 +179,9 @@ public:
     CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) override
     {
         if (CHIP_NO_ERROR == err) {
-            WaitForMs(0);
-
+            dispatch_async(mCallbackQueue, ^{
+                NextTest();
+            });
         } else {
             Exit(chip::ErrorStr(err), err);
         }

--- a/examples/chip-tool-darwin/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool-darwin/templates/tests/partials/test_cluster.zapt
@@ -91,7 +91,7 @@ class {{filename}}: public TestCommandBridge
       }
 
       // Go on to the next test.
-      WaitForMs(0);
+      ContinueOnChipMainThread(CHIP_NO_ERROR);
     }
 
   chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.ValueOr({{chip_tests_config_get_default_value "timeout"}})); }
@@ -272,14 +272,6 @@ class {{filename}}: public TestCommandBridge
     {{/if}}
     {{#if async}}
     NextTest();
-    {{else}}
-    {{#*inline "minCommandTimeout"~}}
-      {{#if (isTestOnlyCluster cluster)~}}
-        {{#if (isStrEqual command "WaitForMs")~}}
-          {{#chip_tests_item_parameters}}{{#if (isStrEqual name "ms")}}({{definedValue}} / 1000) + {{/if}}{{/chip_tests_item_parameters}}
-        {{~/if}}
-      {{~/if}}
-    {{~/inline}}
     {{/if}}
     return CHIP_NO_ERROR;
   }


### PR DESCRIPTION
#### Problem

`chip-tool-darwin` does not use the shared `DelayCommands` code.

#### Change overview
 * use it

#### Testing
I have runned a few tests with:
`./scripts/tests/run_test_suite.py --chip-tool out/debug/standalone/chip-tool-darwin --target Test_TC_LVL_5_1 --log-level debug run --iterations 1 --all-clusters-app out/debug/standalone/chip-all-clusters-app --lock-app out/debug/standalone/chip-lock-app --tv-app out/debug/standalone/chip-tv-app` and `./scripts/tests/run_test_suite.py --chip-tool out/debug/standalone/chip-tool-darwin --target TestDelayCommands --log-level debug run --iterations 1 --all-clusters-app out/debug/standalone/chip-all-clusters-app --lock-app out/debug/standalone/chip-lock-app --tv-app out/debug/standalone/chip-tv-app`