### PR TITLE
Fix the status codes returned from failed Read interactions.

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -244,10 +244,15 @@ public:
      * kReservedPathsPerReadRequest. This function will check if the given ReadHandler will exceed the limitations for the accessing
      * fabric.
      *
+     * If CHIP_NO_ERROR is returned, it's OK to proceed with the read.
+     *
+     * Otherwise the CHIP_ERROR encodes an interaction model status that needs
+     * to turn into a Status Response to the client.
+     *
      * TODO: (#17418) We are now reserving resources for read requests, could be changed to similar algorithm for read resources
      * minimas.
      */
-    bool CanEstablishReadTransaction(const ReadHandler * apReadHandler);
+    CHIP_ERROR CanEstablishReadTransaction(const ReadHandler * apReadHandler);
 
     /**
      * Select the oldest (and the one that exceeds the per subscription resource minimum if there are any) read handler on the

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -384,8 +384,9 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
     }
     ReturnErrorOnFailure(err);
 
-    // Ensure the read transaction doesn't exceed the resources dedicated to read transactions.
-    VerifyOrReturnError(InteractionModelEngine::GetInstance()->CanEstablishReadTransaction(this), CHIP_ERROR_NO_MEMORY);
+    // Ensure the read transaction doesn't exceed the resources dedicated to
+    // read transactions.
+    ReturnErrorOnFailure(InteractionModelEngine::GetInstance()->CanEstablishReadTransaction(this));
 
     bool isFabricFiltered;
     ReturnErrorOnFailure(readRequestParser.GetIsFabricFiltered(&isFabricFiltered));


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/18343

#### Problem
Status responses not following the spec.

#### Change overview
Fix to follow spec.  Need to check path counts first, because an error there should take precedence over lack of read handlers (which is transient).

#### Testing
Unit tests added to exercise the various cases.