### PR TITLE
Clean up group invoke requests

### DIFF
--- a/src/controller/InvokeInteraction.h
+++ b/src/controller/InvokeInteraction.h
@@ -105,7 +105,6 @@ template <typename RequestObjectT>
 CHIP_ERROR InvokeGroupCommandRequest(Messaging::ExchangeManager * exchangeMgr, chip::FabricIndex fabric, chip::GroupId groupId,
                                      const RequestObjectT & requestCommandData)
 {
-    CHIP_ERROR error                   = CHIP_NO_ERROR;
     app::CommandPathParams commandPath = { groupId, RequestObjectT::GetClusterId(), RequestObjectT::GetCommandId(),
                                            app::CommandPathFlags::kGroupIdValid };
     Transport::OutgoingGroupSession session(groupId, fabric);
@@ -113,15 +112,9 @@ CHIP_ERROR InvokeGroupCommandRequest(Messaging::ExchangeManager * exchangeMgr, c
     auto commandSender = chip::Platform::MakeUnique<app::CommandSender>(nullptr, exchangeMgr);
     VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    error = commandSender->AddRequestData(commandPath, requestCommandData);
-    SuccessOrExit(error);
 
-    error = commandSender->SendGroupCommandRequest(SessionHandle(session));
-    SuccessOrExit(error);
-
-exit:
-    chip::Platform::Delete(commandSender.release());
-    return error;
+    ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, requestCommandData));
+    return commandSender->SendGroupCommandRequest(SessionHandle(session));
 }
 
 template <typename RequestObjectT>

--- a/src/controller/InvokeInteraction.h
+++ b/src/controller/InvokeInteraction.h
@@ -112,7 +112,6 @@ CHIP_ERROR InvokeGroupCommandRequest(Messaging::ExchangeManager * exchangeMgr, c
     auto commandSender = chip::Platform::MakeUnique<app::CommandSender>(nullptr, exchangeMgr);
     VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_NO_MEMORY);
 
-
     ReturnErrorOnFailure(commandSender->AddRequestData(commandPath, requestCommandData));
     return commandSender->SendGroupCommandRequest(SessionHandle(session));
 }


### PR DESCRIPTION
#### Problem
* function clean up was doing "tell the auto-ptr to forget the pointer just so we can manually delete it"

#### Change overview
* Simplify function and let the auto-ptr do the clean up

#### Testing
* automated tests to validate regression
