### PR TITLE
Addition of `SessionSharedPtr`

### DIFF
--- a/src/transport/BUILD.gn
+++ b/src/transport/BUILD.gn
@@ -47,6 +47,7 @@ static_library("transport") {
     "SessionManager.h",
     "SessionMessageCounter.h",
     "SessionMessageDelegate.h",
+    "SessionSharedPtr.h",
     "TransportMgr.h",
     "TransportMgrBase.cpp",
     "TransportMgrBase.h",

--- a/src/transport/SessionHolder.cpp
+++ b/src/transport/SessionHolder.cpp
@@ -75,7 +75,7 @@ SessionHolder & SessionHolder::operator=(SessionHolder && that)
 void SessionHolder::Grab(const SessionHandle & session)
 {
     Release();
-    mSession.Emplace(session.mSession);
+    mSession.Emplace(session.mSession.Value());
     session->AddHolder(*this);
 }
 

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -44,7 +44,8 @@ public:
 
     bool Contains(const SessionHandle & session) const
     {
-        return mSession.HasValue() && &mSession.Value().Get() == &session.mSession.Get();
+        auto ourSession = ToOptional();
+        return ourSession.HasValue() && ourSession.Value() == session;
     }
 
     void Grab(const SessionHandle & session);

--- a/src/transport/SessionSharedPtr.h
+++ b/src/transport/SessionSharedPtr.h
@@ -1,0 +1,105 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <access/SubjectDescriptor.h>
+#include <lib/core/Optional.h>
+#include <lib/support/ReferenceCountedHandle.h>
+
+namespace chip {
+
+namespace Transport {
+class Session;
+} // namespace Transport
+
+class SessionHolder;
+
+/** @brief
+ *    A shared_ptr like smart pointer to manage the lifetime of a Session object. Like a shared_ptr,
+ *    this object can start out not tracking any Session and be attached to a Session there-after.
+ *    The underlying Session is guaranteed to remain active and resident until all references to it from SessionSharedPtr
+ *    instances in the system have gone away, at which point it invokes its custom destructor.
+ *
+ *    Just because a Session is refcounted does not mean it actually gets destroyed upon reaching a count of 0.
+ *    UnauthenticatedSession and SecureSession have different logic that gets invoked when the count hits 0.
+ *
+ *    This should really only be used during session setup by the entity setting up the session.
+ *    Once setup, the session should transfer ownership to the SessionManager at which point,
+ *    all clients in the system should only be holding SessionWeakPtrs (SessionWeakPtr doesn't exist yet, but once
+ *    #18399 is complete, SessionHolder will become SessionWeakPtr).
+ *
+ *    This is copy-constructible.
+ */
+class SessionSharedPtr
+{
+public:
+    SessionSharedPtr() {}
+    SessionSharedPtr(Transport::Session & session) { mSession.Emplace(session); }
+
+    SessionSharedPtr(const SessionSharedPtr & session) { Grab(session); }
+
+    /*
+     * Add ourselves as a shared owner on the passed in session (if it points to
+     * a valid session). The passed in
+     * session object can now be free'ed safely without impacting the underlying
+     * Session.
+     */
+    void operator=(const SessionSharedPtr & session) { Grab(session); }
+
+    /*
+     * If we're currently pointing to a valid session, remove ourselves
+     * as a shared owner of that session. If there are no more shared owners
+     * on that session, that session MAY be reclaimed.
+     */
+    void Release() { mSession.ClearValue(); }
+
+    /*
+     * Assume shared ownership of the provided session.
+     */
+    void Grab(Transport::Session & session) { mSession.Emplace(session); }
+
+    Transport::Session * operator->() const { return Get(); }
+
+protected:
+    Transport::Session * Get() const
+    {
+        if (mSession.HasValue())
+        {
+            return &mSession.Value().Get();
+        }
+
+        return nullptr;
+    }
+
+private:
+    void Grab(const SessionSharedPtr & session)
+    {
+        auto * underlyingSession = session.Get();
+        if (underlyingSession)
+        {
+            mSession.Emplace(*underlyingSession);
+        }
+    }
+
+    Optional<ReferenceCountedHandle<Transport::Session>> mSession;
+
+    // TODO: Remove this once SessionHolder pivots to truly being a weak reference (#18399).
+    friend class SessionHolder;
+};
+
+} // namespace chip


### PR DESCRIPTION
#### Problem

`SessionHolder` is used both as a strong, shared_ptr like smart-ptr object (it has ref-counting) as well as a weak_ptr like object (the underlying reference can be removed by SessionManager when evicting a session).

This is confusing and makes it incongruous with similar smart-ptr constructs in STL.

#### Solution

Creates a new `SessionSharedPtr` as per #18399 that now plays the part of a strong, shared_ptr like construct. This sets the stage for us to pivot `SessionHolder` to a pure, weak_ptr like construct.

Entities like `PairingSession`, `DeviceController` that need to momentarily own a session while it is being setup are already pivoting to using a `SessionSharedPtr` like model in #18397.

Once this PR merges, we can fully shift them over.