### PR TITLE
Expose API to generate a CSR in the Darwin framework.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.mm
@@ -31,6 +31,7 @@ CHIP_ERROR CHIPP256KeypairBridge::Init(id<CHIPKeypair> keypair)
     if (![keypair respondsToSelector:@selector(ECDSA_sign_message_DER:)]
         && ![keypair respondsToSelector:@selector(ECDSA_sign_message_raw:)]) {
         // Not a valid CHIPKeypair implementation.
+        NSLog(@"Keypair does not support message signing");
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 

--- a/src/darwin/Framework/CHIP/MTRCertificates.h
+++ b/src/darwin/Framework/CHIP/MTRCertificates.h
@@ -111,6 +111,22 @@ NS_ASSUME_NONNULL_BEGIN
  */
 + (BOOL)isCertificate:(NSData *)certificate1 equalTo:(NSData *)certificate2;
 
+/**
+ * Generate a PKCS#10 certificate signing request from a CHIPKeypair.  This can
+ * then be used to request an operational or ICA certificate from an external
+ * certificate authority.
+ *
+ * The CSR will have the subject OU DN set to 'CSA', because omitting all
+ * identifying information altogether often trips up CSR parsing code.  The CA
+ * being used should expect this and ignore the request subject, producing a
+ * subject that matches the rules for Matter certificates.
+ *
+ * On failure returns nil and if "error" is not null sets *error to the relevant
+ * error.
+ */
++ (nullable NSData *)generateCertificateSigningRequest:(id<CHIPKeypair>)keypair
+                                                 error:(NSError * __autoreleasing _Nullable * _Nullable)error;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/MatterCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MatterCertificateTests.m
@@ -192,4 +192,15 @@
     XCTAssertNil(operationalCert);
 }
 
+- (void)testGenerateCSR
+{
+    __auto_type * testKeys = [[CHIPTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * csr = [MTRCertificates generateCertificateSigningRequest:testKeys error:nil];
+    XCTAssertNotNil(csr);
+
+    // Wish there was something we could test here about the CSR.
+}
+
 @end


### PR DESCRIPTION
There seem to be no OS-provided APIs for this on iOS, and a CSR is
needed to get a NOC issued by an external CA.

#### Problem
See above.

#### Change overview
Just expose the CryptoPAL function to generate a CSR.

#### Testing
Basic "I can call it and it does not fail" test included, and past that there's nothing here that is not exercised in other tests: our keypair bridge, plus converting a Span to NSData.  Plus the CryptoPAL CSR generator, which is assumed to work.