### PR TITLE
Remove useless IsInitialized() checks on fabric info.

### DIFF
--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -83,7 +83,7 @@ public:
         size_t count                    = 0;
         for (const FabricInfo & fabricInfo : Server::GetInstance().GetFabricTable())
         {
-            if (count < ArraySize(response.fabric_info) && fabricInfo.IsInitialized())
+            if (count < ArraySize(response.fabric_info))
             {
                 response.fabric_info[count].fabric_id = fabricInfo.GetFabricId();
                 response.fabric_info[count].node_id   = fabricInfo.GetPeerId().GetNodeId();

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -122,9 +122,6 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadNOCs(EndpointId endpoint, Attri
         {
             Clusters::OperationalCredentials::Structs::NOCStruct::Type noc;
 
-            if (!fabricInfo.IsInitialized())
-                continue;
-
             noc.fabricIndex = fabricInfo.GetFabricIndex();
 
             if (accessingFabricIndex == fabricInfo.GetFabricIndex())
@@ -164,9 +161,6 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadFabricsList(EndpointId endpoint
     return aEncoder.EncodeList([](const auto & encoder) -> CHIP_ERROR {
         for (auto & fabricInfo : Server::GetInstance().GetFabricTable())
         {
-            if (!fabricInfo.IsInitialized())
-                continue;
-
             Clusters::OperationalCredentials::Structs::FabricDescriptor::Type fabricDescriptor;
 
             fabricDescriptor.fabricIndex = fabricInfo.GetFabricIndex();
@@ -193,10 +187,6 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadRootCertificates(EndpointId end
         for (auto & fabricInfo : Server::GetInstance().GetFabricTable())
         {
             ByteSpan cert;
-
-            if (!fabricInfo.IsInitialized())
-                continue;
-
             ReturnErrorOnFailure(fabricInfo.GetRootCert(cert));
             ReturnErrorOnFailure(encoder.Encode(cert));
         }

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -72,10 +72,8 @@ bool DnssdServer::HaveOperationalCredentials()
     // Look for any fabric info that has a useful operational identity.
     for (const FabricInfo & fabricInfo : *mFabricTable)
     {
-        if (fabricInfo.IsInitialized())
-        {
-            return true;
-        }
+        (void) fabricInfo;
+        return true;
     }
 
     return false;
@@ -252,34 +250,31 @@ CHIP_ERROR DnssdServer::AdvertiseOperational()
 
     for (const FabricInfo & fabricInfo : *mFabricTable)
     {
-        if (fabricInfo.IsInitialized())
+        uint8_t macBuffer[DeviceLayer::ConfigurationManager::kPrimaryMACAddressLength];
+        MutableByteSpan mac(macBuffer);
+        if (chip::DeviceLayer::ConfigurationMgr().GetPrimaryMACAddress(mac) != CHIP_NO_ERROR)
         {
-            uint8_t macBuffer[DeviceLayer::ConfigurationManager::kPrimaryMACAddressLength];
-            MutableByteSpan mac(macBuffer);
-            if (chip::DeviceLayer::ConfigurationMgr().GetPrimaryMACAddress(mac) != CHIP_NO_ERROR)
-            {
-                ChipLogError(Discovery, "Failed to get primary mac address of device. Generating a random one.");
-                Crypto::DRBG_get_bytes(macBuffer, sizeof(macBuffer));
-            }
-
-            const auto advertiseParameters = chip::Dnssd::OperationalAdvertisingParameters()
-                                                 .SetPeerId(fabricInfo.GetPeerId())
-                                                 .SetMac(mac)
-                                                 .SetPort(GetSecuredPort())
-                                                 .SetInterfaceId(GetInterfaceId())
-                                                 .SetMRPConfig(GetLocalMRPConfig())
-                                                 .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT))
-                                                 .EnableIpV4(true);
-
-            auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
-
-            ChipLogProgress(Discovery, "Advertise operational node " ChipLogFormatX64 "-" ChipLogFormatX64,
-                            ChipLogValueX64(advertiseParameters.GetPeerId().GetCompressedFabricId()),
-                            ChipLogValueX64(advertiseParameters.GetPeerId().GetNodeId()));
-            // Should we keep trying to advertise the other operational
-            // identities on failure?
-            ReturnErrorOnFailure(mdnsAdvertiser.Advertise(advertiseParameters));
+            ChipLogError(Discovery, "Failed to get primary mac address of device. Generating a random one.");
+            Crypto::DRBG_get_bytes(macBuffer, sizeof(macBuffer));
         }
+
+        const auto advertiseParameters = chip::Dnssd::OperationalAdvertisingParameters()
+                                             .SetPeerId(fabricInfo.GetPeerId())
+                                             .SetMac(mac)
+                                             .SetPort(GetSecuredPort())
+                                             .SetInterfaceId(GetInterfaceId())
+                                             .SetMRPConfig(GetLocalMRPConfig())
+                                             .SetTcpSupported(Optional<bool>(INET_CONFIG_ENABLE_TCP_ENDPOINT))
+                                             .EnableIpV4(true);
+
+        auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
+
+        ChipLogProgress(Discovery, "Advertise operational node " ChipLogFormatX64 "-" ChipLogFormatX64,
+                        ChipLogValueX64(advertiseParameters.GetPeerId().GetCompressedFabricId()),
+                        ChipLogValueX64(advertiseParameters.GetPeerId().GetNodeId()));
+        // Should we keep trying to advertise the other operational
+        // identities on failure?
+        ReturnErrorOnFailure(mdnsAdvertiser.Advertise(advertiseParameters));
     }
     return CHIP_NO_ERROR;
 }

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -70,13 +70,7 @@ bool DnssdServer::HaveOperationalCredentials()
     VerifyOrDie(mFabricTable != nullptr);
 
     // Look for any fabric info that has a useful operational identity.
-    for (const FabricInfo & fabricInfo : *mFabricTable)
-    {
-        (void) fabricInfo;
-        return true;
-    }
-
-    return false;
+    return mFabricTable->FabricCount() != 0;
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY


### PR DESCRIPTION
All the consumers are iterating the fabric table, and that only
iterates the fabric infos that are in fact initialized.

#### Problem
Extra code that is not needed.

#### Change overview
Remove it.

#### Testing
No behavior changes, just less code.