### PR TITLE
[setup_payload] Fixed bug with not reducing span size properly

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -196,6 +196,8 @@ static CHIP_ERROR payloadBase38RepresentationWithTLV(PayloadContents & payload, 
         MutableCharSpan subSpan = outBuffer.SubSpan(prefixLen, outBuffer.size() - prefixLen);
         memcpy(outBuffer.data(), kQRCodePrefix, prefixLen);
         err = base38Encode(bits, subSpan);
+        // Reduce output span size to be the size of written data
+        outBuffer.reduce_size(subSpan.size() + prefixLen);
     }
 
     return err;


### PR DESCRIPTION
#### Problem
Output buffer span is not reduced properly, as `subSpan` is passed to the `base38Encode` method and changed size doesn't
propagate to the `outBuffer`.

#### Change overview
Added reducing `outBuffer` size to the `subSpan` size + `prefixLen` size.

#### Testing

