### PR TITLE
Add chip tool Darwin description to classes.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPCommandPayloadsObjc-src.zapt
@@ -18,6 +18,13 @@ NS_ASSUME_NONNULL_BEGIN
   }
   return self;
 }
+
+- (NSString *)description
+{
+  NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_command_arguments}}{{asStructPropertyName label}}:%@; {{/zcl_command_arguments}}>", NSStringFromClass([self class]) {{#zcl_command_arguments}},{{#if isArray}}_{{asStructPropertyName label}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName label}}{{/if}}{{/zcl_command_arguments}}];
+  return descriptionString;
+}
+
 @end
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/CHIPStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPStructsObjc-src.zapt
@@ -16,6 +16,13 @@ NS_ASSUME_NONNULL_BEGIN
   }
   return self;
 }
+
+- (NSString *)description
+{
+  NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_struct_items}}{{asStructPropertyName label}}:%@; {{/zcl_struct_items}}>", NSStringFromClass([self class]){{#zcl_struct_items}},{{#if isArray}}_{{asStructPropertyName label}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName label}}{{/if}}{{/zcl_struct_items}}];
+  return descriptionString;
+}
+
 @end
 
 {{/zcl_structs}}
@@ -31,6 +38,13 @@ NS_ASSUME_NONNULL_BEGIN
   }
   return self;
 }
+
+- (NSString *)description
+{
+  NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_event_fields}}{{asStructPropertyName name}}:%@; {{/zcl_event_fields}}>", NSStringFromClass([self class]){{#zcl_event_fields}},{{#if isArray}}_{{asStructPropertyName name}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName name}}{{/if}}{{/zcl_event_fields}}];
+  return descriptionString;
+}
+
 @end
 
 {{/zcl_events}}

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCommandPayloadsObjc.mm
@@ -31,6 +31,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: identifyTime:%@; >", NSStringFromClass([self class]), _identifyTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIdentifyClusterTriggerEffectParams
 - (instancetype)init
@@ -44,6 +52,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: effectIdentifier:%@; effectVariant:%@; >",
+                                             NSStringFromClass([self class]), _effectIdentifier, _effectVariant];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterAddGroupParams
 - (instancetype)init
@@ -57,6 +73,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupId:%@; groupName:%@; >", NSStringFromClass([self class]), _groupId, _groupName];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterAddGroupResponseParams
 - (instancetype)init
@@ -70,6 +94,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; >", NSStringFromClass([self class]), _status, _groupId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterViewGroupParams
 - (instancetype)init
@@ -81,6 +113,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; >", NSStringFromClass([self class]), _groupId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterViewGroupResponseParams
 - (instancetype)init
@@ -96,6 +135,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; groupName:%@; >",
+                                             NSStringFromClass([self class]), _status, _groupId, _groupName];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterGetGroupMembershipParams
 - (instancetype)init
@@ -107,6 +154,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupList:%@; >", NSStringFromClass([self class]), _groupList];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterGetGroupMembershipResponseParams
 - (instancetype)init
@@ -120,6 +174,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: capacity:%@; groupList:%@; >", NSStringFromClass([self class]), _capacity, _groupList];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterRemoveGroupParams
 - (instancetype)init
@@ -131,6 +193,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; >", NSStringFromClass([self class]), _groupId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterRemoveGroupResponseParams
 - (instancetype)init
@@ -144,6 +213,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; >", NSStringFromClass([self class]), _status, _groupId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterRemoveAllGroupsParams
 - (instancetype)init
@@ -153,6 +230,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupsClusterAddGroupIfIdentifyingParams
 - (instancetype)init
@@ -166,6 +250,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupId:%@; groupName:%@; >", NSStringFromClass([self class]), _groupId, _groupName];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterAddSceneParams
 - (instancetype)init
@@ -185,6 +277,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupId:%@; sceneId:%@; transitionTime:%@; sceneName:%@; extensionFieldSets:%@; >",
+                  NSStringFromClass([self class]), _groupId, _sceneId, _transitionTime, _sceneName, _extensionFieldSets];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterAddSceneResponseParams
 - (instancetype)init
@@ -200,6 +301,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; >",
+                                             NSStringFromClass([self class]), _status, _groupId, _sceneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterViewSceneParams
 - (instancetype)init
@@ -213,6 +322,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupId:%@; sceneId:%@; >", NSStringFromClass([self class]), _groupId, _sceneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterViewSceneResponseParams
 - (instancetype)init
@@ -234,6 +351,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; transitionTime:%@; sceneName:%@; extensionFieldSets:%@; >",
+        NSStringFromClass([self class]), _status, _groupId, _sceneId, _transitionTime, _sceneName, _extensionFieldSets];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterRemoveSceneParams
 - (instancetype)init
@@ -247,6 +373,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupId:%@; sceneId:%@; >", NSStringFromClass([self class]), _groupId, _sceneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterRemoveSceneResponseParams
 - (instancetype)init
@@ -262,6 +396,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; >",
+                                             NSStringFromClass([self class]), _status, _groupId, _sceneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterRemoveAllScenesParams
 - (instancetype)init
@@ -273,6 +415,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; >", NSStringFromClass([self class]), _groupId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterRemoveAllScenesResponseParams
 - (instancetype)init
@@ -286,6 +435,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; >", NSStringFromClass([self class]), _status, _groupId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterStoreSceneParams
 - (instancetype)init
@@ -299,6 +456,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupId:%@; sceneId:%@; >", NSStringFromClass([self class]), _groupId, _sceneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterStoreSceneResponseParams
 - (instancetype)init
@@ -314,6 +479,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; >",
+                                             NSStringFromClass([self class]), _status, _groupId, _sceneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterRecallSceneParams
 - (instancetype)init
@@ -329,6 +502,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; sceneId:%@; transitionTime:%@; >",
+                                             NSStringFromClass([self class]), _groupId, _sceneId, _transitionTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterGetSceneMembershipParams
 - (instancetype)init
@@ -340,6 +521,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; >", NSStringFromClass([self class]), _groupId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterGetSceneMembershipResponseParams
 - (instancetype)init
@@ -357,6 +545,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; capacity:%@; groupId:%@; sceneList:%@; >",
+                                             NSStringFromClass([self class]), _status, _capacity, _groupId, _sceneList];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterEnhancedAddSceneParams
 - (instancetype)init
@@ -376,6 +572,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupId:%@; sceneId:%@; transitionTime:%@; sceneName:%@; extensionFieldSets:%@; >",
+                  NSStringFromClass([self class]), _groupId, _sceneId, _transitionTime, _sceneName, _extensionFieldSets];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterEnhancedAddSceneResponseParams
 - (instancetype)init
@@ -391,6 +596,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; >",
+                                             NSStringFromClass([self class]), _status, _groupId, _sceneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterEnhancedViewSceneParams
 - (instancetype)init
@@ -404,6 +617,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupId:%@; sceneId:%@; >", NSStringFromClass([self class]), _groupId, _sceneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterEnhancedViewSceneResponseParams
 - (instancetype)init
@@ -425,6 +646,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; transitionTime:%@; sceneName:%@; extensionFieldSets:%@; >",
+        NSStringFromClass([self class]), _status, _groupId, _sceneId, _transitionTime, _sceneName, _extensionFieldSets];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterCopySceneParams
 - (instancetype)init
@@ -444,6 +674,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: mode:%@; groupIdFrom:%@; sceneIdFrom:%@; groupIdTo:%@; sceneIdTo:%@; >",
+                  NSStringFromClass([self class]), _mode, _groupIdFrom, _sceneIdFrom, _groupIdTo, _sceneIdTo];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPScenesClusterCopySceneResponseParams
 - (instancetype)init
@@ -459,6 +698,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupIdFrom:%@; sceneIdFrom:%@; >",
+                                             NSStringFromClass([self class]), _status, _groupIdFrom, _sceneIdFrom];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOnOffClusterOffParams
 - (instancetype)init
@@ -468,6 +715,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOnOffClusterOnParams
 - (instancetype)init
@@ -477,6 +731,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOnOffClusterToggleParams
 - (instancetype)init
@@ -486,6 +747,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOnOffClusterOffWithEffectParams
 - (instancetype)init
@@ -499,6 +767,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: effectId:%@; effectVariant:%@; >", NSStringFromClass([self class]), _effectId, _effectVariant];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOnOffClusterOnWithRecallGlobalSceneParams
 - (instancetype)init
@@ -508,6 +784,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOnOffClusterOnWithTimedOffParams
 - (instancetype)init
@@ -523,6 +806,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: onOffControl:%@; onTime:%@; offWaitTime:%@; >",
+                                             NSStringFromClass([self class]), _onOffControl, _onTime, _offWaitTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLevelControlClusterMoveToLevelParams
 - (instancetype)init
@@ -540,6 +831,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: level:%@; transitionTime:%@; optionMask:%@; optionOverride:%@; >",
+                  NSStringFromClass([self class]), _level, _transitionTime, _optionMask, _optionOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLevelControlClusterMoveParams
 - (instancetype)init
@@ -557,6 +857,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: moveMode:%@; rate:%@; optionMask:%@; optionOverride:%@; >",
+                                             NSStringFromClass([self class]), _moveMode, _rate, _optionMask, _optionOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLevelControlClusterStepParams
 - (instancetype)init
@@ -576,6 +884,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: stepMode:%@; stepSize:%@; transitionTime:%@; optionMask:%@; optionOverride:%@; >",
+                  NSStringFromClass([self class]), _stepMode, _stepSize, _transitionTime, _optionMask, _optionOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLevelControlClusterStopParams
 - (instancetype)init
@@ -589,6 +906,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: optionMask:%@; optionOverride:%@; >",
+                                             NSStringFromClass([self class]), _optionMask, _optionOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLevelControlClusterMoveToLevelWithOnOffParams
 - (instancetype)init
@@ -602,6 +927,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: level:%@; transitionTime:%@; >", NSStringFromClass([self class]), _level, _transitionTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLevelControlClusterMoveWithOnOffParams
 - (instancetype)init
@@ -615,6 +948,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: moveMode:%@; rate:%@; >", NSStringFromClass([self class]), _moveMode, _rate];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLevelControlClusterStepWithOnOffParams
 - (instancetype)init
@@ -630,6 +971,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: stepMode:%@; stepSize:%@; transitionTime:%@; >",
+                                             NSStringFromClass([self class]), _stepMode, _stepSize, _transitionTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLevelControlClusterStopWithOnOffParams
 - (instancetype)init
@@ -639,6 +988,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAlarmsClusterResetAlarmParams
 - (instancetype)init
@@ -652,6 +1008,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: alarmCode:%@; clusterId:%@; >", NSStringFromClass([self class]), _alarmCode, _clusterId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAlarmsClusterAlarmParams
 - (instancetype)init
@@ -665,6 +1029,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: alarmCode:%@; clusterId:%@; >", NSStringFromClass([self class]), _alarmCode, _clusterId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAlarmsClusterResetAllAlarmsParams
 - (instancetype)init
@@ -674,6 +1046,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAlarmsClusterGetAlarmResponseParams
 - (instancetype)init
@@ -691,6 +1070,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; alarmCode:%@; clusterId:%@; timeStamp:%@; >",
+                                             NSStringFromClass([self class]), _status, _alarmCode, _clusterId, _timeStamp];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAlarmsClusterGetAlarmParams
 - (instancetype)init
@@ -700,6 +1087,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAlarmsClusterResetAlarmLogParams
 - (instancetype)init
@@ -709,6 +1103,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfileRequestParams
 - (instancetype)init
@@ -720,6 +1121,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; >", NSStringFromClass([self class]), _powerProfileId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfileNotificationParams
 - (instancetype)init
@@ -737,6 +1146,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: totalProfileNum:%@; powerProfileId:%@; numOfTransferredPhases:%@; transferredPhases:%@; >",
+        NSStringFromClass([self class]), _totalProfileNum, _powerProfileId, _numOfTransferredPhases, _transferredPhases];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfileStateRequestParams
 - (instancetype)init
@@ -746,6 +1164,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfileResponseParams
 - (instancetype)init
@@ -763,6 +1188,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: totalProfileNum:%@; powerProfileId:%@; numOfTransferredPhases:%@; transferredPhases:%@; >",
+        NSStringFromClass([self class]), _totalProfileNum, _powerProfileId, _numOfTransferredPhases, _transferredPhases];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterGetPowerProfilePriceResponseParams
 - (instancetype)init
@@ -780,6 +1214,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; currency:%@; price:%@; priceTrailingDigit:%@; >",
+                  NSStringFromClass([self class]), _powerProfileId, _currency, _price, _priceTrailingDigit];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfileStateResponseParams
 - (instancetype)init
@@ -793,6 +1236,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: powerProfileCount:%@; powerProfileRecords:%@; >",
+                                             NSStringFromClass([self class]), _powerProfileCount, _powerProfileRecords];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterGetOverallSchedulePriceResponseParams
 - (instancetype)init
@@ -808,6 +1259,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: currency:%@; price:%@; priceTrailingDigit:%@; >",
+                                             NSStringFromClass([self class]), _currency, _price, _priceTrailingDigit];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterGetPowerProfilePriceParams
 - (instancetype)init
@@ -819,6 +1278,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; >", NSStringFromClass([self class]), _powerProfileId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleNotificationParams
 - (instancetype)init
@@ -834,6 +1301,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; numOfScheduledPhases:%@; scheduledPhases:%@; >",
+                  NSStringFromClass([self class]), _powerProfileId, _numOfScheduledPhases, _scheduledPhases];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfilesStateNotificationParams
 - (instancetype)init
@@ -847,6 +1323,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: powerProfileCount:%@; powerProfileRecords:%@; >",
+                                             NSStringFromClass([self class]), _powerProfileCount, _powerProfileRecords];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleResponseParams
 - (instancetype)init
@@ -862,6 +1346,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; numOfScheduledPhases:%@; scheduledPhases:%@; >",
+                  NSStringFromClass([self class]), _powerProfileId, _numOfScheduledPhases, _scheduledPhases];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterGetOverallSchedulePriceParams
 - (instancetype)init
@@ -871,6 +1364,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsRequestParams
 - (instancetype)init
@@ -882,6 +1382,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; >", NSStringFromClass([self class]), _powerProfileId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleRequestParams
 - (instancetype)init
@@ -893,6 +1401,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; >", NSStringFromClass([self class]), _powerProfileId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateRequestParams
 - (instancetype)init
@@ -904,6 +1420,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; >", NSStringFromClass([self class]), _powerProfileId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateResponseParams
 - (instancetype)init
@@ -919,6 +1443,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; numOfScheduledPhases:%@; scheduledPhases:%@; >",
+                  NSStringFromClass([self class]), _powerProfileId, _numOfScheduledPhases, _scheduledPhases];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterGetPowerProfilePriceExtendedResponseParams
 - (instancetype)init
@@ -936,6 +1469,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; currency:%@; price:%@; priceTrailingDigit:%@; >",
+                  NSStringFromClass([self class]), _powerProfileId, _currency, _price, _priceTrailingDigit];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterEnergyPhasesScheduleStateNotificationParams
 - (instancetype)init
@@ -951,6 +1493,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: powerProfileId:%@; numOfScheduledPhases:%@; scheduledPhases:%@; >",
+                  NSStringFromClass([self class]), _powerProfileId, _numOfScheduledPhases, _scheduledPhases];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsNotificationParams
 - (instancetype)init
@@ -966,6 +1517,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: powerProfileId:%@; startAfter:%@; stopBefore:%@; >",
+                                             NSStringFromClass([self class]), _powerProfileId, _startAfter, _stopBefore];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterPowerProfileScheduleConstraintsResponseParams
 - (instancetype)init
@@ -981,6 +1540,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: powerProfileId:%@; startAfter:%@; stopBefore:%@; >",
+                                             NSStringFromClass([self class]), _powerProfileId, _startAfter, _stopBefore];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPowerProfileClusterGetPowerProfilePriceExtendedParams
 - (instancetype)init
@@ -996,6 +1563,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: options:%@; powerProfileId:%@; powerProfileStartTime:%@; >",
+                                             NSStringFromClass([self class]), _options, _powerProfileId, _powerProfileStartTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceControlClusterExecutionOfACommandParams
 - (instancetype)init
@@ -1007,6 +1582,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: commandId:%@; >", NSStringFromClass([self class]), _commandId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceControlClusterSignalStateResponseParams
 - (instancetype)init
@@ -1022,6 +1604,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: applianceStatus:%@; remoteEnableFlagsAndDeviceStatus2:%@; applianceStatus2:%@; >",
+                  NSStringFromClass([self class]), _applianceStatus, _remoteEnableFlagsAndDeviceStatus2, _applianceStatus2];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceControlClusterSignalStateParams
 - (instancetype)init
@@ -1031,6 +1622,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceControlClusterSignalStateNotificationParams
 - (instancetype)init
@@ -1046,6 +1644,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: applianceStatus:%@; remoteEnableFlagsAndDeviceStatus2:%@; applianceStatus2:%@; >",
+                  NSStringFromClass([self class]), _applianceStatus, _remoteEnableFlagsAndDeviceStatus2, _applianceStatus2];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceControlClusterWriteFunctionsParams
 - (instancetype)init
@@ -1061,6 +1668,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: functionId:%@; functionDataType:%@; functionData:%@; >",
+                                             NSStringFromClass([self class]), _functionId, _functionDataType, _functionData];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceControlClusterOverloadPauseResumeParams
 - (instancetype)init
@@ -1070,6 +1685,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceControlClusterOverloadPauseParams
 - (instancetype)init
@@ -1079,6 +1701,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceControlClusterOverloadWarningParams
 - (instancetype)init
@@ -1090,6 +1719,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: warningEvent:%@; >", NSStringFromClass([self class]), _warningEvent];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPollControlClusterCheckInParams
 - (instancetype)init
@@ -1099,6 +1736,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPollControlClusterCheckInResponseParams
 - (instancetype)init
@@ -1112,6 +1756,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: startFastPolling:%@; fastPollTimeout:%@; >",
+                                             NSStringFromClass([self class]), _startFastPolling, _fastPollTimeout];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPollControlClusterFastPollStopParams
 - (instancetype)init
@@ -1121,6 +1773,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPollControlClusterSetLongPollIntervalParams
 - (instancetype)init
@@ -1132,6 +1791,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: newLongPollInterval:%@; >", NSStringFromClass([self class]), _newLongPollInterval];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPPollControlClusterSetShortPollIntervalParams
 - (instancetype)init
@@ -1143,6 +1810,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: newShortPollInterval:%@; >", NSStringFromClass([self class]), _newShortPollInterval];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterInstantActionParams
 - (instancetype)init
@@ -1156,6 +1831,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; >", NSStringFromClass([self class]), _actionID, _invokeID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterInstantActionWithTransitionParams
 - (instancetype)init
@@ -1171,6 +1854,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; transitionTime:%@; >",
+                                             NSStringFromClass([self class]), _actionID, _invokeID, _transitionTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterStartActionParams
 - (instancetype)init
@@ -1184,6 +1875,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; >", NSStringFromClass([self class]), _actionID, _invokeID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterStartActionWithDurationParams
 - (instancetype)init
@@ -1199,6 +1898,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; duration:%@; >",
+                                             NSStringFromClass([self class]), _actionID, _invokeID, _duration];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterStopActionParams
 - (instancetype)init
@@ -1212,6 +1919,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; >", NSStringFromClass([self class]), _actionID, _invokeID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterPauseActionParams
 - (instancetype)init
@@ -1225,6 +1940,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; >", NSStringFromClass([self class]), _actionID, _invokeID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterPauseActionWithDurationParams
 - (instancetype)init
@@ -1240,6 +1963,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; duration:%@; >",
+                                             NSStringFromClass([self class]), _actionID, _invokeID, _duration];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterResumeActionParams
 - (instancetype)init
@@ -1253,6 +1984,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; >", NSStringFromClass([self class]), _actionID, _invokeID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterEnableActionParams
 - (instancetype)init
@@ -1266,6 +2005,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; >", NSStringFromClass([self class]), _actionID, _invokeID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterEnableActionWithDurationParams
 - (instancetype)init
@@ -1281,6 +2028,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; duration:%@; >",
+                                             NSStringFromClass([self class]), _actionID, _invokeID, _duration];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterDisableActionParams
 - (instancetype)init
@@ -1294,6 +2049,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; >", NSStringFromClass([self class]), _actionID, _invokeID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBridgedActionsClusterDisableActionWithDurationParams
 - (instancetype)init
@@ -1309,6 +2072,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; duration:%@; >",
+                                             NSStringFromClass([self class]), _actionID, _invokeID, _duration];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBasicClusterMfgSpecificPingParams
 - (instancetype)init
@@ -1318,6 +2089,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOtaSoftwareUpdateProviderClusterQueryImageParams
 - (instancetype)init
@@ -1343,6 +2121,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: vendorId:%@; productId:%@; softwareVersion:%@; protocolsSupported:%@; "
+                                   @"hardwareVersion:%@; location:%@; requestorCanConsent:%@; metadataForProvider:%@; >",
+                  NSStringFromClass([self class]), _vendorId, _productId, _softwareVersion, _protocolsSupported, _hardwareVersion,
+                  _location, _requestorCanConsent, [_metadataForProvider base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOtaSoftwareUpdateProviderClusterQueryImageResponseParams
 - (instancetype)init
@@ -1368,6 +2157,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: status:%@; delayedActionTime:%@; imageURI:%@; softwareVersion:%@; "
+                                   @"softwareVersionString:%@; updateToken:%@; userConsentNeeded:%@; metadataForRequestor:%@; >",
+                  NSStringFromClass([self class]), _status, _delayedActionTime, _imageURI, _softwareVersion, _softwareVersionString,
+                  [_updateToken base64EncodedStringWithOptions:0], _userConsentNeeded,
+                  [_metadataForRequestor base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOtaSoftwareUpdateProviderClusterApplyUpdateRequestParams
 - (instancetype)init
@@ -1381,6 +2182,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: updateToken:%@; newVersion:%@; >", NSStringFromClass([self class]),
+                  [_updateToken base64EncodedStringWithOptions:0], _newVersion];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOtaSoftwareUpdateProviderClusterApplyUpdateResponseParams
 - (instancetype)init
@@ -1394,6 +2204,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: action:%@; delayedActionTime:%@; >", NSStringFromClass([self class]), _action, _delayedActionTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams
 - (instancetype)init
@@ -1407,6 +2225,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: updateToken:%@; softwareVersion:%@; >", NSStringFromClass([self class]),
+                  [_updateToken base64EncodedStringWithOptions:0], _softwareVersion];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams
 - (instancetype)init
@@ -1426,6 +2253,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: providerNodeId:%@; vendorId:%@; announcementReason:%@; metadataForNode:%@; endpoint:%@; >",
+        NSStringFromClass([self class]), _providerNodeId, _vendorId, _announcementReason,
+        [_metadataForNode base64EncodedStringWithOptions:0], _endpoint];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGeneralCommissioningClusterArmFailSafeParams
 - (instancetype)init
@@ -1439,6 +2276,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: expiryLengthSeconds:%@; breadcrumb:%@; >",
+                                             NSStringFromClass([self class]), _expiryLengthSeconds, _breadcrumb];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGeneralCommissioningClusterArmFailSafeResponseParams
 - (instancetype)init
@@ -1452,6 +2297,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: errorCode:%@; debugText:%@; >", NSStringFromClass([self class]), _errorCode, _debugText];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGeneralCommissioningClusterSetRegulatoryConfigParams
 - (instancetype)init
@@ -1467,6 +2320,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: newRegulatoryConfig:%@; countryCode:%@; breadcrumb:%@; >",
+                                             NSStringFromClass([self class]), _newRegulatoryConfig, _countryCode, _breadcrumb];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGeneralCommissioningClusterSetRegulatoryConfigResponseParams
 - (instancetype)init
@@ -1480,6 +2341,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: errorCode:%@; debugText:%@; >", NSStringFromClass([self class]), _errorCode, _debugText];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGeneralCommissioningClusterCommissioningCompleteParams
 - (instancetype)init
@@ -1489,6 +2358,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGeneralCommissioningClusterCommissioningCompleteResponseParams
 - (instancetype)init
@@ -1502,6 +2378,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: errorCode:%@; debugText:%@; >", NSStringFromClass([self class]), _errorCode, _debugText];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterScanNetworksParams
 - (instancetype)init
@@ -1515,6 +2399,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: ssid:%@; breadcrumb:%@; >", NSStringFromClass([self class]),
+                                             [_ssid base64EncodedStringWithOptions:0], _breadcrumb];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterScanNetworksResponseParams
 - (instancetype)init
@@ -1532,6 +2424,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: networkingStatus:%@; debugText:%@; wiFiScanResults:%@; threadScanResults:%@; >",
+                  NSStringFromClass([self class]), _networkingStatus, _debugText, _wiFiScanResults, _threadScanResults];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams
 - (instancetype)init
@@ -1547,6 +2448,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: ssid:%@; credentials:%@; breadcrumb:%@; >", NSStringFromClass([self class]),
+                  [_ssid base64EncodedStringWithOptions:0], [_credentials base64EncodedStringWithOptions:0], _breadcrumb];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterAddOrUpdateThreadNetworkParams
 - (instancetype)init
@@ -1560,6 +2470,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: operationalDataset:%@; breadcrumb:%@; >", NSStringFromClass([self class]),
+                  [_operationalDataset base64EncodedStringWithOptions:0], _breadcrumb];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterRemoveNetworkParams
 - (instancetype)init
@@ -1573,6 +2492,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: networkID:%@; breadcrumb:%@; >", NSStringFromClass([self class]),
+                  [_networkID base64EncodedStringWithOptions:0], _breadcrumb];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterNetworkConfigResponseParams
 - (instancetype)init
@@ -1588,6 +2516,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: networkingStatus:%@; debugText:%@; networkIndex:%@; >",
+                                             NSStringFromClass([self class]), _networkingStatus, _debugText, _networkIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterConnectNetworkParams
 - (instancetype)init
@@ -1601,6 +2537,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: networkID:%@; breadcrumb:%@; >", NSStringFromClass([self class]),
+                  [_networkID base64EncodedStringWithOptions:0], _breadcrumb];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterConnectNetworkResponseParams
 - (instancetype)init
@@ -1616,6 +2561,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: networkingStatus:%@; debugText:%@; errorValue:%@; >",
+                                             NSStringFromClass([self class]), _networkingStatus, _debugText, _errorValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPNetworkCommissioningClusterReorderNetworkParams
 - (instancetype)init
@@ -1631,6 +2584,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: networkID:%@; networkIndex:%@; breadcrumb:%@; >", NSStringFromClass([self class]),
+                  [_networkID base64EncodedStringWithOptions:0], _networkIndex, _breadcrumb];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDiagnosticLogsClusterRetrieveLogsRequestParams
 - (instancetype)init
@@ -1646,6 +2608,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: intent:%@; requestedProtocol:%@; transferFileDesignator:%@; >",
+                                             NSStringFromClass([self class]), _intent, _requestedProtocol,
+                                             [_transferFileDesignator base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDiagnosticLogsClusterRetrieveLogsResponseParams
 - (instancetype)init
@@ -1663,6 +2634,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; content:%@; timeStamp:%@; timeSinceBoot:%@; >",
+                                             NSStringFromClass([self class]), _status, [_content base64EncodedStringWithOptions:0],
+                                             _timeStamp, _timeSinceBoot];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGeneralDiagnosticsClusterTestEventTriggerParams
 - (instancetype)init
@@ -1676,6 +2656,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: enableKey:%@; eventTrigger:%@; >", NSStringFromClass([self class]),
+                  [_enableKey base64EncodedStringWithOptions:0], _eventTrigger];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPSoftwareDiagnosticsClusterResetWatermarksParams
 - (instancetype)init
@@ -1685,6 +2674,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPThreadNetworkDiagnosticsClusterResetCountsParams
 - (instancetype)init
@@ -1694,6 +2690,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPWiFiNetworkDiagnosticsClusterResetCountsParams
 - (instancetype)init
@@ -1703,6 +2706,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPEthernetNetworkDiagnosticsClusterResetCountsParams
 - (instancetype)init
@@ -1712,6 +2722,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAdministratorCommissioningClusterOpenCommissioningWindowParams
 - (instancetype)init
@@ -1731,6 +2748,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: commissioningTimeout:%@; pakeVerifier:%@; discriminator:%@; iterations:%@; salt:%@; >",
+                  NSStringFromClass([self class]), _commissioningTimeout, [_pakeVerifier base64EncodedStringWithOptions:0],
+                  _discriminator, _iterations, [_salt base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAdministratorCommissioningClusterOpenBasicCommissioningWindowParams
 - (instancetype)init
@@ -1742,6 +2769,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: commissioningTimeout:%@; >", NSStringFromClass([self class]), _commissioningTimeout];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAdministratorCommissioningClusterRevokeCommissioningParams
 - (instancetype)init
@@ -1751,6 +2786,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterAttestationRequestParams
 - (instancetype)init
@@ -1762,6 +2804,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: attestationNonce:%@; >", NSStringFromClass([self class]),
+                                             [_attestationNonce base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterAttestationResponseParams
 - (instancetype)init
@@ -1775,6 +2825,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: attestationElements:%@; signature:%@; >", NSStringFromClass([self class]),
+                  [_attestationElements base64EncodedStringWithOptions:0], [_signature base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterCertificateChainRequestParams
 - (instancetype)init
@@ -1786,6 +2845,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: certificateType:%@; >", NSStringFromClass([self class]), _certificateType];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterCertificateChainResponseParams
 - (instancetype)init
@@ -1797,6 +2864,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: certificate:%@; >", NSStringFromClass([self class]),
+                                             [_certificate base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterCSRRequestParams
 - (instancetype)init
@@ -1808,6 +2883,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: csrNonce:%@; >", NSStringFromClass([self class]), [_csrNonce base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterCSRResponseParams
 - (instancetype)init
@@ -1821,6 +2904,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: nocsrElements:%@; attestationSignature:%@; >", NSStringFromClass([self class]),
+                  [_nocsrElements base64EncodedStringWithOptions:0], [_attestationSignature base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterAddNOCParams
 - (instancetype)init
@@ -1840,6 +2932,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: nocValue:%@; icacValue:%@; ipkValue:%@; caseAdminSubject:%@; adminVendorId:%@; >",
+                  NSStringFromClass([self class]), [_nocValue base64EncodedStringWithOptions:0],
+                  [_icacValue base64EncodedStringWithOptions:0], [_ipkValue base64EncodedStringWithOptions:0], _caseAdminSubject,
+                  _adminVendorId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterUpdateNOCParams
 - (instancetype)init
@@ -1853,6 +2956,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: nocValue:%@; icacValue:%@; >", NSStringFromClass([self class]),
+                  [_nocValue base64EncodedStringWithOptions:0], [_icacValue base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterNOCResponseParams
 - (instancetype)init
@@ -1868,6 +2980,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: statusCode:%@; fabricIndex:%@; debugText:%@; >",
+                                             NSStringFromClass([self class]), _statusCode, _fabricIndex, _debugText];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterUpdateFabricLabelParams
 - (instancetype)init
@@ -1879,6 +2999,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: label:%@; >", NSStringFromClass([self class]), _label];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterRemoveFabricParams
 - (instancetype)init
@@ -1890,6 +3017,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: fabricIndex:%@; >", NSStringFromClass([self class]), _fabricIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPOperationalCredentialsClusterAddTrustedRootCertificateParams
 - (instancetype)init
@@ -1901,6 +3036,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: rootCertificate:%@; >", NSStringFromClass([self class]),
+                                             [_rootCertificate base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupKeyManagementClusterKeySetWriteParams
 - (instancetype)init
@@ -1912,6 +3055,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupKeySet:%@; >", NSStringFromClass([self class]), _groupKeySet];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupKeyManagementClusterKeySetReadParams
 - (instancetype)init
@@ -1923,6 +3074,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupKeySetID:%@; >", NSStringFromClass([self class]), _groupKeySetID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupKeyManagementClusterKeySetReadResponseParams
 - (instancetype)init
@@ -1934,6 +3093,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupKeySet:%@; >", NSStringFromClass([self class]), _groupKeySet];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupKeyManagementClusterKeySetRemoveParams
 - (instancetype)init
@@ -1945,6 +3112,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupKeySetID:%@; >", NSStringFromClass([self class]), _groupKeySetID];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupKeyManagementClusterKeySetReadAllIndicesParams
 - (instancetype)init
@@ -1956,6 +3131,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupKeySetIDs:%@; >", NSStringFromClass([self class]), _groupKeySetIDs];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPGroupKeyManagementClusterKeySetReadAllIndicesResponseParams
 - (instancetype)init
@@ -1967,6 +3150,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupKeySetIDs:%@; >", NSStringFromClass([self class]), _groupKeySetIDs];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPModeSelectClusterChangeToModeParams
 - (instancetype)init
@@ -1978,6 +3169,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: newMode:%@; >", NSStringFromClass([self class]), _newMode];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterLockDoorParams
 - (instancetype)init
@@ -1989,6 +3187,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: pinCode:%@; >", NSStringFromClass([self class]), [_pinCode base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterUnlockDoorParams
 - (instancetype)init
@@ -2000,6 +3206,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: pinCode:%@; >", NSStringFromClass([self class]), [_pinCode base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterUnlockWithTimeoutParams
 - (instancetype)init
@@ -2013,6 +3227,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: timeout:%@; pinCode:%@; >", NSStringFromClass([self class]),
+                                             _timeout, [_pinCode base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetLogRecordParams
 - (instancetype)init
@@ -2024,6 +3246,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: logIndex:%@; >", NSStringFromClass([self class]), _logIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetLogRecordResponseParams
 - (instancetype)init
@@ -2047,6 +3276,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: logEntryId:%@; timestamp:%@; eventType:%@; source:%@; eventIdOrAlarmCode:%@; userId:%@; pin:%@; >",
+        NSStringFromClass([self class]), _logEntryId, _timestamp, _eventType, _source, _eventIdOrAlarmCode, _userId,
+        [_pin base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetPINCodeParams
 - (instancetype)init
@@ -2064,6 +3303,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: userId:%@; userStatus:%@; userType:%@; pin:%@; >", NSStringFromClass([self class]),
+                  _userId, _userStatus, _userType, [_pin base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetPINCodeParams
 - (instancetype)init
@@ -2075,6 +3323,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: userId:%@; >", NSStringFromClass([self class]), _userId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetPINCodeResponseParams
 - (instancetype)init
@@ -2092,6 +3347,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: userId:%@; userStatus:%@; userType:%@; pin:%@; >", NSStringFromClass([self class]),
+                  _userId, _userStatus, _userType, [_pin base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearPINCodeParams
 - (instancetype)init
@@ -2103,6 +3367,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: pinSlotIndex:%@; >", NSStringFromClass([self class]), _pinSlotIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearAllPINCodesParams
 - (instancetype)init
@@ -2112,6 +3384,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetUserStatusParams
 - (instancetype)init
@@ -2125,6 +3404,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: userId:%@; userStatus:%@; >", NSStringFromClass([self class]), _userId, _userStatus];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetUserStatusParams
 - (instancetype)init
@@ -2136,6 +3423,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: userId:%@; >", NSStringFromClass([self class]), _userId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetUserStatusResponseParams
 - (instancetype)init
@@ -2149,6 +3443,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: userId:%@; userStatus:%@; >", NSStringFromClass([self class]), _userId, _userStatus];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetWeekDayScheduleParams
 - (instancetype)init
@@ -2172,6 +3474,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: weekDayIndex:%@; userIndex:%@; daysMask:%@; startHour:%@; startMinute:%@; endHour:%@; endMinute:%@; >",
+        NSStringFromClass([self class]), _weekDayIndex, _userIndex, _daysMask, _startHour, _startMinute, _endHour, _endMinute];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetWeekDayScheduleParams
 - (instancetype)init
@@ -2185,6 +3497,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: weekDayIndex:%@; userIndex:%@; >", NSStringFromClass([self class]), _weekDayIndex, _userIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetWeekDayScheduleResponseParams
 - (instancetype)init
@@ -2210,6 +3530,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: weekDayIndex:%@; userIndex:%@; status:%@; daysMask:%@; "
+                                                              @"startHour:%@; startMinute:%@; endHour:%@; endMinute:%@; >",
+                                             NSStringFromClass([self class]), _weekDayIndex, _userIndex, _status, _daysMask,
+                                             _startHour, _startMinute, _endHour, _endMinute];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearWeekDayScheduleParams
 - (instancetype)init
@@ -2223,6 +3553,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: weekDayIndex:%@; userIndex:%@; >", NSStringFromClass([self class]), _weekDayIndex, _userIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetYearDayScheduleParams
 - (instancetype)init
@@ -2240,6 +3578,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: yearDayIndex:%@; userIndex:%@; localStartTime:%@; localEndTime:%@; >",
+                  NSStringFromClass([self class]), _yearDayIndex, _userIndex, _localStartTime, _localEndTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetYearDayScheduleParams
 - (instancetype)init
@@ -2253,6 +3600,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: yearDayIndex:%@; userIndex:%@; >", NSStringFromClass([self class]), _yearDayIndex, _userIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetYearDayScheduleResponseParams
 - (instancetype)init
@@ -2272,6 +3627,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: yearDayIndex:%@; userIndex:%@; status:%@; localStartTime:%@; localEndTime:%@; >",
+                  NSStringFromClass([self class]), _yearDayIndex, _userIndex, _status, _localStartTime, _localEndTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearYearDayScheduleParams
 - (instancetype)init
@@ -2285,6 +3649,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: yearDayIndex:%@; userIndex:%@; >", NSStringFromClass([self class]), _yearDayIndex, _userIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetHolidayScheduleParams
 - (instancetype)init
@@ -2302,6 +3674,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: holidayIndex:%@; localStartTime:%@; localEndTime:%@; operatingMode:%@; >",
+                  NSStringFromClass([self class]), _holidayIndex, _localStartTime, _localEndTime, _operatingMode];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetHolidayScheduleParams
 - (instancetype)init
@@ -2313,6 +3694,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: holidayIndex:%@; >", NSStringFromClass([self class]), _holidayIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetHolidayScheduleResponseParams
 - (instancetype)init
@@ -2332,6 +3721,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: holidayIndex:%@; status:%@; localStartTime:%@; localEndTime:%@; operatingMode:%@; >",
+                  NSStringFromClass([self class]), _holidayIndex, _status, _localStartTime, _localEndTime, _operatingMode];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearHolidayScheduleParams
 - (instancetype)init
@@ -2343,6 +3741,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: holidayIndex:%@; >", NSStringFromClass([self class]), _holidayIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetUserTypeParams
 - (instancetype)init
@@ -2356,6 +3762,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: userId:%@; userType:%@; >", NSStringFromClass([self class]), _userId, _userType];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetUserTypeParams
 - (instancetype)init
@@ -2367,6 +3781,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: userId:%@; >", NSStringFromClass([self class]), _userId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetUserTypeResponseParams
 - (instancetype)init
@@ -2380,6 +3801,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: userId:%@; userType:%@; >", NSStringFromClass([self class]), _userId, _userType];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetRFIDCodeParams
 - (instancetype)init
@@ -2397,6 +3826,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: userId:%@; userStatus:%@; userType:%@; rfidCode:%@; >", NSStringFromClass([self class]),
+                  _userId, _userStatus, _userType, [_rfidCode base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetRFIDCodeParams
 - (instancetype)init
@@ -2408,6 +3846,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: userId:%@; >", NSStringFromClass([self class]), _userId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetRFIDCodeResponseParams
 - (instancetype)init
@@ -2425,6 +3870,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: userId:%@; userStatus:%@; userType:%@; rfidCode:%@; >", NSStringFromClass([self class]),
+                  _userId, _userStatus, _userType, [_rfidCode base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearRFIDCodeParams
 - (instancetype)init
@@ -2436,6 +3890,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: rfidSlotIndex:%@; >", NSStringFromClass([self class]), _rfidSlotIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearAllRFIDCodesParams
 - (instancetype)init
@@ -2445,6 +3907,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetUserParams
 - (instancetype)init
@@ -2468,6 +3937,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: operationType:%@; userIndex:%@; userName:%@; userUniqueId:%@; userStatus:%@; userType:%@; credentialRule:%@; >",
+        NSStringFromClass([self class]), _operationType, _userIndex, _userName, _userUniqueId, _userStatus, _userType,
+        _credentialRule];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetUserParams
 - (instancetype)init
@@ -2479,6 +3959,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: userIndex:%@; >", NSStringFromClass([self class]), _userIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetUserResponseParams
 - (instancetype)init
@@ -2508,6 +3995,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: userIndex:%@; userName:%@; userUniqueId:%@; userStatus:%@; userType:%@; credentialRule:%@; "
+                         @"credentials:%@; creatorFabricIndex:%@; lastModifiedFabricIndex:%@; nextUserIndex:%@; >",
+        NSStringFromClass([self class]), _userIndex, _userName, _userUniqueId, _userStatus, _userType, _credentialRule,
+        _credentials, _creatorFabricIndex, _lastModifiedFabricIndex, _nextUserIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearUserParams
 - (instancetype)init
@@ -2519,6 +4017,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: userIndex:%@; >", NSStringFromClass([self class]), _userIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterOperatingEventNotificationParams
 - (instancetype)init
@@ -2540,6 +4045,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: operationEventSource:%@; operationEventCode:%@; userId:%@; pin:%@; localTime:%@; data:%@; >",
+        NSStringFromClass([self class]), _operationEventSource, _operationEventCode, _userId,
+        [_pin base64EncodedStringWithOptions:0], _localTime, _data];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterProgrammingEventNotificationParams
 - (instancetype)init
@@ -2565,6 +4080,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: programEventSource:%@; programEventCode:%@; userId:%@; "
+                                                              @"pin:%@; userType:%@; userStatus:%@; localTime:%@; data:%@; >",
+                                             NSStringFromClass([self class]), _programEventSource, _programEventCode, _userId,
+                                             [_pin base64EncodedStringWithOptions:0], _userType, _userStatus, _localTime, _data];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetCredentialParams
 - (instancetype)init
@@ -2586,6 +4111,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: operationType:%@; credential:%@; credentialData:%@; userIndex:%@; userStatus:%@; userType:%@; >",
+        NSStringFromClass([self class]), _operationType, _credential, [_credentialData base64EncodedStringWithOptions:0],
+        _userIndex, _userStatus, _userType];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterSetCredentialResponseParams
 - (instancetype)init
@@ -2601,6 +4136,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; userIndex:%@; nextCredentialIndex:%@; >",
+                                             NSStringFromClass([self class]), _status, _userIndex, _nextCredentialIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetCredentialStatusParams
 - (instancetype)init
@@ -2612,6 +4155,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: credential:%@; >", NSStringFromClass([self class]), _credential];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterGetCredentialStatusResponseParams
 - (instancetype)init
@@ -2631,6 +4182,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: credentialExists:%@; userIndex:%@; creatorFabricIndex:%@; lastModifiedFabricIndex:%@; nextCredentialIndex:%@; >",
+        NSStringFromClass([self class]), _credentialExists, _userIndex, _creatorFabricIndex, _lastModifiedFabricIndex,
+        _nextCredentialIndex];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPDoorLockClusterClearCredentialParams
 - (instancetype)init
@@ -2642,6 +4204,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: credential:%@; >", NSStringFromClass([self class]), _credential];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPWindowCoveringClusterUpOrOpenParams
 - (instancetype)init
@@ -2651,6 +4221,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPWindowCoveringClusterDownOrCloseParams
 - (instancetype)init
@@ -2660,6 +4237,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPWindowCoveringClusterStopMotionParams
 - (instancetype)init
@@ -2669,6 +4253,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPWindowCoveringClusterGoToLiftValueParams
 - (instancetype)init
@@ -2680,6 +4271,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: liftValue:%@; >", NSStringFromClass([self class]), _liftValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPWindowCoveringClusterGoToLiftPercentageParams
 - (instancetype)init
@@ -2691,6 +4289,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: liftPercent100thsValue:%@; >", NSStringFromClass([self class]), _liftPercent100thsValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPWindowCoveringClusterGoToTiltValueParams
 - (instancetype)init
@@ -2702,6 +4308,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: tiltValue:%@; >", NSStringFromClass([self class]), _tiltValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPWindowCoveringClusterGoToTiltPercentageParams
 - (instancetype)init
@@ -2713,6 +4326,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: tiltPercent100thsValue:%@; >", NSStringFromClass([self class]), _tiltPercent100thsValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBarrierControlClusterBarrierControlGoToPercentParams
 - (instancetype)init
@@ -2724,6 +4345,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: percentOpen:%@; >", NSStringFromClass([self class]), _percentOpen];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPBarrierControlClusterBarrierControlStopParams
 - (instancetype)init
@@ -2733,6 +4362,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPThermostatClusterSetpointRaiseLowerParams
 - (instancetype)init
@@ -2746,6 +4382,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: mode:%@; amount:%@; >", NSStringFromClass([self class]), _mode, _amount];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPThermostatClusterGetWeeklyScheduleResponseParams
 - (instancetype)init
@@ -2763,6 +4407,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: numberOfTransitionsForSequence:%@; dayOfWeekForSequence:%@; modeForSequence:%@; transitions:%@; >",
+        NSStringFromClass([self class]), _numberOfTransitionsForSequence, _dayOfWeekForSequence, _modeForSequence, _transitions];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPThermostatClusterSetWeeklyScheduleParams
 - (instancetype)init
@@ -2780,6 +4433,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: numberOfTransitionsForSequence:%@; dayOfWeekForSequence:%@; modeForSequence:%@; transitions:%@; >",
+        NSStringFromClass([self class]), _numberOfTransitionsForSequence, _dayOfWeekForSequence, _modeForSequence, _transitions];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPThermostatClusterGetWeeklyScheduleParams
 - (instancetype)init
@@ -2793,6 +4455,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: daysToReturn:%@; modeToReturn:%@; >",
+                                             NSStringFromClass([self class]), _daysToReturn, _modeToReturn];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPThermostatClusterClearWeeklyScheduleParams
 - (instancetype)init
@@ -2802,6 +4472,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveToHueParams
 - (instancetype)init
@@ -2821,6 +4498,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: hue:%@; direction:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _hue, _direction, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveHueParams
 - (instancetype)init
@@ -2838,6 +4524,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: moveMode:%@; rate:%@; optionsMask:%@; optionsOverride:%@; >",
+                                             NSStringFromClass([self class]), _moveMode, _rate, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterStepHueParams
 - (instancetype)init
@@ -2857,6 +4551,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: stepMode:%@; stepSize:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _stepMode, _stepSize, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveToSaturationParams
 - (instancetype)init
@@ -2874,6 +4577,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: saturation:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _saturation, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveSaturationParams
 - (instancetype)init
@@ -2891,6 +4603,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: moveMode:%@; rate:%@; optionsMask:%@; optionsOverride:%@; >",
+                                             NSStringFromClass([self class]), _moveMode, _rate, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterStepSaturationParams
 - (instancetype)init
@@ -2910,6 +4630,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: stepMode:%@; stepSize:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _stepMode, _stepSize, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveToHueAndSaturationParams
 - (instancetype)init
@@ -2929,6 +4658,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: hue:%@; saturation:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _hue, _saturation, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveToColorParams
 - (instancetype)init
@@ -2948,6 +4686,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: colorX:%@; colorY:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _colorX, _colorY, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveColorParams
 - (instancetype)init
@@ -2965,6 +4712,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: rateX:%@; rateY:%@; optionsMask:%@; optionsOverride:%@; >",
+                                             NSStringFromClass([self class]), _rateX, _rateY, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterStepColorParams
 - (instancetype)init
@@ -2984,6 +4739,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: stepX:%@; stepY:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _stepX, _stepY, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveToColorTemperatureParams
 - (instancetype)init
@@ -3001,6 +4765,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: colorTemperature:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _colorTemperature, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterEnhancedMoveToHueParams
 - (instancetype)init
@@ -3020,6 +4793,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: enhancedHue:%@; direction:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _enhancedHue, _direction, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterEnhancedMoveHueParams
 - (instancetype)init
@@ -3037,6 +4819,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: moveMode:%@; rate:%@; optionsMask:%@; optionsOverride:%@; >",
+                                             NSStringFromClass([self class]), _moveMode, _rate, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterEnhancedStepHueParams
 - (instancetype)init
@@ -3056,6 +4846,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: stepMode:%@; stepSize:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _stepMode, _stepSize, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterEnhancedMoveToHueAndSaturationParams
 - (instancetype)init
@@ -3075,6 +4874,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: enhancedHue:%@; saturation:%@; transitionTime:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _enhancedHue, _saturation, _transitionTime, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterColorLoopSetParams
 - (instancetype)init
@@ -3098,6 +4906,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: updateFlags:%@; action:%@; direction:%@; time:%@; startHue:%@; optionsMask:%@; optionsOverride:%@; >",
+        NSStringFromClass([self class]), _updateFlags, _action, _direction, _time, _startHue, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterStopMoveStepParams
 - (instancetype)init
@@ -3111,6 +4929,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: optionsMask:%@; optionsOverride:%@; >",
+                                             NSStringFromClass([self class]), _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterMoveColorTemperatureParams
 - (instancetype)init
@@ -3132,6 +4958,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: moveMode:%@; rate:%@; colorTemperatureMinimumMireds:%@; "
+                                   @"colorTemperatureMaximumMireds:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _moveMode, _rate, _colorTemperatureMinimumMireds, _colorTemperatureMaximumMireds,
+                  _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPColorControlClusterStepColorTemperatureParams
 - (instancetype)init
@@ -3155,6 +4992,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: stepMode:%@; stepSize:%@; transitionTime:%@; colorTemperatureMinimumMireds:%@; "
+                                   @"colorTemperatureMaximumMireds:%@; optionsMask:%@; optionsOverride:%@; >",
+                  NSStringFromClass([self class]), _stepMode, _stepSize, _transitionTime, _colorTemperatureMinimumMireds,
+                  _colorTemperatureMaximumMireds, _optionsMask, _optionsOverride];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasZoneClusterZoneEnrollResponseParams
 - (instancetype)init
@@ -3168,6 +5016,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: enrollResponseCode:%@; zoneId:%@; >",
+                                             NSStringFromClass([self class]), _enrollResponseCode, _zoneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasZoneClusterZoneStatusChangeNotificationParams
 - (instancetype)init
@@ -3185,6 +5041,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: zoneStatus:%@; extendedStatus:%@; zoneId:%@; delay:%@; >",
+                                             NSStringFromClass([self class]), _zoneStatus, _extendedStatus, _zoneId, _delay];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasZoneClusterInitiateNormalOperationModeParams
 - (instancetype)init
@@ -3194,6 +5058,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasZoneClusterZoneEnrollRequestParams
 - (instancetype)init
@@ -3207,6 +5078,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: zoneType:%@; manufacturerCode:%@; >",
+                                             NSStringFromClass([self class]), _zoneType, _manufacturerCode];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasZoneClusterInitiateTestModeParams
 - (instancetype)init
@@ -3220,6 +5099,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: testModeDuration:%@; currentZoneSensitivityLevel:%@; >",
+                                             NSStringFromClass([self class]), _testModeDuration, _currentZoneSensitivityLevel];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasZoneClusterInitiateNormalOperationModeResponseParams
 - (instancetype)init
@@ -3229,6 +5116,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasZoneClusterInitiateTestModeResponseParams
 - (instancetype)init
@@ -3238,6 +5132,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterArmParams
 - (instancetype)init
@@ -3253,6 +5154,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: armMode:%@; armDisarmCode:%@; zoneId:%@; >",
+                                             NSStringFromClass([self class]), _armMode, _armDisarmCode, _zoneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterArmResponseParams
 - (instancetype)init
@@ -3264,6 +5173,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: armNotification:%@; >", NSStringFromClass([self class]), _armNotification];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterBypassParams
 - (instancetype)init
@@ -3279,6 +5196,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: numberOfZones:%@; zoneIds:%@; armDisarmCode:%@; >",
+                                             NSStringFromClass([self class]), _numberOfZones, _zoneIds, _armDisarmCode];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetZoneIdMapResponseParams
 - (instancetype)init
@@ -3320,6 +5245,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: section0:%@; section1:%@; section2:%@; section3:%@; section4:%@; section5:%@; section6:%@; section7:%@; "
+            @"section8:%@; section9:%@; section10:%@; section11:%@; section12:%@; section13:%@; section14:%@; section15:%@; >",
+        NSStringFromClass([self class]), _section0, _section1, _section2, _section3, _section4, _section5, _section6, _section7,
+        _section8, _section9, _section10, _section11, _section12, _section13, _section14, _section15];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterEmergencyParams
 - (instancetype)init
@@ -3329,6 +5266,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetZoneInformationResponseParams
 - (instancetype)init
@@ -3346,6 +5290,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: zoneId:%@; zoneType:%@; ieeeAddress:%@; zoneLabel:%@; >",
+                                             NSStringFromClass([self class]), _zoneId, _zoneType, _ieeeAddress, _zoneLabel];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterFireParams
 - (instancetype)init
@@ -3355,6 +5307,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterZoneStatusChangedParams
 - (instancetype)init
@@ -3372,6 +5331,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: zoneId:%@; zoneStatus:%@; audibleNotification:%@; zoneLabel:%@; >",
+                  NSStringFromClass([self class]), _zoneId, _zoneStatus, _audibleNotification, _zoneLabel];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterPanicParams
 - (instancetype)init
@@ -3381,6 +5349,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterPanelStatusChangedParams
 - (instancetype)init
@@ -3398,6 +5373,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: panelStatus:%@; secondsRemaining:%@; audibleNotification:%@; alarmStatus:%@; >",
+                  NSStringFromClass([self class]), _panelStatus, _secondsRemaining, _audibleNotification, _alarmStatus];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetZoneIdMapParams
 - (instancetype)init
@@ -3407,6 +5391,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetPanelStatusResponseParams
 - (instancetype)init
@@ -3424,6 +5415,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: panelStatus:%@; secondsRemaining:%@; audibleNotification:%@; alarmStatus:%@; >",
+                  NSStringFromClass([self class]), _panelStatus, _secondsRemaining, _audibleNotification, _alarmStatus];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetZoneInformationParams
 - (instancetype)init
@@ -3435,6 +5435,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: zoneId:%@; >", NSStringFromClass([self class]), _zoneId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterSetBypassedZoneListParams
 - (instancetype)init
@@ -3448,6 +5455,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: numberOfZones:%@; zoneIds:%@; >", NSStringFromClass([self class]), _numberOfZones, _zoneIds];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetPanelStatusParams
 - (instancetype)init
@@ -3457,6 +5472,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterBypassResponseParams
 - (instancetype)init
@@ -3470,6 +5492,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: numberOfZones:%@; bypassResult:%@; >",
+                                             NSStringFromClass([self class]), _numberOfZones, _bypassResult];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetBypassedZoneListParams
 - (instancetype)init
@@ -3479,6 +5509,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetZoneStatusResponseParams
 - (instancetype)init
@@ -3494,6 +5531,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: zoneStatusComplete:%@; numberOfZones:%@; zoneStatusResult:%@; >",
+                  NSStringFromClass([self class]), _zoneStatusComplete, _numberOfZones, _zoneStatusResult];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasAceClusterGetZoneStatusParams
 - (instancetype)init
@@ -3511,6 +5557,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: startingZoneId:%@; maxNumberOfZoneIds:%@; zoneStatusMaskFlag:%@; zoneStatusMask:%@; >",
+                  NSStringFromClass([self class]), _startingZoneId, _maxNumberOfZoneIds, _zoneStatusMaskFlag, _zoneStatusMask];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasWdClusterStartWarningParams
 - (instancetype)init
@@ -3528,6 +5583,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: warningInfo:%@; warningDuration:%@; strobeDutyCycle:%@; strobeLevel:%@; >",
+                  NSStringFromClass([self class]), _warningInfo, _warningDuration, _strobeDutyCycle, _strobeLevel];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPIasWdClusterSquawkParams
 - (instancetype)init
@@ -3539,6 +5603,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: squawkInfo:%@; >", NSStringFromClass([self class]), _squawkInfo];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPChannelClusterChangeChannelParams
 - (instancetype)init
@@ -3550,6 +5622,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: match:%@; >", NSStringFromClass([self class]), _match];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPChannelClusterChangeChannelResponseParams
 - (instancetype)init
@@ -3563,6 +5642,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: status:%@; data:%@; >", NSStringFromClass([self class]), _status, _data];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPChannelClusterChangeChannelByNumberParams
 - (instancetype)init
@@ -3576,6 +5663,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: majorNumber:%@; minorNumber:%@; >", NSStringFromClass([self class]), _majorNumber, _minorNumber];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPChannelClusterSkipChannelParams
 - (instancetype)init
@@ -3587,6 +5682,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: count:%@; >", NSStringFromClass([self class]), _count];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTargetNavigatorClusterNavigateTargetParams
 - (instancetype)init
@@ -3600,6 +5702,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: target:%@; data:%@; >", NSStringFromClass([self class]), _target, _data];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTargetNavigatorClusterNavigateTargetResponseParams
 - (instancetype)init
@@ -3613,6 +5723,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: status:%@; data:%@; >", NSStringFromClass([self class]), _status, _data];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterPlayParams
 - (instancetype)init
@@ -3622,6 +5740,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterPauseParams
 - (instancetype)init
@@ -3631,6 +5756,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterStopPlaybackParams
 - (instancetype)init
@@ -3640,6 +5772,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterStartOverParams
 - (instancetype)init
@@ -3649,6 +5788,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterPreviousParams
 - (instancetype)init
@@ -3658,6 +5804,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterNextParams
 - (instancetype)init
@@ -3667,6 +5820,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterRewindParams
 - (instancetype)init
@@ -3676,6 +5836,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterFastForwardParams
 - (instancetype)init
@@ -3685,6 +5852,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterSkipForwardParams
 - (instancetype)init
@@ -3696,6 +5870,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: deltaPositionMilliseconds:%@; >", NSStringFromClass([self class]), _deltaPositionMilliseconds];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterSkipBackwardParams
 - (instancetype)init
@@ -3707,6 +5889,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: deltaPositionMilliseconds:%@; >", NSStringFromClass([self class]), _deltaPositionMilliseconds];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterPlaybackResponseParams
 - (instancetype)init
@@ -3720,6 +5910,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: status:%@; data:%@; >", NSStringFromClass([self class]), _status, _data];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaPlaybackClusterSeekParams
 - (instancetype)init
@@ -3731,6 +5929,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: position:%@; >", NSStringFromClass([self class]), _position];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaInputClusterSelectInputParams
 - (instancetype)init
@@ -3742,6 +5947,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: index:%@; >", NSStringFromClass([self class]), _index];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaInputClusterShowInputStatusParams
 - (instancetype)init
@@ -3751,6 +5963,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaInputClusterHideInputStatusParams
 - (instancetype)init
@@ -3760,6 +5979,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMediaInputClusterRenameInputParams
 - (instancetype)init
@@ -3773,6 +5999,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: index:%@; name:%@; >", NSStringFromClass([self class]), _index, _name];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPLowPowerClusterSleepParams
 - (instancetype)init
@@ -3782,6 +6016,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPKeypadInputClusterSendKeyParams
 - (instancetype)init
@@ -3793,6 +6034,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: keyCode:%@; >", NSStringFromClass([self class]), _keyCode];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPKeypadInputClusterSendKeyResponseParams
 - (instancetype)init
@@ -3804,6 +6052,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; >", NSStringFromClass([self class]), _status];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPContentLauncherClusterLaunchContentParams
 - (instancetype)init
@@ -3819,6 +6074,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: search:%@; autoPlay:%@; data:%@; >", NSStringFromClass([self class]), _search, _autoPlay, _data];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPContentLauncherClusterLaunchURLParams
 - (instancetype)init
@@ -3834,6 +6097,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: contentURL:%@; displayString:%@; brandingInformation:%@; >",
+                                             NSStringFromClass([self class]), _contentURL, _displayString, _brandingInformation];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPContentLauncherClusterLaunchResponseParams
 - (instancetype)init
@@ -3847,6 +6118,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: status:%@; data:%@; >", NSStringFromClass([self class]), _status, _data];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAudioOutputClusterSelectOutputParams
 - (instancetype)init
@@ -3858,6 +6137,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: index:%@; >", NSStringFromClass([self class]), _index];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAudioOutputClusterRenameOutputParams
 - (instancetype)init
@@ -3871,6 +6157,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: index:%@; name:%@; >", NSStringFromClass([self class]), _index, _name];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplicationLauncherClusterLaunchAppParams
 - (instancetype)init
@@ -3884,6 +6178,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: application:%@; data:%@; >", NSStringFromClass([self class]),
+                                             _application, [_data base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplicationLauncherClusterStopAppParams
 - (instancetype)init
@@ -3895,6 +6197,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: application:%@; >", NSStringFromClass([self class]), _application];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplicationLauncherClusterHideAppParams
 - (instancetype)init
@@ -3906,6 +6216,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: application:%@; >", NSStringFromClass([self class]), _application];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplicationLauncherClusterLauncherResponseParams
 - (instancetype)init
@@ -3919,6 +6237,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; data:%@; >", NSStringFromClass([self class]),
+                                             _status, [_data base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAccountLoginClusterGetSetupPINParams
 - (instancetype)init
@@ -3930,6 +6256,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: tempAccountIdentifier:%@; >", NSStringFromClass([self class]), _tempAccountIdentifier];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAccountLoginClusterGetSetupPINResponseParams
 - (instancetype)init
@@ -3941,6 +6275,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: setupPIN:%@; >", NSStringFromClass([self class]), _setupPIN];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAccountLoginClusterLoginParams
 - (instancetype)init
@@ -3954,6 +6295,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: tempAccountIdentifier:%@; setupPIN:%@; >",
+                                             NSStringFromClass([self class]), _tempAccountIdentifier, _setupPIN];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPAccountLoginClusterLogoutParams
 - (instancetype)init
@@ -3963,6 +6312,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestParams
 - (instancetype)init
@@ -3972,6 +6328,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestSpecificResponseParams
 - (instancetype)init
@@ -3983,6 +6346,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: returnValue:%@; >", NSStringFromClass([self class]), _returnValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestNotHandledParams
 - (instancetype)init
@@ -3992,6 +6363,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestAddArgumentsResponseParams
 - (instancetype)init
@@ -4003,6 +6381,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: returnValue:%@; >", NSStringFromClass([self class]), _returnValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestSpecificParams
 - (instancetype)init
@@ -4012,6 +6398,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestSimpleArgumentResponseParams
 - (instancetype)init
@@ -4023,6 +6416,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: returnValue:%@; >", NSStringFromClass([self class]), _returnValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestUnknownCommandParams
 - (instancetype)init
@@ -4032,6 +6433,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestStructArrayArgumentResponseParams
 - (instancetype)init
@@ -4053,6 +6461,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; arg3:%@; arg4:%@; arg5:%@; arg6:%@; >",
+                                             NSStringFromClass([self class]), _arg1, _arg2, _arg3, _arg4, _arg5, _arg6];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestAddArgumentsParams
 - (instancetype)init
@@ -4066,6 +6482,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; >", NSStringFromClass([self class]), _arg1, _arg2];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestListInt8UReverseResponseParams
 - (instancetype)init
@@ -4077,6 +6501,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestSimpleArgumentRequestParams
 - (instancetype)init
@@ -4088,6 +6519,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestEnumsResponseParams
 - (instancetype)init
@@ -4101,6 +6539,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; >", NSStringFromClass([self class]), _arg1, _arg2];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestStructArrayArgumentRequestParams
 - (instancetype)init
@@ -4122,6 +6568,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; arg3:%@; arg4:%@; arg5:%@; arg6:%@; >",
+                                             NSStringFromClass([self class]), _arg1, _arg2, _arg3, _arg4, _arg5, _arg6];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestNullableOptionalResponseParams
 - (instancetype)init
@@ -4139,6 +6593,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: wasPresent:%@; wasNull:%@; value:%@; originalValue:%@; >",
+                                             NSStringFromClass([self class]), _wasPresent, _wasNull, _value, _originalValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestStructArgumentRequestParams
 - (instancetype)init
@@ -4150,6 +6612,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestComplexNullableOptionalResponseParams
 - (instancetype)init
@@ -4215,6 +6684,28 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: nullableIntWasNull:%@; nullableIntValue:%@; optionalIntWasPresent:%@; optionalIntValue:%@; "
+                         @"nullableOptionalIntWasPresent:%@; nullableOptionalIntWasNull:%@; nullableOptionalIntValue:%@; "
+                         @"nullableStringWasNull:%@; nullableStringValue:%@; optionalStringWasPresent:%@; optionalStringValue:%@; "
+                         @"nullableOptionalStringWasPresent:%@; nullableOptionalStringWasNull:%@; nullableOptionalStringValue:%@; "
+                         @"nullableStructWasNull:%@; nullableStructValue:%@; optionalStructWasPresent:%@; optionalStructValue:%@; "
+                         @"nullableOptionalStructWasPresent:%@; nullableOptionalStructWasNull:%@; nullableOptionalStructValue:%@; "
+                         @"nullableListWasNull:%@; nullableListValue:%@; optionalListWasPresent:%@; optionalListValue:%@; "
+                         @"nullableOptionalListWasPresent:%@; nullableOptionalListWasNull:%@; nullableOptionalListValue:%@; >",
+        NSStringFromClass([self class]), _nullableIntWasNull, _nullableIntValue, _optionalIntWasPresent, _optionalIntValue,
+        _nullableOptionalIntWasPresent, _nullableOptionalIntWasNull, _nullableOptionalIntValue, _nullableStringWasNull,
+        _nullableStringValue, _optionalStringWasPresent, _optionalStringValue, _nullableOptionalStringWasPresent,
+        _nullableOptionalStringWasNull, _nullableOptionalStringValue, _nullableStructWasNull, _nullableStructValue,
+        _optionalStructWasPresent, _optionalStructValue, _nullableOptionalStructWasPresent, _nullableOptionalStructWasNull,
+        _nullableOptionalStructValue, _nullableListWasNull, _nullableListValue, _optionalListWasPresent, _optionalListValue,
+        _nullableOptionalListWasPresent, _nullableOptionalListWasNull, _nullableOptionalListValue];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestNestedStructArgumentRequestParams
 - (instancetype)init
@@ -4226,6 +6717,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterBooleanResponseParams
 - (instancetype)init
@@ -4237,6 +6735,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: value:%@; >", NSStringFromClass([self class]), _value];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestListStructArgumentRequestParams
 - (instancetype)init
@@ -4248,6 +6753,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterSimpleStructResponseParams
 - (instancetype)init
@@ -4259,6 +6771,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestListInt8UArgumentRequestParams
 - (instancetype)init
@@ -4270,6 +6789,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestEmitTestEventResponseParams
 - (instancetype)init
@@ -4281,6 +6807,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: value:%@; >", NSStringFromClass([self class]), _value];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestNestedStructListArgumentRequestParams
 - (instancetype)init
@@ -4292,6 +6825,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestEmitTestFabricScopedEventResponseParams
 - (instancetype)init
@@ -4303,6 +6843,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: value:%@; >", NSStringFromClass([self class]), _value];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestListNestedStructListArgumentRequestParams
 - (instancetype)init
@@ -4314,6 +6861,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestListInt8UReverseRequestParams
 - (instancetype)init
@@ -4325,6 +6879,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestEnumsRequestParams
 - (instancetype)init
@@ -4338,6 +6899,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; >", NSStringFromClass([self class]), _arg1, _arg2];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestNullableOptionalRequestParams
 - (instancetype)init
@@ -4349,6 +6918,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestComplexNullableOptionalRequestParams
 - (instancetype)init
@@ -4382,6 +6958,19 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: nullableInt:%@; optionalInt:%@; nullableOptionalInt:%@; nullableString:%@; "
+                                   @"optionalString:%@; nullableOptionalString:%@; nullableStruct:%@; optionalStruct:%@; "
+                                   @"nullableOptionalStruct:%@; nullableList:%@; optionalList:%@; nullableOptionalList:%@; >",
+                  NSStringFromClass([self class]), _nullableInt, _optionalInt, _nullableOptionalInt, _nullableString,
+                  _optionalString, _nullableOptionalString, _nullableStruct, _optionalStruct, _nullableOptionalStruct,
+                  _nullableList, _optionalList, _nullableOptionalList];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterSimpleStructEchoRequestParams
 - (instancetype)init
@@ -4393,6 +6982,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTimedInvokeRequestParams
 - (instancetype)init
@@ -4402,6 +6998,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestSimpleOptionalArgumentRequestParams
 - (instancetype)init
@@ -4413,6 +7016,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestEmitTestEventRequestParams
 - (instancetype)init
@@ -4428,6 +7038,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; arg3:%@; >", NSStringFromClass([self class]), _arg1, _arg2, _arg3];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPTestClusterClusterTestEmitTestFabricScopedEventRequestParams
 - (instancetype)init
@@ -4439,6 +7057,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMessagingClusterDisplayMessageParams
 - (instancetype)init
@@ -4460,6 +7085,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: messageId:%@; messageControl:%@; startTime:%@; durationInMinutes:%@; message:%@; "
+                                   @"optionalExtendedMessageControl:%@; >",
+                  NSStringFromClass([self class]), _messageId, _messageControl, _startTime, _durationInMinutes, _message,
+                  _optionalExtendedMessageControl];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMessagingClusterGetLastMessageParams
 - (instancetype)init
@@ -4469,6 +7105,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMessagingClusterCancelMessageParams
 - (instancetype)init
@@ -4482,6 +7125,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: messageId:%@; messageControl:%@; >", NSStringFromClass([self class]), _messageId, _messageControl];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMessagingClusterMessageConfirmationParams
 - (instancetype)init
@@ -4499,6 +7150,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: messageId:%@; confirmationTime:%@; messageConfirmationControl:%@; messageResponse:%@; >",
+                  NSStringFromClass([self class]), _messageId, _confirmationTime, _messageConfirmationControl,
+                  [_messageResponse base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMessagingClusterDisplayProtectedMessageParams
 - (instancetype)init
@@ -4520,6 +7181,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: messageId:%@; messageControl:%@; startTime:%@; durationInMinutes:%@; message:%@; "
+                                   @"optionalExtendedMessageControl:%@; >",
+                  NSStringFromClass([self class]), _messageId, _messageControl, _startTime, _durationInMinutes, _message,
+                  _optionalExtendedMessageControl];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMessagingClusterGetMessageCancellationParams
 - (instancetype)init
@@ -4531,6 +7203,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: earliestImplementationTime:%@; >", NSStringFromClass([self class]), _earliestImplementationTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPMessagingClusterCancelAllMessagesParams
 - (instancetype)init
@@ -4542,6 +7222,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: implementationDateTime:%@; >", NSStringFromClass([self class]), _implementationDateTime];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceEventsAndAlertClusterGetAlertsParams
 - (instancetype)init
@@ -4551,6 +7239,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceEventsAndAlertClusterGetAlertsResponseParams
 - (instancetype)init
@@ -4564,6 +7259,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: alertsCount:%@; alertStructures:%@; >",
+                                             NSStringFromClass([self class]), _alertsCount, _alertStructures];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceEventsAndAlertClusterAlertsNotificationParams
 - (instancetype)init
@@ -4577,6 +7280,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: alertsCount:%@; alertStructures:%@; >",
+                                             NSStringFromClass([self class]), _alertsCount, _alertStructures];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceEventsAndAlertClusterEventsNotificationParams
 - (instancetype)init
@@ -4590,6 +7301,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: eventHeader:%@; eventId:%@; >", NSStringFromClass([self class]), _eventHeader, _eventId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceStatisticsClusterLogNotificationParams
 - (instancetype)init
@@ -4607,6 +7326,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: timeStamp:%@; logId:%@; logLength:%@; logPayload:%@; >",
+                                             NSStringFromClass([self class]), _timeStamp, _logId, _logLength, _logPayload];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceStatisticsClusterLogRequestParams
 - (instancetype)init
@@ -4618,6 +7345,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: logId:%@; >", NSStringFromClass([self class]), _logId];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceStatisticsClusterLogResponseParams
 - (instancetype)init
@@ -4635,6 +7369,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: timeStamp:%@; logId:%@; logLength:%@; logPayload:%@; >",
+                                             NSStringFromClass([self class]), _timeStamp, _logId, _logLength, _logPayload];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceStatisticsClusterLogQueueRequestParams
 - (instancetype)init
@@ -4644,6 +7386,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceStatisticsClusterLogQueueResponseParams
 - (instancetype)init
@@ -4657,6 +7406,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: logQueueSize:%@; logIds:%@; >", NSStringFromClass([self class]), _logQueueSize, _logIds];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPApplianceStatisticsClusterStatisticsAvailableParams
 - (instancetype)init
@@ -4670,6 +7427,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: logQueueSize:%@; logIds:%@; >", NSStringFromClass([self class]), _logQueueSize, _logIds];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPElectricalMeasurementClusterGetProfileInfoResponseCommandParams
 - (instancetype)init
@@ -4687,6 +7452,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: profileCount:%@; profileIntervalPeriod:%@; maxNumberOfIntervals:%@; listOfAttributes:%@; >",
+        NSStringFromClass([self class]), _profileCount, _profileIntervalPeriod, _maxNumberOfIntervals, _listOfAttributes];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPElectricalMeasurementClusterGetProfileInfoCommandParams
 - (instancetype)init
@@ -4696,6 +7470,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPElectricalMeasurementClusterGetMeasurementProfileResponseCommandParams
 - (instancetype)init
@@ -4717,6 +7498,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: startTime:%@; status:%@; profileIntervalPeriod:%@; "
+                                                              @"numberOfIntervalsDelivered:%@; attributeId:%@; intervals:%@; >",
+                                             NSStringFromClass([self class]), _startTime, _status, _profileIntervalPeriod,
+                                             _numberOfIntervalsDelivered, _attributeId, _intervals];
+    return descriptionString;
+}
+
 @end
 @implementation CHIPElectricalMeasurementClusterGetMeasurementProfileCommandParams
 - (instancetype)init
@@ -4732,6 +7523,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: attributeId:%@; startTime:%@; numberOfIntervals:%@; >",
+                                             NSStringFromClass([self class]), _attributeId, _startTime, _numberOfIntervals];
+    return descriptionString;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
@@ -32,6 +32,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: attributeId:%@; attributeValue:%@; >",
+                                             NSStringFromClass([self class]), _attributeId, _attributeValue];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPScenesClusterExtensionFieldSet
@@ -45,6 +53,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: clusterId:%@; attributeValueList:%@; >",
+                                             NSStringFromClass([self class]), _clusterId, _attributeValueList];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPowerProfileClusterPowerProfileRecord
@@ -62,6 +78,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: powerProfileId:%@; energyPhaseId:%@; powerProfileRemoteControl:%@; powerProfileState:%@; >",
+        NSStringFromClass([self class]), _powerProfileId, _energyPhaseId, _powerProfileRemoteControl, _powerProfileState];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPowerProfileClusterScheduledPhase
@@ -75,6 +100,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: energyPhaseId:%@; scheduledTime:%@; >",
+                                             NSStringFromClass([self class]), _energyPhaseId, _scheduledTime];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPowerProfileClusterTransferredPhase
@@ -96,6 +129,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: energyPhaseId:%@; macroPhaseId:%@; expectedDuration:%@; peakPower:%@; energy:%@; maxActivationDelay:%@; >",
+        NSStringFromClass([self class]), _energyPhaseId, _macroPhaseId, _expectedDuration, _peakPower, _energy,
+        _maxActivationDelay];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPDescriptorClusterDeviceType
@@ -109,6 +153,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: type:%@; revision:%@; >", NSStringFromClass([self class]), _type, _revision];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBindingClusterTargetStruct
@@ -128,6 +180,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: node:%@; group:%@; endpoint:%@; cluster:%@; fabricIndex:%@; >",
+                                             NSStringFromClass([self class]), _node, _group, _endpoint, _cluster, _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPAccessControlClusterTarget
@@ -143,6 +203,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: cluster:%@; endpoint:%@; deviceType:%@; >",
+                                             NSStringFromClass([self class]), _cluster, _endpoint, _deviceType];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPAccessControlClusterAccessControlEntry
@@ -162,6 +230,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: privilege:%@; authMode:%@; subjects:%@; targets:%@; fabricIndex:%@; >",
+                  NSStringFromClass([self class]), _privilege, _authMode, _subjects, _targets, _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPAccessControlClusterExtensionEntry
@@ -175,6 +252,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: data:%@; fabricIndex:%@; >", NSStringFromClass([self class]),
+                                             [_data base64EncodedStringWithOptions:0], _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPAccessControlClusterAccessControlEntryChangedEvent
@@ -194,6 +279,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: adminNodeID:%@; adminPasscodeID:%@; changeType:%@; latestValue:%@; adminFabricIndex:%@; >",
+        NSStringFromClass([self class]), _adminNodeID, _adminPasscodeID, _changeType, _latestValue, _adminFabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPAccessControlClusterAccessControlExtensionChangedEvent
@@ -213,6 +307,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: adminNodeID:%@; adminPasscodeID:%@; changeType:%@; latestValue:%@; adminFabricIndex:%@; >",
+        NSStringFromClass([self class]), _adminNodeID, _adminPasscodeID, _changeType, _latestValue, _adminFabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBridgedActionsClusterActionStruct
@@ -234,6 +337,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: actionID:%@; name:%@; type:%@; endpointListID:%@; supportedCommands:%@; status:%@; >",
+                  NSStringFromClass([self class]), _actionID, _name, _type, _endpointListID, _supportedCommands, _status];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBridgedActionsClusterEndpointListStruct
@@ -251,6 +363,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: endpointListID:%@; name:%@; type:%@; endpoints:%@; >",
+                                             NSStringFromClass([self class]), _endpointListID, _name, _type, _endpoints];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBridgedActionsClusterStateChangedEvent
@@ -266,6 +386,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; newState:%@; >",
+                                             NSStringFromClass([self class]), _actionID, _invokeID, _newState];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBridgedActionsClusterActionFailedEvent
@@ -283,6 +411,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; newState:%@; error:%@; >",
+                                             NSStringFromClass([self class]), _actionID, _invokeID, _newState, _error];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBasicClusterCapabilityMinimaStruct
@@ -296,6 +432,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: caseSessionsPerFabric:%@; subscriptionsPerFabric:%@; >",
+                                             NSStringFromClass([self class]), _caseSessionsPerFabric, _subscriptionsPerFabric];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBasicClusterStartUpEvent
@@ -307,6 +451,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: softwareVersion:%@; >", NSStringFromClass([self class]), _softwareVersion];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBasicClusterShutDownEvent
@@ -316,6 +468,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBasicClusterLeaveEvent
@@ -325,6 +484,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBasicClusterReachableChangedEvent
@@ -336,6 +502,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: reachableNewValue:%@; >", NSStringFromClass([self class]), _reachableNewValue];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPOtaSoftwareUpdateRequestorClusterProviderLocation
@@ -351,6 +525,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: providerNodeID:%@; endpoint:%@; fabricIndex:%@; >",
+                                             NSStringFromClass([self class]), _providerNodeID, _endpoint, _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPOtaSoftwareUpdateRequestorClusterStateTransitionEvent
@@ -368,6 +550,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: previousState:%@; newState:%@; reason:%@; targetSoftwareVersion:%@; >",
+                  NSStringFromClass([self class]), _previousState, _newState, _reason, _targetSoftwareVersion];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPOtaSoftwareUpdateRequestorClusterVersionAppliedEvent
@@ -381,6 +572,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: softwareVersion:%@; productID:%@; >",
+                                             NSStringFromClass([self class]), _softwareVersion, _productID];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPOtaSoftwareUpdateRequestorClusterDownloadErrorEvent
@@ -398,6 +597,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: softwareVersion:%@; bytesDownloaded:%@; progressPercent:%@; platformCode:%@; >",
+                  NSStringFromClass([self class]), _softwareVersion, _bytesDownloaded, _progressPercent, _platformCode];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPowerSourceClusterBatChargeFaultChangeType
@@ -411,6 +619,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: current:%@; previous:%@; >", NSStringFromClass([self class]), _current, _previous];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPowerSourceClusterBatFaultChangeType
@@ -424,6 +640,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: current:%@; previous:%@; >", NSStringFromClass([self class]), _current, _previous];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPowerSourceClusterWiredFaultChangeType
@@ -437,6 +661,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: current:%@; previous:%@; >", NSStringFromClass([self class]), _current, _previous];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGeneralCommissioningClusterBasicCommissioningInfo
@@ -448,6 +680,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: failSafeExpiryLengthSeconds:%@; >", NSStringFromClass([self class]), _failSafeExpiryLengthSeconds];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPNetworkCommissioningClusterNetworkInfo
@@ -461,6 +701,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: networkID:%@; connected:%@; >", NSStringFromClass([self class]),
+                  [_networkID base64EncodedStringWithOptions:0], _connected];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPNetworkCommissioningClusterThreadInterfaceScanResult
@@ -486,6 +735,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: panId:%@; extendedPanId:%@; networkName:%@; channel:%@; version:%@; extendedAddress:%@; rssi:%@; lqi:%@; >",
+        NSStringFromClass([self class]), _panId, _extendedPanId, _networkName, _channel, _version,
+        [_extendedAddress base64EncodedStringWithOptions:0], _rssi, _lqi];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPNetworkCommissioningClusterWiFiInterfaceScanResult
@@ -507,6 +767,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: security:%@; ssid:%@; bssid:%@; channel:%@; wiFiBand:%@; rssi:%@; >",
+                  NSStringFromClass([self class]), _security, [_ssid base64EncodedStringWithOptions:0],
+                  [_bssid base64EncodedStringWithOptions:0], _channel, _wiFiBand, _rssi];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGeneralDiagnosticsClusterNetworkInterfaceType
@@ -532,6 +802,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: name:%@; isOperational:%@; offPremiseServicesReachableIPv4:%@; offPremiseServicesReachableIPv6:%@; "
+                         @"hardwareAddress:%@; iPv4Addresses:%@; iPv6Addresses:%@; type:%@; >",
+        NSStringFromClass([self class]), _name, _isOperational, _offPremiseServicesReachableIPv4, _offPremiseServicesReachableIPv6,
+        [_hardwareAddress base64EncodedStringWithOptions:0], _iPv4Addresses, _iPv6Addresses, _type];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGeneralDiagnosticsClusterHardwareFaultChangeEvent
@@ -545,6 +826,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: current:%@; previous:%@; >", NSStringFromClass([self class]), _current, _previous];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGeneralDiagnosticsClusterRadioFaultChangeEvent
@@ -558,6 +847,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: current:%@; previous:%@; >", NSStringFromClass([self class]), _current, _previous];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGeneralDiagnosticsClusterNetworkFaultChangeEvent
@@ -571,6 +868,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: current:%@; previous:%@; >", NSStringFromClass([self class]), _current, _previous];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGeneralDiagnosticsClusterBootReasonEvent
@@ -582,6 +887,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: bootReason:%@; >", NSStringFromClass([self class]), _bootReason];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSoftwareDiagnosticsClusterSoftwareFaultStruct
@@ -597,6 +910,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: id:%@; name:%@; faultRecording:%@; >", NSStringFromClass([self class]), _id, _name,
+                  [_faultRecording base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSoftwareDiagnosticsClusterThreadMetrics
@@ -616,6 +938,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: id:%@; name:%@; stackFreeCurrent:%@; stackFreeMinimum:%@; stackSize:%@; >",
+                  NSStringFromClass([self class]), _id, _name, _stackFreeCurrent, _stackFreeMinimum, _stackSize];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSoftwareDiagnosticsClusterSoftwareFaultEvent
@@ -627,6 +958,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: softwareFault:%@; >", NSStringFromClass([self class]), _softwareFault];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterNeighborTable
@@ -664,6 +1003,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: extAddress:%@; age:%@; rloc16:%@; linkFrameCounter:%@; mleFrameCounter:%@; lqi:%@; averageRssi:%@; lastRssi:%@; "
+            @"frameErrorRate:%@; messageErrorRate:%@; rxOnWhenIdle:%@; fullThreadDevice:%@; fullNetworkData:%@; isChild:%@; >",
+        NSStringFromClass([self class]), _extAddress, _age, _rloc16, _linkFrameCounter, _mleFrameCounter, _lqi, _averageRssi,
+        _lastRssi, _frameErrorRate, _messageErrorRate, _rxOnWhenIdle, _fullThreadDevice, _fullNetworkData, _isChild];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterOperationalDatasetComponents
@@ -697,6 +1048,19 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: activeTimestampPresent:%@; pendingTimestampPresent:%@; masterKeyPresent:%@; networkNamePresent:%@; "
+                         @"extendedPanIdPresent:%@; meshLocalPrefixPresent:%@; delayPresent:%@; panIdPresent:%@; "
+                         @"channelPresent:%@; pskcPresent:%@; securityPolicyPresent:%@; channelMaskPresent:%@; >",
+        NSStringFromClass([self class]), _activeTimestampPresent, _pendingTimestampPresent, _masterKeyPresent, _networkNamePresent,
+        _extendedPanIdPresent, _meshLocalPrefixPresent, _delayPresent, _panIdPresent, _channelPresent, _pskcPresent,
+        _securityPolicyPresent, _channelMaskPresent];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterRouteTable
@@ -726,6 +1090,17 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: extAddress:%@; rloc16:%@; routerId:%@; nextHop:%@; pathCost:%@; lqiIn:%@; lqiOut:%@; "
+                                   @"age:%@; allocated:%@; linkEstablished:%@; >",
+                  NSStringFromClass([self class]), _extAddress, _rloc16, _routerId, _nextHop, _pathCost, _lqiIn, _lqiOut, _age,
+                  _allocated, _linkEstablished];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterSecurityPolicy
@@ -739,6 +1114,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: rotationTime:%@; flags:%@; >", NSStringFromClass([self class]), _rotationTime, _flags];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPThreadNetworkDiagnosticsClusterConnectionStatusEvent
@@ -750,6 +1133,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: connectionStatus:%@; >", NSStringFromClass([self class]), _connectionStatus];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPWiFiNetworkDiagnosticsClusterDisconnectionEvent
@@ -761,6 +1152,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: reasonCode:%@; >", NSStringFromClass([self class]), _reasonCode];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPWiFiNetworkDiagnosticsClusterAssociationFailureEvent
@@ -774,6 +1173,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: associationFailure:%@; status:%@; >",
+                                             NSStringFromClass([self class]), _associationFailure, _status];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPWiFiNetworkDiagnosticsClusterConnectionStatusEvent
@@ -785,6 +1192,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: connectionStatus:%@; >", NSStringFromClass([self class]), _connectionStatus];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBridgedDeviceBasicClusterStartUpEvent
@@ -796,6 +1211,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: softwareVersion:%@; >", NSStringFromClass([self class]), _softwareVersion];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBridgedDeviceBasicClusterShutDownEvent
@@ -805,6 +1228,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBridgedDeviceBasicClusterLeaveEvent
@@ -814,6 +1244,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBridgedDeviceBasicClusterReachableChangedEvent
@@ -825,6 +1262,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: reachableNewValue:%@; >", NSStringFromClass([self class]), _reachableNewValue];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSwitchClusterSwitchLatchedEvent
@@ -836,6 +1281,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: newPosition:%@; >", NSStringFromClass([self class]), _newPosition];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSwitchClusterInitialPressEvent
@@ -847,6 +1300,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: newPosition:%@; >", NSStringFromClass([self class]), _newPosition];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSwitchClusterLongPressEvent
@@ -858,6 +1319,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: newPosition:%@; >", NSStringFromClass([self class]), _newPosition];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSwitchClusterShortReleaseEvent
@@ -869,6 +1338,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: previousPosition:%@; >", NSStringFromClass([self class]), _previousPosition];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSwitchClusterLongReleaseEvent
@@ -880,6 +1357,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: previousPosition:%@; >", NSStringFromClass([self class]), _previousPosition];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSwitchClusterMultiPressOngoingEvent
@@ -893,6 +1378,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: newPosition:%@; currentNumberOfPressesCounted:%@; >",
+                                             NSStringFromClass([self class]), _newPosition, _currentNumberOfPressesCounted];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPSwitchClusterMultiPressCompleteEvent
@@ -906,6 +1399,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: newPosition:%@; totalNumberOfPressesCounted:%@; >",
+                                             NSStringFromClass([self class]), _newPosition, _totalNumberOfPressesCounted];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPOperationalCredentialsClusterFabricDescriptor
@@ -927,6 +1428,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: rootPublicKey:%@; vendorId:%@; fabricId:%@; nodeId:%@; label:%@; fabricIndex:%@; >",
+                  NSStringFromClass([self class]), [_rootPublicKey base64EncodedStringWithOptions:0], _vendorId, _fabricId, _nodeId,
+                  _label, _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPOperationalCredentialsClusterNOCStruct
@@ -942,6 +1453,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: noc:%@; icac:%@; fabricIndex:%@; >", NSStringFromClass([self class]),
+                  [_noc base64EncodedStringWithOptions:0], [_icac base64EncodedStringWithOptions:0], _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGroupKeyManagementClusterGroupInfoMapStruct
@@ -959,6 +1479,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; endpoints:%@; groupName:%@; fabricIndex:%@; >",
+                                             NSStringFromClass([self class]), _groupId, _endpoints, _groupName, _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGroupKeyManagementClusterGroupKeyMapStruct
@@ -974,6 +1502,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; groupKeySetID:%@; fabricIndex:%@; >",
+                                             NSStringFromClass([self class]), _groupId, _groupKeySetID, _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPGroupKeyManagementClusterGroupKeySetStruct
@@ -999,6 +1535,18 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: groupKeySetID:%@; groupKeySecurityPolicy:%@; epochKey0:%@; epochStartTime0:%@; "
+                                   @"epochKey1:%@; epochStartTime1:%@; epochKey2:%@; epochStartTime2:%@; >",
+                  NSStringFromClass([self class]), _groupKeySetID, _groupKeySecurityPolicy,
+                  [_epochKey0 base64EncodedStringWithOptions:0], _epochStartTime0, [_epochKey1 base64EncodedStringWithOptions:0],
+                  _epochStartTime1, [_epochKey2 base64EncodedStringWithOptions:0], _epochStartTime2];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPFixedLabelClusterLabelStruct
@@ -1012,6 +1560,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: label:%@; value:%@; >", NSStringFromClass([self class]), _label, _value];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPUserLabelClusterLabelStruct
@@ -1025,6 +1581,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: label:%@; value:%@; >", NSStringFromClass([self class]), _label, _value];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPBooleanStateClusterStateChangeEvent
@@ -1036,6 +1600,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: stateValue:%@; >", NSStringFromClass([self class]), _stateValue];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPModeSelectClusterSemanticTag
@@ -1049,6 +1621,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: mfgCode:%@; value:%@; >", NSStringFromClass([self class]), _mfgCode, _value];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPModeSelectClusterModeOptionStruct
@@ -1064,6 +1644,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: label:%@; mode:%@; semanticTags:%@; >",
+                                             NSStringFromClass([self class]), _label, _mode, _semanticTags];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPDoorLockClusterDlCredential
@@ -1077,6 +1665,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: credentialType:%@; credentialIndex:%@; >",
+                                             NSStringFromClass([self class]), _credentialType, _credentialIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPDoorLockClusterDoorLockAlarmEvent
@@ -1088,6 +1684,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: alarmCode:%@; >", NSStringFromClass([self class]), _alarmCode];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPDoorLockClusterDoorStateChangeEvent
@@ -1099,6 +1702,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: doorState:%@; >", NSStringFromClass([self class]), _doorState];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPDoorLockClusterLockOperationEvent
@@ -1120,6 +1730,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:
+            @"<%@: lockOperationType:%@; operationSource:%@; userIndex:%@; fabricIndex:%@; sourceNode:%@; credentials:%@; >",
+        NSStringFromClass([self class]), _lockOperationType, _operationSource, _userIndex, _fabricIndex, _sourceNode, _credentials];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPDoorLockClusterLockOperationErrorEvent
@@ -1143,6 +1763,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: lockOperationType:%@; operationSource:%@; operationError:%@; "
+                                                              @"userIndex:%@; fabricIndex:%@; sourceNode:%@; credentials:%@; >",
+                                             NSStringFromClass([self class]), _lockOperationType, _operationSource, _operationError,
+                                             _userIndex, _fabricIndex, _sourceNode, _credentials];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPDoorLockClusterLockUserChangeEvent
@@ -1166,6 +1796,16 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: lockDataType:%@; dataOperationType:%@; operationSource:%@; "
+                                                              @"userIndex:%@; fabricIndex:%@; sourceNode:%@; dataIndex:%@; >",
+                                             NSStringFromClass([self class]), _lockDataType, _dataOperationType, _operationSource,
+                                             _userIndex, _fabricIndex, _sourceNode, _dataIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterSupplyVoltageLowEvent
@@ -1175,6 +1815,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterSupplyVoltageHighEvent
@@ -1184,6 +1831,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterPowerMissingPhaseEvent
@@ -1193,6 +1847,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterSystemPressureLowEvent
@@ -1202,6 +1863,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterSystemPressureHighEvent
@@ -1211,6 +1879,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterDryRunningEvent
@@ -1220,6 +1895,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterMotorTemperatureHighEvent
@@ -1229,6 +1911,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent
@@ -1238,6 +1927,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterElectronicTemperatureHighEvent
@@ -1247,6 +1943,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterPumpBlockedEvent
@@ -1256,6 +1959,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterSensorFailureEvent
@@ -1265,6 +1975,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent
@@ -1274,6 +1991,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterElectronicFatalFailureEvent
@@ -1283,6 +2007,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterGeneralFaultEvent
@@ -1292,6 +2023,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterLeakageEvent
@@ -1301,6 +2039,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterAirDetectionEvent
@@ -1310,6 +2055,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPPumpConfigurationAndControlClusterTurbineOperationEvent
@@ -1319,6 +2071,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPThermostatClusterThermostatScheduleTransition
@@ -1334,6 +2093,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: transitionTime:%@; heatSetpoint:%@; coolSetpoint:%@; >",
+                                             NSStringFromClass([self class]), _transitionTime, _heatSetpoint, _coolSetpoint];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPIasAceClusterIasAceZoneStatusResult
@@ -1347,6 +2114,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: zoneId:%@; zoneStatus:%@; >", NSStringFromClass([self class]), _zoneId, _zoneStatus];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPChannelClusterChannelInfo
@@ -1366,6 +2141,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: majorNumber:%@; minorNumber:%@; name:%@; callSign:%@; affiliateCallSign:%@; >",
+                  NSStringFromClass([self class]), _majorNumber, _minorNumber, _name, _callSign, _affiliateCallSign];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPChannelClusterLineupInfo
@@ -1383,6 +2167,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: operatorName:%@; lineupName:%@; postalCode:%@; lineupInfoType:%@; >",
+                  NSStringFromClass([self class]), _operatorName, _lineupName, _postalCode, _lineupInfoType];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTargetNavigatorClusterTargetInfo
@@ -1396,6 +2189,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: identifier:%@; name:%@; >", NSStringFromClass([self class]), _identifier, _name];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPMediaPlaybackClusterPlaybackPosition
@@ -1409,6 +2210,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: updatedAt:%@; position:%@; >", NSStringFromClass([self class]), _updatedAt, _position];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPMediaInputClusterInputInfo
@@ -1426,6 +2235,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: index:%@; inputType:%@; name:%@; descriptionString:%@; >",
+                                             NSStringFromClass([self class]), _index, _inputType, _name, _descriptionString];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPContentLauncherClusterDimension
@@ -1441,6 +2258,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: width:%@; height:%@; metric:%@; >", NSStringFromClass([self class]), _width, _height, _metric];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPContentLauncherClusterAdditionalInfo
@@ -1454,6 +2279,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: name:%@; value:%@; >", NSStringFromClass([self class]), _name, _value];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPContentLauncherClusterParameter
@@ -1469,6 +2302,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: type:%@; value:%@; externalIDList:%@; >",
+                                             NSStringFromClass([self class]), _type, _value, _externalIDList];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPContentLauncherClusterContentSearch
@@ -1480,6 +2321,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: parameterList:%@; >", NSStringFromClass([self class]), _parameterList];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPContentLauncherClusterStyleInformation
@@ -1495,6 +2344,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: imageUrl:%@; color:%@; size:%@; >", NSStringFromClass([self class]), _imageUrl, _color, _size];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPContentLauncherClusterBrandingInformation
@@ -1516,6 +2373,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: providerName:%@; background:%@; logo:%@; progressBar:%@; splash:%@; waterMark:%@; >",
+                  NSStringFromClass([self class]), _providerName, _background, _logo, _progressBar, _splash, _waterMark];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPAudioOutputClusterOutputInfo
@@ -1531,6 +2397,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: index:%@; outputType:%@; name:%@; >", NSStringFromClass([self class]), _index, _outputType, _name];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPApplicationLauncherClusterApplication
@@ -1544,6 +2418,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: catalogVendorId:%@; applicationId:%@; >",
+                                             NSStringFromClass([self class]), _catalogVendorId, _applicationId];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPApplicationLauncherClusterApplicationEP
@@ -1557,6 +2439,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: application:%@; endpoint:%@; >", NSStringFromClass([self class]), _application, _endpoint];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPApplicationBasicClusterApplicationBasicApplication
@@ -1570,6 +2460,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: catalogVendorId:%@; applicationId:%@; >",
+                                             NSStringFromClass([self class]), _catalogVendorId, _applicationId];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterSimpleStruct
@@ -1595,6 +2493,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: a:%@; b:%@; c:%@; d:%@; e:%@; f:%@; g:%@; h:%@; >", NSStringFromClass([self class]), _a,
+                  _b, _c, [_d base64EncodedStringWithOptions:0], _e, _f, _g, _h];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterTestFabricScoped
@@ -1620,6 +2527,19 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: fabricSensitiveInt8u:%@; optionalFabricSensitiveInt8u:%@; nullableFabricSensitiveInt8u:%@; "
+                         @"nullableOptionalFabricSensitiveInt8u:%@; fabricSensitiveCharString:%@; fabricSensitiveStruct:%@; "
+                         @"fabricSensitiveInt8uList:%@; fabricIndex:%@; >",
+        NSStringFromClass([self class]), _fabricSensitiveInt8u, _optionalFabricSensitiveInt8u, _nullableFabricSensitiveInt8u,
+        _nullableOptionalFabricSensitiveInt8u, _fabricSensitiveCharString, _fabricSensitiveStruct, _fabricSensitiveInt8uList,
+        _fabricIndex];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterNullablesAndOptionalsStruct
@@ -1653,6 +2573,19 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: nullableInt:%@; optionalInt:%@; nullableOptionalInt:%@; nullableString:%@; "
+                                   @"optionalString:%@; nullableOptionalString:%@; nullableStruct:%@; optionalStruct:%@; "
+                                   @"nullableOptionalStruct:%@; nullableList:%@; optionalList:%@; nullableOptionalList:%@; >",
+                  NSStringFromClass([self class]), _nullableInt, _optionalInt, _nullableOptionalInt, _nullableString,
+                  _optionalString, _nullableOptionalString, _nullableStruct, _optionalStruct, _nullableOptionalStruct,
+                  _nullableList, _optionalList, _nullableOptionalList];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterNestedStruct
@@ -1668,6 +2601,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: a:%@; b:%@; c:%@; >", NSStringFromClass([self class]), _a, _b, _c];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterNestedStructList
@@ -1691,6 +2632,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: a:%@; b:%@; c:%@; d:%@; e:%@; f:%@; g:%@; >",
+                                             NSStringFromClass([self class]), _a, _b, _c, _d, _e, _f, _g];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterDoubleNestedStructList
@@ -1702,6 +2651,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: a:%@; >", NSStringFromClass([self class]), _a];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterTestListStructOctet
@@ -1715,6 +2671,15 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: fabricIndex:%@; operationalCert:%@; >", NSStringFromClass([self class]), _fabricIndex,
+                  [_operationalCert base64EncodedStringWithOptions:0]];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterTestEventEvent
@@ -1736,6 +2701,14 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; arg3:%@; arg4:%@; arg5:%@; arg6:%@; >",
+                                             NSStringFromClass([self class]), _arg1, _arg2, _arg3, _arg4, _arg5, _arg6];
+    return descriptionString;
+}
+
 @end
 
 @implementation CHIPTestClusterClusterTestFabricScopedEventEvent
@@ -1747,6 +2720,13 @@ NS_ASSUME_NONNULL_BEGIN
     }
     return self;
 }
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    return descriptionString;
+}
+
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
#### Problem
When logging a structure class, it does not log any of the attributes. This makes it difficult to validate responses using darwin-framework-tool.
- Fixes #18634 
- Fixes #16148 

#### Change overview
- Updated ZAP files that create the structure classes to include a description function. 
- Update darwin-framework-tool to iterated and log 

#### Testing
- Validated that the darwin-framework-tool display values in classes, even within a list. 
