### PR TITLE
Temporary disable examples-cc13x2x7_26x2x7.yaml CI until we fix out o…

### DIFF
--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -15,8 +15,7 @@
 name: Build example - TI CC26X2X7
 
 on:
-    push:
-    pull_request:
+    workflow_dispatch:
 
 concurrency:
     group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}


### PR DESCRIPTION
…f flash issues

#### Problem
TOT is red for several hours.

#### Change overview
Disables this CI run. NOTE: this is NOT ok for long term. We need a fix like #18562 or #18568 to compile some things on this platform and not let it slip.

This is for unblocking other PRs.

#### Testing
N/A