### PR TITLE
Add Darwin framework API for creating operational certificates.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.h
@@ -84,8 +84,19 @@ public:
         SecKeyRef intermediatePublicKey, NSNumber * _Nullable issuerId, NSNumber * _Nullable fabricId,
         NSData * _Nullable __autoreleasing * _Nonnull intermediateCert);
 
+    // Generate an operational DER-encoded X.509 certificate for the given
+    // signing certificate and operational public key, using the given fabric
+    // id, node id, and CATs.
+    static CHIP_ERROR GenerateOperationalCertificate(id<CHIPKeypair> signingKeypair, NSData * signingCertificate,
+        SecKeyRef operationalPublicKey, NSNumber * fabricId, NSNumber * nodeId,
+        NSArray<NSNumber *> * _Nullable caseAuthenticatedTags, NSData * _Nullable __autoreleasing * _Nonnull operationalCert);
+
 private:
     static bool ToChipEpochTime(uint32_t offset, uint32_t & epoch);
+
+    static CHIP_ERROR GenerateNOC(chip::Crypto::P256Keypair & signingKeypair, NSData * signingCertificate, chip::NodeId nodeId,
+        chip::FabricId fabricId, const chip::CATValues & cats, const chip::Crypto::P256PublicKey & pubkey,
+        chip::MutableByteSpan & noc);
 
     ChipP256KeypairPtr mIssuerKey;
 

--- a/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/CHIPOperationalCredentialsDelegate.mm
@@ -77,6 +77,13 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::Init(CHIPPersistentStorageDelegat
 CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOC(
     NodeId nodeId, FabricId fabricId, const chip::CATValues & cats, const Crypto::P256PublicKey & pubkey, MutableByteSpan & noc)
 {
+    return GenerateNOC(
+        *mIssuerKey, (mIntermediateCert != nil) ? mIntermediateCert : mRootCert, nodeId, fabricId, cats, pubkey, noc);
+}
+
+CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOC(P256Keypair & signingKeypair, NSData * signingCertificate, NodeId nodeId,
+    FabricId fabricId, const CATValues & cats, const P256PublicKey & pubkey, MutableByteSpan & noc)
+{
     uint32_t validityStart, validityEnd;
 
     if (!ToChipEpochTime(0, validityStart)) {
@@ -90,8 +97,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOC(
     }
 
     ChipDN signerSubject;
-    NSData * signer = (mIntermediateCert != nil) ? mIntermediateCert : mRootCert;
-    ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(AsByteSpan(signer), signerSubject));
+    ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(AsByteSpan(signingCertificate), signerSubject));
 
     ChipDN noc_dn;
     ReturnErrorOnFailure(noc_dn.AddAttribute_MatterFabricId(fabricId));
@@ -99,7 +105,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOC(
     ReturnErrorOnFailure(noc_dn.AddCATs(cats));
 
     X509CertRequestParams noc_request = { 1, validityStart, validityEnd, noc_dn, signerSubject };
-    return NewNodeOperationalX509Cert(noc_request, pubkey, *mIssuerKey, noc);
+    return NewNodeOperationalX509Cert(noc_request, pubkey, signingKeypair, noc);
 }
 
 CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateNOCChain(const chip::ByteSpan & csrElements, const chip::ByteSpan & csrNonce,
@@ -199,7 +205,9 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateRootCertificate(id<CHIPKe
     ReturnErrorOnFailure(rcac_dn.AddAttribute_MatterRCACId(GetIssuerId(issuerId)));
 
     if (fabricId != nil) {
-        ReturnErrorOnFailure(rcac_dn.AddAttribute_MatterFabricId([fabricId unsignedLongLongValue]));
+        FabricId fabric = [fabricId unsignedLongLongValue];
+        VerifyOrReturnError(fabric != kUndefinedFabricId, CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(rcac_dn.AddAttribute_MatterFabricId(fabric));
     }
 
     uint32_t validityStart, validityEnd;
@@ -228,7 +236,7 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateIntermediateCertificate(i
 {
     *intermediateCert = nil;
 
-    // Verify that the provided certificate public key matches the root keypair.
+    // Verify that the provided root certificate public key matches the root keypair.
     if ([MTRCertificates keypair:rootKeypair matchesCertificate:rootCertificate] == NO) {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
@@ -248,7 +256,9 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateIntermediateCertificate(i
     ChipDN icac_dn;
     ReturnErrorOnFailure(icac_dn.AddAttribute_MatterICACId(GetIssuerId(issuerId)));
     if (fabricId != nil) {
-        ReturnErrorOnFailure(icac_dn.AddAttribute_MatterFabricId([fabricId unsignedLongLongValue]));
+        FabricId fabric = [fabricId unsignedLongLongValue];
+        VerifyOrReturnError(fabric != kUndefinedFabricId, CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorOnFailure(icac_dn.AddAttribute_MatterFabricId(fabric));
     }
 
     uint32_t validityStart, validityEnd;
@@ -268,5 +278,49 @@ CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateIntermediateCertificate(i
     X509CertRequestParams icac_request = { 0, validityStart, validityEnd, icac_dn, rcac_dn };
     ReturnErrorOnFailure(NewICAX509Cert(icac_request, pubKey, nativeRootKeypair, icac));
     *intermediateCert = AsData(icac);
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CHIPOperationalCredentialsDelegate::GenerateOperationalCertificate(id<CHIPKeypair> signingKeypair,
+    NSData * signingCertificate, SecKeyRef operationalPublicKey, NSNumber * fabricId, NSNumber * nodeId,
+    NSArray<NSNumber *> * _Nullable caseAuthenticatedTags, NSData * _Nullable __autoreleasing * _Nonnull operationalCert)
+{
+    *operationalCert = nil;
+
+    // Verify that the provided signing certificate public key matches the signing keypair.
+    if ([MTRCertificates keypair:signingKeypair matchesCertificate:signingCertificate] == NO) {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if ([caseAuthenticatedTags count] > kMaxSubjectCATAttributeCount) {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    FabricId fabric = [fabricId unsignedLongLongValue];
+    VerifyOrReturnError(fabric != kUndefinedFabricId, CHIP_ERROR_INVALID_ARGUMENT);
+
+    NodeId node = [nodeId unsignedLongLongValue];
+    VerifyOrReturnError(IsOperationalNodeId(node), CHIP_ERROR_INVALID_ARGUMENT);
+
+    CHIPP256KeypairBridge keypairBridge;
+    ReturnErrorOnFailure(keypairBridge.Init(signingKeypair));
+    CHIPP256KeypairNativeBridge nativeSigningKeypair(keypairBridge);
+
+    P256PublicKey pubKey;
+    ReturnErrorOnFailure(CHIPP256KeypairBridge::MatterPubKeyFromSecKeyRef(operationalPublicKey, &pubKey));
+
+    CATValues cats;
+    if (caseAuthenticatedTags != nil) {
+        size_t idx = 0;
+        for (NSNumber * cat in caseAuthenticatedTags) {
+            cats.values[idx++] = [cat unsignedIntValue];
+        }
+    }
+
+    uint8_t nocBuffer[Controller::kMaxCHIPDERCertLength];
+    MutableByteSpan noc(nocBuffer);
+    ReturnErrorOnFailure(GenerateNOC(nativeSigningKeypair, signingCertificate, node, fabric, cats, pubKey, noc));
+
+    *operationalCert = AsData(noc);
     return CHIP_NO_ERROR;
 }

--- a/src/darwin/Framework/CHIP/MTRCertificates.h
+++ b/src/darwin/Framework/CHIP/MTRCertificates.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
  * issuer id is used.
  *
  * If fabricId is not nil, it will be included in the subject DN of the
- * certificate.
+ * certificate.  In this case it must be a valid Matter fabric id.
  *
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  * issuer id is used.
  *
  * If fabricId is not nil, it will be included in the subject DN of the
- * certificate.
+ * certificate.  In this case it must be a valid Matter fabric id.
  *
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
@@ -65,6 +65,35 @@ NS_ASSUME_NONNULL_BEGIN
                                             issuerId:(nullable NSNumber *)issuerId
                                             fabricId:(nullable NSNumber *)fabricId
                                                error:(NSError * __autoreleasing _Nullable * _Nullable)error;
+
+/**
+ * Generate an X.509 DER encoded certificate that has the
+ * right fields to be a valid Matter operational certificate.
+ *
+ * signingKeypair and signingCertificate are the root or intermediate that is
+ * signing the operational certificate.
+ *
+ * nodeId and fabricId are expected to be 64-bit unsigned integers.
+ *
+ * nodeId must be a valid Matter operational node id.
+ *
+ * fabricId must be a valid Matter fabric id.
+ *
+ * caseAuthenticatedTags may be nil to indicate no CASE Authenticated Tags
+ * should be used.  If caseAuthenticatedTags is not nil, it must have length at
+ * most 3 and the values in the array are expected to be 32-bit unsigned Case
+ * Authenticated Tag values.
+ *
+ * On failure returns nil and if "error" is not null sets *error to the relevant
+ * error.
+ */
++ (nullable NSData *)generateOperationalCertificate:(id<CHIPKeypair>)signingKeypair
+                                 signingCertificate:(NSData *)signingCertificate
+                               operationalPublicKey:(SecKeyRef)operationalPublicKey
+                                           fabricId:(NSNumber *)fabricId
+                                             nodeId:(NSNumber *)nodeId
+                              caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
+                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error;
 
 /**
  * Check whether the given keypair's public key matches the given certificate's

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -86,6 +86,32 @@ struct AutoPlatformMemory {
     return intermediate;
 }
 
++ (nullable NSData *)generateOperationalCertificate:(id<CHIPKeypair>)signingKeypair
+                                 signingCertificate:(NSData *)signingCertificate
+                               operationalPublicKey:(SecKeyRef)operationalPublicKey
+                                           fabricId:(NSNumber *)fabricId
+                                             nodeId:(NSNumber *)nodeId
+                              caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
+                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+    NSLog(@"Generating operational certificate");
+
+    AutoPlatformMemory platformMemory;
+
+    NSData * opcert = nil;
+    CHIP_ERROR err = CHIPOperationalCredentialsDelegate::GenerateOperationalCertificate(
+        signingKeypair, signingCertificate, operationalPublicKey, fabricId, nodeId, caseAuthenticatedTags, &opcert);
+    if (error) {
+        *error = [CHIPError errorForCHIPErrorCode:err];
+    }
+
+    if (err != CHIP_NO_ERROR) {
+        NSLog(@"Generating operational certificate failed: %s", ErrorStr(err));
+    }
+
+    return opcert;
+}
+
 + (BOOL)keypair:(id<CHIPKeypair>)keypair matchesCertificate:(NSData *)certificate
 {
     P256PublicKey keypairPubKey;


### PR DESCRIPTION
Will be useful for writing tests, if nothing else.

#### Problem
No way to get an operational certificate as an `NSData *` in ObjC code.

#### Change overview
Add an API for it.

#### Testing
Some unit tests included in the PR.  More tests will be written that use this API in various contexts as part of other PRs.