### PR TITLE
Close BLE connections if commissioning window closes before PASE establishment

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -302,6 +302,15 @@ void CommissioningWindowManager::CloseCommissioningWindow()
 {
     if (mWindowStatus != AdministratorCommissioning::CommissioningWindowStatus::kWindowNotOpen)
     {
+#if CONFIG_NETWORK_LAYER_BLE
+        if (mListeningForPASE)
+        {
+            // We never established PASE, so never armed a fail-safe and hence
+            // can't rely on it expiring to close our BLE connection.  Do that
+            // manually here.
+            mServer->GetBleLayerObject()->CloseAllBleConnections();
+        }
+#endif
         ChipLogProgress(AppServer, "Closing pairing window");
         Cleanup();
     }


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/17508

#### Problem
See #17508

#### Change overview
If we are still listening for an incoming PASE connection when the commissioning window closes, shut down BLE connections.

#### Testing
Not sure how to test this, past compiling.