### PR TITLE
Remove unused functions in DiagnosticDataProviderImpl

### DIFF
--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -179,7 +179,6 @@ public:
     virtual CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree);
     virtual CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed);
     virtual CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark);
-    virtual CHIP_ERROR SetCurrentHeapHighWatermark(uint64_t heapHighWatermark);
     virtual CHIP_ERROR ResetWatermarks();
 
     /*
@@ -264,11 +263,6 @@ inline CHIP_ERROR DiagnosticDataProvider::GetCurrentHeapUsed(uint64_t & currentH
 }
 
 inline CHIP_ERROR DiagnosticDataProvider::GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-inline CHIP_ERROR DiagnosticDataProvider::SetCurrentHeapHighWatermark(uint64_t heapHighWatermark)
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -266,14 +266,6 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
 #endif
 }
 
-CHIP_ERROR DiagnosticDataProviderImpl::SetCurrentHeapHighWatermark(uint64_t heapHighWatermark)
-{
-    // On Linux, the write operation is non-op since we always rely on the mallinfo system
-    // function to get the current heap memory.
-
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
 {
     // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -43,7 +43,6 @@ public:
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
     CHIP_ERROR GetThreadMetrics(ThreadMetrics ** threadMetricsOut) override;
-    CHIP_ERROR SetCurrentHeapHighWatermark(uint64_t heapHighWatermark) override;
     CHIP_ERROR ResetWatermarks() override;
     void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* DiagnosticDataProvider::SetCurrentHeapHighWatermark has been replaced by DiagnosticDataProvider::ResetWatermarks


#### Change overview
Remove unused functions in DiagnosticDataProviderImpl

#### Testing
How was this tested? (at least one bullet point required)
* no logic change
