### PR TITLE
[OTA-R] TC-SU-2.3 OTA-R unable to start new CASE session with OTA-P

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -400,7 +400,9 @@ void DefaultOTARequestor::DisconnectFromProvider()
         return;
     }
 
-    mCASESessionManager->ReleaseSession(fabricInfo->GetPeerIdForNode(mProviderLocation.Value().providerNodeID));
+    PeerId peerID = fabricInfo->GetPeerIdForNode(mProviderLocation.Value().providerNodeID);
+    mCASESessionManager->FindExistingSession(peerID)->Disconnect();
+    mCASESessionManager->ReleaseSession(peerID);
 }
 
 // Requestor is directed to cancel image update in progress. All the Requestor state is


### PR DESCRIPTION
#### Problem

If OTA-P is restarted, OTA-R should time out its session and use a new session for subsequent requests.  OTA-R was still attempting to use the same session ID after timing out with OTA-P (due to OTA-P killed) and therefore subsequent requests to OTA-P when OTA-P is restarted fails.

Fixes: https://github.com/project-chip/connectedhomeip/issues/18484

#### Change overview

Add `OperationalDeviceProxy::Disconnect()` call in `DefaultOTARequestor::DisconnectFromProvider()` to evict the session that we have conclusive evidence for indicating a lack of response from the peer.

#### Testing

1. OTA-R makes a request to OTA-P (successful)
2. Kill OTA provider
3. OTA-R makes a request to OTA-P (unsuccessful)
4. OTA-R eventually times out and prints in the log: [SWU]CASE session may be invalid, tear down session. 
5. Restart OTA provider
7. OTA-R makes a request to OTA-P (successful)
