### PR TITLE
[crypto] Fix message counter init to be 28-bit random.

### DIFF
--- a/src/transport/MessageCounter.h
+++ b/src/transport/MessageCounter.h
@@ -77,8 +77,8 @@ private:
 class LocalSessionMessageCounter : public MessageCounter
 {
 public:
-    static constexpr uint32_t kInitialSyncValue             = 0;         ///< Used for initializing peer counter
-    static constexpr uint32_t kMessageCounterRandomInitMask = 0x0FFFFFF; ///< 28-bit mask
+    static constexpr uint32_t kInitialSyncValue             = 0;          ///< Used for initializing peer counter
+    static constexpr uint32_t kMessageCounterRandomInitMask = 0x0FFFFFFF; ///< 28-bit mask
 
     /**
      * Initialize a local message counter with random value between [1, 2^28]. This increases the difficulty of traffic analysis


### PR DESCRIPTION
#### Problem
NCC-E003350-HRP

The message counter initialization is specified to be a 28-bit random number.
The code has a bug and is initializing it to a 24-bit random number.

#### Change overview
Correct the typo in the initialization constant.

#### Testing
CI