### PR TITLE
fix: changed door lock cluster stub functions to reflect new signatur…

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -5,12 +5,16 @@
 #include <app-common/zap-generated/cluster-id.h>
 #include <app-common/zap-generated/command-id.h>
 
-bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, chip::Optional<chip::ByteSpan> pinCode)
+using namespace ::chip;
+using namespace chip::app::Clusters::DoorLock;
+
+bool emberAfPluginDoorLockOnDoorLockCommand(EndpointId endpointId, const chip::Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
     return true;
 }
 
-bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, chip::Optional<chip::ByteSpan> pinCode)
+bool emberAfPluginDoorLockOnDoorUnlockCommand(EndpointId endpointId, const chip::Optional<ByteSpan> & pinCode,
+                                              DlOperationError & err)
 {
     return true;
 }


### PR DESCRIPTION
…e on https://github.com/project-chip/connectedhomeip/pull/14492/files

#### Problem
Door locks changed signature on https://github.com/project-chip/connectedhomeip/pull/14492/files. That broke compatibility with current stubs

#### Change overview
Stubs for door lock changed

#### Testing
`./chef.py -d <zap configuration with door lock cluster> -t esp32 -b` builds