### PR TITLE
[Tizen] Implement functionality to get WiFi MAC

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -82,6 +82,17 @@
                 "path": ["${workspaceFolder}/out/debug/"],
                 "limitSymbolsToIncludedHeaders": true
             }
+        },
+        {
+            "name": "Tizen examples debug (GN)",
+            "cStandard": "c11",
+            "cppStandard": "gnu++14",
+            "intelliSenseMode": "gcc-arm",
+            "compilerPath": "/opt/tizen-sdk/tools/arm-linux-gnueabi-gcc-9.2/bin/arm-linux-gnueabi-gcc",
+            "browse": {
+                "path": ["${workspaceFolder}/out/debug/"],
+                "limitSymbolsToIncludedHeaders": true
+            }
         }
     ],
     "version": 4

--- a/examples/lighting-app/tizen/tizen-manifest.xml
+++ b/examples/lighting-app/tizen/tizen-manifest.xml
@@ -7,6 +7,8 @@
     <privileges>
         <privilege>http://tizen.org/privilege/bluetooth</privilege>
         <privilege>http://tizen.org/privilege/internet</privilege>
+        <privilege>http://tizen.org/privilege/network.get</privilege>
     </privileges>
     <feature name="http://tizen.org/feature/network.bluetooth.le.gatt.server">true</feature>
+    <feature name="http://tizen.org/feature/network.wifi">true</feature>
 </manifest>

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -31,6 +31,7 @@
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/ConfigurationManager.h>
 #include <platform/Tizen/PosixConfig.h>
+#include <platform/Tizen/WiFiManager.h>
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
 namespace chip {
@@ -91,7 +92,12 @@ CHIP_ERROR ConfigurationManagerImpl::StoreProductId(uint16_t productId)
 
 CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
+#if CHIP_DEVICE_CONFIG_ENABLE_WIFI
+    constexpr size_t kExpectedBufSize = ConfigurationManager::kPrimaryMACAddressLength;
+    return WiFiMgr().GetDeviceMACAddress(buf, kExpectedBufSize);
+#else
     return CHIP_ERROR_NOT_IMPLEMENTED;
+#endif
 }
 
 bool ConfigurationManagerImpl::CanFactoryReset(void)

--- a/src/platform/Tizen/WiFiManager.h
+++ b/src/platform/Tizen/WiFiManager.h
@@ -45,6 +45,7 @@ public:
     CHIP_ERROR Disconnect(const char * ssid);
     CHIP_ERROR RemoveAllConfigs(void);
 
+    CHIP_ERROR GetDeviceMACAddress(uint8_t * macAddress, size_t macAddressLen);
     CHIP_ERROR GetDeviceState(wifi_manager_device_state_e * deviceState);
     CHIP_ERROR SetDeviceState(wifi_manager_device_state_e deviceState);
     CHIP_ERROR GetModuleState(wifi_manager_module_state_e * moduleState);


### PR DESCRIPTION
#### Problem

ConfigurationManagerImpl::GetPrimaryWiFiMACAddress was not implemented for Tizen.

#### Change overview

- get WiFi MAC address using Tizen native API

#### Testing

During application startup there is no longer error like this:
```
E/CHIP    ( 2679): DIS: Failed to get primary mac address of device. Generating a random one.
```