### PR TITLE
[Tizen] vscode and development container fix

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,6 +77,8 @@ RUN chown -R $USERNAME:$USERNAME /opt/fsl-imx-xwayland/5.10-hardknott/
 
 # Add access to openocd for VSCode debugging
 RUN chown -R $USERNAME:$USERNAME /opt/openocd
+
+# Fix Tizen SDK paths for new user
 RUN sed -i '/^TIZEN_SDK_DATA_PATH/d' $TIZEN_SDK_ROOT/sdk.info \
     && echo TIZEN_SDK_DATA_PATH=/home/$USERNAME/tizen-sdk-data >> $TIZEN_SDK_ROOT/sdk.info \
     && ln -sf /home/$USERNAME/.tizen-cli-config $TIZEN_SDK_ROOT/tools/.tizen-cli-config \
@@ -85,6 +87,7 @@ RUN sed -i '/^TIZEN_SDK_DATA_PATH/d' $TIZEN_SDK_ROOT/sdk.info \
 USER $USERNAME
 WORKDIR /home/$USERNAME
 
+# Setup tizen studio CLI
 RUN set -x \
     # Generate authr certificate
     && $TIZEN_SDK_ROOT/tools/ide/bin/tizen certificate --alias=CHIP --name=CHIP --email=chip@tizen.org --password=chiptizen \

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -77,3 +77,18 @@ RUN chown -R $USERNAME:$USERNAME /opt/fsl-imx-xwayland/5.10-hardknott/
 
 # Add access to openocd for VSCode debugging
 RUN chown -R $USERNAME:$USERNAME /opt/openocd
+RUN sed -i '/^TIZEN_SDK_DATA_PATH/d' $TIZEN_SDK_ROOT/sdk.info \
+    && echo TIZEN_SDK_DATA_PATH=/home/$USERNAME/tizen-sdk-data >> $TIZEN_SDK_ROOT/sdk.info \
+    && ln -sf /home/$USERNAME/.tizen-cli-config $TIZEN_SDK_ROOT/tools/.tizen-cli-config \
+    && : # last line
+
+USER $USERNAME
+WORKDIR /home/$USERNAME
+
+RUN set -x \
+    # Generate authr certificate
+    && $TIZEN_SDK_ROOT/tools/ide/bin/tizen certificate --alias=CHIP --name=CHIP --email=chip@tizen.org --password=chiptizen \
+    # Add new security profile
+    && $TIZEN_SDK_ROOT/tools/ide/bin/tizen security-profiles add --active --name=CHIP --author=$HOME/tizen-sdk-data/keystore/author/author.p12 --password=chiptizen \
+    # Cleanup
+    && : # last line

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -83,15 +83,3 @@ RUN sed -i '/^TIZEN_SDK_DATA_PATH/d' $TIZEN_SDK_ROOT/sdk.info \
     && echo TIZEN_SDK_DATA_PATH=/home/$USERNAME/tizen-sdk-data >> $TIZEN_SDK_ROOT/sdk.info \
     && ln -sf /home/$USERNAME/.tizen-cli-config $TIZEN_SDK_ROOT/tools/.tizen-cli-config \
     && : # last line
-
-USER $USERNAME
-WORKDIR /home/$USERNAME
-
-# Setup tizen studio CLI
-RUN set -x \
-    # Generate authr certificate
-    && $TIZEN_SDK_ROOT/tools/ide/bin/tizen certificate --alias=CHIP --name=CHIP --email=chip@tizen.org --password=chiptizen \
-    # Add new security profile
-    && $TIZEN_SDK_ROOT/tools/ide/bin/tizen security-profiles add --active --name=CHIP --author=$HOME/tizen-sdk-data/keystore/author/author.p12 --password=chiptizen \
-    # Cleanup
-    && : # last line

--- a/examples/lighting-app/tizen/README.md
+++ b/examples/lighting-app/tizen/README.md
@@ -1,5 +1,48 @@
 # CHIP Tizen Lighting Example
 
+## Building binary
+
+Activating environment
+
+```sh
+source ./scripts/activate.sh
+```
+
+Generating tizen-arm-light
+
+```sh
+gn gen --check \
+	--fail-on-unused-args \
+	--export-compile-commands \
+	--root=$PW_PROJECT_ROOT/examples/lighting-app/tizen \
+	"--args=target_os=\"tizen\" target_cpu=\"arm\" tizen_sdk_root=\"$TIZEN_SDK_ROOT\" sysroot=\"$TIZEN_SDK_SYSROOT\"" \
+	$PW_PROJECT_ROOT/out/tizen-arm-light
+```
+
+Building tizen-arm-light
+
+```sh
+ninja -C $PW_PROJECT_ROOT/out/tizen-arm-light
+```
+
+## Preparing Tizen SDK certificate
+
+For packaging the Tizen APP, there is a need to generate an author certificate
+and security profile using the commands described below. Change password and
+author data as needed.
+
+```sh
+tizen certificate --alias=CHIP --name=CHIP --email=chip@tizen.org --password=chiptizen
+
+tizen security-profiles add --active --name=CHIP --author=$HOME/tizen-sdk-data/keystore/author/author.p12 --password=chiptizen
+```
+
+## Packaging APP
+
+```sh
+ninja -C $PW_PROJECT_ROOT/out/tizen-arm-light chip-lighting-app:tpk
+```
+
 ## Installing TPK
 
 Upload TPK package to device under test (DUT). Install it with `pkgcmd` as

--- a/examples/lighting-app/tizen/README.md
+++ b/examples/lighting-app/tizen/README.md
@@ -32,9 +32,41 @@ and security profile using the commands described below. Change password and
 author data as needed.
 
 ```sh
-tizen certificate --alias=CHIP --name=CHIP --email=chip@tizen.org --password=chiptizen
+$TIZEN_SDK_ROOT/tools/ide/bin/tizen certificate \
+	--alias=CHIP \
+	--name=CHIP \
+	--email=chip@tizen.org \
+	--password=chiptizen
 
-tizen security-profiles add --active --name=CHIP --author=$HOME/tizen-sdk-data/keystore/author/author.p12 --password=chiptizen
+$TIZEN_SDK_ROOT/tools/ide/bin/tizen security-profiles add \
+	--active \
+	--name=CHIP \
+	--author=$HOME/tizen-sdk-data/keystore/author/author.p12 \
+	--password=chiptizen
+```
+
+This is only _one-time action_. To regenerate the author certificate and
+security profile, you have to remove files from the `$HOME` directory using
+specified commands:
+
+```sh
+rm -r \
+	$HOME/tizen-sdk-data \
+	$HOME/.tizen-cli-config \
+	$HOME/.secretsdb
+```
+
+After that, normally call scripts to generate the author certificate and
+security profile mentioned previously.
+
+### Important
+
+Regenerating the author certificate and security profile makes it necessary to
+remove the previously installed Tizen app. You can't reinstall an application on
+the Tizen device with a different certificate.
+
+```sh
+pkgcmd -u -n org.tizen.matter.example.lighting
 ```
 
 ## Packaging APP

--- a/integrations/docker/images/chip-build-tizen/Dockerfile
+++ b/integrations/docker/images/chip-build-tizen/Dockerfile
@@ -147,13 +147,3 @@ RUN set -x \
 # Switch to the non-root user
 USER $USER_NAME
 WORKDIR $USER_HOME
-
-# ------------------------------------------------------------------------------
-# Setup tizen studio CLI
-RUN set -x \
-    # Generate author certificate
-    && tizen certificate --alias=CHIP --name=CHIP --email=chip@tizen.org --password=chiptizen \
-    # Add new security profile
-    && tizen security-profiles add --active --name=CHIP --author=$HOME/tizen-sdk-data/keystore/author/author.p12 --password=chiptizen \
-    # Cleanup
-    && : # last line

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -75,8 +75,9 @@ ENV SYSROOT_AARCH64=/opt/ubuntu-21.04-aarch64-sysroot
 ENV TELINK_ZEPHYR_BASE=/opt/telink/zephyrproject/zephyr
 ENV TELINK_ZEPHYR_SDK_DIR=/opt/telink/zephyr-sdk-0.13.2
 ENV TI_SYSCONFIG_ROOT=/opt/ti/sysconfig_1.11.0
-ENV TIZEN_SDK_ROOT /opt/tizen-sdk
-ENV TIZEN_SDK_SYSROOT $TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core
-ENV TIZEN_VERSION 6.0
 ENV ZEPHYR_BASE=/opt/NordicSemiconductor/nrfconnect/zephyr
 ENV ZEPHYR_TOOLCHAIN_VARIANT=gnuarmemb
+
+ENV TIZEN_VERSION 6.0
+ENV TIZEN_SDK_ROOT /opt/tizen-sdk
+ENV TIZEN_SDK_SYSROOT $TIZEN_SDK_ROOT/platforms/tizen-$TIZEN_VERSION/mobile/rootstraps/mobile-$TIZEN_VERSION-device.core

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -57,6 +57,7 @@ RUN set -x \
     && chmod -R a+w /opt/android/sdk/licenses \
     && : # last line
 
+# Required for the Tizen SDK
 RUN set -x \
     && apt-get update \
     && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -57,6 +57,14 @@ RUN set -x \
     && chmod -R a+w /opt/android/sdk/licenses \
     && : # last line
 
+RUN set -x \
+    && apt-get update \
+    && DEBIAN_FRONTEND=noninteractive apt-get install -fy --no-install-recommends \
+    zip \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
+    && : # last line
+
 ENV AMEBA_PATH=/opt/ameba/ambd_sdk_with_chip_non_NDA
 ENV ANDROID_HOME=/opt/android/sdk
 ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r21b

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.77 Version bump reason: Update nRF Connect SDK version.
+0.5.78 Version bump reason: [Tizen] Fix environment variable order, add missing tizen dependencies


### PR DESCRIPTION
#### Problem
The vscode container has the wrong order of environment variables and not all of them are created correctly. Certificates are generated with a hardcoded password.
The Tizen SDK has the wrong configuration in the devcontainer image. 

#### Change overview

* set environment variable in vscode docker image in proper order
* add missing zip dependencies for Tizen SDK
* set the proper HOME directory in Tizen SDK configuration 
* describe a way to generate certificates for packaging the Tizen app

#### Testing
Build chip-build-vscode image
``` bash
./integrations/docker/images/chip-build-vscode/build.sh
```
