### PR TITLE
Stateful shell compatibility improvements

### DIFF
--- a/examples/chef/stateful_shell.py
+++ b/examples/chef/stateful_shell.py
@@ -96,7 +96,7 @@ class StatefulShell:
             returncode = proc.wait()
 
         # Load env state from envfile.
-        with open(self.envfile_path) as f:
+        with open(self.envfile_path, encoding="latin1") as f:
             # Split on null char because we use env -0.
             env_entries = f.read().split("\0")
             for entry in env_entries:
@@ -111,6 +111,6 @@ class StatefulShell:
                 f"Error. Return code is not 0. It is: {returncode}")
 
         if return_cmd_output:
-            with open(self.cmd_output_path) as f:
+            with open(self.cmd_output_path, encoding="latin1") as f:
                 output = f.read()
             return output

--- a/examples/chef/stateful_shell.py
+++ b/examples/chef/stateful_shell.py
@@ -16,11 +16,13 @@ import os
 import shlex
 import subprocess
 import sys
-import tempfile
 from typing import Dict, Optional
 
 import constants
 
+_ENV_FILENAME = ".shell_env"
+_OUTPUT_FILENAME = ".shell_output"
+_HERE = os.path.dirname(os.path.abspath(__file__))
 
 TermColors = constants.TermColors
 
@@ -42,8 +44,8 @@ class StatefulShell:
 
         # This file holds the env after running a command. This is a better approach
         # than writing to stdout because commands could redirect the stdout.
-        self.envfile_path: str = os.path.join(tempfile.gettempdir(), "envfile")
-        self.cmd_output_path: str = os.path.join(tempfile.gettempdir(), "cmd_output")
+        self.envfile_path: str = os.path.join(_HERE, _ENV_FILENAME)
+        self.cmd_output_path: str = os.path.join(_HERE, _OUTPUT_FILENAME)
 
     def print_env(self) -> None:
         """Print environment variables in commandline friendly format for export.
@@ -57,7 +59,11 @@ class StatefulShell:
             if env_var:
                 print(f"export {env_var}={quoted_value}")
 
-    def run_cmd(self, cmd: str, *, raise_on_returncode=False, return_cmd_output=True) -> Optional[str]:
+    def run_cmd(
+        self, cmd: str, *,
+        raise_on_returncode=False,
+        return_cmd_output=False,
+    ) -> Optional[str]:
         """Runs a command and updates environment.
 
         Args:


### PR DESCRIPTION
#### Problem
* Stateful shell has compatibility issues with running inside Docker (specifically with where temp files are stored).
* Stateful shell can run into issues executing commands that produce output not covered by utf-8 encoding.

#### Change overview
* Make stateful shell not return output by default (most common usage).
* Use latin1 encoding to cover utf-8 decoding issues.
* Use local dot files adjacent to `stateful_shell.py` to work with Docker. 

#### Testing
Tested in Docker env.