### PR TITLE
Fix CHIPDeviceControllerFactory shutdown

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -101,8 +101,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 
     if (mSystemState != nullptr)
     {
-        mSystemState->Release();
-        chip::Platform::Delete(mSystemState);
+        Platform::Delete(mSystemState);
         mSystemState = nullptr;
     }
 
@@ -154,14 +153,18 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 #endif
                                                             ));
 
-    stateParams.sessionMgr                                    = chip::Platform::New<SessionManager>();
-    SimpleSessionResumptionStorage * sessionResumptionStorage = chip::Platform::New<SimpleSessionResumptionStorage>();
-    stateParams.sessionResumptionStorage                      = sessionResumptionStorage;
-    stateParams.certificateValidityPolicy                     = params.certificateValidityPolicy;
-    stateParams.unsolicitedStatusHandler                      = Platform::New<Protocols::SecureChannel::UnsolicitedStatusHandler>();
-    stateParams.exchangeMgr                                   = chip::Platform::New<Messaging::ExchangeManager>();
-    stateParams.messageCounterManager                         = chip::Platform::New<secure_channel::MessageCounterManager>();
-    stateParams.groupDataProvider                             = params.groupDataProvider;
+    stateParams.sessionMgr                = chip::Platform::New<SessionManager>();
+    stateParams.certificateValidityPolicy = params.certificateValidityPolicy;
+    stateParams.unsolicitedStatusHandler  = Platform::New<Protocols::SecureChannel::UnsolicitedStatusHandler>();
+    stateParams.exchangeMgr               = chip::Platform::New<Messaging::ExchangeManager>();
+    stateParams.messageCounterManager     = chip::Platform::New<secure_channel::MessageCounterManager>();
+    stateParams.groupDataProvider         = params.groupDataProvider;
+
+    // This is constructed with a base class deleter so we can std::move it into
+    // stateParams without a manual conversion below.
+    auto sessionResumptionStorage =
+        std::unique_ptr<SimpleSessionResumptionStorage, Platform::Deleter<chip::SessionResumptionStorage>>(
+            Platform::New<SimpleSessionResumptionStorage>());
 
     // if no fabricTable was provided, create one and track it in stateParams for cleanup
     FabricTable * tempFabricTable = nullptr;
@@ -172,6 +175,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         ReturnErrorOnFailure(stateParams.fabricTable->Init(params.fabricIndependentStorage, params.operationalKeystore));
     }
     ReturnErrorOnFailure(sessionResumptionStorage->Init(params.fabricIndependentStorage));
+    stateParams.sessionResumptionStorage = std::move(sessionResumptionStorage);
 
     auto delegate = chip::Platform::MakeUnique<ControllerFabricDelegate>();
     ReturnErrorOnFailure(delegate->Init(stateParams.sessionMgr, stateParams.groupDataProvider));
@@ -198,7 +202,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 
         // Enable listening for session establishment messages.
         ReturnErrorOnFailure(stateParams.caseServer->ListenForSessionEstablishment(
-            stateParams.exchangeMgr, stateParams.sessionMgr, stateParams.fabricTable, stateParams.sessionResumptionStorage,
+            stateParams.exchangeMgr, stateParams.sessionMgr, stateParams.fabricTable, stateParams.sessionResumptionStorage.get(),
             stateParams.certificateValidityPolicy, stateParams.groupDataProvider));
 
         //
@@ -232,7 +236,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 
     DeviceProxyInitParams deviceInitParams = {
         .sessionManager           = stateParams.sessionMgr,
-        .sessionResumptionStorage = stateParams.sessionResumptionStorage,
+        .sessionResumptionStorage = stateParams.sessionResumptionStorage.get(),
         .exchangeMgr              = stateParams.exchangeMgr,
         .fabricTable              = stateParams.fabricTable,
         .clientPool               = stateParams.caseClientPool,
@@ -250,7 +254,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     ReturnErrorOnFailure(stateParams.caseSessionManager->Init(stateParams.systemLayer, sessionManagerConfig));
 
     // store the system state
-    mSystemState = chip::Platform::New<DeviceControllerSystemState>(stateParams);
+    mSystemState = chip::Platform::New<DeviceControllerSystemState>(std::move(stateParams));
     mSystemState->SetTempFabricTable(tempFabricTable);
     ChipLogDetail(Controller, "System State Initialized...");
     return CHIP_NO_ERROR;
@@ -321,21 +325,20 @@ void DeviceControllerFactory::Shutdown()
 {
     if (mSystemState != nullptr)
     {
-        mSystemState->Release();
-        chip::Platform::Delete(mSystemState);
+        Platform::Delete(mSystemState);
         mSystemState = nullptr;
     }
     mFabricIndependentStorage = nullptr;
     mOperationalKeystore      = nullptr;
 }
 
-CHIP_ERROR DeviceControllerSystemState::Shutdown()
+void DeviceControllerSystemState::Shutdown()
 {
-    VerifyOrReturnError(mRefCount <= 1, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrDie(mRefCount == 0);
     if (mHaveShutDown)
     {
         // Nothing else to do here.
-        return CHIP_NO_ERROR;
+        return;
     }
     mHaveShutDown = true;
 
@@ -405,7 +408,8 @@ CHIP_ERROR DeviceControllerSystemState::Shutdown()
     // Consumers are expected to call PlaformMgr().StopEventLoopTask() before calling
     // DeviceController::Shutdown() in the CONFIG_DEVICE_LAYER configuration
     //
-    ReturnErrorOnFailure(DeviceLayer::PlatformMgr().Shutdown());
+    CHIP_ERROR error = DeviceLayer::PlatformMgr().Shutdown();
+    VerifyOrDie(error == CHIP_NO_ERROR);
 #endif
 
     if (mExchangeMgr != nullptr)
@@ -459,8 +463,6 @@ CHIP_ERROR DeviceControllerSystemState::Shutdown()
         // so that SetupController/Commissioner can use it
         mFabrics = nullptr;
     }
-
-    return CHIP_NO_ERROR;
 }
 
 } // namespace Controller

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -116,7 +116,12 @@ public:
     }
 
     CHIP_ERROR Init(FactoryInitParams params);
+
+    // Shuts down matter and frees the system state.
+    //
+    // Must not be called while any controllers are alive.
     void Shutdown();
+
     CHIP_ERROR SetupController(SetupParams params, DeviceController & controller);
     CHIP_ERROR SetupCommissioner(SetupParams params, DeviceCommissioner & commissioner);
 
@@ -135,8 +140,9 @@ public:
     //
     // Some clients do not prefer a complete shutdown of the stack being initiated if
     // all device controllers have ceased to exist. To avoid that, this method has been
-    // created to permit retention of the underlying system state to avoid that.
+    // created to permit retention of the underlying system state.
     //
+    // NB: The system state will still be freed in Shutdown() regardless of this call.
     void RetainSystemState() { (void) mSystemState->Retain(); }
 
     //
@@ -212,7 +218,7 @@ public:
     };
 
 private:
-    DeviceControllerFactory(){};
+    DeviceControllerFactory() {}
     void PopulateInitParams(ControllerInitParams & controllerParams, const SetupParams & params);
     CHIP_ERROR InitSystemState(FactoryInitParams params);
     CHIP_ERROR InitSystemState();


### PR DESCRIPTION
#### Problem

- SessionResumptionStorage is leaked
    - Ownership is passed using raw pointers. This is bad form,
      and there are many more instances of it (not fixed here).

- DeviceControllerSystemState destructor is called twice
  (once by Release(), then again by Delete())

#### Change overview

- Use UniquePtr to avoid leaking SessionResumptionStorage and retain ownership on DeviceControllerSystemState
- Don't destroy DeviceControllerSystemState in Release()

#### Testing

Unit tests & CI
