### PR TITLE
Remove SessionRecoveryDelegate, deliver its event via SessionHolder

### DIFF
--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -340,6 +340,16 @@ void OperationalDeviceProxy::OnSessionReleased()
     MoveToState(State::HasAddress);
 }
 
+void OperationalDeviceProxy::OnFirstMessageDeliveryFailed()
+{
+    LookupPeerAddress();
+}
+
+void OperationalDeviceProxy::OnSessionHang()
+{
+    // TODO: establish a new session
+}
+
 CHIP_ERROR OperationalDeviceProxy::ShutdownSubscriptions()
 {
     return app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricInfo->GetFabricIndex(), GetDeviceId());

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -145,11 +145,15 @@ public:
     void OnSessionEstablished(const SessionHandle & session) override;
     void OnSessionEstablishmentError(CHIP_ERROR error) override;
 
-    /**
-     *   Called when a connection is closing.
-     *   The object releases all resources associated with the connection.
-     */
+    //////////// SessionDelegate Implementation ///////////////
+
+    // Called when a connection is closing. The object releases all resources associated with the connection.
     void OnSessionReleased() override;
+    // Called when a message is not acked within first retrans timer, try to refresh the peer address
+    void OnFirstMessageDeliveryFailed() override;
+    // Called when a connection is hanging. Try to re-establish another session, and shift to the new session when done, the
+    // original session won't be touched during the period.
+    void OnSessionHang() override;
 
     /**
      *  Mark any open session with the device as expired.

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -282,44 +282,6 @@ CHIP_ERROR DeviceController::DisconnectDevice(NodeId nodeId)
     return CHIP_NO_ERROR;
 }
 
-void DeviceController::OnFirstMessageDeliveryFailed(const SessionHandle & session)
-{
-    if (session->GetSessionType() != Session::SessionType::kSecure)
-    {
-        // Definitely not a CASE session.
-        return;
-    }
-
-    auto * secureSession = session->AsSecureSession();
-    if (secureSession->GetSecureSessionType() != SecureSession::Type::kCASE)
-    {
-        // Still not CASE.
-        return;
-    }
-
-    FabricIndex ourIndex = kUndefinedFabricIndex;
-    CHIP_ERROR err       = GetFabricIndex(&ourIndex);
-    if (err != CHIP_NO_ERROR)
-    {
-        // We can't really do CASE, now can we?
-        return;
-    }
-
-    if (ourIndex != session->GetFabricIndex())
-    {
-        // Not one of our sessions.
-        return;
-    }
-
-    err = UpdateDevice(secureSession->GetPeerNodeId());
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller,
-                     "OnFirstMessageDeliveryFailed was called, but UpdateDevice did not succeed (%" CHIP_ERROR_FORMAT ")",
-                     err.Format());
-    }
-}
-
 CHIP_ERROR DeviceController::GetPeerAddressAndPort(PeerId peerId, Inet::IPAddress & addr, uint16_t & port)
 {
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
@@ -359,8 +321,6 @@ DeviceCommissioner::DeviceCommissioner() :
 CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
 {
     ReturnErrorOnFailure(DeviceController::Init(params));
-
-    params.systemState->SessionMgr()->RegisterRecoveryDelegate(*this);
 
     mPairingDelegate = params.pairingDelegate;
 
@@ -433,8 +393,6 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
         OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
     }
     // TODO: If we have a commissioning step in progress, is there a way to cancel that callback?
-
-    mSystemState->SessionMgr()->UnregisterRecoveryDelegate(*this);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY // make this commissioner discoverable
     if (mUdcTransportMgr != nullptr)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -136,7 +136,7 @@ struct CommissionerInitParams : public ControllerInitParams
  *   and device pairing information for individual devices). Alternatively, this class can retrieve the
  *   relevant information when the application tries to communicate with the device
  */
-class DLL_EXPORT DeviceController : public SessionRecoveryDelegate, public AbstractDnssdDiscoveryController
+class DLL_EXPORT DeviceController : public AbstractDnssdDiscoveryController
 {
 public:
     DeviceController();
@@ -300,9 +300,6 @@ protected:
     /// Fetches the session to use for the current device. Allows overriding
     /// in case subclasses want to create the session if it does not yet exist
     virtual OperationalDeviceProxy * GetDeviceSession(const PeerId & peerId);
-
-    //////////// SessionRecoveryDelegate Implementation ///////////////
-    void OnFirstMessageDeliveryFailed(const SessionHandle & session) override;
 
     DiscoveredNodeList GetDiscoveredNodes() override { return DiscoveredNodeList(mCommissionableNodes); }
 

--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -1054,17 +1054,6 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
 #endif
 
 /**
- * @def CHIP_CONFIG_MAX_SESSION_RECOVERY_DELEGATES
- *
- * @brief Defines the max number of SessionRecoveryDelegate
- *
- * // TODO: Explain what this is for.
- */
-#ifndef CHIP_CONFIG_MAX_SESSION_RECOVERY_DELEGATES
-#define CHIP_CONFIG_MAX_SESSION_RECOVERY_DELEGATES 4
-#endif
-
-/**
  * @def CHIP_CONFIG_CASE_SESSION_RESUME_CACHE_SIZE
  *
  * @brief

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -38,9 +38,6 @@
 namespace chip {
 namespace Messaging {
 
-class ExchangeContext;
-using ExchangeHandle = ReferenceCountedHandle<ExchangeContext>;
-
 enum class SendMessageFlags : uint16_t;
 class ReliableMessageContext;
 

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -92,6 +92,14 @@ public:
 
     bool IsSecureSession() const { return GetSessionType() == SessionType::kSecure; }
 
+    void DispatchSessionEvent(SessionDelegate::Event event)
+    {
+        for (auto & holder : mHolders)
+        {
+            holder.DispatchSessionEvent(event);
+        }
+    }
+
 protected:
     // This should be called by sub-classes at the very beginning of the destructor, before any data field is disposed, such that
     // the session is still functional during the callback.

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -41,27 +41,19 @@ public:
      */
     virtual NewSessionHandlingPolicy GetNewSessionHandlingPolicy() { return NewSessionHandlingPolicy::kShiftToNewSession; }
 
+    using Event = void (SessionDelegate::*)();
+
     /**
      * @brief
      *   Called when a session is releasing
      */
     virtual void OnSessionReleased() = 0;
-};
 
-class DLL_EXPORT SessionRecoveryDelegate
-{
-public:
-    virtual ~SessionRecoveryDelegate() {}
+    /// @brief Called when the first message delivery in a session failed, so actions aiming to recover connection can be performed.
+    virtual void OnFirstMessageDeliveryFailed() {}
 
-    /**
-     * @brief
-     *   Called when the first message delivery in a session failed,
-     *   so actions aiming to recover connection can be performed.
-     *
-     * @param session   The handle to the session.  This may be any session type
-     *                  that supports MRP.
-     */
-    virtual void OnFirstMessageDeliveryFailed(const SessionHandle & session) = 0;
+    /// @brief Called when a session is unresponsive for a while (detected by MRP)
+    virtual void OnSessionHang() {}
 };
 
 } // namespace chip

--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -49,10 +49,20 @@ public:
      */
     virtual void OnSessionReleased() = 0;
 
-    /// @brief Called when the first message delivery in a session failed, so actions aiming to recover connection can be performed.
+    /**
+     * @brief
+     *   Called when the first message delivery in an exchange fails, so actions aiming to recover connection can be performed.
+     *
+     *   Note: the implementation must not do anything that will destroy the session or change the SessionHolder.
+     */
     virtual void OnFirstMessageDeliveryFailed() {}
 
-    /// @brief Called when a session is unresponsive for a while (detected by MRP)
+    /**
+     * @brief
+     *   Called when a session is unresponsive for a while (detected by MRP)
+     *
+     *   Note: the implementation must not do anything that will destroy the session or change the SessionHolder.
+     */
     virtual void OnSessionHang() {}
 };
 

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -66,11 +66,14 @@ public:
 
     Transport::Session * operator->() const { return &mSession.Value().Get(); }
 
+    // There is not delegate, nothing to do here
+    virtual void DispatchSessionEvent(SessionDelegate::Event event) {}
+
 private:
     Optional<ReferenceCountedHandle<Transport::Session>> mSession;
 };
 
-// @brief Extends SessionHolder to allow propagate OnSessionReleased event to an extra given destination
+/// @brief Extends SessionHolder to allow propagate SessionDelegate::* events to a given destination
 class SessionHolderWithDelegate : public SessionHolder
 {
 public:
@@ -85,6 +88,8 @@ public:
         // Note, the session is already cleared during mDelegate.OnSessionReleased
         mDelegate.OnSessionReleased();
     }
+
+    void DispatchSessionEvent(SessionDelegate::Event event) override { (mDelegate.*event)(); }
 
 private:
     SessionDelegate & mDelegate;

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -102,8 +102,6 @@ CHIP_ERROR SessionManager::Init(System::Layer * systemLayer, TransportMgrBase * 
 
 void SessionManager::Shutdown()
 {
-    mSessionRecoveryDelegates.ReleaseAll();
-
     mMessageCounterManager = nullptr;
 
     mState        = State::kNotReady;
@@ -433,38 +431,6 @@ void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::
     {
         UnauthenticatedMessageDispatch(packetHeader, peerAddress, std::move(msg));
     }
-}
-
-void SessionManager::RegisterRecoveryDelegate(SessionRecoveryDelegate & cb)
-{
-#ifndef NDEBUG
-    mSessionRecoveryDelegates.ForEachActiveObject([&](std::reference_wrapper<SessionRecoveryDelegate> * i) {
-        VerifyOrDie(std::addressof(cb) != std::addressof(i->get()));
-        return Loop::Continue;
-    });
-#endif
-    std::reference_wrapper<SessionRecoveryDelegate> * slot = mSessionRecoveryDelegates.CreateObject(cb);
-    VerifyOrDie(slot != nullptr);
-}
-
-void SessionManager::UnregisterRecoveryDelegate(SessionRecoveryDelegate & cb)
-{
-    mSessionRecoveryDelegates.ForEachActiveObject([&](std::reference_wrapper<SessionRecoveryDelegate> * i) {
-        if (std::addressof(cb) == std::addressof(i->get()))
-        {
-            mSessionRecoveryDelegates.ReleaseObject(i);
-            return Loop::Break;
-        }
-        return Loop::Continue;
-    });
-}
-
-void SessionManager::RefreshSessionOperationalData(const SessionHandle & sessionHandle)
-{
-    mSessionRecoveryDelegates.ForEachActiveObject([&](std::reference_wrapper<SessionRecoveryDelegate> * cb) {
-        cb->get().OnFirstMessageDeliveryFailed(sessionHandle);
-        return Loop::Continue;
-    });
 }
 
 void SessionManager::UnauthenticatedMessageDispatch(const PacketHeader & packetHeader, const Transport::PeerAddress & peerAddress,

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -150,10 +150,6 @@ public:
     /// ExchangeManager)
     void SetMessageDelegate(SessionMessageDelegate * cb) { mCB = cb; }
 
-    void RegisterRecoveryDelegate(SessionRecoveryDelegate & cb);
-    void UnregisterRecoveryDelegate(SessionRecoveryDelegate & cb);
-    void RefreshSessionOperationalData(const SessionHandle & sessionHandle);
-
     // Test-only: create a session on the fly.
     CHIP_ERROR InjectPaseSessionWithTestKey(SessionHolder & sessionHolder, uint16_t localSessionId, NodeId peerNodeId,
                                             uint16_t peerSessionId, FabricIndex fabricIndex,
@@ -266,9 +262,6 @@ private:
     chip::Transport::GroupOutgoingCounters mGroupClientCounter;
 
     SessionMessageDelegate * mCB = nullptr;
-
-    ObjectPool<std::reference_wrapper<SessionRecoveryDelegate>, CHIP_CONFIG_MAX_SESSION_RECOVERY_DELEGATES>
-        mSessionRecoveryDelegates;
 
     TransportMgrBase * mTransportMgr                                   = nullptr;
     Transport::MessageCounterManagerInterface * mMessageCounterManager = nullptr;


### PR DESCRIPTION
#### Problem
It is easier to deliver `SessionRecoveryDelegate::OnFirstMessageDeliveryFailed` event via `SessionHolder`, remove it to save code space and heap space.

#### Change overview
* Remove `SessionRecoveryDelegate`
* Deliver `SessionRecoveryDelegate::OnFirstMessageDeliveryFailed` via `SessionHolder`
* Remove `SessionManager::mSessionRecoveryDelegates`

#### Testing
Passed unit-tests