### PR TITLE
Fix clusterStateCache dataVersion bug

### DIFF
--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -96,7 +96,7 @@ struct AttributePathParams
         return true;
     }
 
-    bool IsAttributePathOverlapped(const AttributePathParams & other) const
+    bool Intersects(const AttributePathParams & other) const
     {
         VerifyOrReturnError(HasWildcardEndpointId() || other.HasWildcardEndpointId() || mEndpointId == other.mEndpointId, false);
         VerifyOrReturnError(HasWildcardClusterId() || other.HasWildcardClusterId() || mClusterId == other.mClusterId, false);

--- a/src/app/AttributePathParams.h
+++ b/src/app/AttributePathParams.h
@@ -96,6 +96,15 @@ struct AttributePathParams
         return true;
     }
 
+    bool IsAttributePathOverlapped(const AttributePathParams & other) const
+    {
+        VerifyOrReturnError(HasWildcardEndpointId() || other.HasWildcardEndpointId() || mEndpointId == other.mEndpointId, false);
+        VerifyOrReturnError(HasWildcardClusterId() || other.HasWildcardClusterId() || mClusterId == other.mClusterId, false);
+        VerifyOrReturnError(HasWildcardAttributeId() || other.HasWildcardAttributeId() || mAttributeId == other.mAttributeId,
+                            false);
+        return true;
+    }
+
     bool IncludesAttributesInCluster(const DataVersionFilter & other) const
     {
         VerifyOrReturnError(HasWildcardEndpointId() || mEndpointId == other.mEndpointId, false);

--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -462,6 +462,27 @@ CHIP_ERROR ClusterStateCache::OnUpdateDataVersionFilterList(DataVersionFilterIBs
         }
     }
 
+    for (auto & attribute1 : aAttributePaths)
+    {
+        if (attribute1.HasWildcardAttributeId())
+        {
+            continue;
+        }
+
+        auto attribute2 = std::begin(mRequestPathSet);
+        while (attribute2 != std::end(mRequestPathSet))
+        {
+            if (attribute1.IsAttributePathOverlapped(*attribute2))
+            {
+                attribute2 = mRequestPathSet.erase(attribute2);
+            }
+            else
+            {
+                ++attribute2;
+            }
+        }
+    }
+
     std::vector<std::pair<DataVersionFilter, size_t>> filterVector;
     GetSortedFilters(filterVector);
 

--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -460,9 +460,9 @@ CHIP_ERROR ClusterStateCache::OnUpdateDataVersionFilterList(DataVersionFilterIBs
     // wildcard), (wildcard, C1, A1)
     for (auto & attribute1 : aAttributePaths)
     {
-        bool intersected = false;
         if (attribute1.HasWildcardAttributeId())
         {
+            bool intersected = false;
             for (auto & attribute2 : aAttributePaths)
             {
                 if (attribute2.HasWildcardAttributeId())

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -431,7 +431,8 @@ void TestReadInteraction::TestReadSubscribeAttributeResponseWithCache(nlTestSuit
         NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 6);
         NL_TEST_ASSERT(apSuite, !delegate.mReadError);
         Optional<DataVersion> version1;
-        NL_TEST_ASSERT(apSuite, cache.GetVersion(Test::kMockEndpoint2, Test::MockClusterId(3), version1) == CHIP_NO_ERROR);
+        app::ConcreteClusterPath clusterPath1(Test::kMockEndpoint2, Test::MockClusterId(3));
+        NL_TEST_ASSERT(apSuite, cache.GetVersion(clusterPath1, version1) == CHIP_NO_ERROR);
         NL_TEST_ASSERT(apSuite, !version1.HasValue());
         delegate.mNumAttributeResponse = 0;
     }

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -401,6 +401,41 @@ void TestReadInteraction::TestReadSubscribeAttributeResponseWithCache(nlTestSuit
     app::InteractionModelEngine::GetInstance()->RegisterReadHandlerAppCallback(&gTestReadInteraction);
 
     int testId = 0;
+
+    // Read of E2C3A1(dedup), E*C3A1(E1C3A1 not exit, E2C3A1 exist), E2C3A* (5 supported attributes)
+    // Expect no versions would be cached.
+    {
+        testId++;
+        ChipLogProgress(DataManagement, "\t -- Running Read with ClusterStateCache Test ID %d", testId);
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(),
+                                   cache.GetBufferedCallback(), chip::app::ReadClient::InteractionType::Read);
+        chip::app::AttributePathParams attributePathParams1[3];
+        attributePathParams1[0].mEndpointId  = Test::kMockEndpoint2;
+        attributePathParams1[0].mClusterId   = Test::MockClusterId(3);
+        attributePathParams1[0].mAttributeId = Test::MockAttributeId(1);
+
+        attributePathParams1[1].mEndpointId  = kInvalidEndpointId;
+        attributePathParams1[1].mClusterId   = Test::MockClusterId(3);
+        attributePathParams1[1].mAttributeId = Test::MockAttributeId(1);
+
+        attributePathParams1[2].mEndpointId  = Test::kMockEndpoint2;
+        attributePathParams1[2].mClusterId   = Test::MockClusterId(3);
+        attributePathParams1[2].mAttributeId = kInvalidAttributeId;
+
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams1;
+        readPrepareParams.mAttributePathParamsListSize = 3;
+        err                                            = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 6);
+        NL_TEST_ASSERT(apSuite, !delegate.mReadError);
+        Optional<DataVersion> version1;
+        NL_TEST_ASSERT(apSuite, cache.GetVersion(Test::kMockEndpoint2, Test::MockClusterId(3), version1) == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(apSuite, !version1.HasValue());
+        delegate.mNumAttributeResponse = 0;
+    }
+
     // Read of E2C3A1, E2C3A2 and E3C2A2.
     // Expect no versions would be cached.
     {


### PR DESCRIPTION
#### Problem
We cannot handle dataVersion cache for two paths: (E1, C1, wildcard), (wildcard, C1, A1).

#### Change overview
if there exists any path in the request that references a specific attribute, remove affacted wildcard cluster attribute in requestPathSet used in cached so that we would not cache the dataVersion  for all clusters affected by that attribute.
note: in the worst case, referencing a global attribute in any path in the request with wildcard for cluster would effectively disable all data version caching 

#### Testing
Add the test with paths (E1, C1, wildcard), (wildcard, C1, A1), we would not cache the version for E1C1
