### PR TITLE
Specify Python 3.7 as minimal Python version

### DIFF
--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -189,11 +189,11 @@ try:
         classifiers=[
             "Intended Audience :: Developers",
             "License :: OSI Approved :: Apache Software License",
-            "Programming Language :: Python :: 2",
-            "Programming Language :: Python :: 2.7",
-            "Programming Language :: Python :: 3",
+            "Programming Language :: Python :: 3.7",
+            "Programming Language :: Python :: 3.8",
+            "Programming Language :: Python :: 3.9",
         ],
-        python_requires=">=2.7",
+        python_requires=">=3.7",
         packages=packages,
         package_dir={
             # By default, look in the tmp directory for packages/modules to be included.


### PR DESCRIPTION
#### Problem
The Python wheels specify a wrong Python version compatibility.

#### Change overview
The cluster objects make use of dataclasses, which have been added with
Python 3.7. Bump minimal required version in the wheels metadata to what
is required today.

#### Testing
Built and tested on development machine using `scripts/build_python.sh -m minimal -i separate`.
