### PR TITLE
[ESP32] Replace deprecated portTICK_RATE_MS with portTICK_PERIOD_MS

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -493,7 +493,7 @@ void BLEManagerImpl::DriveBLEState(void)
 
         // Add delay of 500msec while NimBLE host task gets up and running
         {
-            vTaskDelay(500 / portTICK_RATE_MS);
+            vTaskDelay(500 / portTICK_PERIOD_MS);
         }
     }
 


### PR DESCRIPTION
#### Problem
* `portTICK_RATE_MS` is deprecated and would be removed sometime sooner from esp-idf

#### Change overview
* Use `portTICK_PERIOD_MS`

#### Testing
* CI for ESP32 apps must be green