### PR TITLE
Fixing linux tv-casting-app's build

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -104,6 +104,17 @@ jobs:
                     linux debug tv-app \
                     out/tv_app_debug/chip-tv-app \
                     /tmp/bloat_reports/
+            - name: Build example Standalone TV Casting App
+              timeout-minutes: 10
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                     "./scripts/build/build_examples.py \
+                        --target linux-x64-tv-casting-app \
+                        build"
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    linux debug tv-casting-app \
+                    out/linux-x64-tv-casting-app/chip-tv-casting-app \
+                    /tmp/bloat_reports/
             - name: Build example lighting app with RPCs
               timeout-minutes: 10
               run: |

--- a/examples/tv-casting-app/linux/CastingUtils.cpp
+++ b/examples/tv-casting-app/linux/CastingUtils.cpp
@@ -122,7 +122,8 @@ void HandleUDCSendExpiration(System::Layer * aSystemLayer, void * context)
 
     // Send User Directed commissioning request
     ReturnOnFailure(CastingServer::GetInstance()->SendUserDirectedCommissioningRequest(chip::Transport::PeerAddress::UDP(
-        selectedCommissioner->ipAddress[0], selectedCommissioner->port, selectedCommissioner->interfaceId)));
+        selectedCommissioner->resolutionData.ipAddress[0], selectedCommissioner->resolutionData.port,
+        selectedCommissioner->resolutionData.interfaceId)));
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY_CLIENT
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -235,6 +235,8 @@ def HostTargets():
     app_targets.append(
         target_native.Extend('tv-app', app=HostApp.TV_APP))
     app_targets.append(
+        target_native.Extend('tv-casting-app', app=HostApp.TV_CASTING_APP))
+    app_targets.append(
         target_native.Extend('nl-test-runner', app=HostApp.NL_TEST_RUNNER))
 
     for target in targets:

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -28,6 +28,7 @@ class HostApp(Enum):
     MIN_MDNS = auto()
     ADDRESS_RESOLVE = auto()
     TV_APP = auto()
+    TV_CASTING_APP = auto()
     LOCK = auto()
     TESTS = auto()
     SHELL = auto()
@@ -52,6 +53,8 @@ class HostApp(Enum):
             return 'minimal-mdns'
         elif self == HostApp.TV_APP:
             return 'tv-app/linux'
+        elif self == HostApp.TV_CASTING_APP:
+            return 'tv-casting-app/linux'
         elif self == HostApp.LOCK:
             return 'lock-app/linux'
         elif self == HostApp.SHELL:
@@ -95,6 +98,9 @@ class HostApp(Enum):
         elif self == HostApp.TV_APP:
             yield 'chip-tv-app'
             yield 'chip-tv-app.map'
+        elif self == HostApp.TV_CASTING_APP:
+            yield 'chip-tv-casting-app'
+            yield 'chip-tv-casting-app.map'
         elif self == HostApp.LOCK:
             yield 'chip-lock-app'
             yield 'chip-lock-app.map'

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -159,6 +159,12 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-tv-app-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-app-ipv6only
 
+# Generating linux-x64-tv-casting-app
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux {out}/linux-x64-tv-casting-app
+
+# Generating linux-x64-tv-casting-app-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-casting-app-ipv6only
+
 # Building linux-arm64-all-clusters
 ninja -C {out}/linux-arm64-all-clusters
 
@@ -284,3 +290,9 @@ ninja -C {out}/linux-x64-tv-app
 
 # Building linux-x64-tv-app-ipv6only
 ninja -C {out}/linux-x64-tv-app-ipv6only
+
+# Building linux-x64-tv-casting-app
+ninja -C {out}/linux-x64-tv-casting-app
+
+# Building linux-x64-tv-casting-app-ipv6only
+ninja -C {out}/linux-x64-tv-casting-app-ipv6only


### PR DESCRIPTION
#### Problem
Refactoring of DiscoveredNodeData in https://github.com/project-chip/connectedhomeip/pull/18266 led to compilation failure of linux tv-casting-app

#### Change overview
Used the new resolutionData from DiscoveredNodeData.
Also, added linux tv-casting-app build back to CI.

#### Testing
Built and ran linux tv-casting-app and ensured User Directed Commissioning requests are getting delivered from the tv-casting-app to an instance of the tv-app.