### PR TITLE
Fix CHIPTool build on iOS.

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -18,15 +18,17 @@
 #import <CHIP/CHIP.h>
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 extern NSString * const kCHIPToolDefaultsDomain;
 extern NSString * const kNetworkSSIDDefaultsKey;
 extern NSString * const kNetworkPasswordDefaultsKey;
 extern NSString * const kFabricIdKey;
 
-CHIPDeviceController * InitializeCHIP(void);
-CHIPDeviceController * CHIPRestartController(CHIPDeviceController * controller);
-id CHIPGetDomainValueForKey(NSString * domain, NSString * key);
-BOOL CHIPSetDomainValueForKey(NSString * domain, NSString * key, id value);
+CHIPDeviceController * _Nullable InitializeCHIP(void);
+CHIPDeviceController * _Nullable CHIPRestartController(CHIPDeviceController * controller);
+id _Nullable CHIPGetDomainValueForKey(NSString * domain, NSString * key);
+BOOL CHIPSetDomainValueForKey(NSString * domain, NSString * key, id _Nullable value);
 void CHIPRemoveDomainValueForKey(NSString * domain, NSString * key);
 uint64_t CHIPGetNextAvailableDeviceID(void);
 NSString * KeyForPairedDevice(uint64_t id);
@@ -37,12 +39,10 @@ BOOL CHIPIsDevicePaired(uint64_t id);
 BOOL CHIPGetConnectedDevice(CHIPDeviceConnectionCallback completionHandler);
 BOOL CHIPGetConnectedDeviceWithID(uint64_t deviceId, CHIPDeviceConnectionCallback completionHandler);
 void CHIPUnpairDeviceWithID(uint64_t deviceId);
-CHIPDevice * CHIPGetDeviceBeingCommissioned(void);
-
-NS_ASSUME_NONNULL_BEGIN
+CHIPDevice * _Nullable CHIPGetDeviceBeingCommissioned(void);
 
 @interface CHIPToolPersistentStorageDelegate : NSObject <CHIPPersistentStorageDelegate>
-- (NSData *)storageDataForKey:(NSString *)key;
+- (nullable NSData *)storageDataForKey:(NSString *)key;
 - (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key;
 - (BOOL)removeStorageDataForKey:(NSString *)key;
 @end

--- a/src/darwin/Framework/CHIPTests/CHIPTestStorage.h
+++ b/src/darwin/Framework/CHIPTests/CHIPTestStorage.h
@@ -20,7 +20,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPTestStorage : NSObject <CHIPPersistentStorageDelegate>
-- (NSData *)storageDataForKey:(NSString *)key;
+- (nullable NSData *)storageDataForKey:(NSString *)key;
 - (BOOL)setStorageData:(NSData *)value forKey:(NSString *)key;
 - (BOOL)removeStorageDataForKey:(NSString *)key;
 @end

--- a/src/darwin/Framework/CHIPTests/CHIPTestStorage.m
+++ b/src/darwin/Framework/CHIPTests/CHIPTestStorage.m
@@ -22,7 +22,7 @@
 
 @implementation CHIPTestStorage
 
-- (NSData *)storageDataForKey:(NSString *)key
+- (nullable NSData *)storageDataForKey:(NSString *)key
 {
     return _values[key];
 }


### PR DESCRIPTION
The compiler is not happy with nullability specified for only some
things in a header, so have todo it for all of them.

Also fixes incorrect nullability specifications in CHIPTestStorage.

Fixes https://github.com/project-chip/connectedhomeip/issues/18518

#### Problem
See above.

#### Change overview
See above.

#### Testing
Compiled CHIPTool for iOS, commissioned all-clusters-app, issued some commands.