### PR TITLE
Add documentation for the model command destination id.

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -26,24 +26,25 @@ using namespace ::chip;
 CHIP_ERROR ModelCommand::RunCommand()
 {
 
-    if (IsGroupId(mNodeId))
+    if (IsGroupId(mDestinationId))
     {
         FabricIndex fabricIndex;
         ReturnErrorOnFailure(CurrentCommissioner().GetFabricIndex(&fabricIndex));
-        ChipLogProgress(chipTool, "Sending command to group 0x%x", GroupIdFromNodeId(mNodeId));
+        ChipLogProgress(chipTool, "Sending command to group 0x%x", GroupIdFromNodeId(mDestinationId));
 
-        return SendGroupCommand(GroupIdFromNodeId(mNodeId), fabricIndex);
+        return SendGroupCommand(GroupIdFromNodeId(mDestinationId), fabricIndex);
     }
 
-    ChipLogProgress(chipTool, "Sending command to node 0x%" PRIx64, mNodeId);
+    ChipLogProgress(chipTool, "Sending command to node 0x%" PRIx64, mDestinationId);
 
     CommissioneeDeviceProxy * commissioneeDeviceProxy = nullptr;
-    if (CHIP_NO_ERROR == CurrentCommissioner().GetDeviceBeingCommissioned(mNodeId, &commissioneeDeviceProxy))
+    if (CHIP_NO_ERROR == CurrentCommissioner().GetDeviceBeingCommissioned(mDestinationId, &commissioneeDeviceProxy))
     {
         return SendCommand(commissioneeDeviceProxy, mEndPointId);
     }
 
-    return CurrentCommissioner().GetConnectedDevice(mNodeId, &mOnDeviceConnectedCallback, &mOnDeviceConnectionFailureCallback);
+    return CurrentCommissioner().GetConnectedDevice(mDestinationId, &mOnDeviceConnectedCallback,
+                                                    &mOnDeviceConnectionFailureCallback);
 }
 
 void ModelCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device)

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -32,7 +32,9 @@ public:
 
     void AddArguments()
     {
-        AddArgument("node-id/group-id", 0, UINT64_MAX, &mNodeId);
+        AddArgument(
+            "destination-id", 0, UINT64_MAX, &mDestinationId,
+            "64-bit node or group identifier.\n  Group identifiers are detected by being in the 0xFFFF'FFFF'FFFF'xxxx range.");
         AddArgument("endpoint-id-ignored-for-group-commands", 0, UINT16_MAX, &mEndPointId);
         AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
     }
@@ -51,7 +53,7 @@ protected:
     chip::Optional<uint16_t> mTimeout;
 
 private:
-    chip::NodeId mNodeId;
+    chip::NodeId mDestinationId;
     std::vector<chip::EndpointId> mEndPointId;
 
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);


### PR DESCRIPTION
Since the documentation explains what it is, rename from the unwieldy
"node-id/group-id" to "destination-id".

#### Problem
No docs.

#### Change overview
Add docs.

#### Testing
Ran a command without sufficient args, saw the help text.