### PR TITLE
Implement GetClock_RealTimeMS using GetClock_RealTime

### DIFF
--- a/src/platform/Ameba/SystemTimeSupport.cpp
+++ b/src/platform/Ameba/SystemTimeSupport.cpp
@@ -75,33 +75,20 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & curTime)
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    curTime = Clock::Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
+    curTime = Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
 
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & curTime)
+CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)
 {
-    time_t seconds;
-    struct rtkTimeVal tv;
-
-    seconds = rtc_read();
-
-    tv.tv_sec  = (uint32_t) seconds;
-    tv.tv_usec = 0;
-
-    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    curTime =
-        Clock::Milliseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000)) + (static_cast<uint64_t>(tv.tv_usec) / 1000));
-
-    return CHIP_NO_ERROR;
+    Microseconds64 curTimeUs;
+    auto err = GetClock_RealTime(curTimeUs);
+    aCurTime = std::chrono::duration_cast<Milliseconds64>(curTimeUs);
+    return err;
 }
 
-CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
+CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
 {
     struct rtkTimeVal tv;
     tv.tv_sec  = static_cast<uint32_t>(aNewCurTime.count() / UINT64_C(1000000));

--- a/src/platform/Darwin/SystemTimeSupport.cpp
+++ b/src/platform/Darwin/SystemTimeSupport.cpp
@@ -51,7 +51,7 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
     return std::chrono::duration_cast<Milliseconds64>(std::chrono::steady_clock::now().time_since_epoch());
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
 {
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
@@ -67,32 +67,19 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    aCurTime = Clock::Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
+    aCurTime = Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)
 {
-    struct timeval tv;
-    if (gettimeofday(&tv, nullptr) != 0)
-    {
-        return CHIP_ERROR_POSIX(errno);
-    }
-    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    if (tv.tv_usec < 0)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    aCurTime =
-        Clock::Milliseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000)) + (static_cast<uint64_t>(tv.tv_usec) / 1000));
-    return CHIP_NO_ERROR;
+    Microseconds64 curTimeUs;
+    auto err = GetClock_RealTime(curTimeUs);
+    aCurTime = std::chrono::duration_cast<Milliseconds64>(curTimeUs);
+    return err;
 }
 
-CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
+CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
 {
     struct timeval tv;
     tv.tv_sec  = static_cast<time_t>(aNewCurTime.count() / UINT64_C(1000000));

--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -48,7 +48,7 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
     return std::chrono::duration_cast<Milliseconds64>(GetMonotonicMicroseconds64());
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
 {
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
@@ -64,32 +64,19 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    aCurTime = Clock::Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
+    aCurTime = Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)
 {
-    struct timeval tv;
-    if (gettimeofday(&tv, nullptr) != 0)
-    {
-        return CHIP_ERROR_POSIX(errno);
-    }
-    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    if (tv.tv_usec < 0)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    aCurTime =
-        Clock::Milliseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000)) + (static_cast<uint64_t>(tv.tv_usec) / 1000));
-    return CHIP_NO_ERROR;
+    Microseconds64 curTimeUs;
+    auto err = GetClock_RealTime(curTimeUs);
+    aCurTime = std::chrono::duration_cast<Milliseconds64>(curTimeUs);
+    return err;
 }
 
-CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
+CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
 {
     struct timeval tv;
     tv.tv_sec  = static_cast<time_t>(aNewCurTime.count() / UINT64_C(1000000));

--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -50,7 +50,7 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
     return std::chrono::duration_cast<Milliseconds64>(std::chrono::steady_clock::now().time_since_epoch());
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
 {
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
@@ -66,22 +66,19 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    aCurTime = Clock::Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
+    aCurTime = Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)
 {
-    Clock::Microseconds64 curTimeUs;
-    CHIP_ERROR err = GetClock_RealTime(curTimeUs);
-    if (err == CHIP_NO_ERROR)
-    {
-        aCurTime = std::chrono::duration_cast<Clock::Milliseconds64>(curTimeUs);
-    }
+    Microseconds64 curTimeUs;
+    auto err = GetClock_RealTime(curTimeUs);
+    aCurTime = std::chrono::duration_cast<Milliseconds64>(curTimeUs);
     return err;
 }
 
-CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
+CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
 {
     struct timeval tv;
     tv.tv_sec  = static_cast<time_t>(aNewCurTime.count() / UINT64_C(1000000));

--- a/src/platform/Tizen/SystemTimeSupport.cpp
+++ b/src/platform/Tizen/SystemTimeSupport.cpp
@@ -73,12 +73,9 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
 {
-    Clock::Microseconds64 curTimeUs;
-    CHIP_ERROR err = GetClock_RealTime(curTimeUs);
-    if (err == CHIP_NO_ERROR)
-    {
-        aCurTime = std::chrono::duration_cast<Clock::Milliseconds64>(curTimeUs);
-    }
+    Microseconds64 curTimeUs;
+    auto err = GetClock_RealTime(curTimeUs);
+    aCurTime = std::chrono::duration_cast<Milliseconds64>(curTimeUs);
     return err;
 }
 

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -71,7 +71,7 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
     return std::chrono::duration_cast<Milliseconds64>(GetMonotonicMicroseconds64());
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
 {
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
@@ -87,32 +87,19 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    aCurTime = Clock::Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
+    aCurTime = Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)
+CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)
 {
-    struct timeval tv;
-    if (gettimeofday(&tv, nullptr) != 0)
-    {
-        return CHIP_ERROR_INTERNAL;
-    }
-    if (tv.tv_sec < CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    if (tv.tv_usec < 0)
-    {
-        return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
-    }
-    static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
-    aCurTime =
-        Clock::Milliseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000)) + (static_cast<uint64_t>(tv.tv_usec) / 1000));
-    return CHIP_NO_ERROR;
+    Microseconds64 curTimeUs;
+    auto err = GetClock_RealTime(curTimeUs);
+    aCurTime = std::chrono::duration_cast<Milliseconds64>(curTimeUs);
+    return err;
 }
 
-CHIP_ERROR ClockImpl::SetClock_RealTime(Clock::Microseconds64 aNewCurTime)
+CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
 {
     struct timeval tv;
     tv.tv_sec  = static_cast<time_t>(aNewCurTime.count() / UINT64_C(1000000));


### PR DESCRIPTION
#### Problem

In all cases the millisecond version of "get-real-time" function can be implemented with the microsecond version. This PR eliminates code redundancy.

#### Change overview

- implement GetClock_RealTimeMS using GetClock_RealTime
- remove unnecessary `Clock::` namespace (the code is already in the Clock namespace block)

#### Testing

CI should test that.