### PR TITLE
Add ability to remove storage to chip-tools

### DIFF
--- a/examples/chip-tool-darwin/BUILD.gn
+++ b/examples/chip-tool-darwin/BUILD.gn
@@ -48,6 +48,8 @@ executable("chip-tool-darwin") {
     "commands/pairing/Commands.h",
     "commands/pairing/PairingCommandBridge.mm",
     "commands/pairing/PairingDelegateBridge.mm",
+    "commands/storage/Commands.h",
+    "commands/storage/StorageManagementCommand.mm",
     "main.mm",
   ]
 

--- a/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandStorageDelegate.h
@@ -7,6 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSData *)storageDataForKey:(NSString *)key;
 - (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key;
 - (BOOL)removeStorageDataForKey:(NSString *)key;
+- (BOOL)deleteAllStorage;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/examples/chip-tool-darwin/commands/storage/Commands.h
+++ b/examples/chip-tool-darwin/commands/storage/Commands.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2020 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,21 +16,16 @@
  *
  */
 
-#include "commands/common/Commands.h"
+#pragma once
 
-#include "commands/pairing/Commands.h"
+#include "StorageManagementCommand.h"
+#include <commands/common/Commands.h>
 
-#include "commands/storage/Commands.h"
-
-#include <zap-generated/cluster/Commands.h>
-#include <zap-generated/test/Commands.h>
-
-int main(int argc, const char * argv[])
+void registerCommandsStorage(Commands & commands)
 {
-    Commands commands;
-    registerCommandsPairing(commands);
-    registerCommandsStorage(commands);
-    registerCommandsTests(commands);
-    registerClusters(commands);
-    return commands.Run(argc, (char **) argv);
+    const char * clusterName = "storage";
+
+    commands_list clusterCommands = { make_unique<StorageClearAll>() };
+
+    commands.Register(clusterName, clusterCommands);
 }

--- a/examples/chip-tool-darwin/commands/storage/StorageManagementCommand.h
+++ b/examples/chip-tool-darwin/commands/storage/StorageManagementCommand.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,21 +16,16 @@
  *
  */
 
-#include "commands/common/Commands.h"
+#pragma once
 
-#include "commands/pairing/Commands.h"
+#include "../common/CHIPCommandBridge.h"
 
-#include "commands/storage/Commands.h"
+#include <commands/common/Command.h>
 
-#include <zap-generated/cluster/Commands.h>
-#include <zap-generated/test/Commands.h>
-
-int main(int argc, const char * argv[])
+class StorageClearAll : public Command
 {
-    Commands commands;
-    registerCommandsPairing(commands);
-    registerCommandsStorage(commands);
-    registerCommandsTests(commands);
-    registerClusters(commands);
-    return commands.Run(argc, (char **) argv);
-}
+public:
+    StorageClearAll() : Command("clear-all") {}
+
+    CHIP_ERROR Run() override;
+};

--- a/examples/chip-tool-darwin/commands/storage/StorageManagementCommand.mm
+++ b/examples/chip-tool-darwin/commands/storage/StorageManagementCommand.mm
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,21 +16,17 @@
  *
  */
 
-#include "commands/common/Commands.h"
+#include "../common/CHIPCommandStorageDelegate.h"
 
-#include "commands/pairing/Commands.h"
+#include "StorageManagementCommand.h"
 
-#include "commands/storage/Commands.h"
+static CHIPToolPersistentStorageDelegate * storage = nil;
 
-#include <zap-generated/cluster/Commands.h>
-#include <zap-generated/test/Commands.h>
-
-int main(int argc, const char * argv[])
+CHIP_ERROR StorageClearAll::Run()
 {
-    Commands commands;
-    registerCommandsPairing(commands);
-    registerCommandsStorage(commands);
-    registerCommandsTests(commands);
-    registerClusters(commands);
-    return commands.Run(argc, (char **) argv);
+    storage = [[CHIPToolPersistentStorageDelegate alloc] init];
+    if (![storage deleteAllStorage]) {
+        return CHIP_ERROR_INTERNAL;
+    }
+    return CHIP_NO_ERROR;
 }

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -68,6 +68,7 @@ static_library("chip-tool-utils") {
     "commands/payload/SetupPayloadGenerateCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
     "commands/payload/SetupPayloadVerhoeff.cpp",
+    "commands/storage/StorageManagementCommand.cpp",
     "config/PersistentStorage.cpp",
   ]
 

--- a/examples/chip-tool/commands/storage/Commands.h
+++ b/examples/chip-tool/commands/storage/Commands.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2020 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,21 +16,16 @@
  *
  */
 
-#include "commands/common/Commands.h"
+#pragma once
 
-#include "commands/pairing/Commands.h"
+#include "StorageManagementCommand.h"
+#include <commands/common/Commands.h>
 
-#include "commands/storage/Commands.h"
-
-#include <zap-generated/cluster/Commands.h>
-#include <zap-generated/test/Commands.h>
-
-int main(int argc, const char * argv[])
+void registerCommandsStorage(Commands & commands)
 {
-    Commands commands;
-    registerCommandsPairing(commands);
-    registerCommandsStorage(commands);
-    registerCommandsTests(commands);
-    registerClusters(commands);
-    return commands.Run(argc, (char **) argv);
+    const char * clusterName = "storage";
+
+    commands_list clusterCommands = { make_unique<StorageClearAll>() };
+
+    commands.Register(clusterName, clusterCommands);
 }

--- a/examples/chip-tool/commands/storage/StorageManagementCommand.cpp
+++ b/examples/chip-tool/commands/storage/StorageManagementCommand.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,21 +16,13 @@
  *
  */
 
-#include "commands/common/Commands.h"
+#include "../../config/PersistentStorage.h"
 
-#include "commands/pairing/Commands.h"
+#include "StorageManagementCommand.h"
 
-#include "commands/storage/Commands.h"
-
-#include <zap-generated/cluster/Commands.h>
-#include <zap-generated/test/Commands.h>
-
-int main(int argc, const char * argv[])
+CHIP_ERROR StorageClearAll::Run()
 {
-    Commands commands;
-    registerCommandsPairing(commands);
-    registerCommandsStorage(commands);
-    registerCommandsTests(commands);
-    registerClusters(commands);
-    return commands.Run(argc, (char **) argv);
+    PersistentStorage storage;
+    ReturnErrorOnFailure(storage.Init());
+    return storage.SyncClearAll();
 }

--- a/examples/chip-tool/commands/storage/StorageManagementCommand.h
+++ b/examples/chip-tool/commands/storage/StorageManagementCommand.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2021 Project CHIP Authors
+ *   Copyright (c) 2022 Project CHIP Authors
  *   All rights reserved.
  *
  *   Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,21 +16,14 @@
  *
  */
 
-#include "commands/common/Commands.h"
+#pragma once
 
-#include "commands/pairing/Commands.h"
+#include <commands/common/Command.h>
 
-#include "commands/storage/Commands.h"
-
-#include <zap-generated/cluster/Commands.h>
-#include <zap-generated/test/Commands.h>
-
-int main(int argc, const char * argv[])
+class StorageClearAll : public Command
 {
-    Commands commands;
-    registerCommandsPairing(commands);
-    registerCommandsStorage(commands);
-    registerCommandsTests(commands);
-    registerClusters(commands);
-    return commands.Run(argc, (char **) argv);
-}
+public:
+    StorageClearAll() : Command("clear-all") {}
+
+    CHIP_ERROR Run() override;
+};

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -145,6 +145,15 @@ CHIP_ERROR PersistentStorage::SyncDeleteKeyValue(const char * key)
     return CommitConfig(mName);
 }
 
+CHIP_ERROR PersistentStorage::SyncClearAll()
+{
+    ChipLogProgress(chipTool, "Clearing %s storage", kDefaultSectionName);
+    auto section = mConfig.sections[kDefaultSectionName];
+    section.clear();
+    mConfig.sections[kDefaultSectionName] = section;
+    return CommitConfig(mName);
+}
+
 CHIP_ERROR PersistentStorage::CommitConfig(const char * name)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;

--- a/examples/chip-tool/config/PersistentStorage.h
+++ b/examples/chip-tool/config/PersistentStorage.h
@@ -48,6 +48,9 @@ public:
     // Store local CATs.
     CHIP_ERROR SetCommissionerCATs(const chip::CATValues & cats);
 
+    // Clear all of the persistent storage for running session.
+    CHIP_ERROR SyncClearAll();
+
 private:
     CHIP_ERROR CommitConfig(const char * name);
     inipp::Ini<char> mConfig;

--- a/examples/chip-tool/main.cpp
+++ b/examples/chip-tool/main.cpp
@@ -24,6 +24,7 @@
 #include "commands/interactive/Commands.h"
 #include "commands/pairing/Commands.h"
 #include "commands/payload/Commands.h"
+#include "commands/storage/Commands.h"
 
 #include <zap-generated/cluster/Commands.h>
 #include <zap-generated/test/Commands.h>
@@ -42,6 +43,7 @@ int main(int argc, char * argv[])
     registerCommandsTests(commands, &credIssuerCommands);
     registerCommandsGroup(commands, &credIssuerCommands);
     registerClusters(commands, &credIssuerCommands);
+    registerCommandsStorage(commands);
 
     return commands.Run(argc, argv);
 }


### PR DESCRIPTION
#### Problem
Currently there is no way within in the chip-tools to remove the persistent storage. 

#### Change overview
- Add ability to remove all storage in chip-tool
- Add ability to remove all storage in chip-tool-darwin

#### Testing
- Compiled
- Ran clear storage for chip-tool and verified storage was removed.
- Ran clear storage for chip-tool-darwin and verified storage was removed.
- Ran clear on empty storage in chip-tool and chip-tool-darwin.