### PR TITLE
[nrfconnect] Fixed DFU over SMP by external flash handling refactor

### DIFF
--- a/examples/platform/nrfconnect/util/DFUOverSMP.cpp
+++ b/examples/platform/nrfconnect/util/DFUOverSMP.cpp
@@ -44,9 +44,13 @@ void DFUOverSMP::Init(DFUOverSMPRestartAdvertisingHandler startAdvertisingCb)
     img_mgmt_set_upload_cb(UploadConfirmHandler, NULL);
 
     memset(&mBleConnCallbacks, 0, sizeof(mBleConnCallbacks));
+    mBleConnCallbacks.connected    = OnBleConnect;
     mBleConnCallbacks.disconnected = OnBleDisconnect;
 
     bt_conn_cb_register(&mBleConnCallbacks);
+
+    k_work_init(&mFlashSleepWork, [](k_work *) { GetFlashHandler().DoAction(FlashHandler::Action::SLEEP); });
+    k_work_init(&mFlashWakeUpWork, [](k_work *) { GetFlashHandler().DoAction(FlashHandler::Action::WAKE_UP); });
 
     restartAdvertisingCallback = startAdvertisingCb;
 
@@ -130,8 +134,21 @@ void DFUOverSMP::StartBLEAdvertising()
     }
 }
 
+void DFUOverSMP::OnBleConnect(bt_conn * conn, uint8_t err)
+{
+    if (GetDFUOverSMP().IsEnabled())
+    {
+        (void) k_work_submit(&sDFUOverSMP.mFlashWakeUpWork);
+    }
+}
+
 void DFUOverSMP::OnBleDisconnect(struct bt_conn * conId, uint8_t reason)
 {
+    if (GetDFUOverSMP().IsEnabled())
+    {
+        (void) k_work_submit(&sDFUOverSMP.mFlashSleepWork);
+    }
+
     PlatformMgr().LockChipStack();
 
     // After BLE disconnect SMP advertising needs to be restarted. Before making it ensure that BLE disconnect was not triggered
@@ -159,7 +176,7 @@ void DFUOverSMP::ChipEventHandler(const ChipDeviceEvent * event, intptr_t /* arg
                 sDFUOverSMP.restartAdvertisingCallback();
         }
         break;
-    case DeviceEventType::kCommissioningComplete:
+    case DeviceEventType::kCHIPoBLEConnectionClosed:
         // Check if after closing CHIPoBLE connection advertising is working, if no start SMP advertising.
         if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
         {

--- a/examples/platform/nrfconnect/util/DFUOverSMP.cpp
+++ b/examples/platform/nrfconnect/util/DFUOverSMP.cpp
@@ -30,6 +30,8 @@
 
 #include <lib/support/logging/CHIPLogging.h>
 
+#include "OTAUtil.h"
+
 using namespace ::chip::DeviceLayer;
 
 constexpr uint16_t kAdvertisingIntervalMinMs = 400;

--- a/examples/platform/nrfconnect/util/OTAUtil.cpp
+++ b/examples/platform/nrfconnect/util/OTAUtil.cpp
@@ -31,15 +31,19 @@ DefaultOTARequestorStorage sOTARequestorStorage;
 DefaultOTARequestorDriver sOTARequestorDriver;
 chip::BDXDownloader sBDXDownloader;
 chip::DefaultOTARequestor sOTARequestor;
-
 } // namespace
+
+FlashHandler & GetFlashHandler()
+{
+    static FlashHandler sFlashHandler;
+    return sFlashHandler;
+}
 
 // compile-time factory method
 OTAImageProcessorImpl & GetOTAImageProcessor()
 {
 #if CONFIG_PM_DEVICE && CONFIG_NORDIC_QSPI_NOR
-    static ExtFlashHandler sQSPIHandler;
-    static OTAImageProcessorImplPMDevice sOTAImageProcessor{ sQSPIHandler };
+    static OTAImageProcessorImpl sOTAImageProcessor(&GetFlashHandler());
 #else
     static OTAImageProcessorImpl sOTAImageProcessor;
 #endif
@@ -55,4 +59,5 @@ void InitBasicOTARequestor()
     sOTARequestor.Init(Server::GetInstance(), sOTARequestorStorage, sOTARequestorDriver, sBDXDownloader);
     chip::SetRequestorInstance(&sOTARequestor);
     sOTARequestorDriver.Init(&sOTARequestor, &imageProcessor);
+    imageProcessor.TriggerFlashAction(FlashHandler::Action::SLEEP);
 }

--- a/examples/platform/nrfconnect/util/include/DFUOverSMP.h
+++ b/examples/platform/nrfconnect/util/include/DFUOverSMP.h
@@ -42,12 +42,15 @@ private:
     friend DFUOverSMP & GetDFUOverSMP(void);
 
     static int UploadConfirmHandler(uint32_t offset, uint32_t size, void * arg);
+    static void OnBleConnect(bt_conn * conn, uint8_t err);
     static void OnBleDisconnect(bt_conn * conn, uint8_t reason);
     static void ChipEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
 
     bool mIsEnabled;
     bool mIsAdvertisingEnabled;
     bt_conn_cb mBleConnCallbacks;
+    k_work mFlashSleepWork;
+    k_work mFlashWakeUpWork;
     DFUOverSMPRestartAdvertisingHandler restartAdvertisingCallback;
 
     static DFUOverSMP sDFUOverSMP;

--- a/examples/platform/nrfconnect/util/include/OTAUtil.h
+++ b/examples/platform/nrfconnect/util/include/OTAUtil.h
@@ -24,6 +24,14 @@ class OTAImageProcessorImpl;
 } // namespace chip
 
 /**
+ * Get FlashHandler static instance.
+ *
+ * Returned object can be used to control the QSPI external flash,
+ * which can be introduced into sleep mode and woken up on demand.
+ */
+chip::DeviceLayer::FlashHandler & GetFlashHandler();
+
+/**
  * Select recommended OTA image processor implementation.
  *
  * If the application uses QSPI external flash and enables API for controlling

--- a/examples/platform/nrfconnect/util/include/OTAUtil.h
+++ b/examples/platform/nrfconnect/util/include/OTAUtil.h
@@ -17,6 +17,8 @@
 
 #pragma once
 
+#include <platform/nrfconnect/OTAImageProcessorImpl.h>
+
 namespace chip {
 namespace DeviceLayer {
 class OTAImageProcessorImpl;

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -37,6 +37,8 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
 {
     VerifyOrReturnError(mDownloader != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
+    TriggerFlashAction(FlashHandler::Action::WAKE_UP);
+
     return DeviceLayer::SystemLayer().ScheduleLambda([this] { mDownloader->OnPreparedForDownload(PrepareDownloadImpl()); });
 }
 
@@ -56,7 +58,10 @@ CHIP_ERROR OTAImageProcessorImpl::Finalize()
 
 CHIP_ERROR OTAImageProcessorImpl::Abort()
 {
-    return System::MapErrorZephyr(dfu_target_reset());
+    CHIP_ERROR error = System::MapErrorZephyr(dfu_target_reset());
+
+    TriggerFlashAction(FlashHandler::Action::SLEEP);
+    return error;
 }
 
 CHIP_ERROR OTAImageProcessorImpl::Apply()
@@ -67,6 +72,8 @@ CHIP_ERROR OTAImageProcessorImpl::Apply()
         // schedule update of all possible targets by caling this function with argument -1
         err = dfu_target_schedule_update(-1);
     }
+
+    TriggerFlashAction(FlashHandler::Action::SLEEP);
 
 #ifdef CONFIG_CHIP_OTA_REQUESTOR_REBOOT_ON_APPLY
     if (!err)
@@ -214,8 +221,16 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & aBlock)
     return CHIP_NO_ERROR;
 }
 
+void OTAImageProcessorImpl::TriggerFlashAction(FlashHandler::Action action)
+{
+    if (mFlashHandler)
+    {
+        mFlashHandler->DoAction(action);
+    }
+}
+
 // external flash power consumption optimization
-void ExtFlashHandler::DoAction(Action aAction)
+void FlashHandler::DoAction(Action aAction)
 {
 #if CONFIG_PM_DEVICE && CONFIG_NORDIC_QSPI_NOR && !CONFIG_SOC_NRF52840 // nRF52 is optimized per default
     // utilize the QSPI driver sleep power mode
@@ -226,31 +241,6 @@ void ExtFlashHandler::DoAction(Action aAction)
         (void) pm_device_action_run(qspi_dev, requestedAction); // not much can be done in case of a failure
     }
 #endif
-}
-
-OTAImageProcessorImplPMDevice::OTAImageProcessorImplPMDevice(ExtFlashHandler & aHandler) : mHandler(aHandler)
-{
-    mHandler.DoAction(ExtFlashHandler::Action::SLEEP);
-}
-
-CHIP_ERROR OTAImageProcessorImplPMDevice::PrepareDownload()
-{
-    mHandler.DoAction(ExtFlashHandler::Action::WAKE_UP);
-    return OTAImageProcessorImpl::PrepareDownload();
-}
-
-CHIP_ERROR OTAImageProcessorImplPMDevice::Abort()
-{
-    auto status = OTAImageProcessorImpl::Abort();
-    mHandler.DoAction(ExtFlashHandler::Action::SLEEP);
-    return status;
-}
-
-CHIP_ERROR OTAImageProcessorImplPMDevice::Apply()
-{
-    auto status = OTAImageProcessorImpl::Apply();
-    mHandler.DoAction(ExtFlashHandler::Action::SLEEP);
-    return status;
 }
 
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem
Currently DFU over SMP doesn't work properly due to problems with external flash interaction that is put asleep by the OTA
Matter module.

#### Change overview
* Added using BLE connect/disconnect callbacks to control the QSPI NOR power mode.
* Refactored ExternalFlashHandler to be generic FlashHandler that can be also implemented by other backends than NOR QSPI

#### Testing
Verified manually that DFU over SMP works properly.
