### PR TITLE
Do not die if failing to parse an ip address (IPV4 addresses will fai…

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -157,7 +157,12 @@ void PlatformManagerImpl::WiFIIPChangeListener()
                         event.Type                            = DeviceEventType::kInternetConnectivityChange;
                         event.InternetConnectivityChange.IPv4 = kConnectivity_Established;
                         event.InternetConnectivityChange.IPv6 = kConnectivity_NoChange;
-                        VerifyOrDie(chip::Inet::IPAddress::FromString(ipStrBuf, event.InternetConnectivityChange.ipAddress));
+
+                        if (!chip::Inet::IPAddress::FromString(ipStrBuf, event.InternetConnectivityChange.ipAddress))
+                        {
+                            ChipLogDetail(DeviceLayer, "Failed to report IP address - ip address parsing failed");
+                            continue;
+                        }
 
                         CHIP_ERROR status = PlatformMgr().PostEvent(&event);
                         if (status != CHIP_NO_ERROR)


### PR DESCRIPTION
…l to parse in an IPv6 environment)

#### Problem
Crash in chip-tool in ipv6-only mode:

```
[1652968648.059632][3368227:3368231] CHIP:SPT: VerifyOrDie failure at ../../examples/chip-tool/third_party/connectedhomeip/src/platform/Linux/PlatformManagerImpl.cpp:160: chip::Inet::IPAddress::FromString(ipStrBuf, event.InternetConnectivityChange.ipAddress)
```

#### Change overview
Not being able to parse an ip address is not crash worty. Just skip reporting that address.

#### Testing
Compile and ran chip-tool manually.