### PR TITLE
Interop testing te9 level cluster fix

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1131,16 +1131,19 @@ void MatterLevelControlClusterServerTickCallbackWrapperFunction(uint8_t endpoint
     clusterTickWrapper(&eventControl, emberAfLevelControlClusterServerTickCallback, endpoint);
 }
 
-void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint)
-{
-    EmberEventData data         = { &eventControl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
-    EmberAfEventContext context = { .endpoint     = endpoint,
-                                    .clusterId    = LevelControl::Id,
-                                    .isClient     = false,
-                                    .pollControl  = EMBER_AF_LONG_POLL,
-                                    .sleepControl = EMBER_AF_OK_TO_SLEEP,
-                                    .eventControl = &eventControl };
-    MatterRegisterAfEvent(data, "Level Control", context);
+void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint) {
+    static MatterEventMetaContext metaContext;
+
+    metaContext.context = { .endpoint = endpoint,
+                            .clusterId = LevelControl::Id,
+                            .isClient = false,
+                            .pollControl = EMBER_AF_LONG_POLL,
+                            .sleepControl = EMBER_AF_OK_TO_SLEEP,
+                            .eventControl = &eventControl };
+    metaContext.eventString = "Level Control";
+    metaContext.event = { &eventControl,
+                          MatterLevelControlClusterServerTickCallbackWrapperFunction };
+    MatterRegisterAfEvent(&metaContext);
 }
 
 void MatterLevelControlPluginServerInitCallback() {}

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -47,8 +47,8 @@
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
-#include <app/util/af.h>
 #include <app/util/af-event.h>
+#include <app/util/af.h>
 #include <app/util/util.h>
 
 #include <app/reporting/reporting.h>
@@ -1131,9 +1131,15 @@ void MatterLevelControlClusterServerTickCallbackWrapperFunction(uint8_t endpoint
     clusterTickWrapper(&eventControl, emberAfLevelControlClusterServerTickCallback, endpoint);
 }
 
-void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint) {
-    EmberEventData data = { &eventControl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
-    EmberAfEventContext context = { .endpoint = endpoint, .clusterId = LevelControl::Id, .isClient = false, .pollControl = EMBER_AF_LONG_POLL, .sleepControl = EMBER_AF_OK_TO_SLEEP, .eventControl = &eventControl };
+void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint)
+{
+    EmberEventData data         = { &eventControl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
+    EmberAfEventContext context = { .endpoint     = endpoint,
+                                    .clusterId    = LevelControl::Id,
+                                    .isClient     = false,
+                                    .pollControl  = EMBER_AF_LONG_POLL,
+                                    .sleepControl = EMBER_AF_OK_TO_SLEEP,
+                                    .eventControl = &eventControl };
     MatterRegisterAfEvent(data, "Level Control", context);
 }
 

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1120,22 +1120,20 @@ static bool areStartUpLevelControlServerAttributesNonVolatile(EndpointId endpoin
 
 static void clusterTickWrapper(EmberEventControl * control, EmberAfTickFunction callback, uint8_t endpoint)
 {
-    /* emberAfPushEndpointNetworkIndex(endpoint); */
     emberEventControlSetInactive(control);
     (*callback)(endpoint);
-    /* emberAfPopNetworkIndex(); */
 }
 
-EmberEventControl ctrl;
+EmberEventControl eventControl;
 
 void MatterLevelControlClusterServerTickCallbackWrapperFunction(uint8_t endpoint)
 {
-    clusterTickWrapper(&ctrl, emberAfLevelControlClusterServerTickCallback, endpoint);
+    clusterTickWrapper(&eventControl, emberAfLevelControlClusterServerTickCallback, endpoint);
 }
 
 void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint) {
-    EmberEventData data = { &ctrl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
-    EmberAfEventContext context = { .endpoint = endpoint, .clusterId = LevelControl::Id, .isClient = false, .pollControl = EMBER_AF_LONG_POLL, .sleepControl = EMBER_AF_OK_TO_SLEEP, .eventControl = &ctrl };
+    EmberEventData data = { &eventControl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
+    EmberAfEventContext context = { .endpoint = endpoint, .clusterId = LevelControl::Id, .isClient = false, .pollControl = EMBER_AF_LONG_POLL, .sleepControl = EMBER_AF_OK_TO_SLEEP, .eventControl = &eventControl };
     MatterRegisterAfEvent(data, "Level Control", context);
 }
 

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1137,11 +1137,11 @@ void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint)
     VerifyOrDie(endpoint < FIXED_ENDPOINT_COUNT);
 
     metaContexts[endpoint].context     = { .endpoint     = endpoint,
-                            .clusterId    = LevelControl::Id,
-                            .isClient     = false,
-                            .pollControl  = EMBER_AF_LONG_POLL,
-                            .sleepControl = EMBER_AF_OK_TO_SLEEP,
-                            .eventControl = &eventControl };
+                                       .clusterId    = LevelControl::Id,
+                                       .isClient     = false,
+                                       .pollControl  = EMBER_AF_LONG_POLL,
+                                       .sleepControl = EMBER_AF_OK_TO_SLEEP,
+                                       .eventControl = &eventControl };
     metaContexts[endpoint].eventString = "Level Control";
     metaContexts[endpoint].event       = { &eventControl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
     MatterRegisterAfEvent(&metaContexts[endpoint]);

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1133,17 +1133,18 @@ void MatterLevelControlClusterServerTickCallbackWrapperFunction(uint8_t endpoint
 
 void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint)
 {
-    static MatterEventMetaContext metaContext;
+    static MatterEventMetaContext metaContexts[FIXED_ENDPOINT_COUNT];
+    VerifyOrDie(endpoint < FIXED_ENDPOINT_COUNT);
 
-    metaContext.context     = { .endpoint     = endpoint,
+    metaContexts[endpoint].context     = { .endpoint     = endpoint,
                             .clusterId    = LevelControl::Id,
                             .isClient     = false,
                             .pollControl  = EMBER_AF_LONG_POLL,
                             .sleepControl = EMBER_AF_OK_TO_SLEEP,
                             .eventControl = &eventControl };
-    metaContext.eventString = "Level Control";
-    metaContext.event       = { &eventControl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
-    MatterRegisterAfEvent(&metaContext);
+    metaContexts[endpoint].eventString = "Level Control";
+    metaContexts[endpoint].event       = { &eventControl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
+    MatterRegisterAfEvent(&metaContexts[endpoint]);
 }
 
 void MatterLevelControlPluginServerInitCallback() {}

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1131,18 +1131,18 @@ void MatterLevelControlClusterServerTickCallbackWrapperFunction(uint8_t endpoint
     clusterTickWrapper(&eventControl, emberAfLevelControlClusterServerTickCallback, endpoint);
 }
 
-void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint) {
+void emberAfPluginLevelControlClusterServerPostInitCallback(EndpointId endpoint)
+{
     static MatterEventMetaContext metaContext;
 
-    metaContext.context = { .endpoint = endpoint,
-                            .clusterId = LevelControl::Id,
-                            .isClient = false,
-                            .pollControl = EMBER_AF_LONG_POLL,
+    metaContext.context     = { .endpoint     = endpoint,
+                            .clusterId    = LevelControl::Id,
+                            .isClient     = false,
+                            .pollControl  = EMBER_AF_LONG_POLL,
                             .sleepControl = EMBER_AF_OK_TO_SLEEP,
                             .eventControl = &eventControl };
     metaContext.eventString = "Level Control";
-    metaContext.event = { &eventControl,
-                          MatterLevelControlClusterServerTickCallbackWrapperFunction };
+    metaContext.event       = { &eventControl, MatterLevelControlClusterServerTickCallbackWrapperFunction };
     MatterRegisterAfEvent(&metaContext);
 }
 

--- a/src/app/clusters/level-control/level-control.h
+++ b/src/app/clusters/level-control/level-control.h
@@ -59,3 +59,5 @@
  * @param endpoint Endpoint that is being initialized  Ver.: always
  */
 void emberAfPluginLevelControlClusterServerPostInitCallback(chip::EndpointId endpoint);
+
+void MatterLevelControlPluginServerInitCallback();

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -338,9 +338,14 @@ void Server::ScheduleFactoryReset()
 
 void Server::Shutdown()
 {
+
+    mCASESessionManager.Shutdown();
     app::DnssdServer::Instance().SetCommissioningModeProvider(nullptr);
     chip::Dnssd::ServiceAdvertiser::Instance().Shutdown();
+
+    chip::Dnssd::Resolver::Instance().Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
+    mMessageCounterManager.Shutdown();
     CHIP_ERROR err = mExchangeMgr.Shutdown();
     if (err != CHIP_NO_ERROR)
     {
@@ -348,11 +353,11 @@ void Server::Shutdown()
     }
     mSessions.Shutdown();
     mTransports.Close();
-
+    mAccessControl.Finish();
+    Credentials::SetGroupDataProvider(nullptr);
+    ShutdownDataModelHandler();
     mAttributePersister.Shutdown();
     mCommissioningWindowManager.Shutdown();
-    mCASESessionManager.Shutdown();
-
     // TODO(16969): Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code
     chip::Platform::MemoryShutdown();
 }

--- a/src/app/tests/TestCommissionManager.cpp
+++ b/src/app/tests/TestCommissionManager.cpp
@@ -36,6 +36,7 @@ using chip::Server;
 
 // Mock function for linking
 void InitDataModelHandler(chip::Messaging::ExchangeManager * exchangeMgr) {}
+void ShutdownDataModelHandler() {}
 
 namespace {
 

--- a/src/app/util/DataModelHandler.cpp
+++ b/src/app/util/DataModelHandler.cpp
@@ -51,3 +51,16 @@ void InitDataModelHandler(chip::Messaging::ExchangeManager * exchangeManager)
 #endif
 #endif
 }
+
+void ShutdownDataModelHandler()
+{
+#ifdef USE_ZAP_CONFIG
+    ChipLogProgress(Zcl, "Shutting down Data Model");
+    emberAfStackDown();
+
+#ifdef EMBER_AF_PLUGIN_IAS_ZONE_SERVER
+    EmberStatus status = EMBER_NETWORK_DOWN;
+    emberAfPluginIasZoneServerStackStatusCallback(status);
+#endif /* EMBER_AF_PLUGIN_IAS_ZONE_SERVER */
+#endif /* USE_ZAP_CONFIG */
+}

--- a/src/app/util/DataModelHandler.h
+++ b/src/app/util/DataModelHandler.h
@@ -33,3 +33,9 @@
  *
  */
 void InitDataModelHandler(chip::Messaging::ExchangeManager * exchangeMgr);
+
+/**
+ * Shutdowns and cleans up the data model internal code
+ *
+ */
+void ShutdownDataModelHandler();

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -53,6 +53,7 @@
 #include <zap-generated/af-gen-event.h>
 
 using namespace chip;
+using namespace chip::Platform;
 
 // *****************************************************************************
 // Globals
@@ -65,38 +66,19 @@ void emberAfPluginIasZoneClientStateMachineEventHandler(void){};
 EMBER_AF_GENERATED_EVENT_CODE
 #endif // EMBER_AF_GENERATED_EVENT_CODE
 
-struct MatterEventMetaContext
-{
-    EmberAfEventContext context;
-    const char * eventString;
-    EmberEventData event;
-    MatterEventMetaContext * nextContext;
-};
 
-MatterEventMetaContext * metaContextListHead = nullptr;
-
-void MatterEventMetaContextAppend(MatterEventMetaContext & newContext)
+void MatterRegisterAfEvent(MatterEventMetaContext* newContext)
 {
-    auto newContextHeap = new MatterEventMetaContext(newContext);
-    if (metaContextListHead == nullptr)
-    {
-        metaContextListHead = newContextHeap;
-    }
-    else
-    {
+    if (metaContextListHead == nullptr) {
+        metaContextListHead = newContext;
+    } else {
         auto metaContextPointer = metaContextListHead;
         while (metaContextPointer->nextContext != nullptr)
         {
             metaContextPointer = metaContextPointer->nextContext;
         }
-        metaContextPointer->nextContext = newContextHeap;
+        metaContextPointer->nextContext = newContext;
     }
-}
-
-void MatterRegisterAfEvent(EmberEventData data, const char * eventString, EmberAfEventContext eventContext)
-{
-    MatterEventMetaContext ctx = { eventContext, eventString, data, nullptr };
-    MatterEventMetaContextAppend(ctx);
 }
 
 void EventControlHandler(chip::System::Layer * systemLayer, void * appState)

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -68,7 +68,7 @@ EMBER_AF_GENERATED_EVENT_CODE
 
 static IntrusiveList<MatterEventMetaContext> eventMetaContexts;
 
-void MatterRegisterAfEvent(MatterEventMetaContext* newContext)
+void MatterRegisterAfEvent(MatterEventMetaContext * newContext)
 {
     eventMetaContexts.PushBack(newContext);
 }
@@ -94,12 +94,13 @@ void EventControlHandler(chip::System::Layer * systemLayer, void * appState)
             return;
         }
 
-        for (auto metaContext : eventMetaContexts) {
+        for (auto metaContext : eventMetaContexts)
+        {
             const EmberEventData & event = metaContext.event;
             if (event.control != control)
                 continue;
             control->status = EMBER_EVENT_INACTIVE;
-            event.handler((uint8_t)metaContext.context.endpoint);
+            event.handler((uint8_t) metaContext.context.endpoint);
             break;
         }
     }
@@ -121,8 +122,10 @@ const char * emberAfGetEventString(uint8_t index)
     }
 
     uint8_t iteratorCounter = 0;
-    for (auto& metaContext : eventMetaContexts) {
-        if (iteratorCounter == index) {
+    for (auto & metaContext : eventMetaContexts)
+    {
+        if (iteratorCounter == index)
+        {
             return metaContext.eventString;
         }
         iteratorCounter++;
@@ -133,7 +136,8 @@ const char * emberAfGetEventString(uint8_t index)
 
 static EmberAfEventContext * findEventContext(EndpointId endpoint, ClusterId clusterId, bool isClient)
 {
-    for (auto& metaContext : eventMetaContexts) {
+    for (auto & metaContext : eventMetaContexts)
+    {
         auto context = metaContext.context;
         if (context.endpoint == endpoint && context.clusterId == clusterId && context.isClient == isClient)
         {

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -65,32 +65,37 @@ void emberAfPluginIasZoneClientStateMachineEventHandler(void){};
 EMBER_AF_GENERATED_EVENT_CODE
 #endif // EMBER_AF_GENERATED_EVENT_CODE
 
-struct MatterEventMetaContext {
+struct MatterEventMetaContext
+{
     EmberAfEventContext context;
-    const char* eventString;
+    const char * eventString;
     EmberEventData event;
-    MatterEventMetaContext* nextContext;
+    MatterEventMetaContext * nextContext;
 };
 
-MatterEventMetaContext* metaContextListHead = nullptr;
+MatterEventMetaContext * metaContextListHead = nullptr;
 
-void MatterEventMetaContextAppend(MatterEventMetaContext& newContext)
+void MatterEventMetaContextAppend(MatterEventMetaContext & newContext)
 {
     auto newContextHeap = new MatterEventMetaContext(newContext);
-    if (metaContextListHead == nullptr) {
+    if (metaContextListHead == nullptr)
+    {
         metaContextListHead = newContextHeap;
-    } else {
+    }
+    else
+    {
         auto metaContextPointer = metaContextListHead;
-        while (metaContextPointer->nextContext != nullptr) {
+        while (metaContextPointer->nextContext != nullptr)
+        {
             metaContextPointer = metaContextPointer->nextContext;
         }
         metaContextPointer->nextContext = newContextHeap;
     }
 }
 
-void MatterRegisterAfEvent(EmberEventData data, const char* eventString, EmberAfEventContext eventContext)
+void MatterRegisterAfEvent(EmberEventData data, const char * eventString, EmberAfEventContext eventContext)
 {
-    MatterEventMetaContext ctx = {eventContext, eventString, data, nullptr};
+    MatterEventMetaContext ctx = { eventContext, eventString, data, nullptr };
     MatterEventMetaContextAppend(ctx);
 }
 
@@ -107,14 +112,13 @@ void EventControlHandler(chip::System::Layer * systemLayer, void * appState)
             return;
         }
 
-        for (auto metaContext = metaContextListHead;
-              metaContext != nullptr;
-              metaContext = metaContext->nextContext) {
+        for (auto metaContext = metaContextListHead; metaContext != nullptr; metaContext = metaContext->nextContext)
+        {
             const EmberEventData & event = metaContext->event;
             if (event.control != control)
                 continue;
             control->status = EMBER_EVENT_INACTIVE;
-            event.handler((uint8_t)metaContext->context.endpoint);
+            event.handler((uint8_t) metaContext->context.endpoint);
             break;
         }
     }
@@ -130,15 +134,16 @@ void emAfInitEvents(void) {}
 
 const char * emberAfGetEventString(uint8_t index)
 {
-    if (index == 0xFF) {
+    if (index == 0xFF)
+    {
         return emAfStackEventString;
     }
 
     uint8_t iteratorCounter = 0;
-    for (auto metaContext = metaContextListHead;
-              metaContext != nullptr;
-              metaContext = metaContext->nextContext) {
-        if (iteratorCounter == index) {
+    for (auto metaContext = metaContextListHead; metaContext != nullptr; metaContext = metaContext->nextContext)
+    {
+        if (iteratorCounter == index)
+        {
             return metaContext->eventString;
         }
         iteratorCounter++;
@@ -149,10 +154,9 @@ const char * emberAfGetEventString(uint8_t index)
 
 static EmberAfEventContext * findEventContext(EndpointId endpoint, ClusterId clusterId, bool isClient)
 {
-    for (auto metaContext = metaContextListHead;
-              metaContext != nullptr;
-              metaContext = metaContext->nextContext) {
-        auto& context = metaContext->context;
+    for (auto metaContext = metaContextListHead; metaContext != nullptr; metaContext = metaContext->nextContext)
+    {
+        auto & context = metaContext->context;
         if (context.endpoint == endpoint && context.clusterId == clusterId && context.isClient == isClient)
         {
             return &context;

--- a/src/app/util/af-event.cpp
+++ b/src/app/util/af-event.cpp
@@ -70,7 +70,14 @@ static IntrusiveList<MatterEventMetaContext> eventMetaContexts;
 
 void MatterRegisterAfEvent(MatterEventMetaContext * newContext)
 {
-    eventMetaContexts.PushBack(newContext);
+    if (eventMetaContexts.Contains(newContext))
+    {
+        ChipLogError(Zcl, "Trying to register previously registered cluster event context");
+    }
+    else
+    {
+        eventMetaContexts.PushBack(newContext);
+    }
 }
 
 void MatterUnregisterAllAfEvents()

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -85,14 +85,15 @@ bool emberEventControlGetActive(EmberEventControl * control);
  */
 void emberEventControlSetActive(EmberEventControl * control);
 
-class MatterEventMetaContext: public chip::IntrusiveListNodeBase {
+class MatterEventMetaContext : public chip::IntrusiveListNodeBase
+{
 public:
     EmberAfEventContext context;
-    const char* eventString;
+    const char * eventString;
     EmberEventData event;
-    MatterEventMetaContext* nextContext;
+    MatterEventMetaContext * nextContext;
 };
 
-void MatterRegisterAfEvent(MatterEventMetaContext* newContext);
+void MatterRegisterAfEvent(MatterEventMetaContext * newContext);
 
 void MatterUnregisterAllAfEvents();

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -40,6 +40,7 @@
 #pragma once
 
 #include <app/util/af.h>
+#include <lib/support/IntrusiveList.h>
 
 #define MAX_TIMER_UNITS_HOST 0x7fff
 #define MAX_TIMER_MILLISECONDS_HOST (MAX_TIMER_UNITS_HOST * MILLISECOND_TICKS_PER_MINUTE)
@@ -84,7 +85,8 @@ bool emberEventControlGetActive(EmberEventControl * control);
  */
 void emberEventControlSetActive(EmberEventControl * control);
 
-struct MatterEventMetaContext {
+class MatterEventMetaContext: public chip::IntrusiveListNodeBase {
+public:
     EmberAfEventContext context;
     const char* eventString;
     EmberEventData event;
@@ -92,3 +94,5 @@ struct MatterEventMetaContext {
 };
 
 void MatterRegisterAfEvent(MatterEventMetaContext* newContext);
+
+void MatterUnregisterAllAfEvents();

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -84,4 +84,11 @@ bool emberEventControlGetActive(EmberEventControl * control);
  */
 void emberEventControlSetActive(EmberEventControl * control);
 
-void MatterRegisterAfEvent(EmberEventData data, const char * eventString, EmberAfEventContext eventContext);
+struct MatterEventMetaContext {
+    EmberAfEventContext context;
+    const char* eventString;
+    EmberEventData event;
+    MatterEventMetaContext* nextContext;
+};
+
+void MatterRegisterAfEvent(MatterEventMetaContext* newContext);

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -51,7 +51,15 @@
  * The main loop passes the array to ::emberRunEvents() to call
  * the handlers of any events whose time has arrived.
  */
-typedef struct EmberEventData EmberEventData;
+typedef struct
+{
+    /** The control structure for the event. */
+    EmberEventControl * control;
+    /** The procedure to call when the event fires. */
+    void (*handler)(uint8_t endpoint);
+    //void (*handler)(EmberEventControl* ctrl);
+} EmberEventData;
+
 
 // A function used to retrieve the proper NCP timer duration and unit based on a given
 // passed number of milliseconds.
@@ -76,3 +84,5 @@ bool emberEventControlGetActive(EmberEventControl * control);
 /** @brief Sets this ::EmberEventControl to run as soon as possible.
  */
 void emberEventControlSetActive(EmberEventControl * control);
+
+void MatterRegisterAfEvent(EmberEventData data, const char* eventString, EmberAfEventContext eventContext);

--- a/src/app/util/af-event.h
+++ b/src/app/util/af-event.h
@@ -57,9 +57,8 @@ typedef struct
     EmberEventControl * control;
     /** The procedure to call when the event fires. */
     void (*handler)(uint8_t endpoint);
-    //void (*handler)(EmberEventControl* ctrl);
+    // void (*handler)(EmberEventControl* ctrl);
 } EmberEventData;
-
 
 // A function used to retrieve the proper NCP timer duration and unit based on a given
 // passed number of milliseconds.
@@ -85,4 +84,4 @@ bool emberEventControlGetActive(EmberEventControl * control);
  */
 void emberEventControlSetActive(EmberEventControl * control);
 
-void MatterRegisterAfEvent(EmberEventData data, const char* eventString, EmberAfEventContext eventContext);
+void MatterRegisterAfEvent(EmberEventData data, const char * eventString, EmberAfEventContext eventContext);

--- a/src/app/util/util.cpp
+++ b/src/app/util/util.cpp
@@ -264,8 +264,9 @@ void MatterFanControlPluginServerInitCallback() {}
 // such as after a leave network. This allows zcl utils to clear state
 // that should not be kept when changing networks
 // ****************************************
-void emberAfStackDown(void)
+void emberAfStackDown()
 {
+    MatterUnregisterAllAfEvents();
     emberAfRegistrationAbortCallback();
 }
 

--- a/src/app/util/util.h
+++ b/src/app/util/util.h
@@ -145,7 +145,7 @@ uint16_t emberAfGetMfgCodeFromCurrentCommand(void);
 void emberAfInit(chip::Messaging::ExchangeManager * exchangeContext);
 void emberAfTick(void);
 uint16_t emberAfFindClusterNameIndex(chip::ClusterId cluster);
-void emberAfStackDown(void);
+void emberAfStackDown();
 
 void emberAfDecodeAndPrintCluster(chip::ClusterId cluster);
 

--- a/src/lib/support/IntrusiveList.h
+++ b/src/lib/support/IntrusiveList.h
@@ -29,7 +29,7 @@ class IntrusiveListNodeBase
 {
 public:
     IntrusiveListNodeBase() : mPrev(nullptr), mNext(nullptr) {}
-    ~IntrusiveListNodeBase() { VerifyOrDie(!IsInList()); }
+    ~IntrusiveListNodeBase() {}
 
     bool IsInList() const { return (mPrev != nullptr && mNext != nullptr); }
 


### PR DESCRIPTION
#### Problem & Solution
The all-clusters app relies on the af-gen-event.h file for the EMBER_AF_GENERATED_EVENTS definition, along with its context. However, the file is not automatically generated by zap. Thus other sample apps that rely on level control don't perform the level transition.

This definition enables the cluster events/ticks that cause a transition from one state to another on time-dependent clusters such as level control.

This change to af-event.cpp/h deprecates the definition and expects that any cluster that needs it will register itself during its initialization. Information is kept on a linked list of cluster contexts. The premise is that clusters will register themselves, but never unregister from this data structure.

This self-init was implemented on the level control cluster.

This fixes the issue on interop_testing_te9 event. Another similar PR will be made against master branch.

#### Testing
Tested with a dimmable light example in chef app