### PR TITLE
[OTA-R] Use delayedActionTime to delay QueryImage when supplied

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -225,6 +225,7 @@ void DefaultOTARequestor::OnQueryImageResponse(void * context, const QueryImageR
         break;
     }
     case OTAQueryStatus::kBusy: {
+        ChipLogDetail(SoftwareUpdate, "//is: OTAQueryStatus::kBusy delayedActionTime %d", response.delayedActionTime.ValueOr(0));
         CHIP_ERROR status = requestorCore->mOtaRequestorDriver->UpdateNotFound(
             UpdateNotFoundReason::kBusy, System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
         if ((status == CHIP_ERROR_MAX_RETRY_EXCEEDED) || (status == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED))

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -225,7 +225,6 @@ void DefaultOTARequestor::OnQueryImageResponse(void * context, const QueryImageR
         break;
     }
     case OTAQueryStatus::kBusy: {
-        ChipLogDetail(SoftwareUpdate, "//is: OTAQueryStatus::kBusy delayedActionTime %d", response.delayedActionTime.ValueOr(0));
         CHIP_ERROR status = requestorCore->mOtaRequestorDriver->UpdateNotFound(
             UpdateNotFoundReason::kBusy, System::Clock::Seconds32(response.delayedActionTime.ValueOr(0)));
         if ((status == CHIP_ERROR_MAX_RETRY_EXCEEDED) || (status == CHIP_ERROR_PROVIDER_LIST_EXHAUSTED))

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -186,17 +186,17 @@ CHIP_ERROR DefaultOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason
     case UpdateNotFoundReason::kUpToDate:
         break;
     case UpdateNotFoundReason::kBusy: {
-        status = ScheduleQueryRetry(true);
+        status = ScheduleQueryRetry(true, chip::max(kDefaultDelayedActionTime, delay));
         if (status == CHIP_ERROR_MAX_RETRY_EXCEEDED)
         {
             // If max retry exceeded with current provider, try a different provider
-            status = ScheduleQueryRetry(false);
+            status = ScheduleQueryRetry(false, chip::max(kDefaultDelayedActionTime, delay));
         }
         break;
     }
     case UpdateNotFoundReason::kNotAvailable: {
         // Schedule a query only if a different provider is available
-        status = ScheduleQueryRetry(false);
+        status = ScheduleQueryRetry(false, chip::max(kDefaultDelayedActionTime, delay));
         break;
     }
     }
@@ -449,7 +449,7 @@ bool DefaultOTARequestorDriver::GetNextProviderLocation(ProviderLocationType & p
     return false;
 }
 
-CHIP_ERROR DefaultOTARequestorDriver::ScheduleQueryRetry(bool trySameProvider)
+CHIP_ERROR DefaultOTARequestorDriver::ScheduleQueryRetry(bool trySameProvider, System::Clock::Seconds32 delay)
 {
     CHIP_ERROR status = CHIP_NO_ERROR;
 
@@ -483,7 +483,7 @@ CHIP_ERROR DefaultOTARequestorDriver::ScheduleQueryRetry(bool trySameProvider)
     if (status == CHIP_NO_ERROR)
     {
         ChipLogProgress(SoftwareUpdate, "Scheduling a retry");
-        ScheduleDelayedAction(kDefaultDelayedActionTime, StartDelayTimerHandler, this);
+        ScheduleDelayedAction(delay, StartDelayTimerHandler, this);
     }
 
     return status;

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -97,7 +97,7 @@ protected:
     void CancelDelayedAction(System::TimerCompleteCallback action, void * aAppState);
     bool ProviderLocationsEqual(const ProviderLocationType & a, const ProviderLocationType & b);
     // Return value of CHIP_NO_ERROR indicates a query retry has been successfully scheduled.
-    CHIP_ERROR ScheduleQueryRetry(bool trySameProvider);
+    CHIP_ERROR ScheduleQueryRetry(bool trySameProvider, System::Clock::Seconds32 delay);
 
     OTARequestorInterface * mRequestor           = nullptr;
     OTAImageProcessorInterface * mImageProcessor = nullptr;


### PR DESCRIPTION
#### Problem

As per test event 9 TC-SU-2.2 step 5 failed.  The step asked to launch the OTA provider by giving the flag to wait 3 min before DUT sends another QueryImage, but it sends the message after 2 min instead.

See Spec section: _11.20.3.2. Querying the OTA Provider_, subsection _Handling Busy value in Status field_.

Fixes: https://github.com/project-chip/connectedhomeip/issues/18432

OTA-P command:
`out/apps/ota-provider/chip-ota-provider-app -f ~/Downloads/test2.ota --passcode 20202021 --discriminator 3840 --KVS /tmp/chip_kvs_provider -q busy -t 180`

OTA-R command:
`out/apps/ota-requestor/chip-ota-requestor-app --discriminator 30 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor`

Chip-tool announce OTA provider command:
`out/apps/chip-tool/chip-tool otasoftwareupdaterequestor announce-ota-provider 0x00000000ABCD 0 0 0 0x0000001234567890 0`

#### Change overview

If `DelayedActionTime` is supplied in the QueryImage response and OTA-P was `Busy` or `NotAvailable`, take `DelayedActionTime` into account when scheduling a delayed QueryImage retry.

#### Testing

- Launched OTA-P by supplying the `-q busy` flag for busy and `-t 180` for `DelayedActionTime` of 3 minutes.  
- Ensured QueryImage response's delayedActionTime field is 180 seconds.
- Ensured OTA-R delays the QueryImage by 180 seconds.

[Issue #18432 OTA-P with fix.txt](https://github.com/project-chip/connectedhomeip/files/8775854/Issue.18432.OTA-P.with.fix.txt)
[Issue #18432 OTA-R with fix.txt](https://github.com/project-chip/connectedhomeip/files/8775855/Issue.18432.OTA-R.with.fix.txt)
[Issue #18432 chiptool with fix.txt](https://github.com/project-chip/connectedhomeip/files/8775857/Issue.18432.chiptool.with.fix.txt)

