### PR TITLE
Handle GetConnectedDeviceSync failures correctly

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -672,12 +672,14 @@ class DeviceMgrCmd(Cmd):
         try:
             args = shlex.split(line)
             if len(args) == 1:
-                err = self.devCtrl.ResolveNode(int(args[0]))
-                if err == 0:
+                try:
+                    self.devCtrl.ResolveNode(int(args[0]))
                     address = self.devCtrl.GetAddressAndPort(int(args[0]))
                     address = "{}:{}".format(
                         *address) if address else "unknown"
                     print("Current address: " + address)
+                except exceptions.ChipStackException as ex:
+                    print(str(ex))
             else:
                 self.do_help("resolve")
         except exceptions.ChipStackException as ex:

--- a/src/test_driver/mbed/integration_tests/common/utils.py
+++ b/src/test_driver/mbed/integration_tests/common/utils.py
@@ -282,13 +282,10 @@ def resolve_device(devCtrl, nodeId):
     """
     ret = None
     try:
-        err = devCtrl.ResolveNode(int(nodeId))
-        if err == 0:
-            ret = devCtrl.GetAddressAndPort(int(nodeId))
-            if ret == None:
-                log.error("Get address and port failed")
-        else:
-            log.error("Resolve node failed [{}]".format(err))
+        devCtrl.ResolveNode(int(nodeId))
+        ret = devCtrl.GetAddressAndPort(int(nodeId))
+        if ret == None:
+            log.error("Get address and port failed")
     except exceptions.ChipStackException as ex:
         log.error("Resolve node failed {}".format(str(ex)))
 


### PR DESCRIPTION


#### Problem
Calling `ResolveNode` on a non-existing node causes a internal error with the following stack trace:

```
2022-05-25 14:32:22 allenwind __main__[100567] ERROR Error calling method: device_controller.ResolveNode
Traceback (most recent call last):
  File "/home/sag/projects/project-chip/python-matter-server/chip_ws_server/__main__.py", line 115, in handle_message
  File "/home/sag/projects/project-chip/connectedhomeip/out/python_env/lib/python3.9/site-packages/chip/ChipDeviceCtrl.py", line 363, in ResolveNode
    self.GetConnectedDeviceSync(nodeid, allowPASE=False)
  File "/home/sag/projects/project-chip/connectedhomeip/out/python_env/lib/python3.9/site-packages/chip/ChipDeviceCtrl.py", line 536, in GetConnectedDeviceSync
    raise self._ChipStack.ErrorToException(CHIP_ERROR_INTERNAL)
NameError: name 'CHIP_ERROR_INTERNAL' is not defined
```

#### Change overview
Handle the error case correctly and throw an exception in the main
context. Also make ResolveNode more pythonic by not using a return
value but letting the Exception bubble up.

#### Testing
Local Python REPL, using `ResolveNode` which does not exist.