### PR TITLE
Remove use of resolverproxy in non-dnssd-directory

### DIFF
--- a/src/controller/AbstractDnssdDiscoveryController.h
+++ b/src/controller/AbstractDnssdDiscoveryController.h
@@ -40,7 +40,7 @@ class DLL_EXPORT AbstractDnssdDiscoveryController : public Dnssd::CommissioningR
 {
 public:
     AbstractDnssdDiscoveryController() {}
-    ~AbstractDnssdDiscoveryController() override { mDNSResolver.Shutdown(); }
+    ~AbstractDnssdDiscoveryController() override {}
 
     void OnNodeDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
 
@@ -50,7 +50,6 @@ protected:
     const Dnssd::DiscoveredNodeData * GetDiscoveredNode(int idx);
     virtual DiscoveredNodeList GetDiscoveredNodes()    = 0;
     DeviceDiscoveryDelegate * mDeviceDiscoveryDelegate = nullptr;
-    Dnssd::ResolverProxy mDNSResolver;
 };
 
 } // namespace Controller

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -34,23 +34,18 @@ CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Dnssd::DiscoveryF
 
     if (mResolver == nullptr)
     {
-#if CONFIG_DEVICE_LAYER
-        mDNSResolver.Shutdown(); // reset if already inited
-        ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
-#endif
-        mDNSResolver.SetCommissioningDelegate(this);
-        return mDNSResolver.FindCommissioners(discoveryFilter);
+        mResolver = &chip::Dnssd::Resolver::Instance();
     }
 
-#if CONFIG_DEVICE_LAYER
-    ReturnErrorOnFailure(mResolver->Init(DeviceLayer::UDPEndPointManager()));
-#endif
+    mResolver->SetCommissioningDelegate(this);
     return mResolver->FindCommissioners(discoveryFilter);
 }
 
 CommissionableNodeController::~CommissionableNodeController()
 {
-    mDNSResolver.SetCommissioningDelegate(nullptr);
+    // TODO: Uniqueness guarantee of CommissionableNodeController is not obvious.
+    //       Multiplexing of finding commissioning nodes should be done in some other way.
+    mResolver->SetCommissioningDelegate(nullptr);
 }
 
 const Dnssd::DiscoveredNodeData * CommissionableNodeController::GetDiscoveredCommissioner(int idx)

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -117,8 +117,6 @@ CHIP_ERROR DeviceController::Init(ControllerInitParams params)
 
     VerifyOrReturnError(params.systemState->TransportMgr() != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    ReturnErrorOnFailure(mDNSResolver.Init(params.systemState->UDPEndPointManager()));
-    mDNSResolver.SetCommissioningDelegate(this);
     RegisterDeviceDiscoveryDelegate(params.deviceDiscoveryDelegate);
 
     VerifyOrReturnError(params.operationalCredentialsDelegate != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
@@ -241,7 +239,6 @@ CHIP_ERROR DeviceController::Shutdown()
     mSystemState->Release();
     mSystemState = nullptr;
 
-    mDNSResolver.Shutdown();
     mDeviceDiscoveryDelegate = nullptr;
 
     return CHIP_NO_ERROR;
@@ -1352,7 +1349,11 @@ void DeviceCommissioner::OnSessionEstablishmentTimeoutCallback(System::Layer * a
 CHIP_ERROR DeviceCommissioner::DiscoverCommissionableNodes(Dnssd::DiscoveryFilter filter)
 {
     ReturnErrorOnFailure(SetUpNodeDiscovery());
-    return mDNSResolver.FindCommissionableNodes(filter);
+
+    auto & dnssdResolver = chip::Dnssd::Resolver::Instance();
+
+    dnssdResolver.SetCommissioningDelegate(this);
+    return dnssdResolver.FindCommissionableNodes(filter);
 }
 
 const Dnssd::DiscoveredNodeData * DeviceCommissioner::GetDiscoveredDevice(int idx)

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -148,14 +148,6 @@ void TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter(nlTestSuite * inSuit
                        CHIP_NO_ERROR);
 }
 
-void TestDiscoverCommissioners_InitError_ReturnsError(nlTestSuite * inSuite, void * inContext)
-{
-    MockResolver resolver;
-    resolver.InitStatus = CHIP_ERROR_INTERNAL;
-    CommissionableNodeController controller(&resolver);
-    NL_TEST_ASSERT(inSuite, controller.DiscoverCommissioners() != CHIP_NO_ERROR);
-}
-
 void TestDiscoverCommissioners_FindCommissionersError_ReturnsError(nlTestSuite * inSuite, void * inContext)
 {
     MockResolver resolver;
@@ -175,7 +167,6 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr", TestGetDiscoveredCommissioner_NoNodesDiscovered_ReturnsNullptr),
     NL_TEST_DEF("TestDiscoverCommissioners_HappyCase", TestDiscoverCommissioners_HappyCase),
     NL_TEST_DEF("TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter", TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter),
-    NL_TEST_DEF("TestDiscoverCommissioners_InitError_ReturnsError", TestDiscoverCommissioners_InitError_ReturnsError),
     NL_TEST_DEF("TestDiscoverCommissioners_FindCommissionersError_ReturnsError", TestDiscoverCommissioners_FindCommissionersError_ReturnsError),
     NL_TEST_SENTINEL()
 };


### PR DESCRIPTION
#### Problem
ResolverProxy adds lifetime complexity to code and makes it non-obvious when resolvers are or are not multiplexed. 

Lifetime complexity stems from ResolverProxy requiring a separate init from the main dnssd resolution and circular referencing in platform dnssd code (resolver proxy initializes dnssdimpl and dnsssdimpl contains a resolverproxy).

#### Change overview
Replace ResolverProxy with direct calls to the global resolver instance or passed in resolver instance.

NOTE: I believe resolverproxy on bonjour/avahi allows some internal multiplexing even though the implementation for minmdns does not. I am unsure if this is an issue or not or if we need workarounds here (i.e. should "FindCommissionable" or similar take in a callback argument instead of using the global callback argument).

#### Testing
CI will validate that commissionable node discovery still works.