### PR TITLE
Update curl version - latest dockerfiles do not build

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -7,7 +7,7 @@ ARG NCS_REVISION=5ea8f7fa91d7315fcc6cd9eb3aa74f9640d0abac
 RUN set -x \
     && apt-get update \
     && apt-get install --no-install-recommends -fy \
-    curl=7.68.0-1ubuntu2.10 \
+    curl=7.68.0-1ubuntu2.11 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/ \
     && : # last line

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.74 Version bump reason: Telink Thread radio init fixed
+0.5.75 Version bump reason: Update curl version from 7.68.0-1ubuntu2.10 to 7.68.0-1ubuntu2.11


### PR DESCRIPTION
#### Problem
```
E: Version '7.68.0-1ubuntu2.10' for 'curl' was not found
```

#### Change overview
Update curl version

#### Testing
checked available curl version after doing an `apt-get update` in a chip vscode build image.