### PR TITLE
Change declaration order to address GCC 12.1 error

### DIFF
--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -226,12 +226,12 @@ private:
     uint16_t mNextKeyId;
     State mState;
 
-    SessionManager * mSessionManager;
-    ReliableMessageMgr mReliableMessageMgr;
-
     FabricIndex mFabricIndex = 0;
 
     BitMapObjectPool<ExchangeContext, CHIP_CONFIG_MAX_EXCHANGE_CONTEXTS> mContextPool;
+
+    SessionManager * mSessionManager;
+    ReliableMessageMgr mReliableMessageMgr;
 
     UnsolicitedMessageHandlerSlot UMHandlerPool[CHIP_CONFIG_MAX_UNSOLICITED_MESSAGE_HANDLERS];
 


### PR DESCRIPTION
#### Problem
GCC 12.1 complains:

```
../../src/messaging/ExchangeMgr.cpp: In constructor ‘chip::Messaging::ExchangeManager::ExchangeManager()’:
../../src/messaging/ExchangeMgr.cpp:62:58: error: member ‘chip::Messaging::ExchangeManager::mContextPool’ is used uninitialized [-Werror=uninitialized]
   62 | ExchangeManager::ExchangeManager() : mReliableMessageMgr(mContextPool)
      |                                                          ^~~~~~~~~~~~
At global scope:
cc1plus: note: unrecognized command-line option ‘-Wno-unknown-warning-option’ may have been intended to silence earlier diagnostics
cc1plus: all warnings being treated as errors
```

#### Change overview
Make sure mContextPool comes before mReliableMessageMgr in the
declaration order.

#### Testing

Manually, just compiling.
