### PR TITLE
Make errorToCHIPErrorCode safer to use.

### DIFF
--- a/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.h
+++ b/examples/chip-tool-darwin/commands/common/CHIPCommandBridge.h
@@ -44,15 +44,7 @@ public:
 
     void SetCommandExitStatus(CHIP_ERROR status)
     {
-#if CHIP_CONFIG_ERROR_SOURCE
-        // If there is a filename in the status makes a copy of the filename as the pointer may be released
-        // when the autorelease pool is drained.
-        strncpy(mCommandExitStatusFilename, status.GetFile(), sizeof(mCommandExitStatusFilename));
-        mCommandExitStatusFilename[sizeof(mCommandExitStatusFilename) - 1] = '\0';
-        mCommandExitStatus = chip::ChipError(status.AsInteger(), mCommandExitStatusFilename, status.GetLine());
-#else
         mCommandExitStatus = status;
-#endif // CHIP_CONFIG_ERROR_SOURCE
         ShutdownCommissioner();
         StopWaiting();
     }
@@ -90,9 +82,6 @@ private:
     CHIP_ERROR ShutdownCommissioner();
     uint16_t CurrentCommissionerIndex();
 
-#if CHIP_CONFIG_ERROR_SOURCE
-    char mCommandExitStatusFilename[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
-#endif // CHIP_CONFIG_ERROR_SOURCE
     CHIP_ERROR mCommandExitStatus = CHIP_ERROR_INTERNAL;
 
     CHIP_ERROR StartWaiting(chip::System::Clock::Timeout seconds);


### PR DESCRIPTION
The old setup was creating CHIP_ERROR instances pointing to filenames
with non-static lifetime, which could cause use-after-free.

Removes the workaround chip-tool-darwin had for the broken behavior.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Tried some things that should hit this codepath, and seem to be getting sane error filenames/linenumbers.