### PR TITLE
Fail unit tests that leave messages sitting around undrained.

### DIFF
--- a/src/app/tests/TestReportingEngine.cpp
+++ b/src/app/tests/TestReportingEngine.cpp
@@ -158,6 +158,9 @@ void TestReportingEngine::TestBuildAndSendSingleReportData(nlTestSuite * apSuite
     app::ReadHandler readHandler(dummy, exchangeCtx, chip::app::ReadHandler::InteractionType::Read);
     readHandler.OnInitialRequest(std::move(readRequestbuf));
     err = InteractionModelEngine::GetInstance()->GetReportingEngine().BuildAndSendSingleReportData(&readHandler);
+
+    ctx.DrainAndServiceIO();
+
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 }
 

--- a/src/transport/raw/tests/NetworkTestHelpers.h
+++ b/src/transport/raw/tests/NetworkTestHelpers.h
@@ -74,10 +74,9 @@ public:
     void InitLoopbackTransport(System::Layer * systemLayer) { mSystemLayer = systemLayer; }
     void ShutdownLoopbackTransport()
     {
-        // TODO: remove these after #17624 (Ensure tests drain all message in loopback transport) being fixed
-        // Packets are allocated from platform memory, we should release them before Platform::MemoryShutdown
-        while (!mPendingMessageQueue.empty())
-            mPendingMessageQueue.pop();
+        // Make sure no one left packets hanging out that they thought got
+        // delivered but actually didn't.
+        VerifyOrDie(mPendingMessageQueue.empty());
     }
 
     /// Transports are required to have a constructor that takes exactly one argument


### PR DESCRIPTION
Tests might be accidentally forgetting to drain their messages, and
hence think messages got delivered when they did not.  Fail the tests
if that happens.

Fixes https://github.com/project-chip/connectedhomeip/issues/17624

#### Problem
See above.

#### Change overview
See above.

#### Testing
Unit tests still pass.