### PR TITLE
[OTA-R] Correct the implementation of mProviderRetryCount

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -124,11 +124,9 @@ bool CustomOTARequestorDriver::CanConsent()
 
 void CustomOTARequestorDriver::UpdateDownloaded()
 {
-    ChipLogError(SoftwareUpdate, "//is: CustomOTARequestorDriver::UpdateDownloaded");
-
     // Download complete so reset provider retry counter
     mProviderRetryCount = 0;
-    
+
     if (gAutoApplyImage)
     {
         // Let the default driver take further action to apply the image

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -124,16 +124,17 @@ bool CustomOTARequestorDriver::CanConsent()
 
 void CustomOTARequestorDriver::UpdateDownloaded()
 {
-    // Download complete so reset provider retry counter
-    mProviderRetryCount = 0;
-
     if (gAutoApplyImage)
     {
-        // Let the default driver take further action to apply the image
+        // Let the default driver take further action to apply the image.
+        // All member variables will be implicitly reset upon loading into the new image.
         DefaultOTARequestorDriver::UpdateDownloaded();
     }
     else
     {
+        // Download complete but we're not going to apply image, so reset provider retry counter.
+        mProviderRetryCount = 0;
+
         // Reset to put the state back to idle to allow the next OTA update to occur
         gRequestorCore.Reset();
     }

--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -124,6 +124,11 @@ bool CustomOTARequestorDriver::CanConsent()
 
 void CustomOTARequestorDriver::UpdateDownloaded()
 {
+    ChipLogError(SoftwareUpdate, "//is: CustomOTARequestorDriver::UpdateDownloaded");
+
+    // Download complete so reset provider retry counter
+    mProviderRetryCount = 0;
+    
     if (gAutoApplyImage)
     {
         // Let the default driver take further action to apply the image

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -609,23 +609,18 @@ CHIP_ERROR DefaultOTARequestor::AddDefaultOtaProvider(const ProviderLocationType
 
 void DefaultOTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTAChangeReasonEnum reason)
 {
-    ChipLogError(SoftwareUpdate, "//is: DefaultOTARequestor::OnDownloadStateChanged");
-
     VerifyOrDie(mOtaRequestorDriver != nullptr);
 
     switch (state)
     {
     case OTADownloader::State::kComplete:
-        ChipLogError(SoftwareUpdate, "//is: DefaultOTARequestor::OnDownloadStateChanged - kComplete");
         mOtaRequestorDriver->UpdateDownloaded();
         break;
     case OTADownloader::State::kIdle:
-        ChipLogError(SoftwareUpdate, "//is: DefaultOTARequestor::OnDownloadStateChanged - kIdle");
         if (reason != OTAChangeReasonEnum::kSuccess)
         {
             RecordErrorUpdateState(CHIP_ERROR_CONNECTION_ABORTED, reason);
         }
-
         break;
     default:
         break;

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -609,14 +609,18 @@ CHIP_ERROR DefaultOTARequestor::AddDefaultOtaProvider(const ProviderLocationType
 
 void DefaultOTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTAChangeReasonEnum reason)
 {
+    ChipLogError(SoftwareUpdate, "//is: DefaultOTARequestor::OnDownloadStateChanged");
+
     VerifyOrDie(mOtaRequestorDriver != nullptr);
 
     switch (state)
     {
     case OTADownloader::State::kComplete:
+        ChipLogError(SoftwareUpdate, "//is: DefaultOTARequestor::OnDownloadStateChanged - kComplete");
         mOtaRequestorDriver->UpdateDownloaded();
         break;
     case OTADownloader::State::kIdle:
+        ChipLogError(SoftwareUpdate, "//is: DefaultOTARequestor::OnDownloadStateChanged - kIdle");
         if (reason != OTAChangeReasonEnum::kSuccess)
         {
             RecordErrorUpdateState(CHIP_ERROR_CONNECTION_ABORTED, reason);

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -145,8 +145,6 @@ void DefaultOTARequestorDriver::HandleIdleStateEnter(IdleStateReason reason)
         StartSelectedTimer(SelectedTimer::kPeriodicQueryTimer);
         break;
     case IdleStateReason::kInvalidSession:
-        ChipLogProgress(SoftwareUpdate, "//is: DefaultOTARequestorDriver::HandleIdleStateEnter mInvalidSessionRetryCount=%u, mProviderRetryCount=%u", 
-                    mInvalidSessionRetryCount, mProviderRetryCount);
         if (mInvalidSessionRetryCount < kMaxInvalidSessionRetries)
         {
             // An invalid session is detected which may be temporary (such as provider being restarted)
@@ -226,8 +224,6 @@ CHIP_ERROR DefaultOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason
 
 void DefaultOTARequestorDriver::UpdateDownloaded()
 {
-    ChipLogError(SoftwareUpdate, "//is: DefaultOTARequestorDriver::UpdateDownloaded");
-
     // Download complete so reset provider retry counter
     mProviderRetryCount = 0;
 
@@ -237,8 +233,6 @@ void DefaultOTARequestorDriver::UpdateDownloaded()
 
 void DefaultOTARequestorDriver::UpdateConfirmed(System::Clock::Seconds32 delay)
 {
-    ChipLogError(SoftwareUpdate, "//is: DefaultOTARequestorDriver::UpdateConfirmed");
-
     VerifyOrDie(mImageProcessor != nullptr);
     ScheduleDelayedAction(delay, ApplyTimerHandler, this);
 }
@@ -480,8 +474,6 @@ bool DefaultOTARequestorDriver::GetNextProviderLocation(ProviderLocationType & p
 CHIP_ERROR DefaultOTARequestorDriver::ScheduleQueryRetry(bool trySameProvider, System::Clock::Seconds32 delay)
 {
     CHIP_ERROR status = CHIP_NO_ERROR;
-
-    ChipLogProgress(SoftwareUpdate, "//is: DefaultOTARequestorDriver::ScheduleQueryRetry mProviderRetryCount=%u", mProviderRetryCount);
 
     if (trySameProvider == false)
     {

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -224,9 +224,6 @@ CHIP_ERROR DefaultOTARequestorDriver::UpdateNotFound(UpdateNotFoundReason reason
 
 void DefaultOTARequestorDriver::UpdateDownloaded()
 {
-    // Download complete so reset provider retry counter
-    mProviderRetryCount = 0;
-
     VerifyOrDie(mRequestor != nullptr);
     mRequestor->ApplyUpdate();
 }


### PR DESCRIPTION
#### Problem

`mProviderRetryCount` was not implemented correctly.  For example:

So the current code doesn't properly reset `mProviderRetryCount` after a successful download but image is not applied. Given that we now have two retry counters and they are incremented in different locations, we could be incrementing `mProviderRetryCount` even on an invalid session error:

1. Requestor successfully sends QueryImage (CASE established and `mProviderRetryCount` incremented to 1)
2. Provider is restarted
3. Requestor sends QueryImage -> invalid session detected -> CASE torn down
4. `mInvalidSessionRetryCount` incremented to 1 in `HandleIdleStateEnter`
5. `mProviderRetryCount` incremented to 2 in `SendQueryImage`

Given the current example app, after (5), we could get a successful query/download but never applied the image. The next time we attempt to query (and if it were busy), `mProviderRetryCount` already started at 2 instead of 0 and it would at most retry one more time.

Fixes: https://github.com/project-chip/connectedhomeip/issues/18824

#### Change overview

Reset `mProviderRetryCount` to zero when QueryImage download has succeeded.

#### Testing

Ran QueryImage tests and verified that `mProviderRetryCount` is reset to zero upon successful QueryImage download.