### PR TITLE
Allow end-to-end injection of DeviceAttestationVerifier

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -309,7 +309,6 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(std::string key, chip::FabricId f
     chip::Controller::SetupParams commissionerParams;
 
     ReturnLogErrorOnFailure(mCredIssuerCmds->SetupDeviceAttestation(commissionerParams, trustStore));
-    chip::Credentials::SetDeviceAttestationVerifier(commissionerParams.deviceAttestationVerifier);
 
     VerifyOrReturnError(noc.Alloc(chip::Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
     VerifyOrReturnError(icac.Alloc(chip::Controller::kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -363,6 +363,24 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
     params.systemState->SessionMgr()->RegisterRecoveryDelegate(*this);
 
     mPairingDelegate = params.pairingDelegate;
+
+    // Configure device attestation validation
+    mDeviceAttestationVerifier = params.deviceAttestationVerifier;
+    if (mDeviceAttestationVerifier == nullptr)
+    {
+        mDeviceAttestationVerifier = Credentials::GetDeviceAttestationVerifier();
+        if (mDeviceAttestationVerifier == nullptr)
+        {
+            ChipLogError(Controller, "Missing DeviceAttestationVerifier configuration at DeviceCommissioner init and none set with Credentials::SetDeviceAttestationVerifier()!");
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+        else
+        {
+            // We fell back on a default from singleton accessor.
+            ChipLogProgress(Controller, "*** Missing DeviceAttestationVerifier configuration at DeviceCommissioner init: using global default, consider passing one in CommissionerInitParams.");
+        }
+    }
+
     if (params.defaultCommissioner != nullptr)
     {
         mDefaultCommissioner = params.defaultCommissioner;
@@ -1030,10 +1048,9 @@ CHIP_ERROR DeviceCommissioner::ValidateAttestationInfo(const Credentials::Device
 {
     MATTER_TRACE_EVENT_SCOPE("ValidateAttestationInfo", "DeviceCommissioner");
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mDeviceAttestationVerifier != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    DeviceAttestationVerifier * dac_verifier = GetDeviceAttestationVerifier();
-
-    dac_verifier->VerifyAttestationInformation(info, &mDeviceAttestationInformationVerificationCallback);
+    mDeviceAttestationVerifier->VerifyAttestationInformation(info, &mDeviceAttestationInformationVerificationCallback);
 
     // TODO: Validate Firmware Information
 
@@ -1045,8 +1062,7 @@ CHIP_ERROR DeviceCommissioner::ValidateCSR(DeviceProxy * proxy, const ByteSpan &
 {
     MATTER_TRACE_EVENT_SCOPE("ValidateCSR", "DeviceCommissioner");
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
-
-    DeviceAttestationVerifier * dacVerifier = GetDeviceAttestationVerifier();
+    VerifyOrReturnError(mDeviceAttestationVerifier != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     P256PublicKey dacPubkey;
     ReturnErrorOnFailure(ExtractPubkeyFromX509Cert(dac, dacPubkey));
@@ -1056,8 +1072,8 @@ CHIP_ERROR DeviceCommissioner::ValidateCSR(DeviceProxy * proxy, const ByteSpan &
         proxy->GetSecureSession().Value()->AsSecureSession()->GetCryptoContext().GetAttestationChallenge();
 
     // The operational CA should also verify this on its end during NOC generation, if end-to-end attestation is desired.
-    return dacVerifier->VerifyNodeOperationalCSRInformation(NOCSRElements, attestationChallenge, AttestationSignature, dacPubkey,
-                                                            csrNonce);
+    return mDeviceAttestationVerifier->VerifyNodeOperationalCSRInformation(NOCSRElements, attestationChallenge, AttestationSignature, dacPubkey,
+                                                                     csrNonce);
 }
 
 CHIP_ERROR DeviceCommissioner::SendOperationalCertificateSigningRequestCommand(DeviceProxy * device, const ByteSpan & csrNonce)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -376,13 +376,11 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
                          "Credentials::SetDeviceAttestationVerifier()!");
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
-        else
-        {
-            // We fell back on a default from singleton accessor.
-            ChipLogProgress(Controller,
-                            "*** Missing DeviceAttestationVerifier configuration at DeviceCommissioner init: using global default, "
-                            "consider passing one in CommissionerInitParams.");
-        }
+
+        // We fell back on a default from singleton accessor.
+        ChipLogProgress(Controller,
+                        "*** Missing DeviceAttestationVerifier configuration at DeviceCommissioner init: using global default, "
+                        "consider passing one in CommissionerInitParams.");
     }
 
     if (params.defaultCommissioner != nullptr)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -371,13 +371,17 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
         mDeviceAttestationVerifier = Credentials::GetDeviceAttestationVerifier();
         if (mDeviceAttestationVerifier == nullptr)
         {
-            ChipLogError(Controller, "Missing DeviceAttestationVerifier configuration at DeviceCommissioner init and none set with Credentials::SetDeviceAttestationVerifier()!");
+            ChipLogError(Controller,
+                         "Missing DeviceAttestationVerifier configuration at DeviceCommissioner init and none set with "
+                         "Credentials::SetDeviceAttestationVerifier()!");
             return CHIP_ERROR_INVALID_ARGUMENT;
         }
         else
         {
             // We fell back on a default from singleton accessor.
-            ChipLogProgress(Controller, "*** Missing DeviceAttestationVerifier configuration at DeviceCommissioner init: using global default, consider passing one in CommissionerInitParams.");
+            ChipLogProgress(Controller,
+                            "*** Missing DeviceAttestationVerifier configuration at DeviceCommissioner init: using global default, "
+                            "consider passing one in CommissionerInitParams.");
         }
     }
 
@@ -1072,8 +1076,8 @@ CHIP_ERROR DeviceCommissioner::ValidateCSR(DeviceProxy * proxy, const ByteSpan &
         proxy->GetSecureSession().Value()->AsSecureSession()->GetCryptoContext().GetAttestationChallenge();
 
     // The operational CA should also verify this on its end during NOC generation, if end-to-end attestation is desired.
-    return mDeviceAttestationVerifier->VerifyNodeOperationalCSRInformation(NOCSRElements, attestationChallenge, AttestationSignature, dacPubkey,
-                                                                     csrNonce);
+    return mDeviceAttestationVerifier->VerifyNodeOperationalCSRInformation(NOCSRElements, attestationChallenge,
+                                                                           AttestationSignature, dacPubkey, csrNonce);
 }
 
 CHIP_ERROR DeviceCommissioner::SendOperationalCertificateSigningRequestCommand(DeviceProxy * device, const ByteSpan & csrNonce)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -122,6 +122,10 @@ struct CommissionerInitParams : public ControllerInitParams
 {
     DevicePairingDelegate * pairingDelegate     = nullptr;
     CommissioningDelegate * defaultCommissioner = nullptr;
+    // Device attestation verifier instance for the commissioning.
+    // If null, the globally set attestation verifier (e.g. from GetDeviceAttestationVerifier()
+    // singleton) will be used.
+    Credentials::DeviceAttestationVerifier * deviceAttestationVerifier = nullptr;
 };
 
 /**
@@ -803,6 +807,7 @@ private:
     Platform::UniquePtr<app::ClusterStateCache> mAttributeCache;
     Platform::UniquePtr<app::ReadClient> mReadClient;
     Credentials::AttestationVerificationResult mAttestationResult;
+    Credentials::DeviceAttestationVerifier * mDeviceAttestationVerifier = nullptr;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -286,6 +286,7 @@ CHIP_ERROR DeviceControllerFactory::SetupCommissioner(SetupParams params, Device
     // Set commissioner-specific fields not in ControllerInitParams
     commissionerParams.pairingDelegate     = params.pairingDelegate;
     commissionerParams.defaultCommissioner = params.defaultCommissioner;
+    commissionerParams.deviceAttestationVerifier = params.deviceAttestationVerifier;
 
     CHIP_ERROR err = commissioner.Init(commissionerParams);
     return err;

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -284,8 +284,8 @@ CHIP_ERROR DeviceControllerFactory::SetupCommissioner(SetupParams params, Device
     PopulateInitParams(commissionerParams, params);
 
     // Set commissioner-specific fields not in ControllerInitParams
-    commissionerParams.pairingDelegate     = params.pairingDelegate;
-    commissionerParams.defaultCommissioner = params.defaultCommissioner;
+    commissionerParams.pairingDelegate           = params.pairingDelegate;
+    commissionerParams.defaultCommissioner       = params.defaultCommissioner;
     commissionerParams.deviceAttestationVerifier = params.deviceAttestationVerifier;
 
     CHIP_ERROR err = commissioner.Init(commissionerParams);

--- a/src/credentials/attestation_verifier/DeviceAttestationDelegate.h
+++ b/src/credentials/attestation_verifier/DeviceAttestationDelegate.h
@@ -39,7 +39,7 @@ public:
 
     /**
      * @brief
-     *   If valid, value to set for the fail-safe timer before the delegate's OnDeviceAttestionFailed is invoked.
+     *   If valid, value to set for the fail-safe timer before the delegate's OnDeviceAttestationFailed is invoked.
      *
      * @return Optional value for the fail-safe timer in seconds.
      */

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -1112,7 +1112,7 @@
     dispatch_async(dispatch_get_main_queue(), ^{
         UIAlertController * alertController = [UIAlertController
             alertControllerWithTitle:@"Device Attestation"
-                             message:@"Device Attestion failed for device under commissioning. Do you wish to continue pairing?"
+                             message:@"Device Attestation failed for device under commissioning. Do you wish to continue pairing?"
                       preferredStyle:UIAlertControllerStyleAlert];
 
         [alertController addAction:[UIAlertAction actionWithTitle:@"No"

--- a/src/darwin/Framework/CHIP/CHIPDeviceAttestationDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceAttestationDelegateBridge.mm
@@ -22,7 +22,7 @@ void CHIPDeviceAttestationDelegateBridge::OnDeviceAttestationFailed(chip::Contro
     chip::DeviceProxy * device, chip::Credentials::AttestationVerificationResult attestationResult)
 {
     dispatch_async(mQueue, ^{
-        NSLog(@"CHIPDeviceAttestationDelegateBridge::OnDeviceAttestionFailed failed with result: %hu", attestationResult);
+        NSLog(@"CHIPDeviceAttestationDelegateBridge::OnDeviceAttestationFailed failed with result: %hu", attestationResult);
 
         mResult = attestationResult;
 


### PR DESCRIPTION
#### Problem
- Injection exists in SetupParams, but it caused a singleton
  to be set in the end, which would not allow different
  DeviceAttestationVerifier per commissioner instance.

Fixes #18401
Issue #18445

#### Change overview
- This PR passes the attestation verifier end-to-end and stops
  using `GetDeviceAttestationVerifier()` singleton call in
  commissioner. If no attestation verifier is injected, the one
  from `GetDeviceAttestationVerifier()` is used.
- Fix typos in the word "attestation"
- Make chip-tool use the new injection path to prove that it works,
  while chip-repl and others use previous method.

#### Testing
- Unit tests pass
- Cert tests pass
