### PR TITLE
[Ameba] Fix 8710C OTA flash erase size

### DIFF
--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -322,7 +322,7 @@ void AmebaOTAImageProcessor::HandleProcessBlock(intptr_t context)
 
             // Erase target partition
             ChipLogProgress(SoftwareUpdate, "Erasing partition");
-            imageProcessor->NewFWBlkSize = ((0x1F8000 - 1) / 4096) + 1; // Use a fixed image length of 0xF8000, change in the future
+            imageProcessor->NewFWBlkSize = ((0x1AC000 - 1) / 4096) + 1; // Use a fixed image length of 0x1AC000, change in the future
             ChipLogProgress(SoftwareUpdate, "Erasing %d sectors", imageProcessor->NewFWBlkSize);
             device_mutex_lock(RT_DEV_LOCK_FLASH);
             for (int i = 0; i < imageProcessor->NewFWBlkSize; i++)

--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -322,7 +322,8 @@ void AmebaOTAImageProcessor::HandleProcessBlock(intptr_t context)
 
             // Erase target partition
             ChipLogProgress(SoftwareUpdate, "Erasing partition");
-            imageProcessor->NewFWBlkSize = ((0x1AC000 - 1) / 4096) + 1; // Use a fixed image length of 0x1AC000, change in the future
+            imageProcessor->NewFWBlkSize =
+                ((0x1AC000 - 1) / 4096) + 1; // Use a fixed image length of 0x1AC000, change in the future
             ChipLogProgress(SoftwareUpdate, "Erasing %d sectors", imageProcessor->NewFWBlkSize);
             device_mutex_lock(RT_DEV_LOCK_FLASH);
             for (int i = 0; i < imageProcessor->NewFWBlkSize; i++)


### PR DESCRIPTION
#### Problem
- Wrong flash size to erase during OTA for 8710C platform
- Causes other data to be erased

#### Change overview
- Change the flash erase size to the correct size

#### Testing
- Execute OTA successfully, no erasing of other data
