### PR TITLE
Fix the move-to-level max level value accepted by the command handler

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -522,7 +522,7 @@ static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId
 
     if (level > EMBER_AF_PLUGIN_LEVEL_CONTROL_MAXIMUM_LEVEL)
     {
-        return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
+        return EMBER_ZCL_STATUS_INVALID_COMMAND;
     }
 
     if (!shouldExecuteIfOff(endpoint, commandId, optionMask, optionOverride))

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -520,6 +520,11 @@ static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
+    if (level > EMBER_AF_PLUGIN_LEVEL_CONTROL_MAXIMUM_LEVEL)
+    {
+        return EMBER_ZCL_STATUS_MALFORMED_COMMAND;
+    }
+
     if (!shouldExecuteIfOff(endpoint, commandId, optionMask, optionOverride))
     {
         return EMBER_ZCL_STATUS_SUCCESS;


### PR DESCRIPTION
#### Problem
fixes #17380 

#### Change overview
Limit move to level commands to a level value of 254, else error out the command

#### Testing
Build lighting-app on EFR32.
`chip-tool levelcontrol move-to-level 254 100 0xff 0xff 23813 1 ` returns success
`chip-tool levelcontrol move-to-level 254 100 0xff 0xff 23813 1 ` returns `Run command failure: IM Error 0x00000580: General error: 0x80 (INVALID_ACTION)`
`chip-tool levelcontrol move-to-level-with-on-off 254 100 23813 1` returns success
`chip-tool levelcontrol move-to-level-with-on-off 255 100 23813 1` return `Run command failure: IM Error 0x00000580: General error: 0x80 (INVALID_ACTION)`
