### PR TITLE
[chip-tool-darwin] Fix ignored return values for simulated clusters

### DIFF
--- a/examples/chip-tool-darwin/commands/tests/TestCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/tests/TestCommandBridge.h
@@ -20,6 +20,7 @@
 
 #include "../common/CHIPCommandBridge.h"
 #include <app/tests/suites/commands/delay/DelayCommands.h>
+#include <app/tests/suites/commands/log/LogCommands.h>
 #include <app/tests/suites/commands/system/SystemCommands.h>
 #include <app/tests/suites/include/ConstraintsChecker.h>
 #include <app/tests/suites/include/PICSChecker.h>
@@ -60,6 +61,7 @@ class TestCommandBridge : public CHIPCommandBridge,
                           public ConstraintsChecker,
                           public PICSChecker,
                           public DelayCommands,
+                          public LogCommands,
                           public SystemCommands {
 public:
     TestCommandBridge(const char * _Nonnull commandName)
@@ -98,17 +100,6 @@ public:
     {
         ChipLogError(chipTool, " ***** Test Failure: %s\n", message.c_str());
         SetCommandExitStatus(err);
-    }
-
-    void Log(const char * _Nullable identity, const chip::app::Clusters::LogCommands::Commands::Log::Type & value)
-    {
-        NSLog(@"%.*s", static_cast<int>(value.message.size()), value.message.data());
-        NextTest();
-    }
-
-    void UserPrompt(const char * _Nullable identity, const chip::app::Clusters::LogCommands::Commands::UserPrompt::Type & value)
-    {
-        NextTest();
     }
 
     /////////// DelayCommands Interface /////////

--- a/examples/chip-tool-darwin/templates/tests/partials/test_cluster.zapt
+++ b/examples/chip-tool-darwin/templates/tests/partials/test_cluster.zapt
@@ -132,7 +132,7 @@ class {{filename}}: public TestCommandBridge
         {{#chip_tests_item_parameters}}
           {{>commandValue ns=parent.cluster container=(asPropertyValue dontUnwrapValue=true) definedValue=definedValue depth=0}}
         {{/chip_tests_item_parameters}}
-        {{command}}("{{identity}}", value);
+        return {{command}}("{{identity}}", value);
         {{else}}
         CHIPDevice * device = GetDevice("{{identity}}");
         CHIPTest{{asUpperCamelCase cluster}} * cluster = [[CHIPTest{{asUpperCamelCase cluster}} alloc] initWithDevice:device endpoint:{{endpoint}} queue:mCallbackQueue];
@@ -269,11 +269,11 @@ class {{filename}}: public TestCommandBridge
         {{/chip_tests_item_responses}}
     }{{#unless isWaitForReport}}]{{/unless}};
 
-    {{/if}}
     {{#if async}}
     NextTest();
     {{/if}}
     return CHIP_NO_ERROR;
+    {{/if}}
   }
 {{/chip_tests_items}}
 


### PR DESCRIPTION
#### Problem

The error return code of simulated clusters in `chip-tool-darwin` is ignored...

#### Change overview
 * Use the returned error code

Note: This is on top of #18383