### PR TITLE
[Tizen] Enable internet privilege for lighting app

### DIFF
--- a/examples/lighting-app/tizen/tizen-manifest.xml
+++ b/examples/lighting-app/tizen/tizen-manifest.xml
@@ -6,6 +6,7 @@
     </service-application>
     <privileges>
         <privilege>http://tizen.org/privilege/bluetooth</privilege>
+        <privilege>http://tizen.org/privilege/internet</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/network.bluetooth.le.gatt.server">true</feature>
 </manifest>


### PR DESCRIPTION
#### Problem

Without internet privilege, example app will be refused to use mDNS
service - app will crash.

#### Change overview

- added "internet" privilege for tizen-lighting-app

#### Testing

Launching app ion Tizen:
```sh
root:~> app_launcher -s org.tizen.matter.example.lighting
... successfully launched pid = 1196 with debug 0
root:~> app_launcher -S org.tizen.matter.example.lighting
         appId (PID)
          org.tizen.matter.example.lighting (1196)
```