### PR TITLE
Fix DiscoveryImplPlatform::Shutdown so restart works correctly.

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -351,6 +351,7 @@ void DiscoveryImplPlatform::Shutdown()
     VerifyOrReturn(mDnssdInitialized);
     mResolverProxy.Shutdown();
     ChipDnssdShutdown();
+    mDnssdInitialized = false;
 }
 
 void DiscoveryImplPlatform::HandleDnssdInit(void * context, CHIP_ERROR initError)


### PR DESCRIPTION
Until the changes in #18442 DiscoveryImplPlatform::Shutdown was a
no-op on most platforms, so the fact that you could not re-init after
that call did not matter, because nothing had actually been shut down.
Now that we are actually shutting down mResolverProxy, we need to make
sure a future call to Init() will correctly re-initialize things
instead of just bailing out.

#### Problem
Can't re-init platform mdns after shutdown.

#### Change overview
Flag ourselves as not initialized any more once we have shut down.

#### Testing
Made sure that CHIPTool on iOS works again after this (was broken before, because it could not do anything with mdns after restarting the Matter stack).