### PR TITLE
[YAML] Add contains/excludes constraints to TestConstraints.yaml

### DIFF
--- a/examples/chip-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt
+++ b/examples/chip-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt
@@ -28,6 +28,18 @@
 
     {{~#if (hasProperty expectedConstraints "maxValue")}}VerifyOrReturn(CheckConstraintMaxValue("{{asPropertyValue}}", {{asPropertyValue}}, {{asTypedLiteral expectedConstraints.maxValue type}}));{{/if}}
 
+    {{~#if (hasProperty expectedConstraints "contains")}}
+        {{#chip_tests_iterate_expected_list expectedConstraints.contains}}
+    VerifyOrReturn(CheckConstraintContains("{{asPropertyValue}}", {{asPropertyValue}}, {{asTypedLiteral value type}}));
+        {{/chip_tests_iterate_expected_list}}
+    {{/if}}
+
+    {{~#if (hasProperty expectedConstraints "excludes")}}
+        {{#chip_tests_iterate_expected_list expectedConstraints.excludes}}
+    VerifyOrReturn(CheckConstraintExcludes("{{asPropertyValue}}", {{asPropertyValue}}, {{asTypedLiteral value type}}));
+        {{/chip_tests_iterate_expected_list}}
+    {{/if}}
+
     {{~#if (hasProperty expectedConstraints "notValue")}}
         {{#if (isLiteralNull expectedConstraints.notValue)}}
             VerifyOrReturn(CheckValueNonNull("{{asPropertyValue}}", {{asPropertyValue}}));

--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -264,6 +264,31 @@ protected:
         return ConstraintsChecker::CheckConstraintNotValue(itemName, currentValue, expectedValue);
     }
 
+    template <typename T> bool CheckConstraintContains(const char * _Nonnull itemName, const NSArray * _Nonnull current, T expected)
+    {
+        for (id currentElement in current) {
+            if ([currentElement isEqualToNumber:@(expected)]) {
+                return true;
+            }
+        }
+
+        Exit(std::string(itemName) + " expect the value " + std::to_string(expected) + " but the list does not contains it.");
+        return false;
+    }
+
+    template <typename T> bool CheckConstraintExcludes(const char * _Nonnull itemName, const NSArray * _Nonnull current, T expected)
+    {
+        for (id currentElement in current) {
+            if ([currentElement isEqualToNumber:@(expected)]) {
+                Exit(std::string(itemName) + " does not expect the value " + std::to_string(expected)
+                    + " but the list contains it.");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     bool CheckConstraintNotValue(const char * _Nonnull itemName, const NSData * _Nonnull current, const NSData * _Nonnull expected)
     {
         const chip::ByteSpan currentValue(static_cast<const uint8_t *>([current bytes]), [current length]);

--- a/examples/darwin-framework-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt
@@ -1,0 +1,67 @@
+{{#if hasExpectedConstraints}}
+    {{~#*inline "item"}}{{asLowerCamelCase name}}{{/inline}}
+    {{#if (hasProperty expectedConstraints "type")}}VerifyOrReturn(CheckConstraintType("{{>item}}", "", "{{expectedConstraints.type}}"));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "format")}}VerifyOrReturn(CheckConstraintFormat("{{>item}}", "", "{{expectedConstraints.format}}"));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "startsWith")}}VerifyOrReturn(CheckConstraintStartsWith("{{>item}}", {{>actualValue}}, "{{expectedConstraints.startsWith}}"));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "endsWith")}}VerifyOrReturn(CheckConstraintEndsWith("{{>item}}", {{>actualValue}}, "{{expectedConstraints.endsWith}}"));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "isUpperCase")}}VerifyOrReturn(CheckConstraintIsUpperCase("{{>item}}", {{>actualValue}}, {{expectedConstraints.isUpperCase}}));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "isLowerCase")}}VerifyOrReturn(CheckConstraintIsLowerCase("{{>item}}", {{>actualValue}}, {{expectedConstraints.isLowerCase}}));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "isHexString")}}VerifyOrReturn(CheckConstraintIsHexString("{{>item}}", {{>actualValue}}, {{expectedConstraints.isHexString}}));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "minLength")}}VerifyOrReturn(CheckConstraintMinLength("{{>item}}", [{{>actualValue}} length], {{expectedConstraints.minLength}}));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "maxLength")}}VerifyOrReturn(CheckConstraintMaxLength("{{>item}}", [{{>actualValue}} length], {{expectedConstraints.maxLength}}));{{/if}}
+
+    {{~#if (hasProperty expectedConstraints "minValue")}}
+    if ({{>actualValue}} != nil)
+    {
+        VerifyOrReturn(CheckConstraintMinValue<{{chipType}}>("{{>item}}", [{{>actualValue}} {{asObjectiveCNumberType "" type true}}Value], {{asTypedLiteral expectedConstraints.minValue type}}));
+    }
+    {{/if}}
+
+    {{~#if (hasProperty expectedConstraints "maxValue")}}
+    if ({{>actualValue}} != nil)
+    {
+        VerifyOrReturn(CheckConstraintMaxValue<{{chipType}}>("{{>item}}", [{{>actualValue}} {{asObjectiveCNumberType "" type true}}Value], {{asTypedLiteral expectedConstraints.maxValue type}}));
+    }
+    {{/if}}
+
+    {{~#if (hasProperty expectedConstraints "contains")}}
+    if ({{>actualValue}} != nil)
+    {
+        {{#chip_tests_iterate_expected_list expectedConstraints.contains}}
+    VerifyOrReturn(CheckConstraintContains("{{asLowerCamelCase name}}", {{>actualValue}}, {{asTypedLiteral value type}}));
+        {{/chip_tests_iterate_expected_list}}
+    }
+    {{/if}}
+
+    {{~#if (hasProperty expectedConstraints "excludes")}}
+    if ({{>actualValue}} != nil)
+    {
+        {{#chip_tests_iterate_expected_list expectedConstraints.excludes}}
+    VerifyOrReturn(CheckConstraintExcludes("{{asLowerCamelCase name}}", {{>actualValue}}, {{asTypedLiteral value type}}));
+        {{/chip_tests_iterate_expected_list}}
+    }
+    {{/if}}
+
+    {{~#if (hasProperty expectedConstraints "notValue")}}
+        {{#if (isLiteralNull expectedConstraints.notValue)}}
+    VerifyOrReturn(CheckValueNonNull("{{>item}}", {{>actualValue}}));
+        {{else}}
+    if ({{>actualValue}} != nil)
+    {
+            {{#if (isString type)}}
+        VerifyOrReturn(CheckConstraintNotValue("{{>item}}", {{>actualValue}}, {{asTypedLiteral expectedConstraints.notValue type}}));
+            {{else}}
+        VerifyOrReturn(CheckConstraintNotValue("{{>item}}", {{>actualValue}}, {{asTypedLiteral expectedConstraints.notValue type}}));
+            {{/if}}
+    }
+        {{/if}}
+    {{/if}}
+{{/if}}

--- a/examples/darwin-framework-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/test_cluster.zapt
@@ -209,47 +209,13 @@ class {{filename}}: public TestCommandBridge
               {{>check_test_value actual="actualValue" expected=expectedValue cluster=../cluster}}
             }
             {{/if}}
-            {{#if hasExpectedConstraints}}
-            {{~#*inline "item"}}{{asLowerCamelCase name}}{{/inline}}
-            {{#if (hasProperty expectedConstraints "type")}}VerifyOrReturn(CheckConstraintType("{{>item}}", "", "{{expectedConstraints.type}}"));{{/if}}
-            {{~#if (hasProperty expectedConstraints "format")}}VerifyOrReturn(CheckConstraintFormat("{{>item}}", "", "{{expectedConstraints.format}}"));{{/if}}
-            {{~#if (hasProperty expectedConstraints "startsWith")}}VerifyOrReturn(CheckConstraintStartsWith("{{>item}}", {{>actualValue}}, "{{expectedConstraints.startsWith}}"));{{/if}}
-            {{~#if (hasProperty expectedConstraints "endsWith")}}VerifyOrReturn(CheckConstraintEndsWith("{{>item}}", {{>actualValue}}, "{{expectedConstraints.endsWith}}"));{{/if}}
-            {{~#if (hasProperty expectedConstraints "isUpperCase")}}VerifyOrReturn(CheckConstraintIsUpperCase("{{>item}}", {{>actualValue}}, {{expectedConstraints.isUpperCase}}));{{/if}}
-            {{~#if (hasProperty expectedConstraints "isLowerCase")}}VerifyOrReturn(CheckConstraintIsLowerCase("{{>item}}", {{>actualValue}}, {{expectedConstraints.isLowerCase}}));{{/if}}
-            {{~#if (hasProperty expectedConstraints "isHexString")}}VerifyOrReturn(CheckConstraintIsHexString("{{>item}}", {{>actualValue}}, {{expectedConstraints.isHexString}}));{{/if}}
-            {{~#if (hasProperty expectedConstraints "minLength")}}VerifyOrReturn(CheckConstraintMinLength("{{>item}}", [{{>actualValue}} length], {{expectedConstraints.minLength}}));{{/if}}
-            {{~#if (hasProperty expectedConstraints "maxLength")}}VerifyOrReturn(CheckConstraintMaxLength("{{>item}}", [{{>actualValue}} length], {{expectedConstraints.maxLength}}));{{/if}}
-            {{~#if (hasProperty expectedConstraints "minValue")}}
-              if ({{>actualValue}} != nil) {
-                VerifyOrReturn(CheckConstraintMinValue<{{chipType}}>("{{>item}}", [{{>actualValue}} {{asObjectiveCNumberType "" type true}}Value], {{asTypedLiteral expectedConstraints.minValue type}}));
-              }
+            {{>maybeCheckExpectedConstraints}}
+            {{#if saveAs}}
+            {
+              {{saveAs}} = {{>actualValue}};
+            }
             {{/if}}
-            {{~#if (hasProperty expectedConstraints "maxValue")}}
-              if ({{>actualValue}} != nil) {
-                VerifyOrReturn(CheckConstraintMaxValue<{{chipType}}>("{{>item}}", [{{>actualValue}} {{asObjectiveCNumberType "" type true}}Value], {{asTypedLiteral expectedConstraints.maxValue type}}));
-              }
-            {{/if}}
-            {{~#if (hasProperty expectedConstraints "notValue")}}
-              {{#if (isLiteralNull expectedConstraints.notValue)}}
-              VerifyOrReturn(CheckValueNonNull("{{>item}}", {{>actualValue}}));
-              {{else}}
-              if ({{>actualValue}} != nil) {
-                {{#if (isString type)}}
-                VerifyOrReturn(CheckConstraintNotValue("{{>item}}", {{>actualValue}}, {{asTypedLiteral expectedConstraints.notValue type}}));
-                {{else}}
-                VerifyOrReturn(CheckConstraintNotValue("{{>item}}", {{>actualValue}}, {{asTypedLiteral expectedConstraints.notValue type}}));
-                {{/if}}
-              }
-              {{/if}}
-            {{/if}}
-        {{/if}}
-        {{#if saveAs}}
-        {
-          {{saveAs}} = {{>actualValue}};
-        }
-        {{/if}}
-        {{/chip_tests_item_response_parameters}}
+            {{/chip_tests_item_response_parameters}}
 
         {{#unless async}}
         NextTest();

--- a/examples/darwin-framework-tool/templates/tests/templates.json
+++ b/examples/darwin-framework-tool/templates/tests/templates.json
@@ -38,6 +38,10 @@
         {
             "name": "check_test_value",
             "path": "partials/check_test_value.zapt"
+        },
+        {
+            "name": "maybeCheckExpectedConstraints",
+            "path": "partials/checks/maybeCheckExpectedConstraints.zapt"
         }
     ],
     "templates": [

--- a/src/app/tests/suites/TestConstraints.yaml
+++ b/src/app/tests/suites/TestConstraints.yaml
@@ -28,6 +28,36 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
+    # Tests for List of INT8U attribute
+    - label: "Write attribute LIST With List of INT8U"
+      command: "writeAttribute"
+      attribute: "list_int8u"
+      arguments:
+          value: [1, 2, 3, 4]
+
+    - label:
+          "Read attribute LIST With Partial List of INT8U that should be in it"
+      command: "readAttribute"
+      attribute: "list_int8u"
+      response:
+          constraints:
+              contains: [2, 3, 4]
+
+    - label:
+          "Read attribute LIST With Partial List of INT8U that should not be
+          included"
+      command: "readAttribute"
+      attribute: "list_int8u"
+      response:
+          constraints:
+              excludes: [0, 5]
+
+    - label: "Write attribute LIST Back to Default Value"
+      command: "writeAttribute"
+      attribute: "list_int8u"
+      arguments:
+          value: []
+
     # Tests for INT32U attribute
 
     - label: "Write attribute INT32U Value"

--- a/src/app/tests/suites/include/ConstraintsChecker.h
+++ b/src/app/tests/suites/include/ConstraintsChecker.h
@@ -419,4 +419,46 @@ protected:
         }
         return false;
     }
+
+    template <typename T, typename U>
+    bool CheckConstraintContains(const char * itemName, const chip::app::DataModel::DecodableList<T> & current, const U & expected)
+    {
+        auto iterValue = current.begin();
+        while (iterValue.Next())
+        {
+            auto currentValue = iterValue.GetValue();
+            if (currentValue == expected)
+            {
+                return true;
+            }
+        }
+
+        Exit(std::string(itemName) + " expect the value " + std::to_string(expected) + " but the list does not contains it.");
+        return false;
+    }
+
+    template <typename T, typename U>
+    bool CheckConstraintExcludes(const char * itemName, const chip::app::DataModel::DecodableList<T> & current, const U & expected)
+    {
+        auto iterValue = current.begin();
+        while (iterValue.Next())
+        {
+            auto currentValue = iterValue.GetValue();
+            if (currentValue == expected)
+            {
+                Exit(std::string(itemName) + " does not expect the value " + std::to_string(expected) +
+                     " but the list contains it.");
+                return false;
+            }
+        }
+
+        CHIP_ERROR err = iterValue.GetStatus();
+        if (CHIP_NO_ERROR != err)
+        {
+            Exit(std::string(chip::ErrorStr(err)));
+            return false;
+        }
+
+        return true;
+    }
 };

--- a/src/app/zap-templates/common/ClusterTestGeneration.js
+++ b/src/app/zap-templates/common/ClusterTestGeneration.js
@@ -998,6 +998,18 @@ async function chip_tests_only_cluster_response_parameters(options)
   return asBlocks.call(this, Promise.resolve(this.arguments), options);
 }
 
+function chip_tests_iterate_expected_list(values, options)
+{
+  values = values.map(value => {
+    return {
+      global: this.global, parent: this.parent, name: this.name, type: this.type, isArray: this.isArray,
+          isNullable: this.isNullable, value: value,
+    }
+  });
+
+  return asBlocks.call(this, Promise.resolve(values), options);
+}
+
 //
 // Module exports
 //
@@ -1028,3 +1040,4 @@ exports.chip_tests_only_cluster_response_parameters = chip_tests_only_cluster_re
 exports.isHexString                                 = isHexString;
 exports.octetStringLengthFromHexString              = octetStringLengthFromHexString;
 exports.octetStringFromHexString                    = octetStringFromHexString;
+exports.chip_tests_iterate_expected_list            = chip_tests_iterate_expected_list;

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -49112,7 +49112,7 @@ private:
 class TestConstraintsSuite : public TestCommand
 {
 public:
-    TestConstraintsSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestConstraints", 22, credsIssuerConfig)
+    TestConstraintsSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestConstraints", 26, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -49155,12 +49155,37 @@ private:
         case 2:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
+                chip::app::DataModel::DecodableList<uint8_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckConstraintContains("value", value, 2));
+                VerifyOrReturn(CheckConstraintContains("value", value, 3));
+                VerifyOrReturn(CheckConstraintContains("value", value, 4));
+            }
+            break;
+        case 3:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::DecodableList<uint8_t> value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckConstraintExcludes("value", value, 0));
+                VerifyOrReturn(CheckConstraintExcludes("value", value, 5));
+            }
+            break;
+        case 4:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 5:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 6:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
                 uint32_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckConstraintMinValue("value", value, 5UL));
             }
             break;
-        case 3:
+        case 7:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 uint32_t value;
@@ -49168,7 +49193,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxValue("value", value, 5UL));
             }
             break;
-        case 4:
+        case 8:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 uint32_t value;
@@ -49176,13 +49201,13 @@ private:
                 VerifyOrReturn(CheckConstraintNotValue("value", value, 6UL));
             }
             break;
-        case 5:
+        case 9:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 6:
+        case 10:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 7:
+        case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -49190,7 +49215,7 @@ private:
                 VerifyOrReturn(CheckConstraintMinLength("value", value.size(), 5));
             }
             break;
-        case 8:
+        case 12:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -49198,7 +49223,7 @@ private:
                 VerifyOrReturn(CheckConstraintMaxLength("value", value.size(), 20));
             }
             break;
-        case 9:
+        case 13:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
@@ -49206,36 +49231,12 @@ private:
                 VerifyOrReturn(CheckConstraintStartsWith("value", value, "**"));
             }
             break;
-        case 10:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::CharSpan value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckConstraintEndsWith("value", value, "**"));
-            }
-            break;
-        case 11:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 12:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::CharSpan value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckConstraintIsUpperCase("value", value, false));
-                VerifyOrReturn(CheckConstraintIsLowerCase("value", value, true));
-            }
-            break;
-        case 13:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
         case 14:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::CharSpan value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckConstraintIsUpperCase("value", value, true));
-                VerifyOrReturn(CheckConstraintIsLowerCase("value", value, false));
+                VerifyOrReturn(CheckConstraintEndsWith("value", value, "**"));
             }
             break;
         case 15:
@@ -49247,7 +49248,7 @@ private:
                 chip::CharSpan value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckConstraintIsUpperCase("value", value, false));
-                VerifyOrReturn(CheckConstraintIsLowerCase("value", value, false));
+                VerifyOrReturn(CheckConstraintIsLowerCase("value", value, true));
             }
             break;
         case 17:
@@ -49258,7 +49259,8 @@ private:
             {
                 chip::CharSpan value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckConstraintIsHexString("value", value, false));
+                VerifyOrReturn(CheckConstraintIsUpperCase("value", value, true));
+                VerifyOrReturn(CheckConstraintIsLowerCase("value", value, false));
             }
             break;
         case 19:
@@ -49269,10 +49271,33 @@ private:
             {
                 chip::CharSpan value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckConstraintIsHexString("value", value, true));
+                VerifyOrReturn(CheckConstraintIsUpperCase("value", value, false));
+                VerifyOrReturn(CheckConstraintIsLowerCase("value", value, false));
             }
             break;
         case 21:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 22:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::CharSpan value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckConstraintIsHexString("value", value, false));
+            }
+            break;
+        case 23:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 24:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::CharSpan value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckConstraintIsHexString("value", value, true));
+            }
+            break;
+        case 25:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         default:
@@ -49298,87 +49323,97 @@ private:
             return WaitForCommissionee(kIdentityAlpha, value);
         }
         case 1: {
-            LogStep(1, "Write attribute INT32U Value");
+            LogStep(1, "Write attribute LIST With List of INT8U");
+            ListFreer listFreer;
+            chip::app::DataModel::List<const uint8_t> value;
+
+            {
+                auto * listHolder_0 = new ListHolder<uint8_t>(4);
+                listFreer.add(listHolder_0);
+                listHolder_0->mList[0] = 1;
+                listHolder_0->mList[1] = 2;
+                listHolder_0->mList[2] = 3;
+                listHolder_0->mList[3] = 4;
+                value                  = chip::app::DataModel::List<uint8_t>(listHolder_0->mList, 4);
+            }
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 2: {
+            LogStep(2, "Read attribute LIST With Partial List of INT8U that should be in it");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 3: {
+            LogStep(3, "Read attribute LIST With Partial List of INT8U that should not be included");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, true,
+                                 chip::NullOptional);
+        }
+        case 4: {
+            LogStep(4, "Write attribute LIST Back to Default Value");
+            ListFreer listFreer;
+            chip::app::DataModel::List<const uint8_t> value;
+
+            value = chip::app::DataModel::List<uint8_t>();
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::ListInt8u::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 5: {
+            LogStep(5, "Write attribute INT32U Value");
             ListFreer listFreer;
             uint32_t value;
             value = 5UL;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::Int32u::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 2: {
-            LogStep(2, "Read attribute INT32U Value MinValue Constraints");
+        case 6: {
+            LogStep(6, "Read attribute INT32U Value MinValue Constraints");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::Int32u::Id, true,
                                  chip::NullOptional);
         }
-        case 3: {
-            LogStep(3, "Read attribute INT32U Value MaxValue Constraints");
+        case 7: {
+            LogStep(7, "Read attribute INT32U Value MaxValue Constraints");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::Int32u::Id, true,
                                  chip::NullOptional);
         }
-        case 4: {
-            LogStep(4, "Read attribute INT32U Value NotValue Constraints");
+        case 8: {
+            LogStep(8, "Read attribute INT32U Value NotValue Constraints");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::Int32u::Id, true,
                                  chip::NullOptional);
         }
-        case 5: {
-            LogStep(5, "Write attribute INT32U Value Back to Default Value");
+        case 9: {
+            LogStep(9, "Write attribute INT32U Value Back to Default Value");
             ListFreer listFreer;
             uint32_t value;
             value = 0UL;
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::Int32u::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 6: {
-            LogStep(6, "Write attribute CHAR_STRING Value");
+        case 10: {
+            LogStep(10, "Write attribute CHAR_STRING Value");
             ListFreer listFreer;
             chip::CharSpan value;
             value = chip::Span<const char>("** Test **garbage: not in length on purpose", 10);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
-        case 7: {
-            LogStep(7, "Read attribute CHAR_STRING Value MinLength Constraints");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
-                                 chip::NullOptional);
-        }
-        case 8: {
-            LogStep(8, "Read attribute CHAR_STRING Value MaxLength Constraints");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
-                                 chip::NullOptional);
-        }
-        case 9: {
-            LogStep(9, "Read attribute CHAR_STRING Value StartsWith Constraints");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
-                                 chip::NullOptional);
-        }
-        case 10: {
-            LogStep(10, "Read attribute CHAR_STRING Value EndsWith Constraints");
-            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
-                                 chip::NullOptional);
-        }
         case 11: {
-            LogStep(11, "Write attribute CHAR_STRING Value");
-            ListFreer listFreer;
-            chip::CharSpan value;
-            value = chip::Span<const char>("lowercasegarbage: not in length on purpose", 9);
-            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
-                                  chip::NullOptional, chip::NullOptional);
+            LogStep(11, "Read attribute CHAR_STRING Value MinLength Constraints");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
+                                 chip::NullOptional);
         }
         case 12: {
-            LogStep(12, "Read attribute CHAR_STRING Value isLowerCase/isUpperCase Constraints");
+            LogStep(12, "Read attribute CHAR_STRING Value MaxLength Constraints");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
                                  chip::NullOptional);
         }
         case 13: {
-            LogStep(13, "Write attribute CHAR_STRING Value");
-            ListFreer listFreer;
-            chip::CharSpan value;
-            value = chip::Span<const char>("UPPERCASEgarbage: not in length on purpose", 9);
-            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
-                                  chip::NullOptional, chip::NullOptional);
+            LogStep(13, "Read attribute CHAR_STRING Value StartsWith Constraints");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
+                                 chip::NullOptional);
         }
         case 14: {
-            LogStep(14, "Read attribute CHAR_STRING Value isLowerCase/isUpperCase Constraints");
+            LogStep(14, "Read attribute CHAR_STRING Value EndsWith Constraints");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
                                  chip::NullOptional);
         }
@@ -49386,7 +49421,7 @@ private:
             LogStep(15, "Write attribute CHAR_STRING Value");
             ListFreer listFreer;
             chip::CharSpan value;
-            value = chip::Span<const char>("lowUPPERgarbage: not in length on purpose", 8);
+            value = chip::Span<const char>("lowercasegarbage: not in length on purpose", 9);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
@@ -49399,12 +49434,12 @@ private:
             LogStep(17, "Write attribute CHAR_STRING Value");
             ListFreer listFreer;
             chip::CharSpan value;
-            value = chip::Span<const char>("ABCDEF012Vgarbage: not in length on purpose", 10);
+            value = chip::Span<const char>("UPPERCASEgarbage: not in length on purpose", 9);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
         case 18: {
-            LogStep(18, "Read attribute CHAR_STRING Value isHexString Constraints");
+            LogStep(18, "Read attribute CHAR_STRING Value isLowerCase/isUpperCase Constraints");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
                                  chip::NullOptional);
         }
@@ -49412,17 +49447,43 @@ private:
             LogStep(19, "Write attribute CHAR_STRING Value");
             ListFreer listFreer;
             chip::CharSpan value;
-            value = chip::Span<const char>("ABCDEF0123garbage: not in length on purpose", 10);
+            value = chip::Span<const char>("lowUPPERgarbage: not in length on purpose", 8);
             return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
                                   chip::NullOptional, chip::NullOptional);
         }
         case 20: {
-            LogStep(20, "Read attribute CHAR_STRING Value isHexString Constraints");
+            LogStep(20, "Read attribute CHAR_STRING Value isLowerCase/isUpperCase Constraints");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
                                  chip::NullOptional);
         }
         case 21: {
-            LogStep(21, "Write attribute CHAR_STRING Value Back to Default Value");
+            LogStep(21, "Write attribute CHAR_STRING Value");
+            ListFreer listFreer;
+            chip::CharSpan value;
+            value = chip::Span<const char>("ABCDEF012Vgarbage: not in length on purpose", 10);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 22: {
+            LogStep(22, "Read attribute CHAR_STRING Value isHexString Constraints");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
+                                 chip::NullOptional);
+        }
+        case 23: {
+            LogStep(23, "Write attribute CHAR_STRING Value");
+            ListFreer listFreer;
+            chip::CharSpan value;
+            value = chip::Span<const char>("ABCDEF0123garbage: not in length on purpose", 10);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 24: {
+            LogStep(24, "Read attribute CHAR_STRING Value isHexString Constraints");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), TestCluster::Id, TestCluster::Attributes::CharString::Id, true,
+                                 chip::NullOptional);
+        }
+        case 25: {
+            LogStep(25, "Write attribute CHAR_STRING Value Back to Default Value");
             ListFreer listFreer;
             chip::CharSpan value;
             value = chip::Span<const char>("garbage: not in length on purpose", 0);


### PR DESCRIPTION
#### Problem

There is no mechanism to specify a subset of a list to check of inclusion/exclusion.

Fix #18041


#### Change overview
 * Add supports for 2 new constraints: `contains` and `excludes` which applies to list elements
 * For the moment the constraints only works for simple number types, but that should be enough for most use cases


#### Testing
A test for both methods has been added in `TestConstraints.yaml`