### PR TITLE
Fix ReadInteraction.h

### DIFF
--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -134,7 +134,7 @@ class TypedReadEventCallback final : public app::ReadClient::Callback
 public:
     using OnSuccessCallbackType = std::function<void(const app::EventHeader & aEventHeader, const DecodableEventType & aData)>;
     using OnErrorCallbackType   = std::function<void(const app::EventHeader * apEventHeader, CHIP_ERROR aError)>;
-    using OnDoneCallbackType    = std::function<void(TypedReadEventCallback * callback)>;
+    using OnDoneCallbackType    = std::function<void(app::ReadClient * apReadClient)>;
     using OnSubscriptionEstablishedCallbackType = std::function<void()>;
 
     TypedReadEventCallback(OnSuccessCallbackType aOnSuccess, OnErrorCallbackType aOnError, OnDoneCallbackType aOnDone,
@@ -173,7 +173,16 @@ private:
 
     void OnError(CHIP_ERROR aError) override { mOnError(nullptr, aError); }
 
-    void OnDone(app::ReadClient *) override { mOnDone(this); }
+    void OnDone(app::ReadClient * apReadClient) override
+    {
+        if (mOnDone != nullptr)
+        {
+            mOnDone(apReadClient);
+        }
+
+        // Always needs to be the last call
+        chip::Platform::Delete(this);
+    }
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
     {


### PR DESCRIPTION

#### Problem
When dataVersion is matching with the one in server, read attribute API in ReadInteraction.h cannot get anything back, this application would stuck.
When read event, if no event is generated in server, read event API in ReadInteraction.h cannot get anything back, this application would stuck.
#### Change overview
--Remove dataVersion filter from read APIs in
ReadInteraction.h
--Add onDone callback for read event APIs in
ReadInteraction.h

#### Testing
Update the tests.
