### PR TITLE
Prevent Reads/Subscription to attributes with no access privilege

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -26,6 +26,7 @@
 #pragma once
 
 #include <access/AccessControl.h>
+#include <access/SubjectDescriptor.h>
 #include <app/MessageDef/AttributeReportIBs.h>
 #include <app/MessageDef/ReportDataMessage.h>
 #include <lib/core/CHIPCore.h>
@@ -443,6 +444,22 @@ private:
      */
     bool EnsureResourceForSubscription(FabricIndex aFabricIndex, size_t aRequestedAttributePathCount,
                                        size_t aRequestedEventPathCount);
+
+    /**
+     * This parses the attribute path list to ensure it is well formed. If so, for each path in the list, it will expand to a list
+     * of concrete paths and walk each path to check if it has privileges to read that attribute.
+     *
+     * If there is AT LEAST one concrete path that has sufficient privilege, hasValidPath will be set to true. Otherwise, it will be
+     * set to false.
+     *
+     * requestedAttributePathCount will be updated to reflect the number of attribute paths in the request.
+     *
+     * @retval CHIP_NO_ERROR if no error is encountered.
+     *
+     */
+    CHIP_ERROR ParseAttributePaths(Access::SubjectDescriptor & subjectDescriptor,
+                                   AttributePathIBs::Parser & attributePathListParser, bool & hasValidPath,
+                                   size_t & requestedAttributePathCount);
 
     template <typename T, size_t N>
     void ReleasePool(ObjectList<T> *& aObjectList, ObjectPool<ObjectList<T>, N> & aObjectPool);

--- a/src/app/MessageDef/AttributePathIB.cpp
+++ b/src/app/MessageDef/AttributePathIB.cpp
@@ -228,6 +228,63 @@ CHIP_ERROR AttributePathIB::Parser::GetListIndex(ConcreteDataAttributePath & aAt
     return err;
 }
 
+CHIP_ERROR AttributePathIB::Parser::ParsePath(AttributePathParams & params) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = GetEndpoint(&(params.mEndpointId));
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!params.HasWildcardEndpointId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    err = GetCluster(&params.mClusterId);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(IsValidClusterId(params.mClusterId), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    err = GetAttribute(&params.mAttributeId);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(IsValidAttributeId(params.mAttributeId), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    // A wildcard cluster requires that the attribute path either be
+    // wildcard or a global attribute.
+    VerifyOrReturnError(!params.HasWildcardClusterId() || params.HasWildcardAttributeId() || IsGlobalAttribute(params.mAttributeId),
+                        CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    err = GetListIndex(&params.mListIndex);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!params.HasWildcardAttributeId() && !params.HasWildcardListIndex(),
+                            CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    return CHIP_NO_ERROR;
+}
+
 AttributePathIB::Builder & AttributePathIB::Builder::EnableTagCompression(const bool aEnableTagCompression)
 {
     // skip if error has already been set

--- a/src/app/MessageDef/AttributePathIB.h
+++ b/src/app/MessageDef/AttributePathIB.h
@@ -152,6 +152,14 @@ public:
     CHIP_ERROR GetListIndex(ConcreteDataAttributePath & aAttributePath) const;
 
     // TODO(#14934) Add a function to get ConcreteDataAttributePath from AttributePathIB::Parser directly.
+
+    /**
+     * @brief Parse the attribute path into an AttributePathParams object. As part of parsing,
+     * validity checks for each path item will be done as well.
+     *
+     * If any errors are encountered, an IM error of 'InvalidAction' will be returned.
+     */
+    CHIP_ERROR ParsePath(AttributePathParams & params) const;
 };
 
 class Builder : public ListBuilder

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -448,7 +448,7 @@ chip::ChipError::StorageType pychip_ReadClient_Read(void * appContext, ReadClien
             params.mMinIntervalFloorSeconds   = pyParams.minInterval;
             params.mMaxIntervalCeilingSeconds = pyParams.maxInterval;
             params.mKeepSubscriptions         = pyParams.keepSubscriptions;
-            params.mResubscribePolicy         = PythonResubscribePolicy;
+            params.mResubscribePolicy         = nullptr;
             attributePaths.release();
             eventPaths.release();
             err = readClient->SendAutoResubscribeRequest(std::move(params));


### PR DESCRIPTION
#### Problem

Reads and Subscribes from nodes with no access still get serviced to completion (which for subs mean that a subscription is established). This ends up stealing precious resources from nodes that do have access.

#18485.

### Fix

Prevents reads/subs from moving past the processing stage to actual allocation of resources. A StatusResponse is returned immediately.

Caveat: This doesn't address lack of access for event paths. That will come separately.

### Testing

Using two REPL instances, I was able to validate that a 2nd controller with no ACL privileges got successfully rejected for both reads/subscribes.

I then added an ACL grant to the 2nd controller to just a single cluster (Basic), and validated that wildcard reads/subscribes then got serviced correctly, but with returning just the narrow sliver of data.

I also validated that reading/subscribing to a different set of clusters than the Basic cluster did not get serviced.
