### PR TITLE
Fix YAML for OTA transfer test.

### DIFF
--- a/src/app/tests/suites/OTA_SuccessfulTransfer.yaml
+++ b/src/app/tests/suites/OTA_SuccessfulTransfer.yaml
@@ -116,8 +116,8 @@ tests:
                       Privilege: 3,
                       AuthMode: 2,
                       Subjects: null,
-                      Targets: null,
-                      [{ Cluster: 41, Endpoint: null, DeviceType: null }],
+                      Targets:
+                          [{ Cluster: 41, Endpoint: null, DeviceType: null }],
                   },
               ]
 

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -21886,7 +21886,21 @@ private:
                 listHolder_0->mList[1].privilege = static_cast<chip::app::Clusters::AccessControl::Privilege>(3);
                 listHolder_0->mList[1].authMode  = static_cast<chip::app::Clusters::AccessControl::AuthMode>(2);
                 listHolder_0->mList[1].subjects.SetNull();
-                listHolder_0->mList[1].targets.SetNull();
+                listHolder_0->mList[1].targets.SetNonNull();
+
+                {
+                    auto * listHolder_3 = new ListHolder<chip::app::Clusters::AccessControl::Structs::Target::Type>(1);
+                    listFreer.add(listHolder_3);
+
+                    listHolder_3->mList[0].cluster.SetNonNull();
+                    listHolder_3->mList[0].cluster.Value() = 41UL;
+                    listHolder_3->mList[0].endpoint.SetNull();
+                    listHolder_3->mList[0].deviceType.SetNull();
+
+                    listHolder_0->mList[1].targets.Value() =
+                        chip::app::DataModel::List<chip::app::Clusters::AccessControl::Structs::Target::Type>(listHolder_3->mList,
+                                                                                                              1);
+                }
                 listHolder_0->mList[1].fabricIndex = 1;
 
                 value = chip::app::DataModel::List<chip::app::Clusters::AccessControl::Structs::AccessControlEntry::Type>(


### PR DESCRIPTION
Due to a typo the ACLs were not being set right.

This also led to warnings like this:

    AMLWarning: Keys with collection values will be stringified as YAML due to JS Object restrictions. Use mapAsMap: true to avoid this.

#### Problem
See above.

#### Change overview
Fix the YAML.

#### Testing
Ensured generated code now makes sense.