### PR TITLE
Enable setting command timeout for chip-tool pairing open-commissioning-window.

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -310,10 +310,10 @@ public:
         ReportCommand("subscribe-event", credsIssuerConfig),
         mClusterIds(1, clusterId), mEventIds(1, eventId)
     {
-        AddArgument("event-name", eventName, 0, "Event name.");
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval, 0,
+        AddArgument("event-name", eventName, "Event name.");
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval,
                     "The requested minimum interval between reports. Sets MinIntervalFloor in the Subscribe Request.");
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval, 0,
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval,
                     "The requested maximum interval between reports. Sets MaxIntervalCeiling in the Subscribe Request.");
         AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
                     "false - Terminate existing subscriptions from initiator.\n  true - Leave existing subscriptions in place.");

--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -520,7 +520,7 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
     return isValidArgument;
 }
 
-size_t Command::AddArgument(const char * name, const char * value, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, const char * value, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::Attribute;
@@ -532,7 +532,7 @@ size_t Command::AddArgument(const char * name, const char * value, uint8_t flags
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, char ** value, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, char ** value, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::String;
@@ -544,7 +544,7 @@ size_t Command::AddArgument(const char * name, char ** value, uint8_t flags, con
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, chip::CharSpan * value, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, chip::CharSpan * value, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::CharString;
@@ -556,7 +556,7 @@ size_t Command::AddArgument(const char * name, chip::CharSpan * value, uint8_t f
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, chip::ByteSpan * value, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, chip::ByteSpan * value, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::OctetString;
@@ -568,7 +568,7 @@ size_t Command::AddArgument(const char * name, chip::ByteSpan * value, uint8_t f
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, AddressWithInterface * out, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, AddressWithInterface * out, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::Address;
@@ -647,7 +647,7 @@ size_t Command::AddArgument(const char * name, CustomArgument * value, const cha
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, float min, float max, float * out, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, float min, float max, float * out, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::Float;
@@ -660,7 +660,7 @@ size_t Command::AddArgument(const char * name, float min, float max, float * out
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, double min, double max, double * out, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, double min, double max, double * out, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::Double;
@@ -673,8 +673,8 @@ size_t Command::AddArgument(const char * name, double min, double max, double * 
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags,
-                            const char * desc)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, const char * desc,
+                            uint8_t flags)
 {
     Argument arg;
     arg.type  = type;
@@ -688,7 +688,7 @@ size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void *
     return AddArgumentToList(std::move(arg));
 }
 
-size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, uint8_t flags, const char * desc)
+size_t Command::AddArgument(const char * name, int64_t min, uint64_t max, void * out, const char * desc, uint8_t flags)
 {
     Argument arg;
     arg.type  = ArgumentType::Number_uint8;

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -115,7 +115,7 @@ public:
     size_t GetArgumentsCount(void) const { return mArgs.size(); }
 
     bool InitArguments(int argc, char ** argv);
-    size_t AddArgument(const char * name, const char * value, uint8_t flags = 0, const char * desc = "");
+    size_t AddArgument(const char * name, const char * value, const char * desc = "", uint8_t flags = 0);
     /**
      * @brief
      *   Add a char string command argument
@@ -126,55 +126,55 @@ public:
      * @param desc The description of the argument that will be displayed in the command help
      * @returns The number of arguments currently added to the command
      */
-    size_t AddArgument(const char * name, char ** value, uint8_t flags = 0, const char * desc = "");
+    size_t AddArgument(const char * name, char ** value, const char * desc = "", uint8_t flags = 0);
 
     /**
      * Add an octet string command argument
      */
-    size_t AddArgument(const char * name, chip::ByteSpan * value, uint8_t flags = 0, const char * desc = "");
-    size_t AddArgument(const char * name, chip::Span<const char> * value, uint8_t flags = 0, const char * desc = "");
-    size_t AddArgument(const char * name, AddressWithInterface * out, uint8_t flags = 0, const char * desc = "");
+    size_t AddArgument(const char * name, chip::ByteSpan * value, const char * desc = "", uint8_t flags = 0);
+    size_t AddArgument(const char * name, chip::Span<const char> * value, const char * desc = "", uint8_t flags = 0);
+    size_t AddArgument(const char * name, AddressWithInterface * out, const char * desc = "", uint8_t flags = 0);
     size_t AddArgument(const char * name, ComplexArgument * value, const char * desc = "");
     size_t AddArgument(const char * name, CustomArgument * value, const char * desc = "");
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, bool * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Bool, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Bool, desc, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int8_t * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int8, desc, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int16_t * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int16, desc, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int32_t * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int32, desc, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, int64_t * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_int64, desc, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint8_t * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint8, desc, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint16_t * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint16, desc, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint32_t * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint32, desc, flags);
     }
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, uint64_t * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64, flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<void *>(out), Number_uint64, desc, flags);
     }
 
-    size_t AddArgument(const char * name, float min, float max, float * out, uint8_t flags = 0, const char * desc = "");
-    size_t AddArgument(const char * name, double min, double max, double * out, uint8_t flags = 0, const char * desc = "");
+    size_t AddArgument(const char * name, float min, float max, float * out, const char * desc = "", uint8_t flags = 0);
+    size_t AddArgument(const char * name, double min, double max, double * out, const char * desc = "", uint8_t flags = 0);
 
     size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint16_t> * value, const char * desc = "");
     size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint32_t> * value, const char * desc = "");
@@ -182,55 +182,55 @@ public:
                        const char * desc = "");
 
     template <typename T, typename = std::enable_if_t<std::is_enum<T>::value>>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, T * out, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out), flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<std::underlying_type_t<T> *>(out), desc, flags);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::BitFlags<T> * out, uint8_t flags = 0,
-                       const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::BitFlags<T> * out, const char * desc = "",
+                       uint8_t flags = 0)
     {
         // This is a terrible hack that relies on BitFlags only having the one
         // mValue member.
-        return AddArgument(name, min, max, reinterpret_cast<T *>(out), flags, desc);
+        return AddArgument(name, min, max, reinterpret_cast<T *>(out), desc, flags);
     }
 
     template <typename T>
     size_t AddArgument(const char * name, chip::Optional<T> * value, const char * desc = "")
     {
-        return AddArgument(name, reinterpret_cast<T *>(value), Argument::kOptional, desc);
+        return AddArgument(name, reinterpret_cast<T *>(value), desc, Argument::kOptional);
     }
 
     template <typename T>
     size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<T> * value, const char * desc = "")
     {
-        return AddArgument(name, min, max, reinterpret_cast<T *>(value), Argument::kOptional, desc);
+        return AddArgument(name, min, max, reinterpret_cast<T *>(value), desc, Argument::kOptional);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0, const char * desc = "")
+    size_t AddArgument(const char * name, chip::app::DataModel::Nullable<T> * value, const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, reinterpret_cast<T *>(value), flags | Argument::kNullable, desc);
+        return AddArgument(name, reinterpret_cast<T *>(value), desc, flags | Argument::kNullable);
     }
 
     template <typename T>
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value, uint8_t flags = 0,
-                       const char * desc = "")
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::app::DataModel::Nullable<T> * value,
+                       const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<T *>(value), flags | Argument::kNullable, desc);
+        return AddArgument(name, min, max, reinterpret_cast<T *>(value), desc, flags | Argument::kNullable);
     }
 
-    size_t AddArgument(const char * name, float min, float max, chip::app::DataModel::Nullable<float> * value, uint8_t flags = 0,
-                       const char * desc = "")
+    size_t AddArgument(const char * name, float min, float max, chip::app::DataModel::Nullable<float> * value,
+                       const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<float *>(value), flags | Argument::kNullable, desc);
+        return AddArgument(name, min, max, reinterpret_cast<float *>(value), desc, flags | Argument::kNullable);
     }
 
-    size_t AddArgument(const char * name, double min, double max, chip::app::DataModel::Nullable<double> * value, uint8_t flags = 0,
-                       const char * desc = "")
+    size_t AddArgument(const char * name, double min, double max, chip::app::DataModel::Nullable<double> * value,
+                       const char * desc = "", uint8_t flags = 0)
     {
-        return AddArgument(name, min, max, reinterpret_cast<double *>(value), flags | Argument::kNullable, desc);
+        return AddArgument(name, min, max, reinterpret_cast<double *>(value), desc, flags | Argument::kNullable);
     }
 
     void ResetArguments();
@@ -247,9 +247,9 @@ public:
 
 private:
     bool InitArgument(size_t argIndex, char * argValue);
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, uint8_t flags,
-                       const char * desc = "");
-    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, uint8_t flags, const char * desc = "");
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, ArgumentType type, const char * desc,
+                       uint8_t flags);
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, void * out, const char * desc, uint8_t flags);
 
     /**
      * Add the Argument to our list.  This preserves the property that all

--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.cpp
@@ -27,15 +27,16 @@ CHIP_ERROR OpenCommissioningWindowCommand::RunCommand()
     mWindowOpener = Platform::MakeUnique<Controller::CommissioningWindowOpener>(&CurrentCommissioner());
     if (mCommissioningWindowOption == Controller::CommissioningWindowOpener::CommissioningWindowOption::kOriginalSetupCode)
     {
-        return mWindowOpener->OpenBasicCommissioningWindow(mNodeId, System::Clock::Seconds16(mTimeout),
+        return mWindowOpener->OpenBasicCommissioningWindow(mNodeId, System::Clock::Seconds16(mCommissioningWindowTimeout),
                                                            &mOnOpenBasicCommissioningWindowCallback);
     }
 
     if (mCommissioningWindowOption == Controller::CommissioningWindowOpener::CommissioningWindowOption::kTokenWithRandomPIN)
     {
         SetupPayload ignored;
-        return mWindowOpener->OpenCommissioningWindow(mNodeId, System::Clock::Seconds16(mTimeout), mIteration, mDiscriminator,
-                                                      NullOptional, NullOptional, &mOnOpenCommissioningWindowCallback, ignored,
+        return mWindowOpener->OpenCommissioningWindow(mNodeId, System::Clock::Seconds16(mCommissioningWindowTimeout), mIteration,
+                                                      mDiscriminator, NullOptional, NullOptional,
+                                                      &mOnOpenCommissioningWindowCallback, ignored,
                                                       /* readVIDPIDAttributes */ true);
     }
 

--- a/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
+++ b/examples/chip-tool/commands/pairing/OpenCommissioningWindowCommand.h
@@ -31,23 +31,31 @@ public:
         mOnOpenCommissioningWindowCallback(OnOpenCommissioningWindowResponse, this),
         mOnOpenBasicCommissioningWindowCallback(OnOpenBasicCommissioningWindowResponse, this)
     {
-        AddArgument("node-id", 0, UINT64_MAX, &mNodeId);
-        AddArgument("option", 0, 2, &mCommissioningWindowOption);
-        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
-        AddArgument("iteration", chip::kSpake2p_Min_PBKDF_Iterations, chip::kSpake2p_Max_PBKDF_Iterations, &mIteration);
-        AddArgument("discriminator", 0, 4096, &mDiscriminator);
+        AddArgument("node-id", 0, UINT64_MAX, &mNodeId, "Node to send command to.");
+        AddArgument("option", 0, 2, &mCommissioningWindowOption,
+                    "1 to use Enhanced Commissioning Method.\n  0 to use Basic Commissioning Method.");
+        AddArgument("window-timeout", 0, UINT16_MAX, &mCommissioningWindowTimeout,
+                    "Time, in seconds, before the commissioning window closes.");
+        AddArgument("iteration", chip::kSpake2p_Min_PBKDF_Iterations, chip::kSpake2p_Max_PBKDF_Iterations, &mIteration,
+                    "Number of PBKDF iterations to use to derive the verifier.  Ignored if 'option' is 0.");
+        AddArgument("discriminator", 0, 4096, &mDiscriminator, "Discriminator to use for advertising.  Ignored if 'option' is 0.");
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout, "Time, in seconds, before this command is considered to have timed out.");
     }
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(5); }
+    // We issue multiple data model operations for this command, and the default
+    // timeout for those is 10 seconds, so default to 20 seconds.
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.ValueOr(20)); }
 
 private:
     NodeId mNodeId;
     chip::Controller::CommissioningWindowOpener::CommissioningWindowOption mCommissioningWindowOption;
-    uint16_t mTimeout;
+    uint16_t mCommissioningWindowTimeout;
     uint32_t mIteration;
     uint16_t mDiscriminator;
+
+    chip::Optional<uint16_t> mTimeout;
 
     chip::Platform::UniquePtr<chip::Controller::CommissioningWindowOpener> mWindowOpener;
 


### PR DESCRIPTION
Specific changes:

* Allow doing --timeout to set the command timeout.
* Bump the default timeout from 5 seconds to 20 seconds.
* Document the arguments to open-commissioning-window, especially
  because some of them are a bit cryptic.
* Fix an issue with the command field description setup, where for
  some arg types the "flags" had to be specified when specifying the
  description.  The flags are internal bookkeeping, and should never
  be specified explicitly by normal AddArgument callers, so
  Command.h/Command.cpp were modified to put the flags last again,
  after the (optional) description.

Fixes https://github.com/project-chip/connectedhomeip/issues/14490

#### Problem
See above.

#### Change overview
See above.

#### Testing
Made sure that the command does not time out until 20 seconds pass by default and that I can use `--timeout 2` to make it time out after 2 seconds.