### PR TITLE
Android/tv-casting-app: Fixing commissioning and command delivery

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -99,6 +99,8 @@ JNI_METHOD(void, setDACProvider)(JNIEnv *, jobject, jobject provider)
 
 JNI_METHOD(jboolean, openBasicCommissioningWindow)(JNIEnv *, jobject, jint duration)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD openBasicCommissioningWindow called with duration %d", duration);
 
     CHIP_ERROR err = CastingServer::GetInstance()->OpenBasicCommissioningWindow();
@@ -151,16 +153,14 @@ JNI_METHOD(jboolean, initServer)(JNIEnv * env, jobject, jobject jCommissioningCo
 {
     ChipLogProgress(AppServer, "JNI_METHOD initServer called");
     CHIP_ERROR err = SetUpMatterCallbackHandler(env, jCommissioningCompleteHandler, gCommissioningCompleteHandler);
-    if (err == CHIP_NO_ERROR)
-    {
-        CastingServer::GetInstance()->InitServer(CommissioningCompleteHandler);
-        return true;
-    }
-    else
+    if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "initServer error: %s", err.AsString());
         return false;
     }
+
+    CastingServer::GetInstance()->InitServer(CommissioningCompleteHandler);
+    return true;
 }
 
 JNI_METHOD(void, contentLauncherLaunchURL)(JNIEnv * env, jobject, jstring contentUrl, jstring contentDisplayStr)

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -109,6 +109,10 @@ int main(int argc, char * argv[])
 {
     VerifyOrDie(CHIP_NO_ERROR == chip::Platform::MemoryInit());
     VerifyOrDie(CHIP_NO_ERROR == chip::DeviceLayer::PlatformMgr().InitChipStack());
+    // Enter commissioning mode, open commissioning window
+    static chip::CommonCaseDeviceServerInitParams initParams;
+    (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    VerifyOrDie(CHIP_NO_ERROR == chip::Server::GetInstance().Init(initParams));
 
 #if defined(ENABLE_CHIP_SHELL)
     Engine::Root().Init();

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -109,10 +109,6 @@ int main(int argc, char * argv[])
 {
     VerifyOrDie(CHIP_NO_ERROR == chip::Platform::MemoryInit());
     VerifyOrDie(CHIP_NO_ERROR == chip::DeviceLayer::PlatformMgr().InitChipStack());
-    // Enter commissioning mode, open commissioning window
-    static chip::CommonCaseDeviceServerInitParams initParams;
-    (void) initParams.InitializeStaticResourcesBeforeServerInit();
-    VerifyOrDie(CHIP_NO_ERROR == chip::Server::GetInstance().Init(initParams));
 
 #if defined(ENABLE_CHIP_SHELL)
     Engine::Root().Init();
@@ -138,6 +134,11 @@ int main(int argc, char * argv[])
         const chip::Credentials::AttestationTrustStore * testingRootStore = chip::Credentials::GetTestAttestationTrustStore();
         SetDeviceAttestationVerifier(GetDefaultDACVerifier(testingRootStore));
     }
+
+    // Enter commissioning mode, open commissioning window
+    static chip::CommonCaseDeviceServerInitParams initParams;
+    (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    VerifyOrDie(CHIP_NO_ERROR == chip::Server::GetInstance().Init(initParams));
 
     // Send discover commissioners request
     SuccessOrExit(err = CastingServer::GetInstance()->DiscoverCommissioners());

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -43,11 +43,6 @@ void CastingServer::InitServer(std::function<CHIP_ERROR()> commissioningComplete
 
     mCommissioningCompleteCallback = commissioningCompleteCallback;
 
-    // Enter commissioning mode, open commissioning window
-    static chip::CommonCaseDeviceServerInitParams initParams;
-    (void) initParams.InitializeStaticResourcesBeforeServerInit();
-    chip::Server::GetInstance().Init(initParams);
-
     // Initialize binding handlers
     ReturnOnFailure(InitBindingHandlers());
 


### PR DESCRIPTION
#### Problem
Android tv-casting-app failed to commission or send Content Launch commands

#### Change overview
Fixes that would skip starting the chip server a second time and would apply lock before calling the SDK's openBasicCommissioningWindow function

#### Testing
Built and tested by deploying the app to an Android phone and testing against a tv-app running on Raspberry Pi.