### PR TITLE
[OTA] Handle invalid designator in OTA-P and reset OTA-R state on receiving BDX error

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -205,6 +205,11 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
     }
 }
 
+/* Reset() calls bdx::TransferSession::Reset() which sets the output event type to
+ * TransferSession::OutputEventType::kNone. So, bdx::TransferFacilitator::PollForOutput()
+ * will call HandleTransferSessionOutput() with event TransferSession::OutputEventType::kNone.
+ * Since we are ignoring kNone events so, it is okay HandleTransferSessionOutput() being called with event kNone
+ */
 void BdxOtaSender::Reset()
 {
     mFabricIndex.ClearValue();

--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -82,10 +82,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
             // end of the transfer.
             sendFlags.Set(chip::Messaging::SendMessageFlags::kExpectResponse);
         }
-        if (mExchangeCtx == nullptr)
-        {
-            return;
-        }
+        VerifyOrReturn(mExchangeCtx != nullptr);
         err = mExchangeCtx->SendMessage(event.msgTypeData.ProtocolId, event.msgTypeData.MessageType, std::move(event.MsgData),
                                         sendFlags);
 

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -82,10 +82,10 @@ public:
 
 private:
     void PollTransferSession();
+    void CleanupOnError(app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
     CHIP_ERROR HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent);
     void SetState(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
-    void Reset(bool resetBdxTransfer, bool abortImageProcessing,
-               app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
+    void Reset();
 
     chip::bdx::TransferSession mBdxTransfer;
     MessagingDelegate * mMsgDelegate = nullptr;

--- a/src/app/clusters/ota-requestor/BDXDownloader.h
+++ b/src/app/clusters/ota-requestor/BDXDownloader.h
@@ -84,7 +84,8 @@ private:
     void PollTransferSession();
     CHIP_ERROR HandleBdxEvent(const chip::bdx::TransferSession::OutputEvent & outEvent);
     void SetState(State state, app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
-    void Reset();
+    void Reset(bool resetBdxTransfer, bool abortImageProcessing,
+               app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum reason);
 
     chip::bdx::TransferSession mBdxTransfer;
     MessagingDelegate * mMsgDelegate = nullptr;


### PR DESCRIPTION
Dup of #16615 which addresses the comment

#### Problem
- OTA provider do abort the transfer is file designator is invalid. After handling this case, it used to crash.
- OTA requestor do not reset state to Idle if bdx sends a status report

#### Change overview
- [OTA-P] Abort transfer if file designator is invalid, Set the exchange context to null after sending status report
- [OTA-R] Reset ota-requestor state if BDX sends an error

#### Testing
- Tested manually with linux ota-requestor and ota-provider app.
- Programatically used the invalid designator on first attempt and then a valid one, did not reboot the provider and requestor and was able to start the transfer.
- Also, after completion of transfer was able to start the transfer again without rebooting both provider and requestor