### PR TITLE
[Darwin] Add support for multiple paths for generic read/subscribe methods

### DIFF
--- a/examples/chip-tool-darwin/commands/clusters/ClusterCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/clusters/ClusterCommandBridge.h
@@ -60,7 +60,7 @@ public:
 
     ~ClusterCommand() {}
 
-    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId) override
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, std::vector<chip::EndpointId> endpoints) override
     {
         chip::TLV::TLVWriter writer;
         chip::TLV::TLVReader reader;
@@ -78,7 +78,7 @@ public:
         if (commandFields == nil) {
             return CHIP_ERROR_INTERNAL;
         }
-        return ClusterCommand::SendCommand(device, endpointId, mClusterId, mCommandId, commandFields);
+        return ClusterCommand::SendCommand(device, endpoints.front(), mClusterId, mCommandId, commandFields);
     }
 
     CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId, chip::ClusterId clusterId,

--- a/examples/chip-tool-darwin/commands/clusters/ModelCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/clusters/ModelCommandBridge.h
@@ -31,16 +31,16 @@ public:
     void AddArguments()
     {
         AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
-        AddArgument("endpoint-id", 0, UINT16_MAX, &mEndPointId);
+        AddArgument("endpoint-id", 0, UINT16_MAX, &mEndPointIds);
     }
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(10); }
 
-    virtual CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endPointId) = 0;
+    virtual CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, std::vector<chip::EndpointId> endPoints) = 0;
 
 private:
     chip::NodeId mNodeId;
-    chip::EndpointId mEndPointId;
+    std::vector<chip::EndpointId> mEndPointIds;
 };

--- a/examples/chip-tool-darwin/commands/clusters/ModelCommandBridge.mm
+++ b/examples/chip-tool-darwin/commands/clusters/ModelCommandBridge.mm
@@ -38,7 +38,7 @@ CHIP_ERROR ModelCommand::RunCommand()
                                 if (device == nil) {
                                     err = CHIP_ERROR_INTERNAL;
                                 } else {
-                                    err = SendCommand(device, mEndPointId);
+                                    err = SendCommand(device, mEndPointIds);
                                 }
 
                                 if (err != CHIP_NO_ERROR) {

--- a/examples/chip-tool-darwin/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/clusters/WriteAttributeCommandBridge.h
@@ -53,7 +53,7 @@ public:
 
     ~WriteAttribute() {}
 
-    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId) override
+    CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, std::vector<chip::EndpointId> endpoints) override
     {
         chip::TLV::TLVWriter writer;
         chip::TLV::TLVReader reader;
@@ -72,7 +72,7 @@ public:
             return CHIP_ERROR_INTERNAL;
         }
 
-        return WriteAttribute::SendCommand(device, endpointId, mClusterId, mAttributeId, value);
+        return WriteAttribute::SendCommand(device, endpoints.front(), mClusterId, mAttributeId, value);
     }
 
     CHIP_ERROR SendCommand(CHIPDevice * _Nonnull device, chip::EndpointId endpointId, chip::ClusterId clusterId,

--- a/examples/chip-tool-darwin/templates/commands.zapt
+++ b/examples/chip-tool-darwin/templates/commands.zapt
@@ -41,12 +41,12 @@ public:
         ClusterCommand::AddArguments();
     }
 
-    CHIP_ERROR SendCommand(CHIPDevice * device, chip::EndpointId endpointId) override
+    CHIP_ERROR SendCommand(CHIPDevice * device, std::vector<chip::EndpointId> endpoints) override
     {
-        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) command ({{asHex code 8}}) on endpoint %u", endpointId);
+        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) command ({{asHex code 8}}) on endpoint %u", endpoints.front());
 
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        CHIP{{asUpperCamelCase clusterName}} * cluster = [[CHIP{{asUpperCamelCase clusterName}} alloc] initWithDevice:device endpoint:endpointId queue:callbackQueue];
+        CHIP{{asUpperCamelCase clusterName}} * cluster = [[CHIP{{asUpperCamelCase clusterName}} alloc] initWithDevice:device endpoint:endpoints.front() queue:callbackQueue];
         __auto_type * params = [[CHIP{{asUpperCamelCase clusterName}}Cluster{{asUpperCamelCase name}}Params alloc] init];
         params.timedInvokeTimeoutMs = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
         {{#chip_cluster_command_arguments}}
@@ -106,12 +106,12 @@ public:
     {
     }
 
-    CHIP_ERROR SendCommand(CHIPDevice * device, chip::EndpointId endpointId) override
+    CHIP_ERROR SendCommand(CHIPDevice * device, std::vector<chip::EndpointId> endpoints) override
     {
-        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) ReadAttribute ({{asHex code 8}}) on endpoint %u", endpointId);
+        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) ReadAttribute ({{asHex code 8}}) on endpoint %u", endpoints.front());
 
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:endpointId queue:callbackQueue];
+        CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:endpoints.front() queue:callbackQueue];
         {{#if_is_fabric_scoped_struct type}}
         CHIPReadParams * params = [[CHIPReadParams alloc] init];
         params.fabricFiltered = mFabricFiltered.HasValue() ? [NSNumber numberWithBool:mFabricFiltered.Value()] : nil;
@@ -157,11 +157,11 @@ public:
     {
     }
 
-    CHIP_ERROR SendCommand(CHIPDevice * device, chip::EndpointId endpointId) override
+    CHIP_ERROR SendCommand(CHIPDevice * device, std::vector<chip::EndpointId> endpoints) override
     {
-        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) WriteAttribute ({{asHex code 8}}) on endpoint %u", endpointId);
+        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) WriteAttribute ({{asHex code 8}}) on endpoint %u", endpoints.front());
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:endpointId queue:callbackQueue];
+        CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:endpoints.front() queue:callbackQueue];
         CHIPWriteParams * params = [[CHIPWriteParams alloc] init];
         params.timedWriteTimeoutMs = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
         params.dataVersion = mDataVersion.HasValue() ? [NSNumber numberWithUnsignedInt:mDataVersion.Value()] : nil;
@@ -211,11 +211,11 @@ public:
     {
     }
 
-    CHIP_ERROR SendCommand(CHIPDevice * device, chip::EndpointId endpointId) override
+    CHIP_ERROR SendCommand(CHIPDevice * device, std::vector<chip::EndpointId> endpoints) override
     {
-        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) ReportAttribute ({{asHex code 8}}) on endpoint %u", endpointId);
+        ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) ReportAttribute ({{asHex code 8}}) on endpoint %u", endpoints.front());
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:endpointId queue:callbackQueue];
+        CHIP{{asUpperCamelCase parent.name}} * cluster = [[CHIP{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:endpoints.front() queue:callbackQueue];
         CHIPSubscribeParams * params = [[CHIPSubscribeParams alloc] init];
         params.keepPreviousSubscriptions = mKeepSubscriptions.HasValue() ? [NSNumber numberWithBool:mKeepSubscriptions.Value()] : nil;
         params.fabricFiltered = mFabricFiltered.HasValue() ? [NSNumber numberWithBool:mFabricFiltered.Value()] : nil;

--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -175,9 +175,9 @@ extern NSString * const kCHIPArrayValueType;
 /**
  * Read attribute in a designated attribute path
  */
-- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+- (void)readAttributeWithEndpointId:(id _Nullable)endpointId
+                          clusterId:(id _Nullable)clusterId
+                        attributeId:(id _Nullable)attributeId
                              params:(CHIPReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(CHIPDeviceResponseHandler)completion;
@@ -226,9 +226,9 @@ extern NSString * const kCHIPArrayValueType;
 /**
  * Subscribe an attribute in a designated attribute path
  */
-- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+- (void)subscribeAttributeWithEndpointId:(id _Nullable)endpointId
+                               clusterId:(id _Nullable)clusterId
+                             attributeId:(id _Nullable)attributeId
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(CHIPSubscribeParams * _Nullable)params


### PR DESCRIPTION
#### Problem

The current generic APIs for darwin does not allow multiple paths.

#### Change overview
 * Add support for multiple paths by using `id` instead of `NSNumber *`

#### Testing
It was manually tested using `./out/debug/standalone/chip-tool-darwin any subscribe-by-id 6,6 0,0 1 5 1 0x12344321 1,2` and `./out/debug/standalone/chip-tool-darwin any read-by-id 6,6 0,0 1 5 1 0x12344321 1,2`