### PR TITLE
[EFR32] Add a disable lcd flag to efr32 examples

### DIFF
--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -58,6 +58,9 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
+  # Enables LCD on supported devices
+  disable_lcd = false
+
   # Enables LCD Qr Code on supported devices
   show_qr_code = true
 }
@@ -73,10 +76,13 @@ if (chip_enable_wifi) {
 # BRD4166A --> ThunderBoard Sense 2 (No LCD)
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
+  disable_lcd = true
 }
 
-# Enables LCD on supported devices
-lcd_on = show_qr_code
+# Disable QR code if lcd is disabled
+if (disable_lcd) {
+  show_qr_code = false
+}
 
 # WiFi settings
 if (chip_enable_wifi) {
@@ -237,7 +243,7 @@ efr32_executable("light_switch_app") {
     }
   }
 
-  if (lcd_on) {
+  if (!disable_lcd) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
     if (show_qr_code) {

--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -58,7 +58,7 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
-  # Enables LCD on supported devices
+  # Disable LCD on supported devices
   disable_lcd = false
 
   # Enables LCD Qr Code on supported devices

--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -60,10 +60,15 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
-
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = true
 }
+
+declare_args() {
+  # Enables LCD Qr Code on supported devices
+  show_qr_code = !disable_lcd
+}
+
+# qr code cannot be true if lcd is disabled
+assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
@@ -77,11 +82,6 @@ if (chip_enable_wifi) {
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
   disable_lcd = true
-}
-
-# Disable QR code if lcd is disabled
-if (disable_lcd) {
-  show_qr_code = false
 }
 
 # WiFi settings

--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -26,7 +26,9 @@
 
 #ifdef DISPLAY_ENABLED
 #include "lcd.h"
+#ifdef QR_CODE_ENABLED
 #include "qrcodegen.h"
+#endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
 
 #include <app-common/zap-generated/attribute-id.h>

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -58,7 +58,7 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
-  # Enables LCD on supported devices
+  # Disable LCD on supported devices
   disable_lcd = false
 
   # Enables LCD Qr Code on supported devices

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -60,10 +60,15 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
-
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = true
 }
+
+declare_args() {
+  # Enables LCD Qr Code on supported devices
+  show_qr_code = !disable_lcd
+}
+
+# qr code cannot be true if lcd is disabled
+assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
@@ -77,11 +82,6 @@ if (chip_enable_wifi) {
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
   disable_lcd = true
-}
-
-# Disable QR code is lcd is disabled
-if (disable_lcd) {
-  show_qr_code = false
 }
 
 # WiFi settings

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -58,6 +58,9 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
+  # Enables LCD on supported devices
+  disable_lcd = false
+
   # Enables LCD Qr Code on supported devices
   show_qr_code = true
 }
@@ -73,10 +76,13 @@ if (chip_enable_wifi) {
 # BRD4166A --> ThunderBoard Sense 2 (No LCD)
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
+  disable_lcd = true
 }
 
-# Enables LCD on supported devices
-lcd_on = show_qr_code
+# Disable QR code is lcd is disabled
+if (disable_lcd) {
+  show_qr_code = false
+}
 
 # WiFi settings
 if (chip_enable_wifi) {
@@ -236,7 +242,7 @@ efr32_executable("lighting_app") {
     }
   }
 
-  if (lcd_on) {
+  if (!disable_lcd) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
     if (show_qr_code) {

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -23,7 +23,9 @@
 #include "LEDWidget.h"
 #ifdef DISPLAY_ENABLED
 #include "lcd.h"
+#ifdef QR_CODE_ENABLED
 #include "qrcodegen.h"
+#endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
 #include "sl_simple_led_instances.h"
 #include <app-common/zap-generated/attribute-id.h>

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -58,6 +58,9 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
+  # Enables LCD on supported devices
+  disable_lcd = false
+
   # Enables LCD Qr Code on supported devices
   show_qr_code = true
 }
@@ -73,10 +76,13 @@ if (chip_enable_wifi) {
 # BRD4166A --> ThunderBoard Sense 2 (No LCD)
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
+  disable_lcd = true
 }
 
-# Enables LCD on supported devices
-lcd_on = show_qr_code
+# Disable QR code is lcd is disabled
+if (disable_lcd) {
+  show_qr_code = false
+}
 
 # WiFi settings
 if (chip_enable_wifi) {
@@ -238,7 +244,7 @@ efr32_executable("lock_app") {
     }
   }
 
-  if (lcd_on) {
+  if (!disable_lcd) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
     if (show_qr_code) {

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -58,7 +58,7 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
-  # Enables LCD on supported devices
+  # Disable LCD on supported devices
   disable_lcd = false
 
   # Enables LCD Qr Code on supported devices

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -60,10 +60,15 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
-
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = true
 }
+
+declare_args() {
+  # Enables LCD Qr Code on supported devices
+  show_qr_code = !disable_lcd
+}
+
+# qr code cannot be true if lcd is disabled
+assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
@@ -77,11 +82,6 @@ if (chip_enable_wifi) {
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
   disable_lcd = true
-}
-
-# Disable QR code is lcd is disabled
-if (disable_lcd) {
-  show_qr_code = false
 }
 
 # WiFi settings

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -23,7 +23,9 @@
 #include "LEDWidget.h"
 #ifdef DISPLAY_ENABLED
 #include "lcd.h"
+#ifdef QR_CODE_ENABLED
 #include "qrcodegen.h"
+#endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
 #include "sl_simple_led_instances.h"
 #include <app-common/zap-generated/af-structs.h>

--- a/examples/ota-requestor-app/efr32/BUILD.gn
+++ b/examples/ota-requestor-app/efr32/BUILD.gn
@@ -47,20 +47,20 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
-
-  # Enables LCD Qr Code on supported devices
-  show_qr_code = true
 }
+
+declare_args() {
+  # Enables LCD Qr Code on supported devices
+  show_qr_code = !disable_lcd
+}
+
+# qr code cannot be true if lcd is disabled
+assert(!(disable_lcd && show_qr_code))
 
 # BRD4166A --> ThunderBoard Sense 2 (No LCD)
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
   disable_lcd = true
-}
-
-# Disable QR code is lcd is disabled
-if (disable_lcd) {
-  show_qr_code = false
 }
 
 efr32_sdk("sdk") {

--- a/examples/ota-requestor-app/efr32/BUILD.gn
+++ b/examples/ota-requestor-app/efr32/BUILD.gn
@@ -45,7 +45,7 @@ declare_args() {
   # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
 
-  # Enables LCD on supported devices
+  # Disable LCD on supported devices
   disable_lcd = false
 
   # Enables LCD Qr Code on supported devices

--- a/examples/ota-requestor-app/efr32/BUILD.gn
+++ b/examples/ota-requestor-app/efr32/BUILD.gn
@@ -45,6 +45,9 @@ declare_args() {
   # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
 
+  # Enables LCD on supported devices
+  disable_lcd = false
+
   # Enables LCD Qr Code on supported devices
   show_qr_code = true
 }
@@ -52,10 +55,13 @@ declare_args() {
 # BRD4166A --> ThunderBoard Sense 2 (No LCD)
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
+  disable_lcd = true
 }
 
-# Enables LCD on supported devices
-lcd_on = show_qr_code
+# Disable QR code is lcd is disabled
+if (disable_lcd) {
+  show_qr_code = false
+}
 
 efr32_sdk("sdk") {
   sources = [
@@ -125,7 +131,7 @@ efr32_executable("ota_requestor_app") {
     ]
   }
 
-  if (lcd_on) {
+  if (!disable_lcd) {
     sources += [ "${examples_plat_dir}/display/lcd.c" ]
     defines += [ "DISPLAY_ENABLED" ]
     if (show_qr_code) {

--- a/examples/ota-requestor-app/efr32/src/AppTask.cpp
+++ b/examples/ota-requestor-app/efr32/src/AppTask.cpp
@@ -23,7 +23,9 @@
 #include "LEDWidget.h"
 #ifdef DISPLAY_ENABLED
 #include "lcd.h"
+#ifdef QR_CODE_ENABLED
 #include "qrcodegen.h"
+#endif // QR_CODE_ENABLED
 #endif // DISPLAY_ENABLED
 #include "sl_simple_led_instances.h"
 #include <app-common/zap-generated/attribute-id.h>

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -51,7 +51,7 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
-  # Enables LCD on supported devices
+  # Disable LCD on supported devices
   disable_lcd = false
 
   # Enables Qr Code on supported devices

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -53,10 +53,15 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
-
-  # Enables Qr Code on supported devices
-  show_qr_code = true
 }
+
+declare_args() {
+  # Enables LCD Qr Code on supported devices
+  show_qr_code = !disable_lcd
+}
+
+# qr code cannot be true if lcd is disabled
+assert(!(disable_lcd && show_qr_code))
 
 # Sanity check
 assert(!(chip_enable_wifi && chip_enable_openthread))
@@ -70,11 +75,6 @@ if (chip_enable_wifi) {
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
   disable_lcd = true
-}
-
-# Disable QR code is lcd is disabled
-if (disable_lcd) {
-  show_qr_code = false
 }
 
 # WiFi settings

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -51,6 +51,9 @@ declare_args() {
   sl_wfx_config_softap = false
   sl_wfx_config_scan = true
 
+  # Enables LCD on supported devices
+  disable_lcd = false
+
   # Enables Qr Code on supported devices
   show_qr_code = true
 }
@@ -63,13 +66,15 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# Enables LCD on supported devices
-lcd_on = true
-
 # BRD4166A --> ThunderBoard Sense 2 (No LCD)
 if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
   show_qr_code = false
-  lcd_on = false
+  disable_lcd = true
+}
+
+# Disable QR code is lcd is disabled
+if (disable_lcd) {
+  show_qr_code = false
 }
 
 # WiFi settings
@@ -226,7 +231,7 @@ efr32_executable("window_app") {
     }
   }
 
-  if (lcd_on) {
+  if (!disable_lcd) {
     sources += [
       "${examples_plat_dir}/display/lcd.c",
       "src/LcdPainter.cpp",

--- a/third_party/efr32_sdk/efr32_sdk.gni
+++ b/third_party/efr32_sdk/efr32_sdk.gni
@@ -179,7 +179,7 @@ template("efr32_sdk") {
     if ((defined(invoker.chip_enable_pw_rpc) && invoker.chip_enable_pw_rpc) ||
         chip_build_libshell || enable_openthread_cli ||
         (defined(invoker.show_qr_code) && invoker.show_qr_code) ||
-        (defined(invoker.lcd_on) && invoker.lcd_on)) {
+        (defined(invoker.disable_lcd) && !invoker.disable_lcd)) {
       defines += [ "CONFIG_ENABLE_UART" ]
 
       _include_dirs += [
@@ -484,7 +484,8 @@ template("efr32_sdk") {
     # USART sources files
     if ((defined(invoker.chip_enable_pw_rpc) && invoker.chip_enable_pw_rpc) ||
         chip_build_libshell || enable_openthread_cli ||
-        (defined(invoker.show_qr_code) && invoker.show_qr_code)) {
+        (defined(invoker.show_qr_code) && invoker.show_qr_code) ||
+        (defined(invoker.disable_lcd) && !invoker.disable_lcd)) {
       sources += [
         "${efr32_sdk_root}/matter/efr32/${efr32_family}/sl_uartdrv_init.c",
         "${efr32_sdk_root}/platform/emdrv/uartdrv/src/uartdrv.c",
@@ -512,7 +513,7 @@ template("efr32_sdk") {
     }
 
     if ((defined(invoker.show_qr_code) && invoker.show_qr_code) ||
-        (defined(invoker.lcd_on) && invoker.lcd_on)) {
+        (defined(invoker.disable_lcd) && !invoker.disable_lcd)) {
       sources += [
         "${efr32_sdk_root}/hardware/driver/memlcd/src/sl_memlcd.c",
         "${efr32_sdk_root}/hardware/driver/memlcd/src/sl_memlcd_display.c",


### PR DESCRIPTION
#### Problem
* Flag to disable LCD was only available on window app
* Missing check in gn file caused the window app build to fail when trying to remove LCD

#### Change overview
* Add disable lcd flag to all examples
* Add missing LCD on check

#### Testing
Manual tests with efr32 window app
