### PR TITLE
[SetUpCodePairer] Ensure the payload is a valid payload

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -44,8 +44,16 @@ CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, 
     mConnectionType = commission;
 
     bool isQRCode = strncmp(setUpCode, kQRCodePrefix, strlen(kQRCodePrefix)) == 0;
-    ReturnErrorOnFailure(isQRCode ? QRCodeSetupPayloadParser(setUpCode).populatePayload(payload)
-                                  : ManualSetupPayloadParser(setUpCode).populatePayload(payload));
+    if (isQRCode)
+    {
+        ReturnErrorOnFailure(QRCodeSetupPayloadParser(setUpCode).populatePayload(payload));
+        VerifyOrReturnError(payload.isValidQRCodePayload(), CHIP_ERROR_INVALID_ARGUMENT);
+    }
+    else
+    {
+        ReturnErrorOnFailure(ManualSetupPayloadParser(setUpCode).populatePayload(payload));
+        VerifyOrReturnError(payload.isValidManualCode(), CHIP_ERROR_INVALID_ARGUMENT);
+    }
 
     mRemoteId     = remoteId;
     mSetUpPINCode = payload.setUpPINCode;

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -131,6 +131,12 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
         return result;
     }
 
+    // First digit of '8' or '9' would be invalid for v1 and would indicate new format (e.g. version 2)
+    if (chunk1 == 8 || chunk1 == 9)
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
     bool isLongCode = ((chunk1 >> kManualSetupChunk1VidPidPresentBitPos) & 1) == 1;
     result          = CheckCodeLengthValidity(representationWithoutCheckDigit, isLongCode);
     if (result != CHIP_NO_ERROR)

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -119,6 +119,9 @@ struct PayloadContents
     bool isValidManualCode() const;
     bool isShortDiscriminator = false;
     bool operator==(PayloadContents & input) const;
+
+private:
+    bool CheckPayloadCommonConstraints() const;
 };
 
 enum optionalQRCodeInfoType

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -39,13 +39,13 @@ const uint32_t kOptionalDefaultIntValue = 12;
 constexpr char kSerialNumberDefaultStringValue[] = "123456789";
 const uint32_t kSerialNumberDefaultUInt32Value   = 123456789;
 
-constexpr const char * kDefaultPayloadQRCode = "MT:R5L90MP500K64J00000";
+constexpr const char * kDefaultPayloadQRCode = "MT:M5L90MP500K64J00000";
 
 inline SetupPayload GetDefaultPayload()
 {
     SetupPayload payload;
 
-    payload.version               = 5;
+    payload.version               = 0;
     payload.vendorID              = 12;
     payload.productID             = 1;
     payload.commissioningFlow     = CommissioningFlow::kStandard;
@@ -132,14 +132,16 @@ inline bool CompareBinary(SetupPayload & payload, std::string & expectedBinary)
     return (expectedBinary == resultBinary);
 }
 
-inline bool CheckWriteRead(SetupPayload & inPayload)
+inline bool CheckWriteRead(SetupPayload & inPayload, bool allowInvalidPayload = false)
 {
     SetupPayload outPayload;
     std::string result;
 
     uint8_t optionalInfo[kDefaultBufferSizeInBytes];
     memset(optionalInfo, 0xFF, sizeof(optionalInfo));
-    QRCodeSetupPayloadGenerator(inPayload).payloadBase38Representation(result, optionalInfo, sizeof(optionalInfo));
+    auto generator = QRCodeSetupPayloadGenerator(inPayload);
+    generator.SetAllowInvalidPayload(allowInvalidPayload);
+    generator.payloadBase38Representation(result, optionalInfo, sizeof(optionalInfo));
 
     outPayload = {};
     QRCodeSetupPayloadParser(result).populatePayload(outPayload);

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -38,10 +38,11 @@ using namespace chip;
 
 namespace {
 
-bool CheckGenerator(const PayloadContents & payload, std::string expectedResult)
+bool CheckGenerator(const PayloadContents & payload, std::string expectedResult, bool allowInvalidPayload = false)
 {
     std::string result;
     ManualSetupPayloadGenerator generator(payload);
+    generator.SetAllowInvalidPayload(allowInvalidPayload);
     generator.payloadDecimalStringRepresentation(result);
 
     if (!expectedResult.empty())
@@ -62,7 +63,7 @@ bool CheckGenerator(const PayloadContents & payload, std::string expectedResult)
 PayloadContents GetDefaultPayload()
 {
     PayloadContents payload;
-    payload.setUpPINCode  = 123456780;
+    payload.setUpPINCode  = 12345679;
     payload.discriminator = 2560;
 
     return payload;
@@ -72,7 +73,7 @@ void TestDecimalRepresentation_PartialPayload(nlTestSuite * inSuite, void * inCo
 {
     PayloadContents payload = GetDefaultPayload();
 
-    std::string expectedResult = "2361087535";
+    std::string expectedResult = "2412950753";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -82,7 +83,7 @@ void TestDecimalRepresentation_PartialPayload_RequiresCustomFlow(nlTestSuite * i
     PayloadContents payload   = GetDefaultPayload();
     payload.commissioningFlow = CommissioningFlow::kCustom;
 
-    std::string expectedResult = "63610875350000000000";
+    std::string expectedResult = "64129507530000000000";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -94,7 +95,7 @@ void TestDecimalRepresentation_FullPayloadWithZeros(nlTestSuite * inSuite, void 
     payload.vendorID          = 1;
     payload.productID         = 1;
 
-    std::string expectedResult = "63610875350000100001";
+    std::string expectedResult = "64129507530000100001";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -106,7 +107,7 @@ void TestDecimalRepresentation_FullPayloadWithoutZeros(nlTestSuite * inSuite, vo
     payload.vendorID          = 45367;
     payload.productID         = 14526;
 
-    std::string expectedResult = "63610875354536714526";
+    std::string expectedResult = "64129507534536714526";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -117,7 +118,7 @@ void TestDecimalRepresentation_FullPayloadWithoutZeros_DoesNotRequireCustomFlow(
     payload.vendorID        = 45367;
     payload.productID       = 14526;
 
-    std::string expectedResult = "2361087535";
+    std::string expectedResult = "2412950753";
 
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
 }
@@ -144,7 +145,7 @@ void TestDecimalRepresentation_AllOnes(nlTestSuite * inSuite, void * inContext)
 
     std::string expectedResult = "76553581916553565535";
 
-    NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult));
+    NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult, /*allowInvalidPayload*/ true));
 }
 
 void TestDecimalRepresentation_InvalidPayload(nlTestSuite * inSuite, void * inContext)

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -91,15 +91,14 @@ void TestMaximumValues(nlTestSuite * inSuite, void * inContext)
     inPayload.discriminator = static_cast<uint16_t>((1 << kPayloadDiscriminatorFieldLengthInBits) - 1);
     inPayload.setUpPINCode  = static_cast<uint32_t>((1 << kSetupPINCodeFieldLengthInBits) - 1);
 
-    NL_TEST_ASSERT(inSuite, inPayload.isValidQRCodePayload());
-    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
+    NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload, /* allowInvalidPayload */ true));
 }
 
 void TestPayloadByteArrayRep(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload = GetDefaultPayload();
 
-    string expected = " 0000 000000000000000100000000000 000010000000 00000001 00 0000000000000001 0000000000001100 101";
+    string expected = " 0000 000000000000000100000000000 000010000000 00000001 00 0000000000000001 0000000000001100 000";
     NL_TEST_ASSERT(inSuite, CompareBinary(payload, expected));
 }
 


### PR DESCRIPTION
#### Problem

Some invalid payloads, not in terms of encoding, but in terms of what is allowed or not for v1 does initiate a PASE session while it it not expected. Some other just works (for example when the "version" of a QRcode is not 0)

In theory the commissioner could do all those checks but it just seems redundant.

While it resolve the version issue mentioned in  #17205, it does not cover all the tests mentioned in the test plan. Notably the parts related to:
  * Commissioning flow
  * Test Vendor

#### Change overview
 * Hardcode some additional constraints and check them into the setup code pairer

#### Testing
It was tested by using `./out/debug/standalone/chip-tool pairing [qrcode|manualcode] 0x12344321 payload` with various different payloads...