### PR TITLE
Updated docs regarding attributes updates in window covering cluster.

### DIFF
--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -948,10 +948,9 @@ bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(app::CommandHandler 
 /**
  * @brief Cluster Attribute Changed Callback
  *
- * The method is implemented by default as a weak function and it takes care about updating
- * the server attribute values by calling PostAttributeChange method. In case of overriding the method
- * by the application, it needs to handle updating attributes using its own way or either calling
- * PostAttributeChange method.
+ * The method is implemented by default as a weak function and it takes care of updating
+ * the server attribute values by calling the PostAttributeChange method. If the application overrides
+ * this method, it needs to handle updating attributes (ideally by calling PostAttributeChange).
  *
  */
 void __attribute__((weak))

--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -947,6 +947,12 @@ bool emberAfWindowCoveringClusterGoToTiltPercentageCallback(app::CommandHandler 
 
 /**
  * @brief Cluster Attribute Changed Callback
+ *
+ * The method is implemented by default as a weak function and it takes care about updating
+ * the server attribute values by calling PostAttributeChange method. In case of overriding the method
+ * by the application, it needs to handle updating attributes using its own way or either calling
+ * PostAttributeChange method.
+ *
  */
 void __attribute__((weak))
 MatterWindowCoveringClusterServerAttributeChangedCallback(const app::ConcreteAttributePath & attributePath)

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -140,7 +140,11 @@ void TiltPositionSet(chip::EndpointId endpoint, NPercent100ths position);
 EmberAfStatus GetMotionLockStatus(chip::EndpointId endpoint);
 
 /**
- * @brief PostAttributeChange is called when an Attribute is modified
+ * @brief PostAttributeChange is called when an Attribute is modified.
+ *
+ * The method is called by the MatterWindowCoveringClusterServerAttributeChangedCallback
+ * to update cluster attributes values. In case of overriding the MatterWindowCoveringClusterServerAttributeChangedCallback
+ * by the application, it should call the PostAttributeChange on its own.
  *
  * @param[in] endpoint
  * @param[in] attributeId

--- a/src/app/clusters/window-covering-server/window-covering-server.h
+++ b/src/app/clusters/window-covering-server/window-covering-server.h
@@ -142,9 +142,9 @@ EmberAfStatus GetMotionLockStatus(chip::EndpointId endpoint);
 /**
  * @brief PostAttributeChange is called when an Attribute is modified.
  *
- * The method is called by the MatterWindowCoveringClusterServerAttributeChangedCallback
- * to update cluster attributes values. In case of overriding the MatterWindowCoveringClusterServerAttributeChangedCallback
- * by the application, it should call the PostAttributeChange on its own.
+ * The method is called by MatterWindowCoveringClusterServerAttributeChangedCallback
+ * to update cluster attributes values. If the application overrides MatterWindowCoveringClusterServerAttributeChangedCallback,
+ * it should call the PostAttributeChange on its own.
  *
  * @param[in] endpoint
  * @param[in] attributeId


### PR DESCRIPTION
#### Problem
The window-covering-server is missing information about necessity of calling PostAttributeChange to update cluster attributes in case of overriding MatterWindowCoveringClusterServerAttributeChangedCallback method.

#### Change overview
Added appropriate documentation.

#### Testing
Docs only change, no testing needed.
