### PR TITLE
[Telink]: Use docker image 0.5.74

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-telink:0.5.59
+            image: connectedhomeip/chip-build-telink:0.5.74
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 


### PR DESCRIPTION
#### Problem
* Issue with plic_set_priority under irq_connect_dynamic.
#### Change overview
* Use docker image 0.5.74

#### Testing
Tested manually with chip-tool.
Steps:

Run: $ chip-tool pairing ble-thread <...>
Wait till success
Run: $ chip-tool accesscontrol write acl <...>
Wait till success
Run: $ chip-tool binding write binding <...>
Wait till success
Press manually switch button
Check if end device perform command
