### PR TITLE
Enable dependabot updates for MbedTLS 2.28 LTS

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,4 +6,4 @@ updates:
       interval: "weekly"
     allow:
       - dependency-name: "third_party/pigweed/repo"
-    open-pull-requests-limit: 1
+      - dependency-name: "third_party/mbedtls/repo"


### PR DESCRIPTION
#### Problem

Dependencies should be kept up to date, especially security critical ones such as crypto libraries.

#### Change overview

Enable automatic rolls of MbedTLS via dependabot.

#### Testing

Untested.