### PR TITLE
[YAML] Allow hex: prefix for octet strings

### DIFF
--- a/examples/chip-tool/templates/tests/partials/command_value.zapt
+++ b/examples/chip-tool/templates/tests/partials/command_value.zapt
@@ -60,7 +60,11 @@
       {{else if (isCharString type)}}
         chip::Span<const char>("{{definedValue}}garbage: not in length on purpose", {{utf8StringLength definedValue}});
       {{else if (isOctetString type)}}
-        chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral definedValue}}garbage: not in length on purpose"), {{definedValue.length}});
+        {{~#if (isHexString definedValue)}}
+          chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringFromHexString definedValue}}garbage: not in length on purpose"), {{octetStringLengthFromHexString definedValue}});
+        {{else}}
+          chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral definedValue}}garbage: not in length on purpose"), {{definedValue.length}});
+        {{/if}}
       {{else}}
         {{#if_is_strongly_typed_bitmap type}}
           static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>({{asTypedLiteral definedValue type}});

--- a/examples/chip-tool/templates/tests/partials/value_equals.zapt
+++ b/examples/chip-tool/templates/tests/partials/value_equals.zapt
@@ -52,7 +52,12 @@
     VerifyOrReturn(CheckValue{{#if (isString type)}}AsString{{/if}}("{{label}}", {{actual}}, 
       {{~#if (chip_tests_variables_has expected)}}{{expected}}
       {{else if keepAsExpected}}{{expected}}
-      {{else if (isOctetString type)}}chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral expected}}"), {{expected.length}})
+      {{else if (isOctetString type)}}
+        {{~#if (isHexString expected)}}
+          chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringFromHexString expected}}"), {{octetStringLengthFromHexString expected}})
+        {{else}}
+          chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral expected}}"), {{expected.length}})
+        {{/if}}
       {{else if (isCharString type)}}chip::CharSpan("{{expected}}", {{utf8StringLength expected}})
       {{else if (chip_tests_config_has expected)}}m{{asUpperCamelCase expected}}.HasValue() ? m{{asUpperCamelCase expected}}.Value() : {{asTypedLiteral (chip_tests_config_get_default_value expected) (chip_tests_config_get_type expected)}}
       {{else}}{{asTypedExpression expected type}}

--- a/examples/darwin-framework-tool/templates/tests/partials/check_test_value.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/check_test_value.zapt
@@ -38,7 +38,12 @@
   {{else}}
     VerifyOrReturn(CheckValue{{#if (isString type)}}AsString{{/if}}("{{label}}", {{actual}}, 
       {{~#if (chip_tests_variables_has expected)}}{{expected}}
-      {{~else if (isOctetString type)}}[[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral expected}}" length:{{expected.length}}]
+      {{~else if (isOctetString type)}}
+        {{~#if (isHexString expected)}}
+        [[NSData alloc] initWithBytes:"{{octetStringFromHexString expected}}" length:{{octetStringLengthFromHexString expected}}]
+        {{else}}
+        [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral expected}}" length:{{expected.length}}]
+        {{/if}}
       {{~else if (isCharString type)}}@"{{expected}}"
       {{else if (chip_tests_config_has expected)}}m{{asUpperCamelCase expected}}.HasValue() ? m{{asUpperCamelCase expected}}.Value() : {{asTypedLiteral (chip_tests_config_get_default_value expected) (chip_tests_config_get_type expected)}}
       {{~else}}{{asTypedExpressionFromObjectiveC expected type}}

--- a/examples/darwin-framework-tool/templates/tests/partials/test_value.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/test_value.zapt
@@ -46,7 +46,11 @@
       {{#if (isCharString type)}}
         @"{{definedValue}}";
       {{else if (isOctetString type)}}
+        {{~#if (isHexString definedValue)}}
+        [[NSData alloc] initWithBytes:"{{octetStringFromHexString definedValue}}" length:{{octetStringLengthFromHexString definedValue}}];
+        {{else}}
         [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral definedValue}}" length:{{definedValue.length}}];
+        {{/if}}
       {{else}}
         [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{asTypedExpressionFromObjectiveC definedValue type}}];
       {{/if}}

--- a/src/app/tests/suites/TestCluster.yaml
+++ b/src/app/tests/suites/TestCluster.yaml
@@ -727,6 +727,18 @@ tests:
       response:
           value: "Tes\x00ti\x00ng"
 
+    - label: "Write attribute OCTET_STRING with hex: format"
+      command: "writeAttribute"
+      attribute: "octet_string"
+      arguments:
+          value: "hex:000102030405"
+
+    - label: "Read attribute OCTET_STRING with hex: format"
+      command: "readAttribute"
+      attribute: "octet_string"
+      response:
+          value: "hex:000102030405"
+
     - label: "Write attribute OCTET_STRING with weird chars"
       command: "writeAttribute"
       attribute: "octet_string"

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -48,6 +48,8 @@ const kPICSName          = 'PICS';
 const kSaveAsName        = 'saveAs';
 const kFabricFiltered    = 'fabricFiltered';
 
+const kHexPrefix = 'hex:';
+
 class NullObject {
   toString()
   {
@@ -826,6 +828,33 @@ function isLiteralNull(value, options)
   return (value === null) || (value instanceof NullObject);
 }
 
+function isHexString(value)
+{
+  return value && value.startsWith(kHexPrefix);
+}
+
+function octetStringFromHexString(value)
+{
+  const hexString = value.substring(kHexPrefix.length);
+
+  if (hexString.length % 2) {
+    throw new Error("The provided hexadecimal string contains an even number of characters");
+  }
+
+  if (!(/^[0-9a-fA-F]+$/.test(hexString))) {
+    throw new Error("The provided hexadecimal string contains invalid hexadecimal character.");
+  }
+
+  const bytes = hexString.match(/(..)/g);
+  return bytes.map(byte => '\\x' + byte).join('');
+}
+
+function octetStringLengthFromHexString(value)
+{
+  const hexString = value.substring(kHexPrefix.length);
+  return (hexString.length / 2);
+}
+
 function octetStringEscapedForCLiteral(value)
 {
   // Escape control characters, things outside the ASCII range, and single
@@ -996,3 +1025,6 @@ exports.chip_tests_only_cluster_commands            = chip_tests_only_cluster_co
 exports.chip_tests_only_cluster_command_parameters  = chip_tests_only_cluster_command_parameters;
 exports.chip_tests_only_cluster_responses           = chip_tests_only_cluster_responses;
 exports.chip_tests_only_cluster_response_parameters = chip_tests_only_cluster_response_parameters;
+exports.isHexString                                 = isHexString;
+exports.octetStringLengthFromHexString              = octetStringLengthFromHexString;
+exports.octetStringFromHexString                    = octetStringFromHexString;

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -41482,7 +41482,7 @@ private:
 class TestClusterSuite : public TestCommand
 {
 public:
-    TestClusterSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestCluster", 487, credsIssuerConfig)
+    TestClusterSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestCluster", 489, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -42191,7 +42191,7 @@ private:
                 chip::ByteSpan value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueAsString("octetString", value,
-                                                  chip::ByteSpan(chip::Uint8::from_const_char("\015\012\377\042\240"), 5)));
+                                                  chip::ByteSpan(chip::Uint8::from_const_char("\x00\x01\x02\x03\x04\x05"), 6)));
             }
             break;
         case 112:
@@ -42202,12 +42202,12 @@ private:
             {
                 chip::ByteSpan value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(
-                    CheckValueAsString("octetString", value, chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
+                VerifyOrReturn(CheckValueAsString("octetString", value,
+                                                  chip::ByteSpan(chip::Uint8::from_const_char("\015\012\377\042\240"), 5)));
             }
             break;
         case 114:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 115:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -42219,9 +42219,21 @@ private:
             }
             break;
         case 116:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 117:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::ByteSpan value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(
+                    CheckValueAsString("octetString", value, chip::ByteSpan(chip::Uint8::from_const_char("TestValue"), 9)));
+            }
+            break;
+        case 118:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 119:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::ByteSpan value;
@@ -42229,10 +42241,10 @@ private:
                 VerifyOrReturn(CheckValueAsString("longOctetString", value, chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
             }
             break;
-        case 118:
+        case 120:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 119:
+        case 121:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::ByteSpan value;
@@ -42247,17 +42259,6 @@ private:
                         300)));
             }
             break;
-        case 120:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 121:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::CharSpan value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueAsString("charString", value, chip::CharSpan("", 0)));
-            }
-            break;
         case 122:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
@@ -42266,11 +42267,11 @@ private:
             {
                 chip::CharSpan value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueAsString("charString", value, chip::CharSpan("☉T☉", 7)));
+                VerifyOrReturn(CheckValueAsString("charString", value, chip::CharSpan("", 0)));
             }
             break;
         case 124:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 125:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -42281,9 +42282,20 @@ private:
             }
             break;
         case 126:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 127:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::CharSpan value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueAsString("charString", value, chip::CharSpan("☉T☉", 7)));
+            }
+            break;
+        case 128:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 129:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -42291,10 +42303,10 @@ private:
                 VerifyOrReturn(CheckValueAsString("longCharString", value, chip::CharSpan("", 0)));
             }
             break;
-        case 128:
+        case 130:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 129:
+        case 131:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -42308,10 +42320,10 @@ private:
                         900)));
             }
             break;
-        case 130:
+        case 132:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 131:
+        case 133:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<chip::ByteSpan> value;
@@ -42366,10 +42378,10 @@ private:
                 }
             }
             break;
-        case 132:
+        case 134:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 133:
+        case 135:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<chip::ByteSpan> value;
@@ -42435,23 +42447,12 @@ private:
                 }
             }
             break;
-        case 134:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                uint64_t value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("epochUs", value, 0ULL));
-            }
-            break;
-        case 135:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
         case 136:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 uint64_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("epochUs", value, 18446744073709551615ULL));
+                VerifyOrReturn(CheckValue("epochUs", value, 0ULL));
             }
             break;
         case 137:
@@ -42462,26 +42463,26 @@ private:
             {
                 uint64_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("epochUs", value, 0ULL));
+                VerifyOrReturn(CheckValue("epochUs", value, 18446744073709551615ULL));
             }
             break;
         case 139:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                uint32_t value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("epochS", value, 0UL));
-            }
             break;
         case 140:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                uint64_t value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("epochUs", value, 0ULL));
+            }
             break;
         case 141:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 uint32_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("epochS", value, 4294967295UL));
+                VerifyOrReturn(CheckValue("epochS", value, 0UL));
             }
             break;
         case 142:
@@ -42492,10 +42493,21 @@ private:
             {
                 uint32_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("epochS", value, 0UL));
+                VerifyOrReturn(CheckValue("epochS", value, 4294967295UL));
             }
             break;
         case 144:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 145:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                uint32_t value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("epochS", value, 0UL));
+            }
+            break;
+        case 146:
             if (IsUnsupported(status.mStatus))
             {
                 return;
@@ -42507,36 +42519,25 @@ private:
                 VerifyOrReturn(CheckValue("unsupported", value, 0));
             }
             break;
-        case 145:
+        case 147:
             if (IsUnsupported(status.mStatus))
             {
                 return;
             }
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 146:
+        case 148:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT));
             break;
-        case 147:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER));
-            break;
-        case 148:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::VendorId value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("vendorId", value, 0U));
-            }
-            break;
         case 149:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER));
             break;
         case 150:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::VendorId value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("vendorId", value, 17U));
+                VerifyOrReturn(CheckValue("vendorId", value, 0U));
             }
             break;
         case 151:
@@ -42545,27 +42546,22 @@ private:
         case 152:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
+                chip::VendorId value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("vendorId", value, 17U));
+            }
+            break;
+        case 153:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 154:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
                 chip::app::Clusters::TestCluster::Commands::TestEnumsResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("arg1", value.arg1, 20003U));
 
                 VerifyOrReturn(CheckValue("arg2", value.arg2, 101));
-            }
-            break;
-        case 153:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("value", value.value, true));
-            }
-            break;
-        case 154:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("value", value.value, false));
             }
             break;
         case 155:
@@ -42603,6 +42599,22 @@ private:
         case 159:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
+                chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("value", value.value, true));
+            }
+            break;
+        case 160:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("value", value.value, false));
+            }
+            break;
+        case 161:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
                 chip::app::Clusters::TestCluster::Commands::SimpleStructResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("arg1.a", value.arg1.a, 17));
@@ -42616,7 +42628,7 @@ private:
                 VerifyOrReturn(CheckValue("arg1.h", value.arg1.h, 0.1));
             }
             break;
-        case 160:
+        case 162:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
@@ -42624,7 +42636,7 @@ private:
                 VerifyOrReturn(CheckValue("value", value.value, true));
             }
             break;
-        case 161:
+        case 163:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
@@ -42632,7 +42644,7 @@ private:
                 VerifyOrReturn(CheckValue("value", value.value, false));
             }
             break;
-        case 162:
+        case 164:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType value;
@@ -42661,7 +42673,7 @@ private:
                 }
             }
             break;
-        case 163:
+        case 165:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseResponse::DecodableType value;
@@ -42670,22 +42682,6 @@ private:
                     auto iter_0 = value.arg1.begin();
                     VerifyOrReturn(CheckNoMoreListItems<decltype(value.arg1)>("arg1", iter_0, 0));
                 }
-            }
-            break;
-        case 164:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("value", value.value, true));
-            }
-            break;
-        case 165:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("value", value.value, false));
             }
             break;
         case 166:
@@ -42706,8 +42702,24 @@ private:
             break;
         case 168:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("value", value.value, true));
+            }
             break;
         case 169:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::TestCluster::Commands::BooleanResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("value", value.value, false));
+            }
+            break;
+        case 170:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 171:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<uint8_t> value;
@@ -42726,10 +42738,10 @@ private:
                 }
             }
             break;
-        case 170:
+        case 172:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 171:
+        case 173:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<chip::ByteSpan> value;
@@ -42752,10 +42764,10 @@ private:
                 }
             }
             break;
-        case 172:
+        case 174:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 173:
+        case 175:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<chip::app::Clusters::TestCluster::Structs::TestListStructOctet::DecodableType>
@@ -42783,7 +42795,7 @@ private:
                 }
             }
             break;
-        case 174:
+        case 176:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType value;
@@ -42801,7 +42813,7 @@ private:
                 VerifyOrReturn(CheckValue("originalValue.Value().Value()", value.originalValue.Value().Value(), 5));
             }
             break;
-        case 175:
+        case 177:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::TestCluster::Commands::TestNullableOptionalResponse::DecodableType value;
@@ -42809,7 +42821,7 @@ private:
                 VerifyOrReturn(CheckValue("wasPresent", value.wasPresent, false));
             }
             break;
-        case 176:
+        case 178:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<
@@ -42830,10 +42842,10 @@ private:
                 }
             }
             break;
-        case 177:
+        case 179:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 178:
+        case 180:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<
@@ -42867,10 +42879,10 @@ private:
                 }
             }
             break;
-        case 179:
+        case 181:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 180:
+        case 182:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<bool> value;
@@ -42880,10 +42892,10 @@ private:
                 booValueNull = value;
             }
             break;
-        case 181:
+        case 183:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 182:
+        case 184:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<bool> value;
@@ -42892,7 +42904,7 @@ private:
                 VerifyOrReturn(CheckValue("nullableBoolean.Value()", value.Value(), true));
             }
             break;
-        case 183:
+        case 185:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<bool> value;
@@ -42900,10 +42912,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, booValueNull));
             }
             break;
-        case 184:
+        case 186:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 185:
+        case 187:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap8MaskMap>> value;
@@ -42912,10 +42924,10 @@ private:
                 VerifyOrReturn(CheckValue("nullableBitmap8.Value()", value.Value(), 254));
             }
             break;
-        case 186:
+        case 188:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
-        case 187:
+        case 189:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap8MaskMap>> value;
@@ -42926,10 +42938,10 @@ private:
                 nullableValue254 = value;
             }
             break;
-        case 188:
+        case 190:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 189:
+        case 191:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap8MaskMap>> value;
@@ -42937,7 +42949,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableBitmap8", value));
             }
             break;
-        case 190:
+        case 192:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap8MaskMap>> value;
@@ -42945,20 +42957,8 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, nullableValue254));
             }
             break;
-        case 191:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 192:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap16MaskMap>> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableBitmap16", value));
-                VerifyOrReturn(CheckValue("nullableBitmap16.Value()", value.Value(), 65534U));
-            }
-            break;
         case 193:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 194:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -42970,14 +42970,15 @@ private:
             }
             break;
         case 195:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 196:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap16MaskMap>> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableBitmap16", value));
+                VerifyOrReturn(CheckValueNonNull("nullableBitmap16", value));
+                VerifyOrReturn(CheckValue("nullableBitmap16.Value()", value.Value(), 65534U));
             }
             break;
         case 197:
@@ -42986,14 +42987,13 @@ private:
         case 198:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap32MaskMap>> value;
+                chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap16MaskMap>> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableBitmap32", value));
-                VerifyOrReturn(CheckValue("nullableBitmap32.Value()", value.Value(), 4294967294UL));
+                VerifyOrReturn(CheckValueNull("nullableBitmap16", value));
             }
             break;
         case 199:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 200:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43005,14 +43005,15 @@ private:
             }
             break;
         case 201:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 202:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap32MaskMap>> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableBitmap32", value));
+                VerifyOrReturn(CheckValueNonNull("nullableBitmap32", value));
+                VerifyOrReturn(CheckValue("nullableBitmap32.Value()", value.Value(), 4294967294UL));
             }
             break;
         case 203:
@@ -43021,14 +43022,13 @@ private:
         case 204:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap64MaskMap>> value;
+                chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap32MaskMap>> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableBitmap64", value));
-                VerifyOrReturn(CheckValue("nullableBitmap64.Value()", value.Value(), 18446744073709551614ULL));
+                VerifyOrReturn(CheckValueNull("nullableBitmap32", value));
             }
             break;
         case 205:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 206:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43040,14 +43040,15 @@ private:
             }
             break;
         case 207:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 208:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap64MaskMap>> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableBitmap64", value));
+                VerifyOrReturn(CheckValueNonNull("nullableBitmap64", value));
+                VerifyOrReturn(CheckValue("nullableBitmap64.Value()", value.Value(), 18446744073709551614ULL));
             }
             break;
         case 209:
@@ -43056,10 +43057,9 @@ private:
         case 210:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::DataModel::Nullable<uint8_t> value;
+                chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap64MaskMap>> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableInt8u", value));
-                VerifyOrReturn(CheckValue("nullableInt8u.Value()", value.Value(), 0));
+                VerifyOrReturn(CheckValueNull("nullableBitmap64", value));
             }
             break;
         case 211:
@@ -43071,11 +43071,11 @@ private:
                 chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableInt8u", value));
-                VerifyOrReturn(CheckValue("nullableInt8u.Value()", value.Value(), 254));
+                VerifyOrReturn(CheckValue("nullableInt8u.Value()", value.Value(), 0));
             }
             break;
         case 213:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 214:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43087,6 +43087,18 @@ private:
             }
             break;
         case 215:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            break;
+        case 216:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<uint8_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableInt8u", value));
+                VerifyOrReturn(CheckValue("nullableInt8u.Value()", value.Value(), 254));
+            }
+            break;
+        case 217:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
@@ -43094,10 +43106,10 @@ private:
                 VerifyOrReturn(CheckValueNonNull("value", value));
             }
             break;
-        case 216:
+        case 218:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 217:
+        case 219:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
@@ -43105,7 +43117,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableInt8u", value));
             }
             break;
-        case 218:
+        case 220:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
@@ -43114,7 +43126,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 254));
             }
             break;
-        case 219:
+        case 221:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
@@ -43122,10 +43134,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 254));
             }
             break;
-        case 220:
+        case 222:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 221:
+        case 223:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
@@ -43134,24 +43146,12 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 254));
             }
             break;
-        case 222:
+        case 224:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 129));
-            }
-            break;
-        case 223:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 224:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<uint16_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableInt16u", value));
-                VerifyOrReturn(CheckValue("nullableInt16u.Value()", value.Value(), 0U));
             }
             break;
         case 225:
@@ -43163,11 +43163,11 @@ private:
                 chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableInt16u", value));
-                VerifyOrReturn(CheckValue("nullableInt16u.Value()", value.Value(), 65534U));
+                VerifyOrReturn(CheckValue("nullableInt16u.Value()", value.Value(), 0U));
             }
             break;
         case 227:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 228:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43179,9 +43179,21 @@ private:
             }
             break;
         case 229:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 230:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<uint16_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableInt16u", value));
+                VerifyOrReturn(CheckValue("nullableInt16u.Value()", value.Value(), 65534U));
+            }
+            break;
+        case 231:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 232:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint16_t> value;
@@ -43189,7 +43201,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableInt16u", value));
             }
             break;
-        case 231:
+        case 233:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint16_t> value;
@@ -43198,7 +43210,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 65534U));
             }
             break;
-        case 232:
+        case 234:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint16_t> value;
@@ -43206,10 +43218,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 65534U));
             }
             break;
-        case 233:
+        case 235:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 234:
+        case 236:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint16_t> value;
@@ -43218,24 +43230,12 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 65534U));
             }
             break;
-        case 235:
+        case 237:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 32001U));
-            }
-            break;
-        case 236:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 237:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<uint32_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableInt32u", value));
-                VerifyOrReturn(CheckValue("nullableInt32u.Value()", value.Value(), 0UL));
             }
             break;
         case 238:
@@ -43247,11 +43247,11 @@ private:
                 chip::app::DataModel::Nullable<uint32_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableInt32u", value));
-                VerifyOrReturn(CheckValue("nullableInt32u.Value()", value.Value(), 4294967294UL));
+                VerifyOrReturn(CheckValue("nullableInt32u.Value()", value.Value(), 0UL));
             }
             break;
         case 240:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 241:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43263,9 +43263,21 @@ private:
             }
             break;
         case 242:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 243:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<uint32_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableInt32u", value));
+                VerifyOrReturn(CheckValue("nullableInt32u.Value()", value.Value(), 4294967294UL));
+            }
+            break;
+        case 244:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 245:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint32_t> value;
@@ -43273,7 +43285,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableInt32u", value));
             }
             break;
-        case 244:
+        case 246:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint32_t> value;
@@ -43282,7 +43294,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 4294967294UL));
             }
             break;
-        case 245:
+        case 247:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint32_t> value;
@@ -43290,10 +43302,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 4294967294UL));
             }
             break;
-        case 246:
+        case 248:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 247:
+        case 249:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint32_t> value;
@@ -43302,24 +43314,12 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 4294967294UL));
             }
             break;
-        case 248:
+        case 250:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint32_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 2147483648UL));
-            }
-            break;
-        case 249:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 250:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<uint64_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableInt64u", value));
-                VerifyOrReturn(CheckValue("nullableInt64u.Value()", value.Value(), 0ULL));
             }
             break;
         case 251:
@@ -43331,11 +43331,11 @@ private:
                 chip::app::DataModel::Nullable<uint64_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableInt64u", value));
-                VerifyOrReturn(CheckValue("nullableInt64u.Value()", value.Value(), 18446744073709551614ULL));
+                VerifyOrReturn(CheckValue("nullableInt64u.Value()", value.Value(), 0ULL));
             }
             break;
         case 253:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 254:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43347,9 +43347,21 @@ private:
             }
             break;
         case 255:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 256:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<uint64_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableInt64u", value));
+                VerifyOrReturn(CheckValue("nullableInt64u.Value()", value.Value(), 18446744073709551614ULL));
+            }
+            break;
+        case 257:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 258:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint64_t> value;
@@ -43357,7 +43369,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableInt64u", value));
             }
             break;
-        case 257:
+        case 259:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint64_t> value;
@@ -43366,7 +43378,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 18446744073709551614ULL));
             }
             break;
-        case 258:
+        case 260:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint64_t> value;
@@ -43374,10 +43386,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 18446744073709551614ULL));
             }
             break;
-        case 259:
+        case 261:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 260:
+        case 262:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint64_t> value;
@@ -43386,7 +43398,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 18446744073709551614ULL));
             }
             break;
-        case 261:
+        case 263:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint64_t> value;
@@ -43394,20 +43406,8 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 18000000000000000001ULL));
             }
             break;
-        case 262:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 263:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<int8_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableInt8s", value));
-                VerifyOrReturn(CheckValue("nullableInt8s.Value()", value.Value(), -127));
-            }
-            break;
         case 264:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 265:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43419,9 +43419,21 @@ private:
             }
             break;
         case 266:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 267:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<int8_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableInt8s", value));
+                VerifyOrReturn(CheckValue("nullableInt8s.Value()", value.Value(), -127));
+            }
+            break;
+        case 268:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 269:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int8_t> value;
@@ -43429,7 +43441,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableInt8s", value));
             }
             break;
-        case 268:
+        case 270:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int8_t> value;
@@ -43438,7 +43450,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 127));
             }
             break;
-        case 269:
+        case 271:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int8_t> value;
@@ -43446,10 +43458,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, -127));
             }
             break;
-        case 270:
+        case 272:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 271:
+        case 273:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int8_t> value;
@@ -43458,7 +43470,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 127));
             }
             break;
-        case 272:
+        case 274:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int8_t> value;
@@ -43466,20 +43478,8 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, -126));
             }
             break;
-        case 273:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 274:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<int16_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableInt16s", value));
-                VerifyOrReturn(CheckValue("nullableInt16s.Value()", value.Value(), -32767));
-            }
-            break;
         case 275:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 276:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43491,9 +43491,21 @@ private:
             }
             break;
         case 277:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 278:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<int16_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableInt16s", value));
+                VerifyOrReturn(CheckValue("nullableInt16s.Value()", value.Value(), -32767));
+            }
+            break;
+        case 279:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 280:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int16_t> value;
@@ -43501,7 +43513,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableInt16s", value));
             }
             break;
-        case 279:
+        case 281:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int16_t> value;
@@ -43510,7 +43522,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 32767));
             }
             break;
-        case 280:
+        case 282:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int16_t> value;
@@ -43518,10 +43530,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, -32767));
             }
             break;
-        case 281:
+        case 283:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 282:
+        case 284:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int16_t> value;
@@ -43530,7 +43542,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 32767));
             }
             break;
-        case 283:
+        case 285:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int16_t> value;
@@ -43538,20 +43550,8 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, -32766));
             }
             break;
-        case 284:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 285:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<int32_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableInt32s", value));
-                VerifyOrReturn(CheckValue("nullableInt32s.Value()", value.Value(), -2147483647L));
-            }
-            break;
         case 286:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 287:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43563,9 +43563,21 @@ private:
             }
             break;
         case 288:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 289:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<int32_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableInt32s", value));
+                VerifyOrReturn(CheckValue("nullableInt32s.Value()", value.Value(), -2147483647L));
+            }
+            break;
+        case 290:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 291:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int32_t> value;
@@ -43573,7 +43585,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableInt32s", value));
             }
             break;
-        case 290:
+        case 292:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int32_t> value;
@@ -43582,7 +43594,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 2147483647L));
             }
             break;
-        case 291:
+        case 293:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int32_t> value;
@@ -43590,10 +43602,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, -2147483647L));
             }
             break;
-        case 292:
+        case 294:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 293:
+        case 295:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int32_t> value;
@@ -43602,7 +43614,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 2147483647L));
             }
             break;
-        case 294:
+        case 296:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int32_t> value;
@@ -43610,20 +43622,8 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, -2147483646L));
             }
             break;
-        case 295:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 296:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<int64_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableInt64s", value));
-                VerifyOrReturn(CheckValue("nullableInt64s.Value()", value.Value(), -9223372036854775807LL));
-            }
-            break;
         case 297:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 298:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43635,9 +43635,21 @@ private:
             }
             break;
         case 299:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 300:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<int64_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableInt64s", value));
+                VerifyOrReturn(CheckValue("nullableInt64s.Value()", value.Value(), -9223372036854775807LL));
+            }
+            break;
+        case 301:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 302:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int64_t> value;
@@ -43645,7 +43657,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableInt64s", value));
             }
             break;
-        case 301:
+        case 303:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int64_t> value;
@@ -43654,7 +43666,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 9223372036854775807LL));
             }
             break;
-        case 302:
+        case 304:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int64_t> value;
@@ -43662,10 +43674,10 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, -9223372036854775807LL));
             }
             break;
-        case 303:
+        case 305:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 304:
+        case 306:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int64_t> value;
@@ -43674,24 +43686,12 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 9223372036854775807LL));
             }
             break;
-        case 305:
+        case 307:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int64_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckConstraintNotValue("value", value, -9223372036854775806LL));
-            }
-            break;
-        case 306:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 307:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<float> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableFloatSingle", value));
-                VerifyOrReturn(CheckValue("nullableFloatSingle.Value()", value.Value(), 0.1f));
             }
             break;
         case 308:
@@ -43703,7 +43703,7 @@ private:
                 chip::app::DataModel::Nullable<float> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableFloatSingle", value));
-                VerifyOrReturn(CheckValue("nullableFloatSingle.Value()", value.Value(), INFINITY));
+                VerifyOrReturn(CheckValue("nullableFloatSingle.Value()", value.Value(), 0.1f));
             }
             break;
         case 310:
@@ -43715,7 +43715,7 @@ private:
                 chip::app::DataModel::Nullable<float> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableFloatSingle", value));
-                VerifyOrReturn(CheckValue("nullableFloatSingle.Value()", value.Value(), -INFINITY));
+                VerifyOrReturn(CheckValue("nullableFloatSingle.Value()", value.Value(), INFINITY));
             }
             break;
         case 312:
@@ -43726,7 +43726,8 @@ private:
             {
                 chip::app::DataModel::Nullable<float> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableFloatSingle", value));
+                VerifyOrReturn(CheckValueNonNull("nullableFloatSingle", value));
+                VerifyOrReturn(CheckValue("nullableFloatSingle.Value()", value.Value(), -INFINITY));
             }
             break;
         case 314:
@@ -43737,8 +43738,7 @@ private:
             {
                 chip::app::DataModel::Nullable<float> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableFloatSingle", value));
-                VerifyOrReturn(CheckValue("nullableFloatSingle.Value()", value.Value(), 0.0f));
+                VerifyOrReturn(CheckValueNull("nullableFloatSingle", value));
             }
             break;
         case 316:
@@ -43747,10 +43747,10 @@ private:
         case 317:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::DataModel::Nullable<double> value;
+                chip::app::DataModel::Nullable<float> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableFloatDouble", value));
-                VerifyOrReturn(CheckValue("nullableFloatDouble.Value()", value.Value(), 0.1234567890123));
+                VerifyOrReturn(CheckValueNonNull("nullableFloatSingle", value));
+                VerifyOrReturn(CheckValue("nullableFloatSingle.Value()", value.Value(), 0.0f));
             }
             break;
         case 318:
@@ -43762,7 +43762,7 @@ private:
                 chip::app::DataModel::Nullable<double> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableFloatDouble", value));
-                VerifyOrReturn(CheckValue("nullableFloatDouble.Value()", value.Value(), INFINITY));
+                VerifyOrReturn(CheckValue("nullableFloatDouble.Value()", value.Value(), 0.1234567890123));
             }
             break;
         case 320:
@@ -43774,7 +43774,7 @@ private:
                 chip::app::DataModel::Nullable<double> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableFloatDouble", value));
-                VerifyOrReturn(CheckValue("nullableFloatDouble.Value()", value.Value(), -INFINITY));
+                VerifyOrReturn(CheckValue("nullableFloatDouble.Value()", value.Value(), INFINITY));
             }
             break;
         case 322:
@@ -43785,7 +43785,8 @@ private:
             {
                 chip::app::DataModel::Nullable<double> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableFloatDouble", value));
+                VerifyOrReturn(CheckValueNonNull("nullableFloatDouble", value));
+                VerifyOrReturn(CheckValue("nullableFloatDouble.Value()", value.Value(), -INFINITY));
             }
             break;
         case 324:
@@ -43796,8 +43797,7 @@ private:
             {
                 chip::app::DataModel::Nullable<double> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableFloatDouble", value));
-                VerifyOrReturn(CheckValue("nullableFloatDouble.Value()", value.Value(), 0));
+                VerifyOrReturn(CheckValueNull("nullableFloatDouble", value));
             }
             break;
         case 326:
@@ -43806,10 +43806,10 @@ private:
         case 327:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::DataModel::Nullable<uint8_t> value;
+                chip::app::DataModel::Nullable<double> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableEnum8", value));
-                VerifyOrReturn(CheckValue("nullableEnum8.Value()", value.Value(), 0));
+                VerifyOrReturn(CheckValueNonNull("nullableFloatDouble", value));
+                VerifyOrReturn(CheckValue("nullableFloatDouble.Value()", value.Value(), 0));
             }
             break;
         case 328:
@@ -43821,11 +43821,11 @@ private:
                 chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableEnum8", value));
-                VerifyOrReturn(CheckValue("nullableEnum8.Value()", value.Value(), 254));
+                VerifyOrReturn(CheckValue("nullableEnum8.Value()", value.Value(), 0));
             }
             break;
         case 330:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 331:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43837,14 +43837,15 @@ private:
             }
             break;
         case 332:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 333:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableEnum8", value));
+                VerifyOrReturn(CheckValueNonNull("nullableEnum8", value));
+                VerifyOrReturn(CheckValue("nullableEnum8.Value()", value.Value(), 254));
             }
             break;
         case 334:
@@ -43853,10 +43854,9 @@ private:
         case 335:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::DataModel::Nullable<uint16_t> value;
+                chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableEnum16", value));
-                VerifyOrReturn(CheckValue("nullableEnum16.Value()", value.Value(), 0U));
+                VerifyOrReturn(CheckValueNull("nullableEnum8", value));
             }
             break;
         case 336:
@@ -43868,11 +43868,11 @@ private:
                 chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableEnum16", value));
-                VerifyOrReturn(CheckValue("nullableEnum16.Value()", value.Value(), 65534U));
+                VerifyOrReturn(CheckValue("nullableEnum16.Value()", value.Value(), 0U));
             }
             break;
         case 338:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 339:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -43884,14 +43884,15 @@ private:
             }
             break;
         case 340:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 341:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableEnum16", value));
+                VerifyOrReturn(CheckValueNonNull("nullableEnum16", value));
+                VerifyOrReturn(CheckValue("nullableEnum16.Value()", value.Value(), 65534U));
             }
             break;
         case 342:
@@ -43900,10 +43901,9 @@ private:
         case 343:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
+                chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableEnumAttr", value));
-                VerifyOrReturn(CheckValue("nullableEnumAttr.Value()", value.Value(), 0));
+                VerifyOrReturn(CheckValueNull("nullableEnum16", value));
             }
             break;
         case 344:
@@ -43915,13 +43915,25 @@ private:
                 chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableEnumAttr", value));
-                VerifyOrReturn(CheckValue("nullableEnumAttr.Value()", value.Value(), 254));
+                VerifyOrReturn(CheckValue("nullableEnumAttr.Value()", value.Value(), 0));
             }
             break;
         case 346:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 347:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNonNull("nullableEnumAttr", value));
+                VerifyOrReturn(CheckValue("nullableEnumAttr.Value()", value.Value(), 254));
+            }
+            break;
+        case 348:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
+            break;
+        case 349:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
@@ -43932,10 +43944,10 @@ private:
                 nullableEnumAttr254 = value;
             }
             break;
-        case 348:
+        case 350:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 349:
+        case 351:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
@@ -43943,7 +43955,7 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableEnumAttr", value));
             }
             break;
-        case 350:
+        case 352:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
@@ -43951,7 +43963,7 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, nullableEnumAttr254));
             }
             break;
-        case 351:
+        case 353:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::ByteSpan> value;
@@ -43961,10 +43973,10 @@ private:
                                                   chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
             }
             break;
-        case 352:
+        case 354:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 353:
+        case 355:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::ByteSpan> value;
@@ -43989,10 +44001,10 @@ private:
                 }
             }
             break;
-        case 354:
+        case 356:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 355:
+        case 357:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::ByteSpan> value;
@@ -44000,10 +44012,10 @@ private:
                 VerifyOrReturn(CheckValueNull("nullableOctetString", value));
             }
             break;
-        case 356:
+        case 358:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 357:
+        case 359:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::ByteSpan> value;
@@ -44013,7 +44025,7 @@ private:
                                                   chip::ByteSpan(chip::Uint8::from_const_char(""), 0)));
             }
             break;
-        case 358:
+        case 360:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::ByteSpan> value;
@@ -44021,7 +44033,7 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, nullableOctetStrTestValue));
             }
             break;
-        case 359:
+        case 361:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::CharSpan> value;
@@ -44030,10 +44042,10 @@ private:
                 VerifyOrReturn(CheckValueAsString("nullableCharString.Value()", value.Value(), chip::CharSpan("", 0)));
             }
             break;
-        case 360:
+        case 362:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 361:
+        case 363:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::CharSpan> value;
@@ -44057,7 +44069,7 @@ private:
                 }
             }
             break;
-        case 362:
+        case 364:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::CharSpan> value;
@@ -44073,17 +44085,6 @@ private:
                 }
             }
             break;
-        case 363:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 364:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<chip::CharSpan> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableCharString", value));
-            }
-            break;
         case 365:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
@@ -44092,11 +44093,22 @@ private:
             {
                 chip::app::DataModel::Nullable<chip::CharSpan> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNull("nullableCharString", value));
+            }
+            break;
+        case 367:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 368:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<chip::CharSpan> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableCharString", value));
                 VerifyOrReturn(CheckValueAsString("nullableCharString.Value()", value.Value(), chip::CharSpan("", 0)));
             }
             break;
-        case 367:
+        case 369:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<chip::CharSpan> value;
@@ -44104,19 +44116,19 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, nullableCharStringSave));
             }
             break;
-        case 368:
+        case 370:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT));
             break;
-        case 369:
+        case 371:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_UNSUPPORTED_CLUSTER));
             break;
-        case 370:
+        case 372:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_VALUE));
             break;
-        case 371:
+        case 373:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 372:
+        case 374:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<uint8_t> value;
@@ -44135,10 +44147,10 @@ private:
                 }
             }
             break;
-        case 373:
+        case 375:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 374:
+        case 376:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<uint8_t> value;
@@ -44158,19 +44170,13 @@ private:
             }
             shouldContinue = true;
             break;
-        case 375:
+        case 377:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 uint8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 70));
             }
-            break;
-        case 376:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 377:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 378:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
@@ -44179,22 +44185,17 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 380:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                uint8_t value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 70));
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 381:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 382:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 uint8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 20));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 70));
             }
             break;
         case 383:
@@ -44205,7 +44206,7 @@ private:
             {
                 uint8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 100));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 20));
             }
             break;
         case 385:
@@ -44216,22 +44217,27 @@ private:
             {
                 uint8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 50));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 100));
             }
             break;
         case 387:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 388:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                uint8_t value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt8u", value, 50));
+            }
+            break;
+        case 389:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 uint16_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 200U));
             }
-            break;
-        case 388:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 389:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 390:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
@@ -44240,22 +44246,17 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 392:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                uint16_t value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 200U));
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 393:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 394:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 uint16_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 100U));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 200U));
             }
             break;
         case 395:
@@ -44266,7 +44267,7 @@ private:
             {
                 uint16_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 1000U));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 100U));
             }
             break;
         case 397:
@@ -44277,22 +44278,27 @@ private:
             {
                 uint16_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 500U));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 1000U));
             }
             break;
         case 399:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 400:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                uint16_t value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt16u", value, 500U));
+            }
+            break;
+        case 401:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 int8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, -20));
             }
-            break;
-        case 400:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 401:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 402:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
@@ -44301,22 +44307,17 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 404:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                int8_t value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, -20));
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 405:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 406:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 int8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, -40));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, -20));
             }
             break;
         case 407:
@@ -44327,7 +44328,7 @@ private:
             {
                 int8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, 50));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, -40));
             }
             break;
         case 409:
@@ -44338,22 +44339,27 @@ private:
             {
                 int8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, 6));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, 50));
             }
             break;
         case 411:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 412:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                int8_t value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt8s", value, 6));
+            }
+            break;
+        case 413:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 int16_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, -100));
             }
-            break;
-        case 412:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 413:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 414:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
@@ -44362,22 +44368,17 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 416:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                int16_t value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, -100));
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 417:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 418:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 int16_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, -150));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, -100));
             }
             break;
         case 419:
@@ -44388,7 +44389,7 @@ private:
             {
                 int16_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, 200));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, -150));
             }
             break;
         case 421:
@@ -44399,10 +44400,21 @@ private:
             {
                 int16_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, 7));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, 200));
             }
             break;
         case 423:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 424:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                int16_t value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("rangeRestrictedInt16s", value, 7));
+            }
+            break;
+        case 425:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
@@ -44410,12 +44422,6 @@ private:
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8u", value));
                 VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 70));
             }
-            break;
-        case 424:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 425:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 426:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
@@ -44424,16 +44430,10 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 428:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<uint8_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8u", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 70));
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 429:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 430:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -44441,7 +44441,7 @@ private:
                 chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8u", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 20));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 70));
             }
             break;
         case 431:
@@ -44453,7 +44453,7 @@ private:
                 chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8u", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 100));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 20));
             }
             break;
         case 433:
@@ -44465,7 +44465,7 @@ private:
                 chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8u", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 50));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 100));
             }
             break;
         case 435:
@@ -44476,10 +44476,22 @@ private:
             {
                 chip::app::DataModel::Nullable<uint8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableRangeRestrictedInt8u", value));
+                VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8u", value));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8u.Value()", value.Value(), 50));
             }
             break;
         case 437:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 438:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<uint8_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNull("nullableRangeRestrictedInt8u", value));
+            }
+            break;
+        case 439:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<uint16_t> value;
@@ -44487,12 +44499,6 @@ private:
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16u", value));
                 VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 200U));
             }
-            break;
-        case 438:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 439:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 440:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
@@ -44501,16 +44507,10 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 442:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<uint16_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16u", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 200U));
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 443:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 444:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -44518,7 +44518,7 @@ private:
                 chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16u", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 100U));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 200U));
             }
             break;
         case 445:
@@ -44530,7 +44530,7 @@ private:
                 chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16u", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 1000U));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 100U));
             }
             break;
         case 447:
@@ -44542,7 +44542,7 @@ private:
                 chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16u", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 500U));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 1000U));
             }
             break;
         case 449:
@@ -44553,10 +44553,22 @@ private:
             {
                 chip::app::DataModel::Nullable<uint16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableRangeRestrictedInt16u", value));
+                VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16u", value));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16u.Value()", value.Value(), 500U));
             }
             break;
         case 451:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 452:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<uint16_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNull("nullableRangeRestrictedInt16u", value));
+            }
+            break;
+        case 453:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int8_t> value;
@@ -44564,12 +44576,6 @@ private:
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8s", value));
                 VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), -20));
             }
-            break;
-        case 452:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 453:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 454:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
@@ -44578,16 +44584,10 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 456:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<int8_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8s", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), -20));
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 457:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 458:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -44595,7 +44595,7 @@ private:
                 chip::app::DataModel::Nullable<int8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8s", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), -40));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), -20));
             }
             break;
         case 459:
@@ -44607,7 +44607,7 @@ private:
                 chip::app::DataModel::Nullable<int8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8s", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), 50));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), -40));
             }
             break;
         case 461:
@@ -44619,7 +44619,7 @@ private:
                 chip::app::DataModel::Nullable<int8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8s", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), 6));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), 50));
             }
             break;
         case 463:
@@ -44630,10 +44630,22 @@ private:
             {
                 chip::app::DataModel::Nullable<int8_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableRangeRestrictedInt8s", value));
+                VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt8s", value));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt8s.Value()", value.Value(), 6));
             }
             break;
         case 465:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 466:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<int8_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNull("nullableRangeRestrictedInt8s", value));
+            }
+            break;
+        case 467:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::Nullable<int16_t> value;
@@ -44641,12 +44653,6 @@ private:
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16s", value));
                 VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), -100));
             }
-            break;
-        case 466:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
-            break;
-        case 467:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 468:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
@@ -44655,16 +44661,10 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 470:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::DataModel::Nullable<int16_t> value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16s", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), -100));
-            }
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 471:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 472:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -44672,7 +44672,7 @@ private:
                 chip::app::DataModel::Nullable<int16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16s", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), -150));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), -100));
             }
             break;
         case 473:
@@ -44684,7 +44684,7 @@ private:
                 chip::app::DataModel::Nullable<int16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16s", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), 200));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), -150));
             }
             break;
         case 475:
@@ -44696,7 +44696,7 @@ private:
                 chip::app::DataModel::Nullable<int16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16s", value));
-                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), 7));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), 200));
             }
             break;
         case 477:
@@ -44707,14 +44707,20 @@ private:
             {
                 chip::app::DataModel::Nullable<int16_t> value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValueNull("nullableRangeRestrictedInt16s", value));
+                VerifyOrReturn(CheckValueNonNull("nullableRangeRestrictedInt16s", value));
+                VerifyOrReturn(CheckValue("nullableRangeRestrictedInt16s.Value()", value.Value(), 7));
             }
             break;
         case 479:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_DATA_TYPE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 480:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::Nullable<int16_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNull("nullableRangeRestrictedInt16s", value));
+            }
             break;
         case 481:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_DATA_TYPE));
@@ -44723,6 +44729,12 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 483:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_DATA_TYPE));
+            break;
+        case 484:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            break;
+        case 485:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<chip::CommandId> value;
@@ -44769,7 +44781,7 @@ private:
                 }
             }
             break;
-        case 484:
+        case 486:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<chip::CommandId> value;
@@ -44798,10 +44810,10 @@ private:
                 }
             }
             break;
-        case 485:
+        case 487:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 486:
+        case 488:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::TestCluster::Structs::SimpleStruct::DecodableType value;
@@ -45537,28 +45549,28 @@ private:
                                  chip::NullOptional);
         }
         case 110: {
-            LogStep(110, "Write attribute OCTET_STRING with weird chars");
+            LogStep(110, "Write attribute OCTET_STRING with hex: format");
+            ListFreer listFreer;
+            chip::ByteSpan value;
+            value = chip::ByteSpan(chip::Uint8::from_const_char("\x00\x01\x02\x03\x04\x05garbage: not in length on purpose"), 6);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 111: {
+            LogStep(111, "Read attribute OCTET_STRING with hex: format");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, true,
+                                 chip::NullOptional);
+        }
+        case 112: {
+            LogStep(112, "Write attribute OCTET_STRING with weird chars");
             ListFreer listFreer;
             chip::ByteSpan value;
             value = chip::ByteSpan(chip::Uint8::from_const_char("\015\012\377\042\240garbage: not in length on purpose"), 5);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 111: {
-            LogStep(111, "Read attribute OCTET_STRING with weird chars");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, true,
-                                 chip::NullOptional);
-        }
-        case 112: {
-            LogStep(112, "Write attribute OCTET_STRING");
-            ListFreer listFreer;
-            chip::ByteSpan value;
-            value = chip::ByteSpan(chip::Uint8::from_const_char("TestValuegarbage: not in length on purpose"), 9);
-            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, value,
-                                  chip::NullOptional, chip::NullOptional);
-        }
         case 113: {
-            LogStep(113, "Read attribute OCTET_STRING");
+            LogStep(113, "Read attribute OCTET_STRING with weird chars");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, true,
                                  chip::NullOptional);
         }
@@ -45566,7 +45578,7 @@ private:
             LogStep(114, "Write attribute OCTET_STRING");
             ListFreer listFreer;
             chip::ByteSpan value;
-            value = chip::ByteSpan(chip::Uint8::from_const_char("TestValueLongerThan10garbage: not in length on purpose"), 21);
+            value = chip::ByteSpan(chip::Uint8::from_const_char("TestValuegarbage: not in length on purpose"), 9);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
@@ -45579,17 +45591,30 @@ private:
             LogStep(116, "Write attribute OCTET_STRING");
             ListFreer listFreer;
             chip::ByteSpan value;
-            value = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
+            value = chip::ByteSpan(chip::Uint8::from_const_char("TestValueLongerThan10garbage: not in length on purpose"), 21);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
         case 117: {
-            LogStep(117, "Read attribute LONG_OCTET_STRING Default Value");
+            LogStep(117, "Read attribute OCTET_STRING");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, true,
+                                 chip::NullOptional);
+        }
+        case 118: {
+            LogStep(118, "Write attribute OCTET_STRING");
+            ListFreer listFreer;
+            chip::ByteSpan value;
+            value = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::OctetString::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 119: {
+            LogStep(119, "Read attribute LONG_OCTET_STRING Default Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::LongOctetString::Id,
                                  true, chip::NullOptional);
         }
-        case 118: {
-            LogStep(118, "Write attribute LONG_OCTET_STRING");
+        case 120: {
+            LogStep(120, "Write attribute LONG_OCTET_STRING");
             ListFreer listFreer;
             chip::ByteSpan value;
             value = chip::ByteSpan(
@@ -45601,42 +45626,29 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::LongOctetString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 119: {
-            LogStep(119, "Read attribute LONG_OCTET_STRING");
+        case 121: {
+            LogStep(121, "Read attribute LONG_OCTET_STRING");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::LongOctetString::Id,
                                  true, chip::NullOptional);
         }
-        case 120: {
-            LogStep(120, "Write attribute LONG_OCTET_STRING");
+        case 122: {
+            LogStep(122, "Write attribute LONG_OCTET_STRING");
             ListFreer listFreer;
             chip::ByteSpan value;
             value = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::LongOctetString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 121: {
-            LogStep(121, "Read attribute CHAR_STRING Default Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
-                                 chip::NullOptional);
-        }
-        case 122: {
-            LogStep(122, "Write attribute CHAR_STRING");
-            ListFreer listFreer;
-            chip::CharSpan value;
-            value = chip::Span<const char>("☉T☉garbage: not in length on purpose", 7);
-            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
-                                  chip::NullOptional, chip::NullOptional);
-        }
         case 123: {
-            LogStep(123, "Read attribute CHAR_STRING");
+            LogStep(123, "Read attribute CHAR_STRING Default Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
                                  chip::NullOptional);
         }
         case 124: {
-            LogStep(124, "Write attribute CHAR_STRING - Value too long");
+            LogStep(124, "Write attribute CHAR_STRING");
             ListFreer listFreer;
             chip::CharSpan value;
-            value = chip::Span<const char>("☉TestValueLongerThan10☉garbage: not in length on purpose", 27);
+            value = chip::Span<const char>("☉T☉garbage: not in length on purpose", 7);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
@@ -45646,20 +45658,33 @@ private:
                                  chip::NullOptional);
         }
         case 126: {
-            LogStep(126, "Write attribute CHAR_STRING - Empty");
+            LogStep(126, "Write attribute CHAR_STRING - Value too long");
+            ListFreer listFreer;
+            chip::CharSpan value;
+            value = chip::Span<const char>("☉TestValueLongerThan10☉garbage: not in length on purpose", 27);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 127: {
+            LogStep(127, "Read attribute CHAR_STRING");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
+                                 chip::NullOptional);
+        }
+        case 128: {
+            LogStep(128, "Write attribute CHAR_STRING - Empty");
             ListFreer listFreer;
             chip::CharSpan value;
             value = chip::Span<const char>("garbage: not in length on purpose", 0);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 127: {
-            LogStep(127, "Read attribute LONG_CHAR_STRING Default Value");
+        case 129: {
+            LogStep(129, "Read attribute LONG_CHAR_STRING Default Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::LongCharString::Id, true,
                                  chip::NullOptional);
         }
-        case 128: {
-            LogStep(128, "Write attribute LONG_CHAR_STRING");
+        case 130: {
+            LogStep(130, "Write attribute LONG_CHAR_STRING");
             ListFreer listFreer;
             chip::CharSpan value;
             value = chip::Span<const char>(
@@ -45670,26 +45695,26 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::LongCharString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 129: {
-            LogStep(129, "Read attribute LONG_CHAR_STRING");
+        case 131: {
+            LogStep(131, "Read attribute LONG_CHAR_STRING");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::LongCharString::Id, true,
                                  chip::NullOptional);
         }
-        case 130: {
-            LogStep(130, "Write attribute LONG_CHAR_STRING");
+        case 132: {
+            LogStep(132, "Write attribute LONG_CHAR_STRING");
             ListFreer listFreer;
             chip::CharSpan value;
             value = chip::Span<const char>("garbage: not in length on purpose", 0);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::LongCharString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 131: {
-            LogStep(131, "Read attribute LIST_LONG_OCTET_STRING (for chunked read)");
+        case 133: {
+            LogStep(133, "Read attribute LIST_LONG_OCTET_STRING (for chunked read)");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListLongOctetString::Id,
                                  true, chip::NullOptional);
         }
-        case 132: {
-            LogStep(132, "Write attribute LIST_LONG_OCTET_STRING (for chunked write)");
+        case 134: {
+            LogStep(134, "Write attribute LIST_LONG_OCTET_STRING (for chunked write)");
             ListFreer listFreer;
             chip::app::DataModel::List<const chip::ByteSpan> value;
 
@@ -45746,88 +45771,88 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListLongOctetString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 133: {
-            LogStep(133, "Read attribute LIST_LONG_OCTET_STRING (for chunked read)");
+        case 135: {
+            LogStep(135, "Read attribute LIST_LONG_OCTET_STRING (for chunked read)");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListLongOctetString::Id,
                                  true, chip::NullOptional);
         }
-        case 134: {
-            LogStep(134, "Read attribute EPOCH_US Default Value");
+        case 136: {
+            LogStep(136, "Read attribute EPOCH_US Default Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochUs::Id, true,
                                  chip::NullOptional);
         }
-        case 135: {
-            LogStep(135, "Write attribute EPOCH_US Max Value");
+        case 137: {
+            LogStep(137, "Write attribute EPOCH_US Max Value");
             ListFreer listFreer;
             uint64_t value;
             value = 18446744073709551615ULL;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochUs::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 136: {
-            LogStep(136, "Read attribute EPOCH_US Max Value");
+        case 138: {
+            LogStep(138, "Read attribute EPOCH_US Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochUs::Id, true,
                                  chip::NullOptional);
         }
-        case 137: {
-            LogStep(137, "Write attribute EPOCH_US Min Value");
+        case 139: {
+            LogStep(139, "Write attribute EPOCH_US Min Value");
             ListFreer listFreer;
             uint64_t value;
             value = 0ULL;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochUs::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 138: {
-            LogStep(138, "Read attribute EPOCH_US Min Value");
+        case 140: {
+            LogStep(140, "Read attribute EPOCH_US Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochUs::Id, true,
                                  chip::NullOptional);
         }
-        case 139: {
-            LogStep(139, "Read attribute EPOCH_S Default Value");
+        case 141: {
+            LogStep(141, "Read attribute EPOCH_S Default Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochS::Id, true,
                                  chip::NullOptional);
         }
-        case 140: {
-            LogStep(140, "Write attribute EPOCH_S Max Value");
+        case 142: {
+            LogStep(142, "Write attribute EPOCH_S Max Value");
             ListFreer listFreer;
             uint32_t value;
             value = 4294967295UL;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochS::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 141: {
-            LogStep(141, "Read attribute EPOCH_S Max Value");
+        case 143: {
+            LogStep(143, "Read attribute EPOCH_S Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochS::Id, true,
                                  chip::NullOptional);
         }
-        case 142: {
-            LogStep(142, "Write attribute EPOCH_S Min Value");
+        case 144: {
+            LogStep(144, "Write attribute EPOCH_S Min Value");
             ListFreer listFreer;
             uint32_t value;
             value = 0UL;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochS::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 143: {
-            LogStep(143, "Read attribute EPOCH_S Min Value");
+        case 145: {
+            LogStep(145, "Read attribute EPOCH_S Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::EpochS::Id, true,
                                  chip::NullOptional);
         }
-        case 144: {
-            LogStep(144, "Read attribute UNSUPPORTED");
+        case 146: {
+            LogStep(146, "Read attribute UNSUPPORTED");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::Unsupported::Id, true,
                                  chip::NullOptional);
         }
-        case 145: {
-            LogStep(145, "Writeattribute UNSUPPORTED");
+        case 147: {
+            LogStep(147, "Writeattribute UNSUPPORTED");
             ListFreer listFreer;
             bool value;
             value = 0;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::Unsupported::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 146: {
-            LogStep(146, "Send Test Command to unsupported endpoint");
+        case 148: {
+            LogStep(148, "Send Test Command to unsupported endpoint");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::Test::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(200), TestCluster::Id, TestCluster::Commands::Test::Id, value,
@@ -45835,8 +45860,8 @@ private:
 
             );
         }
-        case 147: {
-            LogStep(147, "Send Test Command to unsupported cluster");
+        case 149: {
+            LogStep(149, "Send Test Command to unsupported cluster");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::Test::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(0), TestCluster::Id, TestCluster::Commands::Test::Id, value,
@@ -45844,34 +45869,34 @@ private:
 
             );
         }
-        case 148: {
-            LogStep(148, "Read attribute vendor_id Default Value");
+        case 150: {
+            LogStep(150, "Read attribute vendor_id Default Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::VendorId::Id, true,
                                  chip::NullOptional);
         }
-        case 149: {
-            LogStep(149, "Write attribute vendor_id");
+        case 151: {
+            LogStep(151, "Write attribute vendor_id");
             ListFreer listFreer;
             chip::VendorId value;
             value = static_cast<chip::VendorId>(17);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::VendorId::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 150: {
-            LogStep(150, "Read attribute vendor_id");
+        case 152: {
+            LogStep(152, "Read attribute vendor_id");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::VendorId::Id, true,
                                  chip::NullOptional);
         }
-        case 151: {
-            LogStep(151, "Restore attribute vendor_id");
+        case 153: {
+            LogStep(153, "Restore attribute vendor_id");
             ListFreer listFreer;
             chip::VendorId value;
             value = static_cast<chip::VendorId>(0);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::VendorId::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 152: {
-            LogStep(152, "Send a command with a vendor_id and enum");
+        case 154: {
+            LogStep(154, "Send a command with a vendor_id and enum");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestEnumsRequest::Type value;
             value.arg1 = static_cast<chip::VendorId>(20003);
@@ -45881,8 +45906,8 @@ private:
 
             );
         }
-        case 153: {
-            LogStep(153, "Send Test Command With Struct Argument and arg1.b is true");
+        case 155: {
+            LogStep(155, "Send Test Command With Struct Argument and arg1.b is true");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type value;
 
@@ -45900,8 +45925,8 @@ private:
 
             );
         }
-        case 154: {
-            LogStep(154, "Send Test Command With Struct Argument and arg1.b is false");
+        case 156: {
+            LogStep(156, "Send Test Command With Struct Argument and arg1.b is false");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestStructArgumentRequest::Type value;
 
@@ -45919,8 +45944,8 @@ private:
 
             );
         }
-        case 155: {
-            LogStep(155, "Send Test Command With Nested Struct Argument and arg1.c.b is true");
+        case 157: {
+            LogStep(157, "Send Test Command With Nested Struct Argument and arg1.c.b is true");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type value;
 
@@ -45941,8 +45966,8 @@ private:
 
             );
         }
-        case 156: {
-            LogStep(156, "Send Test Command With Nested Struct Argument arg1.c.b is false");
+        case 158: {
+            LogStep(158, "Send Test Command With Nested Struct Argument arg1.c.b is false");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestNestedStructArgumentRequest::Type value;
 
@@ -45963,8 +45988,8 @@ private:
 
             );
         }
-        case 157: {
-            LogStep(157, "Send Test Command With Nested Struct List Argument and all fields b of arg1.d are true");
+        case 159: {
+            LogStep(159, "Send Test Command With Nested Struct List Argument and all fields b of arg1.d are true");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type value;
 
@@ -46042,8 +46067,8 @@ private:
 
             );
         }
-        case 158: {
-            LogStep(158, "Send Test Command With Nested Struct List Argument and some fields b of arg1.d are false");
+        case 160: {
+            LogStep(160, "Send Test Command With Nested Struct List Argument and some fields b of arg1.d are false");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestNestedStructListArgumentRequest::Type value;
 
@@ -46121,8 +46146,8 @@ private:
 
             );
         }
-        case 159: {
-            LogStep(159, "Send Test Command With Struct Argument and see what we get back");
+        case 161: {
+            LogStep(161, "Send Test Command With Struct Argument and see what we get back");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::SimpleStructEchoRequest::Type value;
 
@@ -46140,8 +46165,8 @@ private:
 
             );
         }
-        case 160: {
-            LogStep(160, "Send Test Command With List of INT8U and none of them is set to 0");
+        case 162: {
+            LogStep(162, "Send Test Command With List of INT8U and none of them is set to 0");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type value;
 
@@ -46164,8 +46189,8 @@ private:
 
             );
         }
-        case 161: {
-            LogStep(161, "Send Test Command With List of INT8U and one of them is set to 0");
+        case 163: {
+            LogStep(163, "Send Test Command With List of INT8U and one of them is set to 0");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestListInt8UArgumentRequest::Type value;
 
@@ -46189,8 +46214,8 @@ private:
 
             );
         }
-        case 162: {
-            LogStep(162, "Send Test Command With List of INT8U and get it reversed");
+        case 164: {
+            LogStep(164, "Send Test Command With List of INT8U and get it reversed");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type value;
 
@@ -46213,8 +46238,8 @@ private:
 
             );
         }
-        case 163: {
-            LogStep(163, "Send Test Command With empty List of INT8U and get an empty list back");
+        case 165: {
+            LogStep(165, "Send Test Command With empty List of INT8U and get an empty list back");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestListInt8UReverseRequest::Type value;
 
@@ -46224,8 +46249,8 @@ private:
 
             );
         }
-        case 164: {
-            LogStep(164, "Send Test Command With List of Struct Argument and arg1.b of first item is true");
+        case 166: {
+            LogStep(166, "Send Test Command With List of Struct Argument and arg1.b of first item is true");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type value;
 
@@ -46261,8 +46286,8 @@ private:
 
             );
         }
-        case 165: {
-            LogStep(165, "Send Test Command With List of Struct Argument and arg1.b of first item is false");
+        case 167: {
+            LogStep(167, "Send Test Command With List of Struct Argument and arg1.b of first item is false");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestListStructArgumentRequest::Type value;
 
@@ -46298,8 +46323,8 @@ private:
 
             );
         }
-        case 166: {
-            LogStep(166,
+        case 168: {
+            LogStep(168,
                     "Send Test Command With List of Nested Struct List Argument and all fields b of elements of arg1.d are true");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type value;
@@ -46387,8 +46412,8 @@ private:
 
             );
         }
-        case 167: {
-            LogStep(167, "Send Test Command With Nested Struct List Argument and some fields b of elements of arg1.d are false");
+        case 169: {
+            LogStep(169, "Send Test Command With Nested Struct List Argument and some fields b of elements of arg1.d are false");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestListNestedStructListArgumentRequest::Type value;
 
@@ -46475,8 +46500,8 @@ private:
 
             );
         }
-        case 168: {
-            LogStep(168, "Write attribute LIST With List of INT8U and none of them is set to 0");
+        case 170: {
+            LogStep(170, "Write attribute LIST With List of INT8U and none of them is set to 0");
             ListFreer listFreer;
             chip::app::DataModel::List<const uint8_t> value;
 
@@ -46492,13 +46517,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 169: {
-            LogStep(169, "Read attribute LIST With List of INT8U");
+        case 171: {
+            LogStep(171, "Read attribute LIST With List of INT8U");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, true,
                                  chip::NullOptional);
         }
-        case 170: {
-            LogStep(170, "Write attribute LIST With List of OCTET_STRING");
+        case 172: {
+            LogStep(172, "Write attribute LIST With List of OCTET_STRING");
             ListFreer listFreer;
             chip::app::DataModel::List<const chip::ByteSpan> value;
 
@@ -46514,13 +46539,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListOctetString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 171: {
-            LogStep(171, "Read attribute LIST With List of OCTET_STRING");
+        case 173: {
+            LogStep(173, "Read attribute LIST With List of OCTET_STRING");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListOctetString::Id,
                                  true, chip::NullOptional);
         }
-        case 172: {
-            LogStep(172, "Write attribute LIST With List of LIST_STRUCT_OCTET_STRING");
+        case 174: {
+            LogStep(174, "Write attribute LIST With List of LIST_STRUCT_OCTET_STRING");
             ListFreer listFreer;
             chip::app::DataModel::List<const chip::app::Clusters::TestCluster::Structs::TestListStructOctet::Type> value;
 
@@ -46551,13 +46576,13 @@ private:
                                   TestCluster::Attributes::ListStructOctetString::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 173: {
-            LogStep(173, "Read attribute LIST With List of LIST_STRUCT_OCTET_STRING");
+        case 175: {
+            LogStep(175, "Read attribute LIST With List of LIST_STRUCT_OCTET_STRING");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::ListStructOctetString::Id, true, chip::NullOptional);
         }
-        case 174: {
-            LogStep(174, "Send Test Command with optional arg set.");
+        case 176: {
+            LogStep(176, "Send Test Command with optional arg set.");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type value;
             value.arg1.Emplace();
@@ -46568,8 +46593,8 @@ private:
 
             );
         }
-        case 175: {
-            LogStep(175, "Send Test Command without its optional arg.");
+        case 177: {
+            LogStep(177, "Send Test Command without its optional arg.");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestNullableOptionalRequest::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
@@ -46577,13 +46602,13 @@ private:
 
             );
         }
-        case 176: {
-            LogStep(176, "Read list of structs containing nullables and optionals");
+        case 178: {
+            LogStep(178, "Read list of structs containing nullables and optionals");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::ListNullablesAndOptionalsStruct::Id, true, chip::NullOptional);
         }
-        case 177: {
-            LogStep(177, "Write list of structs containing nullables and optionals");
+        case 179: {
+            LogStep(179, "Write list of structs containing nullables and optionals");
             ListFreer listFreer;
             chip::app::DataModel::List<const chip::app::Clusters::TestCluster::Structs::NullablesAndOptionalsStruct::Type> value;
 
@@ -46613,26 +46638,26 @@ private:
                                   TestCluster::Attributes::ListNullablesAndOptionalsStruct::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 178: {
-            LogStep(178, "Read list of structs containing nullables and optionals after writing");
+        case 180: {
+            LogStep(180, "Read list of structs containing nullables and optionals after writing");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::ListNullablesAndOptionalsStruct::Id, true, chip::NullOptional);
         }
-        case 179: {
-            LogStep(179, "Write attribute NULLABLE_BOOLEAN null");
+        case 181: {
+            LogStep(181, "Write attribute NULLABLE_BOOLEAN null");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<bool> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBoolean::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 180: {
-            LogStep(180, "Read attribute NULLABLE_BOOLEAN null");
+        case 182: {
+            LogStep(182, "Read attribute NULLABLE_BOOLEAN null");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBoolean::Id,
                                  true, chip::NullOptional);
         }
-        case 181: {
-            LogStep(181, "Write attribute NULLABLE_BOOLEAN True");
+        case 183: {
+            LogStep(183, "Write attribute NULLABLE_BOOLEAN True");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<bool> value;
             value.SetNonNull();
@@ -46640,18 +46665,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBoolean::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 182: {
-            LogStep(182, "Read attribute NULLABLE_BOOLEAN True");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBoolean::Id,
-                                 true, chip::NullOptional);
-        }
-        case 183: {
-            LogStep(183, "Read attribute NULLABLE_BOOLEAN not null");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBoolean::Id,
-                                 true, chip::NullOptional);
-        }
         case 184: {
-            LogStep(184, "Write attribute NULLABLE_BITMAP8 Max Value");
+            LogStep(184, "Read attribute NULLABLE_BOOLEAN True");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBoolean::Id,
+                                 true, chip::NullOptional);
+        }
+        case 185: {
+            LogStep(185, "Read attribute NULLABLE_BOOLEAN not null");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBoolean::Id,
+                                 true, chip::NullOptional);
+        }
+        case 186: {
+            LogStep(186, "Write attribute NULLABLE_BITMAP8 Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap8MaskMap>> value;
             value.SetNonNull();
@@ -46659,13 +46684,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 185: {
-            LogStep(185, "Read attribute NULLABLE_BITMAP8 Max Value");
+        case 187: {
+            LogStep(187, "Read attribute NULLABLE_BITMAP8 Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
                                  true, chip::NullOptional);
         }
-        case 186: {
-            LogStep(186, "Write attribute NULLABLE_BITMAP8 Invalid Value");
+        case 188: {
+            LogStep(188, "Write attribute NULLABLE_BITMAP8 Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap8MaskMap>> value;
             value.SetNonNull();
@@ -46673,31 +46698,31 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 187: {
-            LogStep(187, "Read attribute NULLABLE_BITMAP8 unchanged Value");
+        case 189: {
+            LogStep(189, "Read attribute NULLABLE_BITMAP8 unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
                                  true, chip::NullOptional);
         }
-        case 188: {
-            LogStep(188, "Write attribute NULLABLE_BITMAP8 null Value");
+        case 190: {
+            LogStep(190, "Write attribute NULLABLE_BITMAP8 null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap8MaskMap>> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 189: {
-            LogStep(189, "Read attribute NULLABLE_BITMAP8 null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
-                                 true, chip::NullOptional);
-        }
-        case 190: {
-            LogStep(190, "Read attribute NULLABLE_BITMAP8 not 254 Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
-                                 true, chip::NullOptional);
-        }
         case 191: {
-            LogStep(191, "Write attribute NULLABLE_BITMAP16 Max Value");
+            LogStep(191, "Read attribute NULLABLE_BITMAP8 null Value");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
+                                 true, chip::NullOptional);
+        }
+        case 192: {
+            LogStep(192, "Read attribute NULLABLE_BITMAP8 not 254 Value");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap8::Id,
+                                 true, chip::NullOptional);
+        }
+        case 193: {
+            LogStep(193, "Write attribute NULLABLE_BITMAP16 Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap16MaskMap>> value;
             value.SetNonNull();
@@ -46705,13 +46730,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap16::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 192: {
-            LogStep(192, "Read attribute NULLABLE_BITMAP16 Max Value");
+        case 194: {
+            LogStep(194, "Read attribute NULLABLE_BITMAP16 Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap16::Id,
                                  true, chip::NullOptional);
         }
-        case 193: {
-            LogStep(193, "Write attribute NULLABLE_BITMAP16 Invalid Value");
+        case 195: {
+            LogStep(195, "Write attribute NULLABLE_BITMAP16 Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap16MaskMap>> value;
             value.SetNonNull();
@@ -46719,26 +46744,26 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap16::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 194: {
-            LogStep(194, "Read attribute NULLABLE_BITMAP16 unchanged Value");
+        case 196: {
+            LogStep(196, "Read attribute NULLABLE_BITMAP16 unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap16::Id,
                                  true, chip::NullOptional);
         }
-        case 195: {
-            LogStep(195, "Write attribute NULLABLE_BITMAP16 null Value");
+        case 197: {
+            LogStep(197, "Write attribute NULLABLE_BITMAP16 null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap16MaskMap>> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap16::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 196: {
-            LogStep(196, "Read attribute NULLABLE_BITMAP16 null Value");
+        case 198: {
+            LogStep(198, "Read attribute NULLABLE_BITMAP16 null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap16::Id,
                                  true, chip::NullOptional);
         }
-        case 197: {
-            LogStep(197, "Write attribute NULLABLE_BITMAP32 Max Value");
+        case 199: {
+            LogStep(199, "Write attribute NULLABLE_BITMAP32 Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap32MaskMap>> value;
             value.SetNonNull();
@@ -46746,13 +46771,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap32::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 198: {
-            LogStep(198, "Read attribute NULLABLE_BITMAP32 Max Value");
+        case 200: {
+            LogStep(200, "Read attribute NULLABLE_BITMAP32 Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap32::Id,
                                  true, chip::NullOptional);
         }
-        case 199: {
-            LogStep(199, "Write attribute NULLABLE_BITMAP32 Invalid Value");
+        case 201: {
+            LogStep(201, "Write attribute NULLABLE_BITMAP32 Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap32MaskMap>> value;
             value.SetNonNull();
@@ -46760,26 +46785,26 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap32::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 200: {
-            LogStep(200, "Read attribute NULLABLE_BITMAP32 unchanged Value");
+        case 202: {
+            LogStep(202, "Read attribute NULLABLE_BITMAP32 unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap32::Id,
                                  true, chip::NullOptional);
         }
-        case 201: {
-            LogStep(201, "Write attribute NULLABLE_BITMAP32 null Value");
+        case 203: {
+            LogStep(203, "Write attribute NULLABLE_BITMAP32 null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap32MaskMap>> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap32::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 202: {
-            LogStep(202, "Read attribute NULLABLE_BITMAP32 null Value");
+        case 204: {
+            LogStep(204, "Read attribute NULLABLE_BITMAP32 null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap32::Id,
                                  true, chip::NullOptional);
         }
-        case 203: {
-            LogStep(203, "Write attribute NULLABLE_BITMAP64 Max Value");
+        case 205: {
+            LogStep(205, "Write attribute NULLABLE_BITMAP64 Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap64MaskMap>> value;
             value.SetNonNull();
@@ -46787,13 +46812,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap64::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 204: {
-            LogStep(204, "Read attribute NULLABLE_BITMAP64 Max Value");
+        case 206: {
+            LogStep(206, "Read attribute NULLABLE_BITMAP64 Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap64::Id,
                                  true, chip::NullOptional);
         }
-        case 205: {
-            LogStep(205, "Write attribute NULLABLE_BITMAP64 Invalid Value");
+        case 207: {
+            LogStep(207, "Write attribute NULLABLE_BITMAP64 Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap64MaskMap>> value;
             value.SetNonNull();
@@ -46801,26 +46826,26 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap64::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 206: {
-            LogStep(206, "Read attribute NULLABLE_BITMAP64 unchanged Value");
+        case 208: {
+            LogStep(208, "Read attribute NULLABLE_BITMAP64 unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap64::Id,
                                  true, chip::NullOptional);
         }
-        case 207: {
-            LogStep(207, "Write attribute NULLABLE_BITMAP64 null Value");
+        case 209: {
+            LogStep(209, "Write attribute NULLABLE_BITMAP64 null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::BitFlags<chip::app::Clusters::TestCluster::Bitmap64MaskMap>> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap64::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 208: {
-            LogStep(208, "Read attribute NULLABLE_BITMAP64 null Value");
+        case 210: {
+            LogStep(210, "Read attribute NULLABLE_BITMAP64 null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableBitmap64::Id,
                                  true, chip::NullOptional);
         }
-        case 209: {
-            LogStep(209, "Write attribute NULLABLE_INT8U Min Value");
+        case 211: {
+            LogStep(211, "Write attribute NULLABLE_INT8U Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -46828,13 +46853,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 210: {
-            LogStep(210, "Read attribute NULLABLE_INT8U Min Value");
+        case 212: {
+            LogStep(212, "Read attribute NULLABLE_INT8U Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
                                  chip::NullOptional);
         }
-        case 211: {
-            LogStep(211, "Write attribute NULLABLE_INT8U Max Value");
+        case 213: {
+            LogStep(213, "Write attribute NULLABLE_INT8U Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -46842,13 +46867,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 212: {
-            LogStep(212, "Read attribute NULLABLE_INT8U Max Value");
+        case 214: {
+            LogStep(214, "Read attribute NULLABLE_INT8U Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
                                  chip::NullOptional);
         }
-        case 213: {
-            LogStep(213, "Write attribute NULLABLE_INT8U Invalid Value");
+        case 215: {
+            LogStep(215, "Write attribute NULLABLE_INT8U Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -46856,41 +46881,41 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 214: {
-            LogStep(214, "Read attribute NULLABLE_INT8U unchanged Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 215: {
-            LogStep(215, "Read attribute NULLABLE_INT8U unchanged Value with constraint");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
-                                 chip::NullOptional);
-        }
         case 216: {
-            LogStep(216, "Write attribute NULLABLE_INT8U null Value");
+            LogStep(216, "Read attribute NULLABLE_INT8U unchanged Value");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 217: {
+            LogStep(217, "Read attribute NULLABLE_INT8U unchanged Value with constraint");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 218: {
+            LogStep(218, "Write attribute NULLABLE_INT8U null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 217: {
-            LogStep(217, "Read attribute NULLABLE_INT8U null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 218: {
-            LogStep(218, "Read attribute NULLABLE_INT8U null Value & range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
-                                 chip::NullOptional);
-        }
         case 219: {
-            LogStep(219, "Read attribute NULLABLE_INT8U null Value & not");
+            LogStep(219, "Read attribute NULLABLE_INT8U null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
                                  chip::NullOptional);
         }
         case 220: {
-            LogStep(220, "Write attribute NULLABLE_INT8U Value");
+            LogStep(220, "Read attribute NULLABLE_INT8U null Value & range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 221: {
+            LogStep(221, "Read attribute NULLABLE_INT8U null Value & not");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 222: {
+            LogStep(222, "Write attribute NULLABLE_INT8U Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -46898,18 +46923,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 221: {
-            LogStep(221, "Read attribute NULLABLE_INT8U Value in range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 222: {
-            LogStep(222, "Read attribute NULLABLE_INT8U notValue OK");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
-                                 chip::NullOptional);
-        }
         case 223: {
-            LogStep(223, "Write attribute NULLABLE_INT16U Min Value");
+            LogStep(223, "Read attribute NULLABLE_INT8U Value in range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 224: {
+            LogStep(224, "Read attribute NULLABLE_INT8U notValue OK");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 225: {
+            LogStep(225, "Write attribute NULLABLE_INT16U Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -46917,13 +46942,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 224: {
-            LogStep(224, "Read attribute NULLABLE_INT16U Min Value");
+        case 226: {
+            LogStep(226, "Read attribute NULLABLE_INT16U Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
                                  chip::NullOptional);
         }
-        case 225: {
-            LogStep(225, "Write attribute NULLABLE_INT16U Max Value");
+        case 227: {
+            LogStep(227, "Write attribute NULLABLE_INT16U Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -46931,13 +46956,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 226: {
-            LogStep(226, "Read attribute NULLABLE_INT16U Max Value");
+        case 228: {
+            LogStep(228, "Read attribute NULLABLE_INT16U Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
                                  chip::NullOptional);
         }
-        case 227: {
-            LogStep(227, "Write attribute NULLABLE_INT16U Invalid Value");
+        case 229: {
+            LogStep(229, "Write attribute NULLABLE_INT16U Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -46945,36 +46970,36 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 228: {
-            LogStep(228, "Read attribute NULLABLE_INT16U unchanged Value");
+        case 230: {
+            LogStep(230, "Read attribute NULLABLE_INT16U unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
                                  chip::NullOptional);
         }
-        case 229: {
-            LogStep(229, "Write attribute NULLABLE_INT16U null Value");
+        case 231: {
+            LogStep(231, "Write attribute NULLABLE_INT16U null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 230: {
-            LogStep(230, "Read attribute NULLABLE_INT16U null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 231: {
-            LogStep(231, "Read attribute NULLABLE_INT16U null Value & range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
-                                 chip::NullOptional);
-        }
         case 232: {
-            LogStep(232, "Read attribute NULLABLE_INT16U null Value & not");
+            LogStep(232, "Read attribute NULLABLE_INT16U null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
                                  chip::NullOptional);
         }
         case 233: {
-            LogStep(233, "Write attribute NULLABLE_INT16U Value");
+            LogStep(233, "Read attribute NULLABLE_INT16U null Value & range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 234: {
+            LogStep(234, "Read attribute NULLABLE_INT16U null Value & not");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 235: {
+            LogStep(235, "Write attribute NULLABLE_INT16U Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -46982,18 +47007,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 234: {
-            LogStep(234, "Read attribute NULLABLE_INT16U Value in range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 235: {
-            LogStep(235, "Read attribute NULLABLE_INT16U notValue OK");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
-                                 chip::NullOptional);
-        }
         case 236: {
-            LogStep(236, "Write attribute NULLABLE_INT32U Min Value");
+            LogStep(236, "Read attribute NULLABLE_INT16U Value in range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 237: {
+            LogStep(237, "Read attribute NULLABLE_INT16U notValue OK");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 238: {
+            LogStep(238, "Write attribute NULLABLE_INT32U Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint32_t> value;
             value.SetNonNull();
@@ -47001,13 +47026,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 237: {
-            LogStep(237, "Read attribute NULLABLE_INT32U Min Value");
+        case 239: {
+            LogStep(239, "Read attribute NULLABLE_INT32U Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
                                  chip::NullOptional);
         }
-        case 238: {
-            LogStep(238, "Write attribute NULLABLE_INT32U Max Value");
+        case 240: {
+            LogStep(240, "Write attribute NULLABLE_INT32U Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint32_t> value;
             value.SetNonNull();
@@ -47015,13 +47040,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 239: {
-            LogStep(239, "Read attribute NULLABLE_INT32U Max Value");
+        case 241: {
+            LogStep(241, "Read attribute NULLABLE_INT32U Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
                                  chip::NullOptional);
         }
-        case 240: {
-            LogStep(240, "Write attribute NULLABLE_INT32U Invalid Value");
+        case 242: {
+            LogStep(242, "Write attribute NULLABLE_INT32U Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint32_t> value;
             value.SetNonNull();
@@ -47029,36 +47054,36 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 241: {
-            LogStep(241, "Read attribute NULLABLE_INT32U unchanged Value");
+        case 243: {
+            LogStep(243, "Read attribute NULLABLE_INT32U unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
                                  chip::NullOptional);
         }
-        case 242: {
-            LogStep(242, "Write attribute NULLABLE_INT32U null Value");
+        case 244: {
+            LogStep(244, "Write attribute NULLABLE_INT32U null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint32_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 243: {
-            LogStep(243, "Read attribute NULLABLE_INT32U null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 244: {
-            LogStep(244, "Read attribute NULLABLE_INT32U null Value & range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
-                                 chip::NullOptional);
-        }
         case 245: {
-            LogStep(245, "Read attribute NULLABLE_INT32U null Value & not");
+            LogStep(245, "Read attribute NULLABLE_INT32U null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
                                  chip::NullOptional);
         }
         case 246: {
-            LogStep(246, "Write attribute NULLABLE_INT32U Value");
+            LogStep(246, "Read attribute NULLABLE_INT32U null Value & range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 247: {
+            LogStep(247, "Read attribute NULLABLE_INT32U null Value & not");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 248: {
+            LogStep(248, "Write attribute NULLABLE_INT32U Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint32_t> value;
             value.SetNonNull();
@@ -47066,18 +47091,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 247: {
-            LogStep(247, "Read attribute NULLABLE_INT32U Value in range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 248: {
-            LogStep(248, "Read attribute NULLABLE_INT32U notValue OK");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
-                                 chip::NullOptional);
-        }
         case 249: {
-            LogStep(249, "Write attribute NULLABLE_INT64U Min Value");
+            LogStep(249, "Read attribute NULLABLE_INT32U Value in range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 250: {
+            LogStep(250, "Read attribute NULLABLE_INT32U notValue OK");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 251: {
+            LogStep(251, "Write attribute NULLABLE_INT64U Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint64_t> value;
             value.SetNonNull();
@@ -47085,13 +47110,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 250: {
-            LogStep(250, "Read attribute NULLABLE_INT64U Min Value");
+        case 252: {
+            LogStep(252, "Read attribute NULLABLE_INT64U Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
                                  chip::NullOptional);
         }
-        case 251: {
-            LogStep(251, "Write attribute NULLABLE_INT64U Max Value");
+        case 253: {
+            LogStep(253, "Write attribute NULLABLE_INT64U Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint64_t> value;
             value.SetNonNull();
@@ -47099,13 +47124,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 252: {
-            LogStep(252, "Read attribute NULLABLE_INT64U Max Value");
+        case 254: {
+            LogStep(254, "Read attribute NULLABLE_INT64U Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
                                  chip::NullOptional);
         }
-        case 253: {
-            LogStep(253, "Write attribute NULLABLE_INT64U Invalid Value");
+        case 255: {
+            LogStep(255, "Write attribute NULLABLE_INT64U Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint64_t> value;
             value.SetNonNull();
@@ -47113,36 +47138,36 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 254: {
-            LogStep(254, "Read attribute NULLABLE_INT64U unchanged Value");
+        case 256: {
+            LogStep(256, "Read attribute NULLABLE_INT64U unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
                                  chip::NullOptional);
         }
-        case 255: {
-            LogStep(255, "Write attribute NULLABLE_INT64U null Value");
+        case 257: {
+            LogStep(257, "Write attribute NULLABLE_INT64U null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint64_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 256: {
-            LogStep(256, "Read attribute NULLABLE_INT64U null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 257: {
-            LogStep(257, "Read attribute NULLABLE_INT64U null Value & range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
-                                 chip::NullOptional);
-        }
         case 258: {
-            LogStep(258, "Read attribute NULLABLE_INT64U null Value & not");
+            LogStep(258, "Read attribute NULLABLE_INT64U null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
                                  chip::NullOptional);
         }
         case 259: {
-            LogStep(259, "Write attribute NULLABLE_INT64U Value");
+            LogStep(259, "Read attribute NULLABLE_INT64U null Value & range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 260: {
+            LogStep(260, "Read attribute NULLABLE_INT64U null Value & not");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 261: {
+            LogStep(261, "Write attribute NULLABLE_INT64U Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint64_t> value;
             value.SetNonNull();
@@ -47150,18 +47175,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 260: {
-            LogStep(260, "Read attribute NULLABLE_INT64U Value in range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
-                                 chip::NullOptional);
-        }
-        case 261: {
-            LogStep(261, "Read attribute NULLABLE_INT64U notValue OK");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
-                                 chip::NullOptional);
-        }
         case 262: {
-            LogStep(262, "Write attribute NULLABLE_INT8S Min Value");
+            LogStep(262, "Read attribute NULLABLE_INT64U Value in range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 263: {
+            LogStep(263, "Read attribute NULLABLE_INT64U notValue OK");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 264: {
+            LogStep(264, "Write attribute NULLABLE_INT8S Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -47169,13 +47194,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 263: {
-            LogStep(263, "Read attribute NULLABLE_INT8S Min Value");
+        case 265: {
+            LogStep(265, "Read attribute NULLABLE_INT8S Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
                                  chip::NullOptional);
         }
-        case 264: {
-            LogStep(264, "Write attribute NULLABLE_INT8S Invalid Value");
+        case 266: {
+            LogStep(266, "Write attribute NULLABLE_INT8S Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -47183,36 +47208,36 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 265: {
-            LogStep(265, "Read attribute NULLABLE_INT8S unchanged Value");
+        case 267: {
+            LogStep(267, "Read attribute NULLABLE_INT8S unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
                                  chip::NullOptional);
         }
-        case 266: {
-            LogStep(266, "Write attribute NULLABLE_INT8S null Value");
+        case 268: {
+            LogStep(268, "Write attribute NULLABLE_INT8S null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 267: {
-            LogStep(267, "Read attribute NULLABLE_INT8S null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
-                                 chip::NullOptional);
-        }
-        case 268: {
-            LogStep(268, "Read attribute NULLABLE_INT8S null Value & range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
-                                 chip::NullOptional);
-        }
         case 269: {
-            LogStep(269, "Read attribute NULLABLE_INT8S null Value & not");
+            LogStep(269, "Read attribute NULLABLE_INT8S null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
                                  chip::NullOptional);
         }
         case 270: {
-            LogStep(270, "Write attribute NULLABLE_INT8S Value");
+            LogStep(270, "Read attribute NULLABLE_INT8S null Value & range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 271: {
+            LogStep(271, "Read attribute NULLABLE_INT8S null Value & not");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 272: {
+            LogStep(272, "Write attribute NULLABLE_INT8S Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -47220,18 +47245,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 271: {
-            LogStep(271, "Read attribute NULLABLE_INT8S Value in range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
-                                 chip::NullOptional);
-        }
-        case 272: {
-            LogStep(272, "Read attribute NULLABLE_INT8S notValue OK");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
-                                 chip::NullOptional);
-        }
         case 273: {
-            LogStep(273, "Write attribute NULLABLE_INT16S Min Value");
+            LogStep(273, "Read attribute NULLABLE_INT8S Value in range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 274: {
+            LogStep(274, "Read attribute NULLABLE_INT8S notValue OK");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt8s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 275: {
+            LogStep(275, "Write attribute NULLABLE_INT16S Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -47239,13 +47264,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 274: {
-            LogStep(274, "Read attribute NULLABLE_INT16S Min Value");
+        case 276: {
+            LogStep(276, "Read attribute NULLABLE_INT16S Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
                                  chip::NullOptional);
         }
-        case 275: {
-            LogStep(275, "Write attribute NULLABLE_INT16S Invalid Value");
+        case 277: {
+            LogStep(277, "Write attribute NULLABLE_INT16S Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -47253,36 +47278,36 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 276: {
-            LogStep(276, "Read attribute NULLABLE_INT16S unchanged Value");
+        case 278: {
+            LogStep(278, "Read attribute NULLABLE_INT16S unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
                                  chip::NullOptional);
         }
-        case 277: {
-            LogStep(277, "Write attribute NULLABLE_INT16S null Value");
+        case 279: {
+            LogStep(279, "Write attribute NULLABLE_INT16S null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 278: {
-            LogStep(278, "Read attribute NULLABLE_INT16S null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
-                                 chip::NullOptional);
-        }
-        case 279: {
-            LogStep(279, "Read attribute NULLABLE_INT16S null Value & range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
-                                 chip::NullOptional);
-        }
         case 280: {
-            LogStep(280, "Read attribute NULLABLE_INT16S null Value & not");
+            LogStep(280, "Read attribute NULLABLE_INT16S null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
                                  chip::NullOptional);
         }
         case 281: {
-            LogStep(281, "Write attribute NULLABLE_INT16S Value");
+            LogStep(281, "Read attribute NULLABLE_INT16S null Value & range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 282: {
+            LogStep(282, "Read attribute NULLABLE_INT16S null Value & not");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 283: {
+            LogStep(283, "Write attribute NULLABLE_INT16S Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -47290,18 +47315,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 282: {
-            LogStep(282, "Read attribute NULLABLE_INT16S Value in range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
-                                 chip::NullOptional);
-        }
-        case 283: {
-            LogStep(283, "Read attribute NULLABLE_INT16S notValue OK");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
-                                 chip::NullOptional);
-        }
         case 284: {
-            LogStep(284, "Write attribute NULLABLE_INT32S Min Value");
+            LogStep(284, "Read attribute NULLABLE_INT16S Value in range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 285: {
+            LogStep(285, "Read attribute NULLABLE_INT16S notValue OK");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt16s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 286: {
+            LogStep(286, "Write attribute NULLABLE_INT32S Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int32_t> value;
             value.SetNonNull();
@@ -47309,13 +47334,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 285: {
-            LogStep(285, "Read attribute NULLABLE_INT32S Min Value");
+        case 287: {
+            LogStep(287, "Read attribute NULLABLE_INT32S Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
                                  chip::NullOptional);
         }
-        case 286: {
-            LogStep(286, "Write attribute NULLABLE_INT32S Invalid Value");
+        case 288: {
+            LogStep(288, "Write attribute NULLABLE_INT32S Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int32_t> value;
             value.SetNonNull();
@@ -47323,36 +47348,36 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 287: {
-            LogStep(287, "Read attribute NULLABLE_INT32S unchanged Value");
+        case 289: {
+            LogStep(289, "Read attribute NULLABLE_INT32S unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
                                  chip::NullOptional);
         }
-        case 288: {
-            LogStep(288, "Write attribute NULLABLE_INT32S null Value");
+        case 290: {
+            LogStep(290, "Write attribute NULLABLE_INT32S null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int32_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 289: {
-            LogStep(289, "Read attribute NULLABLE_INT32S null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
-                                 chip::NullOptional);
-        }
-        case 290: {
-            LogStep(290, "Read attribute NULLABLE_INT32S null Value & range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
-                                 chip::NullOptional);
-        }
         case 291: {
-            LogStep(291, "Read attribute NULLABLE_INT32S null Value & not");
+            LogStep(291, "Read attribute NULLABLE_INT32S null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
                                  chip::NullOptional);
         }
         case 292: {
-            LogStep(292, "Write attribute NULLABLE_INT32S Value");
+            LogStep(292, "Read attribute NULLABLE_INT32S null Value & range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 293: {
+            LogStep(293, "Read attribute NULLABLE_INT32S null Value & not");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 294: {
+            LogStep(294, "Write attribute NULLABLE_INT32S Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int32_t> value;
             value.SetNonNull();
@@ -47360,18 +47385,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 293: {
-            LogStep(293, "Read attribute NULLABLE_INT32S Value in range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
-                                 chip::NullOptional);
-        }
-        case 294: {
-            LogStep(294, "Read attribute NULLABLE_INT32S notValue OK");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
-                                 chip::NullOptional);
-        }
         case 295: {
-            LogStep(295, "Write attribute NULLABLE_INT64S Min Value");
+            LogStep(295, "Read attribute NULLABLE_INT32S Value in range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 296: {
+            LogStep(296, "Read attribute NULLABLE_INT32S notValue OK");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt32s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 297: {
+            LogStep(297, "Write attribute NULLABLE_INT64S Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int64_t> value;
             value.SetNonNull();
@@ -47379,13 +47404,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 296: {
-            LogStep(296, "Read attribute NULLABLE_INT64S Min Value");
+        case 298: {
+            LogStep(298, "Read attribute NULLABLE_INT64S Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
                                  chip::NullOptional);
         }
-        case 297: {
-            LogStep(297, "Write attribute NULLABLE_INT64S Invalid Value");
+        case 299: {
+            LogStep(299, "Write attribute NULLABLE_INT64S Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int64_t> value;
             value.SetNonNull();
@@ -47393,36 +47418,36 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 298: {
-            LogStep(298, "Read attribute NULLABLE_INT64S unchanged Value");
+        case 300: {
+            LogStep(300, "Read attribute NULLABLE_INT64S unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
                                  chip::NullOptional);
         }
-        case 299: {
-            LogStep(299, "Write attribute NULLABLE_INT64S null Value");
+        case 301: {
+            LogStep(301, "Write attribute NULLABLE_INT64S null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int64_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 300: {
-            LogStep(300, "Read attribute NULLABLE_INT64S null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
-                                 chip::NullOptional);
-        }
-        case 301: {
-            LogStep(301, "Read attribute NULLABLE_INT64S null Value & range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
-                                 chip::NullOptional);
-        }
         case 302: {
-            LogStep(302, "Read attribute NULLABLE_INT64S null Value & not");
+            LogStep(302, "Read attribute NULLABLE_INT64S null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
                                  chip::NullOptional);
         }
         case 303: {
-            LogStep(303, "Write attribute NULLABLE_INT64S Value");
+            LogStep(303, "Read attribute NULLABLE_INT64S null Value & range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 304: {
+            LogStep(304, "Read attribute NULLABLE_INT64S null Value & not");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 305: {
+            LogStep(305, "Write attribute NULLABLE_INT64S Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int64_t> value;
             value.SetNonNull();
@@ -47430,18 +47455,18 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 304: {
-            LogStep(304, "Read attribute NULLABLE_INT64S Value in range");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
-                                 chip::NullOptional);
-        }
-        case 305: {
-            LogStep(305, "Read attribute NULLABLE_INT64S notValue OK");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
-                                 chip::NullOptional);
-        }
         case 306: {
-            LogStep(306, "Write attribute NULLABLE_SINGLE medium Value");
+            LogStep(306, "Read attribute NULLABLE_INT64S Value in range");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 307: {
+            LogStep(307, "Read attribute NULLABLE_INT64S notValue OK");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableInt64s::Id, true,
+                                 chip::NullOptional);
+        }
+        case 308: {
+            LogStep(308, "Write attribute NULLABLE_SINGLE medium Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<float> value;
             value.SetNonNull();
@@ -47449,13 +47474,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 307: {
-            LogStep(307, "Read attribute NULLABLE_SINGLE medium Value");
+        case 309: {
+            LogStep(309, "Read attribute NULLABLE_SINGLE medium Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                  true, chip::NullOptional);
         }
-        case 308: {
-            LogStep(308, "Write attribute NULLABLE_SINGLE largest Value");
+        case 310: {
+            LogStep(310, "Write attribute NULLABLE_SINGLE largest Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<float> value;
             value.SetNonNull();
@@ -47463,13 +47488,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 309: {
-            LogStep(309, "Read attribute NULLABLE_SINGLE largest Value");
+        case 311: {
+            LogStep(311, "Read attribute NULLABLE_SINGLE largest Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                  true, chip::NullOptional);
         }
-        case 310: {
-            LogStep(310, "Write attribute NULLABLE_SINGLE smallest Value");
+        case 312: {
+            LogStep(312, "Write attribute NULLABLE_SINGLE smallest Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<float> value;
             value.SetNonNull();
@@ -47477,26 +47502,26 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 311: {
-            LogStep(311, "Read attribute NULLABLE_SINGLE smallest Value");
+        case 313: {
+            LogStep(313, "Read attribute NULLABLE_SINGLE smallest Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                  true, chip::NullOptional);
         }
-        case 312: {
-            LogStep(312, "Write attribute NULLABLE_SINGLE null Value");
+        case 314: {
+            LogStep(314, "Write attribute NULLABLE_SINGLE null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<float> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 313: {
-            LogStep(313, "Read attribute NULLABLE_SINGLE null Value");
+        case 315: {
+            LogStep(315, "Read attribute NULLABLE_SINGLE null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                  true, chip::NullOptional);
         }
-        case 314: {
-            LogStep(314, "Write attribute NULLABLE_SINGLE 0 Value");
+        case 316: {
+            LogStep(316, "Write attribute NULLABLE_SINGLE 0 Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<float> value;
             value.SetNonNull();
@@ -47504,13 +47529,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 315: {
-            LogStep(315, "Read attribute NULLABLE_SINGLE 0 Value");
+        case 317: {
+            LogStep(317, "Read attribute NULLABLE_SINGLE 0 Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatSingle::Id,
                                  true, chip::NullOptional);
         }
-        case 316: {
-            LogStep(316, "Write attribute NULLABLE_DOUBLE medium Value");
+        case 318: {
+            LogStep(318, "Write attribute NULLABLE_DOUBLE medium Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<double> value;
             value.SetNonNull();
@@ -47518,13 +47543,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 317: {
-            LogStep(317, "Read attribute NULLABLE_DOUBLE medium Value");
+        case 319: {
+            LogStep(319, "Read attribute NULLABLE_DOUBLE medium Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                  true, chip::NullOptional);
         }
-        case 318: {
-            LogStep(318, "Write attribute NULLABLE_DOUBLE largest Value");
+        case 320: {
+            LogStep(320, "Write attribute NULLABLE_DOUBLE largest Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<double> value;
             value.SetNonNull();
@@ -47532,13 +47557,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 319: {
-            LogStep(319, "Read attribute NULLABLE_DOUBLE largest Value");
+        case 321: {
+            LogStep(321, "Read attribute NULLABLE_DOUBLE largest Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                  true, chip::NullOptional);
         }
-        case 320: {
-            LogStep(320, "Write attribute NULLABLE_DOUBLE smallest Value");
+        case 322: {
+            LogStep(322, "Write attribute NULLABLE_DOUBLE smallest Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<double> value;
             value.SetNonNull();
@@ -47546,26 +47571,26 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 321: {
-            LogStep(321, "Read attribute NULLABLE_DOUBLE smallest Value");
+        case 323: {
+            LogStep(323, "Read attribute NULLABLE_DOUBLE smallest Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                  true, chip::NullOptional);
         }
-        case 322: {
-            LogStep(322, "Write attribute NULLABLE_DOUBLE null Value");
+        case 324: {
+            LogStep(324, "Write attribute NULLABLE_DOUBLE null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<double> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 323: {
-            LogStep(323, "Read attribute NULLABLE_DOUBLE null Value");
+        case 325: {
+            LogStep(325, "Read attribute NULLABLE_DOUBLE null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                  true, chip::NullOptional);
         }
-        case 324: {
-            LogStep(324, "Write attribute NULLABLE_DOUBLE 0 Value");
+        case 326: {
+            LogStep(326, "Write attribute NULLABLE_DOUBLE 0 Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<double> value;
             value.SetNonNull();
@@ -47573,13 +47598,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 325: {
-            LogStep(325, "Read attribute NULLABLE_DOUBLE 0 Value");
+        case 327: {
+            LogStep(327, "Read attribute NULLABLE_DOUBLE 0 Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableFloatDouble::Id,
                                  true, chip::NullOptional);
         }
-        case 326: {
-            LogStep(326, "Write attribute NULLABLE_ENUM8 Min Value");
+        case 328: {
+            LogStep(328, "Write attribute NULLABLE_ENUM8 Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -47587,13 +47612,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum8::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 327: {
-            LogStep(327, "Read attribute NULLABLE_ENUM8 Min Value");
+        case 329: {
+            LogStep(329, "Read attribute NULLABLE_ENUM8 Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum8::Id, true,
                                  chip::NullOptional);
         }
-        case 328: {
-            LogStep(328, "Write attribute NULLABLE_ENUM8 Max Value");
+        case 330: {
+            LogStep(330, "Write attribute NULLABLE_ENUM8 Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -47601,13 +47626,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum8::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 329: {
-            LogStep(329, "Read attribute NULLABLE_ENUM8 Max Value");
+        case 331: {
+            LogStep(331, "Read attribute NULLABLE_ENUM8 Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum8::Id, true,
                                  chip::NullOptional);
         }
-        case 330: {
-            LogStep(330, "Write attribute NULLABLE_ENUM8 Invalid Value");
+        case 332: {
+            LogStep(332, "Write attribute NULLABLE_ENUM8 Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -47615,26 +47640,26 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum8::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 331: {
-            LogStep(331, "Read attribute NULLABLE_ENUM8 unchanged Value");
+        case 333: {
+            LogStep(333, "Read attribute NULLABLE_ENUM8 unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum8::Id, true,
                                  chip::NullOptional);
         }
-        case 332: {
-            LogStep(332, "Write attribute NULLABLE_ENUM8 null Value");
+        case 334: {
+            LogStep(334, "Write attribute NULLABLE_ENUM8 null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum8::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 333: {
-            LogStep(333, "Read attribute NULLABLE_ENUM8 null Value");
+        case 335: {
+            LogStep(335, "Read attribute NULLABLE_ENUM8 null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum8::Id, true,
                                  chip::NullOptional);
         }
-        case 334: {
-            LogStep(334, "Write attribute NULLABLE_ENUM16 Min Value");
+        case 336: {
+            LogStep(336, "Write attribute NULLABLE_ENUM16 Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -47642,13 +47667,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum16::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 335: {
-            LogStep(335, "Read attribute NULLABLE_ENUM16 Min Value");
+        case 337: {
+            LogStep(337, "Read attribute NULLABLE_ENUM16 Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum16::Id, true,
                                  chip::NullOptional);
         }
-        case 336: {
-            LogStep(336, "Write attribute NULLABLE_ENUM16 Max Value");
+        case 338: {
+            LogStep(338, "Write attribute NULLABLE_ENUM16 Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -47656,13 +47681,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum16::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 337: {
-            LogStep(337, "Read attribute NULLABLE_ENUM16 Max Value");
+        case 339: {
+            LogStep(339, "Read attribute NULLABLE_ENUM16 Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum16::Id, true,
                                  chip::NullOptional);
         }
-        case 338: {
-            LogStep(338, "Write attribute NULLABLE_ENUM16 Invalid Value");
+        case 340: {
+            LogStep(340, "Write attribute NULLABLE_ENUM16 Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -47670,26 +47695,26 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum16::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 339: {
-            LogStep(339, "Read attribute NULLABLE_ENUM16 unchanged Value");
+        case 341: {
+            LogStep(341, "Read attribute NULLABLE_ENUM16 unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum16::Id, true,
                                  chip::NullOptional);
         }
-        case 340: {
-            LogStep(340, "Write attribute NULLABLE_ENUM16 null Value");
+        case 342: {
+            LogStep(342, "Write attribute NULLABLE_ENUM16 null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum16::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 341: {
-            LogStep(341, "Read attribute NULLABLE_ENUM16 null Value");
+        case 343: {
+            LogStep(343, "Read attribute NULLABLE_ENUM16 null Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnum16::Id, true,
                                  chip::NullOptional);
         }
-        case 342: {
-            LogStep(342, "Write attribute NULLABLE_SIMPLE_ENUM Min Value");
+        case 344: {
+            LogStep(344, "Write attribute NULLABLE_SIMPLE_ENUM Min Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
             value.SetNonNull();
@@ -47697,13 +47722,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 343: {
-            LogStep(343, "Read attribute NULLABLE_SIMPLE_ENUM Min Value");
+        case 345: {
+            LogStep(345, "Read attribute NULLABLE_SIMPLE_ENUM Min Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
                                  true, chip::NullOptional);
         }
-        case 344: {
-            LogStep(344, "Write attribute NULLABLE_SIMPLE_ENUM Max Value");
+        case 346: {
+            LogStep(346, "Write attribute NULLABLE_SIMPLE_ENUM Max Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
             value.SetNonNull();
@@ -47711,13 +47736,13 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 345: {
-            LogStep(345, "Read attribute NULLABLE_SIMPLE_ENUM Max Value");
+        case 347: {
+            LogStep(347, "Read attribute NULLABLE_SIMPLE_ENUM Max Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
                                  true, chip::NullOptional);
         }
-        case 346: {
-            LogStep(346, "Write attribute NULLABLE_SIMPLE_ENUM Invalid Value");
+        case 348: {
+            LogStep(348, "Write attribute NULLABLE_SIMPLE_ENUM Invalid Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
             value.SetNonNull();
@@ -47725,45 +47750,31 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 347: {
-            LogStep(347, "Read attribute NULLABLE_SIMPLE_ENUM unchanged Value");
+        case 349: {
+            LogStep(349, "Read attribute NULLABLE_SIMPLE_ENUM unchanged Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
                                  true, chip::NullOptional);
         }
-        case 348: {
-            LogStep(348, "Write attribute NULLABLE_SIMPLE_ENUM null Value");
+        case 350: {
+            LogStep(350, "Write attribute NULLABLE_SIMPLE_ENUM null Value");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::app::Clusters::TestCluster::SimpleEnum> value;
             value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 349: {
-            LogStep(349, "Read attribute NULLABLE_SIMPLE_ENUM null Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
-                                 true, chip::NullOptional);
-        }
-        case 350: {
-            LogStep(350, "Read attribute NULLABLE_SIMPLE_ENUM not 254 Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
-                                 true, chip::NullOptional);
-        }
         case 351: {
-            LogStep(351, "Read attribute NULLABLE_OCTET_STRING Default Value");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableOctetString::Id,
+            LogStep(351, "Read attribute NULLABLE_SIMPLE_ENUM null Value");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
                                  true, chip::NullOptional);
         }
         case 352: {
-            LogStep(352, "Write attribute NULLABLE_OCTET_STRING");
-            ListFreer listFreer;
-            chip::app::DataModel::Nullable<chip::ByteSpan> value;
-            value.SetNonNull();
-            value.Value() = chip::ByteSpan(chip::Uint8::from_const_char("TestValuegarbage: not in length on purpose"), 9);
-            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableOctetString::Id,
-                                  value, chip::NullOptional, chip::NullOptional);
+            LogStep(352, "Read attribute NULLABLE_SIMPLE_ENUM not 254 Value");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableEnumAttr::Id,
+                                 true, chip::NullOptional);
         }
         case 353: {
-            LogStep(353, "Read attribute NULLABLE_OCTET_STRING");
+            LogStep(353, "Read attribute NULLABLE_OCTET_STRING Default Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableOctetString::Id,
                                  true, chip::NullOptional);
         }
@@ -47771,7 +47782,8 @@ private:
             LogStep(354, "Write attribute NULLABLE_OCTET_STRING");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::ByteSpan> value;
-            value.SetNull();
+            value.SetNonNull();
+            value.Value() = chip::ByteSpan(chip::Uint8::from_const_char("TestValuegarbage: not in length on purpose"), 9);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableOctetString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
@@ -47784,8 +47796,7 @@ private:
             LogStep(356, "Write attribute NULLABLE_OCTET_STRING");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::ByteSpan> value;
-            value.SetNonNull();
-            value.Value() = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
+            value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableOctetString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
@@ -47795,17 +47806,31 @@ private:
                                  true, chip::NullOptional);
         }
         case 358: {
-            LogStep(358, "Read attribute NULLABLE_OCTET_STRING not TestValue");
+            LogStep(358, "Write attribute NULLABLE_OCTET_STRING");
+            ListFreer listFreer;
+            chip::app::DataModel::Nullable<chip::ByteSpan> value;
+            value.SetNonNull();
+            value.Value() = chip::ByteSpan(chip::Uint8::from_const_char("garbage: not in length on purpose"), 0);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableOctetString::Id,
+                                  value, chip::NullOptional, chip::NullOptional);
+        }
+        case 359: {
+            LogStep(359, "Read attribute NULLABLE_OCTET_STRING");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableOctetString::Id,
                                  true, chip::NullOptional);
         }
-        case 359: {
-            LogStep(359, "Read attribute NULLABLE_CHAR_STRING Default Value");
+        case 360: {
+            LogStep(360, "Read attribute NULLABLE_OCTET_STRING not TestValue");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableOctetString::Id,
+                                 true, chip::NullOptional);
+        }
+        case 361: {
+            LogStep(361, "Read attribute NULLABLE_CHAR_STRING Default Value");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
                                  true, chip::NullOptional);
         }
-        case 360: {
-            LogStep(360, "Write attribute NULLABLE_CHAR_STRING");
+        case 362: {
+            LogStep(362, "Write attribute NULLABLE_CHAR_STRING");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::CharSpan> value;
             value.SetNonNull();
@@ -47813,23 +47838,10 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 361: {
-            LogStep(361, "Read attribute NULLABLE_CHAR_STRING");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
-                                 true, chip::NullOptional);
-        }
-        case 362: {
-            LogStep(362, "Read attribute NULLABLE_CHAR_STRING");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
-                                 true, chip::NullOptional);
-        }
         case 363: {
-            LogStep(363, "Write attribute NULLABLE_CHAR_STRING - Value too long");
-            ListFreer listFreer;
-            chip::app::DataModel::Nullable<chip::CharSpan> value;
-            value.SetNull();
-            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
-                                  value, chip::NullOptional, chip::NullOptional);
+            LogStep(363, "Read attribute NULLABLE_CHAR_STRING");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
+                                 true, chip::NullOptional);
         }
         case 364: {
             LogStep(364, "Read attribute NULLABLE_CHAR_STRING");
@@ -47837,11 +47849,10 @@ private:
                                  true, chip::NullOptional);
         }
         case 365: {
-            LogStep(365, "Write attribute NULLABLE_CHAR_STRING - Empty");
+            LogStep(365, "Write attribute NULLABLE_CHAR_STRING - Value too long");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<chip::CharSpan> value;
-            value.SetNonNull();
-            value.Value() = chip::Span<const char>("garbage: not in length on purpose", 0);
+            value.SetNull();
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
@@ -47851,22 +47862,36 @@ private:
                                  true, chip::NullOptional);
         }
         case 367: {
-            LogStep(367, "Read attribute NULLABLE_CHAR_STRING not ☉T☉");
+            LogStep(367, "Write attribute NULLABLE_CHAR_STRING - Empty");
+            ListFreer listFreer;
+            chip::app::DataModel::Nullable<chip::CharSpan> value;
+            value.SetNonNull();
+            value.Value() = chip::Span<const char>("garbage: not in length on purpose", 0);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
+                                  value, chip::NullOptional, chip::NullOptional);
+        }
+        case 368: {
+            LogStep(368, "Read attribute NULLABLE_CHAR_STRING");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
                                  true, chip::NullOptional);
         }
-        case 368: {
-            LogStep(368, "Read attribute from nonexistent endpoint.");
+        case 369: {
+            LogStep(369, "Read attribute NULLABLE_CHAR_STRING not ☉T☉");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::NullableCharString::Id,
+                                 true, chip::NullOptional);
+        }
+        case 370: {
+            LogStep(370, "Read attribute from nonexistent endpoint.");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(200), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, true,
                                  chip::NullOptional);
         }
-        case 369: {
-            LogStep(369, "Read attribute from nonexistent cluster.");
+        case 371: {
+            LogStep(371, "Read attribute from nonexistent cluster.");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, true,
                                  chip::NullOptional);
         }
-        case 370: {
-            LogStep(370, "Send a command that takes an optional parameter but do not set it.");
+        case 372: {
+            LogStep(372, "Send a command that takes an optional parameter but do not set it.");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestSimpleOptionalArgumentRequest::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
@@ -47874,8 +47899,8 @@ private:
 
             );
         }
-        case 371: {
-            LogStep(371, "Send a command that takes an optional parameter but do not set it.");
+        case 373: {
+            LogStep(373, "Send a command that takes an optional parameter but do not set it.");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Commands::TestSimpleOptionalArgumentRequest::Type value;
             value.arg1.Emplace();
@@ -47885,13 +47910,13 @@ private:
 
             );
         }
-        case 372: {
-            LogStep(372, "Subscribe to list attribute");
+        case 374: {
+            LogStep(374, "Subscribe to list attribute");
             return SubscribeAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, 2, 5,
                                       true, chip::NullOptional, chip::NullOptional);
         }
-        case 373: {
-            LogStep(373, "Write subscribed-to list attribute");
+        case 375: {
+            LogStep(375, "Write subscribed-to list attribute");
             ListFreer listFreer;
             chip::app::DataModel::List<const uint8_t> value;
 
@@ -47907,98 +47932,98 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 374: {
-            LogStep(374, "Check for list attribute report");
+        case 376: {
+            LogStep(376, "Check for list attribute report");
             return WaitForReport();
         }
-        case 375: {
-            LogStep(375, "Read range-restricted unsigned 8-bit integer");
+        case 377: {
+            LogStep(377, "Read range-restricted unsigned 8-bit integer");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8u::Id,
                                  true, chip::NullOptional);
         }
-        case 376: {
-            LogStep(376, "Write min value to a range-restricted unsigned 8-bit integer");
+        case 378: {
+            LogStep(378, "Write min value to a range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             uint8_t value;
             value = 0;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8u::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 377: {
-            LogStep(377, "Write just-below-range value to a range-restricted unsigned 8-bit integer");
+        case 379: {
+            LogStep(379, "Write just-below-range value to a range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             uint8_t value;
             value = 19;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8u::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 378: {
-            LogStep(378, "Write just-above-range value to a range-restricted unsigned 8-bit integer");
+        case 380: {
+            LogStep(380, "Write just-above-range value to a range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             uint8_t value;
             value = 101;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8u::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 379: {
-            LogStep(379, "Write max value to a range-restricted unsigned 8-bit integer");
+        case 381: {
+            LogStep(381, "Write max value to a range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             uint8_t value;
             value = 255;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8u::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 380: {
-            LogStep(380, "Verify range-restricted unsigned 8-bit integer value has not changed");
+        case 382: {
+            LogStep(382, "Verify range-restricted unsigned 8-bit integer value has not changed");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8u::Id,
                                  true, chip::NullOptional);
         }
-        case 381: {
-            LogStep(381, "Write min valid value to a range-restricted unsigned 8-bit integer");
+        case 383: {
+            LogStep(383, "Write min valid value to a range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             uint8_t value;
             value = 20;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8u::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 382: {
-            LogStep(382, "Verify range-restricted unsigned 8-bit integer value is at min valid");
+        case 384: {
+            LogStep(384, "Verify range-restricted unsigned 8-bit integer value is at min valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8u::Id,
                                  true, chip::NullOptional);
         }
-        case 383: {
-            LogStep(383, "Write max valid value to a range-restricted unsigned 8-bit integer");
+        case 385: {
+            LogStep(385, "Write max valid value to a range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             uint8_t value;
             value = 100;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8u::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 384: {
-            LogStep(384, "Verify range-restricted unsigned 8-bit integer value is at max valid");
+        case 386: {
+            LogStep(386, "Verify range-restricted unsigned 8-bit integer value is at max valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8u::Id,
                                  true, chip::NullOptional);
         }
-        case 385: {
-            LogStep(385, "Write middle valid value to a range-restricted unsigned 8-bit integer");
+        case 387: {
+            LogStep(387, "Write middle valid value to a range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             uint8_t value;
             value = 50;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8u::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 386: {
-            LogStep(386, "Verify range-restricted unsigned 8-bit integer value is at mid valid");
+        case 388: {
+            LogStep(388, "Verify range-restricted unsigned 8-bit integer value is at mid valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8u::Id,
                                  true, chip::NullOptional);
         }
-        case 387: {
-            LogStep(387, "Read range-restricted unsigned 16-bit integer");
+        case 389: {
+            LogStep(389, "Read range-restricted unsigned 16-bit integer");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 388: {
-            LogStep(388, "Write min value to a range-restricted unsigned 16-bit integer");
+        case 390: {
+            LogStep(390, "Write min value to a range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             uint16_t value;
             value = 0U;
@@ -48006,8 +48031,8 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 389: {
-            LogStep(389, "Write just-below-range value to a range-restricted unsigned 16-bit integer");
+        case 391: {
+            LogStep(391, "Write just-below-range value to a range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             uint16_t value;
             value = 99U;
@@ -48015,8 +48040,8 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 390: {
-            LogStep(390, "Write just-above-range value to a range-restricted unsigned 16-bit integer");
+        case 392: {
+            LogStep(392, "Write just-above-range value to a range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             uint16_t value;
             value = 1001U;
@@ -48024,8 +48049,8 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 391: {
-            LogStep(391, "Write max value to a range-restricted unsigned 16-bit integer");
+        case 393: {
+            LogStep(393, "Write max value to a range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             uint16_t value;
             value = 65535U;
@@ -48033,13 +48058,13 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 392: {
-            LogStep(392, "Verify range-restricted unsigned 16-bit integer value has not changed");
+        case 394: {
+            LogStep(394, "Verify range-restricted unsigned 16-bit integer value has not changed");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 393: {
-            LogStep(393, "Write min valid value to a range-restricted unsigned 16-bit integer");
+        case 395: {
+            LogStep(395, "Write min valid value to a range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             uint16_t value;
             value = 100U;
@@ -48047,13 +48072,13 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 394: {
-            LogStep(394, "Verify range-restricted unsigned 16-bit integer value is at min valid");
+        case 396: {
+            LogStep(396, "Verify range-restricted unsigned 16-bit integer value is at min valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 395: {
-            LogStep(395, "Write max valid value to a range-restricted unsigned 16-bit integer");
+        case 397: {
+            LogStep(397, "Write max valid value to a range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             uint16_t value;
             value = 1000U;
@@ -48061,13 +48086,13 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 396: {
-            LogStep(396, "Verify range-restricted unsigned 16-bit integer value is at max valid");
+        case 398: {
+            LogStep(398, "Verify range-restricted unsigned 16-bit integer value is at max valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 397: {
-            LogStep(397, "Write middle valid value to a range-restricted unsigned 16-bit integer");
+        case 399: {
+            LogStep(399, "Write middle valid value to a range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             uint16_t value;
             value = 500U;
@@ -48075,99 +48100,99 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 398: {
-            LogStep(398, "Verify range-restricted unsigned 16-bit integer value is at mid valid");
+        case 400: {
+            LogStep(400, "Verify range-restricted unsigned 16-bit integer value is at mid valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 399: {
-            LogStep(399, "Read range-restricted signed 8-bit integer");
+        case 401: {
+            LogStep(401, "Read range-restricted signed 8-bit integer");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8s::Id,
                                  true, chip::NullOptional);
         }
-        case 400: {
-            LogStep(400, "Write min value to a range-restricted signed 8-bit integer");
+        case 402: {
+            LogStep(402, "Write min value to a range-restricted signed 8-bit integer");
             ListFreer listFreer;
             int8_t value;
             value = -128;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8s::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 401: {
-            LogStep(401, "Write just-below-range value to a range-restricted signed 8-bit integer");
+        case 403: {
+            LogStep(403, "Write just-below-range value to a range-restricted signed 8-bit integer");
             ListFreer listFreer;
             int8_t value;
             value = -41;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8s::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 402: {
-            LogStep(402, "Write just-above-range value to a range-restricted signed 8-bit integer");
+        case 404: {
+            LogStep(404, "Write just-above-range value to a range-restricted signed 8-bit integer");
             ListFreer listFreer;
             int8_t value;
             value = 51;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8s::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 403: {
-            LogStep(403, "Write max value to a range-restricted signed 8-bit integer");
+        case 405: {
+            LogStep(405, "Write max value to a range-restricted signed 8-bit integer");
             ListFreer listFreer;
             int8_t value;
             value = 127;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8s::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 404: {
-            LogStep(404, "Verify range-restricted signed 8-bit integer value has not changed");
+        case 406: {
+            LogStep(406, "Verify range-restricted signed 8-bit integer value has not changed");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8s::Id,
                                  true, chip::NullOptional);
         }
-        case 405: {
-            LogStep(405, "Write min valid value to a range-restricted signed 8-bit integer");
+        case 407: {
+            LogStep(407, "Write min valid value to a range-restricted signed 8-bit integer");
             ListFreer listFreer;
             int8_t value;
             value = -40;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8s::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 406: {
-            LogStep(406, "Verify range-restricted signed 8-bit integer value is at min valid");
+        case 408: {
+            LogStep(408, "Verify range-restricted signed 8-bit integer value is at min valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8s::Id,
                                  true, chip::NullOptional);
         }
-        case 407: {
-            LogStep(407, "Write max valid value to a range-restricted signed 8-bit integer");
+        case 409: {
+            LogStep(409, "Write max valid value to a range-restricted signed 8-bit integer");
             ListFreer listFreer;
             int8_t value;
             value = 50;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8s::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 408: {
-            LogStep(408, "Verify range-restricted signed 8-bit integer value is at max valid");
+        case 410: {
+            LogStep(410, "Verify range-restricted signed 8-bit integer value is at max valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8s::Id,
                                  true, chip::NullOptional);
         }
-        case 409: {
-            LogStep(409, "Write middle valid value to a range-restricted signed 8-bit integer");
+        case 411: {
+            LogStep(411, "Write middle valid value to a range-restricted signed 8-bit integer");
             ListFreer listFreer;
             int8_t value;
             value = 6;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                   TestCluster::Attributes::RangeRestrictedInt8s::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 410: {
-            LogStep(410, "Verify range-restricted signed 8-bit integer value is at mid valid");
+        case 412: {
+            LogStep(412, "Verify range-restricted signed 8-bit integer value is at mid valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::RangeRestrictedInt8s::Id,
                                  true, chip::NullOptional);
         }
-        case 411: {
-            LogStep(411, "Read range-restricted signed 16-bit integer");
+        case 413: {
+            LogStep(413, "Read range-restricted signed 16-bit integer");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 412: {
-            LogStep(412, "Write min value to a range-restricted signed 16-bit integer");
+        case 414: {
+            LogStep(414, "Write min value to a range-restricted signed 16-bit integer");
             ListFreer listFreer;
             int16_t value;
             value = -32768;
@@ -48175,8 +48200,8 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 413: {
-            LogStep(413, "Write just-below-range value to a range-restricted signed 16-bit integer");
+        case 415: {
+            LogStep(415, "Write just-below-range value to a range-restricted signed 16-bit integer");
             ListFreer listFreer;
             int16_t value;
             value = -151;
@@ -48184,8 +48209,8 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 414: {
-            LogStep(414, "Write just-above-range value to a range-restricted signed 16-bit integer");
+        case 416: {
+            LogStep(416, "Write just-above-range value to a range-restricted signed 16-bit integer");
             ListFreer listFreer;
             int16_t value;
             value = 201;
@@ -48193,8 +48218,8 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 415: {
-            LogStep(415, "Write max value to a range-restricted signed 16-bit integer");
+        case 417: {
+            LogStep(417, "Write max value to a range-restricted signed 16-bit integer");
             ListFreer listFreer;
             int16_t value;
             value = 32767;
@@ -48202,13 +48227,13 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 416: {
-            LogStep(416, "Verify range-restricted signed 16-bit integer value has not changed");
+        case 418: {
+            LogStep(418, "Verify range-restricted signed 16-bit integer value has not changed");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 417: {
-            LogStep(417, "Write min valid value to a range-restricted signed 16-bit integer");
+        case 419: {
+            LogStep(419, "Write min valid value to a range-restricted signed 16-bit integer");
             ListFreer listFreer;
             int16_t value;
             value = -150;
@@ -48216,13 +48241,13 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 418: {
-            LogStep(418, "Verify range-restricted signed 16-bit integer value is at min valid");
+        case 420: {
+            LogStep(420, "Verify range-restricted signed 16-bit integer value is at min valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 419: {
-            LogStep(419, "Write max valid value to a range-restricted signed 16-bit integer");
+        case 421: {
+            LogStep(421, "Write max valid value to a range-restricted signed 16-bit integer");
             ListFreer listFreer;
             int16_t value;
             value = 200;
@@ -48230,13 +48255,13 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 420: {
-            LogStep(420, "Verify range-restricted signed 16-bit integer value is at max valid");
+        case 422: {
+            LogStep(422, "Verify range-restricted signed 16-bit integer value is at max valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 421: {
-            LogStep(421, "Write middle valid value to a range-restricted signed 16-bit integer");
+        case 423: {
+            LogStep(423, "Write middle valid value to a range-restricted signed 16-bit integer");
             ListFreer listFreer;
             int16_t value;
             value = 7;
@@ -48244,18 +48269,18 @@ private:
                                   TestCluster::Attributes::RangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 422: {
-            LogStep(422, "Verify range-restricted signed 16-bit integer value is at mid valid");
+        case 424: {
+            LogStep(424, "Verify range-restricted signed 16-bit integer value is at mid valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::RangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 423: {
-            LogStep(423, "Read nullable range-restricted unsigned 8-bit integer");
+        case 425: {
+            LogStep(425, "Read nullable range-restricted unsigned 8-bit integer");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, true, chip::NullOptional);
         }
-        case 424: {
-            LogStep(424, "Write min value to a nullable range-restricted unsigned 8-bit integer");
+        case 426: {
+            LogStep(426, "Write min value to a nullable range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -48264,8 +48289,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 425: {
-            LogStep(425, "Write just-below-range value to a nullable range-restricted unsigned 8-bit integer");
+        case 427: {
+            LogStep(427, "Write just-below-range value to a nullable range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -48274,8 +48299,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 426: {
-            LogStep(426, "Write just-above-range value to a nullable range-restricted unsigned 8-bit integer");
+        case 428: {
+            LogStep(428, "Write just-above-range value to a nullable range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -48284,8 +48309,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 427: {
-            LogStep(427, "Write max value to a nullable range-restricted unsigned 8-bit integer");
+        case 429: {
+            LogStep(429, "Write max value to a nullable range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -48294,13 +48319,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 428: {
-            LogStep(428, "Verify nullable range-restricted unsigned 8-bit integer value has not changed");
+        case 430: {
+            LogStep(430, "Verify nullable range-restricted unsigned 8-bit integer value has not changed");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, true, chip::NullOptional);
         }
-        case 429: {
-            LogStep(429, "Write min valid value to a nullable range-restricted unsigned 8-bit integer");
+        case 431: {
+            LogStep(431, "Write min valid value to a nullable range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -48309,13 +48334,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 430: {
-            LogStep(430, "Verify nullable range-restricted unsigned 8-bit integer value is at min valid");
+        case 432: {
+            LogStep(432, "Verify nullable range-restricted unsigned 8-bit integer value is at min valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, true, chip::NullOptional);
         }
-        case 431: {
-            LogStep(431, "Write max valid value to a nullable range-restricted unsigned 8-bit integer");
+        case 433: {
+            LogStep(433, "Write max valid value to a nullable range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -48324,13 +48349,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 432: {
-            LogStep(432, "Verify nullable range-restricted unsigned 8-bit integer value is at max valid");
+        case 434: {
+            LogStep(434, "Verify nullable range-restricted unsigned 8-bit integer value is at max valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, true, chip::NullOptional);
         }
-        case 433: {
-            LogStep(433, "Write middle valid value to a nullable range-restricted unsigned 8-bit integer");
+        case 435: {
+            LogStep(435, "Write middle valid value to a nullable range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNonNull();
@@ -48339,13 +48364,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 434: {
-            LogStep(434, "Verify nullable range-restricted unsigned 8-bit integer value is at mid valid");
+        case 436: {
+            LogStep(436, "Verify nullable range-restricted unsigned 8-bit integer value is at mid valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, true, chip::NullOptional);
         }
-        case 435: {
-            LogStep(435, "Write null value to a nullable range-restricted unsigned 8-bit integer");
+        case 437: {
+            LogStep(437, "Write null value to a nullable range-restricted unsigned 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint8_t> value;
             value.SetNull();
@@ -48353,18 +48378,18 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 436: {
-            LogStep(436, "Verify nullable range-restricted unsigned 8-bit integer value is null");
+        case 438: {
+            LogStep(438, "Verify nullable range-restricted unsigned 8-bit integer value is null");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8u::Id, true, chip::NullOptional);
         }
-        case 437: {
-            LogStep(437, "Read nullable range-restricted unsigned 16-bit integer");
+        case 439: {
+            LogStep(439, "Read nullable range-restricted unsigned 16-bit integer");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 438: {
-            LogStep(438, "Write min value to a nullable range-restricted unsigned 16-bit integer");
+        case 440: {
+            LogStep(440, "Write min value to a nullable range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -48373,8 +48398,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 439: {
-            LogStep(439, "Write just-below-range value to a nullable range-restricted unsigned 16-bit integer");
+        case 441: {
+            LogStep(441, "Write just-below-range value to a nullable range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -48383,8 +48408,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 440: {
-            LogStep(440, "Write just-above-range value to a nullable range-restricted unsigned 16-bit integer");
+        case 442: {
+            LogStep(442, "Write just-above-range value to a nullable range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -48393,8 +48418,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 441: {
-            LogStep(441, "Write max value to a nullable range-restricted unsigned 16-bit integer");
+        case 443: {
+            LogStep(443, "Write max value to a nullable range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -48403,13 +48428,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 442: {
-            LogStep(442, "Verify nullable range-restricted unsigned 16-bit integer value has not changed");
+        case 444: {
+            LogStep(444, "Verify nullable range-restricted unsigned 16-bit integer value has not changed");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 443: {
-            LogStep(443, "Write min valid value to a nullable range-restricted unsigned 16-bit integer");
+        case 445: {
+            LogStep(445, "Write min valid value to a nullable range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -48418,13 +48443,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 444: {
-            LogStep(444, "Verify nullable range-restricted unsigned 16-bit integer value is at min valid");
+        case 446: {
+            LogStep(446, "Verify nullable range-restricted unsigned 16-bit integer value is at min valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 445: {
-            LogStep(445, "Write max valid value to a nullable range-restricted unsigned 16-bit integer");
+        case 447: {
+            LogStep(447, "Write max valid value to a nullable range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -48433,13 +48458,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 446: {
-            LogStep(446, "Verify nullable range-restricted unsigned 16-bit integer value is at max valid");
+        case 448: {
+            LogStep(448, "Verify nullable range-restricted unsigned 16-bit integer value is at max valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 447: {
-            LogStep(447, "Write middle valid value to a nullable range-restricted unsigned 16-bit integer");
+        case 449: {
+            LogStep(449, "Write middle valid value to a nullable range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNonNull();
@@ -48448,13 +48473,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 448: {
-            LogStep(448, "Verify nullable range-restricted unsigned 16-bit integer value is at mid valid");
+        case 450: {
+            LogStep(450, "Verify nullable range-restricted unsigned 16-bit integer value is at mid valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 449: {
-            LogStep(449, "Write null value to a nullable range-restricted unsigned 16-bit integer");
+        case 451: {
+            LogStep(451, "Write null value to a nullable range-restricted unsigned 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<uint16_t> value;
             value.SetNull();
@@ -48462,18 +48487,18 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 450: {
-            LogStep(450, "Verify nullable range-restricted unsigned 16-bit integer value is null");
+        case 452: {
+            LogStep(452, "Verify nullable range-restricted unsigned 16-bit integer value is null");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16u::Id, true, chip::NullOptional);
         }
-        case 451: {
-            LogStep(451, "Read nullable range-restricted signed 8-bit integer");
+        case 453: {
+            LogStep(453, "Read nullable range-restricted signed 8-bit integer");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, true, chip::NullOptional);
         }
-        case 452: {
-            LogStep(452, "Write min value to a nullable range-restricted signed 8-bit integer");
+        case 454: {
+            LogStep(454, "Write min value to a nullable range-restricted signed 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -48482,8 +48507,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 453: {
-            LogStep(453, "Write just-below-range value to a nullable range-restricted signed 8-bit integer");
+        case 455: {
+            LogStep(455, "Write just-below-range value to a nullable range-restricted signed 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -48492,8 +48517,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 454: {
-            LogStep(454, "Write just-above-range value to a nullable range-restricted signed 8-bit integer");
+        case 456: {
+            LogStep(456, "Write just-above-range value to a nullable range-restricted signed 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -48502,8 +48527,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 455: {
-            LogStep(455, "Write max value to a nullable range-restricted signed 8-bit integer");
+        case 457: {
+            LogStep(457, "Write max value to a nullable range-restricted signed 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -48512,13 +48537,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 456: {
-            LogStep(456, "Verify nullable range-restricted signed 8-bit integer value has not changed");
+        case 458: {
+            LogStep(458, "Verify nullable range-restricted signed 8-bit integer value has not changed");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, true, chip::NullOptional);
         }
-        case 457: {
-            LogStep(457, "Write min valid value to a nullable range-restricted signed 8-bit integer");
+        case 459: {
+            LogStep(459, "Write min valid value to a nullable range-restricted signed 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -48527,13 +48552,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 458: {
-            LogStep(458, "Verify nullable range-restricted signed 8-bit integer value is at min valid");
+        case 460: {
+            LogStep(460, "Verify nullable range-restricted signed 8-bit integer value is at min valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, true, chip::NullOptional);
         }
-        case 459: {
-            LogStep(459, "Write max valid value to a nullable range-restricted signed 8-bit integer");
+        case 461: {
+            LogStep(461, "Write max valid value to a nullable range-restricted signed 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -48542,13 +48567,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 460: {
-            LogStep(460, "Verify nullable range-restricted signed 8-bit integer value is at max valid");
+        case 462: {
+            LogStep(462, "Verify nullable range-restricted signed 8-bit integer value is at max valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, true, chip::NullOptional);
         }
-        case 461: {
-            LogStep(461, "Write middle valid value to a nullable range-restricted signed 8-bit integer");
+        case 463: {
+            LogStep(463, "Write middle valid value to a nullable range-restricted signed 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNonNull();
@@ -48557,13 +48582,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 462: {
-            LogStep(462, "Verify nullable range-restricted signed 8-bit integer value is at mid valid");
+        case 464: {
+            LogStep(464, "Verify nullable range-restricted signed 8-bit integer value is at mid valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, true, chip::NullOptional);
         }
-        case 463: {
-            LogStep(463, "Write null value to a nullable range-restricted signed 8-bit integer");
+        case 465: {
+            LogStep(465, "Write null value to a nullable range-restricted signed 8-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int8_t> value;
             value.SetNull();
@@ -48571,18 +48596,18 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 464: {
-            LogStep(464, "Verify nullable range-restricted signed 8-bit integer value is at null");
+        case 466: {
+            LogStep(466, "Verify nullable range-restricted signed 8-bit integer value is at null");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt8s::Id, true, chip::NullOptional);
         }
-        case 465: {
-            LogStep(465, "Read nullable range-restricted signed 16-bit integer");
+        case 467: {
+            LogStep(467, "Read nullable range-restricted signed 16-bit integer");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 466: {
-            LogStep(466, "Write min value to a nullable range-restricted signed 16-bit integer");
+        case 468: {
+            LogStep(468, "Write min value to a nullable range-restricted signed 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -48591,8 +48616,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 467: {
-            LogStep(467, "Write just-below-range value to a nullable range-restricted signed 16-bit integer");
+        case 469: {
+            LogStep(469, "Write just-below-range value to a nullable range-restricted signed 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -48601,8 +48626,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 468: {
-            LogStep(468, "Write just-above-range value to a nullable range-restricted signed 16-bit integer");
+        case 470: {
+            LogStep(470, "Write just-above-range value to a nullable range-restricted signed 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -48611,8 +48636,8 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 469: {
-            LogStep(469, "Write max value to a nullable range-restricted signed 16-bit integer");
+        case 471: {
+            LogStep(471, "Write max value to a nullable range-restricted signed 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -48621,13 +48646,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 470: {
-            LogStep(470, "Verify nullable range-restricted signed 16-bit integer value has not changed");
+        case 472: {
+            LogStep(472, "Verify nullable range-restricted signed 16-bit integer value has not changed");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 471: {
-            LogStep(471, "Write min valid value to a nullable range-restricted signed 16-bit integer");
+        case 473: {
+            LogStep(473, "Write min valid value to a nullable range-restricted signed 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -48636,13 +48661,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 472: {
-            LogStep(472, "Verify nullable range-restricted signed 16-bit integer value is at min valid");
+        case 474: {
+            LogStep(474, "Verify nullable range-restricted signed 16-bit integer value is at min valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 473: {
-            LogStep(473, "Write max valid value to a nullable range-restricted signed 16-bit integer");
+        case 475: {
+            LogStep(475, "Write max valid value to a nullable range-restricted signed 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -48651,13 +48676,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 474: {
-            LogStep(474, "Verify nullable range-restricted signed 16-bit integer value is at max valid");
+        case 476: {
+            LogStep(476, "Verify nullable range-restricted signed 16-bit integer value is at max valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 475: {
-            LogStep(475, "Write middle valid value to a nullable range-restricted signed 16-bit integer");
+        case 477: {
+            LogStep(477, "Write middle valid value to a nullable range-restricted signed 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNonNull();
@@ -48666,13 +48691,13 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 476: {
-            LogStep(476, "Verify nullable range-restricted signed 16-bit integer value is at mid valid");
+        case 478: {
+            LogStep(478, "Verify nullable range-restricted signed 16-bit integer value is at mid valid");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 477: {
-            LogStep(477, "Write null value to a nullable range-restricted signed 16-bit integer");
+        case 479: {
+            LogStep(479, "Write null value to a nullable range-restricted signed 16-bit integer");
             ListFreer listFreer;
             chip::app::DataModel::Nullable<int16_t> value;
             value.SetNull();
@@ -48680,49 +48705,49 @@ private:
                                   TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, value, chip::NullOptional,
                                   chip::NullOptional);
         }
-        case 478: {
-            LogStep(478, "Verify nullable range-restricted signed 16-bit integer value is null");
+        case 480: {
+            LogStep(480, "Verify nullable range-restricted signed 16-bit integer value is null");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id,
                                  TestCluster::Attributes::NullableRangeRestrictedInt16s::Id, true, chip::NullOptional);
         }
-        case 479: {
-            LogStep(479, "Write attribute that returns general status on write");
+        case 481: {
+            LogStep(481, "Write attribute that returns general status on write");
             ListFreer listFreer;
             bool value;
             value = false;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::GeneralErrorBoolean::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 480: {
-            LogStep(480, "Write attribute that returns cluster-specific status on write");
+        case 482: {
+            LogStep(482, "Write attribute that returns cluster-specific status on write");
             ListFreer listFreer;
             bool value;
             value = false;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ClusterErrorBoolean::Id,
                                   value, chip::NullOptional, chip::NullOptional);
         }
-        case 481: {
-            LogStep(481, "Read attribute that returns general status on read");
+        case 483: {
+            LogStep(483, "Read attribute that returns general status on read");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::GeneralErrorBoolean::Id,
                                  true, chip::NullOptional);
         }
-        case 482: {
-            LogStep(482, "read attribute that returns cluster-specific status on read");
+        case 484: {
+            LogStep(484, "read attribute that returns cluster-specific status on read");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ClusterErrorBoolean::Id,
                                  true, chip::NullOptional);
         }
-        case 483: {
-            LogStep(483, "read AcceptedCommandList attribute");
+        case 485: {
+            LogStep(485, "read AcceptedCommandList attribute");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::AcceptedCommandList::Id,
                                  true, chip::NullOptional);
         }
-        case 484: {
-            LogStep(484, "read GeneratedCommandList attribute");
+        case 486: {
+            LogStep(486, "read GeneratedCommandList attribute");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::GeneratedCommandList::Id,
                                  true, chip::NullOptional);
         }
-        case 485: {
-            LogStep(485, "Write struct-typed attribute");
+        case 487: {
+            LogStep(487, "Write struct-typed attribute");
             ListFreer listFreer;
             chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type value;
 
@@ -48738,8 +48763,8 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::StructAttr::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 486: {
-            LogStep(486, "Read struct-typed attribute");
+        case 488: {
+            LogStep(488, "Read struct-typed attribute");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::StructAttr::Id, true,
                                  chip::NullOptional);
         }


### PR DESCRIPTION
#### Problem

Octet strings can not be specified using the `hex:` notation.

#### Change overview
 * Supports `hex:` prefix for octet strings

#### Testing
A test has been added to TestCluster.
