### PR TITLE
TV Example: add dummy data for test cases

### DIFF
--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -37,6 +37,22 @@ void AppContentLauncherManager::HandleLaunchContent(CommandResponseHelper<Launch
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleLaunchContent for endpoint %d", mEndpointId);
     string dataString(data.data(), data.size());
 
+    ChipLogProgress(Zcl, " AutoPlay=%s", (autoplay ? "true" : "false"));
+
+    bool foundMatch = false;
+    auto iter       = parameterList.begin();
+    while (iter.Next())
+    {
+        auto & parameterType = iter.GetValue();
+        ChipLogProgress(Zcl, " TEST CASE found match=Example TV Show type=%d", static_cast<uint16_t>(parameterType.type));
+        foundMatch = true;
+    }
+
+    if (!foundMatch)
+    {
+        ChipLogProgress(Zcl, " TEST CASE did not find a match");
+    }
+
     LaunchResponseType response;
     // TODO: Insert code here
     response.data   = chip::MakeOptional(CharSpan::fromCharString("exampleData"));

--- a/examples/tv-app/android/java/src/com/tcl/chip/tvapp/ContentLaunchManagerStub.java
+++ b/examples/tv-app/android/java/src/com/tcl/chip/tvapp/ContentLaunchManagerStub.java
@@ -33,6 +33,12 @@ public class ContentLaunchManagerStub implements ContentLaunchManager {
       ContentLaunchSearchParameter[] search, boolean autoplay, String data) {
     Log.d(TAG, "launchContent:" + data + " autoplay=" + autoplay + " at " + endpoint);
 
+    if (search != null && search.length > 0) {
+      Log.d(TAG, " TEST CASE found match=Example TV Show");
+    } else {
+      Log.d(TAG, " TEST CASE did not find a match");
+    }
+
     if ("err".equals(data)) {
       return new ContentLaunchResponse(
           ContentLaunchResponse.STATUS_URL_NOT_AVAILABLE, "Error data in Java");
@@ -43,7 +49,8 @@ public class ContentLaunchManagerStub implements ContentLaunchManager {
   @Override
   public ContentLaunchResponse launchUrl(
       String url, String display, ContentLaunchBrandingInformation branding) {
-    Log.d(TAG, "launchUrl:" + url + " display=" + display + " at " + endpoint);
+    Log.d(TAG, "launchUrl:" + url + " display=" + display + " branding.providerName=" 
+      + (branding == null ? "NULL" : branding.providerName)+ " at " + endpoint);
 
     if ("err".equals(display)) {
       return new ContentLaunchResponse(

--- a/examples/tv-app/android/java/src/com/tcl/chip/tvapp/ContentLaunchManagerStub.java
+++ b/examples/tv-app/android/java/src/com/tcl/chip/tvapp/ContentLaunchManagerStub.java
@@ -49,8 +49,16 @@ public class ContentLaunchManagerStub implements ContentLaunchManager {
   @Override
   public ContentLaunchResponse launchUrl(
       String url, String display, ContentLaunchBrandingInformation branding) {
-    Log.d(TAG, "launchUrl:" + url + " display=" + display + " branding.providerName=" 
-      + (branding == null ? "NULL" : branding.providerName)+ " at " + endpoint);
+    Log.d(
+        TAG,
+        "launchUrl:"
+            + url
+            + " display="
+            + display
+            + " branding.providerName="
+            + (branding == null ? "NULL" : branding.providerName)
+            + " at "
+            + endpoint);
 
     if ("err".equals(display)) {
       return new ContentLaunchResponse(

--- a/examples/tv-app/android/java/src/com/tcl/chip/tvapp/MediaInputManagerStub.java
+++ b/examples/tv-app/android/java/src/com/tcl/chip/tvapp/MediaInputManagerStub.java
@@ -72,9 +72,18 @@ public class MediaInputManagerStub implements MediaInputManager {
   public boolean showInputStatus() {
     Log.d(TAG, "showInputStatus at " + endpoint);
     for (MediaInputInfo mii : info) {
-      Log.d(TAG, " ["+mii.index+"] type="+mii.type+" selected="+(currentInput == mii.index ? 1 : 0)
-        +" name="+(mii.name == null ? "null" : mii.name)
-        +" desc="+(mii.description == null ? "null" : mii.description));
+      Log.d(
+          TAG,
+          " ["
+              + mii.index
+              + "] type="
+              + mii.type
+              + " selected="
+              + (currentInput == mii.index ? 1 : 0)
+              + " name="
+              + (mii.name == null ? "null" : mii.name)
+              + " desc="
+              + (mii.description == null ? "null" : mii.description));
     }
     return true;
   }

--- a/examples/tv-app/android/java/src/com/tcl/chip/tvapp/MediaInputManagerStub.java
+++ b/examples/tv-app/android/java/src/com/tcl/chip/tvapp/MediaInputManagerStub.java
@@ -24,14 +24,12 @@ public class MediaInputManagerStub implements MediaInputManager {
   private final String TAG = MediaInputManagerStub.class.getSimpleName();
 
   private int endpoint;
+  private MediaInputInfo[] info = new MediaInputInfo[3];
+  private int currentInput = 1;
 
   public MediaInputManagerStub(int endpoint) {
     this.endpoint = endpoint;
-  }
 
-  @Override
-  public MediaInputInfo[] getInputList() {
-    MediaInputInfo[] info = new MediaInputInfo[3];
     info[0] = new MediaInputInfo();
     info[0].name = "HDMI 1";
     info[0].description = "Living room Playstation";
@@ -47,25 +45,37 @@ public class MediaInputManagerStub implements MediaInputManager {
     info[2] = new MediaInputInfo();
     info[2].index = 2;
     info[2].type = MediaInputInfo.INPUT_TYPE_HDMI;
+  }
 
+  @Override
+  public MediaInputInfo[] getInputList() {
     return info;
   }
 
   @Override
   public int getCurrentInput() {
     Log.d(TAG, "getCurrentInput at " + endpoint);
-    return 1;
+    return currentInput;
   }
 
   @Override
   public boolean selectInput(int index) {
     Log.d(TAG, "selectInput:" + index + " at " + endpoint);
+    if (index < 0 || index >= info.length) {
+      return false;
+    }
+    currentInput = index;
     return true;
   }
 
   @Override
   public boolean showInputStatus() {
     Log.d(TAG, "showInputStatus at " + endpoint);
+    for (MediaInputInfo mii : info) {
+      Log.d(TAG, " ["+mii.index+"] type="+mii.type+" selected="+(currentInput == mii.index ? 1 : 0)
+        +" name="+(mii.name == null ? "null" : mii.name)
+        +" desc="+(mii.description == null ? "null" : mii.description));
+    }
     return true;
   }
 
@@ -78,6 +88,10 @@ public class MediaInputManagerStub implements MediaInputManager {
   @Override
   public boolean renameInput(int index, String name) {
     Log.d(TAG, "renameInput index:" + index + " name:" + name + " at " + endpoint);
+    if (index < 0 || index >= info.length) {
+      return false;
+    }
+    info[index].name = name;
     return true;
   }
 }

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.cpp
@@ -28,6 +28,67 @@ ContentLauncherManager::ContentLauncherManager(list<std::string> acceptHeaderLis
 {
     mAcceptHeaderList            = acceptHeaderList;
     mSupportedStreamingProtocols = supportedStreamingProtocols;
+
+    // Add dummy content for test cases
+    ContentEntry entry1;
+    entry1.mName = "TV Show Example";
+    ParameterType parameter1;
+    parameter1.type  = ParameterEnum::kActor;
+    parameter1.value = chip::CharSpan::fromCharString("Gaby sHoffman");
+    ParameterType parameter2;
+    parameter2.type  = ParameterEnum::kChannel;
+    parameter2.value = chip::CharSpan::fromCharString("PBS");
+    ParameterType parameter3;
+    parameter3.type  = ParameterEnum::kCharacter;
+    parameter3.value = chip::CharSpan::fromCharString("Snow White");
+    ParameterType parameter4;
+    parameter4.type  = ParameterEnum::kDirector;
+    parameter4.value = chip::CharSpan::fromCharString("Spike Lee");
+    ParameterType parameter5;
+    parameter5.type  = ParameterEnum::kFranchise;
+    parameter5.value = chip::CharSpan::fromCharString("Star Wars");
+    ParameterType parameter6;
+    parameter6.type  = ParameterEnum::kGenre;
+    parameter6.value = chip::CharSpan::fromCharString("Horror");
+    ParameterType parameter7;
+    parameter7.type  = ParameterEnum::kPopularity;
+    parameter7.value = chip::CharSpan::fromCharString("Popularity");
+    ParameterType parameter8;
+    parameter8.type  = ParameterEnum::kProvider;
+    parameter8.value = chip::CharSpan::fromCharString("Netflix");
+    entry1.mSearchFields.push_back(parameter1);
+    entry1.mSearchFields.push_back(parameter2);
+    entry1.mSearchFields.push_back(parameter3);
+    entry1.mSearchFields.push_back(parameter4);
+    entry1.mSearchFields.push_back(parameter5);
+    entry1.mSearchFields.push_back(parameter6);
+    entry1.mSearchFields.push_back(parameter7);
+    entry1.mSearchFields.push_back(parameter8);
+    mContentList.push_back(entry1);
+
+    ContentEntry entry2;
+    entry2.mName = "Sports Example";
+    ParameterType parameter21;
+    parameter21.type  = ParameterEnum::kEvent;
+    parameter21.value = chip::CharSpan::fromCharString("Football games");
+    ParameterType parameter22;
+    parameter22.type  = ParameterEnum::kLeague;
+    parameter22.value = chip::CharSpan::fromCharString("NCAA");
+    ParameterType parameter23;
+    parameter23.type  = ParameterEnum::kSport;
+    parameter23.value = chip::CharSpan::fromCharString("football");
+    ParameterType parameter24;
+    parameter24.type  = ParameterEnum::kSportsTeam;
+    parameter24.value = chip::CharSpan::fromCharString("Arsenel");
+    ParameterType parameter25;
+    parameter25.type  = ParameterEnum::kType;
+    parameter25.value = chip::CharSpan::fromCharString("TVSeries");
+    entry2.mSearchFields.push_back(parameter21);
+    entry2.mSearchFields.push_back(parameter22);
+    entry2.mSearchFields.push_back(parameter23);
+    entry2.mSearchFields.push_back(parameter24);
+    entry2.mSearchFields.push_back(parameter25);
+    mContentList.push_back(entry2);
 }
 
 void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchResponseType> & helper,
@@ -36,6 +97,38 @@ void ContentLauncherManager::HandleLaunchContent(CommandResponseHelper<LaunchRes
 {
     ChipLogProgress(Zcl, "ContentLauncherManager::HandleLaunchContent for endpoint %d", mEndpointId);
     string dataString(data.data(), data.size());
+
+    ChipLogProgress(Zcl, "ContentLauncherManager::HandleLaunchUrl TEST CASE autoplay=%d data=%s ", (autoplay ? 1 : 0),
+                    dataString.c_str());
+
+    bool foundMatch = false;
+    for (auto const & contentEntry : this->mContentList)
+    {
+        auto iter = parameterList.begin();
+        while (iter.Next())
+        {
+            auto & parameterType = iter.GetValue();
+            for (auto const & parameter : contentEntry.mSearchFields)
+            {
+                if (parameter.type == parameterType.type)
+                {
+                    string val1(parameter.value.data(), parameter.value.size());
+                    string val2(parameterType.value.data(), parameterType.value.size());
+                    if (strcmp(val1.c_str(), val2.c_str()) == 0)
+                    {
+                        ChipLogProgress(Zcl, " TEST CASE found match=%s type=%d", contentEntry.mName.c_str(),
+                                        static_cast<uint16_t>(parameter.type));
+                        foundMatch = true;
+                    }
+                }
+            }
+        }
+    }
+
+    if (!foundMatch)
+    {
+        ChipLogProgress(Zcl, " TEST CASE did not find a match");
+    }
 
     LaunchResponseType response;
     // TODO: Insert code here

--- a/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.h
+++ b/examples/tv-app/linux/include/content-launcher/ContentLauncherManager.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <app/clusters/content-launch-server/content-launch-server.h>
+#include <vector>
 
 using chip::CharSpan;
 using chip::EndpointId;
@@ -28,6 +29,13 @@ using ContentLauncherDelegate = chip::app::Clusters::ContentLauncher::Delegate;
 using LaunchResponseType      = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type;
 using ParameterType           = chip::app::Clusters::ContentLauncher::Structs::Parameter::DecodableType;
 using BrandingInformationType = chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type;
+
+class ContentEntry
+{
+public:
+    std::string mName;
+    std::vector<ParameterType> mSearchFields;
+};
 
 class ContentLauncherManager : public ContentLauncherDelegate
 {
@@ -46,6 +54,7 @@ public:
 protected:
     std::list<std::string> mAcceptHeaderList;
     uint32_t mSupportedStreamingProtocols;
+    std::vector<ContentEntry> mContentList;
 
 private:
     EndpointId mEndpointId;

--- a/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
@@ -17,6 +17,7 @@
 
 #include "MediaInputManager.h"
 
+using namespace std;
 using namespace chip;
 using namespace chip::app::Clusters::MediaInput;
 
@@ -70,13 +71,20 @@ bool MediaInputManager::HandleSelectInput(const uint8_t index)
 
 bool MediaInputManager::HandleShowInputStatus()
 {
-    // TODO: Insert code here
+    ChipLogProgress(Zcl, " MediaInputManager::HandleShowInputStatus()");
+    for (auto const & inputInfo : this->mInputs)
+    {
+        string name(inputInfo.name.data(), inputInfo.name.size());
+        string desc(inputInfo.description.data(), inputInfo.description.size());
+        ChipLogProgress(Zcl, " [%d] type=%hhu selected=%d name=%s desc=%s", inputInfo.index, inputInfo.inputType,
+                        (mCurrentInput == inputInfo.index ? 1 : 0), name.c_str(), desc.c_str());
+    }
     return true;
 }
 
 bool MediaInputManager::HandleHideInputStatus()
 {
-    // TODO: Insert code here
+    ChipLogProgress(Zcl, " MediaInputManager::HandleHideInputStatus()");
     return true;
 }
 

--- a/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
+++ b/examples/tv-app/linux/include/media-input/MediaInputManager.cpp
@@ -76,8 +76,9 @@ bool MediaInputManager::HandleShowInputStatus()
     {
         string name(inputInfo.name.data(), inputInfo.name.size());
         string desc(inputInfo.description.data(), inputInfo.description.size());
-        ChipLogProgress(Zcl, " [%d] type=%hhu selected=%d name=%s desc=%s", inputInfo.index, inputInfo.inputType,
-                        (mCurrentInput == inputInfo.index ? 1 : 0), name.c_str(), desc.c_str());
+        ChipLogProgress(Zcl, " [%d] type=%d selected=%d name=%s desc=%s", inputInfo.index,
+                        static_cast<uint16_t>(inputInfo.inputType), (mCurrentInput == inputInfo.index ? 1 : 0), name.c_str(),
+                        desc.c_str());
     }
     return true;
 }


### PR DESCRIPTION
#### Problem
* Fixes https://github.com/project-chip/connectedhomeip/issues/18714

#### Change overview
Add dummy data so that media input and content launcher search test cases pass on example tv-app

#### Testing
* Tested using tv-app and chip-tool, following test cases
