### PR TITLE
[WIP] Configure restyled to use clang-format-13.0.1 instead of clang-format…

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -125,7 +125,7 @@ restylers:
       interpreters: []
     - name: clang-format
       enabled: true
-      image: restyled/restyler-clang-format:v9.0.0
+      image: restyled/restyler-clang-format:v13.0.1
       command:
           - clang-format
           - "-i"


### PR DESCRIPTION
…-9.0.0

#### Problem

Per my understanding the CI is using clang-format-9 to format the files. This is highly impractical since this is an old version that is not available by default on some platforms. for my part I had to compile my own version of llvm to get it.

This is a WIP since I have just updated the version used by CI but have not done any changes.

#### Change overview
  * Update the version used by CI
