### PR TITLE
Handle fabric removal in the Door Lock Cluster and fix GetUser/GetCredentialStatus commands

### DIFF
--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -75,8 +75,8 @@ public:
     bool GetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, DlCredentialType credentialType,
                        EmberAfPluginDoorLockCredentialInfo & credential) const;
 
-    bool SetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, DlCredentialStatus credentialStatus,
-                       DlCredentialType credentialType, const chip::ByteSpan & credentialData);
+    bool SetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, chip::FabricIndex creator, chip::FabricIndex modifier,
+                       DlCredentialStatus credentialStatus, DlCredentialType credentialType, const chip::ByteSpan & credentialData);
 
     bool setLockState(chip::EndpointId endpointId, DlLockState lockState, const Optional<chip::ByteSpan> & pin,
                       DlOperationError & err);

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -230,7 +230,7 @@ bool LockManager::GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo & us
     user.userUniqueId   = userInDb.userUniqueId;
     user.userType       = userInDb.userType;
     user.credentialRule = userInDb.credentialRule;
-    // So far there's no way to actually create the credential outside the matter, so here we always set the creation/modification
+    // So far there's no way to actually create the credential outside Matter, so here we always set the creation/modification
     // source to Matter
     user.creationSource     = DlAssetSource::kMatterIM;
     user.createdBy          = userInDb.createdBy;
@@ -322,7 +322,7 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
     }
     credential.credentialType = credentialInStorage.credentialType;
     credential.credentialData = credentialInStorage.credentialData;
-    // So far there's no way to actually create the credential outside the matter, so here we always set the creation/modification
+    // So far there's no way to actually create the credential outside Matter, so here we always set the creation/modification
     // source to Matter
     credential.creationSource     = DlAssetSource::kMatterIM;
     credential.modificationSource = DlAssetSource::kMatterIM;

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -230,8 +230,12 @@ bool LockManager::GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo & us
     user.userUniqueId   = userInDb.userUniqueId;
     user.userType       = userInDb.userType;
     user.credentialRule = userInDb.credentialRule;
-    user.createdBy      = userInDb.createdBy;
-    user.lastModifiedBy = userInDb.lastModifiedBy;
+    // So far there's no way to actually create the credential outside the matter, so here we always set the creation/modification
+    // source to Matter
+    user.creationSource     = DlAssetSource::kMatterIM;
+    user.createdBy          = userInDb.createdBy;
+    user.modificationSource = DlAssetSource::kMatterIM;
+    user.lastModifiedBy     = userInDb.lastModifiedBy;
 
     ChipLogDetail(Zcl,
                   "Found occupied user "
@@ -318,6 +322,10 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
     }
     credential.credentialType = credentialInStorage.credentialType;
     credential.credentialData = credentialInStorage.credentialData;
+    // So far there's no way to actually create the credential outside the matter, so here we always set the creation/modification
+    // source to Matter
+    credential.creationSource     = DlAssetSource::kMatterIM;
+    credential.modificationSource = DlAssetSource::kMatterIM;
 
     ChipLogDetail(Zcl, "Found occupied credential [type=%u,dataSize=%u]", to_underlying(credential.credentialType),
                   credential.credentialData.size());

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -322,6 +322,8 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
     }
     credential.credentialType = credentialInStorage.credentialType;
     credential.credentialData = credentialInStorage.credentialData;
+    credential.createdBy      = credentialInStorage.createdBy;
+    credential.lastModifiedBy = credentialInStorage.lastModifiedBy;
     // So far there's no way to actually create the credential outside Matter, so here we always set the creation/modification
     // source to Matter
     credential.creationSource     = DlAssetSource::kMatterIM;
@@ -333,13 +335,14 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
     return true;
 }
 
-bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, DlCredentialStatus credentialStatus,
-                                DlCredentialType credentialType, const chip::ByteSpan & credentialData)
+bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, chip::FabricIndex creator,
+                                chip::FabricIndex modifier, DlCredentialStatus credentialStatus, DlCredentialType credentialType,
+                                const chip::ByteSpan & credentialData)
 {
     ChipLogProgress(Zcl,
                     "Door Lock App: LockManager::SetCredential "
-                    "[credentialStatus=%u,credentialType=%u,credentialDataSize=%u]",
-                    to_underlying(credentialStatus), to_underlying(credentialType), credentialData.size());
+                    "[credentialStatus=%u,credentialType=%u,credentialDataSize=%u,creator=%d,modifier=%d]",
+                    to_underlying(credentialStatus), to_underlying(credentialType), credentialData.size(), creator, modifier);
 
     auto & credentialInStorage = mLockCredentials;
     if (credentialData.size() > DOOR_LOCK_CREDENTIAL_INFO_MAX_DATA_SIZE)
@@ -352,6 +355,8 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
     }
     credentialInStorage.status         = credentialStatus;
     credentialInStorage.credentialType = credentialType;
+    credentialInStorage.createdBy      = creator;
+    credentialInStorage.lastModifiedBy = modifier;
 
     memcpy(mCredentialData, credentialData.data(), credentialData.size());
     mCredentialData[credentialData.size()] = 0;

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -90,10 +90,12 @@ bool emberAfPluginDoorLockGetCredential(chip::EndpointId endpointId, uint16_t cr
     return LockMgr().GetCredential(endpointId, credentialIndex, credentialType, credential);
 }
 
-bool emberAfPluginDoorLockSetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, DlCredentialStatus credentialStatus,
+bool emberAfPluginDoorLockSetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, chip::FabricIndex creator,
+                                        chip::FabricIndex modifier, DlCredentialStatus credentialStatus,
                                         DlCredentialType credentialType, const chip::ByteSpan & credentialData)
 {
-    return LockMgr().SetCredential(endpointId, credentialIndex, credentialStatus, credentialType, credentialData);
+    return LockMgr().SetCredential(endpointId, credentialIndex, creator, modifier, credentialStatus, credentialType,
+                                   credentialData);
 }
 
 bool emberAfPluginDoorLockGetUser(chip::EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user)

--- a/examples/lock-app/linux/src/LockEndpoint.cpp
+++ b/examples/lock-app/linux/src/LockEndpoint.cpp
@@ -55,8 +55,12 @@ bool LockEndpoint::GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo & u
     user.userUniqueId   = userInDb.userUniqueId;
     user.userType       = userInDb.userType;
     user.credentialRule = userInDb.credentialRule;
-    user.createdBy      = userInDb.createdBy;
-    user.lastModifiedBy = userInDb.lastModifiedBy;
+    // So far there's no way to actually create the credential outside the matter, so here we always set the creation/modification
+    // source to Matter
+    user.creationSource     = DlAssetSource::kMatterIM;
+    user.createdBy          = userInDb.createdBy;
+    user.modificationSource = DlAssetSource::kMatterIM;
+    user.lastModifiedBy     = userInDb.lastModifiedBy;
 
     ChipLogDetail(Zcl,
                   "Found occupied user "
@@ -151,8 +155,12 @@ bool LockEndpoint::GetCredential(uint16_t credentialIndex, DlCredentialType cred
     }
     credential.credentialType = credentialInStorage.credentialType;
     credential.credentialData = chip::ByteSpan(credentialInStorage.credentialData, credentialInStorage.credentialDataSize);
-    credential.createdBy      = credentialInStorage.createdBy;
-    credential.lastModifiedBy = credentialInStorage.modifiedBy;
+    // So far there's no way to actually create the credential outside the matter, so here we always set the creation/modification
+    // source to Matter
+    credential.creationSource     = DlAssetSource::kMatterIM;
+    credential.createdBy          = credentialInStorage.createdBy;
+    credential.modificationSource = DlAssetSource::kMatterIM;
+    credential.lastModifiedBy     = credentialInStorage.modifiedBy;
 
     ChipLogDetail(Zcl, "Found occupied credential [endpoint=%d,index=%u,type=%u,dataSize=%u,createdBy=%u,modifiedBy=%u]",
                   mEndpointId, credentialIndex, to_underlying(credential.credentialType),

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -1470,7 +1470,7 @@ bool DoorLockServer::findOccupiedCredentialSlot(chip::EndpointId endpointId, DlC
         return false;
     }
 
-    // Programming PIN index starts with 0, and it is assumed that it is unique. Therefor different bounds checking for that
+    // Programming PIN index starts with 0, and it is assumed that it is unique. Therefore different bounds checking for that
     // credential type
     if (DlCredentialType::kProgrammingPIN == credentialType)
     {

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -217,6 +217,8 @@ private:
     EmberAfStatus clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId, chip::NodeId sourceNodeId,
                             uint16_t userIndex, const EmberAfPluginDoorLockUserInfo & user, bool sendUserChangeEvent);
 
+    bool cleanFabricFromUsers(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
+
     DlStatus createNewCredentialAndUser(chip::EndpointId endpointId, chip::FabricIndex creatorFabricIdx, chip::NodeId sourceNodeId,
                                         const Nullable<DlUserStatus> & userStatus, const Nullable<DlUserType> & userType,
                                         const DlCredential & credential, const chip::ByteSpan & credentialData,
@@ -248,6 +250,9 @@ private:
     EmberAfStatus clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId);
     EmberAfStatus clearCredentials(chip::EndpointId endpointId, chip::FabricIndex modifier, chip::NodeId sourceNodeId,
                                    DlCredentialType credentialType);
+
+    bool clearFabricFromCredentials(chip::EndpointId endpointId, DlCredentialType credentialType, chip::FabricIndex fabricToRemove);
+    bool clearFabricFromCredentials(chip::EndpointId endpointId, chip::FabricIndex fabricToRemove);
 
     CHIP_ERROR sendSetCredentialResponse(chip::app::CommandHandler * commandObj, DlStatus status, uint16_t userIndex,
                                          uint16_t nextCredentialIndex);

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -191,9 +191,13 @@ private:
     bool getCredentialRange(chip::EndpointId endpointId, DlCredentialType type, size_t & minSize, size_t & maxSize);
     bool getMaxNumberOfCredentials(chip::EndpointId endpointId, DlCredentialType credentialType, uint16_t & maxNumberOfCredentials);
 
+    bool findOccupiedUserSlot(chip::EndpointId endpointId, uint16_t startIndex, uint16_t & userIndex);
+
     bool findUnoccupiedUserSlot(chip::EndpointId endpointId, uint16_t & userIndex);
     bool findUnoccupiedUserSlot(chip::EndpointId endpointId, uint16_t startIndex, uint16_t & userIndex);
 
+    bool findOccupiedCredentialSlot(chip::EndpointId endpointId, DlCredentialType credentialType, uint16_t startIndex,
+                                    uint16_t & credentialIndex);
     bool findUnoccupiedCredentialSlot(chip::EndpointId endpointId, DlCredentialType credentialType, uint16_t startIndex,
                                       uint16_t & credentialIndex);
 
@@ -438,12 +442,12 @@ enum class DlAssetSource : uint8_t
  */
 struct EmberAfPluginDoorLockCredentialInfo
 {
-    DlCredentialStatus status;        /**< Indicates if credential slot is occupied or not. */
-    DlCredentialType credentialType;  /**< Specifies the type of the credential (PIN, RFID, etc.). */
-    chip::ByteSpan credentialData;    /**< Credential data bytes. */
+    DlCredentialStatus status;       /**< Indicates if credential slot is occupied or not. */
+    DlCredentialType credentialType; /**< Specifies the type of the credential (PIN, RFID, etc.). */
+    chip::ByteSpan credentialData;   /**< Credential data bytes. */
 
     DlAssetSource creationSource;
-    chip::FabricIndex createdBy;      /**< ID of the fabric that created the user. */
+    chip::FabricIndex createdBy; /**< ID of the fabric that created the user. */
 
     DlAssetSource modificationSource;
     chip::FabricIndex lastModifiedBy; /**< ID of the fabric that modified the user. */
@@ -462,10 +466,10 @@ struct EmberAfPluginDoorLockUserInfo
     DlCredentialRule credentialRule;            /**< Number of supported credentials. */
 
     DlAssetSource creationSource;
-    chip::FabricIndex createdBy;                /**< ID of the fabric that created the user. */
+    chip::FabricIndex createdBy; /**< ID of the fabric that created the user. */
 
     DlAssetSource modificationSource;
-    chip::FabricIndex lastModifiedBy;           /**< ID of the fabric that modified the user. */
+    chip::FabricIndex lastModifiedBy; /**< ID of the fabric that modified the user. */
 };
 
 /**

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -427,6 +427,12 @@ enum class DlCredentialStatus : uint8_t
     kOccupied  = 0x01, /**< Indicates if credential slot is already occupied. */
 };
 
+enum class DlAssetSource : uint8_t
+{
+    kUnspecified = 0x00,
+    kMatterIM    = 0x01,
+};
+
 /**
  * @brief Structure that holds the credential information.
  */
@@ -435,7 +441,11 @@ struct EmberAfPluginDoorLockCredentialInfo
     DlCredentialStatus status;        /**< Indicates if credential slot is occupied or not. */
     DlCredentialType credentialType;  /**< Specifies the type of the credential (PIN, RFID, etc.). */
     chip::ByteSpan credentialData;    /**< Credential data bytes. */
+
+    DlAssetSource creationSource;
     chip::FabricIndex createdBy;      /**< ID of the fabric that created the user. */
+
+    DlAssetSource modificationSource;
     chip::FabricIndex lastModifiedBy; /**< ID of the fabric that modified the user. */
 };
 
@@ -450,7 +460,11 @@ struct EmberAfPluginDoorLockUserInfo
     DlUserStatus userStatus;                    /**< Status of the user slot (available/occupied). */
     DlUserType userType;                        /**< Type of the user. */
     DlCredentialRule credentialRule;            /**< Number of supported credentials. */
+
+    DlAssetSource creationSource;
     chip::FabricIndex createdBy;                /**< ID of the fabric that created the user. */
+
+    DlAssetSource modificationSource;
     chip::FabricIndex lastModifiedBy;           /**< ID of the fabric that modified the user. */
 };
 

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -175,6 +175,8 @@ public:
         return HasFeature(endpointId, DoorLockFeature::kUsersManagement) && SupportsPIN(endpointId);
     }
 
+    bool OnFabricRemoved(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
+
 private:
     chip::FabricIndex getFabricIndex(const chip::app::CommandHandler * commandObj);
     chip::NodeId getNodeId(const chip::app::CommandHandler * commandObj);

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -160,7 +160,7 @@ public:
 
     inline bool SupportsPIN(chip::EndpointId endpointId) { return HasFeature(endpointId, DoorLockFeature::kPINCredentials); }
 
-    inline bool SupportsPFID(chip::EndpointId endpointId) { return HasFeature(endpointId, DoorLockFeature::kRFIDCredentials); }
+    inline bool SupportsRFID(chip::EndpointId endpointId) { return HasFeature(endpointId, DoorLockFeature::kRFIDCredentials); }
 
     inline bool SupportsFingers(chip::EndpointId endpointId) { return HasFeature(endpointId, DoorLockFeature::kFingerCredentials); }
 
@@ -221,7 +221,7 @@ private:
     EmberAfStatus clearUser(chip::EndpointId endpointId, chip::FabricIndex modifierFabricId, chip::NodeId sourceNodeId,
                             uint16_t userIndex, const EmberAfPluginDoorLockUserInfo & user, bool sendUserChangeEvent);
 
-    bool cleanFabricFromUsers(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
+    bool clearFabricFromUsers(chip::EndpointId endpointId, chip::FabricIndex fabricIndex);
 
     DlStatus createNewCredentialAndUser(chip::EndpointId endpointId, chip::FabricIndex creatorFabricIdx, chip::NodeId sourceNodeId,
                                         const Nullable<DlUserStatus> & userStatus, const Nullable<DlUserType> & userType,

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -447,7 +447,7 @@ struct EmberAfPluginDoorLockCredentialInfo
     chip::ByteSpan credentialData;   /**< Credential data bytes. */
 
     DlAssetSource creationSource;
-    chip::FabricIndex createdBy; /**< ID of the fabric that created the user. */
+    chip::FabricIndex createdBy; /**< Index of the fabric that created the user. */
 
     DlAssetSource modificationSource;
     chip::FabricIndex lastModifiedBy; /**< ID of the fabric that modified the user. */

--- a/src/app/tests/suites/DL_UsersAndCredentials.yaml
+++ b/src/app/tests/suites/DL_UsersAndCredentials.yaml
@@ -55,7 +55,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Get number of supported users and verify default value"
       command: "readAttribute"
@@ -130,7 +130,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Set user at the occupied index fails with appropriate response"
       command: "SetUser"
@@ -202,7 +202,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Modify userUniqueId for existing user"
       command: "SetUser"
@@ -251,7 +251,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Modify userStatus for existing user"
       command: "SetUser"
@@ -300,7 +300,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Modify userType for existing user"
       command: "SetUser"
@@ -349,7 +349,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Modify credentialRule for existing user"
       command: "SetUser"
@@ -398,7 +398,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Modify all fields for existing user"
       command: "SetUser"
@@ -447,7 +447,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Add another user with non-default fields"
       command: "SetUser"
@@ -496,7 +496,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 3
+                value: null
 
     - label: "Create user in the last slot"
       command: "SetUser"
@@ -626,7 +626,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 3 # Slot 2 is still occupied
+                value: 2 # Slot 2 is still occupied
 
     - label: "Create new user in the cleared slot"
       command: "SetUser"
@@ -676,7 +676,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 3 # Slot 2 is still occupied
+                value: 2 # Slot 2 is still occupied
 
     - label: "Clear user with index 0 fails"
       command: "ClearUser"
@@ -733,7 +733,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 3
+                value: null
 
     - label: "Read last cleared user and verify it is available"
       command: "GetUser"
@@ -792,7 +792,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 2
+                value: null
 
     - label: "Reading PIN credential with index 0 fails"
       command: "GetCredentialStatus"
@@ -869,7 +869,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Verify created PIN credential"
       command: "GetCredentialStatus"
@@ -888,7 +888,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextCredentialIndex"
-                value: 2
+                value: null
 
     - label: "Create new PIN credential and user with index 0 fails"
       command: "SetCredential"
@@ -992,7 +992,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 3
+                value: null
 
     - label: "Create new RFID credential and add it to existing user"
       command: "SetCredential"
@@ -1051,7 +1051,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Verify created credential"
       command: "GetCredentialStatus"
@@ -1070,7 +1070,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextCredentialIndex"
-                value: 3
+                value: null
 
     - label: "Create new RFID credential and user with index 0 fails"
       command: "SetCredential"
@@ -1510,7 +1510,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 3
+                value: 2
 
     - label: "Create new RFID credential and add it to existing user"
       command: "SetCredential"
@@ -1571,7 +1571,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 3
+                value: 2
 
     - label: "Clear first PIN credential"
       command: "ClearCredential"
@@ -1598,7 +1598,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 6
+                value: 2
 
     - label: "Read the user back and make sure PIN credential is deleted"
       command: "GetUser"
@@ -1632,7 +1632,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 3
+                value: 2
 
     - label: "Clear the second PIN credential"
       command: "ClearCredential"
@@ -1659,7 +1659,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 6
+                value: 4
 
     - label: "Read the user back and make sure related user is deleted"
       command: "GetUser"
@@ -1688,7 +1688,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 3
+                value: null
 
     - label: "Create new RFID credential with user"
       command: "SetCredential"
@@ -1741,7 +1741,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 2
+                value: 5
 
     - label: "Read back the second RFID credential and make sure it is deleted"
       command: "GetCredentialStatus"
@@ -1760,7 +1760,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 3
+                value: 5
 
     - label: "Read back the third RFID credential and make sure it is deleted"
       command: "GetCredentialStatus"
@@ -1779,7 +1779,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 6
+                value: 5
 
     - label:
           "Read the user related with first RFID back and make sure it has only
@@ -1810,7 +1810,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label:
           "Read the user related with second RFID back and make sure it is
@@ -1841,7 +1841,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 3
+                value: null
 
     - label: "Create new PIN credential with user"
       command: "SetCredential"
@@ -1948,7 +1948,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 2
+                value: null
 
     - label: "Read back the first RFID credential and make sure it is deleted"
       command: "GetCredentialStatus"
@@ -1967,7 +1967,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 3
+                value: null
 
     - label: "Read back the second PIN credential and make sure it is deleted"
       command: "GetCredentialStatus"
@@ -1986,7 +1986,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextCredentialIndex"
-                value: 7
+                value: null
 
     - label:
           "Read the user related with first PIN back and make sure it is deleted"
@@ -2016,7 +2016,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label:
           "Read the user related with first RFID back and make sure it is
@@ -2047,7 +2047,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 3
+                value: null
 
     - label:
           "Read the user related with second PIN back and make sure it is
@@ -2078,7 +2078,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 4
+                value: null
 
     - label:
           "Read the user related with last RFID back and make sure it is deleted"
@@ -2108,7 +2108,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 5
+                value: null
 
     - label: "Create new Programming PIN credential with invalid index"
       command: "SetCredential"
@@ -2189,7 +2189,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: 1
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Verify created programming PIN credential"
       command: "GetCredentialStatus"
@@ -2340,7 +2340,7 @@ tests:
               - name: "lastModifiedFabricIndex"
                 value: null
               - name: "nextUserIndex"
-                value: 2
+                value: null
 
     - label: "Make sure programming PIN credential is deleted"
       command: "GetCredentialStatus"

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -56169,8 +56169,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 2:
@@ -56221,8 +56220,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 7:
@@ -56260,8 +56258,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 10:
@@ -56297,8 +56294,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 12:
@@ -56334,8 +56330,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 14:
@@ -56371,8 +56366,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 16:
@@ -56408,8 +56402,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 18:
@@ -56445,8 +56438,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 20:
@@ -56482,8 +56474,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 22:
@@ -56554,7 +56545,7 @@ private:
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
                 VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
             }
             break;
         case 28:
@@ -56590,7 +56581,7 @@ private:
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
                 VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
             }
             break;
         case 30:
@@ -56625,8 +56616,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 34:
@@ -56678,8 +56668,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextCredentialIndex", value.nextCredentialIndex));
             }
             break;
         case 37:
@@ -56738,8 +56727,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 41:
@@ -56758,8 +56746,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextCredentialIndex", value.nextCredentialIndex));
             }
             break;
         case 42:
@@ -56816,8 +56803,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 3U));
+                VerifyOrReturn(CheckValueNull("nextCredentialIndex", value.nextCredentialIndex));
             }
             break;
         case 48:
@@ -56872,8 +56858,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 50:
@@ -56892,8 +56877,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 3U));
+                VerifyOrReturn(CheckValueNull("nextCredentialIndex", value.nextCredentialIndex));
             }
             break;
         case 51:
@@ -57134,7 +57118,7 @@ private:
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
                 VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
             }
             break;
         case 67:
@@ -57196,7 +57180,7 @@ private:
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
                 VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
             }
             break;
         case 69:
@@ -57216,7 +57200,7 @@ private:
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
                 VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 6U));
+                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 2U));
             }
             break;
         case 71:
@@ -57262,7 +57246,7 @@ private:
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
                 VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
             }
             break;
         case 72:
@@ -57282,7 +57266,7 @@ private:
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
                 VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 6U));
+                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 4U));
             }
             break;
         case 74:
@@ -57308,8 +57292,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 75:
@@ -57343,7 +57326,7 @@ private:
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
                 VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 2U));
+                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 5U));
             }
             break;
         case 78:
@@ -57360,7 +57343,7 @@ private:
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
                 VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 3U));
+                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 5U));
             }
             break;
         case 79:
@@ -57377,7 +57360,7 @@ private:
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
                 VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 6U));
+                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 5U));
             }
             break;
         case 80:
@@ -57416,8 +57399,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 81:
@@ -57443,8 +57425,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 82:
@@ -57505,8 +57486,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextCredentialIndex", value.nextCredentialIndex));
             }
             break;
         case 87:
@@ -57522,8 +57502,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 3U));
+                VerifyOrReturn(CheckValueNull("nextCredentialIndex", value.nextCredentialIndex));
             }
             break;
         case 88:
@@ -57539,8 +57518,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextCredentialIndex", value.nextCredentialIndex));
-                VerifyOrReturn(CheckValue("nextCredentialIndex.Value()", value.nextCredentialIndex.Value(), 7U));
+                VerifyOrReturn(CheckValueNull("nextCredentialIndex", value.nextCredentialIndex));
             }
             break;
         case 89:
@@ -57566,8 +57544,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 90:
@@ -57593,8 +57570,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 3U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 91:
@@ -57620,8 +57596,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 4U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 92:
@@ -57647,8 +57622,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 5U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 93:
@@ -57712,8 +57686,7 @@ private:
                 VerifyOrReturn(CheckValueNonNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
                 VerifyOrReturn(CheckValue("lastModifiedFabricIndex.Value()", value.lastModifiedFabricIndex.Value(), 1));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 96:
@@ -57791,8 +57764,7 @@ private:
 
                 VerifyOrReturn(CheckValueNull("lastModifiedFabricIndex", value.lastModifiedFabricIndex));
 
-                VerifyOrReturn(CheckValueNonNull("nextUserIndex", value.nextUserIndex));
-                VerifyOrReturn(CheckValue("nextUserIndex.Value()", value.nextUserIndex.Value(), 2U));
+                VerifyOrReturn(CheckValueNull("nextUserIndex", value.nextUserIndex));
             }
             break;
         case 106:


### PR DESCRIPTION
#### Problem
* Door lock cluster did not handle the fabric removal properly.
* Fixes #14919.

#### Change overview
* Now door lock cluster fixes the fabric removal according to spec: 
  * If the fabric was deleted, the creator/modifier fabric index in user/credential records is set to 0 (both supported in SDK and Linux App)
  * If the credential was created outside Matter IM the creator/modifier fabric index in user/credential records is set to null (only SDK support as there's no way to create users/credentials outside Matter IM for now in the Linux App).
* GetUserResponse/GetCredentialStatusResponse status command now return next *occupied* index in the payload.

#### Testing
* Ran DL_UsersCredentials, DL_LockUnlock and DL_Schedules YAML tests.
* To test the fabric removal I've used the following procedure:
  1. Run the Linux `chip-lock-app`
  2. Pair with the app using the `chip-tool`:
     ```
     ? ./chip-tool pairing onnetwork 1 20202021
     ```
  3. Open commissioning window again so we can pair with another fabric:
     ```
     ? ./chip-tool pairing open-commissioning-window 1 0 200 1000 3840
     ```
  4. Pair with different fabric:
     ```
     ? ./chip-tool pairing onnetwork 1 20202021 --commissioner-name beta
     ```
  5. Create new credentials and users from the first fabric: 
     ```
     ? ./chip-tool doorlock set-credential 0 '{ "credentialType" : 1 , "credentialIndex" : 1 }' 123456 null null null 1 1 --timedInteractionTimeoutMs 1000
     ```
  6. Create new credentials and users from the second fabric:
     ```
     ? ./chip-tool doorlock set-credential 0 '{ "credentialType" : 2 , "credentialIndex" : 2 }' 12345678901213 null null null 1 1 --timedInteractionTimeoutMs 1000 --commissioner-name beta
     ```
  7. Delete the second fabric:
     ```
     ? ./chip-tool operationalcredentials remove-fabric 2 1 0 --commissioner-name beta
     ```
  8. Make sure the fabric index in the users/credentials created by the first fabric is the same:
     ```
     ? chip-tool doorlock get-user 1 1 1
     ? chip-tool doorlock get-credential-status '{ "credentialType" : 1 , "credentialIndex" : 1 }' 1 1
     ```
  9. Make sure the fabric index in the users/credentials created by the second fabric is set to `0`:
     ```
     ? chip-tool doorlock get-user 2 1 1
     ? chip-tool doorlock get-credential-status '{ "credentialType" : 2 , "credentialIndex" : 2 }' 1 1
     ```
