### PR TITLE
[esp32] fix mdns config when using external platform

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -101,6 +101,8 @@ endif()
 
 if (NOT CONFIG_USE_MINIMAL_MDNS)
     chip_gn_arg_append("chip_mdns"                          "\"platform\"")
+else()
+    chip_gn_arg_append("chip_mdns"                          "\"minimal\"")
 endif()
 
 if (CONFIG_ENABLE_CHIP_SHELL)


### PR DESCRIPTION
#### Problem

ESP32 will use none mdns implementation by default if using external platform.

#### Change overview

Add config to explicitly use minimal mDNS by default.

#### Testing

* External platform changes, tested on other repos.