### PR TITLE
Remove raw `SessionHolder::Get`

### DIFF
--- a/examples/shell/shell_common/cmd_ping.cpp
+++ b/examples/shell/shell_common/cmd_ping.cpp
@@ -320,7 +320,7 @@ void StartPinging(streamer_t * stream, char * destination)
     err = EstablishSecureSession(stream, GetEchoPeerAddress());
     SuccessOrExit(err);
 
-    err = gEchoClient.Init(&gExchangeManager, gSession.Get());
+    err = gEchoClient.Init(&gExchangeManager, gSession.Get().Value());
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/examples/shell/shell_common/cmd_send.cpp
+++ b/examples/shell/shell_common/cmd_send.cpp
@@ -128,7 +128,7 @@ CHIP_ERROR SendMessage(streamer_t * stream)
     uint32_t payloadSize = gSendArguments.GetPayloadSize();
 
     // Create a new exchange context.
-    auto * ec = gExchangeManager.NewContext(gSession.Get(), &gMockAppDelegate);
+    auto * ec = gExchangeManager.NewContext(gSession.Get().Value(), &gMockAppDelegate);
     VerifyOrExit(ec != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     payloadBuf = MessagePacketBuffer::New(payloadSize);

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -191,7 +191,7 @@ CHIP_ERROR OperationalDeviceProxy::UpdateDeviceData(const Transport::PeerAddress
             return CHIP_NO_ERROR;
         }
 
-        mSecureSession.Get()->AsSecureSession()->SetPeerAddress(addr);
+        mSecureSession.Get().Value()->AsSecureSession()->SetPeerAddress(addr);
     }
 
     return err;
@@ -305,7 +305,7 @@ CHIP_ERROR OperationalDeviceProxy::Disconnect()
     ReturnErrorCodeIf(mState != State::SecureConnected, CHIP_ERROR_INCORRECT_STATE);
     if (mSecureSession)
     {
-        mInitParams.sessionManager->ExpirePairing(mSecureSession.Get());
+        mInitParams.sessionManager->ExpirePairing(mSecureSession.Get().Value());
     }
     MoveToState(State::Initialized);
 

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -182,7 +182,7 @@ public:
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mInitParams.exchangeMgr; }
 
-    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.ToOptional(); }
+    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.Get(); }
 
     Transport::PeerAddress GetPeerAddress() const { return mDeviceAddress; }
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -269,7 +269,9 @@ CHIP_ERROR ReadClient::SendReadRequest(ReadPrepareParams & aReadPrepareParams)
     ReturnErrorOnFailure(request.EndOfReadRequestMessage().GetError());
     ReturnErrorOnFailure(writer.Finalize(&msgBuf));
 
-    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHolder.Get(), this);
+    VerifyOrReturnError(aReadPrepareParams.mSessionHolder, CHIP_ERROR_MISSING_SECURE_SESSION);
+
+    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHolder.Get().Value(), this);
     VerifyOrReturnError(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
 
     mpExchangeCtx->SetResponseTimeout(aReadPrepareParams.mTimeout);
@@ -913,7 +915,9 @@ CHIP_ERROR ReadClient::SendSubscribeRequest(ReadPrepareParams & aReadPreparePara
     ReturnErrorOnFailure(err = request.EndOfSubscribeRequestMessage().GetError());
     ReturnErrorOnFailure(writer.Finalize(&msgBuf));
 
-    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHolder.Get(), this);
+    VerifyOrReturnError(aReadPrepareParams.mSessionHolder, CHIP_ERROR_MISSING_SECURE_SESSION);
+
+    mpExchangeCtx = mpExchangeMgr->NewContext(aReadPrepareParams.mSessionHolder.Get().Value(), this);
     VerifyOrReturnError(mpExchangeCtx != nullptr, err = CHIP_ERROR_NO_MEMORY);
     mpExchangeCtx->SetResponseTimeout(kImMessageTimeout);
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -221,7 +221,7 @@ CHIP_ERROR ReadHandler::SendStatusReport(Protocols::InteractionModel::Status aSt
     {
         VerifyOrReturnLogError(mpExchangeCtx == nullptr, CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnLogError(mSessionHandle, CHIP_ERROR_INCORRECT_STATE);
-        mpExchangeCtx = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(mSessionHandle.Get(), this);
+        mpExchangeCtx = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(mSessionHandle.Get().Value(), this);
     }
     VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
@@ -240,7 +240,7 @@ CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload, b
     {
         VerifyOrReturnLogError(mpExchangeCtx == nullptr, CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnLogError(mSessionHandle, CHIP_ERROR_INCORRECT_STATE);
-        mpExchangeCtx = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(mSessionHandle.Get(), this);
+        mpExchangeCtx = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(mSessionHandle.Get().Value(), this);
     }
 
     VerifyOrReturnLogError(mpExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -266,7 +266,7 @@ CHIP_ERROR SendCommandRequest(std::unique_ptr<chip::app::CommandSender> && comma
     err = commandSender->FinishCommand();
     SuccessOrExit(err);
 
-    err = commandSender->SendCommandRequest(gSession.Get(), chip::MakeOptional(gMessageTimeout));
+    err = commandSender->SendCommandRequest(gSession.Get().Value(), chip::MakeOptional(gMessageTimeout));
     SuccessOrExit(err);
 
     gCommandCount++;
@@ -302,7 +302,7 @@ CHIP_ERROR SendBadCommandRequest(std::unique_ptr<chip::app::CommandSender> && co
     err = commandSender->FinishCommand();
     SuccessOrExit(err);
 
-    err = commandSender->SendCommandRequest(gSession.Get(), chip::MakeOptional(gMessageTimeout));
+    err = commandSender->SendCommandRequest(gSession.Get().Value(), chip::MakeOptional(gMessageTimeout));
     SuccessOrExit(err);
     gCommandCount++;
     commandSender.release();
@@ -330,7 +330,7 @@ CHIP_ERROR SendReadRequest()
 
     printf("\nSend read request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
 
-    chip::app::ReadPrepareParams readPrepareParams(gSession.Get());
+    chip::app::ReadPrepareParams readPrepareParams(gSession.Get().Value());
     readPrepareParams.mTimeout                     = gMessageTimeout;
     readPrepareParams.mpAttributePathParamsList    = &attributePathParams;
     readPrepareParams.mAttributePathParamsListSize = 1;
@@ -367,7 +367,7 @@ CHIP_ERROR SendWriteRequest(chip::app::WriteClient & apWriteClient)
 
     SuccessOrExit(err = apWriteClient.EncodeAttribute(
                       chip::app::AttributePathParams(2 /* endpoint */, 3 /* cluster */, 4 /* attribute */), true));
-    SuccessOrExit(err = apWriteClient.SendWriteRequest(gSession.Get(), gMessageTimeout));
+    SuccessOrExit(err = apWriteClient.SendWriteRequest(gSession.Get().Value(), gMessageTimeout));
 
     gWriteCount++;
 
@@ -384,7 +384,7 @@ CHIP_ERROR SendSubscribeRequest()
     CHIP_ERROR err   = CHIP_NO_ERROR;
     gLastMessageTime = chip::System::SystemClock().GetMonotonicTimestamp();
 
-    chip::app::ReadPrepareParams readPrepareParams(gSession.Get());
+    chip::app::ReadPrepareParams readPrepareParams(gSession.Get().Value());
     chip::app::EventPathParams * eventPathParams           = new chip::app::EventPathParams[2];
     chip::app::AttributePathParams * attributePathParams   = new chip::app::AttributePathParams[1];
     readPrepareParams.mpEventPathParamsList                = eventPathParams;

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -47,7 +47,7 @@ CHIP_ERROR CommissioneeDeviceProxy::SendCommands(app::CommandSender * commandObj
 {
     VerifyOrReturnError(mSecureSession, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(commandObj != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(mSecureSession.Get().HasValue(), CHIP_ERROR_MISSING_SECURE_SESSION);
+    VerifyOrReturnError(mSecureSession, CHIP_ERROR_MISSING_SECURE_SESSION);
     return commandObj->SendCommandRequest(mSecureSession.Get().Value(), timeout);
 }
 

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -47,7 +47,8 @@ CHIP_ERROR CommissioneeDeviceProxy::SendCommands(app::CommandSender * commandObj
 {
     VerifyOrReturnError(mSecureSession, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(commandObj != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    return commandObj->SendCommandRequest(mSecureSession.Get(), timeout);
+    VerifyOrReturnError(mSecureSession.Get().HasValue(), CHIP_ERROR_MISSING_SECURE_SESSION);
+    return commandObj->SendCommandRequest(mSecureSession.Get().Value(), timeout);
 }
 
 void CommissioneeDeviceProxy::OnSessionReleased()
@@ -60,7 +61,7 @@ CHIP_ERROR CommissioneeDeviceProxy::CloseSession()
     ReturnErrorCodeIf(mState != ConnectionState::SecureConnected, CHIP_ERROR_INCORRECT_STATE);
     if (mSecureSession)
     {
-        mSessionManager->ExpirePairing(mSecureSession.Get());
+        mSessionManager->ExpirePairing(mSecureSession.Get().Value());
     }
     mState = ConnectionState::NotConnected;
     mPairing.Clear();
@@ -87,7 +88,7 @@ CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddres
         return CHIP_NO_ERROR;
     }
 
-    Transport::SecureSession * secureSession = mSecureSession.Get()->AsSecureSession();
+    Transport::SecureSession * secureSession = mSecureSession.Get().Value()->AsSecureSession();
     secureSession->SetPeerAddress(addr);
 
     return CHIP_NO_ERROR;

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -137,7 +137,7 @@ public:
     CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) override;
     const Transport::PeerAddress & GetPeerAddress() const { return mDeviceAddress; }
 
-    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.ToOptional(); }
+    chip::Optional<SessionHandle> GetSecureSession() const override { return mSecureSession.Get(); }
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mExchangeMgr; }
 

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -85,7 +85,7 @@ OnReportBeginCallback gOnReportEndCallback                           = nullptr;
 
 void PythonResubscribePolicy(uint32_t aNumCumulativeRetries, uint32_t & aNextSubscriptionIntervalMsec, bool & aShouldResubscribe)
 {
-    aShouldResubscribe = false;
+    aShouldResubscribe = true;
 }
 
 class ReadClientCallback : public ReadClient::Callback

--- a/src/lib/core/CHIPError.cpp
+++ b/src/lib/core/CHIPError.cpp
@@ -206,6 +206,9 @@ bool FormatCHIPError(char * buf, uint16_t bufSize, CHIP_ERROR err)
     case CHIP_ERROR_TLV_TAG_NOT_FOUND.AsInteger():
         desc = "TLV tag not found";
         break;
+    case CHIP_ERROR_MISSING_SECURE_SESSION.AsInteger():
+        desc = "Missing secure session";
+        break;
     case CHIP_ERROR_INVALID_PATH_LIST.AsInteger():
         desc = "Invalid TLV path list";
         break;
@@ -712,9 +715,6 @@ bool FormatCHIPError(char * buf, uint16_t bufSize, CHIP_ERROR err)
         break;
     case CHIP_ERROR_IM_MALFORMED_STATUS_RESPONSE_MESSAGE.AsInteger():
         desc = "Malformed Interaction Model Status Response Message";
-        break;
-    case CHIP_ERROR_MISSING_SECURE_SESSION.AsInteger():
-        desc = "Missing secure session";
         break;
     }
 #endif // !CHIP_CONFIG_SHORT_ERROR_STR

--- a/src/lib/core/CHIPError.cpp
+++ b/src/lib/core/CHIPError.cpp
@@ -713,6 +713,9 @@ bool FormatCHIPError(char * buf, uint16_t bufSize, CHIP_ERROR err)
     case CHIP_ERROR_IM_MALFORMED_STATUS_RESPONSE_MESSAGE.AsInteger():
         desc = "Malformed Interaction Model Status Response Message";
         break;
+    case CHIP_ERROR_MISSING_SECURE_SESSION.AsInteger():
+        desc = "Missing secure session";
+        break;
     }
 #endif // !CHIP_CONFIG_SHORT_ERROR_STR
 

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -2389,8 +2389,13 @@ using CHIP_ERROR = ::chip::ChipError;
 #define CHIP_ERROR_IM_MALFORMED_STATUS_RESPONSE_MESSAGE      CHIP_CORE_ERROR(0xe1)
 
 /**
- *  @}
+ * @def CHIP_ERROR_MISSING_SECURE_SESSION
+ *
+ * @brief
+ *
+ *  A secure session is needed to do work, but is missing/is not present.
  */
+#define CHIP_ERROR_MISSING_SECURE_SESSION                   CHIP_CORE_ERROR(0xe2)
 
 // clang-format on
 

--- a/src/lib/core/CHIPError.h
+++ b/src/lib/core/CHIPError.h
@@ -1500,7 +1500,14 @@ using CHIP_ERROR = ::chip::ChipError;
  */
 #define CHIP_ERROR_TLV_TAG_NOT_FOUND                           CHIP_CORE_ERROR(0x76)
 
-// unused CHIP_CORE_ERROR(0x77)
+/**
+ * @def CHIP_ERROR_MISSING_SECURE_SESSION
+ *
+ * @brief
+ *
+ *  A secure session is needed to do work, but is missing/is not present.
+ */
+#define CHIP_ERROR_MISSING_SECURE_SESSION                      CHIP_CORE_ERROR(0x77)
 
 // unused CHIP_CORE_ERROR(0x78)
 
@@ -2387,15 +2394,6 @@ using CHIP_ERROR = ::chip::ChipError;
  *   the required elements
  */
 #define CHIP_ERROR_IM_MALFORMED_STATUS_RESPONSE_MESSAGE      CHIP_CORE_ERROR(0xe1)
-
-/**
- * @def CHIP_ERROR_MISSING_SECURE_SESSION
- *
- * @brief
- *
- *  A secure session is needed to do work, but is missing/is not present.
- */
-#define CHIP_ERROR_MISSING_SECURE_SESSION                   CHIP_CORE_ERROR(0xe2)
 
 // clang-format on
 

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -183,10 +183,17 @@ CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgTyp
             return CHIP_ERROR_INTERNAL;
         }
 
+        //
+        // Our session should still be valid, since it had been evicted, all exchanges on that session would have been torn down
+        // as a side-effect. So for us to get here to send a message and still not have a session, something terribly wrong must
+        // have happened.
+        //
+        VerifyOrDie(mSession);
+
         // Create a new scope for `err`, to avoid shadowing warning previous `err`.
-        CHIP_ERROR err = mDispatch.SendMessage(GetExchangeMgr()->GetSessionManager(), mSession.Get(), mExchangeId, IsInitiator(),
-                                               GetReliableMessageContext(), reliableTransmissionRequested, protocolId, msgType,
-                                               std::move(msgBuf));
+        CHIP_ERROR err = mDispatch.SendMessage(GetExchangeMgr()->GetSessionManager(), mSession.Get().Value(), mExchangeId,
+                                               IsInitiator(), GetReliableMessageContext(), reliableTransmissionRequested,
+                                               protocolId, msgType, std::move(msgBuf));
         if (err != CHIP_NO_ERROR && IsResponseExpected())
         {
             CancelResponseTimer();

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -156,7 +156,13 @@ public:
 
     ExchangeMessageDispatch & GetMessageDispatch() { return mDispatch; }
 
-    SessionHandle GetSessionHandle() const { return mSession.Get(); }
+    SessionHandle GetSessionHandle() const
+    {
+        VerifyOrDie(mSession);
+        auto sessionHandle = mSession.Get();
+        return std::move(sessionHandle.Value());
+    }
+
     bool HasSessionHandle() const { return mSession; }
 
     uint16_t GetExchangeId() const { return mExchangeId; }

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -107,12 +107,14 @@ CHIP_ERROR MessagingContext::CreateSessionBobToFriends()
 
 SessionHandle MessagingContext::GetSessionBobToAlice()
 {
-    return mSessionBobToAlice.Get();
+    auto sessionHandle = mSessionBobToAlice.Get();
+    return std::move(sessionHandle.Value());
 }
 
 SessionHandle MessagingContext::GetSessionAliceToBob()
 {
-    return mSessionAliceToBob.Get();
+    auto sessionHandle = mSessionAliceToBob.Get();
+    return std::move(sessionHandle.Value());
 }
 
 SessionHandle MessagingContext::GetSessionBobToFriends()
@@ -122,12 +124,18 @@ SessionHandle MessagingContext::GetSessionBobToFriends()
 
 void MessagingContext::ExpireSessionBobToAlice()
 {
-    mSessionManager.ExpirePairing(mSessionBobToAlice.Get());
+    if (mSessionBobToAlice)
+    {
+        mSessionManager.ExpirePairing(mSessionBobToAlice.Get().Value());
+    }
 }
 
 void MessagingContext::ExpireSessionAliceToBob()
 {
-    mSessionManager.ExpirePairing(mSessionAliceToBob.Get());
+    if (mSessionAliceToBob)
+    {
+        mSessionManager.ExpirePairing(mSessionAliceToBob.Get().Value());
+    }
 }
 
 void MessagingContext::ExpireSessionBobToFriends()

--- a/src/messaging/tests/echo/echo_requester.cpp
+++ b/src/messaging/tests/echo/echo_requester.cpp
@@ -255,7 +255,7 @@ int main(int argc, char * argv[])
     err = EstablishSecureSession();
     SuccessOrExit(err);
 
-    err = gEchoClient.Init(&gExchangeManager, gSession.Get());
+    err = gEchoClient.Init(&gExchangeManager, gSession.Get().Value());
     SuccessOrExit(err);
 
     // Arrange to get a callback whenever an Echo Response is received.

--- a/src/protocols/echo/EchoClient.cpp
+++ b/src/protocols/echo/EchoClient.cpp
@@ -70,8 +70,10 @@ CHIP_ERROR EchoClient::SendEchoRequest(System::PacketBufferHandle && payload, Me
         mExchangeCtx = nullptr;
     }
 
+    VerifyOrReturnError(mSecureSession, CHIP_ERROR_INVALID_MESSAGE_TYPE);
+
     // Create a new exchange context.
-    mExchangeCtx = mExchangeMgr->NewContext(mSecureSession.Get(), this);
+    mExchangeCtx = mExchangeMgr->NewContext(mSecureSession.Get().Value(), this);
     if (mExchangeCtx == nullptr)
     {
         return CHIP_ERROR_NO_MEMORY;

--- a/src/protocols/secure_channel/PairingSession.cpp
+++ b/src/protocols/secure_channel/PairingSession.cpp
@@ -67,7 +67,8 @@ void PairingSession::Finish()
     CHIP_ERROR err = ActivateSecureSession(address);
     if (err == CHIP_NO_ERROR)
     {
-        mDelegate->OnSessionEstablished(mSecureSessionHolder.Get());
+        VerifyOrDie(mSecureSessionHolder);
+        mDelegate->OnSessionEstablished(mSecureSessionHolder.Get().Value());
     }
     else
     {
@@ -155,14 +156,14 @@ void PairingSession::Clear()
 
     if (mSecureSessionHolder)
     {
-        SessionHandle session = mSecureSessionHolder.Get();
+        auto session = mSecureSessionHolder.Get();
         // Call Release before ExpirePairing because we don't want to receive OnSessionReleased() event here
         mSecureSessionHolder.Release();
-        if (!session->AsSecureSession()->IsActiveSession() && mSessionManager != nullptr)
+        if (!session.Value()->AsSecureSession()->IsActiveSession() && mSessionManager != nullptr)
         {
             // Make sure to clean up our pending session, since we're the only
             // ones who have access to it do do so.
-            mSessionManager->ExpirePairing(session);
+            mSessionManager->ExpirePairing(session.Value());
         }
     }
 

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -51,10 +51,10 @@ public:
     void Release();
 
     operator bool() const { return mSession.HasValue(); }
-    SessionHandle Get() const { return SessionHandle{ mSession.Value().Get() }; }
-    Optional<SessionHandle> ToOptional() const
+    Optional<SessionHandle> Get() const
     {
-        return mSession.HasValue() ? chip::MakeOptional<SessionHandle>(Get()) : chip::Optional<SessionHandle>::Missing();
+        return mSession.HasValue() ? chip::MakeOptional<SessionHandle>(mSession.Value().Get())
+                                   : chip::Optional<SessionHandle>::Missing();
     }
 
     Transport::Session * operator->() const { return &mSession.Value().Get(); }

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -53,6 +53,12 @@ public:
     operator bool() const { return mSession.HasValue(); }
     Optional<SessionHandle> Get() const
     {
+        //
+        // We cannot return mSession directly even if Optional<SessionHandle> is internally composed of the same bits,
+        // since they are not actually equivalent type-wise, and SessionHandle does not permit copy-construction.
+        //
+        // So, construct a new Optional<SessionHandle> from the underlying Transport::Session reference.
+        //
         return mSession.HasValue() ? chip::MakeOptional<SessionHandle>(mSession.Value().Get())
                                    : chip::Optional<SessionHandle>::Missing();
     }

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -179,10 +179,10 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
     payloadHeader.SetMessageType(chip::Protocols::Echo::MsgType::EchoRequest);
 
     EncryptedPacketBufferHandle preparedMessage;
-    err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(buffer), preparedMessage);
+    err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(buffer), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -194,10 +194,10 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     callback.LargeMessageSent = true;
 
-    err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(large_buffer), preparedMessage);
+    err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(large_buffer), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -211,7 +211,8 @@ void CheckMessageTest(nlTestSuite * inSuite, void * inContext)
 
     callback.LargeMessageSent = true;
 
-    err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(extra_large_buffer), preparedMessage);
+    err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(extra_large_buffer),
+                                        preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_MESSAGE_TOO_LONG);
 
     sessionManager.Shutdown();
@@ -288,20 +289,20 @@ void SendEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     payloadHeader.SetInitiator(true);
 
-    err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(buffer), preparedMessage);
+    err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(buffer), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
     NL_TEST_ASSERT(inSuite, callback.ReceiveHandlerCallCount == 1);
 
     // Reset receive side message counter, or duplicated message will be denied.
-    Transport::SecureSession * session = bobToAliceSession.Get()->AsSecureSession();
+    Transport::SecureSession * session = bobToAliceSession.Get().Value()->AsSecureSession();
     session->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(1);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -381,10 +382,10 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     payloadHeader.SetInitiator(true);
 
-    err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(buffer), preparedMessage);
+    err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(buffer), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -392,7 +393,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
 
     /* -------------------------------------------------------------------------------------------*/
     // Reset receive side message counter, or duplicated message will be denied.
-    Transport::SecureSession * session = bobToAliceSession.Get()->AsSecureSession();
+    Transport::SecureSession * session = bobToAliceSession.Get().Value()->AsSecureSession();
     session->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(1);
 
     PacketHeader packetHeader;
@@ -405,7 +406,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     packetHeader.SetMessageCounter(messageCounter + 1);
     NL_TEST_ASSERT(inSuite, badMessageCounterMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), badMessageCounterMsg);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), badMessageCounterMsg);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -422,7 +423,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     packetHeader.SetSessionId(3);
     NL_TEST_ASSERT(inSuite, badKeyIdMsg.InsertPacketHeader(packetHeader) == CHIP_NO_ERROR);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), badKeyIdMsg);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), badKeyIdMsg);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -432,7 +433,7 @@ void SendBadEncryptedPacketTest(nlTestSuite * inSuite, void * inContext)
     session->GetSessionMessageCounter().GetPeerMessageCounter().SetCounter(1);
 
     // Send the correct encrypted msg
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -511,10 +512,10 @@ void SendPacketWithOldCounterTest(nlTestSuite * inSuite, void * inContext)
 
     payloadHeader.SetInitiator(true);
 
-    err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(buffer), preparedMessage);
+    err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(buffer), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -527,11 +528,11 @@ void SendPacketWithOldCounterTest(nlTestSuite * inSuite, void * inContext)
         buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
         NL_TEST_ASSERT(inSuite, !buffer.IsNull());
 
-        err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(buffer), newMessage);
+        err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(buffer), newMessage);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     }
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), newMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), newMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -539,7 +540,7 @@ void SendPacketWithOldCounterTest(nlTestSuite * inSuite, void * inContext)
 
     // Now resend our original message.  It should be rejected as a duplicate.
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -618,10 +619,10 @@ void SendPacketWithTooOldCounterTest(nlTestSuite * inSuite, void * inContext)
 
     payloadHeader.SetInitiator(true);
 
-    err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(buffer), preparedMessage);
+    err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(buffer), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -636,11 +637,11 @@ void SendPacketWithTooOldCounterTest(nlTestSuite * inSuite, void * inContext)
         buffer = chip::MessagePacketBuffer::NewWithData(PAYLOAD, payload_len);
         NL_TEST_ASSERT(inSuite, !buffer.IsNull());
 
-        err = sessionManager.PrepareMessage(aliceToBobSession.Get(), payloadHeader, std::move(buffer), newMessage);
+        err = sessionManager.PrepareMessage(aliceToBobSession.Get().Value(), payloadHeader, std::move(buffer), newMessage);
         NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     }
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), newMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), newMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();
@@ -648,7 +649,7 @@ void SendPacketWithTooOldCounterTest(nlTestSuite * inSuite, void * inContext)
 
     // Now resend our original message.  It should be rejected as a duplicate.
 
-    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get(), preparedMessage);
+    err = sessionManager.SendPreparedMessage(aliceToBobSession.Get().Value(), preparedMessage);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     ctx.DrainAndServiceIO();


### PR DESCRIPTION
#### Problem

The `SessionHolder::Get` API returns the underlying SessionHandle under the assumption that one exists in the holder. It assumes callers have previously called `operator bool()` to check to see if there is a valid session in the holder BEFORE calling this API.

However, most consumers are lulled into thinking with that API that there is always a `SessionHandle` in that holder, which is not true since holders act as weak-references where the invalidation of a given session removes the referenced handles from all holders in the system.

This results in crashes if clients assume incorrectly about the session stored in the holder.

E.g If a subscription is setup with re-subscription enabled, the invalidation of the underlying session results in a crash later at re-subscription time.

#### Fix

Fix the API to return an `Optional<SessionHandle>` at all times to make it clear that the holder MAY NOT be holding on-to a session.

Consequently, I scrubbed and fixed all existing call-sites (including the buggy `ReadClient` one) to either test for the right invariance about session presence, or to return an error appropriately if the holder was not holding onto a session at the time.

#### Test

Using the REPL, I setup a subscription to a peer, then called `CloseSession` to emulate the forcible termination of a given session to a peer, then waited for the re-subscription to kick-in.

Validated that it crashed pre-fix, and correctly error'ed out post-fix.