### PR TITLE
Enable IPv6 for WiFi (rs911x)

### DIFF
--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -60,6 +60,9 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
+
+  # Argument to Disable IPv4 for wifi(rs911)
+  chip_disable_wifi_ipv4 = false
 }
 
 declare_args() {
@@ -213,6 +216,10 @@ efr32_executable("light_switch_app") {
   if (chip_enable_ota_requestor) {
     defines += [ "EFR32_OTA_ENABLED" ]
     sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
+  }
+
+  if (chip_disable_wifi_ipv4) {
+    defines += [ "WIFI_IPV4_DISABLED" ]
   }
 
   # WiFi Settings

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -60,6 +60,9 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
+
+  # Argument to Disable IPv4 for wifi(rs911)
+  chip_disable_wifi_ipv4 = false
 }
 
 declare_args() {
@@ -212,6 +215,10 @@ efr32_executable("lighting_app") {
   if (chip_enable_ota_requestor) {
     defines += [ "EFR32_OTA_ENABLED" ]
     sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
+  }
+
+  if (chip_disable_wifi_ipv4) {
+    defines += [ "WIFI_IPV4_DISABLED" ]
   }
 
   # WiFi Settings

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -60,6 +60,9 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
+
+  # Argument to Disable IPv4 for wifi(rs911)
+  chip_disable_wifi_ipv4 = false
 }
 
 declare_args() {
@@ -214,6 +217,10 @@ efr32_executable("lock_app") {
   if (chip_enable_ota_requestor) {
     defines += [ "EFR32_OTA_ENABLED" ]
     sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
+  }
+
+  if (chip_disable_wifi_ipv4) {
+    defines += [ "WIFI_IPV4_DISABLED" ]
   }
 
   # WiFi Settings

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -53,6 +53,9 @@ declare_args() {
 
   # Disable LCD on supported devices
   disable_lcd = false
+
+  # Argument to Disable IPv4 for wifi(rs911)
+  chip_disable_wifi_ipv4 = false
 }
 
 declare_args() {
@@ -201,6 +204,10 @@ efr32_executable("window_app") {
   if (chip_enable_ota_requestor) {
     defines += [ "EFR32_OTA_ENABLED" ]
     sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
+  }
+
+  if (chip_disable_wifi_ipv4) {
+    defines += [ "WIFI_IPV4_DISABLED" ]
   }
 
   # WiFi Settings

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -137,6 +137,10 @@ else
                 optArgs+="enable_sleepy_device=true chip_openthread_ftd=false "
                 shift
                 ;;
+            --chip_disable_wifi_ipv4)
+                optArgs+="chip_disable_wifi_ipv4=true "
+                shift
+                ;;
             *)
                 if [ "$1" =~ *"use_rs911x=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
                     USE_WIFI=true

--- a/src/platform/EFR32/CHIPDevicePlatformConfig.h
+++ b/src/platform/EFR32/CHIPDevicePlatformConfig.h
@@ -48,6 +48,18 @@
 
 #define CHIP_DEVICE_CONFIG_ENABLE_CHIP_TIME_SERVICE_TIME_SYNC 0
 
+#if defined(RS911X_WIFI)
+
+#if defined(WIFI_IPV4_DISABLED)
+#define CHIP_DEVICE_CONFIG_ENABLE_IPV4 0
+#define CHIP_DEVICE_CONFIG_ENABLE_IPV6 1
+#else
+#define CHIP_DEVICE_CONFIG_ENABLE_IPV4 1
+#define CHIP_DEVICE_CONFIG_ENABLE_IPV6 1
+#endif
+
+#endif
+
 // ========== Platform-specific Configuration =========
 
 // These are configuration options that are unique to the EFR32 platform.

--- a/src/platform/EFR32/ConnectivityManagerImpl_WIFI.cpp
+++ b/src/platform/EFR32/ConnectivityManagerImpl_WIFI.cpp
@@ -33,6 +33,7 @@
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.ipp>
 #endif
 
+#include "CHIPDevicePlatformConfig.h"
 #include "wfx_host_events.h"
 
 using namespace ::chip;
@@ -388,8 +389,10 @@ void ConnectivityManagerImpl::UpdateInternetConnectivityState(void)
     if (mWiFiStationState == kWiFiStationState_Connected)
     {
 #if 1 //! defined (SL_WF200) || (SL_WF200 == 0)
-
         haveIPv4Conn = wfx_have_ipv4_addr(SL_WFX_STA_INTERFACE);
+#if (CHIP_DEVICE_CONFIG_ENABLE_IPV6)
+        haveIPv6Conn = wfx_have_ipv6_addr(SL_WFX_STA_INTERFACE);
+#endif
         /* TODO  - haveIPv6Conn */
 #else  /* Old code that needed LWIP and its internals */
         // Get the LwIP netif for the WiFi station interface.


### PR DESCRIPTION
Added build flag for Enabling and disabling IPv4/IPv6

Signed-off-by: Sharad Patil <sharad.patil@silabs.com>

#### Problem
What is being fixed?  Examples:
* Enabled IPv6 for EFR32 Wifi builds

#### Change overview
* Created a notification event IPv6.
* Added build flag to enable disable IPv4/IPv6 based on requirement.

#### Testing
How was this tested? (at least one bullet point required)
* Manually tested on EFR32 MG12 + RS9116 HW .
