### PR TITLE
Revert using sl_bt_advertiser_set_random_address for MG24 family 

### DIFF
--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -743,10 +743,14 @@ CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
         ChipLogDetail(DeviceLayer, "Start BLE advertissement");
     }
 
+#ifndef EFR32MG24
+    // set_random_address causes issues in BLE driver later on with MG24 family.
+    // To be remove when updateing to GSDK4.0
     const uint8_t kResolvableRandomAddrType = 2; // Private resolvable random address type
     bd_addr unusedBdAddr;                        // We can ignore this field when setting random address.
     sl_bt_advertiser_set_random_address(advertising_set_handle, kResolvableRandomAddrType, unusedBdAddr, &unusedBdAddr);
     (void) unusedBdAddr;
+#endif
 
     err = ConfigureAdvertisingData();
     SuccessOrExit(err);


### PR DESCRIPTION
#### Problem
using sl_bt_advertiser_set_random_address for MG24 family cause intermittent problems with ble usage. 

#### Change overview
Revert the change I made in #18330 by adding back the `#ifndef`
Update to GSDK4.0 will be needed

#### Testing
Build efr32 lighting app on MG24. Complete commissioning multiple times.
