### PR TITLE
Use log level Progress instead of Error in one of controller log

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -300,7 +300,7 @@ Optional<System::Clock::Timeout> AutoCommissioner::GetCommandTimeout(Commissioni
     switch (stage)
     {
     case CommissioningStage::kWiFiNetworkEnable:
-        ChipLogError(Controller, "Setting wifi connection time min = %u", mDeviceCommissioningInfo.network.wifi.minConnectionTime);
+        ChipLogProgress(Controller, "Setting wifi connection time min = %u", mDeviceCommissioningInfo.network.wifi.minConnectionTime);
         seconds = std::max(mDeviceCommissioningInfo.network.wifi.minConnectionTime, seconds);
         break;
     case CommissioningStage::kThreadNetworkEnable:

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -300,7 +300,8 @@ Optional<System::Clock::Timeout> AutoCommissioner::GetCommandTimeout(Commissioni
     switch (stage)
     {
     case CommissioningStage::kWiFiNetworkEnable:
-        ChipLogProgress(Controller, "Setting wifi connection time min = %u", mDeviceCommissioningInfo.network.wifi.minConnectionTime);
+        ChipLogProgress(Controller, "Setting wifi connection time min = %u",
+                        mDeviceCommissioningInfo.network.wifi.minConnectionTime);
         seconds = std::max(mDeviceCommissioningInfo.network.wifi.minConnectionTime, seconds);
         break;
     case CommissioningStage::kThreadNetworkEnable:


### PR DESCRIPTION
#### Problem
* Below log is logged with level Error
```
CHIP: [CTL] Setting wifi connection time min = 30
```
#### Change overview
* Changed the log level to Progress

#### Testing
* Chip-tool compilation successful
