### PR TITLE
Fix rpc_console README indentation

### DIFF
--- a/examples/common/pigweed/rpc_console/README.md
+++ b/examples/common/pigweed/rpc_console/README.md
@@ -15,50 +15,50 @@ files required for CHIP.
 
 ## Building
 
-    If this is the first time using the checkout the environment must first be
-    bootstrapped to install all dependencies.
+If this is the first time using the checkout the environment must first be
+bootstrapped to install all dependencies.
 
-        ```
-        $ source <project_root>/scripts/bootstrap.sh
-        ```
+```
+$ source <project_root>/scripts/bootstrap.sh
+```
 
-    If bootstrap has previously been run, then simply activate.
+If bootstrap has previously been run, then simply activate.
 
-        ```
-        $ source <project_root>/scripts/activate.sh
-        ```
+```
+$ source <project_root>/scripts/activate.sh
+```
 
-    The python console is built and installed in the venv using gn:
+The python console is built and installed in the venv using gn:
 
-        ```
-        $ cd <project_root>/examples/common/pigweed/rpc_console
-        $ gn gen out/debug
-        $ ninja -C out/debug
-        ```
+```
+$ cd <project_root>/examples/common/pigweed/rpc_console
+$ gn gen out/debug
+$ ninja -C out/debug
+```
 
-    After building the output directory also contains a folder
-    (chip_rpc_console_wheels), with all the wheels required for the tool. These
-    can be used to install the console without needing the sdk. Simply install
-    all the wheels in the folder:
+After building the output directory also contains a folder
+(chip_rpc_console_wheels), with all the wheels required for the tool. These can
+be used to install the console without needing the sdk. Simply install all the
+wheels in the folder:
 
-        ```
-        $ cd <project_root>/examples/common/pigweed/rpc_console/out/debug
-        $ pip install chip_rpc_console_wheels/*.whl
-        ```
+```
+$ cd <project_root>/examples/common/pigweed/rpc_console/out/debug
+$ pip install chip_rpc_console_wheels/*.whl
+```
 
 ## Running
 
 To start the console provide the path to the device, for example:
 
-    ```
-    $ chip-console --device /dev/ttyUSB0
-    ```
+```
+$ chip-console --device /dev/ttyUSB0
+```
 
 Note that `chip-console` is an entry point for chip_rpc.console and could also
 be run with `python -m chip_rpc.console`.
 
 An example RPC command:
 
-    ```python
-    $ rpcs.chip.rpc.Device.GetDeviceInfo()
-    ```
+```python
+rpcs.chip.rpc.Device.GetDeviceInfo()
+```


### PR DESCRIPTION
#### Problem
The README for rpc_console has incorrect indentation for intended rendering. It looks like this was changed with https://github.com/project-chip/connectedhomeip/pull/17335 in an attempt to affect how code blocks in readmes were parsed.

#### Change overview
Changed indentation in `examples/common/pigweed/rpc_console/README.md`