### PR TITLE
[Ameba] Save and use WIFI information in persistent storage for autoconnect

### DIFF
--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -3,7 +3,7 @@ FROM connectedhomeip/chip-build:${VERSION}
 
 # Setup Ameba
 ARG AMEBA_DIR=/opt/ameba
-ARG TAG_NAME=ameba_update_2022_05_10
+ARG TAG_NAME=ameba_update_2022_05_20
 RUN set -x \
     && apt-get update \
     && mkdir ${AMEBA_DIR} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.75 Version bump reason: Update curl version from 7.68.0-1ubuntu2.10 to 7.68.0-1ubuntu2.11
+0.5.76 Version bump reason: [Ameba] Save wifi information in persistent storage for autoconnect


### PR DESCRIPTION
#### Problem
The wifi information was not stored in persistent storage.
 
#### Change overview
* Update chip-build-ameba/Dockerfile
* Update version

#### Testing
Tested docker build