### PR TITLE
[Mbed] Update Mbed platform implementation

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -74,3 +74,6 @@ RUN chown -R $USERNAME:$USERNAME /opt/ameba/ambd_sdk_with_chip_non_NDA/
 RUN chown -R $USERNAME:$USERNAME /opt/sdk/sdks/
 
 RUN chown -R $USERNAME:$USERNAME /opt/fsl-imx-xwayland/5.10-hardknott/
+
+# Add access to openocd for VSCode debugging
+RUN chown -R $USERNAME:$USERNAME /opt/openocd

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -97,8 +97,8 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
-            "openocdPath": "${env:OPENOCD_PATH/bin}",
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
+            "serverpath": "${env:OPENOCD_PATH}/bin/openocd",
             "servertype": "openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
@@ -130,7 +130,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
@@ -157,8 +157,8 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
-            "openocdPath": "${env:OPENOCD_PATH/bin}",
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
+            "serverpath": "${env:OPENOCD_PATH}/bin/openocd",
             "servertype": "openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
@@ -182,7 +182,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/${input:mbedApp}/mbed",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-${input:mbedApp}-example.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
@@ -200,9 +200,9 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/mbed/unit_tests",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-unit-tests.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
             "servertype": "openocd",
-            "openocdPath": "${env:OPENOCD_PATH/bin}",
+            "serverpath": "${env:OPENOCD_PATH}/bin/openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
                 "${env:OPENOCD_PATH}/scripts"
@@ -233,7 +233,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/mbed/unit_tests",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-unit-tests.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
@@ -260,9 +260,9 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/mbed//unit_tests",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-unit-tests.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
             "servertype": "openocd",
-            "openocdPath": "${env:OPENOCD_PATH/bin}",
+            "serverpath": "${env:OPENOCD_PATH}/bin/openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
                 "${env:OPENOCD_PATH/scripts}"
@@ -285,7 +285,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/src/test_driver/mbed/unit_tests",
             "executable": "./build-${input:mbedTarget}/${input:mbedFlashProfile}/chip-mbed-unit-tests.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [
@@ -303,9 +303,9 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/platform/mbed/bootloader",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-bootloader.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
             "servertype": "openocd",
-            "openocdPath": "${env:OPENOCD_PATH/bin}",
+            "serverpath": "${env:OPENOCD_PATH}/bin/openocd",
             "searchDir": [
                 "${workspaceRoot}/config/mbed/scripts",
                 "${env:OPENOCD_PATH}/scripts"
@@ -336,7 +336,7 @@
             "request": "launch",
             "cwd": "${workspaceRoot}/examples/platform/mbed/bootloader",
             "executable": "./build-${input:mbedTarget}/${input:mbedDebugProfile}/chip-mbed-bootloader.elf",
-            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/pigweed/bin/", // Pigweed environment bootstraping required
+            "armToolchainPath": "${env:PW_ENVIRONMENT_ROOT}/cipd/packages/arm/bin/", // Pigweed environment bootstraping required
             "servertype": "external",
             "gdbTarget": "host.docker.internal:3334", //port 3333 for the CM0+, 3334 for the CM4
             "overrideLaunchCommands": [

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -51,7 +51,56 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
 
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
-    return CHIP_NO_ERROR;
+    CHIP_ERROR err;
+    uint32_t rebootCount;
+
+    if (MbedConfig::ConfigValueExists(MbedConfig::kCounterKey_RebootCount))
+    {
+        err = GetRebootCount(rebootCount);
+        SuccessOrExit(err);
+
+        err = StoreRebootCount(rebootCount + 1);
+        SuccessOrExit(err);
+    }
+    else
+    {
+        // The first boot after factory reset of the Node.
+        err = StoreRebootCount(1);
+        SuccessOrExit(err);
+    }
+
+    if (!MbedConfig::ConfigValueExists(MbedConfig::kCounterKey_TotalOperationalHours))
+    {
+        err = StoreTotalOperationalHours(0);
+        SuccessOrExit(err);
+    }
+
+    // Initialize the generic implementation base class.
+    err = Internal::GenericConfigurationManagerImpl<MbedConfig>::Init();
+    SuccessOrExit(err);
+
+exit:
+    return err;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
+{
+    return ReadConfigValue(MbedConfig::kCounterKey_RebootCount, rebootCount);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
+{
+    return WriteConfigValue(MbedConfig::kCounterKey_RebootCount, rebootCount);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
+{
+    return ReadConfigValue(MbedConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
+{
+    return WriteConfigValue(MbedConfig::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)

--- a/src/platform/mbed/ConfigurationManagerImpl.h
+++ b/src/platform/mbed/ConfigurationManagerImpl.h
@@ -39,6 +39,11 @@ public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 
+    CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
+    CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
+    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
+
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 

--- a/src/platform/mbed/ConnectivityManagerImpl.h
+++ b/src/platform/mbed/ConnectivityManagerImpl.h
@@ -79,6 +79,8 @@ private:
     CHIP_ERROR InitWiFi(void);
     void OnWiFiPlatformEvent(const ChipDeviceEvent * event);
 
+    void ChangeWiFiStationState(WiFiStationState newState);
+
     WiFiStationMode _GetWiFiStationMode();
     CHIP_ERROR _SetWiFiStationMode(WiFiStationMode val);
     bool _IsWiFiStationEnabled();

--- a/src/platform/mbed/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/mbed/KeyValueStoreManagerImpl.cpp
@@ -43,6 +43,13 @@ public:
     {
         auto ret = snprintf(buffer, sizeof(buffer), "%s%s", prefix, key);
         valid    = (ret > 0) && ((size_t) ret <= (sizeof(buffer) - 1));
+        // Key must not include '*' '/' '?' ':' ';' '\' '"' '|' ' ' '<' '>' '\'.
+        // It's replaced by '-'
+        char * ptr = buffer + strlen(prefix);
+        while ((ptr = strpbrk(ptr, " */?:;\"|<>\\")) != NULL)
+        {
+            *ptr = '-';
+        }
     }
 
     const char * str() const { return valid ? buffer : nullptr; }

--- a/src/platform/mbed/MbedConfig.cpp
+++ b/src/platform/mbed/MbedConfig.cpp
@@ -55,6 +55,7 @@ namespace Internal {
 
 #define FACTORY_KEY(key) CHIP_CONFIG_KV_STORE_PARTITION CHIP_CONFIG_FACTORY_PREFIX key
 #define CONFIG_KEY(key) CHIP_CONFIG_KV_STORE_PARTITION CHIP_CONFIG_CONFIG_PREFIX key
+#define COUNTER_KEY(key) CHIP_CONFIG_KV_STORE_PARTITION CHIP_CONFIG_COUNTER_PREFIX key
 
 const char MbedConfig::kConfigNamespace_ChipFactory[]  = CHIP_CONFIG_KV_STORE_PARTITION CHIP_CONFIG_FACTORY_PREFIX;
 const char MbedConfig::kConfigNamespace_ChipConfig[]   = CHIP_CONFIG_KV_STORE_PARTITION CHIP_CONFIG_CONFIG_PREFIX;
@@ -84,6 +85,11 @@ const MbedConfig::Key MbedConfig::kConfigKey_WiFiStationSecType = { CONFIG_KEY("
 const MbedConfig::Key MbedConfig::kConfigKey_RegulatoryLocation = { CONFIG_KEY("regulatory-location") };
 const MbedConfig::Key MbedConfig::kConfigKey_CountryCode        = { CONFIG_KEY("country-code") };
 const MbedConfig::Key MbedConfig::kConfigKey_UniqueId           = { CONFIG_KEY("unique-id") };
+
+// Keys stored in the Chip-counters namespace
+const MbedConfig::Key MbedConfig::kCounterKey_RebootCount           = { COUNTER_KEY("reboot-count") };
+const MbedConfig::Key MbedConfig::kCounterKey_UpTime                = { COUNTER_KEY("up-time") };
+const MbedConfig::Key MbedConfig::kCounterKey_TotalOperationalHours = { COUNTER_KEY("total-hours") };
 
 CHIP_ERROR MbedConfig::ReadConfigValue(Key key, bool & val)
 {

--- a/src/platform/mbed/MbedConfig.h
+++ b/src/platform/mbed/MbedConfig.h
@@ -73,6 +73,11 @@ public:
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
 
+    // CHIP Counter keys
+    static const Key kCounterKey_RebootCount;
+    static const Key kCounterKey_UpTime;
+    static const Key kCounterKey_TotalOperationalHours;
+
     // Config value accessors.
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);

--- a/src/platform/mbed/NetworkCommissioningDriver.h
+++ b/src/platform/mbed/NetworkCommissioningDriver.h
@@ -114,6 +114,11 @@ public:
                               uint8_t & outNetworkIndex) override;
     void ScanNetworks(ByteSpan ssid, ScanCallback * callback) override;
 
+    CHIP_ERROR SetLastDisconnectReason(const ChipDeviceEvent * event);
+    int32_t GetLastDisconnectReason();
+
+    void OnNetworkStatusChange();
+
     static WiFiDriverImpl & GetInstance()
     {
         static WiFiDriverImpl instance;
@@ -150,6 +155,9 @@ private:
     nsapi_security_t mSecurityType = NSAPI_SECURITY_NONE;
     Inet::IPAddress mIp4Address    = Inet::IPAddress::Any;
     Inet::IPAddress mIp6Address    = Inet::IPAddress::Any;
+
+    NetworkStatusChangeCallback * mStatusChangeCallback = nullptr;
+    int32_t mLastDisconnectedReason;
 };
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 } // namespace NetworkCommissioning


### PR DESCRIPTION
#### Problem
Update the Mbed platform port to be compatible with the new version of the CHIP stack implementation

#### Change overview

- Fix Mbed examples debugging issue

Add user access to openocd in VSCode Docker file
Update the arm toolchain path in launch.json
Update path to server setting name and set the correct value
for cortex-debug extension in launch.json

- Autonomous connection status for network commissioning

Add NetworkStatusChangeCallback service in the network
commissioning driver
Add last disconnect reason with getter and setter
Implement OnNetworkStatusChange function

 - Fix key-value builder issue

Key value must not include some specific characters in Mbed
They will be replaced by '-' sign

- Update configuration manager implementation

Add reboot count, uptime, and total operational hours keys
Implement get/set reboot count functions
Implement get/set reboot total operational hours
Improve init function - add generic class initalization

#### Testing
Build and run mbed examples
