### PR TITLE
Use FastWriter for TlvJson

### DIFF
--- a/src/lib/support/jsontlv/TlvJson.cpp
+++ b/src/lib/support/jsontlv/TlvJson.cpp
@@ -106,7 +106,8 @@ void InsertKeyValue(Json::Value & json, const KeyContext & keyContext, T val)
 
 std::string JsonToString(Json::Value & json)
 {
-    Json::StyledWriter writer;
+    Json::FastWriter writer;
+    writer.omitEndingLineFeed();
     return writer.write(json);
 }
 

--- a/src/lib/support/tests/TestTlvToJson.cpp
+++ b/src/lib/support/tests/TestTlvToJson.cpp
@@ -54,55 +54,30 @@ CHIP_ERROR SetupReader()
 
 bool Matches(const char * referenceString, Json::Value & generatedValue)
 {
-    Json::StyledWriter writer;
     auto generatedStr = JsonToString(generatedValue);
 
-    auto matches = (generatedStr == std::string(referenceString));
+    // Normalize the reference string to the expected compact value.
+    Json::Reader reader;
+    Json::Value referenceValue;
+    reader.parse(referenceString, referenceValue);
+
+    Json::FastWriter writer;
+    writer.omitEndingLineFeed();
+    auto compactReferenceString = writer.write(referenceValue);
+
+    auto matches = (generatedStr == compactReferenceString);
 
     if (!matches)
     {
         printf("Didn't match!\n");
         printf("Reference:\n");
-        printf("%s\n", referenceString);
+        printf("%s\n", compactReferenceString.c_str());
 
         printf("Generated:\n");
         printf("%s\n", generatedStr.c_str());
     }
 
     return matches;
-
-#if 0
-    //
-    // Converting the reference string to a JSON representation and comparing
-    // that against the generated JSON object would have been preferable. This avoids
-    // the need to have reference strings expressed precisely to match the generated string
-    // from the JSON converter, right down to the number of spaces,etc. This would have made
-    // the reference string less britle and coupled to the jsoncpp converter implementation.
-    //
-    // However, jsoncpp converter converts positive values in the JSON to a signed
-    // integer C type. This results in a mis-match with the generated JSON objects
-    // that are created from spec-compliant TLV that correctly represents them as unsigned
-    // integers in the JSON object.
-    //
-    // This mismatch nullifies this approach unfortunately.
-    //
-    // TODO: Investigate a way to compare using JSON objects.
-    //
-    Json::Reader reader;
-    Json::Value referenceValue;
-
-    bool ret = reader.parse(referenceString, referenceValue);
-    if (ret != true) {
-        return ret;
-    }
-
-    std::cout << generatedValue << "\n";
-    std::cout << referenceValue << "\n";
-
-    int rett = generatedValue.compare(referenceValue);
-    printf("%d\n", rett);
-    return (rett == 0);
-#endif
 }
 
 template <typename T>


### PR DESCRIPTION
TlvJson now outputs a compact machine-readable string, instead of one that's human-readable.

#### Problem

I'm using TlvJson to generate attribute values in JSON format, and I want the string to be compact.  It's currently outputting human-readable JSON that's full of extra white space.

I don't believe this library was meant for debug purposes only, so I propose to change the TlvJson behavior rather than re-formatting the JSON on the app side.  Folks that are using it to debug can always run it through `python -m json.tool`

#### Change overview

Adjust TlvJson to output a compact machine-readable JSON format.

##### Before

```
{
   "value" : {
      "0" : 20,
      "1" : true,
      "2" : 0,
      "3" : "AQIDBP/+mYjdzQ==",
      "4" : "hello",
      "5" : 0,
      "6" : 1.0,
      "7" : 1.0
   }
}
```

##### After

```
{"value":{"0":20,"1":true,"2":0,"3":"AQIDBP/+mYjdzQ==","4":"hello","5":0,"6":1.0,"7":1.0}}
```

#### Testing
- Successfully ran `ninja -v -k 0 check`
- Verified that the output is the compact format that was desired.