### PR TITLE
Add --debug argument to REPL

### DIFF
--- a/src/controller/python/chip-repl.py
+++ b/src/controller/python/chip-repl.py
@@ -18,31 +18,17 @@
 #
 
 import IPython
-import chip
-import chip.logging
-import coloredlogs
-import logging
 from traitlets.config import Config
-from rich import print
-from rich import pretty
-from rich import inspect
 import builtins
-import argparse
 import sys
 
 
 def main():
-    parser = argparse.ArgumentParser()
-    parser.add_argument("-p", "--storagepath", help="Path to persistent storage configuration file (default: /tmp/repl-storage.json)",
-                        action="store", default="/tmp/repl-storage.json")
-
-    args = parser.parse_args()
-
     c = Config()
     c.InteractiveShellApp.exec_lines = [
         "import pkgutil",
         "module = pkgutil.get_loader('chip.ChipReplStartup')",
-        "%run {module.path} --storagepath " + f"{args.storagepath}"
+        "%run {module.path} " + " ".join(sys.argv[1:])
     ]
 
     sys.argv = [sys.argv[0]]

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -66,7 +66,7 @@ def CreateDefaultDeviceController():
     return _fabricAdmins[0].NewController()
 
 
-def ReplInit():
+def ReplInit(debug):
     #
     # Install the pretty printer that rich provides to replace the existing
     # printer.
@@ -92,8 +92,10 @@ def ReplInit():
     coloredlogs.install(level='DEBUG')
     chip.logging.RedirectToPythonLogging()
 
-    # logging.getLogger().setLevel(logging.DEBUG)
-    logging.getLogger().setLevel(logging.WARN)
+    if debug:
+        logging.getLogger().setLevel(logging.DEBUG)
+    else:
+        logging.getLogger().setLevel(logging.WARN)
 
 
 def matterhelp(classOrObj=None):
@@ -122,8 +124,11 @@ console = Console()
 parser = argparse.ArgumentParser()
 parser.add_argument(
     "-p", "--storagepath", help="Path to persistent storage configuration file (default: /tmp/repl-storage.json)", action="store", default="/tmp/repl-storage.json")
+parser.add_argument(
+    "-d", "--debug", help="Set default logging level to debug.", action="store_true")
 args = parser.parse_args()
-ReplInit()
+
+ReplInit(args.debug)
 chipStack = ChipStack(persistentStoragePath=args.storagepath)
 fabricAdmins = LoadFabricAdmins()
 devCtrl = CreateDefaultDeviceController()


### PR DESCRIPTION
#### Problem
Sometimes more logging during REPL startup is helpful.

#### Change overview
This adds an option to enable debug log level at startup.

#### Testing
Running Python REPL in local Python dev environment.
