### PR TITLE
Make QR code parsing error out if the padding bits are not all 0.

### DIFF
--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -365,6 +365,11 @@ CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     outPayload.setUpPINCode = static_cast<uint32_t>(dest);
 
     ReturnErrorOnFailure(readBits(buf, indexToReadFrom, dest, kPaddingFieldLengthInBits));
+    if (dest != 0)
+    {
+        ChipLogError(SetupPayload, "Payload padding bits are not all 0: 0x%x", static_cast<unsigned>(dest));
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     return populateTLV(outPayload, buf, indexToReadFrom);
 }


### PR DESCRIPTION
Right now we accept invalid QR codes with nonzero padding.

#### Problem
A QR code that has nonzero padding bits is accepted.

#### Change overview
Make that log and fail.

#### Testing
Modified an existing all-clusters-app QR code (`MT:-24J029Q00KA0648G00`) to have a single bit set in the padding (so `MT:-24J029Q00KA0640A30`) and then ran the chip-tool `parse-setup-payload` command.