### PR TITLE
Add an ENFORCE_FORMAT annotation to the declaration of PrettyPrintIM.

### DIFF
--- a/src/app/MessageDef/AttributeDataIB.cpp
+++ b/src/app/MessageDef/AttributeDataIB.cpp
@@ -247,7 +247,7 @@ CHIP_ERROR AttributeDataIB::Parser::CheckSchemaValidity() const
         }
     }
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/AttributeDataIBs.cpp
+++ b/src/app/MessageDef/AttributeDataIBs.cpp
@@ -69,7 +69,7 @@ CHIP_ERROR AttributeDataIBs::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/AttributeReportIB.cpp
+++ b/src/app/MessageDef/AttributeReportIB.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR AttributeReportIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/AttributeReportIBs.cpp
+++ b/src/app/MessageDef/AttributeReportIBs.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR AttributeReportIBs::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/AttributeStatusIB.cpp
+++ b/src/app/MessageDef/AttributeStatusIB.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR AttributeStatusIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/AttributeStatusIBs.cpp
+++ b/src/app/MessageDef/AttributeStatusIBs.cpp
@@ -73,7 +73,7 @@ CHIP_ERROR AttributeStatusIBs::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/CommandDataIB.cpp
+++ b/src/app/MessageDef/CommandDataIB.cpp
@@ -248,7 +248,7 @@ CHIP_ERROR CommandDataIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/CommandPathIB.cpp
+++ b/src/app/MessageDef/CommandPathIB.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR CommandPathIB::Parser::CheckSchemaValidity() const
         }
     }
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/CommandStatusIB.cpp
+++ b/src/app/MessageDef/CommandStatusIB.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR CommandStatusIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/DataVersionFilterIB.cpp
+++ b/src/app/MessageDef/DataVersionFilterIB.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR DataVersionFilterIB::Parser::CheckSchemaValidity() const
         }
     }
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/DataVersionFilterIBs.cpp
+++ b/src/app/MessageDef/DataVersionFilterIBs.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR DataVersionFilterIBs::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/EventDataIB.cpp
+++ b/src/app/MessageDef/EventDataIB.cpp
@@ -316,7 +316,7 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
         }
     }
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/EventFilterIB.cpp
+++ b/src/app/MessageDef/EventFilterIB.cpp
@@ -84,7 +84,7 @@ CHIP_ERROR EventFilterIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/EventFilterIBs.cpp
+++ b/src/app/MessageDef/EventFilterIBs.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR EventFilterIBs::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -125,7 +125,7 @@ CHIP_ERROR EventPathIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/EventPathIBs.cpp
+++ b/src/app/MessageDef/EventPathIBs.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR EventPathIBs::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/EventReportIB.cpp
+++ b/src/app/MessageDef/EventReportIB.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR EventReportIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/EventReportIBs.cpp
+++ b/src/app/MessageDef/EventReportIBs.cpp
@@ -57,7 +57,7 @@ CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/EventStatusIB.cpp
+++ b/src/app/MessageDef/EventStatusIB.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR EventStatusIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -95,7 +95,7 @@ CHIP_ERROR InvokeRequestMessage::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR InvokeRequests::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/InvokeResponseIB.cpp
+++ b/src/app/MessageDef/InvokeResponseIB.cpp
@@ -80,7 +80,7 @@ CHIP_ERROR InvokeResponseIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -54,7 +54,7 @@ CHIP_ERROR InvokeResponseIBs::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("],");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)

--- a/src/app/MessageDef/InvokeResponseMessage.cpp
+++ b/src/app/MessageDef/InvokeResponseMessage.cpp
@@ -82,7 +82,7 @@ CHIP_ERROR InvokeResponseMessage::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/MessageDefHelper.h
+++ b/src/app/MessageDef/MessageDefHelper.h
@@ -30,12 +30,25 @@
 
 #include <app/AppBuildConfig.h>
 
+// We need CHIPLogging.h to get the right value for CHIP_DETAIL_LOGGING here.
+#include <lib/support/logging/CHIPLogging.h>
+
 namespace chip {
 namespace app {
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK && CHIP_DETAIL_LOGGING
-void PrettyPrintIM(bool aIsNewLine, const char * aFmt, ...);
+/**
+ * Start a new "blank" line.  This will actually print out whitespace to the
+ * current indent level, which can be followed with PRETTY_PRINT_SAMELINE calls.
+ */
+void PrettyPrintIMBlankLine();
+void PrettyPrintIM(bool aIsNewLine, const char * aFmt, ...) ENFORCE_FORMAT(2, 3);
 void IncreaseDepth();
 void DecreaseDepth();
+#define PRETTY_PRINT_BLANK_LINE()                                                                                                  \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        PrettyPrintIMBlankLine();                                                                                                  \
+    } while (0)
 #define PRETTY_PRINT(fmt, ...)                                                                                                     \
     do                                                                                                                             \
     {                                                                                                                              \
@@ -57,6 +70,7 @@ void DecreaseDepth();
         DecreaseDepth();                                                                                                           \
     } while (0)
 #else
+#define PRETTY_PRINT_BLANK_LINE()
 #define PRETTY_PRINT(fmt, ...)
 #define PRETTY_PRINT(fmt, ...)
 #define PRETTY_PRINT_SAMELINE(fmt, ...)

--- a/src/app/MessageDef/ReadRequestMessage.cpp
+++ b/src/app/MessageDef/ReadRequestMessage.cpp
@@ -121,7 +121,7 @@ CHIP_ERROR ReadRequestMessage::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/ReportDataMessage.cpp
+++ b/src/app/MessageDef/ReportDataMessage.cpp
@@ -79,7 +79,7 @@ CHIP_ERROR ReportDataMessage::Parser::CheckSchemaValidity() const
             {
                 SubscriptionId subscriptionId;
                 ReturnErrorOnFailure(reader.Get(subscriptionId));
-                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx64 ",", subscriptionId);
+                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx32 ",", subscriptionId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -135,7 +135,7 @@ CHIP_ERROR ReportDataMessage::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("}");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR StatusIB::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/StatusResponseMessage.cpp
+++ b/src/app/MessageDef/StatusResponseMessage.cpp
@@ -62,7 +62,7 @@ CHIP_ERROR StatusResponseMessage::Parser::CheckSchemaValidity() const
         }
     }
     PRETTY_PRINT("}");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/SubscribeRequestMessage.cpp
+++ b/src/app/MessageDef/SubscribeRequestMessage.cpp
@@ -165,7 +165,7 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/SubscribeResponseMessage.cpp
+++ b/src/app/MessageDef/SubscribeResponseMessage.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
             {
                 SubscriptionId subscriptionId;
                 ReturnErrorOnFailure(reader.Get(subscriptionId));
-                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx64 ",", subscriptionId);
+                PRETTY_PRINT("\tSubscriptionId = 0x%" PRIx32 ",", subscriptionId);
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
@@ -87,7 +87,7 @@ CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
         }
     }
     PRETTY_PRINT("}");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/TimedRequestMessage.cpp
+++ b/src/app/MessageDef/TimedRequestMessage.cpp
@@ -61,7 +61,7 @@ CHIP_ERROR TimedRequestMessage::Parser::CheckSchemaValidity() const
         }
     }
     PRETTY_PRINT("}");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
     if (CHIP_END_OF_TLV == err)
     {
         const int RequiredFields = (1 << to_underlying(Tag::kTimeoutMs));

--- a/src/app/MessageDef/WriteRequestMessage.cpp
+++ b/src/app/MessageDef/WriteRequestMessage.cpp
@@ -112,7 +112,7 @@ CHIP_ERROR WriteRequestMessage::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("},");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {

--- a/src/app/MessageDef/WriteResponseMessage.cpp
+++ b/src/app/MessageDef/WriteResponseMessage.cpp
@@ -67,7 +67,7 @@ CHIP_ERROR WriteResponseMessage::Parser::CheckSchemaValidity() const
     }
 
     PRETTY_PRINT("}");
-    PRETTY_PRINT("");
+    PRETTY_PRINT_BLANK_LINE();
 
     if (CHIP_END_OF_TLV == err)
     {


### PR DESCRIPTION
We weren't actually doing the format checks on the callers of this
function, just annotating its implementation to make the tree compile.

Fixes https://github.com/project-chip/connectedhomeip/issues/18922

#### Problem
Incorrect logging in IM in some places (using wrong format sizes, reading un-initialized stack memory).

#### Change overview
Fix that and add enforcement.

#### Testing
Tree compiles.