### PR TITLE
Device info provider efr32, some fixes for nrf and linux

### DIFF
--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -197,6 +197,7 @@ efr32_executable("chef_app") {
   deps = [
     ":chef-common",
     ":sdk",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/chef/efr32/src/main.cpp
+++ b/examples/chef/efr32/src/main.cpp
@@ -23,6 +23,8 @@
 #include "init_efrPlatform.h"
 #include "sl_simple_button_instances.h"
 #include "sl_system_kernel.h"
+#include <DeviceInfoProviderImpl.h>
+#include <app/server/Server.h>
 #include <matter_config.h>
 
 #define BLE_DEV_NAME "SiLabs-Chef-App"
@@ -33,6 +35,8 @@ using namespace ::chip::DeviceLayer;
 #define UNUSED_PARAMETER(a) (a = a)
 
 volatile int apperror_cnt;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+
 // ================================================================================
 // Main Code
 // ================================================================================
@@ -41,6 +45,9 @@ int main(void)
     init_efrPlatform();
     if (EFR32MatterConfig::InitMatter(BLE_DEV_NAME) != CHIP_NO_ERROR)
         appError(CHIP_ERROR_INTERNAL);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     EFR32_LOG("Starting App Task");
     if (GetAppTask().StartAppTask() != CHIP_NO_ERROR)

--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -185,6 +185,7 @@ efr32_executable("light_switch_app") {
   deps = [
     ":sdk",
     "${chip_root}/examples/light-switch-app/light-switch-common",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/light-switch-app/efr32/src/main.cpp
+++ b/examples/light-switch-app/efr32/src/main.cpp
@@ -23,6 +23,8 @@
 #include "init_efrPlatform.h"
 #include "sl_simple_button_instances.h"
 #include "sl_system_kernel.h"
+#include <DeviceInfoProviderImpl.h>
+#include <app/server/Server.h>
 #include <matter_config.h>
 
 #define BLE_DEV_NAME "SiLabs-Light-Switch"
@@ -33,6 +35,8 @@ using namespace ::chip::DeviceLayer;
 #define UNUSED_PARAMETER(a) (a = a)
 
 volatile int apperror_cnt;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+
 // ================================================================================
 // Main Code
 // ================================================================================
@@ -41,6 +45,9 @@ int main(void)
     init_efrPlatform();
     if (EFR32MatterConfig::InitMatter(BLE_DEV_NAME) != CHIP_NO_ERROR)
         appError(CHIP_ERROR_INTERNAL);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     EFR32_LOG("Starting App Task");
     if (GetAppTask().StartAppTask() != CHIP_NO_ERROR)

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -184,6 +184,7 @@ efr32_executable("lighting_app") {
   deps = [
     ":sdk",
     "${chip_root}/examples/lighting-app/lighting-common",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/lighting-app/efr32/src/main.cpp
+++ b/examples/lighting-app/efr32/src/main.cpp
@@ -23,6 +23,8 @@
 #include "init_efrPlatform.h"
 #include "sl_simple_button_instances.h"
 #include "sl_system_kernel.h"
+#include <DeviceInfoProviderImpl.h>
+#include <app/server/Server.h>
 #include <matter_config.h>
 
 #define BLE_DEV_NAME "SiLabs-Light"
@@ -33,6 +35,7 @@ using namespace ::chip::DeviceLayer;
 #define UNUSED_PARAMETER(a) (a = a)
 
 volatile int apperror_cnt;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 // ================================================================================
 // Main Code
@@ -42,6 +45,9 @@ int main(void)
     init_efrPlatform();
     if (EFR32MatterConfig::InitMatter(BLE_DEV_NAME) != CHIP_NO_ERROR)
         appError(CHIP_ERROR_INTERNAL);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     EFR32_LOG("Starting App Task");
     if (GetAppTask().StartAppTask() != CHIP_NO_ERROR)

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -176,6 +176,7 @@ CHIP_ERROR AppTask::Init()
 
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -183,6 +183,7 @@ efr32_executable("lock_app") {
   deps = [
     ":sdk",
     "${chip_root}/examples/lock-app/lock-common",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
     "${chip_root}/third_party/openthread/platforms:libopenthread-platform",

--- a/examples/lock-app/efr32/src/main.cpp
+++ b/examples/lock-app/efr32/src/main.cpp
@@ -23,6 +23,8 @@
 #include "init_efrPlatform.h"
 #include "sl_simple_button_instances.h"
 #include "sl_system_kernel.h"
+#include <DeviceInfoProviderImpl.h>
+#include <app/server/Server.h>
 #include <matter_config.h>
 
 #define BLE_DEV_NAME "SiLabs-Door-Lock"
@@ -33,6 +35,7 @@ using namespace ::chip::DeviceLayer;
 #define UNUSED_PARAMETER(a) (a = a)
 
 volatile int apperror_cnt;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 // ================================================================================
 // Main Code
@@ -42,6 +45,9 @@ int main(void)
     init_efrPlatform();
     if (EFR32MatterConfig::InitMatter(BLE_DEV_NAME) != CHIP_NO_ERROR)
         appError(CHIP_ERROR_INTERNAL);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     EFR32_LOG("Starting App Task");
     if (GetAppTask().StartAppTask() != CHIP_NO_ERROR)

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -240,6 +240,8 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions)
     err = chip::examples::InitCommissionableDataProvider(gCommissionableDataProvider, LinuxDeviceOptions::GetInstance());
     SuccessOrExit(err);
     DeviceLayer::SetCommissionableDataProvider(&gCommissionableDataProvider);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
     DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     err = chip::examples::InitConfigurationManager(reinterpret_cast<ConfigurationManagerImpl &>(ConfigurationMgr()),

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -241,9 +241,6 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions)
     SuccessOrExit(err);
     DeviceLayer::SetCommissionableDataProvider(&gCommissionableDataProvider);
 
-    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
-    DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
-
     err = chip::examples::InitConfigurationManager(reinterpret_cast<ConfigurationManagerImpl &>(ConfigurationMgr()),
                                                    LinuxDeviceOptions::GetInstance());
     SuccessOrExit(err);
@@ -354,6 +351,9 @@ void ChipLinuxAppMainLoop()
 
     // Init ZCL Data Model and CHIP App Server
     Server::GetInstance().Init(initParams);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
+    DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Now that the server has started and we are done with our startup logging,
     // log our discovery/onboarding information again so it's not lost in the

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -172,6 +172,7 @@ efr32_executable("window_app") {
 
   deps = [
     ":sdk",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/examples/window-app/common:window-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",

--- a/examples/window-app/efr32/src/main.cpp
+++ b/examples/window-app/efr32/src/main.cpp
@@ -23,6 +23,8 @@
 #include "init_efrPlatform.h"
 #include "sl_simple_button_instances.h"
 #include "sl_system_kernel.h"
+#include <DeviceInfoProviderImpl.h>
+#include <app/server/Server.h>
 #include <matter_config.h>
 
 #define BLE_DEV_NAME "Silabs-Window"
@@ -31,6 +33,7 @@ using namespace ::chip::DeviceLayer;
 #define UNUSED_PARAMETER(a) (a = a)
 
 volatile int apperror_cnt;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 // ================================================================================
 // Main Code
@@ -42,6 +45,9 @@ int main(void)
     init_efrPlatform();
     if (EFR32MatterConfig::InitMatter(BLE_DEV_NAME) != CHIP_NO_ERROR)
         appError(CHIP_ERROR_INTERNAL);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     WindowApp & app = WindowApp::Instance();
 


### PR DESCRIPTION
#### Problem
EFR32 does not have a device info provider, so setting user labels and querying locales on demo apps do not work.

#### Change overview
- Add deviceinfoprovider for efr32 targets
- Ensure storage is initialized also on nrf and linux (efr32 was crashing, let me to finding that storage needs initialization)

Fixes #18317 

#### Testing
Ran EFR32 test for setting and reading user labels.