### PR TITLE
CASE resumption: fix incorrect error log messages

### DIFF
--- a/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
@@ -87,7 +87,7 @@ CHIP_ERROR DefaultSessionResumptionStorage::Delete(const ScopedNodeId & node)
                          ChipLogValueX64(node.GetNodeId()), err.Format());
         }
     }
-    else
+    else if (err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogError(SecureChannel,
                      "Unable to load session resumption state during session deletion for node " ChipLogFormatX64
@@ -96,7 +96,7 @@ CHIP_ERROR DefaultSessionResumptionStorage::Delete(const ScopedNodeId & node)
     }
 
     err = DeleteState(node);
-    if (err != CHIP_NO_ERROR)
+    if (err != CHIP_NO_ERROR && err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
     {
         ChipLogError(SecureChannel, "Unable to delete session resumption state for node " ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
                      ChipLogValueX64(node.GetNodeId()), err.Format());


### PR DESCRIPTION
#### Problem
CASE resumption was generating incorrect error log messages under normal conditions, making finding of real error messages harder.

```
[1653587684916] [96959:9058254] CHIP: [SC] Unable to load session resumption state during session deletion for node 0000000000BC5C01: ../../examples/chip-tool/config/PersistentStorage.cpp:108: CHIP Error 0x000000A0: Value not found in the persisted storag
[1653587684917] [96959:9058254] CHIP: [SC] Unable to delete session resumption state for node 0000000000BC5C01: ../../examples/chip-tool/config/PersistentStorage.cpp:140: CHIP Error 0x000000A0: Value not found in the persisted storage
```
Fixes https://github.com/project-chip/connectedhomeip/issues/18887

#### Change overview
Stop issuing error messages when trying to delete something that does not exist.

#### Testing
* tested manually using chip-tool. Since it's just a logging fix there is no functionality affected.
