### PR TITLE
Handle saveAs in YAML for an optional value.

### DIFF
--- a/examples/chip-tool/templates/tests/partials/saveAs/maybeSaveAs.zapt
+++ b/examples/chip-tool/templates/tests/partials/saveAs/maybeSaveAs.zapt
@@ -4,11 +4,17 @@
 {{#*inline "size"}}
 {{#if isNullable}}{{asPropertyValue}}.Value().size(){{else}}{{asPropertyValue}}.size(){{/if}}
 {{/inline}}
+{{#*inline "saveAsTarget"~}}
+{{saveAs}}{{#if isOptional}}.Emplace(){{/if}}
+{{~/inline}}
 {{#if saveAs}}
     {{#if (isString type)}}
+        {{#if isOptional}}
+        if ({{asPropertyValue dontUnwrapValue=true}}.HasValue()) {
+        {{/if}}
         {{#if isNullable}}
             if ({{asPropertyValue}}.IsNull()){
-                {{saveAs}}.SetNull();
+                {{> saveAsTarget}}.SetNull();
             }
             else {
         {{/if}}
@@ -19,12 +25,19 @@
         {{saveAs}}Buffer = static_cast<{{#if (isOctetString type)}}uint8_t{{else}}char{{/if}} *>(chip::Platform::MemoryAlloc({{>size}}));
         memcpy({{saveAs}}Buffer, {{>data}}, {{>size}});
         {{#if isNullable}}
-            {{saveAs}}.SetNonNull({{saveAs}}Buffer, {{>size}});
+            {{> saveAsTarget}}.SetNonNull({{saveAs}}Buffer, {{>size}});
             }
         {{else}}
-            {{saveAs}} = {{chipType}}({{saveAs}}Buffer, {{>size}});
+            {{> saveAsTarget}} = {{chipType}}({{saveAs}}Buffer, {{>size}});
+        {{/if}}
+        {{#if isOptional}}
+        }
+        else
+        {
+            {{saveAs}} = NullOptional;
+        }
         {{/if}}
     {{else}}
-        {{saveAs}} = {{asPropertyValue}};
+        {{saveAs}} = {{asPropertyValue dontUnwrapValue=true}};
     {{/if}}
 {{/if}}

--- a/src/app/tests/suites/include/ConstraintsChecker.h
+++ b/src/app/tests/suites/include/ConstraintsChecker.h
@@ -229,6 +229,17 @@ protected:
         return CheckConstraintMinValue(itemName, current.Value(), static_cast<T>(expected));
     }
 
+    template <typename T, typename U>
+    bool CheckConstraintMinValue(const char * itemName, const T & current, const chip::Optional<U> & expected)
+    {
+        if (!expected.HasValue())
+        {
+            Exit(std::string(itemName) + ": expected min value does not have a value");
+            return false;
+        }
+        return CheckConstraintMinValue(itemName, current, expected.Value());
+    }
+
     template <typename T, typename U, std::enable_if_t<!std::is_enum<T>::value, int> = 0>
     bool CheckConstraintMaxValue(const char * itemName, T current, U expected)
     {
@@ -267,6 +278,17 @@ protected:
             return true;
         }
         return CheckConstraintMaxValue(itemName, current.Value(), static_cast<T>(expected));
+    }
+
+    template <typename T, typename U>
+    bool CheckConstraintMaxValue(const char * itemName, const T & current, const chip::Optional<U> & expected)
+    {
+        if (!expected.HasValue())
+        {
+            Exit(std::string(itemName) + ": expected max value does not have a value");
+            return false;
+        }
+        return CheckConstraintMaxValue(itemName, current, expected.Value());
     }
 
     template <typename T>
@@ -366,5 +388,16 @@ protected:
         }
 
         return true;
+    }
+
+    template <typename T, typename U>
+    bool CheckConstraintNotValue(const char * itemName, const T & current, const chip::Optional<U> & expected)
+    {
+        if (!expected.HasValue())
+        {
+            Exit(std::string(itemName) + ": expected disallowed value does not have a value");
+            return false;
+        }
+        return CheckConstraintNotValue(itemName, current, expected.Value());
     }
 };


### PR DESCRIPTION
* Store the optional value as-is, except for strings where we either store a
  NullOptional or emplace a value using our buffer.
* Adjust constraint checks (MinValue, MaxValue, NotValue) to handle an optional
  expected value.

Fixes https://github.com/project-chip/connectedhomeip/issues/18591

#### Problem
We're generating code that does not compile when saveAs is used on an optional value.

#### Change overview
See above.

#### Testing
Applied the YAML changes from #18591 and they generated code that compiles.