### PR TITLE
[ESP32] Server the requested file in file designator

### DIFF
--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -83,9 +83,6 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
             sendFlags.Set(chip::Messaging::SendMessageFlags::kExpectResponse);
         }
         VerifyOrReturn(mExchangeCtx != nullptr);
-        {
-            return;
-        }
         err = mExchangeCtx->SendMessage(event.msgTypeData.ProtocolId, event.msgTypeData.MessageType, std::move(event.MsgData),
                                         sendFlags);
         if (err == CHIP_NO_ERROR)

--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -82,17 +82,24 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
             // end of the transfer.
             sendFlags.Set(chip::Messaging::SendMessageFlags::kExpectResponse);
         }
-        VerifyOrReturn(mExchangeCtx != nullptr, ChipLogError(BDX, "%s: mExchangeCtx is null", __FUNCTION__));
+        if (mExchangeCtx == nullptr)
+        {
+            return;
+        }
         err = mExchangeCtx->SendMessage(event.msgTypeData.ProtocolId, event.msgTypeData.MessageType, std::move(event.MsgData),
                                         sendFlags);
-        if (err != CHIP_NO_ERROR)
+        if (err == CHIP_NO_ERROR)
         {
-            ChipLogError(BDX, "SendMessage failed: %s", chip::ErrorStr(err));
+            if (!sendFlags.Has(chip::Messaging::SendMessageFlags::kExpectResponse))
+            {
+                // After sending the StatusReport, exchange context gets closed so, set mExchangeCtx to null
+                mExchangeCtx = nullptr;
+            }
         }
-        if (event.msgTypeData.HasMessageType(chip::Protocols::SecureChannel::MsgType::StatusReport))
+        else
         {
-            // After sending the StatusReport, exchange context gets closed so, set mExchangeCtx to null
-            mExchangeCtx = nullptr;
+            ChipLogError(BDX, "SendMessage failed: %" CHIP_ERROR_FORMAT, err.Format());
+            Reset();
         }
         break;
     }

--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -82,7 +82,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
             // end of the transfer.
             sendFlags.Set(chip::Messaging::SendMessageFlags::kExpectResponse);
         }
-        if (mExchangeCtx == nullptr)
+        VerifyOrReturn(mExchangeCtx != nullptr);
         {
             return;
         }

--- a/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/esp32/main/BdxOtaSender.cpp
@@ -221,6 +221,11 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
     }
 }
 
+/* Reset() calls bdx::TransferSession::Reset() which sets the output event type to
+ * TransferSession::OutputEventType::kNone. So, bdx::TransferFacilitator::PollForOutput()
+ * will call HandleTransferSessionOutput() with event TransferSession::OutputEventType::kNone.
+ * Since we are ignoring kNone events so, it is okay HandleTransferSessionOutput() being called with event kNone
+ */
 void BdxOtaSender::Reset()
 {
     mFabricIndex.ClearValue();

--- a/examples/ota-provider-app/esp32/main/include/ota-provider-common/BdxOtaSender.h
+++ b/examples/ota-provider-app/esp32/main/include/ota-provider-common/BdxOtaSender.h
@@ -71,6 +71,8 @@ struct BdxOtaSenderCallbacks
 class BdxOtaSender : public chip::bdx::Responder
 {
 public:
+    BdxOtaSender() { memset(mFileDesignator, 0, sizeof(mFileDesignator)); }
+
     // Initializes BDX transfer-related metadata. Should always be called first.
     CHIP_ERROR InitializeTransfer(chip::FabricIndex fabricIndex, chip::NodeId nodeId);
 
@@ -92,6 +94,14 @@ public:
      */
     uint64_t GetTransferLength(void);
 
+    /**
+     * @brief
+     *  Get the file designator for the transfer
+     *
+     * @return File designator for the transfer
+     */
+    const char * GetFileDesignator() const { return mFileDesignator; }
+
 private:
     // Inherited from bdx::TransferFacilitator
     void HandleTransferSessionOutput(chip::bdx::TransferSession::OutputEvent & event) override;
@@ -109,4 +119,9 @@ private:
     chip::Callback::Callback<OnBdxBlockQuery> * mOnBlockQueryCallback             = nullptr;
     chip::Callback::Callback<OnBdxTransferComplete> * mOnTransferCompleteCallback = nullptr;
     chip::Callback::Callback<OnBdxTransferFailed> * mOnTransferFailedCallback     = nullptr;
+
+    // Maximum file designator length
+    static constexpr uint8_t kMaxFDLen = 30;
+    // Null-terminated string representing file designator
+    char mFileDesignator[kMaxFDLen];
 };

--- a/examples/ota-provider-app/esp32/main/main.cpp
+++ b/examples/ota-provider-app/esp32/main/main.cpp
@@ -98,7 +98,7 @@ static void InitServer(intptr_t context)
     bdxOtaSender->SetCallbacks(callbacks);
 
     esp_vfs_spiffs_conf_t spiffs_conf = {
-        .base_path              = "/spiffs",
+        .base_path              = "/fs",
         .partition_label        = NULL,
         .max_files              = 3,
         .format_if_mount_failed = false,
@@ -114,13 +114,16 @@ static void InitServer(intptr_t context)
     err = esp_spiffs_info(NULL, &total, &used);
     ESP_LOGI(TAG, "Partition size: total: %d, used: %d", total, used);
     char otaImagePath[kMaxImagePathlen];
-    sprintf(otaImagePath, "/spiffs/%s", otaFilename);
+    memset(otaImagePath, 0, sizeof(otaImagePath));
+    snprintf(otaImagePath, sizeof(otaImagePath), "/fs/%s", otaFilename);
+
     otaImageFile = fopen(otaImagePath, "r");
     if (otaImageFile == NULL)
     {
         ESP_LOGE(TAG, "Failed to open %s", otaFilename);
         return;
     }
+
     fseek(otaImageFile, 0, SEEK_END);
     otaImageLen = ftell(otaImageFile);
     rewind(otaImageFile);
@@ -130,6 +133,8 @@ static void InitServer(intptr_t context)
         otaProvider.SetQueryImageStatus(OTAQueryStatus::kUpdateAvailable);
         otaProvider.SetOTAFilePath(otaImagePath);
     }
+    fclose(otaImageFile);
+    otaImageFile = NULL;
 
     chip::app::Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, &otaProvider);
 
@@ -144,18 +149,32 @@ static void InitServer(intptr_t context)
 
 CHIP_ERROR OnBlockQuery(void * context, chip::System::PacketBufferHandle & blockBuf, size_t & size, bool & isEof, uint32_t offset)
 {
+    BdxOtaSender * bdxOtaSender = otaProvider.GetBdxOtaSender();
+    VerifyOrReturnError(bdxOtaSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
     if (otaTransferInProgress == false)
     {
-        if (otaImageFile == NULL || otaImageLen == 0)
+        const char * fileDesignator = bdxOtaSender->GetFileDesignator();
+        if (fileDesignator == nullptr || fileDesignator[0] == 0)
+        {
+            ESP_LOGE(TAG, "File designator is null");
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+
+        char otaImagePath[kMaxImagePathlen];
+        memset(otaImagePath, 0, sizeof(otaImagePath));
+        snprintf(otaImagePath, sizeof(otaImagePath), "%s", fileDesignator);
+        ESP_LOGI(TAG, "File designator: %s", otaImagePath);
+
+        otaImageFile = fopen(otaImagePath, "r");
+        if (otaImageFile == NULL)
+
         {
             ESP_LOGE(TAG, "Failed to open the OTA image file");
             return CHIP_ERROR_OPEN_FAILED;
         }
         otaTransferInProgress = true;
     }
-
-    BdxOtaSender * bdxOtaSender = otaProvider.GetBdxOtaSender();
-    VerifyOrReturnError(bdxOtaSender != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     uint16_t blockBufAvailableLength = blockBuf->AvailableDataLength();
     uint16_t transferBlockSize       = bdxOtaSender->GetTransferBlockSize();
@@ -186,12 +205,22 @@ void OnTransferComplete(void * context)
 {
     ESP_LOGI(TAG, "OTA Image Transfer Complete");
     otaTransferInProgress = false;
+    if (otaImageFile)
+    {
+        fclose(otaImageFile);
+        otaImageFile = NULL;
+    }
 }
 
 void OnTransferFailed(void * context, BdxSenderErrorTypes status)
 {
     ESP_LOGI(TAG, "OTA Image Transfer Failed, status:%x", status);
     otaTransferInProgress = false;
+    if (otaImageFile)
+    {
+        fclose(otaImageFile);
+        otaImageFile = NULL;
+    }
 }
 
 extern "C" void app_main()


### PR DESCRIPTION
* Dup of #16616 as it was closed by stale bot.

#### Problem
* Fixes #15757
* OTA-Provider crashes if file designator is invalid

#### Change overview
* Server the file requested in file designator
* Set the exchange context to null after sending status report

#### Testing
* Tested using Linux OTA-R and ESP32 OTA-P