### PR TITLE
Add Unpair to chip-tool-darwin

### DIFF
--- a/examples/chip-tool-darwin/commands/pairing/Commands.h
+++ b/examples/chip-tool-darwin/commands/pairing/Commands.h
@@ -50,13 +50,19 @@ public:
     PairBleThread() : PairingCommandBridge("ble-thread", PairingMode::Ble, PairingNetworkType::Thread) {}
 };
 
+class Unpair : public PairingCommandBridge
+{
+public:
+    Unpair() : PairingCommandBridge("unpair", PairingMode::None, PairingNetworkType::None) {}
+};
+
 void registerCommandsPairing(Commands & commands)
 {
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
         make_unique<PairQRCode>(),  make_unique<PairManualCode>(), make_unique<PairWithIPAddress>(),
-        make_unique<PairBleWiFi>(), make_unique<PairBleThread>(),
+        make_unique<PairBleWiFi>(), make_unique<PairBleThread>(),  make_unique<Unpair>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/pairing/PairingCommandBridge.h
@@ -22,6 +22,7 @@
 
 enum class PairingMode
 {
+    None,
     QRCode,
     ManualCode,
     Ethernet,
@@ -59,6 +60,8 @@ public:
 
         switch (mode)
         {
+        case PairingMode::None:
+            break;
         case PairingMode::QRCode:
             AddArgument("payload", &mOnboardingPayload);
             break;
@@ -86,6 +89,7 @@ private:
     void PairWithCode(NSError * __autoreleasing * error);
     void PairWithPayload(NSError * __autoreleasing * error);
     void PairWithIPAddress(NSError * __autoreleasing * error);
+    void Unpair();
     void SetUpPairingDelegate();
 
     const PairingMode mPairingMode;


### PR DESCRIPTION
#### Problem
Currently, chip-tool-darwin does not support unpairing.
* Fixes #18273

#### Change overview
- Add a new command to chip-tool-darwin that will perform unpair.

#### Testing
- Built 
- Paired and unpaired several times.
