### PR TITLE
Fix app/util/util.h to fix lighting app build

### DIFF
--- a/examples/lighting-app/esp32/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/esp32/main/DeviceCallbacks.cpp
@@ -26,6 +26,8 @@
 #include "DeviceCallbacks.h"
 #include "LEDWidget.h"
 
+#include <app/util/util.h>
+
 static const char * TAG = "light-app-callbacks";
 
 extern LEDWidget AppLED;


### PR DESCRIPTION
#### Problem
Currently building lighting app according to README.md fails with:
```
/home/sag/projects/project-chip/connectedhomeip/examples/lighting-app/esp32/main/DeviceCallbacks.cpp: In member function 'void AppDeviceCallbacks::OnColorControlAttributeChangeCallback(chip::EndpointId, chip::AttributeId, uint8_t*)':
/home/sag/projects/project-chip/connectedhomeip/examples/lighting-app/esp32/main/DeviceCallbacks.cpp:105:9: error: 'emberAfReadServerAttribute' was not declared in this scope
         emberAfReadServerAttribute(endpointId, ColorControl::Id, ColorControl::Attributes::CurrentSaturation::Id, &saturation,
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
/home/sag/projects/project-chip/connectedhomeip/examples/lighting-app/esp32/main/DeviceCallbacks.cpp:105:9: note: maximum limit of 1000 namespaces searched for 'emberAfReadServerAttribute'
/home/sag/projects/project-chip/connectedhomeip/examples/lighting-app/esp32/main/DeviceCallbacks.cpp:105:9: note: suggested alternative: 'emberAfIsStringAttributeType'
         emberAfReadServerAttribute(endpointId, ColorControl::Id, ColorControl::Attributes::CurrentSaturation::Id, &saturation,
         ^~~~~~~~~~~~~~~~~~~~~~~~~~
         emberAfIsStringAttributeType
```


#### Change overview
Include app/util/util.h to fix the build.

#### Testing
Compiled locally using IDF SDK v4.4.1 connectedhomeip as of 054d820b5215c7a0137b92baf918c5942c099b0a.