### PR TITLE
Refactor the switch delegate APIs from platform layer to application domain

### DIFF
--- a/src/app/clusters/switch-server/switch-server.cpp
+++ b/src/app/clusters/switch-server/switch-server.cpp
@@ -41,20 +41,20 @@ namespace app {
 namespace Clusters {
 namespace Switch {
 
-SwitchServer SwitchServer::instance;
+Server Server::instance;
 
 /**********************************************************
- * SwitchServer Implementation
+ * Server Implementation
  *********************************************************/
 
-SwitchServer & SwitchServer::Instance()
+Server & Server::Instance()
 {
     return instance;
 }
 
-void SwitchServer::OnSwitchLatched(EndpointId endpoint, uint8_t newPosition)
+void Server::OnSwitchLatch(EndpointId endpoint, uint8_t newPosition)
 {
-    ChipLogProgress(Zcl, "SwitchServer: OnSwitchLatched");
+    ChipLogProgress(Zcl, "Server: OnSwitchLatch");
 
     // Record SwitchLatched event
     EventNumber eventNumber;
@@ -62,13 +62,13 @@ void SwitchServer::OnSwitchLatched(EndpointId endpoint, uint8_t newPosition)
 
     if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
     {
-        ChipLogError(Zcl, "SwitchServer: Failed to record SwitchLatched event");
+        ChipLogError(Zcl, "Server: Failed to record SwitchLatched event");
     }
 }
 
-void SwitchServer::OnInitialPressed(EndpointId endpoint, uint8_t newPosition)
+void Server::OnInitialPress(EndpointId endpoint, uint8_t newPosition)
 {
-    ChipLogProgress(Zcl, "SwitchServer: OnInitialPressed");
+    ChipLogProgress(Zcl, "Server: OnInitialPress");
 
     // Record InitialPress event
     EventNumber eventNumber;
@@ -76,13 +76,13 @@ void SwitchServer::OnInitialPressed(EndpointId endpoint, uint8_t newPosition)
 
     if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
     {
-        ChipLogError(Zcl, "SwitchServer: Failed to record InitialPress event");
+        ChipLogError(Zcl, "Server: Failed to record InitialPress event");
     }
 }
 
-void SwitchServer::OnLongPressed(EndpointId endpoint, uint8_t newPosition)
+void Server::OnLongPress(EndpointId endpoint, uint8_t newPosition)
 {
-    ChipLogProgress(Zcl, "SwitchServer: OnLongPressed");
+    ChipLogProgress(Zcl, "Server: OnLongPress");
 
     // Record LongPress event
     EventNumber eventNumber;
@@ -90,13 +90,13 @@ void SwitchServer::OnLongPressed(EndpointId endpoint, uint8_t newPosition)
 
     if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
     {
-        ChipLogError(Zcl, "SwitchServer: Failed to record LongPress event");
+        ChipLogError(Zcl, "Server: Failed to record LongPress event");
     }
 }
 
-void SwitchServer::OnShortReleased(EndpointId endpoint, uint8_t previousPosition)
+void Server::OnShortRelease(EndpointId endpoint, uint8_t previousPosition)
 {
-    ChipLogProgress(Zcl, "SwitchServer: OnShortReleased");
+    ChipLogProgress(Zcl, "Server: OnShortRelease");
 
     // Record ShortRelease event
     EventNumber eventNumber;
@@ -104,13 +104,13 @@ void SwitchServer::OnShortReleased(EndpointId endpoint, uint8_t previousPosition
 
     if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
     {
-        ChipLogError(Zcl, "SwitchServer: Failed to record ShortRelease event");
+        ChipLogError(Zcl, "Server: Failed to record ShortRelease event");
     }
 }
 
-void SwitchServer::OnLongReleased(EndpointId endpoint, uint8_t previousPosition)
+void Server::OnLongRelease(EndpointId endpoint, uint8_t previousPosition)
 {
-    ChipLogProgress(Zcl, "SwitchServer: OnLongReleased");
+    ChipLogProgress(Zcl, "Server: OnLongRelease");
 
     // Record LongRelease event
     EventNumber eventNumber;
@@ -118,13 +118,13 @@ void SwitchServer::OnLongReleased(EndpointId endpoint, uint8_t previousPosition)
 
     if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
     {
-        ChipLogError(Zcl, "SwitchServer: Failed to record LongRelease event");
+        ChipLogError(Zcl, "Server: Failed to record LongRelease event");
     }
 }
 
-void SwitchServer::OnMultiPressOngoing(EndpointId endpoint, uint8_t newPosition, uint8_t count)
+void Server::OnMultiPressOngoing(EndpointId endpoint, uint8_t newPosition, uint8_t count)
 {
-    ChipLogProgress(Zcl, "SwitchServer: OnMultiPressOngoing");
+    ChipLogProgress(Zcl, "Server: OnMultiPressOngoing");
 
     // Record MultiPressOngoing event
     EventNumber eventNumber;
@@ -132,13 +132,13 @@ void SwitchServer::OnMultiPressOngoing(EndpointId endpoint, uint8_t newPosition,
 
     if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
     {
-        ChipLogError(Zcl, "SwitchServer: Failed to record MultiPressOngoing event");
+        ChipLogError(Zcl, "Server: Failed to record MultiPressOngoing event");
     }
 }
 
-void SwitchServer::OnMultiPressComplete(EndpointId endpoint, uint8_t newPosition, uint8_t count)
+void Server::OnMultiPressComplete(EndpointId endpoint, uint8_t newPosition, uint8_t count)
 {
-    ChipLogProgress(Zcl, "SwitchServer: OnMultiPressComplete");
+    ChipLogProgress(Zcl, "Server: OnMultiPressComplete");
 
     // Record MultiPressComplete event
     EventNumber eventNumber;
@@ -146,7 +146,7 @@ void SwitchServer::OnMultiPressComplete(EndpointId endpoint, uint8_t newPosition
 
     if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
     {
-        ChipLogError(Zcl, "SwitchServer: Failed to record MultiPressComplete event");
+        ChipLogError(Zcl, "Server: Failed to record MultiPressComplete event");
     }
 }
 

--- a/src/app/clusters/switch-server/switch-server.cpp
+++ b/src/app/clusters/switch-server/switch-server.cpp
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#include "switch-server.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app-common/zap-generated/ids/Attributes.h>
@@ -35,166 +36,123 @@ using namespace chip::app::Clusters::Switch;
 using namespace chip::app::Clusters::Switch::Attributes;
 using chip::DeviceLayer::DeviceControlServer;
 
-namespace {
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace Switch {
 
-class SwitchDelegate : public DeviceLayer::SwitchDeviceControlDelegate
+SwitchServer SwitchServer::instance;
+
+/**********************************************************
+ * SwitchServer Implementation
+ *********************************************************/
+
+SwitchServer & SwitchServer::Instance()
 {
-    /**
-     * @brief
-     *   Called when the latching switch is moved to a new position.
-     */
-    void OnSwitchLatched(uint8_t newPosition) override
-    {
-        ChipLogProgress(Zcl, "SwitchDelegate: OnSwitchLatched");
-
-        for (auto endpointId : EnabledEndpointsWithServerCluster(Switch::Id))
-        {
-            // Record SwitchLatched event
-            EventNumber eventNumber;
-            Events::SwitchLatched::Type event{ newPosition };
-
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
-            {
-                ChipLogError(Zcl, "SwitchDelegate: Failed to record SwitchLatched event");
-            }
-        }
-    }
-
-    /**
-     * @brief
-     *   Called when the momentary switch starts to be pressed.
-     */
-    void OnInitialPressed(uint8_t newPosition) override
-    {
-        ChipLogProgress(Zcl, "SwitchDelegate: OnInitialPressed");
-
-        for (auto endpointId : EnabledEndpointsWithServerCluster(Switch::Id))
-        {
-            // Record InitialPress event
-            EventNumber eventNumber;
-            Events::InitialPress::Type event{ newPosition };
-
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
-            {
-                ChipLogError(Zcl, "SwitchDelegate: Failed to record InitialPress event");
-            }
-        }
-    }
-
-    /**
-     * @brief
-     *   Called when the momentary switch has been pressed for a "long" time.
-     */
-    void OnLongPressed(uint8_t newPosition) override
-    {
-        ChipLogProgress(Zcl, "SwitchDelegate: OnLongPressed");
-
-        for (auto endpointId : EnabledEndpointsWithServerCluster(Switch::Id))
-        {
-            // Record LongPress event
-            EventNumber eventNumber;
-            Events::LongPress::Type event{ newPosition };
-
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
-            {
-                ChipLogError(Zcl, "SwitchDelegate: Failed to record LongPress event");
-            }
-        }
-    }
-
-    /**
-     * @brief
-     *   Called when the momentary switch has been released.
-     */
-    void OnShortReleased(uint8_t previousPosition) override
-    {
-        ChipLogProgress(Zcl, "SwitchDelegate: OnShortReleased");
-
-        for (auto endpointId : EnabledEndpointsWithServerCluster(Switch::Id))
-        {
-            // Record ShortRelease event
-            EventNumber eventNumber;
-            Events::ShortRelease::Type event{ previousPosition };
-
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
-            {
-                ChipLogError(Zcl, "SwitchDelegate: Failed to record ShortRelease event");
-            }
-        }
-    }
-
-    /**
-     * @brief
-     *   Called when the momentary switch has been released (after debouncing)
-     *   and after having been pressed for a long time.
-     */
-    void OnLongReleased(uint8_t previousPosition) override
-    {
-        ChipLogProgress(Zcl, "SwitchDelegate: OnLongReleased");
-
-        for (auto endpointId : EnabledEndpointsWithServerCluster(Switch::Id))
-        {
-            // Record LongRelease event
-            EventNumber eventNumber;
-            Events::LongRelease::Type event{ previousPosition };
-
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
-            {
-                ChipLogError(Zcl, "SwitchDelegate: Failed to record LongRelease event");
-            }
-        }
-    }
-
-    /**
-     * @brief
-     *   Called to indicate how many times the momentary switch has been pressed
-     *   in a multi-press sequence, during that sequence.
-     */
-    void OnMultiPressOngoing(uint8_t newPosition, uint8_t count) override
-    {
-        ChipLogProgress(Zcl, "SwitchDelegate: OnMultiPressOngoing");
-
-        for (auto endpointId : EnabledEndpointsWithServerCluster(Switch::Id))
-        {
-            // Record MultiPressOngoing event
-            EventNumber eventNumber;
-            Events::MultiPressOngoing::Type event{ newPosition, count };
-
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
-            {
-                ChipLogError(Zcl, "SwitchDelegate: Failed to record MultiPressOngoing event");
-            }
-        }
-    }
-
-    /**
-     * @brief
-     *   Called to indicate how many times the momentary switch has been pressed
-     *   in a multi-press sequence, after it has been detected that the sequence has ended.
-     */
-    void OnMultiPressComplete(uint8_t newPosition, uint8_t count) override
-    {
-        ChipLogProgress(Zcl, "SwitchDelegate: OnMultiPressComplete");
-
-        for (auto endpointId : EnabledEndpointsWithServerCluster(Switch::Id))
-        {
-            // Record MultiPressComplete event
-            EventNumber eventNumber;
-            Events::MultiPressComplete::Type event{ newPosition, count };
-
-            if (CHIP_NO_ERROR != LogEvent(event, endpointId, eventNumber))
-            {
-                ChipLogError(Zcl, "SwitchDelegate: Failed to record MultiPressComplete event");
-            }
-        }
-    }
-};
-
-SwitchDelegate gSwitchDelegate;
-
-} // anonymous namespace
-
-void MatterSwitchPluginServerInitCallback()
-{
-    DeviceControlServer::DeviceControlSvr().SetSwitchDelegate(&gSwitchDelegate);
+    return instance;
 }
+
+void SwitchServer::OnSwitchLatched(EndpointId endpoint, uint8_t newPosition)
+{
+    ChipLogProgress(Zcl, "SwitchServer: OnSwitchLatched");
+
+    // Record SwitchLatched event
+    EventNumber eventNumber;
+    Events::SwitchLatched::Type event{ newPosition };
+
+    if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+    {
+        ChipLogError(Zcl, "SwitchServer: Failed to record SwitchLatched event");
+    }
+}
+
+void SwitchServer::OnInitialPressed(EndpointId endpoint, uint8_t newPosition)
+{
+    ChipLogProgress(Zcl, "SwitchServer: OnInitialPressed");
+
+    // Record InitialPress event
+    EventNumber eventNumber;
+    Events::InitialPress::Type event{ newPosition };
+
+    if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+    {
+        ChipLogError(Zcl, "SwitchServer: Failed to record InitialPress event");
+    }
+}
+
+void SwitchServer::OnLongPressed(EndpointId endpoint, uint8_t newPosition)
+{
+    ChipLogProgress(Zcl, "SwitchServer: OnLongPressed");
+
+    // Record LongPress event
+    EventNumber eventNumber;
+    Events::LongPress::Type event{ newPosition };
+
+    if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+    {
+        ChipLogError(Zcl, "SwitchServer: Failed to record LongPress event");
+    }
+}
+
+void SwitchServer::OnShortReleased(EndpointId endpoint, uint8_t previousPosition)
+{
+    ChipLogProgress(Zcl, "SwitchServer: OnShortReleased");
+
+    // Record ShortRelease event
+    EventNumber eventNumber;
+    Events::ShortRelease::Type event{ previousPosition };
+
+    if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+    {
+        ChipLogError(Zcl, "SwitchServer: Failed to record ShortRelease event");
+    }
+}
+
+void SwitchServer::OnLongReleased(EndpointId endpoint, uint8_t previousPosition)
+{
+    ChipLogProgress(Zcl, "SwitchServer: OnLongReleased");
+
+    // Record LongRelease event
+    EventNumber eventNumber;
+    Events::LongRelease::Type event{ previousPosition };
+
+    if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+    {
+        ChipLogError(Zcl, "SwitchServer: Failed to record LongRelease event");
+    }
+}
+
+void SwitchServer::OnMultiPressOngoing(EndpointId endpoint, uint8_t newPosition, uint8_t count)
+{
+    ChipLogProgress(Zcl, "SwitchServer: OnMultiPressOngoing");
+
+    // Record MultiPressOngoing event
+    EventNumber eventNumber;
+    Events::MultiPressOngoing::Type event{ newPosition, count };
+
+    if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+    {
+        ChipLogError(Zcl, "SwitchServer: Failed to record MultiPressOngoing event");
+    }
+}
+
+void SwitchServer::OnMultiPressComplete(EndpointId endpoint, uint8_t newPosition, uint8_t count)
+{
+    ChipLogProgress(Zcl, "SwitchServer: OnMultiPressComplete");
+
+    // Record MultiPressComplete event
+    EventNumber eventNumber;
+    Events::MultiPressComplete::Type event{ newPosition, count };
+
+    if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+    {
+        ChipLogError(Zcl, "SwitchServer: Failed to record MultiPressComplete event");
+    }
+}
+
+} // namespace Switch
+} // namespace Clusters
+} // namespace app
+} // namespace chip
+
+void MatterSwitchPluginServerInitCallback() {}

--- a/src/app/clusters/switch-server/switch-server.h
+++ b/src/app/clusters/switch-server/switch-server.h
@@ -46,7 +46,7 @@ public:
      * @brief
      *   Called when the momentary switch starts to be pressed.
      */
-    void OnInitialPressed(EndpointId endpoint, uint8_t newPosition);
+    void OnInitialPress(EndpointId endpoint, uint8_t newPosition);
 
     /**
      * @brief

--- a/src/app/clusters/switch-server/switch-server.h
+++ b/src/app/clusters/switch-server/switch-server.h
@@ -52,7 +52,7 @@ public:
      * @brief
      *   Called when the momentary switch has been pressed for a "long" time.
      */
-    void OnLongPressed(EndpointId endpoint, uint8_t newPosition);
+    void OnLongPress(EndpointId endpoint, uint8_t newPosition);
 
     /**
      * @brief

--- a/src/app/clusters/switch-server/switch-server.h
+++ b/src/app/clusters/switch-server/switch-server.h
@@ -58,7 +58,7 @@ public:
      * @brief
      *   Called when the momentary switch has been released.
      */
-    void OnShortReleased(EndpointId endpoint, uint8_t previousPosition);
+    void OnShortRelease(EndpointId endpoint, uint8_t previousPosition);
 
     /**
      * @brief

--- a/src/app/clusters/switch-server/switch-server.h
+++ b/src/app/clusters/switch-server/switch-server.h
@@ -31,16 +31,16 @@ namespace Switch {
 /**
  * @brief switch-server class
  */
-class SwitchServer
+class Server
 {
 public:
-    static SwitchServer & Instance();
+    static Server & Instance();
 
     /**
      * @brief
      *   Called when the latching switch is moved to a new position.
      */
-    void OnSwitchLatched(EndpointId endpoint, uint8_t newPosition);
+    void OnSwitchLatch(EndpointId endpoint, uint8_t newPosition);
 
     /**
      * @brief
@@ -82,7 +82,7 @@ public:
     void OnMultiPressComplete(EndpointId endpoint, uint8_t newPosition, uint8_t count);
 
 private:
-    static SwitchServer instance;
+    static Server instance;
 };
 
 } // namespace Switch

--- a/src/app/clusters/switch-server/switch-server.h
+++ b/src/app/clusters/switch-server/switch-server.h
@@ -65,7 +65,7 @@ public:
      *   Called when the momentary switch has been released (after debouncing)
      *   after having been pressed for a long time.
      */
-    void OnLongReleased(EndpointId endpoint, uint8_t previousPosition);
+    void OnLongRelease(EndpointId endpoint, uint8_t previousPosition);
 
     /**
      * @brief

--- a/src/app/clusters/switch-server/switch-server.h
+++ b/src/app/clusters/switch-server/switch-server.h
@@ -63,7 +63,7 @@ public:
     /**
      * @brief
      *   Called when the momentary switch has been released (after debouncing)
-     *   and after having been pressed for a long time.
+     *   after having been pressed for a long time.
      */
     void OnLongReleased(EndpointId endpoint, uint8_t previousPosition);
 

--- a/src/app/clusters/switch-server/switch-server.h
+++ b/src/app/clusters/switch-server/switch-server.h
@@ -1,0 +1,91 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterface.h>
+#include <app/CommandResponseHelper.h>
+#include <app/util/af.h>
+
+namespace chip {
+namespace app {
+namespace Clusters {
+namespace Switch {
+
+/**
+ * @brief switch-server class
+ */
+class SwitchServer
+{
+public:
+    static SwitchServer & Instance();
+
+    /**
+     * @brief
+     *   Called when the latching switch is moved to a new position.
+     */
+    void OnSwitchLatched(EndpointId endpoint, uint8_t newPosition);
+
+    /**
+     * @brief
+     *   Called when the momentary switch starts to be pressed.
+     */
+    void OnInitialPressed(EndpointId endpoint, uint8_t newPosition);
+
+    /**
+     * @brief
+     *   Called when the momentary switch has been pressed for a "long" time.
+     */
+    void OnLongPressed(EndpointId endpoint, uint8_t newPosition);
+
+    /**
+     * @brief
+     *   Called when the momentary switch has been released.
+     */
+    void OnShortReleased(EndpointId endpoint, uint8_t previousPosition);
+
+    /**
+     * @brief
+     *   Called when the momentary switch has been released (after debouncing)
+     *   and after having been pressed for a long time.
+     */
+    void OnLongReleased(EndpointId endpoint, uint8_t previousPosition);
+
+    /**
+     * @brief
+     *   Called to indicate how many times the momentary switch has been pressed
+     *   in a multi-press sequence, during that sequence.
+     */
+    void OnMultiPressOngoing(EndpointId endpoint, uint8_t newPosition, uint8_t count);
+
+    /**
+     * @brief
+     *   Called to indicate how many times the momentary switch has been pressed
+     *   in a multi-press sequence, after it has been detected that the sequence has ended.
+     */
+    void OnMultiPressComplete(EndpointId endpoint, uint8_t newPosition, uint8_t count);
+
+private:
+    static SwitchServer instance;
+};
+
+} // namespace Switch
+} // namespace Clusters
+} // namespace app
+} // namespace chip

--- a/src/include/platform/DeviceControlServer.h
+++ b/src/include/platform/DeviceControlServer.h
@@ -29,60 +29,6 @@
 namespace chip {
 namespace DeviceLayer {
 
-/**
- * Defines the Swtich Device Control Delegate class to notify platform events.
- */
-class SwitchDeviceControlDelegate
-{
-public:
-    virtual ~SwitchDeviceControlDelegate() {}
-
-    /**
-     * @brief
-     *   Called when the latching switch is moved to a new position.
-     */
-    virtual void OnSwitchLatched(uint8_t newPosition) {}
-
-    /**
-     * @brief
-     *   Called when the momentary switch starts to be pressed.
-     */
-    virtual void OnInitialPressed(uint8_t newPosition) {}
-
-    /**
-     * @brief
-     *   Called when the momentary switch has been pressed for a "long" time.
-     */
-    virtual void OnLongPressed(uint8_t newPosition) {}
-
-    /**
-     * @brief
-     *   Called when the momentary switch has been released.
-     */
-    virtual void OnShortReleased(uint8_t previousPosition) {}
-
-    /**
-     * @brief
-     *   Called when the momentary switch has been released (after debouncing)
-     *   and after having been pressed for a long time.
-     */
-    virtual void OnLongReleased(uint8_t previousPosition) {}
-
-    /**
-     * @brief
-     *   Called to indicate how many times the momentary switch has been pressed
-     *   in a multi-press sequence, during that sequence.
-     */
-    virtual void OnMultiPressOngoing(uint8_t newPosition, uint8_t count) {}
-
-    /**
-     * @brief
-     *   Called to indicate how many times the momentary switch has been pressed
-     *   in a multi-press sequence, after it has been detected that the sequence has ended.
-     */
-    virtual void OnMultiPressComplete(uint8_t newPosition, uint8_t count) {}
-};
-
 class DeviceControlServer final
 {
 public:
@@ -92,8 +38,6 @@ public:
     CHIP_ERROR SetRegulatoryConfig(uint8_t location, const CharSpan & countryCode);
     CHIP_ERROR ConnectNetworkForOperational(ByteSpan networkID);
 
-    void SetSwitchDelegate(SwitchDeviceControlDelegate * delegate) { mSwitchDelegate = delegate; }
-    SwitchDeviceControlDelegate * GetSwitchDelegate() const { return mSwitchDelegate; }
     FailSafeContext & GetFailSafeContext() { return mFailSafeContext; }
 
     static DeviceControlServer & DeviceControlSvr();
@@ -102,7 +46,6 @@ private:
     // ===== Members for internal use by the following friends.
     static DeviceControlServer sInstance;
     FailSafeContext mFailSafeContext;
-    SwitchDeviceControlDelegate * mSwitchDelegate = nullptr;
 
     // ===== Private members reserved for use by this class only.
 

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -78,9 +78,6 @@ void SignalHandler(int signum)
     case SIGTTIN:
         PlatformMgrImpl().HandleGeneralFault(GeneralDiagnostics::Events::NetworkFaultChange::Id);
         break;
-    case SIGTSTP:
-        PlatformMgrImpl().HandleSwitchEvent(Switch::Events::SwitchLatched::Id);
-        break;
     default:
         break;
     }
@@ -325,89 +322,6 @@ void PlatformManagerImpl::HandleSoftwareFault(uint32_t EventId)
         softwareFault.faultRecording     = ByteSpan(Uint8::from_const_char("FaultRecording"), strlen("FaultRecording"));
 
         delegate->OnSoftwareFaultDetected(softwareFault);
-    }
-}
-
-void PlatformManagerImpl::HandleSwitchEvent(uint32_t EventId)
-{
-    SwitchDeviceControlDelegate * delegate = DeviceControlServer::DeviceControlSvr().GetSwitchDelegate();
-
-    if (delegate == nullptr)
-    {
-        ChipLogError(DeviceLayer, "No delegate registered to handle Switch event");
-        return;
-    }
-
-    if (EventId == Switch::Events::SwitchLatched::Id)
-    {
-        uint8_t newPosition = 0;
-
-#if CHIP_CONFIG_TEST
-        newPosition = 100;
-#endif
-        delegate->OnSwitchLatched(newPosition);
-    }
-    else if (EventId == Switch::Events::InitialPress::Id)
-    {
-        uint8_t newPosition = 0;
-
-#if CHIP_CONFIG_TEST
-        newPosition = 100;
-#endif
-        delegate->OnInitialPressed(newPosition);
-    }
-    else if (EventId == Switch::Events::LongPress::Id)
-    {
-        uint8_t newPosition = 0;
-
-#if CHIP_CONFIG_TEST
-        newPosition = 100;
-#endif
-        delegate->OnLongPressed(newPosition);
-    }
-    else if (EventId == Switch::Events::ShortRelease::Id)
-    {
-        uint8_t previousPosition = 0;
-
-#if CHIP_CONFIG_TEST
-        previousPosition = 50;
-#endif
-        delegate->OnShortReleased(previousPosition);
-    }
-    else if (EventId == Switch::Events::LongRelease::Id)
-    {
-        uint8_t previousPosition = 0;
-
-#if CHIP_CONFIG_TEST
-        previousPosition = 50;
-#endif
-        delegate->OnLongReleased(previousPosition);
-    }
-    else if (EventId == Switch::Events::MultiPressOngoing::Id)
-    {
-        uint8_t newPosition                   = 0;
-        uint8_t currentNumberOfPressesCounted = 0;
-
-#if CHIP_CONFIG_TEST
-        newPosition                   = 10;
-        currentNumberOfPressesCounted = 5;
-#endif
-        delegate->OnMultiPressOngoing(newPosition, currentNumberOfPressesCounted);
-    }
-    else if (EventId == Switch::Events::MultiPressComplete::Id)
-    {
-        uint8_t newPosition                 = 0;
-        uint8_t totalNumberOfPressesCounted = 0;
-
-#if CHIP_CONFIG_TEST
-        newPosition                 = 10;
-        totalNumberOfPressesCounted = 5;
-#endif
-        delegate->OnMultiPressComplete(newPosition, totalNumberOfPressesCounted);
-    }
-    else
-    {
-        ChipLogError(DeviceLayer, "Unknow event ID:%d", EventId);
     }
 }
 

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -58,7 +58,6 @@ public:
 
     void HandleGeneralFault(uint32_t EventId);
     void HandleSoftwareFault(uint32_t EventId);
-    void HandleSwitchEvent(uint32_t EventId);
 
 private:
     // ===== Methods that implement the PlatformManager abstract interface.


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* expected behavior: Events triggered on the device should be sent only to a particular endpoint_id.
actual behavior: Events triggered are sent to all the endpoints that have the cluster included.
* Fixes #14624

#### Change overview
Refactor the switch delegate APIs from platform layer to application domain and event is only triggered on a particular endpoint_id.

TODO: Implement switch event trigger on one of existing example app

#### Testing
How was this tested? (at least one bullet point required)
* Tested with tested app with switch cluster enabled
