### PR TITLE
Set the initial lock state to null

### DIFF
--- a/examples/lock-app/linux/include/LockEndpoint.h
+++ b/examples/lock-app/linux/include/LockEndpoint.h
@@ -57,6 +57,8 @@ public:
         {
             lockUser.credentials.reserve(numberOfCredentialsPerUser);
         }
+
+        DoorLockServer::Instance().SetLockState(endpointId, mLockState);
     }
 
     inline chip::EndpointId GetEndpointId() const { return mEndpointId; }

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -72,13 +72,22 @@ void DoorLockServer::InitServer(chip::EndpointId endpointId)
 {
     emberAfDoorLockClusterPrintln("Door Lock cluster initialized at endpoint #%u", endpointId);
 
-    SetLockState(endpointId, DlLockState::kLocked, DlOperationSource::kUnspecified);
+    auto status = Attributes::LockState::SetNull(endpointId);
+    if (EMBER_ZCL_STATUS_SUCCESS != status)
+    {
+        ChipLogError(Zcl, "[InitDoorLockServer] Unable to set the Lock State attribute to null [status=%d]", status);
+    }
     SetActuatorEnabled(endpointId, true);
+}
+
+bool DoorLockServer::SetLockState(chip::EndpointId endpointId, DlLockState newLockState)
+{
+    return SetAttribute(endpointId, Attributes::LockState::Id, Attributes::LockState::Set, newLockState);
 }
 
 bool DoorLockServer::SetLockState(chip::EndpointId endpointId, DlLockState newLockState, DlOperationSource opSource)
 {
-    bool success = SetAttribute(endpointId, Attributes::LockState::Id, Attributes::LockState::Set, newLockState);
+    bool success = SetLockState(endpointId, newLockState);
 
     // Remote operations are handled separately as they use more data unavailable here
     VerifyOrReturnError(DlOperationSource::kRemote != opSource, success);

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -74,7 +74,30 @@ public:
 
     void InitServer(chip::EndpointId endpointId);
 
+    /**
+     * Updates the LockState attribute with new value and sends LockOperation event.
+     *
+     * @note Does not send an event of opSource is kRemote.
+     *
+     * @param endpointId ID of the endpoint to the lock state
+     * @param newLockState new lock state
+     * @param opSource source of the operation (will be used in the event).
+     *
+     * @return true on success, false on failure.
+     */
     bool SetLockState(chip::EndpointId endpointId, DlLockState newLockState, DlOperationSource opSource);
+
+    /**
+     * Updates the LockState attribute with new value.
+     *
+     * @note Does not generate Lock Operation event
+     *
+     * @param endpointId ID of the endpoint to the lock state
+     * @param newLockState new lock state
+     *
+     * @return true on success, false on failure.
+     */
+    bool SetLockState(chip::EndpointId endpointId, DlLockState newLockState);
     bool SetActuatorEnabled(chip::EndpointId endpointId, bool newActuatorState);
     bool SetDoorState(chip::EndpointId endpointId, DlDoorState newDoorState);
 
@@ -112,9 +135,6 @@ public:
 
     void ClearCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                        const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData);
-
-    void LockUnlockDoorCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                      DlLockOperationType operationType, const chip::Optional<chip::ByteSpan> & pinCode);
 
     void SetWeekDayScheduleCommandHandler(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,


### PR DESCRIPTION
#### Problem
* Fixes #18677 when door lock's lock state was set to the "locked" even though its actual state was unknown

#### Change overview
- Set the actual lock state from the app without event generation

#### Testing
* Used chip-tool to verify that there's no events at app startup (lock-app).

