### PR TITLE
Add direct include in CommandPathParams.h

### DIFF
--- a/src/app/CommandPathParams.h
+++ b/src/app/CommandPathParams.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <app/util/basic-types.h>
+#include "lib/core/GroupId.h"
 #include <lib/support/BitFlags.h>
 
 namespace chip {

--- a/src/app/CommandPathParams.h
+++ b/src/app/CommandPathParams.h
@@ -19,7 +19,7 @@
 #pragma once
 
 #include <app/util/basic-types.h>
-#include "lib/core/GroupId.h"
+#include <lib/core/GroupId.h>
 #include <lib/support/BitFlags.h>
 
 namespace chip {


### PR DESCRIPTION
#### Problem
CommandPathParams relies on transitive includes (things defined in a header that is included by another header that is included by it). This is not ideal for "include what you use" rationale (see https://github.com/include-what-you-use/include-what-you-use/blob/master/docs/WhyIWYU.md).

Having "include what you use" makes some integrations easier if their automated tools validate this.

#### Change overview
Add include in CommandPathParams.h

#### Testing
* Compile 
