### PR TITLE
Allow external ownership of CHIPDeviceController operational key

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -127,7 +127,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     mVendorId = params.controllerVendorId;
     if (params.operationalKeypair != nullptr || !params.controllerNOC.empty() || !params.controllerRCAC.empty())
     {
-        ReturnErrorOnFailure(ProcessControllerNOCChain(params));
+        ReturnErrorOnFailure(InitControllerNOCChain(params));
 
         if (params.enableServerInteractions)
         {
@@ -144,7 +144,7 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceController::ProcessControllerNOCChain(const ControllerInitParams & params)
+CHIP_ERROR DeviceController::InitControllerNOCChain(const ControllerInitParams & params)
 {
     FabricInfo newFabric;
     constexpr uint32_t chipCertAllocatedLen = kMaxCHIPCertLength;
@@ -152,7 +152,15 @@ CHIP_ERROR DeviceController::ProcessControllerNOCChain(const ControllerInitParam
     Credentials::P256PublicKeySpan rootPublicKey;
     FabricId fabricId;
 
-    ReturnErrorOnFailure(newFabric.SetOperationalKeypair(params.operationalKeypair));
+    if (params.hasExternallyOwnedOperationalKeypair)
+    {
+        ReturnErrorOnFailure(newFabric.SetExternallyOwnedOperationalKeypair(params.operationalKeypair));
+    }
+    else
+    {
+        ReturnErrorOnFailure(newFabric.SetOperationalKeypair(params.operationalKeypair));
+    }
+
     newFabric.SetVendorId(params.controllerVendorId);
 
     ReturnErrorCodeIf(!chipCert.Alloc(chipCertAllocatedLen), CHIP_ERROR_NO_MEMORY);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -249,8 +249,14 @@ public:
 
     /**
      * @brief
-     *   Configures a new set of operational credentials to be used with this
-     *   controller.
+     *   Reconfigures a new set of operational credentials to be used with this
+     *   controller given ControllerInitParams state.
+     *
+     * WARNING: This is a low-level method that should only be called directly
+     *          if you know exactly how this will interact with controller state,
+     *          since there are several integrations that do this call for you.
+     *          It can be used for fine-grained dependency injection of a controller's
+     *          NOC and operational keypair.
      */
     CHIP_ERROR InitControllerNOCChain(const ControllerInitParams & params);
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -95,6 +95,13 @@ struct ControllerInitParams
        controllerNOC. It's used by controller to establish CASE sessions with devices */
     Crypto::P256Keypair * operationalKeypair = nullptr;
 
+    /**
+     * Controls whether or not the operationalKeypair should be owned by the caller.
+     * By default, this is false, but if the keypair cannot be serialized, then
+     * setting this to true will allow you to manage this keypair's lifecycle.
+     */
+    bool hasExternallyOwnedOperationalKeypair = false;
+
     /* The following certificates must be in x509 DER format */
     ByteSpan controllerNOC;
     ByteSpan controllerICAC;
@@ -240,6 +247,13 @@ public:
      */
     CHIP_ERROR DisconnectDevice(NodeId nodeId);
 
+    /**
+     * @brief
+     *   Configures a new set of operational credentials to be used with this
+     *   controller.
+     */
+    CHIP_ERROR InitControllerNOCChain(const ControllerInitParams & params);
+
 protected:
     enum class State
     {
@@ -275,8 +289,6 @@ protected:
 
 private:
     void ReleaseOperationalDevice(OperationalDeviceProxy * device);
-
-    CHIP_ERROR ProcessControllerNOCChain(const ControllerInitParams & params);
 };
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -221,11 +221,11 @@ CHIP_ERROR FabricInfo::LoadFromStorage(PersistentStorageDelegate * storage)
 
             if (mOperationalKey == nullptr)
             {
-    #ifdef ENABLE_HSM_CASE_OPS_KEY
+#ifdef ENABLE_HSM_CASE_OPS_KEY
                 mOperationalKey = chip::Platform::New<P256KeypairHSM>();
-    #else
+#else
                 mOperationalKey = chip::Platform::New<P256Keypair>();
-    #endif
+#endif
             }
             VerifyOrReturnError(mOperationalKey != nullptr, CHIP_ERROR_NO_MEMORY);
             ReturnErrorOnFailure(mOperationalKey->Deserialize(serializedOpKey));

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -351,7 +351,7 @@ CHIP_ERROR FabricInfo::SetExternallyOwnedOperationalKeypair(P256Keypair * keyPai
     }
 
     mHasExternallyOwnedOperationalKey = true;
-    mOperationalKey = keyPair;
+    mOperationalKey                   = keyPair;
     return CHIP_NO_ERROR;
 }
 

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -124,7 +124,6 @@ public:
         return mOperationalKey;
     }
 
-
     /**
      * Sets the P256Keypair used for this fabric, transferring ownership of the
      * key to this object by making a copy via the P256Keypair::Serialize and

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -125,9 +125,10 @@ public:
     }
 
     /**
-     * Sets the P256Keypair used for this fabric, transferring ownership of the
-     * key to this object by making a copy via the P256Keypair::Serialize and
-     * P256Keypair::Deserialize methods.
+     * Sets the P256Keypair used for this fabric.  This will make a copy of the keypair
+     * via the P256Keypair::Serialize and P256Keypair::Deserialize methods.
+     *
+     * The keyPair argument is safe to deallocate once this method returns.
      *
      * If your P256Keypair does not support serialization, use the
      * `SetExternallyOwnedOperationalKeypair` method instead.
@@ -212,7 +213,8 @@ public:
         if (mHasExternallyOwnedOperationalKey && mOperationalKey != nullptr)
         {
             chip::Platform::Delete(mOperationalKey);
-            mOperationalKey = nullptr;
+        }
+        mOperationalKey = nullptr;
         }
         ReleaseOperationalCerts();
         mFabricIndex = kUndefinedFabricIndex;

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -133,16 +133,17 @@ public:
      * If your P256Keypair does not support serialization, use the
      * `SetExternallyOwnedOperationalKeypair` method instead.
      */
-    CHIP_ERROR SetOperationalKeypair(Crypto::P256Keypair * keyPair);
+    CHIP_ERROR SetOperationalKeypair(const Crypto::P256Keypair * keyPair);
 
     /**
      * Sets the P256Keypair used for this fabric, delegating ownership of the
      * key to the caller. The P256Keypair provided here must be freed later by
-     * the caller of this method.
+     * the caller of this method if it was allocated dynamically.
      *
      * This should be used if your P256Keypair does not support serialization
      * and deserialization (e.g. your private key is held in a secure element
-     * and cannot be accessed directly).
+     * and cannot be accessed directly), or if you back your operational
+     * private keys by external implementation of the cryptographic interfaces.
      *
      * To have the ownership of the key managed for you, use
      * SetOperationalKeypair instead.
@@ -215,7 +216,7 @@ public:
             chip::Platform::Delete(mOperationalKey);
         }
         mOperationalKey = nullptr;
-        }
+
         ReleaseOperationalCerts();
         mFabricIndex = kUndefinedFabricIndex;
     }

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -111,8 +111,9 @@ public:
 
     Crypto::P256Keypair * GetOperationalKey() const
     {
-        if (mOperationalKey == nullptr)
+        if (!mHasExternallyOwnedOperationalKey && (mOperationalKey == nullptr))
         {
+            // TODO: Refactor the following two cases to go through SetOperationalKey()
 #ifdef ENABLE_HSM_CASE_OPS_KEY
             mOperationalKey = chip::Platform::New<Crypto::P256KeypairHSM>();
             mOperationalKey->CreateOperationalKey(mFabricIndex);


### PR DESCRIPTION
#### Problem
- For controllers that make use of their own key management,
  such as OS-aided key management, it is currently impossible
  to pass-in the Operational Key pair to use for a given controller.

Issue #18444
Issue #7695

#### Change overview
This PR adds APIs to avoid FabricTable from trying to manage
the lifecycle of the operational key, and allow the caller/initializer
of CHIPDeviceControllerFactory to properly inject its own operational
key that it manages, without attempts of storage or dynamic memory
management.

#### Testing
- Unit tests still pass, cert tests as well
- This was tested internally by us using the APIs to
  manage a key for Android. That change will be a follow-up
