### PR TITLE
[TI] disable OTA for all clusters

### DIFF
--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -15,7 +15,8 @@
 name: Build example - TI CC26X2X7
 
 on:
-    workflow_dispatch:
+    push:
+    pull_request:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/args.gni
@@ -27,15 +27,13 @@ optimize_debug_level = "s"
 lwip_debug = false
 
 #optimize_for_size=true
-chip_enable_ota_requestor = true
+chip_enable_ota_requestor = false
 
 # Disable FTD Build for all-clusters app to save Flash
 chip_openthread_ftd = false
 
 # Disable CHIP Logging
 chip_progress_logging = false
-
-# Dsiable verbose logs for all-clusters app to save Flash
 chip_detail_logging = false
 chip_automation_logging = false
 

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -30,13 +30,8 @@
 
 #include <platform/CHIPDeviceLayer.h>
 
-#include <app/clusters/ota-requestor/BDXDownloader.h>
-#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
-#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
-#include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
 
 #ifdef AUTO_PRINT_METRICS
 #include <platform/cc13x2_26x2/DiagnosticDataProviderImpl.h>
@@ -65,25 +60,7 @@ static Button_Handle sAppRightHandle;
 
 AppTask AppTask::sAppTask;
 
-static DefaultOTARequestor sRequestorCore;
-static DefaultOTARequestorStorage sRequestorStorage;
-static DefaultOTARequestorDriver sRequestorUser;
-static BDXDownloader sDownloader;
-static OTAImageProcessorImpl sImageProcessor;
-
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
-
-void InitializeOTARequestor(void)
-{
-    // Initialize and interconnect the Requestor and Image Processor objects
-    SetRequestorInstance(&sRequestorCore);
-
-    sRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
-    sRequestorCore.Init(Server::GetInstance(), sRequestorStorage, sRequestorUser, sDownloader);
-    sImageProcessor.SetOTADownloader(&sDownloader);
-    sDownloader.SetImageProcessorDelegate(&sImageProcessor);
-    sRequestorUser.Init(&sRequestorCore, &sImageProcessor);
-}
 
 #ifdef AUTO_PRINT_METRICS
 static void printMetrics(void)
@@ -260,8 +237,6 @@ int AppTask::Init()
     // Register a function to receive events from the CHIP device layer.  Note that calls to
     // this function will happen on the CHIP event loop thread, not the app_main thread.
     PlatformMgr().AddEventHandler(DeviceEventCallback, reinterpret_cast<intptr_t>(nullptr));
-
-    InitializeOTARequestor();
 
     // QR code will be used with CHIP Tool
     PrintOnboardingCodes(RendezvousInformationFlags(RendezvousInformationFlag::kBLE));

--- a/examples/shell/cc13x2x7_26x2x7/args.gni
+++ b/examples/shell/cc13x2x7_26x2x7/args.gni
@@ -25,7 +25,7 @@ ti_simplelink_board = "LP_CC2652R7"
 # use -Os instead of -Og, LWIP release build
 is_debug = false
 
-chip_enable_ota_requestor = true
+chip_enable_ota_requestor = false
 
 # Disable FTD Build for all-clusters app to save Flash
 chip_openthread_ftd = false

--- a/examples/shell/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/shell/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -30,14 +30,9 @@
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
-#include <app/clusters/ota-requestor/BDXDownloader.h>
-#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
-#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
-#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <lib/shell/Engine.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
-#include <platform/cc13x2_26x2/OTAImageProcessorImpl.h>
 
 #include <app/server/OnboardingCodesUtil.h>
 
@@ -59,24 +54,6 @@ static TaskHandle_t sAppTaskHandle;
 // Logging
 extern "C" {
 int cc13x2_26x2LogInit(void);
-}
-
-static DefaultOTARequestor sRequestorCore;
-static DefaultOTARequestorStorage sRequestorStorage;
-static DefaultOTARequestorDriver sRequestorUser;
-static BDXDownloader sDownloader;
-static OTAImageProcessorImpl sImageProcessor;
-
-void InitializeOTARequestor(void)
-{
-    // Initialize and interconnect the Requestor and Image Processor objects
-    SetRequestorInstance(&sRequestorCore);
-
-    sRequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
-    sRequestorCore.Init(Server::GetInstance(), sRequestorStorage, sRequestorUser, sDownloader);
-    sImageProcessor.SetOTADownloader(&sDownloader);
-    sDownloader.SetImageProcessorDelegate(&sImageProcessor);
-    sRequestorUser.Init(&sRequestorCore, &sImageProcessor);
 }
 
 CHIP_ERROR AppTask::StartAppTask()
@@ -147,8 +124,6 @@ CHIP_ERROR AppTask::Init()
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-
-    InitializeOTARequestor();
 
     return err;
 }

--- a/scripts/build/builders/cc13x2x7_26x2x7.py
+++ b/scripts/build/builders/cc13x2x7_26x2x7.py
@@ -87,7 +87,18 @@ class cc13x2x7_26x2x7Builder(GnBuilder):
 
     def build_outputs(self):
         items = {}
-        for extension in [".out", ".bin", ".out.map", "-bim.hex"]:
+        if (self.app == cc13x2x7_26x2x7App.LOCK
+                or self.app == cc13x2x7_26x2x7App.PUMP
+                or self.app == cc13x2x7_26x2x7App.PUMP_CONTROLLER):
+            extensions = [".out", ".bin", ".out.map", "-bim.hex"]
+
+        elif self.app == cc13x2x7_26x2x7App.ALL_CLUSTERS or self.app == cc13x2x7_26x2x7App.SHELL:
+            extensions = [".out", ".out.map"]
+
+        else:
+            raise Exception('Unknown app type: %r' % self.app)
+
+        for extension in extensions:
             name = '%s%s' % (self.app.AppNamePrefix(), extension)
             items[name] = os.path.join(self.output_dir, name)
 


### PR DESCRIPTION
#### Problem
The size of Matter is too large to allow for the all clusters examples to run in 704K of flash.

#### Change overview
Disable OTA on these examples to free up space used by the bootloader and OTA processing code.

#### Testing
Build test for all-clusters-app and shell-app
