### PR TITLE
Fix infinite recusion possibility in QName parsing

### DIFF
--- a/src/lib/dnssd/minimal_mdns/core/QName.cpp
+++ b/src/lib/dnssd/minimal_mdns/core/QName.cpp
@@ -74,6 +74,14 @@ bool SerializedQNameIterator::Next(bool followIndirectPointers)
                 return false;
             }
 
+            // Look behind has to keep going backwards, otherwise we may
+            // get into an infinite list
+            if (offset >= static_cast<size_t>(mCurrentPosition - mValidData.Start()))
+            {
+                mIsValid = false;
+                return false;
+            }
+
             mLookBehindMax   = offset;
             mCurrentPosition = mValidData.Start() + offset;
         }


### PR DESCRIPTION
#### Problem
QName parsing had the possibility to infinitely recurse, which can result in a DOS attack.

#### Change overview
Fix infinite recursion by requiring back-referencing to actually go "back".
Added unit test for this.

#### Testing
Unit test. Without the change, unit test enters in an infinite loop.