### PR TITLE
[OTA-R Linux] Timers were not being cancelled as intended

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -152,13 +152,29 @@ void DefaultOTARequestorDriver::DownloadUpdateTimerHandler(System::Layer * syste
     driver->mRequestor->DownloadUpdate();
 }
 
+void DefaultOTARequestorDriver::ApplyUpdateTimerHandler(System::Layer * systemLayer, void * appState)
+{
+    DefaultOTARequestorDriver * driver = ToDriver(appState);
+
+    VerifyOrDie(driver->mRequestor != nullptr);
+    driver->mRequestor->ApplyUpdate();
+}
+
+void DefaultOTARequestorDriver::ApplyTimerHandler(System::Layer * systemLayer, void * appState)
+{
+    DefaultOTARequestorDriver * driver = ToDriver(appState);
+
+    VerifyOrDie(driver->mImageProcessor != nullptr);
+    driver->mImageProcessor->Apply();
+}
+
 void DefaultOTARequestorDriver::UpdateAvailable(const UpdateDescription & update, System::Clock::Seconds32 delay)
 {
     // IMPLEMENTATION CHOICE:
     // This implementation unconditionally downloads an available update
 
     VerifyOrDie(mRequestor != nullptr);
-    ScheduleDelayedAction( delay, DownloadUpdateTimerHandler, this);
+    ScheduleDelayedAction(delay, DownloadUpdateTimerHandler, this);
 }
 
 CHIP_ERROR DefaultOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason, System::Clock::Seconds32 delay)
@@ -196,8 +212,7 @@ void DefaultOTARequestorDriver::UpdateDownloaded()
 void DefaultOTARequestorDriver::UpdateConfirmed(System::Clock::Seconds32 delay)
 {
     VerifyOrDie(mImageProcessor != nullptr);
-    ScheduleDelayedAction(
-        delay, [](System::Layer *, void * context) { ToDriver(context)->mImageProcessor->Apply(); }, this);
+    ScheduleDelayedAction(delay, ApplyTimerHandler, this);
 }
 
 void DefaultOTARequestorDriver::UpdateSuspended(System::Clock::Seconds32 delay)
@@ -209,8 +224,7 @@ void DefaultOTARequestorDriver::UpdateSuspended(System::Clock::Seconds32 delay)
         delay = kDefaultDelayedActionTime;
     }
 
-    ScheduleDelayedAction(
-        delay, [](System::Layer *, void * context) { ToDriver(context)->mRequestor->ApplyUpdate(); }, this);
+    ScheduleDelayedAction(delay, ApplyUpdateTimerHandler, this);
 }
 
 void DefaultOTARequestorDriver::UpdateDiscontinued()
@@ -228,8 +242,8 @@ void DefaultOTARequestorDriver::UpdateCancelled()
     // Cancel all OTA Update timers started by OTARequestorDriver regardless of whether thery are running or not
     CancelDelayedAction(DownloadUpdateTimerHandler, this);
     CancelDelayedAction(StartDelayTimerHandler, this);
-    CancelDelayedAction([](System::Layer *, void * context) { ToDriver(context)->mImageProcessor->Apply(); }, this);
-    CancelDelayedAction([](System::Layer *, void * context) { ToDriver(context)->mRequestor->ApplyUpdate(); }, this);
+    CancelDelayedAction(ApplyTimerHandler, this);
+    CancelDelayedAction(ApplyUpdateTimerHandler, this);
 }
 
 void DefaultOTARequestorDriver::ScheduleDelayedAction(System::Clock::Seconds32 delay, System::TimerCompleteCallback action,

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -85,6 +85,8 @@ protected:
     static void PeriodicQueryTimerHandler(System::Layer * systemLayer, void * appState);
     static void WatchdogTimerHandler(System::Layer * systemLayer, void * appState);
     static void DownloadUpdateTimerHandler(System::Layer * systemLayer, void * appState);
+    static void ApplyUpdateTimerHandler(System::Layer * systemLayer, void * appState);
+    static void ApplyTimerHandler(System::Layer * systemLayer, void * appState);
 
     void StartPeriodicQueryTimer();
     void StopPeriodicQueryTimer();

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -84,6 +84,7 @@ public:
 protected:
     static void PeriodicQueryTimerHandler(System::Layer * systemLayer, void * appState);
     static void WatchdogTimerHandler(System::Layer * systemLayer, void * appState);
+    static void DownloadUpdateTimerHandler(System::Layer * systemLayer, void * appState);
 
     void StartPeriodicQueryTimer();
     void StopPeriodicQueryTimer();

--- a/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
@@ -100,12 +100,7 @@ void ExtendedOTARequestorDriver::HandleUserConsentState(chip::ota::UserConsentSt
     switch (userConsentState)
     {
     case chip::ota::UserConsentState::kGranted:
-        ScheduleDelayedAction(
-            mDelayedActionTime,
-            [](System::Layer *, void * context) {
-                static_cast<ExtendedOTARequestorDriver *>(context)->mRequestor->DownloadUpdate();
-            },
-            this);
+        ScheduleDelayedAction(mDelayedActionTime, DownloadUpdateTimerHandler, this);
         break;
 
     case chip::ota::UserConsentState::kDenied:


### PR DESCRIPTION
#### Problem

`CancelDelayedAction()` calls to cancel `DownloadUpdate()`, `Apply()`, and `ApplyUpdate()` actions were not being cancelled as intended.  This is due to `TimerCompleteCallback aOnComplete` mismatch in the `TimerList::Remove()` call.

`TimerList::Node * TimerList::Remove(TimerCompleteCallback aOnComplete, void * aAppState)`

Need to pass in correct `TimerCompleteCallback` in `ScheduleDelayedAction()` and `CancelDelayedAction()` calls so that a match is found when `TimerList::Remove()` gets called.

#### Change overview
Created timer callbacks to pass into `ScheduleDelayedAction()` and `CancelDelayedAction()` calls to schedule the `DownloadUpdate()`, `Apply()`, and `ApplyUpdate()` actions.

#### Testing

Instrumented and stepped through the code to verify that the timers are now being cancelled as expected.
Verified Query Image command.

`out/apps/chip-tool/chip-tool otasoftwareupdaterequestor announce-ota-provider 0x00000000ABCD 0 0 0 0x0000001234567890 0`
