### PR TITLE
Fix retrieval of attestation challenge in Java

### DIFF
--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -59,6 +59,25 @@ public:
 
     const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const { return mRemoteMRPConfig; }
 
+    /**
+     * @brief
+     *   This function returns the attestation challenge for the secure session.
+     *
+     * @param[out] attestationChallenge The output for the attestationChallenge
+     *
+     * @return CHIP_ERROR               CHIP_NO_ERROR on success, or CHIP_ERROR_INVALID_ARGUMENT if no secure session is active
+     */
+    virtual CHIP_ERROR GetAttestationChallenge(ByteSpan & attestationChallenge)
+    {
+        Optional<SessionHandle> secureSessionHandle;
+
+        secureSessionHandle = GetSecureSession();
+        VerifyOrReturnError(secureSessionHandle.HasValue(), CHIP_ERROR_INCORRECT_STATE);
+
+        attestationChallenge = secureSessionHandle.Value()->AsSecureSession()->GetCryptoContext().GetAttestationChallenge();
+        return CHIP_NO_ERROR;
+    }
+
 protected:
     virtual bool IsSecureConnected() const = 0;
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -778,19 +778,6 @@ DeviceCommissioner::ContinueCommissioningAfterDeviceAttestationFailure(DevicePro
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceCommissioner::GetAttestationChallenge(ByteSpan & attestationChallenge)
-{
-    Optional<SessionHandle> secureSessionHandle;
-
-    VerifyOrReturnError(mDeviceBeingCommissioned != nullptr, CHIP_ERROR_INCORRECT_STATE);
-
-    secureSessionHandle = mDeviceBeingCommissioned->GetSecureSession();
-    VerifyOrReturnError(secureSessionHandle.HasValue(), CHIP_ERROR_INCORRECT_STATE);
-
-    attestationChallenge = secureSessionHandle.Value()->AsSecureSession()->GetCryptoContext().GetAttestationChallenge();
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR DeviceCommissioner::StopPairing(NodeId remoteDeviceId)
 {
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -468,16 +468,6 @@ public:
 
     /**
      * @brief
-     *   This function returns the attestation challenge for the secure session of the device being commissioned.
-     *
-     * @param[out] attestationChallenge The output for the attestationChallenge
-     *
-     * @return CHIP_ERROR               CHIP_NO_ERROR on success, or CHIP_ERROR_INVALID_ARGUMENT if no secure session is active
-     */
-    CHIP_ERROR GetAttestationChallenge(ByteSpan & attestationChallenge);
-
-    /**
-     * @brief
      *   This function stops a pairing process that's in progress. It does not delete the pairing of a previously
      *   paired device.
      *

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -655,8 +655,7 @@ JNI_METHOD(jbyteArray, getAttestationChallenge)
         JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, CHIP_ERROR_INCORRECT_STATE);
     }
 
-    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err                                      = wrapper->Controller()->GetAttestationChallenge(attestationChallenge);
+    err = chipDevice->GetAttestationChallenge(attestationChallenge);
     SuccessOrExit(err);
     VerifyOrExit(attestationChallenge.size() == 16, err = CHIP_ERROR_INVALID_ARGUMENT);
 


### PR DESCRIPTION
When not using the auto-commissioning flow, the mDeviceBeingCommissioned
proxy is no longer assigned, so the default behavior of retrieving the
attestation challenge fails.

Since at the time of use we already have a reference to the correct
DeviceProxy, added an overload to pass the proxy along to retrieve the
challenge.