### PR TITLE
Only add avahi as build dependency when platform mDNS is selected

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -30,7 +30,7 @@ if (chip_enable_openthread) {
   }
 }
 
-if (chip_device_platform == "linux" && chip_mdns != "none") {
+if (chip_device_platform == "linux" && chip_mdns == "platform") {
   pkg_config("avahi_client_config") {
     packages = [ "avahi-client" ]
   }

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -30,12 +30,6 @@ if (chip_enable_openthread) {
   }
 }
 
-if (chip_device_platform == "linux" && chip_mdns == "platform") {
-  pkg_config("avahi_client_config") {
-    packages = [ "avahi-client" ]
-  }
-}
-
 if (chip_device_platform != "none" && chip_device_platform != "external") {
   declare_args() {
     # Extra header to include in CHIPDeviceConfig.h for project.

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -26,7 +26,7 @@ if (chip_enable_openthread) {
   import("//build_overrides/ot_br_posix.gni")
 }
 
-if (chip_mdns != "none") {
+if (chip_mdns == "platform") {
   pkg_config("avahi_client_config") {
     packages = [ "avahi-client" ]
   }
@@ -92,7 +92,7 @@ static_library("Linux") {
 
   public_configs = []
 
-  if (chip_mdns != "none") {
+  if (chip_mdns == "platform") {
     sources += [
       "DnssdImpl.cpp",
       "DnssdImpl.h",

--- a/src/platform/webos/BUILD.gn
+++ b/src/platform/webos/BUILD.gn
@@ -31,7 +31,7 @@ if (chip_enable_openthread) {
   import("//build_overrides/ot_br_posix.gni")
 }
 
-if (chip_mdns != "none") {
+if (chip_mdns == "platform") {
   pkg_config("avahi_client_config") {
     packages = [ "avahi-client" ]
   }
@@ -111,7 +111,7 @@ static_library("webos") {
 
   public_configs = []
 
-  if (chip_mdns != "none") {
+  if (chip_mdns == "platform") {
     sources += [
       "DnssdImpl.cpp",
       "DnssdImpl.h",


### PR DESCRIPTION
#### Problem
When using the built-in minimal mdns implementation, CHIP still requires the avahi client libraries to be built on Linux. If no client libraries are present, building (e.g. using `scripts/build_python.sh -m minimal`) fails with:

```
#20 232.1 ERROR at //build/config/linux/pkg_config.gni:116:17: Script returned non-zero exit code.
#20 232.1     pkgresult = exec_script(pkg_config_script, args, "value")
#20 232.1                 ^----------
#20 232.1 Current dir: /usr/src/connectedhomeip/.environment/gn_out/
#20 232.1 Command: python3 /usr/src/connectedhomeip/build/config/linux/pkg-config.py avahi-client
#20 232.1 Returned 1.
#20 232.1 stderr:
#20 232.1 
#20 232.1 Package avahi-client was not found in the pkg-config search path.
#20 232.1 Perhaps you should add the directory containing `avahi-client.pc'
#20 232.1 to the PKG_CONFIG_PATH environment variable
#20 232.1 No package 'avahi-client' found
#20 232.1 Could not run pkg-config.
```


#### Change overview
Compile Platform DnssdImpl on Linux/WebOS only when platform mdns implementation is selected. Also drop avahi dependency accordingly.

#### Testing
Build test using Debian Bullseye container.