### PR TITLE
WindowCovering: Zap fix deviceType endpoint versions

### DIFF
--- a/examples/window-app/common/window-app.zap
+++ b/examples/window-app/common/window-app.zap
@@ -10506,7 +10506,7 @@
       "profileId": 259,
       "endpointId": 1,
       "networkId": 0,
-      "endpointVersion": 1,
+      "endpointVersion": 2,
       "deviceIdentifier": 514
     },
     {
@@ -10515,7 +10515,7 @@
       "profileId": 259,
       "endpointId": 2,
       "networkId": 0,
-      "endpointVersion": 1,
+      "endpointVersion": 2,
       "deviceIdentifier": 514
     }
   ],

--- a/zzz_generated/window-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/window-app/zap-generated/endpoint_config.h
@@ -1104,7 +1104,7 @@ static_assert(ATTRIBUTE_LARGEST <= CHIP_CONFIG_MAX_ATTRIBUTE_STORE_ELEMENT_SIZE,
 // Array of device types
 #define FIXED_DEVICE_TYPES                                                                                                         \
     {                                                                                                                              \
-        { 0x0016, 1 }, { 0x0202, 1 }, { 0x0202, 1 }                                                                                \
+        { 0x0016, 1 }, { 0x0202, 2 }, { 0x0202, 2 }                                                                                \
     }
 
 // Array of device type offsets


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* WindowCovering Device type revisions are not the right ones

#### Change overview
What's in this PR
update the revision following the Matter specs device type library

fix https://github.com/project-chip/connectedhomeip/issues/18320

#### Testing
How was this tested? (at least one bullet point required)
* no unit test cover this 
* Tested on EFR32 - I did a read with chip-tool following TC-DESC-2.1 test steps to obtain the expected revision
