### PR TITLE
Fix EFR lock app

### DIFF
--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -235,7 +235,6 @@ CHIP_ERROR AppTask::Init()
     chip::EndpointId endpointId{ 1 };
     chip::DeviceLayer::PlatformMgr().LockChipStack();
     chip::app::Clusters::DoorLock::Attributes::LockState::Get(endpointId, state);
-    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     uint8_t maxCredentialsPerUser = 0;
     if (!DoorLockServer::Instance().GetNumberOfCredentialsSupportedPerUser(endpointId, maxCredentialsPerUser))
@@ -246,6 +245,7 @@ CHIP_ERROR AppTask::Init()
                      endpointId);
         maxCredentialsPerUser = 5;
     }
+    chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
     err = LockMgr().Init(state, maxCredentialsPerUser);
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
#### Problem
The EFR lock app now crashes, the logs indicate this is from a chip stack lock issue:

```
20220519 11:41:41  DBG  CHIP  [DL]   Start BLE advertissement
20220519 11:41:41  INF  APP          Current Software Version: 0.1ALPHA
20220519 11:41:41  DBG  CHIP  [DMG]  Endpoint 0, Cluster 0x0000_002A update version to 9e7ffbf5
20220519 11:41:41  INF  CHIP  [ZCL]  Cluster callback: 0x0000_002A
20220519 11:41:41  DBG  CHIP  [DMG]  Endpoint 0, Cluster 0x0000_002A update version to 9e7ffbf6
20220519 11:41:41  INF  CHIP  [ZCL]  Cluster callback: 0x0000_002A
20220519 11:41:41  INF  CHIP  [DL]   _OnPlatformEvent default:  event->Type = 32780
20220519 11:41:41  DBG  CHIP  [DL]   OpenThread State Changed (Flags: 0x00038200)
20220519 11:41:41  DBG  CHIP  [DL]      Network Name: OpenThread
20220519 11:41:41  DBG  CHIP  [DL]      PAN Id: 0xFFFF
20220519 11:41:41  DBG  CHIP  [DL]      Extended PAN Id: 0xDEAD00BEEF00CAFE
20220519 11:41:41  DBG  CHIP  [DL]      Channel: 11
20220519 11:41:41  DBG  CHIP  [DL]      Mesh Prefix: fdde:ad00:beef:0:0:0:0:0/64
20220519 11:41:41  ERR  CHIP  [DL]   Chip stack locking error at '../../examples/lock-app/efr32/third_party/connectedhomeip/src/app/util/attribute-stor
20220519 11:41:41  INF               age.cpp:549'. Code is unsafe/racy
20220519 11:41:41  ERR  CHIP  [-]    chipDie chipDie chipDie
```
Bisect indicates it was introduced from: #18280

#### Change overview
Lock chip stack for 'GetNumberOfCredentialsSupportedPerUser' at init.

#### Testing
Efr32mg12 lock example now boots. 

