### PR TITLE
 partial overlap fix between subscribed path and setDirty path

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -994,26 +994,6 @@ CHIP_ERROR InteractionModelEngine::PushFront(ObjectList<T> *& aObjectList, T & a
     return CHIP_NO_ERROR;
 }
 
-bool InteractionModelEngine::IsOverlappedAttributePath(AttributePathParams & aAttributePath)
-{
-    return (mReadHandlers.ForEachActiveObject([&aAttributePath](ReadHandler * handler) {
-        if (handler->IsType(ReadHandler::InteractionType::Subscribe) &&
-            (handler->IsGeneratingReports() || handler->IsAwaitingReportResponse()))
-        {
-            for (auto object = handler->GetAttributePathList(); object != nullptr; object = object->mpNext)
-            {
-                if (object->mValue.IsAttributePathSupersetOf(aAttributePath) ||
-                    aAttributePath.IsAttributePathSupersetOf(object->mValue))
-                {
-                    return Loop::Break;
-                }
-            }
-        }
-
-        return Loop::Continue;
-    }) == Loop::Break);
-}
-
 void InteractionModelEngine::DispatchCommand(CommandHandler & apCommandObj, const ConcreteCommandPath & aCommandPath,
                                              TLV::TLVReader & apPayload)
 {

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -175,8 +175,6 @@ public:
     CHIP_ERROR PushFrontDataVersionFilterList(ObjectList<DataVersionFilter> *& aDataVersionFilterList,
                                               DataVersionFilter & aDataVersionFilter);
 
-    bool IsOverlappedAttributePath(AttributePathParams & aAttributePath);
-
     CHIP_ERROR RegisterCommandHandler(CommandHandlerInterface * handler);
     CHIP_ERROR UnregisterCommandHandler(CommandHandlerInterface * handler);
     CommandHandlerInterface * FindCommandHandler(EndpointId endpointId, ClusterId clusterId);

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -773,31 +773,32 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
 {
     BumpDirtySetGeneration();
 
-    InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject([&aAttributePath](ReadHandler * handler) {
-        // We call SetDirty for both read interactions and subscribe interactions, since we may sent inconsistent attribute data
-        // between two chunks. SetDirty will be ignored automatically by read handlers which is waiting for response to last message
-        // chunk for read interactions.
-        if (handler->IsGeneratingReports() || handler->IsAwaitingReportResponse())
-        {
-            for (auto object = handler->GetAttributePathList(); object != nullptr; object = object->mpNext)
+    bool hasOverlappedPath = false;
+    InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject(
+        [&aAttributePath, &hasOverlappedPath](ReadHandler * handler) {
+            // We call SetDirty for both read interactions and subscribe interactions, since we may sent inconsistent attribute data
+            // between two chunks. SetDirty will be ignored automatically by read handlers which is waiting for response to last
+            // message chunk for read interactions.
+            if (handler->IsGeneratingReports() || handler->IsAwaitingReportResponse())
             {
-                if (aAttributePath.IsAttributePathSupersetOf(object->mValue) ||
-                    object->mValue.IsAttributePathSupersetOf(aAttributePath))
+                for (auto object = handler->GetAttributePathList(); object != nullptr; object = object->mpNext)
                 {
-                    handler->SetDirty(aAttributePath);
-                    break;
+                    if (object->mValue.IsAttributePathOverlapped(aAttributePath))
+                    {
+                        handler->SetDirty(aAttributePath);
+                        hasOverlappedPath = true;
+                        break;
+                    }
                 }
             }
-        }
 
-        return Loop::Continue;
-    });
+            return Loop::Continue;
+        });
 
-    if (!InteractionModelEngine::GetInstance()->IsOverlappedAttributePath(aAttributePath))
+    if (!hasOverlappedPath)
     {
         return CHIP_NO_ERROR;
     }
-
     ReturnErrorOnFailure(InsertPathIntoDirtySet(aAttributePath));
 
     // Schedule work to run asynchronously on the CHIP thread. The scheduled
@@ -827,8 +828,7 @@ void Engine::UpdateReadHandlerDirty(ReadHandler & aReadHandler)
     for (auto object = aReadHandler.GetAttributePathList(); object != nullptr; object = object->mpNext)
     {
         mGlobalDirtySet.ForEachActiveObject([&](auto * path) {
-            if ((path->IsAttributePathSupersetOf(object->mValue) || object->mValue.IsAttributePathSupersetOf(*path)) &&
-                path->mGeneration > aReadHandler.mPreviousReportsBeginGeneration)
+            if (path->IsAttributePathOverlapped(object->mValue) && path->mGeneration > aReadHandler.mPreviousReportsBeginGeneration)
             {
                 intersected = true;
                 return Loop::Break;

--- a/src/app/tests/TestClusterInfo.cpp
+++ b/src/app/tests/TestClusterInfo.cpp
@@ -34,6 +34,65 @@ using namespace chip::Test;
 namespace chip {
 namespace app {
 namespace TestPath {
+void TestAttributePathIntersect(nlTestSuite * apSuite, void * apContext)
+{
+    EndpointId endpointIdArray[2]   = { 1, kInvalidEndpointId };
+    ClusterId clusterIdArray[2]     = { 2, kInvalidClusterId };
+    AttributeId attributeIdArray[2] = { 3, kInvalidAttributeId };
+
+    for (auto endpointId1 : endpointIdArray)
+    {
+        for (auto clusterId1 : clusterIdArray)
+        {
+            for (auto attributeId1 : attributeIdArray)
+            {
+                for (auto endpointId2 : endpointIdArray)
+                {
+                    for (auto clusterId2 : clusterIdArray)
+                    {
+                        for (auto attributeId2 : attributeIdArray)
+                        {
+                            AttributePathParams path1;
+                            path1.mEndpointId  = endpointId1;
+                            path1.mClusterId   = clusterId1;
+                            path1.mAttributeId = attributeId1;
+                            AttributePathParams path2;
+                            path2.mEndpointId  = endpointId2;
+                            path2.mClusterId   = clusterId2;
+                            path2.mAttributeId = attributeId2;
+                            NL_TEST_ASSERT(apSuite, path1.Intersects(path2));
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    {
+        AttributePathParams path1;
+        path1.mEndpointId = 1;
+        AttributePathParams path2;
+        path2.mEndpointId = 2;
+        NL_TEST_ASSERT(apSuite, !path1.Intersects(path2));
+    }
+
+    {
+        AttributePathParams path1;
+        path1.mClusterId = 1;
+        AttributePathParams path2;
+        path2.mClusterId = 2;
+        NL_TEST_ASSERT(apSuite, !path1.Intersects(path2));
+    }
+
+    {
+        AttributePathParams path1;
+        path1.mAttributeId = 1;
+        AttributePathParams path2;
+        path2.mAttributeId = 2;
+        NL_TEST_ASSERT(apSuite, !path1.Intersects(path2));
+    }
+}
+
 void TestAttributePathIncludedSameFieldId(nlTestSuite * apSuite, void * apContext)
 {
     AttributePathParams clusterInfo1;
@@ -179,6 +238,7 @@ const nlTest sTests[] = {
     NL_TEST_DEF("TestEventPathDifferentEventId", chip::app::TestPath::TestEventPathDifferentEventId),
     NL_TEST_DEF("TestEventPathDifferentClusterId", chip::app::TestPath::TestEventPathDifferentClusterId),
     NL_TEST_DEF("TestEventPathDifferentEndpointId", chip::app::TestPath::TestEventPathDifferentEndpointId),
+    NL_TEST_DEF("TestAttributePathIntersect", chip::app::TestPath::TestAttributePathIntersect),
     NL_TEST_SENTINEL()
 };
 }

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -168,6 +168,7 @@ public:
     {
         if (status.mStatus == chip::Protocols::InteractionModel::Status::Success)
         {
+            mReceivedAttributePaths.push_back(aPath);
             mNumAttributeResponse++;
             mGotReport = true;
         }
@@ -209,6 +210,7 @@ public:
     chip::app::ReadHandler * mpReadHandler = nullptr;
     chip::app::StatusIB mLastStatusReceived;
     CHIP_ERROR mError = CHIP_NO_ERROR;
+    std::vector<chip::app::ConcreteAttributePath> mReceivedAttributePaths;
 };
 
 //
@@ -1907,6 +1909,9 @@ void TestReadInteraction::TestSubscribePartialOverlap(nlTestSuite * apSuite, voi
 
             NL_TEST_ASSERT(apSuite, delegate.mGotReport);
             NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 1);
+            NL_TEST_ASSERT(apSuite, delegate.mReceivedAttributePaths[0].mEndpointId == Test::kMockEndpoint2);
+            NL_TEST_ASSERT(apSuite, delegate.mReceivedAttributePaths[0].mClusterId == Test::MockClusterId(3));
+            NL_TEST_ASSERT(apSuite, delegate.mReceivedAttributePaths[0].mAttributeId == Test::MockAttributeId(1));
         }
     }
 
@@ -1977,6 +1982,9 @@ void TestReadInteraction::TestSubscribeSetDirtyFullyOverlap(nlTestSuite * apSuit
 
             NL_TEST_ASSERT(apSuite, delegate.mGotReport);
             NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 1);
+            NL_TEST_ASSERT(apSuite, delegate.mReceivedAttributePaths[0].mEndpointId == Test::kMockEndpoint2);
+            NL_TEST_ASSERT(apSuite, delegate.mReceivedAttributePaths[0].mClusterId == Test::MockClusterId(3));
+            NL_TEST_ASSERT(apSuite, delegate.mReceivedAttributePaths[0].mAttributeId == Test::MockAttributeId(1));
         }
     }
 

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -303,6 +303,8 @@ public:
     static void TestSubscribeRoundtrip(nlTestSuite * apSuite, void * apContext);
     static void TestSubscribeUrgentWildcardEvent(nlTestSuite * apSuite, void * apContext);
     static void TestSubscribeWildcard(nlTestSuite * apSuite, void * apContext);
+    static void TestSubscribePartialOverlap(nlTestSuite * apSuite, void * apContext);
+    static void TestSubscribeSetDirtyFullyOverlap(nlTestSuite * apSuite, void * apContext);
     static void TestSubscribeEarlyShutdown(nlTestSuite * apSuite, void * apContext);
     static void TestSubscribeInvalidAttributePathRoundtrip(nlTestSuite * apSuite, void * apContext);
     static void TestReadInvalidAttributePathRoundtrip(nlTestSuite * apSuite, void * apContext);
@@ -1841,6 +1843,148 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
+// Subscribe (wildcard, C3, A1), then setDirty (E2, C3, wildcard), receive one attribute after setDirty
+void TestReadInteraction::TestSubscribePartialOverlap(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+
+    Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
+    // Shouldn't have anything in the retransmit table when starting the test.
+    NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);
+
+    MockInteractionModelApp delegate;
+    auto * engine = chip::app::InteractionModelEngine::GetInstance();
+    err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable());
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+
+    ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+    readPrepareParams.mEventPathParamsListSize = 0;
+
+    chip::app::AttributePathParams * attributePathParams = new chip::app::AttributePathParams[1];
+    attributePathParams[0].mClusterId                    = Test::MockClusterId(3);
+    attributePathParams[0].mAttributeId                  = Test::MockAttributeId(1);
+    readPrepareParams.mpAttributePathParamsList          = attributePathParams;
+    readPrepareParams.mAttributePathParamsListSize       = 1;
+
+    readPrepareParams.mMinIntervalFloorSeconds   = 0;
+    readPrepareParams.mMaxIntervalCeilingSeconds = 0;
+    printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+
+    {
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Subscribe);
+
+        delegate.mGotReport = false;
+
+        err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+
+        NL_TEST_ASSERT(apSuite, delegate.mGotReport);
+
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 1);
+        NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe) == 1);
+        NL_TEST_ASSERT(apSuite, engine->ActiveHandlerAt(0) != nullptr);
+        delegate.mpReadHandler = engine->ActiveHandlerAt(0);
+
+        // Set a partial overlapped path dirty
+        {
+            delegate.mpReadHandler->mFlags.Set(ReadHandler::ReadHandlerFlags::HoldReport, false);
+            delegate.mGotReport            = false;
+            delegate.mNumAttributeResponse = 0;
+
+            AttributePathParams dirtyPath;
+            dirtyPath.mEndpointId = Test::kMockEndpoint2;
+            dirtyPath.mClusterId  = Test::MockClusterId(3);
+
+            err = engine->GetReportingEngine().SetDirty(dirtyPath);
+            NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+
+            NL_TEST_ASSERT(apSuite, delegate.mGotReport);
+            NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 1);
+        }
+    }
+
+    NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadClients() == 0);
+    engine->Shutdown();
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
+// Subscribe (E2, C3, A1), then setDirty (wildcard, wildcard, wildcard), receive one attribute after setDirty
+void TestReadInteraction::TestSubscribeSetDirtyFullyOverlap(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+
+    Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
+    // Shouldn't have anything in the retransmit table when starting the test.
+    NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);
+
+    MockInteractionModelApp delegate;
+    auto * engine = chip::app::InteractionModelEngine::GetInstance();
+    err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable());
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+
+    ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+    readPrepareParams.mEventPathParamsListSize = 0;
+
+    chip::app::AttributePathParams * attributePathParams = new chip::app::AttributePathParams[1];
+    attributePathParams[0].mClusterId                    = Test::kMockEndpoint2;
+    attributePathParams[0].mClusterId                    = Test::MockClusterId(3);
+    attributePathParams[0].mAttributeId                  = Test::MockAttributeId(1);
+    readPrepareParams.mpAttributePathParamsList          = attributePathParams;
+    readPrepareParams.mAttributePathParamsListSize       = 1;
+
+    readPrepareParams.mMinIntervalFloorSeconds   = 0;
+    readPrepareParams.mMaxIntervalCeilingSeconds = 0;
+    printf("\nSend subscribe request message to Node: %" PRIu64 "\n", chip::kTestDeviceNodeId);
+
+    {
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Subscribe);
+
+        delegate.mGotReport = false;
+
+        err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+
+        NL_TEST_ASSERT(apSuite, delegate.mGotReport);
+
+        NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 1);
+        NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe) == 1);
+        NL_TEST_ASSERT(apSuite, engine->ActiveHandlerAt(0) != nullptr);
+        delegate.mpReadHandler = engine->ActiveHandlerAt(0);
+
+        // Set a full overlapped path dirty and expect to receive one E2C3A1
+        {
+            delegate.mpReadHandler->mFlags.Set(ReadHandler::ReadHandlerFlags::HoldReport, false);
+            delegate.mGotReport            = false;
+            delegate.mNumAttributeResponse = 0;
+
+            AttributePathParams dirtyPath;
+            err = engine->GetReportingEngine().SetDirty(dirtyPath);
+            NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+
+            NL_TEST_ASSERT(apSuite, delegate.mGotReport);
+            NL_TEST_ASSERT(apSuite, delegate.mNumAttributeResponse == 1);
+        }
+    }
+
+    NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadClients() == 0);
+    engine->Shutdown();
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
 // Verify that subscription can be shut down just after receiving SUBSCRIBE RESPONSE,
 // before receiving any subsequent REPORT DATA.
 void TestReadInteraction::TestSubscribeEarlyShutdown(nlTestSuite * apSuite, void * apContext)
@@ -2588,8 +2732,11 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestReadHandlerInvalidAttributePath", chip::app::TestReadInteraction::TestReadHandlerInvalidAttributePath),
     NL_TEST_DEF("TestProcessSubscribeRequest", chip::app::TestReadInteraction::TestProcessSubscribeRequest),
     NL_TEST_DEF("TestSubscribeRoundtrip", chip::app::TestReadInteraction::TestSubscribeRoundtrip),
+
     NL_TEST_DEF("TestSubscribeUrgentWildcardEvent", chip::app::TestReadInteraction::TestSubscribeUrgentWildcardEvent),
     NL_TEST_DEF("TestSubscribeWildcard", chip::app::TestReadInteraction::TestSubscribeWildcard),
+    NL_TEST_DEF("TestSubscribePartialOverlap", chip::app::TestReadInteraction::TestSubscribePartialOverlap),
+    NL_TEST_DEF("TestSubscribeSetDirtyFullyOverlap", chip::app::TestReadInteraction::TestSubscribeSetDirtyFullyOverlap),
     NL_TEST_DEF("TestSubscribeEarlyShutdown", chip::app::TestReadInteraction::TestSubscribeEarlyShutdown),
     NL_TEST_DEF("TestSubscribeInvalidAttributePathRoundtrip", chip::app::TestReadInteraction::TestSubscribeInvalidAttributePathRoundtrip),
     NL_TEST_DEF("TestReadInvalidAttributePathRoundtrip", chip::app::TestReadInteraction::TestReadInvalidAttributePathRoundtrip),


### PR DESCRIPTION
#### Problem
We cannot handle the partial overlap between subscribed path and setDirty path, for example, subscribe path (E1, C1, wildcard), setDirty with (wildcard, C1, A1).

#### Change overview
Update SetDirty function via using IsAttributePathOverlapped, remove duplicate functionality IsOverlappedAttributePath in InteracitonModelEngine.

#### Testing
Add the test where we subscribe path (E1, C1, wildcard), setDirty with (wildcard, C1, A1), we expected to receive the one attribute E1,C1,A1
Add unit test to cover all intersected situation and negative test cases.