### PR TITLE
MessageDef: enforce format for PrettyPrintIM and fix usage of subscriptionId after size change

### DIFF
--- a/examples/chip-tool/commands/clusters/SubscriptionsCommands.h
+++ b/examples/chip-tool/commands/clusters/SubscriptionsCommands.h
@@ -23,7 +23,7 @@ class ShutdownSubscription : public CHIPCommand
 public:
     ShutdownSubscription(CredentialIssuerCommands * credsIssuerConfig) : CHIPCommand("shutdown-subscription", credsIssuerConfig)
     {
-        AddArgument("subscription-id", 0, UINT64_MAX, &mSubscriptionId);
+        AddArgument("subscription-id", 0, UINT32_MAX, &mSubscriptionId);
     }
 
     /////////// CHIPCommand Interface /////////

--- a/examples/tv-casting-app/tv-casting-common/commands/clusters/SubscriptionsCommands.h
+++ b/examples/tv-casting-app/tv-casting-common/commands/clusters/SubscriptionsCommands.h
@@ -26,7 +26,7 @@ class ShutdownSubscription : public CHIPCommand
 public:
     ShutdownSubscription(CredentialIssuerCommands * credsIssuerConfig) : CHIPCommand("shutdown-subscription", credsIssuerConfig)
     {
-        AddArgument("subscription-id", 0, UINT64_MAX, &mSubscriptionId);
+        AddArgument("subscription-id", 0, UINT32_MAX, &mSubscriptionId);
     }
 
     /////////// CHIPCommand Interface /////////

--- a/src/app/MessageDef/MessageDefHelper.h
+++ b/src/app/MessageDef/MessageDefHelper.h
@@ -29,11 +29,12 @@
 #include <stdio.h>
 
 #include <app/AppBuildConfig.h>
+#include <lib/support/EnforceFormat.h>
 
 namespace chip {
 namespace app {
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK && CHIP_DETAIL_LOGGING
-void PrettyPrintIM(bool aIsNewLine, const char * aFmt, ...);
+void PrettyPrintIM(bool aIsNewLine, const char * aFmt, ...) ENFORCE_FORMAT(2, 3);
 void IncreaseDepth();
 void DecreaseDepth();
 #define PRETTY_PRINT(fmt, ...)                                                                                                     \

--- a/src/app/MessageDef/ReportDataMessage.cpp
+++ b/src/app/MessageDef/ReportDataMessage.cpp
@@ -79,7 +79,7 @@ CHIP_ERROR ReportDataMessage::Parser::CheckSchemaValidity() const
             {
                 SubscriptionId subscriptionId;
                 ReturnErrorOnFailure(reader.Get(subscriptionId));
-                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx64 ",", subscriptionId);
+                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx32 ",", subscriptionId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;

--- a/src/app/MessageDef/SubscribeResponseMessage.cpp
+++ b/src/app/MessageDef/SubscribeResponseMessage.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
             {
                 SubscriptionId subscriptionId;
                 ReturnErrorOnFailure(reader.Get(subscriptionId));
-                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx64 ",", subscriptionId);
+                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx32 ",", subscriptionId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;


### PR DESCRIPTION
#### Problem
* There is no format checking in PRETTY_PRINT causing format errors to be undetected
* Fixes #18922

#### Change overview
* Add format checking to PRETTY_PRINT
* Fix the previously undetected errors
* Fix usage of subscriptionId after size change

#### Testing
How was this tested? (at least one bullet point required)
* Fix build errors after enforcing format
* Verified that chip-tool subscriptions shutdown-subscription no longer accepts out of range values
