### PR TITLE
[OTA] Only supply DelayActionTime field for busy status response

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -296,9 +296,14 @@ void OTAProviderExample::SendQueryImageResponse(app::CommandHandler * commandObj
         }
     }
 
+    // Delay action time is only applicable when the provider is busy
+    if (mQueryImageStatus == OTAQueryStatus::kBusy)
+    {
+        response.delayedActionTime.Emplace(mDelayedQueryActionTimeSec);
+    }
+
     // Set remaining fields common to all status types
     response.status = mQueryImageStatus;
-    response.delayedActionTime.Emplace(mDelayedQueryActionTimeSec);
     if (mUserConsentNeeded && requestorCanConsent)
     {
         response.userConsentNeeded.Emplace(true);


### PR DESCRIPTION
#### Problem
Per spec change at https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/5248, the language clearly states:

```
The `DelayedActionTime` field SHALL only be present if the `Status` field is set to Busy.
```

#### Change overview
Only include `DelayedActionTime` field when status is busy

#### Testing
- When status is `Available`, there is no `DelayedActionTime` included
- When status is `NotAvailable`, there is no `DelayedActionTime` included
- When status is `Busy`, `DelayedActionTime` is included