### PR TITLE
[OTA-R] Fix retries on Query Image failure due to invalid session

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -648,9 +648,6 @@ IdleStateReason DefaultOTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
 
 void DefaultOTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
 {
-    ChipLogProgress(SoftwareUpdate, "//is: DefaultOTARequestorDriver::HandleIdleStateEnter newState %hhu, reason %hhu", newState, reason);
-    ChipLogProgress(SoftwareUpdate, "//is: DefaultOTARequestorDriver::HandleIdleStateEnter error %" CHIP_ERROR_FORMAT, error.Format());
-
     bool handleIdleStateEnter = true;
     IdleStateReason idleStateReason = IdleStateReason::kUnknown;
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -668,22 +668,18 @@ void DefaultOTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAC
     }
     OtaRequestorServerOnStateTransition(mCurrentUpdateState, newState, reason, targetSoftwareVersion);
 
-    if ((newState == OTAUpdateStateEnum::kIdle) && (mCurrentUpdateState != OTAUpdateStateEnum::kIdle))
+    OTAUpdateStateEnum prevState = mCurrentUpdateState;
+    // Update the new state before handling the state transition
+    mCurrentUpdateState = newState;
+
+    if ((newState == OTAUpdateStateEnum::kIdle) && (prevState != OTAUpdateStateEnum::kIdle))
     {
         IdleStateReason idleStateReason = MapErrorToIdleStateReason(error);
-        // Update the new state before handling the state transition
-        mCurrentUpdateState = newState;
         mOtaRequestorDriver->HandleIdleStateEnter(idleStateReason);
     }
-    else if ((mCurrentUpdateState == OTAUpdateStateEnum::kIdle) && (newState != OTAUpdateStateEnum::kIdle))
+    else if ((prevState == OTAUpdateStateEnum::kIdle) && (newState != OTAUpdateStateEnum::kIdle))
     {
-        // Update the new state before handling the state transition
-        mCurrentUpdateState = newState;
         mOtaRequestorDriver->HandleIdleStateExit();
-    }
-    else
-    {
-        mCurrentUpdateState = newState;
     }
 }
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -648,7 +648,7 @@ IdleStateReason DefaultOTARequestor::MapErrorToIdleStateReason(CHIP_ERROR error)
 
 void DefaultOTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAChangeReasonEnum reason, CHIP_ERROR error)
 {
-    bool handleIdleStateEnter = true;
+    bool handleIdleStateEnter       = true;
     IdleStateReason idleStateReason = IdleStateReason::kUnknown;
 
     // Set server UpdateState attribute
@@ -673,7 +673,7 @@ void DefaultOTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAC
 
     if ((newState == OTAUpdateStateEnum::kIdle) && (mCurrentUpdateState != OTAUpdateStateEnum::kIdle))
     {
-        idleStateReason = MapErrorToIdleStateReason(error);
+        idleStateReason      = MapErrorToIdleStateReason(error);
         handleIdleStateEnter = true;
     }
     else if ((mCurrentUpdateState == OTAUpdateStateEnum::kIdle) && (newState != OTAUpdateStateEnum::kIdle))
@@ -684,7 +684,7 @@ void DefaultOTARequestor::RecordNewUpdateState(OTAUpdateStateEnum newState, OTAC
     // Update the new state before handling the state transition
     mCurrentUpdateState = newState;
 
-    if( handleIdleStateEnter )
+    if (handleIdleStateEnter)
     {
         mOtaRequestorDriver->HandleIdleStateEnter(idleStateReason);
     }

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -145,10 +145,6 @@ void DefaultOTARequestorDriver::HandleIdleStateEnter(IdleStateReason reason)
         StartSelectedTimer(SelectedTimer::kPeriodicQueryTimer);
         break;
     case IdleStateReason::kInvalidSession:
-        ChipLogProgress(SoftwareUpdate,
-                        "//is: IdleStateReason::kInvalidSession mProviderRetryCount %d, mInvalidSessionRetryCount %d, "
-                        "kMaxInvalidSessionRetries %d",
-                        mProviderRetryCount, mInvalidSessionRetryCount, kMaxInvalidSessionRetries);
         if (mInvalidSessionRetryCount < kMaxInvalidSessionRetries)
         {
             // An invalid session is detected which may be temporary (such as provider being restarted)

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -148,7 +148,9 @@ void DefaultOTARequestorDriver::HandleIdleStateEnter(IdleStateReason reason)
         if (mInvalidSessionRetryCount < kMaxInvalidSessionRetries)
         {
             // An invalid session is detected which may be temporary (such as provider being restarted)
-            // so try to query the same provider again.
+            // so try to query the same provider again. Since the session has already been disconnected prior to
+            // getting here, this new query should trigger an attempt to re-establish CASE. If that subsequently fails,
+            // we conclusively know the provider is not available, and will fall into the else clause below on that attempt.
             SendQueryImage();
             mInvalidSessionRetryCount++;
         }

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -59,9 +59,9 @@ DefaultOTARequestorDriver * ToDriver(void * context)
 
 void DefaultOTARequestorDriver::Init(OTARequestorInterface * requestor, OTAImageProcessorInterface * processor)
 {
-    mRequestor          = requestor;
-    mImageProcessor     = processor;
-    mProviderRetryCount = 0;
+    mRequestor                = requestor;
+    mImageProcessor           = processor;
+    mProviderRetryCount       = 0;
     mInvalidSessionRetryCount = 0;
 
     if (mImageProcessor->IsFirstImageRun())
@@ -129,20 +129,23 @@ void DefaultOTARequestorDriver::HandleIdleStateExit()
 
 void DefaultOTARequestorDriver::HandleIdleStateEnter(IdleStateReason reason)
 {
+    if (reason != IdleStateReason::kInvalidSession)
+    {
+        mInvalidSessionRetryCount = 0;
+    }
+
     switch (reason)
     {
     case IdleStateReason::kUnknown:
-        mInvalidSessionRetryCount = 0;
         ChipLogProgress(SoftwareUpdate, "Unknown idle state reason so set the periodic timer for a next attempt");
         StartSelectedTimer(SelectedTimer::kPeriodicQueryTimer);
         break;
     case IdleStateReason::kIdle:
-        mInvalidSessionRetryCount = 0;
         // There is no current OTA update in progress so start the periodic query timer
         StartSelectedTimer(SelectedTimer::kPeriodicQueryTimer);
         break;
     case IdleStateReason::kInvalidSession:
-        if(mInvalidSessionRetryCount < kMaxInvalidSessionRetries)
+        if (mInvalidSessionRetryCount < kMaxInvalidSessionRetries)
         {
             // An invalid session is detected which may be temporary so try to query the same provider again
             SendQueryImage();

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -127,6 +127,8 @@ void DefaultOTARequestorDriver::HandleIdleStateExit()
 
 void DefaultOTARequestorDriver::HandleIdleStateEnter(IdleStateReason reason)
 {
+    ChipLogProgress(SoftwareUpdate, "//is: DefaultOTARequestorDriver::HandleIdleStateEnter IdleStateReason %d", reason);
+
     switch (reason)
     {
     case IdleStateReason::kUnknown:
@@ -306,6 +308,8 @@ void DefaultOTARequestorDriver::ProcessAnnounceOTAProviders(
 
 void DefaultOTARequestorDriver::SendQueryImage()
 {
+    ChipLogProgress(SoftwareUpdate, "//is: DefaultOTARequestorDriver::SendQueryImage");
+
     OTAUpdateStateEnum currentUpdateState;
     Optional<ProviderLocationType> lastUsedProvider;
     mRequestor->GetProviderLocation(lastUsedProvider);

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -141,7 +141,8 @@ void DefaultOTARequestorDriver::HandleIdleStateEnter(IdleStateReason reason)
     case IdleStateReason::kInvalidSession:
         if (mProviderRetryCount < kMaxInvalidSessionRetries)
         {
-            // An invalid session is detected which may be temporary so try to query the same provider again
+            // An invalid session is detected which may be temporary (such as provider being restarted)
+            // so try to query the same provider again.
             SendQueryImage();
         }
         else

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -110,7 +110,7 @@ protected:
     // Maximum number of times to retry a BUSY OTA provider before moving to the next available one
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;
     // Track retry count for the current provider
-    uint8_t mProviderRetryCount; 
+    uint8_t mProviderRetryCount;
     // Track query image retry count on invalid session error
     uint8_t mInvalidSessionRetryCount;
 };

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -110,9 +110,9 @@ protected:
     // Maximum number of times to retry a BUSY OTA provider before moving to the next available one
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;
     // Track retry count for the current provider
-    uint8_t mProviderRetryCount;
+    uint8_t mProviderRetryCount = 0;
     // Track query image retry count on invalid session error
-    uint8_t mInvalidSessionRetryCount;
+    uint8_t mInvalidSessionRetryCount = 0;
 };
 
 } // namespace DeviceLayer

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -111,6 +111,8 @@ protected:
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;
     // Track retry count for the current provider
     uint8_t mProviderRetryCount = 0;
+    // Track query image retry count on invalid session error
+    uint8_t mInvalidSessionRetryCount = 0;
 };
 
 } // namespace DeviceLayer

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -111,8 +111,6 @@ protected:
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;
     // Track retry count for the current provider
     uint8_t mProviderRetryCount = 0;
-    // Track query image retry count on invalid session error
-    uint8_t mInvalidSessionRetryCount = 0;
 };
 
 } // namespace DeviceLayer

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -109,7 +109,10 @@ protected:
     uint16_t maxDownloadBlockSize  = 1024;
     // Maximum number of times to retry a BUSY OTA provider before moving to the next available one
     static constexpr uint8_t kMaxBusyProviderRetryCount = 3;
-    uint8_t mProviderRetryCount; // Track retry count for the current provider
+    // Track retry count for the current provider
+    uint8_t mProviderRetryCount; 
+    // Track query image retry count on invalid session error
+    uint8_t mInvalidSessionRetryCount;
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem

When tester starts OTA-P with one set of arguments, initiates QueryImage, then kills and restarts OTA-P with a different set of arguments, the first QueryImage will fail due to invalid CASE session but the second QueryImage succeeds.  For easier testing, the first QueryImage should also succeed after OTA-P is restarted.

Example sequence:

* Requestor does one successful QueryImage (CASE established)
* Provider killed
* Provider relaunched
* Requestor tries QueryImage again and gets the timeout error. Requestor invalidates the CASE.

```
[1653079824317] [28414:956800] CHIP: [DMG] Time out! failed to receive invoke command response from Exchange: 39593i
[1653079824317] [28414:956800] CHIP: [SWU] Received QueryImage failure response: ../../../examples/ota-requestor-app/linux/third_party/connectedhomeip/src/app/CommandSender.cpp:211: CHIP Error 0x00000032: Timeout
[1653079824317] [28414:956800] CHIP: [SWU] CASE session may be invalid, tear down session
```

* Requestor tries QueryImage again and gets Query already in progress error.

```
[1653079824318] [28414:956800] CHIP: [SWU] Query already in progress
```

* Initiate another QueryImage and now it succeeds.

#### Change overview

* In `DefaultOTARequestor::RecordNewUpdateState()`, update new state before handling state transition.
* In `DefaultOTARequestorDriver::HandleIdleStateEnter()`, add QueryImage retry cap.

#### Testing

* Requestor does one successful QueryImage (CASE established)
* Provider killed
* Provider relaunched
* Requestor tries QueryImage again and gets the timeout error -> requestor invalidates the CASE -> requestor tries QueryImage again and this time succeeds
