### PR TITLE
Check Value Returned by BN_bn2binpad()

### DIFF
--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -653,8 +653,9 @@ CHIP_ERROR P256Keypair::ECDSA_sign_hash(const uint8_t * hash, const size_t hash_
 
     // Concatenate r and s to output. Sizes were checked above.
     VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
-    BN_bn2binpad(r, out_signature.Bytes() + 0u, kP256_FE_Length);
-    BN_bn2binpad(s, out_signature.Bytes() + kP256_FE_Length, kP256_FE_Length);
+    VerifyOrExit(BN_bn2binpad(r, out_signature.Bytes() + 0u, kP256_FE_Length) == kP256_FE_Length, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(BN_bn2binpad(s, out_signature.Bytes() + kP256_FE_Length, kP256_FE_Length) == kP256_FE_Length,
+                 error = CHIP_ERROR_INTERNAL);
 
 exit:
     if (sig != nullptr)


### PR DESCRIPTION
#### Change overview
Need to check value returned by BN_bn2binpad() in the ECDSA_sign_hash() function.

#### Testing
existing tests