### PR TITLE
MdnsAvahi: do not fail when instance is reinited

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -328,7 +328,11 @@ CHIP_ERROR MdnsAvahi::Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncRetu
     CHIP_ERROR error = CHIP_NO_ERROR;
     int avahiError   = 0;
 
-    Shutdown();
+    if (Shutdown() != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Shutdown() failed, continue anyway...");
+    }
+
     VerifyOrExit(initCallback != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(errorCallback != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(mClient == nullptr && mGroup == nullptr, error = CHIP_ERROR_INCORRECT_STATE);

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -328,6 +328,7 @@ CHIP_ERROR MdnsAvahi::Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncRetu
     CHIP_ERROR error = CHIP_NO_ERROR;
     int avahiError   = 0;
 
+    Shutdown();
     VerifyOrExit(initCallback != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(errorCallback != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(mClient == nullptr && mGroup == nullptr, error = CHIP_ERROR_INCORRECT_STATE);


### PR DESCRIPTION
#### Problem
Seen with TE9 image in several configurations, chip-tool was exiting because MdnsAvahi::Init was called twice, making it impossible to use.

#### Change overview
Do not fail when instance is reinited, instead call Shutdown() first. If Init is only called once then the change is a no-op..

#### Testing
* tested extensively during TE9 on Raspi (Linux) platform using chip-tool and chip-ota-provider-app
* other platforms are not affected
* non MdnsAvahi builds are not affected
