### PR TITLE
Avoid crashing if Bluez is not ready to scan

### DIFF
--- a/src/platform/Linux/bluez/ChipDeviceScanner.cpp
+++ b/src/platform/Linux/bluez/ChipDeviceScanner.cpp
@@ -124,10 +124,16 @@ CHIP_ERROR ChipDeviceScanner::StartScan(System::Clock::Timeout timeout)
     ReturnErrorOnFailure(MainLoop::Instance().EnsureStarted());
 
     mIsScanning = true; // optimistic, to allow all callbacks to check this
-    if (!MainLoop::Instance().Schedule(MainLoopStartScan, this))
+    if (!MainLoop::Instance().ScheduleAndWait(MainLoopStartScan, this))
     {
         ChipLogError(Ble, "Failed to schedule BLE scan start.");
         mIsScanning = false;
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    if (!mIsScanning)
+    {
+        ChipLogError(Ble, "Failed to start BLE scan.");
         return CHIP_ERROR_INTERNAL;
     }
 
@@ -288,7 +294,7 @@ int ChipDeviceScanner::MainLoopStartScan(ChipDeviceScanner * self)
     {
         // Not critical: ignore if fails
         ChipLogError(Ble, "Failed to set discovery filters: %s", error->message);
-        g_error_free(error);
+        g_clear_error(&error);
     }
 
     ChipLogProgress(Ble, "BLE initiating scan.");


### PR DESCRIPTION
#### Problem

Crash when scanning devices via Bluez when Bluez is not ready (e.g. rfkill).

```
2022-05-12 18:28:59 allenwind chip.BLE[404699] ERROR Failed to set discovery filters: GDBus.Error:org.bluez.Error.NotReady: Resource Not Ready
(process:404699): GLib-GIO-CRITICAL **: 18:28:59.720: g_dbus_proxy_call_sync_internal: assertion 'error == NULL || *error == NULL' failed
2022-05-12 18:28:59 allenwind chip.BLE[404699] ERROR Failed to start discovery: (null)
Thread 5 "python3" received signal SIGSEGV, Segmentation fault.
```

#### Change overview

Make sure to properly clear the error variable in error cases.

Also propagate errors when scanning fails (e.g. when Bluez is
not ready due to rfkill).

#### Testing

Manually tested on Development host (Arch Linux Desktop), manually pairing a BLE device.
