### PR TITLE
[nrfconnect] Fixed window covering bug in updating cluster attributes

### DIFF
--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -1868,7 +1868,7 @@ endpoint 1 {
     persist  attribute installedClosedLimitLift default = 0xFFFF;
     persist  attribute installedOpenLimitTilt;
     persist  attribute installedClosedLimitTilt default = 0xFFFF;
-    persist  attribute mode default = 0x14;
+    persist  attribute mode;
     ram      attribute safetyStatus;
     ram      attribute featureMap default = 0x0017;
     ram      attribute clusterRevision default = 5;

--- a/examples/window-app/common/window-app.zap
+++ b/examples/window-app/common/window-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 70,
+  "featureLevel": 71,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -8780,7 +8780,7 @@
               "storageOption": "NVM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x14",
+              "defaultValue": "0x0",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,
@@ -10438,5 +10438,6 @@
       "endpointVersion": 1,
       "deviceIdentifier": 514
     }
-  ]
+  ],
+  "log": []
 }

--- a/examples/window-app/nrfconnect/main/WindowCovering.cpp
+++ b/examples/window-app/nrfconnect/main/WindowCovering.cpp
@@ -322,3 +322,22 @@ uint8_t WindowCovering::PositionToBrightness(uint16_t aPosition, MoveType aMoveT
 
     return Percent100thsToValue(pwmLimits, aPosition);
 }
+
+void WindowCovering::SchedulePostAttributeChange(chip::EndpointId aEndpoint, chip::AttributeId aAttributeId)
+{
+    AttributeUpdateData * data = chip::Platform::New<AttributeUpdateData>();
+    VerifyOrReturn(data != nullptr);
+
+    data->mEndpoint    = aEndpoint;
+    data->mAttributeId = aAttributeId;
+
+    chip::DeviceLayer::PlatformMgr().ScheduleWork(DoPostAttributeChange, reinterpret_cast<intptr_t>(data));
+}
+
+void WindowCovering::DoPostAttributeChange(intptr_t aArg)
+{
+    AttributeUpdateData * data = reinterpret_cast<AttributeUpdateData *>(aArg);
+    VerifyOrReturn(data != nullptr);
+
+    PostAttributeChange(data->mEndpoint, data->mAttributeId);
+}

--- a/examples/window-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/window-app/nrfconnect/main/ZclCallbacks.cpp
@@ -75,5 +75,5 @@ void MatterWindowCoveringClusterServerAttributeChangedCallback(const app::Concre
             break;
         };
     }
-    PostAttributeChange(attributePath.mEndpointId, attributePath.mAttributeId);
+    WindowCovering::Instance().SchedulePostAttributeChange(attributePath.mEndpointId, attributePath.mAttributeId);
 }

--- a/examples/window-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/window-app/nrfconnect/main/ZclCallbacks.cpp
@@ -75,4 +75,5 @@ void MatterWindowCoveringClusterServerAttributeChangedCallback(const app::Concre
             break;
         };
     }
+    PostAttributeChange(attributePath.mEndpointId, attributePath.mAttributeId);
 }

--- a/examples/window-app/nrfconnect/main/include/WindowCovering.h
+++ b/examples/window-app/nrfconnect/main/include/WindowCovering.h
@@ -36,6 +36,12 @@ public:
         NONE
     };
 
+    struct AttributeUpdateData
+    {
+        chip::EndpointId mEndpoint;
+        chip::AttributeId mAttributeId;
+    };
+
     WindowCovering();
     static WindowCovering & Instance()
     {
@@ -49,6 +55,7 @@ public:
     MoveType GetMoveType() { return mCurrentUIMoveType; }
     void PositionLEDUpdate(MoveType aMoveType);
 
+    static void SchedulePostAttributeChange(chip::EndpointId aEndpoint, chip::AttributeId aAttributeId);
     static constexpr chip::EndpointId Endpoint() { return 1; };
 
 private:
@@ -63,6 +70,7 @@ private:
     static void DriveCurrentLiftPosition(intptr_t);
     static void DriveCurrentTiltPosition(intptr_t);
     static void MoveTimerTimeoutCallback(k_timer * aTimer);
+    static void DoPostAttributeChange(intptr_t aArg);
 
     MoveType mCurrentUIMoveType;
     LEDWidget mLiftLED;

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -587,12 +587,6 @@ EmberEventControl * ConfigureFakeMotionEventControl(EndpointId endpoint)
     return controller;
 }
 
-/**
- * @brief PostAttributeChange is called when an Attribute is modified
- *
- * @param[in] endpoint
- * @param[in] attributeId
- */
 void PostAttributeChange(chip::EndpointId endpoint, chip::AttributeId attributeId)
 {
     // all-cluster-app: simulation for the CI testing

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -139,6 +139,14 @@ void TiltPositionSet(chip::EndpointId endpoint, NPercent100ths position);
 
 EmberAfStatus GetMotionLockStatus(chip::EndpointId endpoint);
 
+/**
+ * @brief PostAttributeChange is called when an Attribute is modified
+ *
+ * @param[in] endpoint
+ * @param[in] attributeId
+ */
+void PostAttributeChange(chip::EndpointId endpoint, chip::AttributeId attributeId);
+
 } // namespace WindowCovering
 } // namespace Clusters
 } // namespace app

--- a/zzz_generated/window-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/window-app/zap-generated/endpoint_config.h
@@ -126,7 +126,7 @@
         { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0x1 }, /* HourFormat */                                                       \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Window Covering (server) */                                                                   \
-            { (uint16_t) 0x14, (uint16_t) 0x0, (uint16_t) 0xF }, /* Mode */                                                        \
+            { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xF }, /* Mode */                                                         \
                                                                                                                                    \
         /* Endpoint: 2, Cluster: Window Covering (server) */ { (uint16_t) 0x0, (uint16_t) 0x0, (uint16_t) 0xF } /* Mode */         \
     }


### PR DESCRIPTION
#### Problem
Nrfconnect window covering example doesn't update window covering cluster attributes properly.

#### Change overview
* Moved PostAttributeChange method from window-covering-server.cpp to header.
* Called PostAttributeChange method in nrfconnect implementation of MatterWindowCoveringClusterServerAttributeChangedCallback
* Changed mode default value from 0x14 to 0.

#### Testing
Reproduced manually tests described in: https://github.com/project-chip/connectedhomeip/issues/18371

Fixes: https://github.com/project-chip/connectedhomeip/issues/18371
