### PR TITLE
Remove some examples builds from .github/workflows/darwin.yaml since …

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -91,22 +91,10 @@ jobs:
             - name: Clean Build
               run: xcodebuild clean
               working-directory: src/darwin/Framework
-            - name: Build example chip-tool-darwin
-              timeout-minutes: 15
-              run: |
-                  scripts/examples/gn_build_example.sh examples/chip-tool-darwin out/debug chip_config_network_layer_ble=false is_asan=true
             - name: Build example All Clusters Server
               timeout-minutes: 15
               run: |
                   scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug chip_config_network_layer_ble=false
-            - name: Build example OTA Provider
-              timeout-minutes: 5
-              run: |
-                  scripts/examples/gn_build_example.sh examples/ota-provider-app/linux out/debug chip_config_network_layer_ble=false
-            - name: Build example OTA Requestor
-              timeout-minutes: 5
-              run: |
-                  scripts/examples/gn_build_example.sh examples/ota-requestor-app/linux out/debug chip_config_network_layer_ble=false
             - name: Delete Defaults
               run: defaults delete com.apple.dt.xctest.tool
               continue-on-error: true


### PR DESCRIPTION
…there are already built in other workflows

#### Problem

Those examples apps are already built in `.github/workflows/darwin-tests.yaml` and `.github/workflows/tests.yaml` so it just seems redundant and it should save something like 15 minutes of build time for this task.

#### Change overview
 * Remove some examples apps
