### PR TITLE
Fix for ineffectual assert

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -796,7 +796,7 @@ void InteractionModelEngine::RemoveReadClient(ReadClient * apReadClient)
         // Item must exist in this tracker list. If not, there's a bug somewhere.
         //
         VerifyOrDie(pCurListItem != nullptr);
-        
+
         pPrevListItem = pCurListItem;
         pCurListItem  = pCurListItem->GetNextClient();
     }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -792,14 +792,14 @@ void InteractionModelEngine::RemoveReadClient(ReadClient * apReadClient)
 
     while (pCurListItem != apReadClient)
     {
+        //
+        // Item must exist in this tracker list. If not, there's a bug somewhere.
+        //
+        VerifyOrDie(pCurListItem != nullptr);
+        
         pPrevListItem = pCurListItem;
         pCurListItem  = pCurListItem->GetNextClient();
     }
-
-    //
-    // Item must exist in this tracker list. If not, there's a bug somewhere.
-    //
-    VerifyOrDie(pCurListItem != nullptr);
 
     if (pPrevListItem)
     {


### PR DESCRIPTION
#### Problem
Minor fix for an assert that will never get hit.

#### Change overview
An assert was being used to detect an unexpected `nullptr` value, but it was never actually hit because the pointer was dereferenced before reaching the assert, resulting in a crash instead.

#### Testing
No testing. This is just a small logic bug.
