### PR TITLE
Stop converting values to base64 for Darwin storage.

### DIFF
--- a/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.h
@@ -1,8 +1,13 @@
 #import <CHIP/CHIP.h>
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
-- (NSData *)valueForKey:(NSString *)key;
-- (BOOL)setValue:(NSData *)value forKey:(NSString *)key;
+- (nullable NSData *)valueForKey:(NSString *)key;
+// value is nullable because NSKeyValueCoding has a selector collision with us.
+- (BOOL)setValue:(nullable NSData *)value forKey:(NSString *)key;
 - (BOOL)removeValueForKey:(NSString *)key;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.h
@@ -4,10 +4,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
-- (nullable NSData *)valueForKey:(NSString *)key;
-// value is nullable because NSKeyValueCoding has a selector collision with us.
-- (BOOL)setValue:(nullable NSData *)value forKey:(NSString *)key;
-- (BOOL)removeValueForKey:(NSString *)key;
+- (nullable NSData *)storageDataForKey:(NSString *)key;
+- (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key;
+- (BOOL)removeStorageDataForKey:(NSString *)key;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.h
@@ -2,7 +2,7 @@
 #import <Foundation/Foundation.h>
 
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
-- (NSString *)CHIPGetKeyValue:(NSString *)key;
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value;
-- (void)CHIPDeleteKeyValue:(NSString *)key;
+- (NSData *)valueForKey:(NSString *)key;
+- (BOOL)setValue:(NSData *)value forKey:(NSString *)key;
+- (BOOL)removeValueForKey:(NSString *)key;
 @end

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.mm
@@ -27,19 +27,19 @@ void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key)
 
 // MARK: CHIPPersistentStorageDelegate
 
-- (nullable NSData *)valueForKey:(NSString *)key
+- (nullable NSData *)storageDataForKey:(NSString *)key
 {
     NSData * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
     NSLog(@"CHIPPersistentStorageDelegate Get Value for Key: %@, value %@", key, value);
     return value;
 }
 
-- (BOOL)setValue:(NSData *)value forKey:(NSString *)key
+- (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key
 {
     return CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
 }
 
-- (BOOL)removeValueForKey:(NSString *)key
+- (BOOL)removeStorageDataForKey:(NSString *)key
 {
     if (CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key) == nil) {
         return NO;

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.mm
@@ -11,10 +11,10 @@ id CHIPGetDomainValueForKey(NSString * domain, NSString * key)
     return nil;
 }
 
-void CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value)
+BOOL CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value)
 {
     CFPreferencesSetAppValue((CFStringRef) key, (__bridge CFPropertyListRef _Nullable)(value), (CFStringRef) domain);
-    CFPreferencesAppSynchronize((CFStringRef) domain);
+    return CFPreferencesAppSynchronize((CFStringRef) domain) == true;
 }
 
 void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key)
@@ -27,21 +27,25 @@ void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key)
 
 // MARK: CHIPPersistentStorageDelegate
 
-- (NSString *)CHIPGetKeyValue:(NSString *)key
+- (nullable NSData *)valueForKey:(NSString *)key
 {
-    NSString * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
+    NSData * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
     NSLog(@"CHIPPersistentStorageDelegate Get Value for Key: %@, value %@", key, value);
     return value;
 }
 
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value
+- (BOOL)setValue:(NSData *)value forKey:(NSString *)key
 {
-    CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
+    return CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
 }
 
-- (void)CHIPDeleteKeyValue:(NSString *)key
+- (BOOL)removeValueForKey:(NSString *)key
 {
+    if (CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key) == nil) {
+        return NO;
+    }
     CHIPRemoveDomainValueForKey(kCHIPToolDefaultsDomain, key);
+    return YES;
 }
 
 @end

--- a/examples/chip-tool-darwin/commands/common/CHIPToolKeypair.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPToolKeypair.mm
@@ -87,7 +87,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
     effectiveTime.Day = 1;
     ReturnErrorOnFailure(chip::Credentials::ASN1ToChipEpochTime(effectiveTime, _mNow));
 
-    value = [storage valueForKey:kOperationalCredentialsIssuerKeypairStorage];
+    value = [storage storageDataForKey:kOperationalCredentialsIssuerKeypairStorage];
     err = [self initSerializedKeyFromValue:value serializedKey:serializedKey];
 
     if (err != CHIP_NO_ERROR) {
@@ -98,12 +98,12 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
         ReturnErrorOnFailure([self Serialize:serializedKey]);
 
         NSData * valueData = [NSData dataWithBytes:serializedKey.Bytes() length:serializedKey.Length()];
-        [storage setValue:valueData forKey:kOperationalCredentialsIssuerKeypairStorage];
+        [storage setStorageData:valueData forKey:kOperationalCredentialsIssuerKeypairStorage];
     } else {
         ReturnErrorOnFailure([self Deserialize:serializedKey]);
     }
 
-    NSData * ipk = [storage valueForKey:kOperationalCredentialsIPK];
+    NSData * ipk = [storage storageDataForKey:kOperationalCredentialsIPK];
     if (ipk == nil) {
         err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
@@ -113,7 +113,7 @@ static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
         ReturnLogErrorOnFailure(chip::Crypto::DRBG_get_bytes(tempIPK, sizeof(tempIPK)));
 
         _ipk = [NSData dataWithBytes:tempIPK length:sizeof(tempIPK)];
-        [storage setValue:_ipk forKey:kOperationalCredentialsIPK];
+        [storage setStorageData:_ipk forKey:kOperationalCredentialsIPK];
     } else {
         _ipk = ipk;
     }

--- a/examples/chip-tool-darwin/commands/common/CHIPToolKeypair.mm
+++ b/examples/chip-tool-darwin/commands/common/CHIPToolKeypair.mm
@@ -3,10 +3,7 @@
 #include <credentials/CHIPCert.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/asn1/ASN1.h>
-#include <lib/core/CHIPSafeCasts.h>
-#include <lib/support/Base64.h>
 #include <stddef.h>
-#include <string>
 
 #define CHIPPlugin_CAKeyTag "com.apple.matter.commissioner.ca.issuer.id"
 #define Public_KeySize "256"
@@ -14,31 +11,6 @@
 static NSString * const kCHIPToolKeychainLabel = @"Chip Tool Keypair";
 static NSString * const kOperationalCredentialsIssuerKeypairStorage = @"ChipToolOpCredsCAKey";
 static NSString * const kOperationalCredentialsIPK = @"ChipToolOpCredsIPK";
-
-std::string StringToBase64(const std::string & value)
-{
-    std::unique_ptr<char[]> buffer(new char[BASE64_ENCODED_LEN(value.length())]);
-
-    uint32_t len = chip::Base64Encode32(
-        reinterpret_cast<const uint8_t *>(value.data()), static_cast<uint32_t>(value.length()), buffer.get());
-    if (len == UINT32_MAX) {
-        return "";
-    }
-
-    return std::string(buffer.get(), len);
-}
-
-std::string Base64ToString(const std::string & b64Value)
-{
-    std::unique_ptr<uint8_t[]> buffer(new uint8_t[BASE64_MAX_DECODED_LEN(b64Value.length())]);
-
-    uint32_t len = chip::Base64Decode32(b64Value.data(), static_cast<uint32_t>(b64Value.length()), buffer.get());
-    if (len == UINT32_MAX) {
-        return "";
-    }
-
-    return std::string(reinterpret_cast<const char *>(buffer.get()), len);
-}
 
 @interface CHIPToolKeypair ()
 @property (nonatomic) chip::Crypto::P256Keypair mKeyPair;
@@ -105,7 +77,7 @@ std::string Base64ToString(const std::string & b64Value)
 {
     chip::ASN1::ASN1UniversalTime effectiveTime;
     chip::Crypto::P256SerializedKeypair serializedKey;
-    NSString * value;
+    NSData * value;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     // Initializing the default start validity to start of 2021. The default validity duration is 10 years.
@@ -115,8 +87,8 @@ std::string Base64ToString(const std::string & b64Value)
     effectiveTime.Day = 1;
     ReturnErrorOnFailure(chip::Credentials::ASN1ToChipEpochTime(effectiveTime, _mNow));
 
-    value = [storage CHIPGetKeyValue:kOperationalCredentialsIssuerKeypairStorage];
-    err = [self decodeNSStringWithValue:value serializedKey:serializedKey];
+    value = [storage valueForKey:kOperationalCredentialsIssuerKeypairStorage];
+    err = [self initSerializedKeyFromValue:value serializedKey:serializedKey];
 
     if (err != CHIP_NO_ERROR) {
         // Storage doesn't have an existing keypair. Let's create one and add it to the storage.
@@ -125,25 +97,23 @@ std::string Base64ToString(const std::string & b64Value)
         }
         ReturnErrorOnFailure([self Serialize:serializedKey]);
 
-        std::string serializedString(chip::Uint8::to_const_char(serializedKey.Bytes()), serializedKey.Length());
-        std::string base64Value = StringToBase64(serializedString);
-        NSString * valueString = [NSString stringWithUTF8String:base64Value.c_str()];
-        [storage CHIPSetKeyValue:kOperationalCredentialsIssuerKeypairStorage value:valueString];
+        NSData * valueData = [NSData dataWithBytes:serializedKey.Bytes() length:serializedKey.Length()];
+        [storage setValue:valueData forKey:kOperationalCredentialsIssuerKeypairStorage];
     } else {
         ReturnErrorOnFailure([self Deserialize:serializedKey]);
     }
 
-    NSData * ipk;
-    value = [storage CHIPGetKeyValue:kOperationalCredentialsIPK];
-    err = [self decodeNSStringToNSData:value serializedKey:&ipk];
+    NSData * ipk = [storage valueForKey:kOperationalCredentialsIPK];
+    if (ipk == nil) {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
     if (err != CHIP_NO_ERROR) {
         uint8_t tempIPK[chip::Crypto::CHIP_CRYPTO_SYMMETRIC_KEY_LENGTH_BYTES];
 
         ReturnLogErrorOnFailure(chip::Crypto::DRBG_get_bytes(tempIPK, sizeof(tempIPK)));
 
         _ipk = [NSData dataWithBytes:tempIPK length:sizeof(tempIPK)];
-        NSString * valueString = [_ipk base64EncodedStringWithOptions:0];
-        [storage CHIPSetKeyValue:kOperationalCredentialsIPK value:valueString];
+        [storage setValue:_ipk forKey:kOperationalCredentialsIPK];
     } else {
         _ipk = ipk;
     }
@@ -151,30 +121,19 @@ std::string Base64ToString(const std::string & b64Value)
     return CHIP_NO_ERROR;
 }
 
-- (CHIP_ERROR)decodeNSStringWithValue:(NSString *)value serializedKey:(chip::Crypto::P256SerializedKeypair &)serializedKey
+- (CHIP_ERROR)initSerializedKeyFromValue:(NSData *)value serializedKey:(chip::Crypto::P256SerializedKeypair &)serializedKey
 {
     if (value == nil) {
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
 
-    std::string decoded = Base64ToString([value UTF8String]);
-
-    if (serializedKey.Capacity() < decoded.length()) {
+    if (serializedKey.Capacity() < [value length]) {
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    memcpy(serializedKey.Bytes(), decoded.data(), decoded.length());
-    serializedKey.SetLength(decoded.length());
+    memcpy(serializedKey.Bytes(), [value bytes], [value length]);
+    serializedKey.SetLength([value length]);
     return CHIP_NO_ERROR;
 }
 
-- (CHIP_ERROR)decodeNSStringToNSData:(NSString *)value serializedKey:(NSData **)decodedData
-{
-    if (value == nil) {
-        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
-    }
-
-    *decodedData = [[NSData alloc] initWithBase64EncodedString:value options:0];
-    return CHIP_NO_ERROR;
-}
 @end

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -39,8 +39,12 @@ BOOL CHIPGetConnectedDeviceWithID(uint64_t deviceId, CHIPDeviceConnectionCallbac
 void CHIPUnpairDeviceWithID(uint64_t deviceId);
 CHIPDevice * CHIPGetDeviceBeingCommissioned(void);
 
+NS_ASSUME_NONNULL_BEGIN
+
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
-- (NSData *)valueForKey:(NSString *)key;
-- (BOOL)setValue:(NSData *)value forKey:(NSString *)key;
-- (BOOL)removeValueForKey:(NSString *)key;
+- (NSData *)storageDataForKey:(NSString *)key;
+- (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key;
+- (BOOL)removeStorageDataForKey:(NSString *)key;
 @end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -26,7 +26,7 @@ extern NSString * const kFabricIdKey;
 CHIPDeviceController * InitializeCHIP(void);
 CHIPDeviceController * CHIPRestartController(CHIPDeviceController * controller);
 id CHIPGetDomainValueForKey(NSString * domain, NSString * key);
-void CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value);
+BOOL CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value);
 void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key);
 uint64_t CHIPGetNextAvailableDeviceID(void);
 NSString * KeyForPairedDevice(uint64_t id);
@@ -40,5 +40,7 @@ void CHIPUnpairDeviceWithID(uint64_t deviceId);
 CHIPDevice * CHIPGetDeviceBeingCommissioned(void);
 
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
-
+- (NSData *)valueForKey:(NSString *)key;
+- (BOOL)setValue:(NSData *)value forKey:(NSString *)key;
+- (BOOL)removeValueForKey:(NSString *)key;
 @end

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -34,10 +34,10 @@ id CHIPGetDomainValueForKey(NSString * domain, NSString * key)
     return nil;
 }
 
-void CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value)
+BOOL CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value)
 {
     CFPreferencesSetAppValue((CFStringRef) key, (__bridge CFPropertyListRef _Nullable)(value), (CFStringRef) domain);
-    CFPreferencesAppSynchronize((CFStringRef) domain);
+    return CFPreferencesAppSynchronize((CFStringRef) domain) == true;
 }
 
 void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key)
@@ -209,21 +209,25 @@ void CHIPUnpairDeviceWithID(uint64_t deviceId)
 
 // MARK: CHIPPersistentStorageDelegate
 
-- (NSString *)CHIPGetKeyValue:(NSString *)key
+- (nullable NSData *)valueForKey:(NSString *)key
 {
-    NSString * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
+    NSData * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
     NSLog(@"CHIPPersistentStorageDelegate Get Value for Key: %@, value %@", key, value);
     return value;
 }
 
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value
+- (BOOL)setValue:(NSData *)value forKey:(NSString *)key
 {
-    CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
+    return CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
 }
 
-- (void)CHIPDeleteKeyValue:(NSString *)key
+- (BOOL)removeValueForKey:(NSString *)key
 {
+    if (CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key) == nil) {
+        return NO;
+    }
     CHIPRemoveDomainValueForKey(kCHIPToolDefaultsDomain, key);
+    return YES;
 }
 
 @end

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -209,19 +209,19 @@ void CHIPUnpairDeviceWithID(uint64_t deviceId)
 
 // MARK: CHIPPersistentStorageDelegate
 
-- (nullable NSData *)valueForKey:(NSString *)key
+- (nullable NSData *)storageDataForKey:(NSString *)key
 {
     NSData * value = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
     NSLog(@"CHIPPersistentStorageDelegate Get Value for Key: %@, value %@", key, value);
     return value;
 }
 
-- (BOOL)setValue:(NSData *)value forKey:(NSString *)key
+- (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key
 {
     return CHIPSetDomainValueForKey(kCHIPToolDefaultsDomain, key, value);
 }
 
-- (BOOL)removeValueForKey:(NSString *)key
+- (BOOL)removeStorageDataForKey:(NSString *)key
 {
     if (CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, key) == nil) {
         return NO;

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
@@ -28,22 +28,22 @@ NS_ASSUME_NONNULL_BEGIN
 @required
 
 /**
- * Get the value for the given key.  Returns nil if there is no value for the
+ * Get the data for the given key.  Returns nil if there is no data for the
  * key.
  */
-- (nullable NSData *)valueForKey:(NSString *)key;
+- (nullable NSData *)storageDataForKey:(NSString *)key;
 
 /**
- * Set the value of the key to the given value.  Returns YES if the key was set
- * successfully, NO otherwise.
+ * Set the data for the viven key to the given value.  Returns YES if the key
+ * was set successfully, NO otherwise.
  */
-- (BOOL)setValue:(NSData *)value forKey:(NSString *)key;
+- (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key;
 
 /**
- * Delete the key and corresponding value.  Returns YES if the key was present,
+ * Delete the key and corresponding data.  Returns YES if the key was present,
  * NO if the key was not present.
  */
-- (BOOL)removeValueForKey:(NSString *)key;
+- (BOOL)removeStorageDataForKey:(NSString *)key;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegate.h
@@ -28,22 +28,22 @@ NS_ASSUME_NONNULL_BEGIN
 @required
 
 /**
- * Get the value for the given key
- *
+ * Get the value for the given key.  Returns nil if there is no value for the
+ * key.
  */
-- (nullable NSString *)CHIPGetKeyValue:(NSString *)key;
+- (nullable NSData *)valueForKey:(NSString *)key;
 
 /**
- * Set the value of the key to the given value
- *
+ * Set the value of the key to the given value.  Returns YES if the key was set
+ * successfully, NO otherwise.
  */
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value;
+- (BOOL)setValue:(NSData *)value forKey:(NSString *)key;
 
 /**
- * Delete the key and corresponding value
- *
+ * Delete the key and corresponding value.  Returns YES if the key was present,
+ * NO if the key was not present.
  */
-- (void)CHIPDeleteKeyValue:(NSString *)key;
+- (BOOL)removeValueForKey:(NSString *)key;
 
 @end
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -17,40 +17,6 @@
 
 #import "CHIPPersistentStorageDelegateBridge.h"
 
-#include <algorithm>
-#include <lib/support/Base64.h>
-#include <memory>
-#include <string>
-
-namespace {
-
-std::string StringToBase64(const std::string & value)
-{
-    std::unique_ptr<char[]> buffer(new char[BASE64_ENCODED_LEN(value.length())]);
-
-    uint32_t len = chip::Base64Encode32(
-        reinterpret_cast<const uint8_t *>(value.data()), static_cast<uint32_t>(value.length()), buffer.get());
-    if (len == UINT32_MAX) {
-        return "";
-    }
-
-    return std::string(buffer.get(), len);
-}
-
-std::string Base64ToString(const std::string & b64Value)
-{
-    std::unique_ptr<uint8_t[]> buffer(new uint8_t[BASE64_MAX_DECODED_LEN(b64Value.length())]);
-
-    uint32_t len = chip::Base64Decode32(b64Value.data(), static_cast<uint32_t>(b64Value.length()), buffer.get());
-    if (len == UINT32_MAX) {
-        return "";
-    }
-
-    return std::string(reinterpret_cast<const char *>(buffer.get()), len);
-}
-
-} // namespace
-
 CHIPPersistentStorageDelegateBridge::CHIPPersistentStorageDelegateBridge(id<CHIPPersistentStorageDelegate> delegate)
     : mDelegate(delegate)
     , mWorkQueue(dispatch_queue_create("com.zigbee.chip.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL))
@@ -61,72 +27,79 @@ CHIPPersistentStorageDelegateBridge::~CHIPPersistentStorageDelegateBridge(void) 
 
 CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key, void * buffer, uint16_t & size)
 {
+    if (buffer == nullptr && size != 0) {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
     __block CHIP_ERROR error = CHIP_NO_ERROR;
     NSString * keyString = [NSString stringWithUTF8String:key];
 
     dispatch_sync(mWorkQueue, ^{
         NSLog(@"PersistentStorageDelegate Sync Get Value for Key: %@", keyString);
 
-        NSString * valueString = nil;
+        NSData * value = [mDelegate valueForKey:keyString];
 
-        valueString = [mDelegate CHIPGetKeyValue:keyString];
-
-        if (valueString != nil) {
-            std::string decoded = Base64ToString([valueString UTF8String]);
-
-            if (decoded.length() > UINT16_MAX) {
-                error = CHIP_ERROR_BUFFER_TOO_SMALL;
-                size = 0;
-            } else {
-                if (buffer != nullptr) {
-                    memcpy(buffer, decoded.data(), std::min<size_t>(decoded.length(), size));
-                    if (size < decoded.length()) {
-                        error = CHIP_ERROR_BUFFER_TOO_SMALL;
-                    }
-                } else {
-                    error = CHIP_ERROR_NO_MEMORY;
-                }
-                size = static_cast<uint16_t>(decoded.length());
-            }
-        } else {
+        if (value == nil) {
             error = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+            return;
+        }
+
+        if ([value length] > UINT16_MAX) {
+            error = CHIP_ERROR_BUFFER_TOO_SMALL;
+            size = 0;
+            return;
+        }
+
+        uint16_t valueSize = static_cast<uint16_t>([value length]);
+        if (valueSize > size) {
+            error = CHIP_ERROR_BUFFER_TOO_SMALL;
+            size = valueSize;
+            return;
+        }
+
+        size = valueSize;
+        if (size != 0) {
+            // buffer is known to be non-null here.
+            memcpy(buffer, [value bytes], size);
         }
     });
+
     return error;
 }
 
 CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
 {
-    std::string base64Value = StringToBase64(std::string(static_cast<const char *>(value), size));
+    if (value == nullptr && size != 0) {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     NSString * keyString = [NSString stringWithUTF8String:key];
-    NSString * valueString = [NSString stringWithUTF8String:base64Value.c_str()];
+    NSData * valueData = (value == nullptr) ? [NSData data] : [NSData dataWithBytes:value length:size];
 
+    __block CHIP_ERROR error = CHIP_NO_ERROR;
     dispatch_sync(mWorkQueue, ^{
         NSLog(@"PersistentStorageDelegate Set Key %@", keyString);
 
-        [mDelegate CHIPSetKeyValue:keyString value:valueString];
+        if ([mDelegate setValue:valueData forKey:keyString] == NO) {
+            error = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+        }
     });
 
-    // TODO: ideally the error from the dispatch should be returned
-    // however we expect to replace the storage delegate with KVS so for now
-    // we return no error (return used to be void due to async dispatch anyway)
-
-    return CHIP_NO_ERROR;
+    return error;
 }
 
 CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncDeleteKeyValue(const char * key)
 {
     NSString * keyString = [NSString stringWithUTF8String:key];
+
+    __block CHIP_ERROR error = CHIP_NO_ERROR;
     dispatch_sync(mWorkQueue, ^{
         NSLog(@"PersistentStorageDelegate Delete Key: %@", keyString);
 
-        [mDelegate CHIPDeleteKeyValue:keyString];
+        if ([mDelegate removeValueForKey:keyString] == NO) {
+            error = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+        }
     });
 
-    // TODO: ideally the error from the dispatch should be returned
-    // however we expect to replace the storage delegate with KVS so for now
-    // we return no error (return used to be void due to async dispatch anyway)
-
-    return CHIP_NO_ERROR;
+    return error;
 }

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -37,7 +37,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key
     dispatch_sync(mWorkQueue, ^{
         NSLog(@"PersistentStorageDelegate Sync Get Value for Key: %@", keyString);
 
-        NSData * value = [mDelegate valueForKey:keyString];
+        NSData * value = [mDelegate storageDataForKey:keyString];
 
         if (value == nil) {
             error = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -80,7 +80,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncSetKeyValue(const char * key
     dispatch_sync(mWorkQueue, ^{
         NSLog(@"PersistentStorageDelegate Set Key %@", keyString);
 
-        if ([mDelegate setValue:valueData forKey:keyString] == NO) {
+        if ([mDelegate setStorageData:valueData forKey:keyString] == NO) {
             error = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
         }
     });
@@ -96,7 +96,7 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncDeleteKeyValue(const char * 
     dispatch_sync(mWorkQueue, ^{
         NSLog(@"PersistentStorageDelegate Delete Key: %@", keyString);
 
-        if ([mDelegate removeValueForKey:keyString] == NO) {
+        if ([mDelegate removeStorageDataForKey:keyString] == NO) {
             error = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
         }
     });

--- a/src/darwin/Framework/CHIPTests/CHIPTestStorage.h
+++ b/src/darwin/Framework/CHIPTests/CHIPTestStorage.h
@@ -20,9 +20,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPTestStorage : NSObject <CHIPPersistentStorageDelegate>
-- (NSString *)CHIPGetKeyValue:(NSString *)key;
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value;
-- (void)CHIPDeleteKeyValue:(NSString *)key;
+- (NSData *)valueForKey:(NSString *)key;
+// value is nullable because NSKeyValueCoding has a selector collision with us.
+- (BOOL)setValue:(nullable NSData *)value forKey:(NSString *)key;
+- (BOOL)removeValueForKey:(NSString *)key;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/CHIPTestStorage.h
+++ b/src/darwin/Framework/CHIPTests/CHIPTestStorage.h
@@ -20,10 +20,9 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPTestStorage : NSObject <CHIPPersistentStorageDelegate>
-- (NSData *)valueForKey:(NSString *)key;
-// value is nullable because NSKeyValueCoding has a selector collision with us.
-- (BOOL)setValue:(nullable NSData *)value forKey:(NSString *)key;
-- (BOOL)removeValueForKey:(NSString *)key;
+- (NSData *)storageDataForKey:(NSString *)key;
+- (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key;
+- (BOOL)removeStorageDataForKey:(NSString *)key;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/CHIPTestStorage.m
+++ b/src/darwin/Framework/CHIPTests/CHIPTestStorage.m
@@ -17,22 +17,25 @@
 #import "CHIPTestStorage.h"
 
 @interface CHIPTestStorage ()
-@property (strong, nonatomic) NSMutableDictionary<NSString *, NSString *> * values;
+@property (strong, nonatomic) NSMutableDictionary<NSString *, NSData *> * values;
 @end
 
 @implementation CHIPTestStorage
 
-- (NSString *)CHIPGetKeyValue:(NSString *)key
+- (NSData *)valueForKey:(NSString *)key
 {
     return _values[key];
 }
-- (void)CHIPSetKeyValue:(NSString *)key value:(NSString *)value
+- (BOOL)setValue:(NSData *)value forKey:(NSString *)key
 {
     _values[key] = value;
+    return YES;
 }
-- (void)CHIPDeleteKeyValue:(NSString *)key
+- (BOOL)removeValueForKey:(NSString *)key
 {
+    BOOL present = (_values[key] != nil);
     [_values removeObjectForKey:key];
+    return present;
 }
 
 - (instancetype)init

--- a/src/darwin/Framework/CHIPTests/CHIPTestStorage.m
+++ b/src/darwin/Framework/CHIPTests/CHIPTestStorage.m
@@ -22,16 +22,16 @@
 
 @implementation CHIPTestStorage
 
-- (NSData *)valueForKey:(NSString *)key
+- (NSData *)storageDataForKey:(NSString *)key
 {
     return _values[key];
 }
-- (BOOL)setValue:(NSData *)value forKey:(NSString *)key
+- (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key
 {
     _values[key] = value;
     return YES;
 }
-- (BOOL)removeValueForKey:(NSString *)key
+- (BOOL)removeStorageDataForKey:(NSString *)key
 {
     BOOL present = (_values[key] != nil);
     [_values removeObjectForKey:key];


### PR DESCRIPTION
We can just store NSData directly.

#### Problem
Unnecessary conversions to NSData, incorrect handling of things like null inputs and 0 lengths.

#### Change overview
Align API with API definition, just store NSData directly.

#### Testing
Passes XCTest, compiles across the board.