### PR TITLE
Black list all clusters app from default build set since it runs out …

### DIFF
--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -99,13 +99,6 @@ jobs:
                     cc13x2_26x2 LP_CC2652R7 pump-controller-app \
                     out/artifacts/cc13x2x7_26x2x7-pump-controller/chip-LP_CC2652R7-pump-controller-example.out \
                     /tmp/bloat_reports/
-            - name: Get All Clusters App size stats
-              timeout-minutes: 5
-              run: |
-                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    cc13x2_26x2 LP_CC2652R7 all-clusters-app \
-                    out/artifacts/cc13x2x7_26x2x7-all-clusters/chip-LP_CC2652R7-all-clusters-example.out \
-                    /tmp/bloat_reports/
             - name: Get Shell App size stats
               timeout-minutes: 5
               run: |

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -494,7 +494,7 @@ def cc13x2x7_26x2x7Targets():
     yield target.Extend('lock-mtd', app=cc13x2x7_26x2x7App.LOCK, openthread_ftd=False)
     yield target.Extend('pump', app=cc13x2x7_26x2x7App.PUMP)
     yield target.Extend('pump-controller', app=cc13x2x7_26x2x7App.PUMP_CONTROLLER)
-    yield target.Extend('all-clusters', app=cc13x2x7_26x2x7App.ALL_CLUSTERS)
+    yield target.Extend('all-clusters', app=cc13x2x7_26x2x7App.ALL_CLUSTERS).Blacklist("Running out of flash")
     yield target.Extend('shell', app=cc13x2x7_26x2x7App.SHELL)
 
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -494,7 +494,7 @@ def cc13x2x7_26x2x7Targets():
     yield target.Extend('lock-mtd', app=cc13x2x7_26x2x7App.LOCK, openthread_ftd=False)
     yield target.Extend('pump', app=cc13x2x7_26x2x7App.PUMP)
     yield target.Extend('pump-controller', app=cc13x2x7_26x2x7App.PUMP_CONTROLLER)
-    yield target.Extend('all-clusters', app=cc13x2x7_26x2x7App.ALL_CLUSTERS).Blacklist("Running out of flash")
+    yield target.Extend('all-clusters', app=cc13x2x7_26x2x7App.ALL_CLUSTERS).GlobBlacklist("Running out of flash")
     yield target.Extend('shell', app=cc13x2x7_26x2x7App.SHELL)
 
 

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -17,7 +17,7 @@ android-x64-chip-tvserver
 android-x86-chip-tool
 android-x86-chip-tvserver
 bl602-light
-cc13x2x7_26x2x7-all-clusters
+cc13x2x7_26x2x7-all-clusters (NOGLOB: Running out of flash)
 cc13x2x7_26x2x7-lock-ftd
 cc13x2x7_26x2x7-lock-mtd
 cc13x2x7_26x2x7-pump

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -17,7 +17,6 @@ android-x64-chip-tvserver
 android-x86-chip-tool
 android-x86-chip-tvserver
 bl602-light
-cc13x2x7_26x2x7-all-clusters
 cc13x2x7_26x2x7-lock-ftd
 cc13x2x7_26x2x7-lock-mtd
 cc13x2x7_26x2x7-pump


### PR DESCRIPTION
…of flash

#### Problem
Running out of flash

#### Change overview
Blacklist all clusters build from the default 'build all' glob.

#### Testing
CI will validate.