### PR TITLE
Fix ESP32 Dnssd compile error

### DIFF
--- a/src/platform/ESP32/DnssdImpl.cpp
+++ b/src/platform/ESP32/DnssdImpl.cpp
@@ -373,7 +373,7 @@ CHIP_ERROR OnResolveQuerySrvDone(ResolveContext * ctx)
                 auto * addr = ctx->mResult->addr;
                 while (addr)
                 {
-                    GetIPAddress(ctx->mAddressCount[addressIndex], addr);
+                    GetIPAddress(ctx->mAddresses[addressIndex], addr);
                     addressIndex++;
                     addr = addr->next;
                 }


### PR DESCRIPTION
#### Problem
Compiling all-clusters-app for ESP32 results in the following error:

../../../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/DnssdImpl.cpp: In function 'CHIP_ERROR chip::Dnssd::OnResolveQuerySrvDone(chip::Dnssd::ResolveContext*)':
../../../../../../config/esp32/third_party/connectedhomeip/src/platform/ESP32/DnssdImpl.cpp:376:65: error: invalid types 'size_t {aka unsigned int}[size_t {aka unsigned int}]' for array subscript
                     GetIPAddress(ctx->mAddressCount[addressIndex], addr);

#### Change overview
Update variable name.

#### Testing
Compiled all-clusters-app for ESP32
