### PR TITLE
Add an attestation elements and NOC CSR parser to chip tool.

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -27,6 +27,7 @@ config("config") {
     "${chip_root}/zzz_generated/app-common/app-common",
     "${chip_root}/zzz_generated/chip-tool",
     "${chip_root}/src/lib",
+    "${chip_root}/src/credentials",
   ]
 
   defines = [
@@ -65,6 +66,7 @@ static_library("chip-tool-utils") {
     "commands/pairing/OpenCommissioningWindowCommand.h",
     "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
+    "commands/payload/CredentialResponseParser.cpp",
     "commands/payload/SetupPayloadGenerateCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
     "commands/payload/SetupPayloadVerhoeff.cpp",
@@ -90,6 +92,7 @@ static_library("chip-tool-utils") {
     "${chip_root}/src/app/tests/suites/commands/system",
     "${chip_root}/src/app/tests/suites/pics",
     "${chip_root}/src/controller/data_model",
+    "${chip_root}/src/credentials",
     "${chip_root}/src/credentials:file_attestation_trust_store",
     "${chip_root}/src/lib",
     "${chip_root}/src/platform",

--- a/examples/chip-tool/commands/clusters/DataModelLogger.h
+++ b/examples/chip-tool/commands/clusters/DataModelLogger.h
@@ -34,7 +34,7 @@ public:
     static CHIP_ERROR LogCommand(const chip::app::ConcreteCommandPath & path, chip::TLV::TLVReader * data);
     static CHIP_ERROR LogEvent(const chip::app::EventHeader & header, chip::TLV::TLVReader * data);
 
-private:
+protected:
     static CHIP_ERROR LogValue(const char * label, size_t indent, bool value)
     {
         DataModelLogger::LogString(label, indent, value ? "TRUE" : "FALSE");

--- a/examples/chip-tool/commands/payload/Commands.h
+++ b/examples/chip-tool/commands/payload/Commands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include "AdditionalDataParseCommand.h"
+#include "CredentialResponseParser.h"
 #include "SetupPayloadGenerateCommand.h"
 #include "SetupPayloadParseCommand.h"
 #include "SetupPayloadVerhoeff.h"
@@ -33,6 +34,8 @@ void registerCommandsPayload(Commands & commands)
         make_unique<AdditionalDataParseCommand>(),            //
         make_unique<SetupPayloadVerhoeffVerify>(),            //
         make_unique<SetupPayloadVerhoeffGenerate>(),          //
+        make_unique<AttestationElementsParser>(),             //
+        make_unique<NOCCSRElementsParser>(),                  //
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/chip-tool/commands/payload/CredentialResponseParser.cpp
+++ b/examples/chip-tool/commands/payload/CredentialResponseParser.cpp
@@ -1,0 +1,164 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "CredentialResponseParser.h"
+#include <credentials/CertificationDeclaration.h>
+#include <credentials/DeviceAttestationConstructor.h>
+#include <string>
+
+using namespace ::chip;
+
+enum
+{
+    // Attestation Elements
+    kTag_CertDeclaration = 1,
+    kTag_Nonce           = 2,
+    kTag_TimeStamp       = 3,
+    kTag_FirmwareVersion = 4,
+};
+
+CHIP_ERROR AttestationElementsParser::Run()
+{
+    ChipLogProgress(chipTool, "Parsing Attestation Response Elements.");
+    ReturnErrorOnFailure(ParseAttestationElements(mAttResponse));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR AttestationElementsParser::ParseAttestationElements(const ByteSpan & responsePayload)
+{
+    TLV::TLVReader reader;
+    TLV::TLVType outerContainer1;
+
+    reader.Init(responsePayload);
+    ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
+    ReturnErrorOnFailure(reader.EnterContainer(outerContainer1));
+
+    ByteSpan certDeclaration;
+    ReturnErrorOnFailure(reader.Next(TLV::ContextTag(kTag_CertDeclaration)));
+    ReturnErrorOnFailure(reader.Get(certDeclaration));
+
+    ByteSpan nonce;
+    ReturnErrorOnFailure(reader.Next(TLV::ContextTag(kTag_Nonce)));
+    ReturnErrorOnFailure(reader.Get(nonce));
+
+    uint32_t timeStamp;
+    ReturnErrorOnFailure(reader.Next(TLV::ContextTag(kTag_TimeStamp)));
+    ReturnErrorOnFailure(reader.Get(timeStamp));
+
+    bool fwPresent = false;
+    ByteSpan firmwareVersion;
+    if (reader.Next(TLV::ContextTag(kTag_FirmwareVersion)) == CHIP_NO_ERROR)
+    {
+        ReturnErrorOnFailure(reader.Get(firmwareVersion));
+        fwPresent = true;
+    }
+
+    ByteSpan certDeclarationContent;
+    ReturnErrorOnFailure(Credentials::CMS_ExtractCDContent(certDeclaration, certDeclarationContent));
+
+    size_t indent = 0;
+    DataModelLogger::LogString("Attestation Response Elements", indent, "{");
+    DataModelLogger::LogString("certDeclarationContent", indent + 1, "{");
+
+    Credentials::CertificationElements certElements;
+    ReturnErrorOnFailure(DecodeCertificationElements(certDeclarationContent, certElements));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("FormatVersion", indent + 2, certElements.FormatVersion));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("VendorId", indent + 2, certElements.VendorId));
+
+    std::string arrayString = "";
+    DataModelLogger::LogString(indent + 2, "ProductIds = [");
+    for (int i = 1; i < certElements.ProductIdsCount + 1; i++)
+    {
+        arrayString += std::to_string(certElements.ProductIds[i - 1]) + ", ";
+        if (i % 10 == 0)
+        {
+            DataModelLogger::LogString(indent + 5, arrayString);
+            arrayString = "";
+        }
+    }
+    DataModelLogger::LogString(indent + 2, "]");
+
+    ReturnErrorOnFailure(DataModelLogger::LogValue("ProductIdsCount", indent + 2, certElements.ProductIdsCount));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("DeviceTypeId", indent + 2, certElements.DeviceTypeId));
+    DataModelLogger::LogString("CertificateId", indent + 2, std::string(certElements.CertificateId));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("SecurityLevel", indent + 2, certElements.SecurityLevel));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("SecurityInformation", indent + 2, certElements.SecurityInformation));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("VersionNumber", indent + 2, certElements.VersionNumber));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("CertificationType", indent + 2, certElements.CertificationType));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("DACOriginVendorId (Optional)", indent + 2, certElements.DACOriginVendorId));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("DACOriginProductId (Optional)", indent + 2, certElements.DACOriginProductId));
+    ReturnErrorOnFailure(
+        DataModelLogger::LogValue("DACOriginVIDandPIDPresent (Optional)", indent + 2, certElements.DACOriginVIDandPIDPresent));
+    // TODO: Figure out how to log.
+    // ReturnErrorOnFailure(DataModelLogger::LogValue("AuthorizedPAAList", indent + 2, certElements.AuthorizedPAAList));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("AuthorizedPAAListCount", indent + 2, certElements.AuthorizedPAAListCount));
+
+    DataModelLogger::LogString(indent + 1, "}");
+    ReturnErrorOnFailure(DataModelLogger::LogValue("Nonce", indent + 1, nonce));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("Time Stamp", indent + 1, timeStamp));
+    if (fwPresent)
+    {
+        ReturnErrorOnFailure(DataModelLogger::LogValue("Firmware Version", indent + 1, firmwareVersion));
+    }
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR NOCCSRElementsParser::Run()
+{
+    // static uint8_t buf[] = {0x48, 0x45, 0x4C, 0x4C, 0x4F, 0x57};
+    // ByteSpan test(buf, sizeof(buf));
+    ChipLogProgress(chipTool, "Parsing NOC CSR Elements");
+    ReturnErrorOnFailure(ParseNOCCSRResponse(mCSRResponse));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR NOCCSRElementsParser::ParseNOCCSRResponse(const ByteSpan & responsePayload)
+{
+    ByteSpan csr;
+    ByteSpan nonce;
+    ByteSpan vendorReserved1;
+    ByteSpan vendorReserved2;
+    ByteSpan vendorReserved3;
+    Credentials::DeconstructNOCSRElements(responsePayload, csr, nonce, vendorReserved1, vendorReserved2, vendorReserved3);
+
+    size_t indent = 0;
+    DataModelLogger::LogString("NOC CSR Response Elements", indent, "{");
+
+    ReturnErrorOnFailure(DataModelLogger::LogValue("CSR", indent + 1, csr));
+    ReturnErrorOnFailure(DataModelLogger::LogValue("CSR Nonce", indent + 1, nonce));
+
+    if (!vendorReserved1.empty())
+    {
+        ReturnErrorOnFailure(DataModelLogger::LogValue("Vendor Reserved 1", indent + 1, vendorReserved1));
+    }
+    if (!vendorReserved2.empty())
+    {
+        ReturnErrorOnFailure(DataModelLogger::LogValue("Vendor Reserved 1", indent + 1, vendorReserved2));
+    }
+    if (!vendorReserved3.empty())
+    {
+        ReturnErrorOnFailure(DataModelLogger::LogValue("Vendor Reserved 1", indent + 1, vendorReserved3));
+    }
+    DataModelLogger::LogString(indent, "}");
+
+    return CHIP_NO_ERROR;
+}

--- a/examples/chip-tool/commands/payload/CredentialResponseParser.h
+++ b/examples/chip-tool/commands/payload/CredentialResponseParser.h
@@ -1,0 +1,46 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "../clusters/DataModelLogger.h"
+#include "../common/Command.h"
+#include <setup_payload/SetupPayload.h>
+
+class AttestationElementsParser : public Command, public DataModelLogger
+{
+public:
+    AttestationElementsParser() : Command("attestation-elements-parse") { AddArgument("payload", &mAttResponse); }
+    CHIP_ERROR Run() override;
+
+private:
+    chip::ByteSpan mAttResponse;
+    CHIP_ERROR ParseAttestationElements(const chip::ByteSpan & responsePayload);
+};
+
+class NOCCSRElementsParser : public Command, public DataModelLogger
+{
+
+public:
+    NOCCSRElementsParser() : Command("noccsr-elements-parse") { AddArgument("payload", &mCSRResponse); }
+    CHIP_ERROR Run() override;
+
+private:
+    chip::ByteSpan mCSRResponse;
+    CHIP_ERROR ParseNOCCSRResponse(const chip::ByteSpan & responsePayload);
+};


### PR DESCRIPTION
#### Problem
For certification validation of the attestation elements response and NOC CSR elements response, there is no way to validate the response payloads. 

#### Change overview
Adds an attestation elements response parser to chip-tool. 
Adds a CSR NOC elements response parser to chip-tool.

#### Testing
- Compiled
- Tested malformed payload to trigger error.
- Tested parsing from an attestation elements response. 
- Tested parsing from a NOC CSR elements response.
