### PR TITLE
Mark all ancestor parts lists dirty when an endpoint's enabled state changes.

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -953,8 +953,19 @@ bool emberAfEndpointEnableDisable(EndpointId endpoint, bool enable)
             }
         }
 
-        // TODO: Once endpoints are in parts lists other than that of endpoint
-        // 0, something more complicated might need to happen here.
+        EndpointId parentEndpointId = emberAfParentEndpointFromIndex(index);
+        while (parentEndpointId != kInvalidEndpointId)
+        {
+            MatterReportingAttributeChangeCallback(parentEndpointId, app::Clusters::Descriptor::Id,
+                                                   app::Clusters::Descriptor::Attributes::PartsList::Id);
+            uint16_t parentIndex = emberAfIndexFromEndpoint(parentEndpointId);
+            if (parentIndex == kEmberInvalidEndpointIndex)
+            {
+                // Something has gone wrong.
+                break;
+            }
+            parentEndpointId = emberAfParentEndpointFromIndex(parentIndex);
+        }
 
         MatterReportingAttributeChangeCallback(/* endpoint = */ 0, app::Clusters::Descriptor::Id,
                                                app::Clusters::Descriptor::Attributes::PartsList::Id);


### PR DESCRIPTION
If an endpoint is present on a parts list other than that of endpoint
0, we were not correctly marking that parts list dirty when the
endpoint was added/removed.

#### Problem
See above.

#### Change overview
Walk the parent chain, mark parts lists dirty.

#### Testing
Not sure how to test this easily so far.... Ideas very welcome.  @leorozendaal 