### PR TITLE
Remove the updateDevice API from the Darwin SDK.

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -671,40 +671,6 @@
     }
 }
 
-- (void)onAddNetworkResponse:(NSError *)error
-{
-    if (error != nil) {
-        NSLog(@"Error adding network: %@", error);
-        return;
-    }
-
-    __auto_type * params = [[CHIPNetworkCommissioningClusterConnectNetworkParams alloc] init];
-
-    NSString * ssid = CHIPGetDomainValueForKey(kCHIPToolDefaultsDomain, kNetworkSSIDDefaultsKey);
-    params.networkID = [ssid dataUsingEncoding:NSUTF8StringEncoding];
-    params.breadcrumb = @(0);
-
-    __weak typeof(self) weakSelf = self;
-    [_cluster connectNetworkWithParams:params
-                     completionHandler:^(CHIPNetworkCommissioningClusterConnectNetworkResponseParams * _Nullable response,
-                         NSError * _Nullable err) {
-                         // TODO: connectNetworkWithParams returns status in its
-                         // response, not via the NSError!
-                         [weakSelf onConnectNetworkResponse:err];
-                     }];
-}
-
-- (void)onConnectNetworkResponse:(NSError *)error
-{
-    if (error != nil) {
-        NSLog(@"Error enabling network: %@", error);
-    }
-
-    uint64_t deviceId = CHIPGetNextAvailableDeviceID() - 1;
-    CHIPDeviceController * controller = InitializeCHIP();
-    [controller updateDevice:deviceId fabricId:0];
-}
-
 - (void)onCommissioningComplete:(NSError * _Nullable)error
 {
     if (error != nil) {

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.h
@@ -94,7 +94,6 @@ typedef void (^CHIPDeviceConnectionCallback)(CHIPDevice * _Nullable device, NSEr
                               error:(NSError * __autoreleasing *)error;
 
 - (BOOL)stopDevicePairing:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
-- (void)updateDevice:(uint64_t)deviceID fabricId:(uint64_t)fabricId;
 
 - (nullable CHIPDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error;
 - (BOOL)getConnectedDevice:(uint64_t)deviceID

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -611,21 +611,6 @@ static NSString * const kErrorSetupCodeGen = @"Generating Manual Pairing Code fa
     return [NSString stringWithCString:outCode.c_str() encoding:[NSString defaultCStringEncoding]];
 }
 
-- (void)updateDevice:(uint64_t)deviceID fabricId:(uint64_t)fabricId
-{
-    __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
-    if (![self isRunning]) {
-        [self checkForError:errorCode logMsg:kErrorNotRunning error:nil];
-        return;
-    }
-    dispatch_sync(_chipWorkQueue, ^{
-        if ([self isRunning]) {
-            errorCode = self.cppCommissioner->UpdateDevice(deviceID);
-            CHIP_LOG_ERROR("Update device address returned: %s", chip::ErrorStr(errorCode));
-        }
-    });
-}
-
 - (void)setPairingDelegate:(id<CHIPDevicePairingDelegate>)delegate queue:(dispatch_queue_t)queue
 {
     dispatch_async(_chipWorkQueue, ^{

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC.m
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerOverXPC.m
@@ -91,11 +91,6 @@ static void SetupXPCQueue(void)
     return NO;
 }
 
-- (void)updateDevice:(uint64_t)deviceID fabricId:(uint64_t)fabricId
-{
-    CHIP_LOG_ERROR("CHIPDevice doesn't support updateDevice:fabricId: over XPC");
-}
-
 - (nullable CHIPDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error
 {
     CHIP_LOG_ERROR("CHIPDevice doesn't support getDeviceBeingCommissioned over XPC");


### PR DESCRIPTION
It's not really well-defined, and there are no non-dead-code
consumers.

#### Problem
API we don't want.

#### Change overview
Remove it.

#### Testing
Made sure CHIPTool iOS can still commission over both BLE and IP transports.