### PR TITLE
Remove unused CHIP_DEVICE_INFO_PATH

### DIFF
--- a/src/platform/Linux/CHIPLinuxStorage.h
+++ b/src/platform/Linux/CHIPLinuxStorage.h
@@ -61,9 +61,6 @@
 #define CHIP_DEFAULT_DATA_PATH                                                                                                     \
     LOCALSTATEDIR "/"                                                                                                              \
                   "chip_counters.ini"
-#define CHIP_DEVICE_INFO_PATH                                                                                                      \
-    DEVICEINFODIR "/"                                                                                                              \
-                  "chip_device_info.ini"
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Linux/CHIPLinuxStorage.h
+++ b/src/platform/Linux/CHIPLinuxStorage.h
@@ -48,10 +48,6 @@
 #define LOCALSTATEDIR "/tmp"
 #endif
 
-#ifndef DEVICEINFODIR
-#define DEVICEINFODIR "/tmp"
-#endif
-
 #define CHIP_DEFAULT_FACTORY_PATH                                                                                                  \
     FATCONFDIR "/"                                                                                                                 \
                "chip_factory.ini"

--- a/src/platform/webos/CHIPWebOSStorage.h
+++ b/src/platform/webos/CHIPWebOSStorage.h
@@ -48,10 +48,6 @@
 #define LOCALSTATEDIR "/tmp"
 #endif
 
-#ifndef DEVICEINFODIR
-#define DEVICEINFODIR "/tmp"
-#endif
-
 #define CHIP_DEFAULT_FACTORY_PATH                                                                                                  \
     FATCONFDIR "/"                                                                                                                 \
                "chip_factory.ini"
@@ -61,9 +57,6 @@
 #define CHIP_DEFAULT_DATA_PATH                                                                                                     \
     LOCALSTATEDIR "/"                                                                                                              \
                   "chip_counters.ini"
-#define CHIP_DEVICE_INFO_PATH                                                                                                      \
-    DEVICEINFODIR "/"                                                                                                              \
-                  "chip_device_info.ini"
 
 namespace chip {
 namespace DeviceLayer {


### PR DESCRIPTION
#### Problem
Unused pre-processor define.

#### Change overview
Remove unused CHIP_DEVICE_INFO_PATH, its use has been removed by 30edacd0a6d5.

#### Testing
None
