### PR TITLE
[zephyr] Small settings load optimization

### DIFF
--- a/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Zephyr/KeyValueStoreManagerImpl.cpp
@@ -76,7 +76,8 @@ int LoadEntryCallback(const char * name, size_t entrySize, settings_read_cb read
         entry.result = bytesRead > 0 ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     }
 
-    return 0;
+    // Return 1 to stop processing further keys
+    return 1;
 }
 
 int DeleteSubtreeCallback(const char * name, size_t /* entrySize */, settings_read_cb /* readCb */, void * /* cbArg */,

--- a/src/platform/Zephyr/ZephyrConfig.cpp
+++ b/src/platform/Zephyr/ZephyrConfig.cpp
@@ -108,14 +108,16 @@ int ConfigValueCallback(const char * name, size_t configSize, settings_read_cb r
     {
         request.result     = CHIP_ERROR_BUFFER_TOO_SMALL;
         request.configSize = configSize;
-        return 0;
+        return 1;
     }
 
     // Found requested key
     const ssize_t bytesRead = readCb(cbArg, request.destination, request.bufferSize);
     request.result          = bytesRead > 0 ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_FAILED;
     request.configSize      = bytesRead > 0 ? bytesRead : 0;
-    return 0;
+
+    // Return 1 to stop processing further keys
+    return 1;
 }
 
 // Read configuration value of maximum size `bufferSize` and store the actual size in `configSize`.


### PR DESCRIPTION
#### Problem
Zephyr settings API does not have a function for loading a single key, so Matter uses an API for loading a subtree
of keys. This can be slightly optimized by exiting the key lookup after finding an exact match.

#### Change overview
Optimize the settings key lookup.

#### Testing
Tested that nRF Connect lighting-app can correctly store and read settings (such as reboot count)
