### PR TITLE
Fix setting numberOfHolidaySchedules default

### DIFF
--- a/examples/lock-app/linux/src/LockManager.cpp
+++ b/examples/lock-app/linux/src/LockManager.cpp
@@ -96,7 +96,7 @@ bool LockManager::InitEndpoint(chip::EndpointId endpointId)
             Zcl,
             "Unable to get number of supported holiday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
             endpointId);
-        numberOfYearDaySchedulesPerUser = 10;
+        numberOfHolidaySchedules = 10;
     }
 
     mEndpoints.emplace_back(endpointId, numberOfSupportedUsers, numberOfSupportedCredentials, numberOfWeekDaySchedulesPerUser,


### PR DESCRIPTION
#### Problem
Default for numberOfHolidaySchedules was not properly set when. Seems like a copy paste error

#### Change overview
Set numberOfHolidaySchedules default to 10 instead of numberOfYearDaySchedulesPerUser

#### Testing
How was this tested? (at least one bullet point required)
* None, just noticed a copy paste error during code inspection. It is a one line change
