### PR TITLE
Make the error-handling in OnReadInitialRequest clearer.

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -377,13 +377,12 @@ private:
 
     /**
      * Called when Interaction Model receives a Read Request message.  Errors processing
-     * the Read Request are handled entirely within this function. The caller pre-sets status to failure and the callee is
-     * expected to set it to success if it does not want an automatic status response message to be sent.
+     * the Read Request are handled entirely within this function.  If the
+     * status returned is not Status::Success, the caller will send a status
+     * response message with that status.
      */
-
-    CHIP_ERROR OnReadInitialRequest(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
-                                    System::PacketBufferHandle && aPayload, ReadHandler::InteractionType aInteractionType,
-                                    Protocols::InteractionModel::Status & aStatus);
+    Status OnReadInitialRequest(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
+                                System::PacketBufferHandle && aPayload, ReadHandler::InteractionType aInteractionType);
 
     /**
      * Called when Interaction Model receives a Write Request message.  Errors processing


### PR DESCRIPTION
Instead of having both a status outparam and an error return, just use a status return.

Also fixes some bugs where we were not checking the results of some
TLV parsing operations, and not converting some TVL parsing failures
to the right status.

Fixes https://github.com/project-chip/connectedhomeip/issues/11724

Fixes https://github.com/project-chip/connectedhomeip/issues/17623

#### Problem
Confusing error handling, missing error checks.

#### Change overview
Fix that.

#### Testing
Just makes sure that we can't forget to set our status.