### PR TITLE
[chip-tool] Add support for setting the isUrgent flag of when subscri…

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -350,11 +350,7 @@ public:
     {
         AddArgument("cluster-id", 0, UINT32_MAX, &mClusterIds);
         AddArgument("event-id", 0, UINT32_MAX, &mEventIds);
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
-        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
-        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions);
+        AddCommonArguments();
         SubscribeCommand::AddArguments();
     }
 
@@ -362,11 +358,7 @@ public:
         SubscribeCommand("subscribe-event-by-id", credsIssuerConfig), mClusterIds(1, clusterId)
     {
         AddArgument("event-id", 0, UINT32_MAX, &mEventIds);
-        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval);
-        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval);
-        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
-        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
-        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions);
+        AddCommonArguments();
         SubscribeCommand::AddArguments();
     }
 
@@ -376,6 +368,12 @@ public:
         mClusterIds(1, clusterId), mEventIds(1, eventId)
     {
         AddArgument("event-name", eventName, "Event name.");
+        AddCommonArguments();
+        SubscribeCommand::AddArguments();
+    }
+
+    void AddCommonArguments()
+    {
         AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval,
                     "The requested minimum interval between reports. Sets MinIntervalFloor in the Subscribe Request.");
         AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval,
@@ -384,7 +382,14 @@ public:
         AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
                     "false - Terminate existing subscriptions from initiator.\n  true - Leave existing subscriptions in place.");
-        SubscribeCommand::AddArguments();
+        AddArgument(
+            "is-urgent", 0, 1, &mIsUrgents,
+            "Sets isUrgent in the Subscribe Request.\n"
+            "  The queueing of any urgent event SHALL force an immediate generation of reports containing all events queued "
+            "leading up to (and including) the urgent event in question.\n"
+            "  This argument takes a comma separated list of true/false values.\n"
+            "  If the number of paths exceeds the number of entries provided to is-urgent, then isUrgent will be false for the "
+            "extra paths.");
     }
 
     ~SubscribeEvent() {}
@@ -392,7 +397,7 @@ public:
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
         return SubscribeCommand::SubscribeEvent(device, endpointIds, mClusterIds, mEventIds, mMinInterval, mMaxInterval,
-                                                mFabricFiltered, mEventNumber, mKeepSubscriptions);
+                                                mFabricFiltered, mEventNumber, mKeepSubscriptions, mIsUrgents);
     }
 
 private:
@@ -404,4 +409,5 @@ private:
     chip::Optional<bool> mFabricFiltered;
     chip::Optional<chip::EventNumber> mEventNumber;
     chip::Optional<bool> mKeepSubscriptions;
+    chip::Optional<std::vector<bool>> mIsUrgents;
 };

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -70,6 +70,7 @@ enum ArgumentType
     Address,
     Complex,
     Custom,
+    VectorBool,
     Vector16,
     Vector32,
 };
@@ -178,6 +179,8 @@ public:
 
     size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint16_t> * value, const char * desc = "");
     size_t AddArgument(const char * name, int64_t min, uint64_t max, std::vector<uint32_t> * value, const char * desc = "");
+    size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<bool>> * value,
+                       const char * desc = "");
     size_t AddArgument(const char * name, int64_t min, uint64_t max, chip::Optional<std::vector<uint32_t>> * value,
                        const char * desc = "");
 

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -318,15 +318,18 @@ CHIP_ERROR InteractionModelReports::ReportEvent(DeviceProxy * device, std::vecto
                                                 std::vector<ClusterId> clusterIds, std::vector<EventId> eventIds,
                                                 ReadClient::InteractionType interactionType, uint16_t minInterval,
                                                 uint16_t maxInterval, const Optional<bool> & fabricFiltered,
-                                                const Optional<EventNumber> & eventNumber, const Optional<bool> & keepSubscriptions)
+                                                const Optional<EventNumber> & eventNumber, const Optional<bool> & keepSubscriptions,
+                                                const Optional<std::vector<bool>> & isUrgents)
 {
     const size_t clusterCount  = clusterIds.size();
     const size_t eventCount    = eventIds.size();
     const size_t endpointCount = endpointIds.size();
+    const size_t isUrgentCount = isUrgents.HasValue() ? isUrgents.Value().size() : 0;
 
     VerifyOrReturnError(clusterCount > 0 && clusterCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(eventCount > 0 && eventCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(endpointCount > 0 && endpointCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(isUrgentCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
 
     const bool hasSameIdsCount   = (clusterCount == eventCount) && (clusterCount == endpointCount);
     const bool multipleClusters  = clusterCount > 1 && eventCount == 1 && endpointCount == 1;
@@ -388,6 +391,11 @@ CHIP_ERROR InteractionModelReports::ReportEvent(DeviceProxy * device, std::vecto
         if (endpointId != kInvalidEndpointId)
         {
             eventPathParams[i].mEndpointId = endpointId;
+        }
+
+        if (isUrgents.HasValue() && isUrgents.Value().size() > i)
+        {
+            eventPathParams[i].mIsUrgentEvent = isUrgents.Value().at(i);
         }
     }
 

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -76,10 +76,11 @@ protected:
                               uint16_t minInterval = 0, uint16_t maxInterval = 0,
                               const chip::Optional<bool> & fabricFiltered           = chip::Optional<bool>(true),
                               const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional,
-                              const chip::Optional<bool> & keepSubscriptions        = chip::NullOptional)
+                              const chip::Optional<bool> & keepSubscriptions        = chip::NullOptional,
+                              const chip::Optional<std::vector<bool>> & isUrgents   = chip::NullOptional)
     {
         return ReportEvent(device, endpointIds, clusterIds, eventIds, chip::app::ReadClient::InteractionType::Subscribe,
-                           minInterval, maxInterval, fabricFiltered, eventNumber, keepSubscriptions);
+                           minInterval, maxInterval, fabricFiltered, eventNumber, keepSubscriptions, isUrgents);
     }
 
     CHIP_ERROR ReportEvent(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
@@ -87,7 +88,8 @@ protected:
                            chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval = 0,
                            uint16_t maxInterval = 0, const chip::Optional<bool> & fabricFiltered = chip::Optional<bool>(true),
                            const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional,
-                           const chip::Optional<bool> & keepSubscriptions        = chip::NullOptional);
+                           const chip::Optional<bool> & keepSubscriptions        = chip::NullOptional,
+                           const chip::Optional<std::vector<bool>> & isUrgents   = chip::NullOptional);
 
     void Shutdown() { mReadClients.clear(); }
 


### PR DESCRIPTION
…bing to events

#### Problem

Setting the `isUrgent` flag when subscribing to events is not supported in `chip-tool`.

#### Change overview
 * Add supports for it

#### Testing
`./out/debug/standalone/chip-tool basic subscribe-event-by-id 0,1,2 3 5 0x12344321 0 --isUrgent true,false,true`