### PR TITLE
[Ameba] Remove GetUniqueId in ConfigurationManagerImpl

### DIFF
--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -42,25 +42,25 @@ namespace Internal {
 // *** CAUTION ***: Changing the names or namespaces of these values will *break* existing devices.
 
 // NVS namespaces used to store device configuration information.
-const char AmebaConfig::kConfigNamespace_ChipFactory[]                = "chip-factory";
-const char AmebaConfig::kConfigNamespace_ChipConfig[]                 = "chip-config";
-const char AmebaConfig::kConfigNamespace_ChipCounters[]               = "chip-counters";
-const char AmebaConfig::kConfigNamespace_ChipFabric1[]                = "chip-fabric-1";
-const char AmebaConfig::kConfigNamespace_ChipFabric2[]                = "chip-fabric-2";
-const char AmebaConfig::kConfigNamespace_ChipFabric3[]                = "chip-fabric-3";
-const char AmebaConfig::kConfigNamespace_ChipFabric4[]                = "chip-fabric-4";
-const char AmebaConfig::kConfigNamespace_ChipFabric5[]                = "chip-fabric-5";
-const char AmebaConfig::kConfigNamespace_ChipACL[]                    = "chip-acl";
-const char AmebaConfig::kConfigNamespace_ChipGroupMessageCounters[]   = "chip-groupmsgcounters";
-const char AmebaConfig::kConfigNamespace_ChipAttributes[]             = "chip-attributes";
-const char AmebaConfig::kConfigNamespace_ChipBindingTable[]           = "chip-bindingtable";
-const char AmebaConfig::kConfigNamespace_ChipOTA[]                    = "chip-ota";
-const char AmebaConfig::kConfigNamespace_ChipFailSafe[]               = "chip-failsafe";
-const char AmebaConfig::kConfigNamespace_ChipSessionResumption[]      = "chip-sessionresumption";
-const char AmebaConfig::kConfigNamespace_ChipDeviceInfoProvider[]     = "chip-deviceinfoprovider";
-const char AmebaConfig::kConfigNamespace_ChipGroupDataProvider[]      = "chip-groupdataprovider";
-const char AmebaConfig::kConfigNamespace_ChipOthers[]                 = "chip-others";
-const char AmebaConfig::kConfigNamespace_ChipOthers2[]                = "chip-others2";
+const char AmebaConfig::kConfigNamespace_ChipFactory[]              = "chip-factory";
+const char AmebaConfig::kConfigNamespace_ChipConfig[]               = "chip-config";
+const char AmebaConfig::kConfigNamespace_ChipCounters[]             = "chip-counters";
+const char AmebaConfig::kConfigNamespace_ChipFabric1[]              = "chip-fabric-1";
+const char AmebaConfig::kConfigNamespace_ChipFabric2[]              = "chip-fabric-2";
+const char AmebaConfig::kConfigNamespace_ChipFabric3[]              = "chip-fabric-3";
+const char AmebaConfig::kConfigNamespace_ChipFabric4[]              = "chip-fabric-4";
+const char AmebaConfig::kConfigNamespace_ChipFabric5[]              = "chip-fabric-5";
+const char AmebaConfig::kConfigNamespace_ChipACL[]                  = "chip-acl";
+const char AmebaConfig::kConfigNamespace_ChipGroupMessageCounters[] = "chip-groupmsgcounters";
+const char AmebaConfig::kConfigNamespace_ChipAttributes[]           = "chip-attributes";
+const char AmebaConfig::kConfigNamespace_ChipBindingTable[]         = "chip-bindingtable";
+const char AmebaConfig::kConfigNamespace_ChipOTA[]                  = "chip-ota";
+const char AmebaConfig::kConfigNamespace_ChipFailSafe[]             = "chip-failsafe";
+const char AmebaConfig::kConfigNamespace_ChipSessionResumption[]    = "chip-sessionresumption";
+const char AmebaConfig::kConfigNamespace_ChipDeviceInfoProvider[]   = "chip-deviceinfoprovider";
+const char AmebaConfig::kConfigNamespace_ChipGroupDataProvider[]    = "chip-groupdataprovider";
+const char AmebaConfig::kConfigNamespace_ChipOthers[]               = "chip-others";
+const char AmebaConfig::kConfigNamespace_ChipOthers2[]              = "chip-others2";
 
 // Keys stored in the chip-factory namespace
 const AmebaConfig::Key AmebaConfig::kConfigKey_SerialNum             = { kConfigNamespace_ChipFactory, "serial-num" };

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -56,9 +56,9 @@ const char AmebaConfig::kConfigNamespace_ChipAttributes[]             = "chip-at
 const char AmebaConfig::kConfigNamespace_ChipBindingTable[]           = "chip-bindingtable";
 const char AmebaConfig::kConfigNamespace_ChipOTA[]                    = "chip-ota";
 const char AmebaConfig::kConfigNamespace_ChipFailSafe[]               = "chip-failsafe";
-const char AmebaConfig::kConfigNamespace_ChipSessionResumptionIndex[] = "chip-sessionresumptionindex";
 const char AmebaConfig::kConfigNamespace_ChipSessionResumption[]      = "chip-sessionresumption";
 const char AmebaConfig::kConfigNamespace_ChipDeviceInfoProvider[]     = "chip-deviceinfoprovider";
+const char AmebaConfig::kConfigNamespace_ChipGroupDataProvider[]      = "chip-groupdataprovider";
 const char AmebaConfig::kConfigNamespace_ChipOthers[]                 = "chip-others";
 const char AmebaConfig::kConfigNamespace_ChipOthers2[]                = "chip-others2";
 

--- a/src/platform/Ameba/AmebaConfig.h
+++ b/src/platform/Ameba/AmebaConfig.h
@@ -51,9 +51,9 @@ public:
     static const char kConfigNamespace_ChipBindingTable[];
     static const char kConfigNamespace_ChipOTA[];
     static const char kConfigNamespace_ChipFailSafe[];
-    static const char kConfigNamespace_ChipSessionResumptionIndex[];
     static const char kConfigNamespace_ChipSessionResumption[];
     static const char kConfigNamespace_ChipDeviceInfoProvider[];
+    static const char kConfigNamespace_ChipGroupDataProvider[];
     static const char kConfigNamespace_ChipOthers[];
     static const char kConfigNamespace_ChipOthers2[];
 

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -77,11 +77,11 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
     SuccessOrExit(err);
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipFailSafe);
     SuccessOrExit(err);
-    err = AmebaConfig::EnsureNamespace2(AmebaConfig::kConfigNamespace_ChipSessionResumptionIndex);
-    SuccessOrExit(err);
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipSessionResumption);
     SuccessOrExit(err);
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipDeviceInfoProvider);
+    SuccessOrExit(err);
+    err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipGroupDataProvider);
     SuccessOrExit(err);
     err = AmebaConfig::EnsureNamespace(AmebaConfig::kConfigNamespace_ChipOthers);
     SuccessOrExit(err);
@@ -175,30 +175,6 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
         buf[i] = mac[i] & 0xFF;
 
     return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize)
-{
-#ifdef CHIP_DEVICE_CONFIG_UNIQUE_ID
-    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_UNIQUE_ID), CHIP_ERROR_BUFFER_TOO_SMALL);
-    strcpy(buf, CHIP_DEVICE_CONFIG_UNIQUE_ID);
-    return CHIP_NO_ERROR;
-#else
-    ReturnErrorCodeIf(bufSize != 32, CHIP_ERROR_INVALID_MESSAGE_LENGTH);
-    char temp[32];
-    int i = 0, j = 0;
-
-    memset(&temp[0], 0, 32);
-    ReturnErrorCodeIf(wifi_get_mac_address(temp) != 0, CHIP_ERROR_INVALID_ARGUMENT);
-
-    for (i = 0; i < bufSize; i++)
-    {
-        if (temp[i] != ':')
-            buf[j++] = temp[i];
-    }
-
-    return CHIP_NO_ERROR;
-#endif
 }
 
 bool ConfigurationManagerImpl::CanFactoryReset()

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -55,7 +55,6 @@ private:
     void InitiateFactoryReset(void) override;
     CHIP_ERROR ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value) override;
     CHIP_ERROR WritePersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t value) override;
-    CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
     // NOTE: Other public interface methods are implemented by GenericConfigurationManagerImpl<>.
 
     // ===== Members that implement the GenericConfigurationManagerImpl protected interface.


### PR DESCRIPTION
#### Problem
- Get unique-id using chip-tool will fail with `CHIP_ERROR_INVALID_MESSAGE_LENGTH` if uniqueId length != 32
- If success, Ameba's GetUniqueId implementation will return a hardcoded value instead of retrieving from persistent storage
- Need to update persistent storage domains to include GroupDataProvider related keys

#### Change overview
- Remove Ameba's implementation of GetUniqueId, use the default one in GenericConfigurationManager
- Remove CHIPSessionResumptionIndex key
- Added CHIPGroupDataProvider key

#### Testing
- Get unique-id using chip-tool commands successfully
