### PR TITLE
Fix guaranteed failure when resetting wifi/ethernet diagnostics counts.

### DIFF
--- a/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
+++ b/src/app/clusters/ethernet-network-diagnostics-server/ethernet-network-diagnostics-server.cpp
@@ -177,29 +177,9 @@ bool emberAfEthernetNetworkDiagnosticsClusterResetCountsCallback(app::CommandHan
                                                                  const app::ConcreteCommandPath & commandPath,
                                                                  const Commands::ResetCounts::DecodableType & commandData)
 {
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    DeviceLayer::GetDiagnosticDataProvider().ResetEthNetworkDiagnosticsCounts();
+    commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
 
-    VerifyOrExit(DeviceLayer::GetDiagnosticDataProvider().ResetEthNetworkDiagnosticsCounts() == CHIP_NO_ERROR,
-                 status = EMBER_ZCL_STATUS_FAILURE);
-
-    status = EthernetNetworkDiagnostics::Attributes::PacketRxCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketRxCount attribute"));
-
-    status = EthernetNetworkDiagnostics::Attributes::PacketTxCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketTxCount attribute"));
-
-    status = EthernetNetworkDiagnostics::Attributes::TxErrCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset TxErrCount attribute"));
-
-    status = EthernetNetworkDiagnostics::Attributes::CollisionCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset CollisionCount attribute"));
-
-    status = EthernetNetworkDiagnostics::Attributes::OverrunCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset OverrunCount attribute"));
-
-exit:
-    emberAfSendImmediateDefaultResponse(status);
     return true;
 }
 

--- a/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
+++ b/src/app/clusters/wifi-network-diagnostics-server/wifi-network-diagnostics-server.cpp
@@ -293,35 +293,8 @@ bool emberAfWiFiNetworkDiagnosticsClusterResetCountsCallback(app::CommandHandler
                                                              const app::ConcreteCommandPath & commandPath,
                                                              const Commands::ResetCounts::DecodableType & commandData)
 {
-    EndpointId endpoint  = commandPath.mEndpointId;
-    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
-
-    VerifyOrExit(DeviceLayer::GetDiagnosticDataProvider().ResetWiFiNetworkDiagnosticsCounts() == CHIP_NO_ERROR,
-                 status = EMBER_ZCL_STATUS_FAILURE);
-
-    status = WiFiNetworkDiagnostics::Attributes::BeaconLostCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset BeaconLostCount attribute"));
-
-    status = WiFiNetworkDiagnostics::Attributes::BeaconRxCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset BeaconRxCount attribute"));
-
-    status = WiFiNetworkDiagnostics::Attributes::PacketMulticastRxCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketMulticastRxCount attribute"));
-
-    status = WiFiNetworkDiagnostics::Attributes::PacketMulticastTxCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketMulticastTxCount attribute"));
-
-    status = WiFiNetworkDiagnostics::Attributes::PacketUnicastRxCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketUnicastRxCount attribute"));
-
-    status = WiFiNetworkDiagnostics::Attributes::PacketUnicastTxCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset PacketUnicastTxCount attribute"));
-
-    status = WiFiNetworkDiagnostics::Attributes::OverrunCount::Set(endpoint, 0);
-    VerifyOrExit(status == EMBER_ZCL_STATUS_SUCCESS, ChipLogError(Zcl, "Failed to reset OverrunCount attribute"));
-
-exit:
-    emberAfSendImmediateDefaultResponse(status);
+    DeviceLayer::GetDiagnosticDataProvider().ResetWiFiNetworkDiagnosticsCounts();
+    commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::Success);
 
     return true;
 }


### PR DESCRIPTION
We were trying to set attributes in the attribute store that are
forced to be internal, and that was guaranteed to fail.

Instead, just call the relevant reset function, which is expected to
always succeed (including for the "not implemented" case, where there
is nothing to reset).

Fixes https://github.com/project-chip/connectedhomeip/issues/18321

#### Problem
See above.

#### Change overview
See above.

#### Testing
Manually ran `chip-tool ethernetnetworkdiagnostics reset-counts node-id 0` and `chip-tool wifinetworkdiagnostics reset-counts node-id 0`