### PR TITLE
[chip-tool] Add --repeat-count and --repeat-delay-ms to write commands

### DIFF
--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -86,7 +86,7 @@ public:
         ChipLogProgress(chipTool, "Sending WriteAttribute to cluster " ChipLogFormatMEI " on endpoint %u",
                         ChipLogValueMEI(clusterId), endpointId);
         return InteractionModelWriter::WriteAttribute(device, endpointId, clusterId, attributeId, value, mTimedInteractionTimeoutMs,
-                                                      mSuppressResponse, mDataVersion);
+                                                      mSuppressResponse, mDataVersion, mRepeatCount, mRepeatDelayInMs);
     }
 
     template <class T>
@@ -111,6 +111,8 @@ protected:
                     "If provided, do a timed write with the given timed interaction timeout.");
         AddArgument("data-version", 0, UINT32_MAX, &mDataVersion);
         AddArgument("suppressResponse", 0, 1, &mSuppressResponse);
+        AddArgument("repeat-count", 1, UINT16_MAX, &mRepeatCount);
+        AddArgument("repeat-delay-ms", 0, UINT16_MAX, &mRepeatDelayInMs);
         ModelCommand::AddArguments();
     }
 
@@ -122,4 +124,6 @@ private:
     chip::Optional<chip::DataVersion> mDataVersion = chip::NullOptional;
     chip::Optional<bool> mSuppressResponse;
     CustomArgument mAttributeValue;
+    chip::Optional<uint16_t> mRepeatCount;
+    chip::Optional<uint16_t> mRepeatDelayInMs;
 };


### PR DESCRIPTION
#### Problem

Add `--repeat-count` and `--repeat-delay-ms` to write commands for `chip-tool`

Fix #18601

@bzbarsky-apple Similar to the YAML way. This is not exactly doing what the test step says in the sense that we don't really know if the "status response message" has been received but in practice it does the job...

#### Change overview
 * Add `--repeat-count` and `--repeat-delay-ms` to write commands for `chip-tool`

#### Testing

I tried to do:
`./out/debug/standalone/chip-tool testcluster write timed-write-boolean false 0x12344321 1 --timedInteractionTimeoutMs 200 --repeat-count 1 --repeat-delay-ms 5000`
`./out/debug/standalone/chip-tool administratorcommissioning open-basic-commissioning-window 180 0x12344321 0 --timedInteractionTimeoutMs 200 --repeat-count 1 --repeat-delay-ms 5000`