### PR TITLE
[Tizen] Improve app-preferences get/set/remove functions

### DIFF
--- a/src/platform/Tizen/AppPreference.cpp
+++ b/src/platform/Tizen/AppPreference.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR GetData(const char * key, void * data, size_t dataSize, size_t * getD
     }
     if (err != PREFERENCE_ERROR_NONE)
     {
-        ChipLogProgress(DeviceLayer, "FAIL: Get preference [%s]: %s", key, get_error_message(err));
+        ChipLogError(DeviceLayer, "Failed to get preference [%s]: %s", key, get_error_message(err));
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -96,7 +96,7 @@ CHIP_ERROR SaveData(const char * key, const void * data, size_t dataSize)
     }
     if (err != PREFERENCE_ERROR_NONE)
     {
-        ChipLogProgress(DeviceLayer, "FAIL: Set preference [%s]: %s", key, get_error_message(err));
+        ChipLogError(DeviceLayer, "Failed to set preference [%s]: %s", key, get_error_message(err));
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
@@ -113,7 +113,7 @@ CHIP_ERROR RemoveData(const char * key)
     }
     if (err != PREFERENCE_ERROR_NONE)
     {
-        ChipLogProgress(DeviceLayer, "FAIL: Remove preference [%s]: %s", key, get_error_message(err));
+        ChipLogError(DeviceLayer, "Failed to remove preference [%s]: %s", key, get_error_message(err));
         return CHIP_ERROR_INCORRECT_STATE;
     }
 

--- a/src/platform/Tizen/AppPreference.cpp
+++ b/src/platform/Tizen/AppPreference.cpp
@@ -19,6 +19,7 @@
 #include <app_preference.h>
 #include <lib/support/Base64.h>
 #include <lib/support/CHIPMem.h>
+#include <memory>
 
 namespace chip {
 namespace DeviceLayer {
@@ -26,138 +27,98 @@ namespace PersistedStorage {
 namespace Internal {
 namespace AppPreference {
 
-static CHIP_ERROR __IsKeyExist(const char * key)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    int preErr     = PREFERENCE_ERROR_NONE;
-    bool isExist   = false;
-
-    preErr = preference_is_existing(key, &isExist);
-    if (preErr != PREFERENCE_ERROR_NONE)
-    {
-        err = CHIP_ERROR_INCORRECT_STATE;
-    }
-    else if (isExist == false)
-    {
-        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
-    }
-
-    return err;
-}
-
 CHIP_ERROR CheckData(const char * key)
 {
-    return __IsKeyExist(key);
+    bool isExist = false;
+    int err      = preference_is_existing(key, &isExist);
+    VerifyOrReturnError(err == PREFERENCE_ERROR_NONE, CHIP_ERROR_INCORRECT_STATE);
+    return isExist ? CHIP_NO_ERROR : CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
 }
 
 CHIP_ERROR GetData(const char * key, void * data, size_t dataSize, size_t * getDataSize, size_t offset)
 {
-    CHIP_ERROR err                = CHIP_NO_ERROR;
-    int preErr                    = PREFERENCE_ERROR_NONE;
-    char * encodedData            = NULL;
-    uint8_t * decodedData         = NULL;
-    size_t encodedDataSize        = 0;
-    size_t encodedDataPaddingSize = 0;
-    size_t decodedDataSize        = 0;
-    size_t expectedDecodedSize    = 0;
-    size_t copy_size              = 0;
+    VerifyOrReturnError(data != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    VerifyOrExit(data != NULL, err = CHIP_ERROR_INVALID_ARGUMENT);
+    char * encodedData = nullptr;
+    // Make sure that string allocated by preference_get_string() will be freed
+    std::unique_ptr<char, decltype(&::free)> _{ encodedData, &::free };
 
-    err = __IsKeyExist(key);
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogProgress(DeviceLayer, "Not found data [%s]", key));
-
-    preErr = preference_get_string(key, &encodedData);
-    VerifyOrExit(preErr == PREFERENCE_ERROR_NONE, err = CHIP_ERROR_INCORRECT_STATE);
-    encodedDataSize = strlen(encodedData);
-
-    if ((encodedDataSize > 0) && (encodedData[encodedDataSize - 1] == '='))
+    int err = preference_get_string(key, &encodedData);
+    if (err == PREFERENCE_ERROR_NO_KEY)
     {
-        encodedDataPaddingSize++;
-        if ((encodedDataSize > 1) && (encodedData[encodedDataSize - 2] == '='))
-            encodedDataPaddingSize++;
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
-    expectedDecodedSize = ((encodedDataSize - encodedDataPaddingSize) * 3) / 4;
-
-    decodedData = static_cast<uint8_t *>(chip::Platform::MemoryAlloc(expectedDecodedSize));
-    VerifyOrExit(decodedData != NULL, err = CHIP_ERROR_INCORRECT_STATE);
-
-    decodedDataSize = Base64Decode(encodedData, static_cast<uint16_t>(encodedDataSize), decodedData);
-
-    copy_size = min(dataSize, decodedDataSize - offset);
-    if (getDataSize != NULL)
+    if (err == PREFERENCE_ERROR_OUT_OF_MEMORY)
     {
-        *getDataSize = copy_size;
+        return CHIP_ERROR_NO_MEMORY;
     }
-    memset(data, 0, dataSize);
-    memcpy(data, decodedData + offset, copy_size);
+    if (err != PREFERENCE_ERROR_NONE)
+    {
+        ChipLogProgress(DeviceLayer, "FAIL: Get preference [%s]: %s", key, get_error_message(err));
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
 
-    ChipLogProgress(DeviceLayer, "Get data [%s:%s]", key, (char *) data);
+    size_t encodedDataSize = strlen(encodedData);
 
-    chip::Platform::MemoryFree(decodedData);
+    Platform::ScopedMemoryBuffer<uint8_t> decodedData;
+    size_t expectedMaxDecodedSize = BASE64_MAX_DECODED_LEN(encodedDataSize);
+    VerifyOrReturnError(decodedData.Alloc(expectedMaxDecodedSize), CHIP_ERROR_NO_MEMORY);
 
-    VerifyOrExit(dataSize >= decodedDataSize - offset, err = CHIP_ERROR_BUFFER_TOO_SMALL);
+    size_t decodedDataSize = Base64Decode(encodedData, static_cast<uint16_t>(encodedDataSize), decodedData.Get());
+    VerifyOrReturnError(dataSize >= decodedDataSize - offset, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-exit:
-    free(encodedData);
-    return err;
+    size_t copySize = std::min(dataSize, decodedDataSize - offset);
+    if (getDataSize != nullptr)
+    {
+        *getDataSize = copySize;
+    }
+    ::memcpy(data, decodedData.Get() + offset, copySize);
+
+    ChipLogProgress(DeviceLayer, "Get data [%s:%.*s]", key, static_cast<int>(copySize), static_cast<char *>(data));
+    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR SaveData(const char * key, const uint8_t * data, size_t dataSize)
+CHIP_ERROR SaveData(const char * key, const void * data, size_t dataSize)
 {
-    CHIP_ERROR err             = CHIP_NO_ERROR;
-    int preErr                 = PREFERENCE_ERROR_NONE;
-    char * encodedData         = NULL;
-    size_t encodedDataSize     = 0;
-    size_t expectedEncodedSize = ((dataSize + 3) * 4) / 3;
+    // Expected size for null-terminated base64 string
+    size_t expectedEncodedSize = BASE64_ENCODED_LEN(dataSize) + 1;
 
-    err = __IsKeyExist(key);
-    if (err == CHIP_NO_ERROR)
+    Platform::ScopedMemoryBuffer<char> encodedData;
+    VerifyOrReturnError(encodedData.Alloc(expectedEncodedSize), CHIP_ERROR_NO_MEMORY);
+
+    size_t encodedDataSize = Base64Encode(static_cast<const uint8_t *>(data), static_cast<uint16_t>(dataSize), encodedData.Get());
+    encodedData[encodedDataSize] = '\0';
+
+    int err = preference_set_string(key, encodedData.Get());
+    if (err == PREFERENCE_ERROR_OUT_OF_MEMORY)
     {
-        VerifyOrExit(RemoveData(key) == CHIP_NO_ERROR, err = CHIP_ERROR_INCORRECT_STATE);
+        return CHIP_ERROR_NO_MEMORY;
     }
-    err = CHIP_NO_ERROR;
-
-    encodedData = static_cast<char *>(chip::Platform::MemoryAlloc(expectedEncodedSize));
-    VerifyOrExit(encodedData != NULL, err = CHIP_ERROR_INCORRECT_STATE);
-
-    encodedDataSize              = Base64Encode(data, static_cast<uint16_t>(dataSize), encodedData);
-    encodedData[encodedDataSize] = 0;
-
-    preErr = preference_set_string(key, encodedData);
-    if (preErr == PREFERENCE_ERROR_NONE)
+    if (err != PREFERENCE_ERROR_NONE)
     {
-        ChipLogProgress(DeviceLayer, "Save data [%s:%s]", key, data);
-    }
-    else
-    {
-        ChipLogProgress(DeviceLayer, "FAIL: set string [%s]", get_error_message(preErr));
-        err = CHIP_ERROR_INCORRECT_STATE;
+        ChipLogProgress(DeviceLayer, "FAIL: Set preference [%s]: %s", key, get_error_message(err));
+        return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    chip::Platform::MemoryFree(encodedData);
-
-exit:
-    return err;
+    ChipLogProgress(DeviceLayer, "Save data [%s:%.*s]", key, static_cast<int>(dataSize), static_cast<const char *>(data));
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR RemoveData(const char * key)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    int preErr     = PREFERENCE_ERROR_NONE;
-
-    preErr = preference_remove(key);
-    if (preErr == PREFERENCE_ERROR_NONE)
+    int err = preference_remove(key);
+    if (err == PREFERENCE_ERROR_NO_KEY)
     {
-        ChipLogProgress(DeviceLayer, "Remove data [%s]", key);
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
-    else
+    if (err != PREFERENCE_ERROR_NONE)
     {
-        ChipLogProgress(DeviceLayer, "FAIL: remove preference [%s]", get_error_message(preErr));
-        err = CHIP_ERROR_INCORRECT_STATE;
+        ChipLogProgress(DeviceLayer, "FAIL: Remove preference [%s]: %s", key, get_error_message(err));
+        return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    return err;
+    ChipLogProgress(DeviceLayer, "Remove data [%s]", key);
+    return CHIP_NO_ERROR;
 }
 
 } // namespace AppPreference

--- a/src/platform/Tizen/AppPreference.h
+++ b/src/platform/Tizen/AppPreference.h
@@ -28,7 +28,7 @@ namespace AppPreference {
 
 CHIP_ERROR CheckData(const char * key);
 CHIP_ERROR GetData(const char * key, void * data, size_t dataSize, size_t * getDataSize, size_t offset);
-CHIP_ERROR SaveData(const char * key, const uint8_t * data, size_t size);
+CHIP_ERROR SaveData(const char * key, const void * data, size_t size);
 CHIP_ERROR RemoveData(const char * key);
 
 } // namespace AppPreference

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -79,7 +79,7 @@ void BLEManagerImpl::GattConnectionStateChangedCb(int result, bool connected, co
 
     if (result != BT_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, connected ? "Connection req failed" : "Disconnection req failed");
+        ChipLogError(DeviceLayer, "%s", connected ? "Connection req failed" : "Disconnection req failed");
         if (connected)
             sInstance.NotifyHandleConnectFailed(CHIP_ERROR_INTERNAL);
     }

--- a/src/platform/Tizen/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Tizen/KeyValueStoreManagerImpl.cpp
@@ -43,7 +43,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)
 {
-    return Internal::AppPreference::SaveData(key, reinterpret_cast<const uint8_t *>(value), value_size);
+    return Internal::AppPreference::SaveData(key, value, value_size);
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)


### PR DESCRIPTION
#### Problem

Out-of-bound read when logging data in `KeyValueStoreManagerImpl` on Tizen.

#### Change overview

- Do not check for key existence before calling get/set functions. The key existence status will be reported by these functions anyway.
- Prevent memory leaks with scope allocators instead of manually calling free() functions.
- Prevent out-of-bound read when logging non-string values by passing the data length to the printf-like function with "%.*s" specifier.

#### Testing

Running example app on Tizen to see whether terminal will not be corrupted after printing non-string data:
```
I/CHIP    ( 1607): DL: Get data [vendor-id:*]
I/CHIP    ( 1607): DL: Get data [product-id:]
I/CHIP    ( 1607): DIS: Advertise commission parameter vendorID=42 productID=20 discriminator=0000/00
```