### PR TITLE
[ember] Optimize out ember strings in release builds

### DIFF
--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -261,14 +261,15 @@ bool IsFeatureSupported(EndpointId endpoint, EmberAfStatus (*getFn1)(chip::Endpo
     return false;
 }
 
+template <typename T1, typename T2>
+const char * FeatureSupportedDebugString(EndpointId endpoint, EmberAfStatus (*getFn1)(chip::EndpointId endpointId, T1 & value),
+                                         EmberAfStatus (*getFn2)(chip::EndpointId endpointId, T2 & value))
+{
+    return IsFeatureSupported(endpoint, getFn1, getFn2) ? "Supported" : "Not Supported";
+}
+
 void emberAfPumpConfigurationAndControlClusterServerInitCallback(EndpointId endpoint)
 {
-    bool constPressureSupported     = false;
-    bool constPropPressureSupported = false;
-    bool constFlowSupported         = false;
-    bool constTemperatureSupported  = false;
-    bool constSpeedSupported        = false;
-
     emberAfDebugPrintln("Initialize PCC Server Cluster [EP:%d]", endpoint);
 
     // Determine the internal feature set of the pump, depending on the pump
@@ -283,16 +284,17 @@ void emberAfPumpConfigurationAndControlClusterServerInitCallback(EndpointId endp
     // has finished its init process, it might setup these attributevalues
     // to something NonNull, and then we must re-calcualte the feature set.
 
-    constPressureSupported = IsFeatureSupported(endpoint, Attributes::MinConstPressure::Get, Attributes::MaxConstPressure::Get);
-    emberAfDebugPrintln("Constant Pressure %s", constPressureSupported ? "Supported" : "Not Supported");
-    constPropPressureSupported = IsFeatureSupported(endpoint, Attributes::MinCompPressure::Get, Attributes::MaxCompPressure::Get);
-    emberAfDebugPrintln("Constant Proportional Pressure %s", constPropPressureSupported ? "Supported" : "Not Supported");
-    constFlowSupported = IsFeatureSupported(endpoint, Attributes::MinConstFlow::Get, Attributes::MaxConstFlow::Get);
-    emberAfDebugPrintln("Constant Flow %s", constFlowSupported ? "Supported" : "Not Supported");
-    constTemperatureSupported = IsFeatureSupported(endpoint, Attributes::MinConstTemp::Get, Attributes::MaxConstTemp::Get);
-    emberAfDebugPrintln("Constant Temperature %s", constTemperatureSupported ? "Supported" : "Not Supported");
-    constSpeedSupported = IsFeatureSupported(endpoint, Attributes::MinConstSpeed::Get, Attributes::MaxConstSpeed::Get);
-    emberAfDebugPrintln("Constant Speed %s", constSpeedSupported ? "Supported" : "Not Supported");
+    emberAfDebugPrintln(
+        "Constant Pressure %s",
+        FeatureSupportedDebugString(endpoint, Attributes::MinConstPressure::Get, Attributes::MaxConstPressure::Get));
+    emberAfDebugPrintln("Constant Proportional Pressure %s",
+                        FeatureSupportedDebugString(endpoint, Attributes::MinCompPressure::Get, Attributes::MaxCompPressure::Get));
+    emberAfDebugPrintln("Constant Flow %s",
+                        FeatureSupportedDebugString(endpoint, Attributes::MinConstFlow::Get, Attributes::MaxConstFlow::Get));
+    emberAfDebugPrintln("Constant Temperature %s",
+                        FeatureSupportedDebugString(endpoint, Attributes::MinConstTemp::Get, Attributes::MaxConstTemp::Get));
+    emberAfDebugPrintln("Constant Speed %s",
+                        FeatureSupportedDebugString(endpoint, Attributes::MinConstSpeed::Get, Attributes::MaxConstSpeed::Get));
 }
 
 chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClusterServerPreAttributeChangedCallback(

--- a/src/app/util/ember-print.cpp
+++ b/src/app/util/ember-print.cpp
@@ -29,9 +29,10 @@ bool emberAfPrintReceivedMessages = true;
 
 using namespace chip::Logging;
 
+#if CHIP_PROGRESS_LOGGING
+
 void emberAfPrint(int category, const char * format, ...)
 {
-#if _CHIP_USE_LOGGING
     if (format != nullptr)
     {
         va_list args;
@@ -39,13 +40,11 @@ void emberAfPrint(int category, const char * format, ...)
         chip::Logging::LogV(chip::Logging::kLogModule_Zcl, chip::Logging::kLogCategory_Progress, format, args);
         va_end(args);
     }
-#endif
 }
 
 #if !CHIP_PW_TOKENIZER_LOGGING
 void emberAfPrintln(int category, const char * format, ...)
 {
-#if _CHIP_USE_LOGGING
     if (format != nullptr)
     {
         va_list args;
@@ -53,7 +52,6 @@ void emberAfPrintln(int category, const char * format, ...)
         chip::Logging::LogV(chip::Logging::kLogModule_Zcl, chip::Logging::kLogCategory_Progress, format, args);
         va_end(args);
     }
-#endif
 }
 #endif
 
@@ -101,3 +99,5 @@ void emberAfPrintString(int category, const uint8_t * string)
 {
     emberAfPrint(category, "%.*s", emberAfStringLength(string), string + 1);
 }
+
+#endif // CHIP_PROGRESS_LOGGING

--- a/src/app/util/ember-print.h
+++ b/src/app/util/ember-print.h
@@ -27,18 +27,24 @@
  * @brief Prints a log message
  * @param category - Currently ignored as zcl categories do not map to chip categories. Defaults to kLogCategory_Progress
  * @param format - Format string to print
- * */
+ */
+#if CHIP_PROGRESS_LOGGING
 void emberAfPrint(int category, const char * format, ...) ENFORCE_FORMAT(2, 3);
+#else
+#define emberAfPrint(...) ((void) 0)
+#endif
 
 /**
  * @brief Prints a log followed by new line line
  * @param category - Currently ignored as zcl categories do not map to chip categories. Defaults to kLogCategory_Progress
  * @param format - Format string to print
- * */
+ */
 #if CHIP_PW_TOKENIZER_LOGGING
 #define emberAfPrintln(MOD, MSG, ...) ChipLogProgress(Zcl, MSG, __VA_ARGS__);
-#else
+#elif CHIP_PROGRESS_LOGGING
 void emberAfPrintln(int category, const char * format, ...) ENFORCE_FORMAT(2, 3);
+#else
+#define emberAfPrintln(...) ((void) 0)
 #endif
 
 /**
@@ -47,12 +53,20 @@ void emberAfPrintln(int category, const char * format, ...) ENFORCE_FORMAT(2, 3)
  * @param buffer - Buffer to print.
  * @param length - Length of buffer
  * @param withSpace - Pass in true if a space should be printed between each byte.
- * */
+ */
+#if CHIP_PROGRESS_LOGGING
 void emberAfPrintBuffer(int category, const uint8_t * buffer, uint16_t length, bool withSpace);
+#else
+#define emberAfPrintBuffer(...) ((void) 0)
+#endif
 
 /**
  * @brief Prints a strings
  * @param category - Currently ignored as zcl categories do not map to chip categories. Defaults to kLogCategory_Progress.
  * @param string - Buffer to print as a string
- * */
+ */
+#if CHIP_PROGRESS_LOGGING
 void emberAfPrintString(int category, const uint8_t * string);
+#else
+#define emberAfPrintString(...) ((void) 0)
+#endif

--- a/src/app/util/time-util.h
+++ b/src/app/util/time-util.h
@@ -103,12 +103,6 @@ uint32_t emberAfGetUtcFromTimeStruct(EmberAfTimeStruct * time);
  */
 uint8_t emberAfGetWeekdayFromUtc(uint32_t utcTime);
 
-/*
- * @brief Prints out a human readable date form from the given ZCL data type.
- */
-void emberAfPrintDate(const EmberAfDate * date);
-void emberAfPrintDateln(const EmberAfDate * date);
-
 /**
  * @brief Sets current time.
  * Convenience function for setting the time to a value.


### PR DESCRIPTION
#### Problem
Ember strings are still included in the binary even if the progress logging is disabled. 

#### Change overview
Resolve emberPrint to noop if the progress logging is disabled.
The change saves around 14kB of flash in the case of nRF connect examples.

#### Testing
CI + smoke tests on nRF Connect platform.
