### PR TITLE
Add support for scope IDs for link-local addresses in Java

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -330,6 +330,17 @@ CHIP_ERROR DeviceController::GetPeerAddressAndPort(PeerId peerId, Inet::IPAddres
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR DeviceController::GetPeerAddressInterfaceAndPort(PeerId peerId, Inet::IPAddress & addr, Inet::InterfaceId & iface,
+                                                            uint16_t & port) {
+    VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+    Transport::PeerAddress peerAddr;
+    ReturnErrorOnFailure(mSystemState->CASESessionMgr()->GetPeerAddress(peerId, peerAddr));
+    addr = peerAddr.GetIPAddress();
+    port = peerAddr.GetPort();
+    iface = peerAddr.GetInterface();
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR DeviceController::ComputePASEVerifier(uint32_t iterations, uint32_t setupPincode, const ByteSpan & salt,
                                                  Spake2pVerifier & outVerifier)
 {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -45,6 +45,7 @@
 #include <credentials/FabricTable.h>
 #include <credentials/attestation_verifier/DeviceAttestationDelegate.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
+#include <inet/InetInterface.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
@@ -62,8 +63,6 @@
 #include <transport/SessionManager.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>
-
-#include <controller/CHIPDeviceControllerSystemState.h>
 
 #if CONFIG_DEVICE_LAYER
 #include <platform/CHIPDeviceLayer.h>
@@ -166,6 +165,8 @@ public:
     }
 
     CHIP_ERROR GetPeerAddressAndPort(PeerId peerId, Inet::IPAddress & addr, uint16_t & port);
+
+    CHIP_ERROR GetPeerAddressInterfaceAndPort(PeerId peerId, Inet::IPAddress & addr, Inet::InterfaceId & iface, uint16_t & port);
 
     /**
      * This function finds the device corresponding to deviceId, and establishes

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -70,7 +70,7 @@ using namespace chip::Credentials;
 
 static void * IOThreadMain(void * arg);
 static CHIP_ERROR N2J_PaseVerifierParams(JNIEnv * env, jlong setupPincode, jbyteArray pakeVerifier, jobject & outParams);
-static CHIP_ERROR N2J_NetworkLocation(JNIEnv * env, jstring ipAddress, jint port, jobject & outLocation);
+static CHIP_ERROR N2J_NetworkLocation(JNIEnv * env, jstring ipAddress, jint port, jint interfaceIndex, jobject & outLocation);
 static CHIP_ERROR GetChipPathIdValue(jobject chipPathId, uint32_t wildcardValue, uint32_t & outValue);
 static CHIP_ERROR ParseAttributePathList(jobject attributePathList,
                                          std::vector<app::AttributePathParams> & outAttributePathParamsList);
@@ -267,16 +267,13 @@ JNI_METHOD(void, pairDeviceWithAddress)
 
     ChipLogProgress(Controller, "pairDeviceWithAddress() called");
 
-    Inet::IPAddress addr;
     JniUtfString addrJniString(env, address);
-    VerifyOrReturn(Inet::IPAddress::FromString(addrJniString.c_str(), addr),
-                   ChipLogError(Controller, "Failed to parse IP address."),
-                   JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, CHIP_ERROR_INVALID_ARGUMENT));
 
-    RendezvousParameters rendezvousParams = RendezvousParameters()
-                                                .SetDiscriminator(discriminator)
-                                                .SetSetupPINCode(pinCode)
-                                                .SetPeerAddress(Transport::PeerAddress::UDP(addr, port));
+    RendezvousParameters rendezvousParams =
+        RendezvousParameters()
+            .SetDiscriminator(discriminator)
+            .SetSetupPINCode(pinCode)
+            .SetPeerAddress(Transport::PeerAddress::UDP(const_cast<char *>(addrJniString.c_str()), port));
     CommissioningParameters commissioningParams = CommissioningParameters();
     if (csrNonce != nullptr)
     {
@@ -523,15 +520,16 @@ JNI_METHOD(jobject, getNetworkLocation)(JNIEnv * env, jobject self, jlong handle
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
 
     chip::Inet::IPAddress addr;
+    chip::Inet::InterfaceId iface;
     uint16_t port;
     jobject networkLocation;
     char addrStr[50];
 
-    CHIP_ERROR err =
-        wrapper->Controller()->GetPeerAddressAndPort(PeerId()
-                                                         .SetCompressedFabricId(wrapper->Controller()->GetCompressedFabricId())
-                                                         .SetNodeId(static_cast<chip::NodeId>(deviceId)),
-                                                     addr, port);
+    CHIP_ERROR err = wrapper->Controller()->GetPeerAddressInterfaceAndPort(
+        PeerId()
+            .SetCompressedFabricId(wrapper->Controller()->GetCompressedFabricId())
+            .SetNodeId(static_cast<chip::NodeId>(deviceId)),
+        addr, iface, port);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -541,7 +539,8 @@ JNI_METHOD(jobject, getNetworkLocation)(JNIEnv * env, jobject self, jlong handle
 
     addr.ToString(addrStr);
 
-    err = N2J_NetworkLocation(env, env->NewStringUTF(addrStr), static_cast<jint>(port), networkLocation);
+    err = N2J_NetworkLocation(env, env->NewStringUTF(addrStr), static_cast<jint>(port),
+                              static_cast<jint>(iface.GetPlatformInterface()), networkLocation);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed to create NetworkLocation");
@@ -953,7 +952,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR N2J_NetworkLocation(JNIEnv * env, jstring ipAddress, jint port, jobject & outLocation)
+CHIP_ERROR N2J_NetworkLocation(JNIEnv * env, jstring ipAddress, jint port, jint interfaceIndex, jobject & outLocation)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     jmethodID constructor;
@@ -964,10 +963,10 @@ CHIP_ERROR N2J_NetworkLocation(JNIEnv * env, jstring ipAddress, jint port, jobje
     SuccessOrExit(err);
 
     env->ExceptionClear();
-    constructor = env->GetMethodID(locationClass, "<init>", "(Ljava/lang/String;I)V");
+    constructor = env->GetMethodID(locationClass, "<init>", "(Ljava/lang/String;II)V");
     VerifyOrExit(constructor != nullptr, err = CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
-    outLocation = (jobject) env->NewObject(locationClass, constructor, ipAddress, port);
+    outLocation = (jobject) env->NewObject(locationClass, constructor, ipAddress, port, interfaceIndex);
 
     VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 exit:

--- a/src/controller/java/src/chip/devicecontroller/NetworkLocation.java
+++ b/src/controller/java/src/chip/devicecontroller/NetworkLocation.java
@@ -6,10 +6,12 @@ import java.util.Locale;
 public final class NetworkLocation {
   private final String ipAddress;
   private final int port;
+  private final int interfaceIndex;
 
-  public NetworkLocation(String ipAddress, int port) {
+  public NetworkLocation(String ipAddress, int port, int interfaceIndex) {
     this.ipAddress = ipAddress;
     this.port = port;
+    this.interfaceIndex = interfaceIndex;
   }
 
   /** Returns the IP address (e.g. fe80::3e61:5ff:fe0c:89f8). */
@@ -21,8 +23,18 @@ public final class NetworkLocation {
     return port;
   }
 
+  /** Returns the index of the network interface to which this address belongs, or zero. */
+  public int getInterfaceIndex() {
+    return interfaceIndex;
+  }
+
   @Override
   public String toString() {
-    return String.format(Locale.ROOT, "%s[%d]", ipAddress, port);
+    return String.format(
+        Locale.ROOT,
+        "%s%s[%d]",
+        ipAddress,
+        (interfaceIndex == 0 ? "" : "%" + interfaceIndex),
+        port);
   }
 }

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -34,6 +34,7 @@
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
+#include <lib/support/SafeInt.h>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP && !CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT
 #include <lwip/netif.h>
@@ -435,6 +436,23 @@ CHIP_ERROR InterfaceId::GetInterfaceName(char * nameBuf, size_t nameBufSize) con
 
 CHIP_ERROR InterfaceId::InterfaceNameToId(const char * intfName, InterfaceId & interface)
 {
+    // First attempt to parse as a numeric ID:
+    char * parseEnd;
+    unsigned long intfNum = strtoul(intfName, &parseEnd, 10);
+    if (*parseEnd == 0)
+    {
+        if (intfNum > 0 && intfNum < UINT8_MAX && CanCastTo<InterfaceId::PlatformType>(intfNum))
+        {
+            interface = InterfaceId(static_cast<InterfaceId::PlatformType>(intfNum));
+            return CHIP_NO_ERROR;
+        }
+        else
+        {
+            return INET_ERROR_UNKNOWN_INTERFACE;
+        }
+    }
+
+    // Falling back to name -> ID lookup otherwise (e.g. wlan0)
     unsigned int intfId = if_nametoindex(intfName);
     interface           = InterfaceId(intfId);
     if (intfId == 0)

--- a/src/transport/raw/PeerAddress.h
+++ b/src/transport/raw/PeerAddress.h
@@ -186,12 +186,14 @@ public:
     static PeerAddress BLE() { return PeerAddress(Type::kBle); }
     static PeerAddress UDP(const Inet::IPAddress & addr) { return PeerAddress(addr, Type::kUdp); }
     static PeerAddress UDP(const Inet::IPAddress & addr, uint16_t port) { return UDP(addr).SetPort(port); }
+    static PeerAddress UDP(char *addrStr, uint16_t port) { return PeerAddress::FromString(addrStr, port, Type::kUdp); }
     static PeerAddress UDP(const Inet::IPAddress & addr, uint16_t port, Inet::InterfaceId interface)
     {
         return UDP(addr).SetPort(port).SetInterface(interface);
     }
     static PeerAddress TCP(const Inet::IPAddress & addr) { return PeerAddress(addr, Type::kTcp); }
     static PeerAddress TCP(const Inet::IPAddress & addr, uint16_t port) { return TCP(addr).SetPort(port); }
+    static PeerAddress TCP(char *addrStr, uint16_t port) { return PeerAddress::FromString(addrStr, port, Type::kTcp); }
     static PeerAddress TCP(const Inet::IPAddress & addr, uint16_t port, Inet::InterfaceId interface)
     {
         return TCP(addr).SetPort(port).SetInterface(interface);
@@ -214,6 +216,31 @@ public:
     }
 
 private:
+    static PeerAddress FromString(char * addrStr, uint16_t port, Type type)
+    {
+        char * addrPart  = nullptr;
+        char * scopePart = nullptr;
+        Inet::IPAddress addr;
+
+        addrPart = strtok(addrStr, "%");
+        if (addrPart != nullptr)
+        {
+            scopePart = strtok(nullptr, "%");
+        }
+
+        if (addrPart == nullptr || scopePart == nullptr)
+        {
+            Inet::IPAddress::FromString(addrStr, addr);
+            return PeerAddress(addr, type).SetPort(port);
+        }
+        else
+        {
+            Inet::InterfaceId interfaceId;
+            Inet::InterfaceId::InterfaceNameToId(scopePart, interfaceId);
+            Inet::IPAddress::FromString(addrPart, addr);
+            return PeerAddress(addr, type).SetPort(port).SetInterface(interfaceId);
+        }
+    }
     Inet::IPAddress mIPAddress   = {};
     Type mTransportType          = Type::kUndefined;
     uint16_t mPort               = CHIP_PORT; ///< Relevant for UDP data sending.


### PR DESCRIPTION
Currently the DNS-SD resolver endpoints, and the getNetworkLocation()
and establishPaseConnection() entry points which expect an address as a
String do not support receiving an address string which includes the
scope ID. For example, fe80::2%wlan0.

Added support to accept either form, either the index (%47) or the name
(%wlan0).

Tested internally as well as internally by commissioning with CHIPTool.