### PR TITLE
CASE resumption storage: fix remaining erroneous logging

### DIFF
--- a/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
@@ -80,7 +80,7 @@ CHIP_ERROR DefaultSessionResumptionStorage::Delete(const ScopedNodeId & node)
     if (err == CHIP_NO_ERROR)
     {
         err = DeleteLink(resumptionId);
-        if (err != CHIP_NO_ERROR)
+        if (err != CHIP_NO_ERROR && err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
         {
             ChipLogError(SecureChannel,
                          "Unable to delete session resumption link for node " ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,


### PR DESCRIPTION
#### Problem
There was a third case of erroneous logging that was not caught with previous fixes which now popped up with multi admin testing. Same scenario: trying to delete something that by default does not exist and logging it as an error. Most prominent on Darwin because there all error messages show up in bold red color.

#### Change overview
Do not output error log message for normal expected condition.

#### Testing
How was this tested? (at least one bullet point required)
* tested manually using chip-tool. Logging fix, does not affect functionality.
