### PR TITLE
Allow actually initializing a controller with an external keypair.

### DIFF
--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -98,7 +98,7 @@ struct ControllerInitParams
     /**
      * Controls whether or not the operationalKeypair should be owned by the caller.
      * By default, this is false, but if the keypair cannot be serialized, then
-     * setting this to true will allow you to manage this keypair's lifecycle.
+     * setting this to true will allow the caller to manage this keypair's lifecycle.
      */
     bool hasExternallyOwnedOperationalKeypair = false;
 

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -249,11 +249,12 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 
 void DeviceControllerFactory::PopulateInitParams(ControllerInitParams & controllerParams, const SetupParams & params)
 {
-    controllerParams.operationalCredentialsDelegate = params.operationalCredentialsDelegate;
-    controllerParams.operationalKeypair             = params.operationalKeypair;
-    controllerParams.controllerNOC                  = params.controllerNOC;
-    controllerParams.controllerICAC                 = params.controllerICAC;
-    controllerParams.controllerRCAC                 = params.controllerRCAC;
+    controllerParams.operationalCredentialsDelegate       = params.operationalCredentialsDelegate;
+    controllerParams.operationalKeypair                   = params.operationalKeypair;
+    controllerParams.hasExternallyOwnedOperationalKeypair = params.hasExternallyOwnedOperationalKeypair;
+    controllerParams.controllerNOC                        = params.controllerNOC;
+    controllerParams.controllerICAC                       = params.controllerICAC;
+    controllerParams.controllerRCAC                       = params.controllerRCAC;
 
     controllerParams.systemState        = mSystemState;
     controllerParams.controllerVendorId = params.controllerVendorId;

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -46,6 +46,14 @@ struct SetupParams
     controllerNOC. It's used by controller to establish CASE sessions with devices */
     Crypto::P256Keypair * operationalKeypair = nullptr;
 
+    /**
+     * Controls whether or not the operationalKeypair should be owned by the
+     * caller.  By default, this is false, but if the keypair cannot be
+     * serialized, then setting this to true will allow the caller to manage
+     * this keypair's lifecycle.
+     */
+    bool hasExternallyOwnedOperationalKeypair = false;
+
     /* The following certificates must be in x509 DER format */
     ByteSpan controllerNOC;
     ByteSpan controllerICAC;


### PR DESCRIPTION
The boolean had not been added to Controller::SetupParams, so could
not be passed through to controller startup via the controller
factory.

#### Problem
See above.

#### Change overview
Add the boolean to the right struct and propagate it through.

#### Testing
No good way to test this yet, but I am working on Darwin APIs that would let me do it.