### PR TITLE
[nrfconnect] Minor OTA Requestor fixes

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.mcuboot.defaults
@@ -36,10 +36,6 @@ config BOOT_ENCRYPT_X25519
     bool
     default n
 
-choice BOOT_IMAGE_UPGRADE_MODE
-    default BOOT_UPGRADE_ONLY
-endchoice
-
 config BOOT_BOOTSTRAP
     bool
     default n
@@ -118,6 +114,11 @@ config PCD_APP
 config UPDATEABLE_IMAGE_NUMBER
     int
     default 2
+
+# Multi-image updates do not support image swapping yet.
+choice BOOT_IMAGE_UPGRADE_MODE
+    default BOOT_UPGRADE_ONLY
+endchoice
 
 # The network core cannot access external flash directly. The flash simulator must be used to
 # provide a memory region that is used to forward the new firmware to the network core.

--- a/examples/light-switch-app/nrfconnect/main/AppTask.cpp
+++ b/examples/light-switch-app/nrfconnect/main/AppTask.cpp
@@ -153,7 +153,10 @@ CHIP_ERROR AppTask::Init()
     // Initialize DFU
 #ifdef CONFIG_MCUMGR_SMP_BT
     GetDFUOverSMP().Init(RequestSMPAdvertisingStart);
+#ifndef CONFIG_CHIP_OTA_REQUESTOR
+    // When OTA Requestor is enabled, it is responsible for confirming new images.
     GetDFUOverSMP().ConfirmNewImage();
+#endif
 #endif
 
     // Print initial configs

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -161,7 +161,10 @@ CHIP_ERROR AppTask::Init()
 #ifdef CONFIG_MCUMGR_SMP_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init(RequestSMPAdvertisingStart);
+#ifndef CONFIG_CHIP_OTA_REQUESTOR
+    // When OTA Requestor is enabled, it is responsible for confirming new images.
     GetDFUOverSMP().ConfirmNewImage();
+#endif
 #endif
 
     // Initialize CHIP server

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -145,7 +145,10 @@ CHIP_ERROR AppTask::Init()
 #ifdef CONFIG_MCUMGR_SMP_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init(RequestSMPAdvertisingStart);
+#ifndef CONFIG_CHIP_OTA_REQUESTOR
+    // When OTA Requestor is enabled, it is responsible for confirming new images.
     GetDFUOverSMP().ConfirmNewImage();
+#endif
 #endif
 
     // Initialize CHIP server

--- a/examples/platform/nrfconnect/util/OTAUtil.cpp
+++ b/examples/platform/nrfconnect/util/OTAUtil.cpp
@@ -53,6 +53,6 @@ void InitBasicOTARequestor()
     sBDXDownloader.SetImageProcessorDelegate(&imageProcessor);
     sOTARequestorStorage.Init(Server::GetInstance().GetPersistentStorage());
     sOTARequestor.Init(Server::GetInstance(), sOTARequestorStorage, sOTARequestorDriver, sBDXDownloader);
-    sOTARequestorDriver.Init(&sOTARequestor, &imageProcessor);
     chip::SetRequestorInstance(&sOTARequestor);
+    sOTARequestorDriver.Init(&sOTARequestor, &imageProcessor);
 }

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -141,7 +141,10 @@ CHIP_ERROR AppTask::Init()
 #ifdef CONFIG_MCUMGR_SMP_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init(RequestSMPAdvertisingStart);
+#ifndef CONFIG_CHIP_OTA_REQUESTOR
+    // When OTA Requestor is enabled, it is responsible for confirming new images.
     GetDFUOverSMP().ConfirmNewImage();
+#endif
 #endif
 
     // Initialize CHIP server

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -138,7 +138,10 @@ CHIP_ERROR AppTask::Init()
 #ifdef CONFIG_MCUMGR_SMP_BT
     // Initialize DFU over SMP
     GetDFUOverSMP().Init(RequestSMPAdvertisingStart);
+#ifndef CONFIG_CHIP_OTA_REQUESTOR
+    // When OTA Requestor is enabled, it is responsible for confirming new images.
     GetDFUOverSMP().ConfirmNewImage();
+#endif
 #endif
 
     // Initialize CHIP server

--- a/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPDevicePlatformConfig.h
@@ -70,7 +70,7 @@
 #ifndef CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS
 /// Time to sleep after running server shutdown actions to let lower layers complete the actions.
 /// This may include transmitting packets created by the actions.
-#define CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS 10
+#define CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS 500
 #endif // CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS
 
 #ifndef CHIP_DEVICE_CONFIG_HEAP_STATISTICS_MALLINFO

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -18,6 +18,7 @@
 #include "OTAImageProcessorImpl.h"
 
 #include <app/clusters/ota-requestor/OTADownloader.h>
+#include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <system/SystemError.h>
@@ -160,7 +161,14 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & aBlock)
 
 bool OTAImageProcessorImpl::IsFirstImageRun()
 {
-    return mcuboot_swap_type() == BOOT_SWAP_TYPE_REVERT;
+    OTARequestorInterface * requestor = GetRequestorInstance();
+    ReturnErrorCodeIf(requestor == nullptr, false);
+
+    uint32_t currentVersion;
+    ReturnErrorCodeIf(ConfigurationMgr().GetSoftwareVersion(currentVersion) != CHIP_NO_ERROR, false);
+
+    return requestor->GetCurrentUpdateState() == OTARequestorInterface::OTAUpdateStateEnum::kApplying &&
+        requestor->GetTargetVersion() == currentVersion;
 }
 
 CHIP_ERROR OTAImageProcessorImpl::ConfirmCurrentImage()


### PR DESCRIPTION
#### Problem
1. OTA Requestor may not emit the shutdown event before rebooting to apply a new image.
2. OTA Requetsor may not send NotifyUpdateApplied request.

#### Change overview
1. Increase the default sleep time between emitting the shutdown event and rebooting the device to apply a new image. That is to increase chances of delivering the event to subscribers.
2. Do not auto-confirm a new image using the DFUoverSMP module when OTA Requestor is enabled. In such a case, it is the OTA Requestor's job to confirm the image and notify OTA Provider that it has just happened.
3. Limit UPGRADE_ONLY mode to nRF53 (it was mistakenly enabled for all Nordic boards)
4. Change OTAImageProcessorImpl::IsFirstImageRun impl to make it work even if UPGRADE_ONLY mode is enabled.

#### Testing
Verified both functionalities using nRF Connect Lock.
