### PR TITLE
[chip-tool] Add an optional timeout parameter to the pairing command

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -132,11 +132,13 @@ public:
             AddArgument("name", &mDiscoveryFilterInstanceName);
             break;
         }
+
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(120); }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.ValueOr(120)); }
 
     /////////// DevicePairingDelegate Interface /////////
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
@@ -161,6 +163,7 @@ private:
     const chip::Dnssd::DiscoveryFilterType mFilterType;
     Command::AddressWithInterface mRemoteAddr;
     NodeId mNodeId;
+    chip::Optional<uint16_t> mTimeout;
     uint16_t mRemotePort;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;


### PR DESCRIPTION
#### Problem

There is no mechanism to configure the default timeout of the pairing command.

Fix #18143

#### Change overview
 * Add an optional "timeout" parameter

#### Testing
`./out/debug/standalone/chip-tool pairing qrcode 0x12344321 MT:-24J029Q00KA0648G00 --timeout 3`
