### PR TITLE
[opcreds] Fix LEAVE event on RemoveFabric

### DIFF
--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -333,21 +333,6 @@ private:
                                  static_cast<unsigned>(fabricIndex), err.Format());
                 }
             }
-
-            {
-                // Remove access control entries in reverse order. (It could be
-                // any order, but reverse order will cause less churn in
-                // persistent storage.)
-                size_t count = 0;
-                if (Access::GetAccessControl().GetEntryCount(fabricIndex, count) == CHIP_NO_ERROR)
-                {
-                    while (count)
-                    {
-                        (void) Access::GetAccessControl().DeleteEntry(nullptr, fabricIndex, --count);
-                    }
-                }
-            }
-            app::EventManagement::GetInstance().FabricRemoved(fabricIndex);
         };
 
         void OnFabricRetrievedFromStorage(FabricTable & fabricTable, FabricIndex fabricIndex) override


### PR DESCRIPTION
#### Problem
LEAVE event is not emitted on RemoveFabric or factory reset.
There are two reasons for that:
- Removing a fabric causes closing all active ReadHandlers
  for a given fabric, so we must flush the event log before
  that happens.
- There are two listeners for removing a fabric; the one
  that removes ACLs for a given fabric index is executed
  prior to the other one that generates LEAVE event. That
  causes "Acccess control: denied" error.

#### Change overview
Fix both issues.

#### Testing
Verified using nRF Connect examples that LEAVE event is delivered successfully.
