### PR TITLE
Correct default featuremap value in tv-apps target navigator cluster

### DIFF
--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -2344,7 +2344,7 @@ endpoint 1 {
   server cluster TargetNavigator {
     callback attribute targetList;
     ram      attribute currentTarget;
-    ram      attribute featureMap default = 0x0001;
+    ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }
 

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -8329,7 +8329,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "0x0001",
+              "defaultValue": "0",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/zzz_generated/tv-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-app/zap-generated/endpoint_config.h
@@ -524,7 +524,7 @@
             /* Endpoint: 1, Cluster: Target Navigator (server) */                                                                  \
             { 0x00000000, ZAP_TYPE(ARRAY), 0, ZAP_ATTRIBUTE_MASK(EXTERNAL_STORAGE), ZAP_EMPTY_DEFAULT() }, /* TargetList */        \
             { 0x00000001, ZAP_TYPE(INT8U), 1, 0, ZAP_SIMPLE_DEFAULT(0) },                                  /* CurrentTarget */     \
-            { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(0x0001) },                          /* FeatureMap */        \
+            { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(0) },                               /* FeatureMap */        \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(1) },                                 /* ClusterRevision */   \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Media Playback (server) */                                                                    \


### PR DESCRIPTION
#### Problem
* Fixes https://github.com/project-chip/connectedhomeip/issues/18934 

#### Change overview
Correct default featuremap value in tv-apps target navigator cluster to 0.

#### Testing
* Using linux tv-app confirmed response to `./chip-tool targetnavigator read feature-map 1 1` was 0 instead of 1.
