### PR TITLE
[esp32] fix empty is_debug value when debug disabled

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -40,6 +40,7 @@ if (NOT CMAKE_BUILD_EARLY_EXPANSION)
         if (NOT CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE)
             message(FATAL_ERROR "CONFIG_COMPILER_OPTIMIZATION_ASSERTIONS_DISABLE shall be set")
         endif()
+        set(is_debug FALSE)
     endif()
 endif()
 


### PR DESCRIPTION
#### Problem

`is_debug` value will be empty if debug is disabled on ESP32, causing the build to fail.


#### Change overview

Add `is_debug` false value.

#### Testing

Build with debug disabled.
