### PR TITLE
Ensure memcpy of mac lengths does not overflow buffers

### DIFF
--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -130,13 +130,24 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
     CHIP_ERROR error           = CHIP_NO_ERROR;
     bool found                 = false;
 
+    // TODO: ideally the buffer size should have been passed as a span, however
+    //       for now use the size that is validated in GenericConfigurationManagerImpl.ipp
+    constexpr size_t kExpectedBufMinSize = ConfigurationManager::kPrimaryMACAddressLength;
+
     VerifyOrExit(getifaddrs(&addresses) == 0, error = CHIP_ERROR_INTERNAL);
     for (auto addr = addresses; addr != nullptr; addr = addr->ifa_next)
     {
         if ((addr->ifa_addr) && (addr->ifa_addr->sa_family == AF_PACKET) && strncmp(addr->ifa_name, "lo", IFNAMSIZ) != 0)
         {
             struct sockaddr_ll * mac = (struct sockaddr_ll *) addr->ifa_addr;
-            memcpy(buf, mac->sll_addr, mac->sll_halen);
+
+            size_t mac_len = mac->sll_halen;
+            if (mac_len > kExpectedBufMinSize)
+            {
+                mac_len = kExpectedBufMinSize;
+            }
+
+            memcpy(buf, mac->sll_addr, mac_len);
             found = true;
             break;
         }

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -133,6 +133,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
     // TODO: ideally the buffer size should have been passed as a span, however
     //       for now use the size that is validated in GenericConfigurationManagerImpl.ipp
     constexpr size_t kExpectedBufMinSize = ConfigurationManager::kPrimaryMACAddressLength;
+    memset(buf, 0, kExpectedBufMinSize);
 
     VerifyOrExit(getifaddrs(&addresses) == 0, error = CHIP_ERROR_INTERNAL);
     for (auto addr = addresses; addr != nullptr; addr = addr->ifa_next)

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -141,14 +141,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
         if ((addr->ifa_addr) && (addr->ifa_addr->sa_family == AF_PACKET) && strncmp(addr->ifa_name, "lo", IFNAMSIZ) != 0)
         {
             struct sockaddr_ll * mac = (struct sockaddr_ll *) addr->ifa_addr;
-
-            size_t mac_len = mac->sll_halen;
-            if (mac_len > kExpectedBufMinSize)
-            {
-                mac_len = kExpectedBufMinSize;
-            }
-
-            memcpy(buf, mac->sll_addr, mac_len);
+            memcpy(buf, mac->sll_addr, std::min(mac->sll_halen, kExpectedBufMinSize));
             found = true;
             break;
         }

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -37,6 +37,8 @@
 #include <platform/Linux/PosixConfig.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
+#include <algorithm>
+
 namespace chip {
 namespace DeviceLayer {
 
@@ -141,7 +143,7 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
         if ((addr->ifa_addr) && (addr->ifa_addr->sa_family == AF_PACKET) && strncmp(addr->ifa_name, "lo", IFNAMSIZ) != 0)
         {
             struct sockaddr_ll * mac = (struct sockaddr_ll *) addr->ifa_addr;
-            memcpy(buf, mac->sll_addr, std::min(mac->sll_halen, kExpectedBufMinSize));
+            memcpy(buf, mac->sll_addr, std::min<size_t>(mac->sll_halen, kExpectedBufMinSize));
             found = true;
             break;
         }


### PR DESCRIPTION
#### Problem
MAC address fetching does not provide buffer sizes and this may overflow buffers (see #16623)

#### Change overview
Limit size of memcpy for MAC addresses.

Fixes #16623

#### Testing
Compilation testing. CI will execute things on linux as well that will execute this code.