### PR TITLE
Move `TestContext` to a scoped variable

### DIFF
--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -103,8 +103,6 @@ private:
     chip::MonotonicallyIncreasingCounter<chip::EventNumber> mEventCounter;
 };
 
-TestContext sContext;
-
 class TestEventGenerator : public chip::app::EventLoggingDelegate
 {
 public:
@@ -2622,6 +2620,7 @@ nlTestSuite sSuite =
 
 int TestReadInteraction()
 {
+    TestContext sContext;
     nlTestRunner(&sSuite, &sContext);
     return (nlTestRunnerStats(&sSuite));
 }

--- a/src/messaging/tests/TestExchangeMgr.cpp
+++ b/src/messaging/tests/TestExchangeMgr.cpp
@@ -56,8 +56,6 @@ enum : uint8_t
     kMsgType_TEST2 = 2,
 };
 
-TestContext sContext;
-
 class MockAppDelegate : public UnsolicitedMessageHandler, public ExchangeDelegate
 {
 public:
@@ -262,6 +260,8 @@ nlTestSuite sSuite =
  */
 int TestExchangeMgr()
 {
+    TestContext sContext;
+
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);
 

--- a/src/messaging/tests/TestReliableMessageProtocol.cpp
+++ b/src/messaging/tests/TestReliableMessageProtocol.cpp
@@ -218,10 +218,10 @@ void CheckResendApplicationMessage(nlTestSuite * inSuite, void * inContext)
     });
 
     // Let's drop the initial message
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 2;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 2;
+    loopback.mDroppedMessageCount = 0;
 
     // Ensure the retransmit table is empty right now
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
@@ -233,27 +233,27 @@ void CheckResendApplicationMessage(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the message was dropped, and was added to retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessagesToDrop == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
 
     // Wait for the first re-transmit (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 2; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 2; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was dropped, and is still there in the retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessagesToDrop == 0);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 2);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
 
     // Wait for the second re-transmit (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 3; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 3; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was NOT dropped, and the retransmit table is empty, as we should have gotten an ack
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 3);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount >= 3);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 2);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 
     exchange->Close();
@@ -282,10 +282,10 @@ void CheckCloseExchangeAndResendApplicationMessage(nlTestSuite * inSuite, void *
     });
 
     // Let's drop the initial message
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 2;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 2;
+    loopback.mDroppedMessageCount = 0;
 
     // Ensure the retransmit table is empty right now
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
@@ -295,27 +295,27 @@ void CheckCloseExchangeAndResendApplicationMessage(nlTestSuite * inSuite, void *
     ctx.DrainAndServiceIO();
 
     // Ensure the message was dropped, and was added to retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessagesToDrop == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
 
     // Wait for the first re-transmit (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 2; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 2; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was dropped, and is still there in the retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessagesToDrop == 0);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 2);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
 
     // Wait for the second re-transmit (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 3; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 3; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was NOT dropped, and the retransmit table is empty, as we should have gotten an ack
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 3);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount >= 3);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 2);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 }
 
@@ -342,10 +342,10 @@ void CheckFailedMessageRetainOnSend(nlTestSuite * inSuite, void * inContext)
 
     mockSender.mMessageDispatch.mRetainMessageOnSend = false;
     // Let's drop the initial message
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 1;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 1;
+    loopback.mDroppedMessageCount = 0;
 
     // Ensure the retransmit table is empty right now
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
@@ -354,10 +354,10 @@ void CheckFailedMessageRetainOnSend(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the message was dropped
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
 
     // Wait for the first re-transmit (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 2; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 2; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit table is empty, as we did not provide a message to retain
@@ -385,10 +385,10 @@ void CheckUnencryptedMessageReceiveFailure(nlTestSuite * inSuite, void * inConte
     ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
     NL_TEST_ASSERT(inSuite, rm != nullptr);
 
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
 
     // We are sending a malicious packet, doesn't expect an ack
     err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer), SendFlags(SendMessageFlags::kNoAutoRequestAck));
@@ -396,8 +396,8 @@ void CheckUnencryptedMessageReceiveFailure(nlTestSuite * inSuite, void * inConte
     ctx.DrainAndServiceIO();
 
     // Test that the message was actually sent (and not dropped)
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
     // Test that the message was dropped by the receiver
     NL_TEST_ASSERT(inSuite, !mockReceiver.IsOnMessageReceivedCalled);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
@@ -431,10 +431,10 @@ void CheckResendApplicationMessageWithPeerExchange(nlTestSuite * inSuite, void *
     });
 
     // Let's drop the initial message
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 1;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 1;
+    loopback.mDroppedMessageCount = 0;
 
     // Ensure the retransmit table is empty right now
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
@@ -444,18 +444,18 @@ void CheckResendApplicationMessageWithPeerExchange(nlTestSuite * inSuite, void *
     ctx.DrainAndServiceIO();
 
     // Ensure the message was dropped, and was added to retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessagesToDrop == 0);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
     NL_TEST_ASSERT(inSuite, !mockReceiver.IsOnMessageReceivedCalled);
 
     // Wait for the first re-transmit (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 2; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 2; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was not dropped, and is no longer in the retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount >= 2);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);
 
@@ -493,10 +493,10 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
     });
 
     // Let's not drop the message. Expectation is that it is received by the peer, but the ack is dropped
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
 
     // Drop the ack, and also close the peer exchange
     mockReceiver.mDropAckResponse = true;
@@ -511,8 +511,8 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
 
     // Ensure the message was sent
     // The ack was dropped, and message was added to the retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
 
     // Let's not drop the duplicate message
@@ -522,13 +522,13 @@ void CheckDuplicateMessageClosedExchange(nlTestSuite * inSuite, void * inContext
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Wait for the first re-transmit and ack (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 3; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 3; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was sent and the ack was sent
     // and retransmit table was cleared
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 3);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 }
 
@@ -560,10 +560,10 @@ void CheckDuplicateOldMessageClosedExchange(nlTestSuite * inSuite, void * inCont
     });
 
     // Let's not drop the message. Expectation is that it is received by the peer, but the ack is dropped
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
 
     // Drop the ack, and also close the peer exchange
     mockReceiver.mDropAckResponse = true;
@@ -578,8 +578,8 @@ void CheckDuplicateOldMessageClosedExchange(nlTestSuite * inSuite, void * inCont
 
     // Ensure the message was sent
     // The ack was dropped, and message was added to the retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
 
     // Make sure we don't accidentally retransmit before we are done with our
@@ -610,8 +610,8 @@ void CheckDuplicateOldMessageClosedExchange(nlTestSuite * inSuite, void * inCont
         ctx.DrainAndServiceIO();
 
         // Ensure the message was sent, but not added to the retransmit table.
-        NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1 + (i + 1));
-        NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+        NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1 + (i + 1));
+        NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
         NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
     }
 
@@ -623,13 +623,13 @@ void CheckDuplicateOldMessageClosedExchange(nlTestSuite * inSuite, void * inCont
 
     // Wait for the first re-transmit and ack (should take 64ms)
     rm->StartTimer();
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 3 + extraMessages; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 3 + extraMessages; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was sent and the ack was sent
     // and retransmit table was cleared
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3 + extraMessages);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 3 + extraMessages);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 }
 
@@ -665,10 +665,10 @@ void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuit
     });
 
     // Let's drop the initial message
-    auto & gLoopback               = inctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 1;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = inctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 1;
+    loopback.mDroppedMessageCount = 0;
 
     // Ensure the retransmit table is empty right now
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
@@ -678,18 +678,18 @@ void CheckResendSessionEstablishmentMessageWithPeerExchange(nlTestSuite * inSuit
     inctx.DrainAndServiceIO();
 
     // Ensure the message was dropped, and was added to retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessagesToDrop == 0);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
     NL_TEST_ASSERT(inSuite, !mockReceiver.IsOnMessageReceivedCalled);
 
     // Wait for the first re-transmit (should take 64ms)
-    inctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 2; });
+    inctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 2; });
     inctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was not dropped, and is no longer in the retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount >= 2);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);
 
@@ -729,10 +729,10 @@ void CheckDuplicateMessage(nlTestSuite * inSuite, void * inContext)
     });
 
     // Let's not drop the message. Expectation is that it is received by the peer, but the ack is dropped
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
 
     // Drop the ack, and keep the exchange around to receive the duplicate message
     mockReceiver.mDropAckResponse = true;
@@ -747,8 +747,8 @@ void CheckDuplicateMessage(nlTestSuite * inSuite, void * inContext)
 
     // Ensure the message was sent
     // The ack was dropped, and message was added to the retransmit table
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
 
     err = ctx.GetExchangeManager().UnregisterUnsolicitedMessageHandlerForType(Echo::MsgType::EchoRequest);
@@ -759,13 +759,13 @@ void CheckDuplicateMessage(nlTestSuite * inSuite, void * inContext)
     mockReceiver.mRetainExchange  = false;
 
     // Wait for the first re-transmit and ack (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 3; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 3; });
     ctx.DrainAndServiceIO();
 
     // Ensure the retransmit message was sent and the ack was sent
     // and retransmit table was cleared
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 3);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 
     mockReceiver.CloseExchangeIfNeeded();
@@ -803,19 +803,19 @@ void CheckReceiveAfterStandaloneAck(nlTestSuite * inSuite, void * inContext)
     // exchange alive until it does the message send (so we can send the
     // response from the receiver and so the initial sender exchange can get
     // it).
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
-    mockReceiver.mRetainExchange   = true;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
+    mockReceiver.mRetainExchange  = true;
 
     err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer), SendFlags(SendMessageFlags::kExpectResponse));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     // Ensure the message was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that it was received.
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);
@@ -831,8 +831,8 @@ void CheckReceiveAfterStandaloneAck(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the ack was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // Ensure that we have not gotten any app-level responses so far.
     NL_TEST_ASSERT(inSuite, !mockSender.IsOnMessageReceivedCalled);
@@ -849,8 +849,8 @@ void CheckReceiveAfterStandaloneAck(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the response and its ack was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 4);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 4);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // Ensure that we have received that response.
     NL_TEST_ASSERT(inSuite, mockSender.IsOnMessageReceivedCalled);
@@ -894,20 +894,20 @@ void CheckPiggybackAfterPiggyback(nlTestSuite * inSuite, void * inContext)
     // piggybacked.  We need to keep both exchanges alive for that (so we can
     // send the response from the receiver and so the initial sender exchange
     // can get it).
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
-    mockReceiver.mRetainExchange   = true;
-    mockSender.mRetainExchange     = true;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
+    mockReceiver.mRetainExchange  = true;
+    mockSender.mRetainExchange    = true;
 
     err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer), SendFlags(SendMessageFlags::kExpectResponse));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     // Ensure the message was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that it was received.
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);
@@ -934,8 +934,8 @@ void CheckPiggybackAfterPiggyback(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the response was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // Ensure that we have received that response and it had a piggyback ack.
     NL_TEST_ASSERT(inSuite, mockSender.IsOnMessageReceivedCalled);
@@ -957,8 +957,8 @@ void CheckPiggybackAfterPiggyback(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the message was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 3);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 3);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that it was received.
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);
@@ -979,8 +979,8 @@ void CheckPiggybackAfterPiggyback(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the response and its ack was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 5);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // Ensure that we have received that response and it had a piggyback ack.
     NL_TEST_ASSERT(inSuite, mockSender.IsOnMessageReceivedCalled);
@@ -1023,10 +1023,10 @@ void CheckSendUnsolicitedStandaloneAckMessage(nlTestSuite * inSuite, void * inCo
 
     // We send a message, have it get received by the peer, expect an ack from
     // the peer.
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
 
     // Purposefully sending a standalone ack that requests an ack!
     err = exchange->SendMessage(SecureChannel::MsgType::StandaloneAck, std::move(buffer));
@@ -1036,8 +1036,8 @@ void CheckSendUnsolicitedStandaloneAckMessage(nlTestSuite * inSuite, void * inCo
     ctx.DrainAndServiceIO();
 
     // Ensure the message and its ack were sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that nothing is waiting for acks.
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
@@ -1104,10 +1104,10 @@ void CheckMessageAfterClosed(nlTestSuite * inSuite, void * inContext)
     // Ensure the retransmit table is empty right now
     NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
 
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
     // We need to keep both exchanges alive for the thing we are testing here.
     mockReceiver.mRetainExchange = true;
     mockSender.mRetainExchange   = true;
@@ -1120,8 +1120,8 @@ void CheckMessageAfterClosed(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the message was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that it was received.
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);
@@ -1147,8 +1147,8 @@ void CheckMessageAfterClosed(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the response was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // Ensure that we have received that response and it had a piggyback ack.
     NL_TEST_ASSERT(inSuite, mockSender.IsOnMessageReceivedCalled);
@@ -1171,8 +1171,8 @@ void CheckMessageAfterClosed(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the message was sent (and the ack for it was also sent).
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 4);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 4);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that it was not received (because the exchange is closed on the
     // receiver).
@@ -1236,19 +1236,19 @@ void CheckLostResponseWithPiggyback(nlTestSuite * inSuite, void * inContext)
     // we can send the response from the receiver), but don't need anything
     // special for the sender exchange, because it will be waiting for the
     // application-level response.
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
-    mockReceiver.mRetainExchange   = true;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
+    mockReceiver.mRetainExchange  = true;
 
     err = exchange->SendMessage(Echo::MsgType::EchoRequest, std::move(buffer), SendFlags(SendMessageFlags::kExpectResponse));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
     // Ensure the message was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that it was received.
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);
@@ -1269,7 +1269,7 @@ void CheckLostResponseWithPiggyback(nlTestSuite * inSuite, void * inContext)
     });
 
     // Now send a message from the other side, but drop it.
-    gLoopback.mNumMessagesToDrop = 1;
+    loopback.mNumMessagesToDrop = 1;
 
     buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, sizeof(PAYLOAD));
     NL_TEST_ASSERT(inSuite, !buffer.IsNull());
@@ -1282,9 +1282,9 @@ void CheckLostResponseWithPiggyback(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the response was sent but dropped.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessagesToDrop == 0);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
 
     // Ensure that we have not received that response.
     NL_TEST_ASSERT(inSuite, !mockSender.IsOnMessageReceivedCalled);
@@ -1300,7 +1300,7 @@ void CheckLostResponseWithPiggyback(nlTestSuite * inSuite, void * inContext)
     mockSender.mReceivedPiggybackAck       = false;
 
     // Wait for re-transmit from sender and ack (should take 64ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 4; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 4; });
     ctx.DrainAndServiceIO();
 
     // We resent our first message, which did not make it to the app-level
@@ -1310,11 +1310,11 @@ void CheckLostResponseWithPiggyback(nlTestSuite * inSuite, void * inContext)
     // Now the annoying part is that depending on how long we _actually_ slept
     // we might have also triggered the retransmit from the other side, even
     // though we did not want to.  Handle both cases here.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 4 || gLoopback.mSentMessageCount == 6);
-    if (gLoopback.mSentMessageCount == 4)
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 4 || loopback.mSentMessageCount == 6);
+    if (loopback.mSentMessageCount == 4)
     {
         // Just triggered the retransmit from the sender.
-        NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+        NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
         NL_TEST_ASSERT(inSuite, !mockSender.IsOnMessageReceivedCalled);
         NL_TEST_ASSERT(inSuite, !mockReceiver.IsOnMessageReceivedCalled);
         NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 1);
@@ -1322,20 +1322,20 @@ void CheckLostResponseWithPiggyback(nlTestSuite * inSuite, void * inContext)
     else
     {
         // Also triggered the retransmit from the receiver.
-        NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+        NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
         NL_TEST_ASSERT(inSuite, mockSender.IsOnMessageReceivedCalled);
         NL_TEST_ASSERT(inSuite, !mockReceiver.IsOnMessageReceivedCalled);
         NL_TEST_ASSERT(inSuite, rm->TestGetCountRetransTable() == 0);
     }
 
     // Wait for re-transmit from receiver (should take 256ms)
-    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return gLoopback.mSentMessageCount >= 6; });
+    ctx.GetIOContext().DriveIOUntil(1000_ms32, [&] { return loopback.mSentMessageCount >= 6; });
     ctx.DrainAndServiceIO();
 
     // And now we've definitely resent our response message, which should show
     // up as an app-level message and trigger a standalone ack.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 6);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 6);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 1);
     NL_TEST_ASSERT(inSuite, mockSender.IsOnMessageReceivedCalled);
 
     // Should be all done now.
@@ -1384,12 +1384,12 @@ void CheckLostStandaloneAck(nlTestSuite * inSuite, void * inContext)
     // We need to keep both exchanges alive for that (so we can send the
     // response from the receiver and so the initial sender exchange can send a
     // response to that).
-    auto & gLoopback               = ctx.GetLoopback();
-    gLoopback.mSentMessageCount    = 0;
-    gLoopback.mNumMessagesToDrop   = 0;
-    gLoopback.mDroppedMessageCount = 0;
-    mockReceiver.mRetainExchange   = true;
-    mockSender.mRetainExchange     = true;
+    auto & loopback               = ctx.GetLoopback();
+    loopback.mSentMessageCount    = 0;
+    loopback.mNumMessagesToDrop   = 0;
+    loopback.mDroppedMessageCount = 0;
+    mockReceiver.mRetainExchange  = true;
+    mockSender.mRetainExchange    = true;
 
     // And ensure the ack heading back our way is dropped.
     mockReceiver.mDropAckResponse = true;
@@ -1399,8 +1399,8 @@ void CheckLostStandaloneAck(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the message was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that it was received.
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);
@@ -1426,8 +1426,8 @@ void CheckLostStandaloneAck(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the response was sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // Ensure that we have received that response and had a piggyback ack.
     NL_TEST_ASSERT(inSuite, mockSender.IsOnMessageReceivedCalled);
@@ -1453,8 +1453,8 @@ void CheckLostStandaloneAck(nlTestSuite * inSuite, void * inContext)
     ctx.DrainAndServiceIO();
 
     // Ensure the message and the standalone ack to it were sent.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 4);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 4);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 0);
 
     // And that it was received.
     NL_TEST_ASSERT(inSuite, mockReceiver.IsOnMessageReceivedCalled);

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -53,10 +53,6 @@ using namespace chip::Protocols;
 using TestContext = Test::LoopbackMessagingContext;
 
 namespace {
-TestContext sContext;
-
-auto & gLoopback = sContext.GetLoopback();
-
 FabricTable gCommissionerFabrics;
 FabricIndex gCommissionerFabricIndex;
 GroupDataProviderImpl gCommissionerGroupDataProvider;
@@ -227,6 +223,7 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
                    pairing.EstablishSession(sessionManager, fabric, Node01_01, context, nullptr, &delegate) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
+    auto & gLoopback = ctx.GetLoopback();
     NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
 
     // Clear pending packet in CRMP
@@ -264,6 +261,7 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     ReliableMessageProtocolConfig nonSleepyCommissionerRmpConfig(System::Clock::Milliseconds32(5000),
                                                                  System::Clock::Milliseconds32(300));
 
+    auto & gLoopback            = ctx.GetLoopback();
     gLoopback.mSentMessageCount = 0;
 
     NL_TEST_ASSERT(inSuite,
@@ -317,6 +315,7 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
 
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
+    auto & gLoopback            = ctx.GetLoopback();
     gLoopback.mSentMessageCount = 0;
 
     // Use the same session manager on both CASE client and server sides to validate that both
@@ -740,6 +739,7 @@ static void CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContex
         },
     };
 
+    auto & gLoopback = ctx.GetLoopback();
     for (size_t i = 0; i < sizeof(testVectors) / sizeof(testVectors[0]); ++i)
     {
         auto * pairingCommissioner = chip::Platform::New<CASESession>();
@@ -847,6 +847,8 @@ int CASE_TestSecurePairing_Teardown(void * inContext)
  */
 int TestCASESession()
 {
+    TestContext sContext;
+
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -223,29 +223,29 @@ void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
                    pairing.EstablishSession(sessionManager, fabric, Node01_01, context, nullptr, &delegate) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
-    auto & gLoopback = ctx.GetLoopback();
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
+    auto & loopback = ctx.GetLoopback();
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
 
     // Clear pending packet in CRMP
     ReliableMessageMgr * rm     = ctx.GetExchangeManager().GetReliableMessageMgr();
     ReliableMessageContext * rc = context->GetReliableMessageContext();
     rm->ClearRetransTable(rc);
 
-    gLoopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
+    loopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
 
     CASESession pairing1;
     pairing1.SetGroupDataProvider(&gCommissionerGroupDataProvider);
 
-    gLoopback.mSentMessageCount = 0;
-    gLoopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
-    ExchangeContext * context1  = ctx.NewUnauthenticatedExchangeToBob(&pairing1);
+    loopback.mSentMessageCount = 0;
+    loopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
+    ExchangeContext * context1 = ctx.NewUnauthenticatedExchangeToBob(&pairing1);
 
     NL_TEST_ASSERT(inSuite,
                    pairing1.EstablishSession(sessionManager, fabric, Node01_01, context1, nullptr, &delegate) ==
                        CHIP_ERROR_BAD_REQUEST);
     ctx.DrainAndServiceIO();
 
-    gLoopback.mMessageSendError = CHIP_NO_ERROR;
+    loopback.mMessageSendError = CHIP_NO_ERROR;
 }
 
 void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, SessionManager & sessionManager,
@@ -261,8 +261,8 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
     ReliableMessageProtocolConfig nonSleepyCommissionerRmpConfig(System::Clock::Milliseconds32(5000),
                                                                  System::Clock::Milliseconds32(300));
 
-    auto & gLoopback            = ctx.GetLoopback();
-    gLoopback.mSentMessageCount = 0;
+    auto & loopback            = ctx.GetLoopback();
+    loopback.mSentMessageCount = 0;
 
     NL_TEST_ASSERT(inSuite,
                    ctx.GetExchangeManager().RegisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1,
@@ -283,7 +283,7 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
                                                         MakeOptional(nonSleepyCommissionerRmpConfig)) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 5);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
     NL_TEST_ASSERT(inSuite, pairingAccessory.GetRemoteMRPConfig().mIdleRetransTimeout == System::Clock::Milliseconds32(5000));
@@ -315,8 +315,8 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
 
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 
-    auto & gLoopback            = ctx.GetLoopback();
-    gLoopback.mSentMessageCount = 0;
+    auto & loopback            = ctx.GetLoopback();
+    loopback.mSentMessageCount = 0;
 
     // Use the same session manager on both CASE client and server sides to validate that both
     // components may work simultaneously on a single device.
@@ -335,7 +335,7 @@ void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inConte
                                                          nullptr, &delegateCommissioner) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 5);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 5);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
 
     // Validate that secure session is created
@@ -739,12 +739,12 @@ static void CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContex
         },
     };
 
-    auto & gLoopback = ctx.GetLoopback();
+    auto & loopback = ctx.GetLoopback();
     for (size_t i = 0; i < sizeof(testVectors) / sizeof(testVectors[0]); ++i)
     {
         auto * pairingCommissioner = chip::Platform::New<CASESession>();
         pairingCommissioner->SetGroupDataProvider(&gCommissionerGroupDataProvider);
-        gLoopback.mSentMessageCount = 0;
+        loopback.mSentMessageCount = 0;
         NL_TEST_ASSERT(inSuite,
                        gPairingServer.ListenForSessionEstablishment(&ctx.GetExchangeManager(), &ctx.GetSecureSessionManager(),
                                                                     &gDeviceFabrics, &testVectors[i].responderStorage,
@@ -755,7 +755,7 @@ static void CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContex
                                                   &testVectors[i].initiatorStorage, &delegateCommissioner);
         ctx.DrainAndServiceIO();
         NL_TEST_ASSERT(inSuite, establishmentReturnVal == CHIP_NO_ERROR);
-        NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == testVectors[i].expectedSentMessageCount);
+        NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == testVectors[i].expectedSentMessageCount);
         NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == i + 1);
         SessionHolder & holder = delegateCommissioner.GetSessionHolder();
         NL_TEST_ASSERT(inSuite, bool(holder));

--- a/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
+++ b/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
@@ -48,7 +48,6 @@ using namespace chip::Messaging;
 using namespace chip::Protocols;
 
 using TestContext = chip::Test::LoopbackMessagingContext;
-TestContext sContext;
 
 const char PAYLOAD[] = "Hello!";
 
@@ -169,6 +168,8 @@ int Finalize(void * aContext)
  */
 int TestMessageCounterManager()
 {
+    TestContext sContext;
+
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);
 

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -117,8 +117,8 @@ void SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, pairing.GetSecureSessionType() == SecureSession::Type::kPASE);
 
-    auto & gLoopback = ctx.GetLoopback();
-    gLoopback.Reset();
+    auto & loopback = ctx.GetLoopback();
+    loopback.Reset();
 
     NL_TEST_ASSERT(inSuite,
                    pairing.WaitForPairing(sessionManager, sTestSpake2p01_PASEVerifier, sTestSpake2p01_IterationCount,
@@ -156,8 +156,8 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegate;
     PASESession pairing;
 
-    auto & gLoopback = ctx.GetLoopback();
-    gLoopback.Reset();
+    auto & loopback = ctx.GetLoopback();
+    loopback.Reset();
 
     ExchangeContext * context = ctx.NewUnauthenticatedExchangeToBob(&pairing);
 
@@ -165,22 +165,22 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
                    pairing.Pair(sessionManager, sTestSpake2p01_PinCode, Optional<ReliableMessageProtocolConfig>::Missing(), nullptr,
                                 nullptr) != CHIP_NO_ERROR);
 
-    gLoopback.Reset();
+    loopback.Reset();
     NL_TEST_ASSERT(inSuite,
                    pairing.Pair(sessionManager, sTestSpake2p01_PinCode, Optional<ReliableMessageProtocolConfig>::Missing(), context,
                                 &delegate) == CHIP_NO_ERROR);
     ctx.DrainAndServiceIO();
 
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount == 1);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount == 1);
 
     // Clear pending packet in CRMP
     ReliableMessageMgr * rm     = ctx.GetExchangeManager().GetReliableMessageMgr();
     ReliableMessageContext * rc = context->GetReliableMessageContext();
     rm->ClearRetransTable(rc);
 
-    gLoopback.Reset();
-    gLoopback.mSentMessageCount = 0;
-    gLoopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
+    loopback.Reset();
+    loopback.mSentMessageCount = 0;
+    loopback.mMessageSendError = CHIP_ERROR_BAD_REQUEST;
 
     PASESession pairing1;
     ExchangeContext * context1 = ctx.NewUnauthenticatedExchangeToBob(&pairing1);
@@ -189,7 +189,7 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
                                  context1, &delegate) == CHIP_ERROR_BAD_REQUEST);
     ctx.DrainAndServiceIO();
 
-    gLoopback.mMessageSendError = CHIP_NO_ERROR;
+    loopback.mMessageSendError = CHIP_NO_ERROR;
 }
 
 void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, SessionManager & sessionManager,
@@ -204,13 +204,13 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
     PASESession pairingAccessory;
 
     PASETestLoopbackTransportDelegate delegate;
-    auto & gLoopback = ctx.GetLoopback();
-    gLoopback.SetLoopbackTransportDelegate(&delegate);
-    gLoopback.mSentMessageCount = 0;
+    auto & loopback = ctx.GetLoopback();
+    loopback.SetLoopbackTransportDelegate(&delegate);
+    loopback.mSentMessageCount = 0;
 
     ExchangeContext * contextCommissioner = ctx.NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 
-    if (gLoopback.mNumMessagesToDrop != 0)
+    if (loopback.mNumMessagesToDrop != 0)
     {
         ReliableMessageMgr * rm     = ctx.GetExchangeManager().GetReliableMessageMgr();
         ReliableMessageContext * rc = contextCommissioner->GetReliableMessageContext();
@@ -250,7 +250,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
     // via piggybacked acks. So we cannot check for a specific value of mSentMessageCount.
     // Let's make sure atleast number is >= than the minimum messages required to complete the
     // handshake.
-    NL_TEST_ASSERT(inSuite, gLoopback.mSentMessageCount >= 5);
+    NL_TEST_ASSERT(inSuite, loopback.mSentMessageCount >= 5);
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 1);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 1);
 
@@ -274,7 +274,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
                            mrpAccessoryConfig.Value().mActiveRetransTimeout);
     }
 
-    gLoopback.SetLoopbackTransportDelegate(nullptr);
+    loopback.SetLoopbackTransportDelegate(nullptr);
 }
 
 void SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
@@ -283,8 +283,8 @@ void SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    auto & gLoopback  = ctx.GetLoopback();
-    gLoopback.Reset();
+    auto & loopback   = ctx.GetLoopback();
+    loopback.Reset();
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
                                      Optional<ReliableMessageProtocolConfig>::Missing(),
                                      Optional<ReliableMessageProtocolConfig>::Missing(), delegateCommissioner);
@@ -296,8 +296,8 @@ void SecurePairingHandshakeWithCommissionerMRPTest(nlTestSuite * inSuite, void *
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    auto & gLoopback  = ctx.GetLoopback();
-    gLoopback.Reset();
+    auto & loopback   = ctx.GetLoopback();
+    loopback.Reset();
     ReliableMessageProtocolConfig config(1000_ms32, 10000_ms32);
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
                                      Optional<ReliableMessageProtocolConfig>::Value(config),
@@ -310,8 +310,8 @@ void SecurePairingHandshakeWithDeviceMRPTest(nlTestSuite * inSuite, void * inCon
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    auto & gLoopback  = ctx.GetLoopback();
-    gLoopback.Reset();
+    auto & loopback   = ctx.GetLoopback();
+    loopback.Reset();
     ReliableMessageProtocolConfig config(1000_ms32, 10000_ms32);
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
                                      Optional<ReliableMessageProtocolConfig>::Missing(),
@@ -324,8 +324,8 @@ void SecurePairingHandshakeWithAllMRPTest(nlTestSuite * inSuite, void * inContex
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    auto & gLoopback  = ctx.GetLoopback();
-    gLoopback.Reset();
+    auto & loopback   = ctx.GetLoopback();
+    loopback.Reset();
     ReliableMessageProtocolConfig commissionerConfig(1000_ms32, 10000_ms32);
     ReliableMessageProtocolConfig deviceConfig(2000_ms32, 7000_ms32);
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
@@ -339,14 +339,14 @@ void SecurePairingHandshakeWithPacketLossTest(nlTestSuite * inSuite, void * inCo
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
-    auto & gLoopback  = ctx.GetLoopback();
-    gLoopback.Reset();
-    gLoopback.mNumMessagesToDrop = 2;
+    auto & loopback   = ctx.GetLoopback();
+    loopback.Reset();
+    loopback.mNumMessagesToDrop = 2;
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
                                      Optional<ReliableMessageProtocolConfig>::Missing(),
                                      Optional<ReliableMessageProtocolConfig>::Missing(), delegateCommissioner);
-    NL_TEST_ASSERT(inSuite, gLoopback.mDroppedMessageCount == 2);
-    NL_TEST_ASSERT(inSuite, gLoopback.mNumMessagesToDrop == 0);
+    NL_TEST_ASSERT(inSuite, loopback.mDroppedMessageCount == 2);
+    NL_TEST_ASSERT(inSuite, loopback.mNumMessagesToDrop == 0);
 }
 
 void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
@@ -360,9 +360,9 @@ void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegateAccessory;
     PASESession pairingAccessory;
 
-    auto & gLoopback = ctx.GetLoopback();
-    gLoopback.Reset();
-    gLoopback.mSentMessageCount = 0;
+    auto & loopback = ctx.GetLoopback();
+    loopback.Reset();
+    loopback.mSentMessageCount = 0;
 
     ExchangeContext * contextCommissioner = ctx.NewUnauthenticatedExchangeToBob(&pairingCommissioner);
 

--- a/src/protocols/secure_channel/tests/TestPASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestPASESession.cpp
@@ -81,9 +81,6 @@ public:
 
 using TestContext = chip::Test::LoopbackMessagingContext;
 
-TestContext sContext;
-auto & gLoopback = sContext.GetLoopback();
-
 class TestSecurePairingDelegate : public SessionEstablishmentDelegate
 {
 public:
@@ -120,6 +117,7 @@ void SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, pairing.GetSecureSessionType() == SecureSession::Type::kPASE);
 
+    auto & gLoopback = ctx.GetLoopback();
     gLoopback.Reset();
 
     NL_TEST_ASSERT(inSuite,
@@ -158,6 +156,7 @@ void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegate;
     PASESession pairing;
 
+    auto & gLoopback = ctx.GetLoopback();
     gLoopback.Reset();
 
     ExchangeContext * context = ctx.NewUnauthenticatedExchangeToBob(&pairing);
@@ -205,6 +204,7 @@ void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, S
     PASESession pairingAccessory;
 
     PASETestLoopbackTransportDelegate delegate;
+    auto & gLoopback = ctx.GetLoopback();
     gLoopback.SetLoopbackTransportDelegate(&delegate);
     gLoopback.mSentMessageCount = 0;
 
@@ -282,6 +282,8 @@ void SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
     SessionManager sessionManager;
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+    auto & gLoopback  = ctx.GetLoopback();
     gLoopback.Reset();
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
                                      Optional<ReliableMessageProtocolConfig>::Missing(),
@@ -293,6 +295,8 @@ void SecurePairingHandshakeWithCommissionerMRPTest(nlTestSuite * inSuite, void *
     SessionManager sessionManager;
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+    auto & gLoopback  = ctx.GetLoopback();
     gLoopback.Reset();
     ReliableMessageProtocolConfig config(1000_ms32, 10000_ms32);
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
@@ -305,6 +309,8 @@ void SecurePairingHandshakeWithDeviceMRPTest(nlTestSuite * inSuite, void * inCon
     SessionManager sessionManager;
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+    auto & gLoopback  = ctx.GetLoopback();
     gLoopback.Reset();
     ReliableMessageProtocolConfig config(1000_ms32, 10000_ms32);
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
@@ -317,6 +323,8 @@ void SecurePairingHandshakeWithAllMRPTest(nlTestSuite * inSuite, void * inContex
     SessionManager sessionManager;
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+    auto & gLoopback  = ctx.GetLoopback();
     gLoopback.Reset();
     ReliableMessageProtocolConfig commissionerConfig(1000_ms32, 10000_ms32);
     ReliableMessageProtocolConfig deviceConfig(2000_ms32, 7000_ms32);
@@ -330,6 +338,8 @@ void SecurePairingHandshakeWithPacketLossTest(nlTestSuite * inSuite, void * inCo
     SessionManager sessionManager;
     TestSecurePairingDelegate delegateCommissioner;
     PASESession pairingCommissioner;
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+    auto & gLoopback  = ctx.GetLoopback();
     gLoopback.Reset();
     gLoopback.mNumMessagesToDrop = 2;
     SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner,
@@ -350,6 +360,7 @@ void SecurePairingFailedHandshake(nlTestSuite * inSuite, void * inContext)
     TestSecurePairingDelegate delegateAccessory;
     PASESession pairingAccessory;
 
+    auto & gLoopback = ctx.GetLoopback();
     gLoopback.Reset();
     gLoopback.mSentMessageCount = 0;
 
@@ -471,6 +482,8 @@ int TestSecurePairing_Teardown(void * inContext)
  */
 int TestPASESession()
 {
+    TestContext sContext;
+
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);
 

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -70,7 +70,6 @@ constexpr NodeId kDestinationNodeId = 111222333;
 constexpr uint32_t kMessageCounter  = 18;
 
 using TestContext = chip::Test::IOContext;
-TestContext sContext;
 
 const char PAYLOAD[] = "Hello!";
 
@@ -503,6 +502,8 @@ static int Finalize(void * aContext)
 
 int TestTCP()
 {
+    TestContext sContext;
+
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);
 

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -47,7 +47,6 @@ constexpr NodeId kDestinationNodeId = 111222333;
 constexpr uint32_t kMessageCounter  = 18;
 
 using TestContext = chip::Test::IOContext;
-TestContext sContext;
 
 const char PAYLOAD[]        = "Hello!";
 int ReceiveHandlerCallCount = 0;
@@ -211,6 +210,8 @@ static int Finalize(void * aContext)
 
 int TestUDP()
 {
+    TestContext sContext;
+
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);
 

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -54,8 +54,6 @@ using namespace chip::TestCerts;
 
 using TestContext = chip::Test::LoopbackTransportManager;
 
-TestContext sContext;
-
 const char PAYLOAD[] = "Hello!";
 
 const char LARGE_PAYLOAD[kMaxAppMessageLen + 1] = "test message";
@@ -825,6 +823,8 @@ int Finalize(void * aContext)
  */
 int TestSessionManager()
 {
+    TestContext sContext;
+
     // Run test suit against one context
     nlTestRunner(&sSuite, &sContext);
 


### PR DESCRIPTION
#### Problem
Because multiple test files are linked together to generate final test binary, even if a test is not runned, the global variable `TestContext sContext` is still linked and initialized, which may be distractive while debugging test cases, because lots of objects are initialized but not used.

#### Change overview
Move `TestContext sContext` to a scoped variable

#### Testing
Passed unit-tests