### PR TITLE
[esp32] support CHIP project config

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -137,6 +137,24 @@ if (CONFIG_CHIP_ENABLE_EXTERNAL_PLATFORM)
     chip_gn_arg_append("chip_platform_target"   "\"//${CONFIG_CHIP_EXTERNAL_PLATFORM_DIR}\"")
 endif()
 
+# Set up CHIP project configuration file
+
+if (CONFIG_CHIP_PROJECT_CONFIG)
+    get_filename_component(CHIP_PROJECT_CONFIG
+        ${CONFIG_CHIP_PROJECT_CONFIG}
+        REALPATH
+        BASE_DIR ${CMAKE_SOURCE_DIR}
+    )
+    set(CHIP_PROJECT_CONFIG "<${CHIP_PROJECT_CONFIG}>")
+else()
+    set(CHIP_PROJECT_CONFIG "")
+endif()
+
+if (CHIP_PROJECT_CONFIG)
+    chip_gn_arg_append("chip_project_config_include" "\"${CHIP_PROJECT_CONFIG}\"")
+    chip_gn_arg_append("chip_system_project_config_include" "\"${CHIP_PROJECT_CONFIG}\"")
+endif()
+
 if (CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER)
     chip_gn_arg_append("chip_use_transitional_commissionable_data_provider" "false")
 endif()

--- a/src/test_driver/esp32/main/Kconfig.projbuild
+++ b/src/test_driver/esp32/main/Kconfig.projbuild
@@ -37,5 +37,5 @@ menu "Crypto Tests"
 
     config CHIP_PROJECT_CONFIG
         string "CHIP Project Configuration file"
-        default "$(PROJECT_PATH)/main/include/CHIPProjectConfig.h"
+        default "main/include/CHIPProjectConfig.h"
 endmenu


### PR DESCRIPTION
#### Problem
There is no option to set a custom CHIP project config file to define compile time CHIP stack configuration values.

#### Change overview
Add support to specify a project config header file similar to other platforms. This allows to add `CONFIG_CHIP_PROJECT_CONFIG` to a projects `sdkconfig`, which points to a config header file.

#### Testing
Locally tested by building ESP32 firmwares.
