### PR TITLE
Move ActiveResolveAttempt types to Variant.

### DIFF
--- a/src/lib/dnssd/ActiveResolveAttempts.h
+++ b/src/lib/dnssd/ActiveResolveAttempts.h
@@ -146,7 +146,7 @@ public:
                 return false;
             }
         }
-        bool IsEmpty() const { return resolveData.Valid(); }
+        bool IsEmpty() const { return !resolveData.Valid(); }
         bool IsResolve() const { return resolveData.Is<Resolve>(); }
         bool IsBrowse() const { return resolveData.Is<Browse>(); }
         void Clear() { resolveData = DataType(); }

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -528,38 +528,38 @@ CHIP_ERROR MinMdnsResolver::SendPendingBrowseQueries()
 
         mdns::Minimal::FullQName qname;
 
-        switch (attempt.Value().browse.type)
+        switch (attempt.Value().BrowseData().type)
         {
         case DiscoveryType::kOperational:
             qname = CheckAndAllocateQName(kOperationalServiceName, kOperationalProtocol, kLocalDomain);
             break;
         case DiscoveryType::kCommissionableNode:
-            if (attempt.Value().browse.filter.type == DiscoveryFilterType::kNone)
+            if (attempt.Value().BrowseData().filter.type == DiscoveryFilterType::kNone)
             {
                 qname = CheckAndAllocateQName(kCommissionableServiceName, kCommissionProtocol, kLocalDomain);
             }
-            else if (attempt.Value().browse.filter.type == DiscoveryFilterType::kInstanceName)
+            else if (attempt.Value().BrowseData().filter.type == DiscoveryFilterType::kInstanceName)
             {
-                qname = CheckAndAllocateQName(attempt.Value().browse.filter.instanceName, kCommissionableServiceName,
+                qname = CheckAndAllocateQName(attempt.Value().BrowseData().filter.instanceName, kCommissionableServiceName,
                                               kCommissionProtocol, kLocalDomain);
             }
             else
             {
                 char subtypeStr[Common::kSubTypeMaxLength + 1];
-                ReturnErrorOnFailure(MakeServiceSubtype(subtypeStr, sizeof(subtypeStr), attempt.Value().browse.filter));
+                ReturnErrorOnFailure(MakeServiceSubtype(subtypeStr, sizeof(subtypeStr), attempt.Value().BrowseData().filter));
                 qname = CheckAndAllocateQName(subtypeStr, kSubtypeServiceNamePart, kCommissionableServiceName, kCommissionProtocol,
                                               kLocalDomain);
             }
             break;
         case DiscoveryType::kCommissionerNode:
-            if (attempt.Value().browse.filter.type == DiscoveryFilterType::kNone)
+            if (attempt.Value().BrowseData().filter.type == DiscoveryFilterType::kNone)
             {
                 qname = CheckAndAllocateQName(kCommissionerServiceName, kCommissionProtocol, kLocalDomain);
             }
             else
             {
                 char subtypeStr[Common::kSubTypeMaxLength + 1];
-                ReturnErrorOnFailure(MakeServiceSubtype(subtypeStr, sizeof(subtypeStr), attempt.Value().browse.filter));
+                ReturnErrorOnFailure(MakeServiceSubtype(subtypeStr, sizeof(subtypeStr), attempt.Value().BrowseData().filter));
                 qname = CheckAndAllocateQName(subtypeStr, kSubtypeServiceNamePart, kCommissionerServiceName, kCommissionProtocol,
                                               kLocalDomain);
             }
@@ -638,7 +638,7 @@ CHIP_ERROR MinMdnsResolver::SendPendingResolveQueries()
             char nameBuffer[kMaxOperationalServiceNameSize] = "";
 
             // Node and fabricid are encoded in server names.
-            ReturnErrorOnFailure(MakeInstanceName(nameBuffer, sizeof(nameBuffer), resolve.Value().peerId));
+            ReturnErrorOnFailure(MakeInstanceName(nameBuffer, sizeof(nameBuffer), resolve.Value().ResolveData().peerId));
 
             const char * instanceQName[] = { nameBuffer, kOperationalServiceName, kOperationalProtocol, kLocalDomain };
             Query query(instanceQName);

--- a/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/tests/TestActiveResolveAttempts.cpp
@@ -242,7 +242,7 @@ void TestLRU(nlTestSuite * inSuite, void * inContext)
 
     for (Optional<ActiveResolveAttempts::ScheduledAttempt> s = attempts.NextScheduled(); s.HasValue(); s = attempts.NextScheduled())
     {
-        NL_TEST_ASSERT(inSuite, s.Value().peerId.GetNodeId() != 9999);
+        NL_TEST_ASSERT(inSuite, s.Value().ResolveData().peerId.GetNodeId() != 9999);
     }
 
     // Still have active pending items (queue is full)
@@ -266,7 +266,7 @@ void TestLRU(nlTestSuite * inSuite, void * inContext)
         Optional<ActiveResolveAttempts::ScheduledAttempt> s = attempts.NextScheduled();
         while (s.HasValue())
         {
-            NL_TEST_ASSERT(inSuite, s.Value().peerId.GetNodeId() != 9999);
+            NL_TEST_ASSERT(inSuite, s.Value().ResolveData().peerId.GetNodeId() != 9999);
             s = attempts.NextScheduled();
         }
     }


### PR DESCRIPTION
Will start expanding with AAAA query support for #18256 , so switching to a
slightly more extensible way of storing values.

#### Problem
Hard to extend active resolve retries to more types.

#### Change overview
use chip Variant type instead of a manually hard-coded type (enum + union)

#### Testing
Ran unit tests.
CI will validate more tests.