### PR TITLE
[nrfconnect] Increased BT RX stack size to 1200

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -169,7 +169,7 @@ config BT_BUF_ACL_TX_SIZE
 
 config BT_RX_STACK_SIZE
     int
-    default 1120
+    default 1200
 
 # Enable NFC support
 


### PR DESCRIPTION
#### Problem
We see that with newer NCS versions in some cases current BT RX
stack size is not big enough and we get hardfault.

#### Change overview
Increased BT RX stack size to 1200.

#### Testing
No testing needed.
