### PR TITLE
[zephyr] Initialize realtime clock

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -229,6 +229,11 @@ if (CONFIG_CHIP_ENABLE_DNSSD_SRP)
     chip_gn_arg_string("chip_mdns" "platform")
 endif()
 
+if (CONFIG_CHIP_FIRMWARE_BUILD_UNIX_TIME)
+    string(TIMESTAMP CHIP_FIRMWARE_BUILD_UNIX_TIME "%s")
+    chip_gn_arg_string("chip_device_config_firmware_build_unix_time" ${CHIP_FIRMWARE_BUILD_UNIX_TIME})
+endif()
+
 if (CHIP_PROJECT_CONFIG)
     chip_gn_arg_string("chip_project_config_include"        ${CHIP_PROJECT_CONFIG})
     chip_gn_arg_string("chip_system_project_config_include" ${CHIP_PROJECT_CONFIG})

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -209,6 +209,13 @@ config CHIP_MALLOC_SYS_HEAP_SIZE
 
 endif
 
+config CHIP_FIRMWARE_BUILD_UNIX_TIME
+	bool "Make Unix time of compilation available in source code"
+	default y
+	help
+	  When enabled, the Unix time of the firmware build is exposed to the
+	  source code and used to initialize the last known UTC time.
+
 config APP_LINK_WITH_CHIP
 	bool "Link 'app' with Connected Home over IP"
 	default y

--- a/scripts/examples/nrfconnect_example.sh
+++ b/scripts/examples/nrfconnect_example.sh
@@ -22,7 +22,8 @@ APP="$1"
 BOARD="$2"
 shift 2
 
-COMMON_CI_FLAGS=(-DCONFIG_CHIP_DEBUG_SYMBOLS=n)
+# Disable debug symbols and firmware build time to increase ccache hit ratio in CI
+COMMON_CI_FLAGS=(-DCONFIG_CHIP_DEBUG_SYMBOLS=n -DCONFIG_CHIP_FIRMWARE_BUILD_UNIX_TIME=n)
 
 if [[ ! -f "$APP/nrfconnect/CMakeLists.txt" || -z "$BOARD" ]]; then
     echo "Usage: $0 <application> <board>" >&2

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -47,6 +47,9 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     # Time the firmware was built.
     chip_device_config_firmware_build_time = ""
 
+    # Unix time the firmware was built at (seconds since the epoch)
+    chip_device_config_firmware_build_unix_time = ""
+
     # Use OpenThread ftd or mtd library
     chip_device_config_thread_ftd = chip_openthread_ftd
 
@@ -140,6 +143,9 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     }
     if (chip_device_config_firmware_build_time != "") {
       defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME=\"${chip_device_config_firmware_build_time}\"" ]
+    }
+    if (chip_device_config_firmware_build_unix_time != "") {
+      defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_UNIX_TIME=${chip_device_config_firmware_build_unix_time}" ]
     }
 
     if (chip_use_transitional_commissionable_data_provider) {

--- a/src/platform/Zephyr/SystemTimeSupport.cpp
+++ b/src/platform/Zephyr/SystemTimeSupport.cpp
@@ -35,32 +35,58 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
+
 ClockImpl gClockImpl;
+
 } // namespace Internal
 
-Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)
+namespace {
+
+// Last known UTC time in Unix format.
+#ifdef CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_UNIX_TIME
+Clock::Microseconds64 gRealTime = Microseconds64(CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_UNIX_TIME * UINT64_C(1000000));
+#else
+Clock::Microseconds64 gRealTime = Microseconds64(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD * UINT64_C(1000000));
+#endif
+
+// Monotonic time of setting the last known UTC time.
+Clock::Microseconds64 gRealTimeSetTime;
+
+} // namespace
+
+Microseconds64 ClockImpl::GetMonotonicMicroseconds64()
 {
     return Microseconds64(k_ticks_to_us_floor64(k_uptime_ticks()));
 }
 
-Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
+Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
 {
     return Milliseconds64(k_uptime_get());
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    aCurTime = GetMonotonicMicroseconds64() - gRealTimeSetTime + gRealTime;
+
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    Microseconds64 curTimeUs;
+
+    ReturnErrorOnFailure(GetClock_RealTime(curTimeUs));
+    aCurTime = std::chrono::duration_cast<Milliseconds64>(curTimeUs);
+
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
+CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    gRealTime        = aNewCurTime;
+    gRealTimeSetTime = GetMonotonicMicroseconds64();
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace Clock

--- a/src/platform/Zephyr/SystemTimeSupport.cpp
+++ b/src/platform/Zephyr/SystemTimeSupport.cpp
@@ -44,13 +44,13 @@ namespace {
 
 // Last known UTC time in Unix format.
 #ifdef CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_UNIX_TIME
-Clock::Microseconds64 gRealTime = Microseconds64(CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_UNIX_TIME * UINT64_C(1000000));
+Microseconds64 gRealTime = Seconds64(CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_UNIX_TIME * UINT64_C(1000000));
 #else
-Clock::Microseconds64 gRealTime = Microseconds64(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD * UINT64_C(1000000));
+Microseconds64 gRealTime = Seconds64(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD * UINT64_C(1000000));
 #endif
 
 // Monotonic time of setting the last known UTC time.
-Clock::Microseconds64 gRealTimeSetTime;
+Microseconds64 gRealTimeSetTime;
 
 } // namespace
 


### PR DESCRIPTION
#### Problem
According to the spec the initial last known UTC time should be initialized to the compilation time. Real time clock is yet unsupported on the nRF Connect platform and "The device does not support GetClock_RealTimeMS()" message is printed during CASE.

#### Change overview
When `CONFIG_CHIP_FIRMWARE_BUILD_UNIX_TIME` Kconfig option is set (it is set by default), use the unix time of compilation to initialize the last known UTC time on the device.

#### Testing
Tested that commissioning work and "The device does not support GetClock_RealTimeMS()" does not appear. Verified with debug logs that returned real time makes sense.
