### PR TITLE
Add support to delegate key storage and signing to the Java layer

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -47,6 +47,12 @@ AndroidDeviceControllerWrapper::~AndroidDeviceControllerWrapper()
         JniReferences::GetInstance().GetEnvForCurrentThread()->DeleteGlobalRef(mJavaObjectRef);
     }
     mController->Shutdown();
+
+    if (mKeypairBridge != nullptr)
+    {
+        chip::Platform::Delete(mKeypairBridge);
+        mKeypairBridge = nullptr;
+    }
 }
 
 void AndroidDeviceControllerWrapper::SetJavaObjectRef(JavaVM * vm, jobject obj)

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -26,6 +26,7 @@
 #include <controller/CHIPDeviceController.h>
 #include <credentials/GroupDataProviderImpl.h>
 #include <lib/support/TimeUtils.h>
+#include <platform/android/CHIPP256KeypairBridge.h>
 #include <platform/internal/DeviceNetworkInfo.h>
 
 #include "AndroidOperationalCredentialsIssuer.h"
@@ -45,6 +46,15 @@ public:
     void SetJavaObjectRef(JavaVM * vm, jobject obj);
     jobject JavaObjectRef() { return mJavaObjectRef; }
     jlong ToJNIHandle();
+
+    chip::Crypto::CHIPP256KeypairBridge * GetP256KeypairBridge()
+    {
+        if (mKeypairBridge == nullptr)
+        {
+            mKeypairBridge = chip::Platform::New<chip::Crypto::CHIPP256KeypairBridge>();
+        }
+        return mKeypairBridge;
+    }
 
     void CallJavaMethod(const char * methodName, jint argument);
     CHIP_ERROR InitializeOperationalCredentialsIssuer();
@@ -79,6 +89,8 @@ public:
                                                         AndroidOperationalCredentialsIssuerPtr opCredsIssuer,
                                                         CHIP_ERROR * errInfoOnFailure);
 
+    chip::Credentials::GroupDataProvider * GroupDataProvider() { return &mGroupDataProvider; }
+
 private:
     using ChipDeviceControllerPtr = std::unique_ptr<chip::Controller::DeviceCommissioner>;
 
@@ -87,8 +99,9 @@ private:
     // TODO: This may need to be injected as a GroupDataProvider*
     chip::Credentials::GroupDataProviderImpl mGroupDataProvider;
 
-    JavaVM * mJavaVM       = nullptr;
-    jobject mJavaObjectRef = nullptr;
+    JavaVM * mJavaVM                                     = nullptr;
+    jobject mJavaObjectRef                               = nullptr;
+    chip::Crypto::CHIPP256KeypairBridge * mKeypairBridge = nullptr;
 
     // These fields allow us to release the string/byte array memory later.
     jstring ssidStr                    = nullptr;

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -86,6 +86,7 @@ android_library("java") {
     "src/chip/devicecontroller/ChipDeviceController.java",
     "src/chip/devicecontroller/ChipDeviceControllerException.java",
     "src/chip/devicecontroller/GetConnectedDeviceCallbackJni.java",
+    "src/chip/devicecontroller/KeypairDelegate.java",
     "src/chip/devicecontroller/NetworkCredentials.java",
     "src/chip/devicecontroller/NetworkLocation.java",
     "src/chip/devicecontroller/PaseVerifierParams.java",

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -35,6 +35,7 @@
 #include <atomic>
 #include <ble/BleUUID.h>
 #include <controller/CHIPDeviceController.h>
+#include <controller/CHIPDeviceControllerFactory.h>
 #include <controller/CommissioningWindowOpener.h>
 #include <controller/java/AndroidClusterExceptions.h>
 #include <credentials/CHIPCert.h>
@@ -191,6 +192,55 @@ exit:
     }
 
     return result;
+}
+
+JNI_METHOD(void, setOperationalKeyConfig)
+(JNIEnv * env, jobject self, jlong handle, jobject keypairBridge, jbyteArray rcac, jbyteArray icac, jbyteArray noc, jbyteArray ipk)
+{
+    chip::DeviceLayer::StackLock lock;
+    CHIP_ERROR err                               = CHIP_NO_ERROR;
+    AndroidDeviceControllerWrapper * wrapper     = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+    FabricInfo * fabricInfo                      = nullptr;
+    uint8_t compressedFabricId[sizeof(uint64_t)] = { 0 };
+    chip::MutableByteSpan compressedFabricIdSpan(compressedFabricId);
+    CommissionerInitParams params;
+
+    JniByteArray jniRcac(env, rcac);
+    JniByteArray jniIcac(env, icac);
+    JniByteArray jniNoc(env, noc);
+    JniByteArray jniIpk(env, ipk);
+
+    params.controllerRCAC = jniRcac.byteSpan();
+    params.controllerICAC = jniIcac.byteSpan();
+    params.controllerNOC  = jniNoc.byteSpan();
+
+    CHIPP256KeypairBridge * nativeKeypairBridge = wrapper->GetP256KeypairBridge();
+    nativeKeypairBridge->SetDelegate(keypairBridge);
+    err = nativeKeypairBridge->Initialize();
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to initialize KeypairBridge."));
+
+    params.operationalKeypair                   = nativeKeypairBridge;
+    params.hasExternallyOwnedOperationalKeypair = true;
+    params.systemState = const_cast<DeviceControllerSystemState *>(DeviceControllerFactory::GetInstance().GetSystemState());
+
+    err = wrapper->Controller()->InitControllerNOCChain(params);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to process NOC chain."));
+
+    // Compressed fabric ID can be generated only after the NOC chain is initialized
+    fabricInfo = wrapper->Controller()->GetFabricInfo();
+    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
+
+    err = fabricInfo->GetCompressedId(compressedFabricIdSpan);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to get compressed fabric ID."));
+
+    err = chip::Credentials::SetSingleIpkEpochKey(wrapper->GroupDataProvider(), fabricInfo->GetFabricIndex(), jniIpk.byteSpan(),
+                                                  compressedFabricIdSpan);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to set IPK epoch key."));
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+    }
 }
 
 JNI_METHOD(void, commissionDevice)

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -372,6 +372,39 @@ public class ChipDeviceController {
   private native PaseVerifierParams computePaseVerifier(
       long deviceControllerPtr, long devicePtr, long setupPincode, long iterations, byte[] salt);
 
+  /**
+   * Sets the key configuration used for operational control of devices. This includes all necessary
+   * credential elements for a Java controller to be used for operational control of devices.
+   *
+   * @param keypairDelegate a delegate for signing operations
+   * @param rootCertificate the trusted root X.509 certificate in DER-encoded form
+   * @param intermediateCertificate the intermediate X.509 certificate in DER-encoded form
+   * @param operationalCertificate the node operational X.509 certificate in DER-encoded form
+   * @param ipk the IPK epoch key to use (assuming a single one)
+   */
+  public void setOperationalKeyConfig(
+      KeypairDelegate keypairDelegate,
+      byte[] rootCertificate,
+      byte[] intermediateCertificate,
+      byte[] operationalCertificate,
+      byte[] ipk) {
+    setOperationalKeyConfig(
+        deviceControllerPtr,
+        keypairDelegate,
+        rootCertificate,
+        intermediateCertificate,
+        operationalCertificate,
+        ipk);
+  }
+
+  private native void setOperationalKeyConfig(
+      long deviceControllerPtr,
+      KeypairDelegate keypairDelegate,
+      byte[] rootCertificate,
+      byte[] intermediateCertificate,
+      byte[] operationalCertificate,
+      byte[] ipk);
+
   private native void subscribeToPath(
       long deviceControllerPtr,
       long callbackHandle,

--- a/src/controller/java/src/chip/devicecontroller/KeypairDelegate.java
+++ b/src/controller/java/src/chip/devicecontroller/KeypairDelegate.java
@@ -1,0 +1,52 @@
+package chip.devicecontroller;
+
+/** Delegate for a P256Keypair for use within the Java environment. */
+public interface KeypairDelegate {
+  /**
+   * Ensure that a private key is generated when this method returns.
+   *
+   * @throws KeypairException if a private key could not be generated or resolved
+   */
+  void generatePrivateKey() throws KeypairException;
+
+  /**
+   * Returns an operational PKCS#10 CSR in DER-encoded form, signed by the underlying private key.
+   *
+   * @throws KeypairException if the CSR could not be generated
+   */
+  byte[] createCertificateSigningRequest() throws KeypairException;
+
+  /**
+   * Returns the DER-encoded X.509 public key, generating a new private key if one has not already
+   * been created.
+   *
+   * @throws KeypairException if a private key could not be resolved
+   */
+  byte[] getPublicKey() throws KeypairException;
+
+  /**
+   * Signs the given message with the private key (generating one if it has not yet been created)
+   * using ECDSA and returns a DER-encoded signature.
+   *
+   * @throws KeypairException if a private key could not be resolved, or the message could not be
+   *     signed
+   */
+  byte[] ecdsaSignMessage(byte[] message) throws KeypairException;
+
+  /** Encompassing exception to encapsulate errors thrown during operations. */
+  final class KeypairException extends Exception {
+    private static final long serialVersionUID = 2646523289554350914L;
+
+    /** Constructs an exception with the specified {@code msg} as the message. */
+    public KeypairException(String msg) {
+      super(msg);
+    }
+    /**
+     * Constructs an exception with the specified {@code msg} as the message and the provided {@code
+     * cause}.
+     */
+    public KeypairException(String msg, Throwable cause) {
+      super(msg, cause);
+    }
+  }
+}

--- a/src/platform/android/BUILD.gn
+++ b/src/platform/android/BUILD.gn
@@ -36,6 +36,8 @@ static_library("android") {
     "BLEManagerImpl.h",
     "BlePlatformConfig.h",
     "CHIPDevicePlatformEvent.h",
+    "CHIPP256KeypairBridge.cpp",
+    "CHIPP256KeypairBridge.h",
     "CommissionableDataProviderImpl.cpp",
     "CommissionableDataProviderImpl.h",
     "ConfigurationManagerImpl.cpp",

--- a/src/platform/android/CHIPP256KeypairBridge.cpp
+++ b/src/platform/android/CHIPP256KeypairBridge.cpp
@@ -1,0 +1,196 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+#include <platform/android/CHIPP256KeypairBridge.h>
+
+#include <array>
+#include <cstdint>
+#include <cstdlib>
+#include <jni.h>
+#include <platform/PlatformManager.h>
+#include <string.h>
+#include <type_traits>
+
+using namespace chip;
+using namespace chip::Crypto;
+
+CHIPP256KeypairBridge::~CHIPP256KeypairBridge()
+{
+    VerifyOrReturn(mDelegate != nullptr);
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturn(env != nullptr);
+    env->DeleteGlobalRef(mDelegate);
+};
+
+CHIP_ERROR CHIPP256KeypairBridge::SetDelegate(jobject delegate)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrExit(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
+
+    mDelegate = env->NewGlobalRef(delegate);
+
+    err = JniReferences::GetInstance().GetClassRef(env, "chip/devicecontroller/KeypairDelegate", mKeypairDelegateClass);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to find class for KeypairDelegate."));
+
+    err = JniReferences::GetInstance().FindMethod(env, delegate, "createCertificateSigningRequest", "()[B",
+                                                  &mCreateCertificateSigningRequestMethod);
+    VerifyOrExit(err == CHIP_NO_ERROR,
+                 ChipLogError(Controller, "Failed to find KeypairDelegate.createCertificateSigningRequest() method."));
+
+    err = JniReferences::GetInstance().FindMethod(env, delegate, "getPublicKey", "()[B", &mGetPublicKeyMethod);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to find KeypairDelegate.getPublicKey() method."));
+
+    err = JniReferences::GetInstance().FindMethod(env, delegate, "ecdsaSignMessage", "([B)[B", &mEcdsaSignMessageMethod);
+    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(Controller, "Failed to find KeypairDelegate.ecdsaSignMessage() method."));
+
+exit:
+    return err;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::Initialize()
+{
+    if (HasKeypair())
+    {
+        SetPubkey();
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::Serialize(P256SerializedKeypair & output) const
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::Deserialize(P256SerializedKeypair & input)
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) const
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    // Not supported for use from within the CHIP SDK. We provide our own
+    // implementation that is JVM-specific.
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature) const
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    jbyteArray jniMsg;
+    jobject signedResult = nullptr;
+    JNIEnv * env         = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnError(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
+    err = JniReferences::GetInstance().N2J_ByteArray(env, msg, msg_length, jniMsg);
+    VerifyOrReturnError(err == CHIP_NO_ERROR, err);
+    VerifyOrReturnError(jniMsg != nullptr, err);
+
+    signedResult = env->CallObjectMethod(mDelegate, mEcdsaSignMessageMethod, jniMsg);
+
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(Controller, "Java exception in KeypairDelegate.ecdsaSignMessage()");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return CHIP_JNI_ERROR_EXCEPTION_THROWN;
+    }
+
+    JniByteArray jniSignature(env, static_cast<jbyteArray>(signedResult));
+    MutableByteSpan signatureSpan(out_signature, out_signature.Capacity());
+    ReturnErrorOnFailure(EcdsaAsn1SignatureToRaw(CHIP_CRYPTO_GROUP_SIZE_BYTES, jniSignature.byteSpan(), signatureSpan));
+    ReturnErrorOnFailure(out_signature.SetLength(signatureSpan.size()));
+
+    return err;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_hash(const uint8_t * hash, size_t hash_length,
+                                                  P256ECDSASignature & out_signature) const
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    // Not required for Java SDK.
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::ECDH_derive_secret(const P256PublicKey & remote_public_key,
+                                                     P256ECDHDerivedSecret & out_secret) const
+{
+    if (!HasKeypair())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    // Not required for Java SDK.
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR CHIPP256KeypairBridge::SetPubkey()
+{
+    jobject publicKey = nullptr;
+    JNIEnv * env      = nullptr;
+
+    VerifyOrReturnError(HasKeypair(), CHIP_ERROR_INCORRECT_STATE);
+
+    env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    VerifyOrReturnError(env != nullptr, CHIP_JNI_ERROR_NO_ENV);
+
+    publicKey = env->CallObjectMethod(mDelegate, mGetPublicKeyMethod);
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(Controller, "Java exception in KeypairDelegate.getPublicKey()");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return CHIP_JNI_ERROR_EXCEPTION_THROWN;
+    }
+
+    VerifyOrReturnError(publicKey != nullptr, CHIP_JNI_ERROR_NULL_OBJECT);
+    JniByteArray jniPublicKey(env, static_cast<jbyteArray>(publicKey));
+
+    VerifyOrReturnError(jniPublicKey.size() == kP256_PublicKey_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    FixedByteSpan<Crypto::kP256_PublicKey_Length> publicKeySpan =
+        FixedByteSpan<kP256_PublicKey_Length>(reinterpret_cast<const uint8_t *>(jniPublicKey.data()));
+    mPublicKey = P256PublicKey(publicKeySpan);
+    return CHIP_NO_ERROR;
+}

--- a/src/platform/android/CHIPP256KeypairBridge.h
+++ b/src/platform/android/CHIPP256KeypairBridge.h
@@ -1,0 +1,79 @@
+/**
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <jni.h>
+
+#include "crypto/CHIPCryptoPAL.h"
+#include "lib/core/CHIPError.h"
+#include "lib/support/logging/CHIPLogging.h"
+
+namespace chip {
+namespace Crypto {
+
+/**
+ * Bridging implementation of P256Keypair to allow delegation of signing and
+ * key generation to the JVM layer (through the KeypairDelegate Java interface).
+ *
+ * This implementation explicitly does not support serialization or
+ * deserialization and will always return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE if
+ * either of them are invoked (as this bridge is not expected to ever have
+ * access to the raw key bits).
+ */
+class CHIPP256KeypairBridge : public P256Keypair
+{
+public:
+    ~CHIPP256KeypairBridge() override;
+
+    /**
+     * Sets a reference to the Java implementation of the KeypairDelegate
+     * interface that will be called whenever this P256Keypair is used.
+     */
+    CHIP_ERROR SetDelegate(jobject delegate);
+
+    bool HasKeypair() const { return mDelegate != nullptr; }
+
+    CHIP_ERROR Initialize() override;
+
+    CHIP_ERROR Serialize(P256SerializedKeypair & output) const override;
+
+    CHIP_ERROR Deserialize(P256SerializedKeypair & input) override;
+
+    CHIP_ERROR NewCertificateSigningRequest(uint8_t * csr, size_t & csr_length) const override;
+
+    CHIP_ERROR ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature) const override;
+
+    CHIP_ERROR ECDSA_sign_hash(const uint8_t * hash, size_t hash_length, P256ECDSASignature & out_signature) const override;
+
+    CHIP_ERROR ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const override;
+
+    const P256PublicKey & Pubkey() const override { return mPublicKey; };
+
+private:
+    jobject mDelegate;
+    jclass mKeypairDelegateClass;
+    jmethodID mGetPublicKeyMethod;
+    jmethodID mCreateCertificateSigningRequestMethod;
+    jmethodID mEcdsaSignMessageMethod;
+
+    P256PublicKey mPublicKey;
+
+    CHIP_ERROR SetPubkey();
+};
+
+} // namespace Crypto
+} // namespace chip


### PR DESCRIPTION
To support the use of the Android KeyStore to securely hold the private
keys used for operational control, we cannot pass the raw private key to
the SDK.

This adds a bridging layer for Java that allows interception at the Java
layer of key generation requests as well as ECDSA signing.

Tested internally by delegating to a KeyStore. Tested externally via
standard commissioning in CHIPTool.