### PR TITLE
Shutdown Python REPL correctly

### DIFF
--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -12,6 +12,7 @@ import chip.logging
 import argparse
 import builtins
 import chip.FabricAdmin
+import atexit
 
 _fabricAdmins = None
 
@@ -96,6 +97,12 @@ def ReplInit():
     logging.getLogger().setLevel(logging.WARN)
 
 
+def StackShutdown():
+    chip.FabricAdmin.FabricAdmin.ShutdownAll()
+    ChipDeviceCtrl.ChipDeviceController.ShutdownAll()
+    builtins.chipStack.Shutdown()
+
+
 def matterhelp(classOrObj=None):
     if (classOrObj is None):
         inspect(builtins.devCtrl, methods=True, help=True, private=False)
@@ -129,6 +136,8 @@ fabricAdmins = LoadFabricAdmins()
 devCtrl = CreateDefaultDeviceController()
 
 builtins.devCtrl = devCtrl
+
+atexit.register(StackShutdown)
 
 console.print(
     '\n\n[blue]Default CHIP Device Controller has been initialized to manage [bold red]fabricAdmins[0][blue], and is available as [bold red]devCtrl')

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -318,6 +318,8 @@ class ChipStack(object):
             self._ChipStackLib.pychip_Stack_SetLogFunct(logFunct)
 
     def Shutdown(self):
+        # Make sure PersistentStorage is destructed before chipStack
+        # to avoid accessing builtins.chipStack after destruction.
         self._persistentStorage = None
         self.Call(lambda: self._ChipStackLib.pychip_Stack_Shutdown())
         self.networkLock = None

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -318,6 +318,7 @@ class ChipStack(object):
             self._ChipStackLib.pychip_Stack_SetLogFunct(logFunct)
 
     def Shutdown(self):
+        self._persistentStorage = None
         self.Call(lambda: self._ChipStackLib.pychip_Stack_Shutdown())
         self.networkLock = None
         self.completeEvent = None


### PR DESCRIPTION
#### Problem
* Fix crash when REPL is being shutdown
* Fixes #18409

#### Change overview
Uses `atexit` module to Shutdown the CHIP stack when they Python REPL quits. Also addresses an issue where the Storage manager tries to access the chipStack after Shutdown.

#### Testing
Using `chip-repl` in dev environment, quit while debugger is attached. No more segfaults.