### PR TITLE
Shutdown of server initialized classes in reverse order of initialization

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -345,9 +345,13 @@ void Server::ScheduleFactoryReset()
 
 void Server::Shutdown()
 {
+    mCASESessionManager.Shutdown();
     app::DnssdServer::Instance().SetCommissioningModeProvider(nullptr);
     chip::Dnssd::ServiceAdvertiser::Instance().Shutdown();
+
+    chip::Dnssd::Resolver::Instance().Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
+    mMessageCounterManager.Shutdown();
     CHIP_ERROR err = mExchangeMgr.Shutdown();
     if (err != CHIP_NO_ERROR)
     {
@@ -355,11 +359,10 @@ void Server::Shutdown()
     }
     mSessions.Shutdown();
     mTransports.Close();
-
+    mAccessControl.Finish();
+    Credentials::SetGroupDataProvider(nullptr);
     mAttributePersister.Shutdown();
     mCommissioningWindowManager.Shutdown();
-    mCASESessionManager.Shutdown();
-
     // TODO(16969): Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code
     chip::Platform::MemoryShutdown();
 }


### PR DESCRIPTION
#### Problem
[Server initializes](https://github.com/project-chip/connectedhomeip/blob/131b13c8b5ccb49585069c743b530310301deddd/src/app/server/Server.cpp#L100) several classes, but not all of them are on [server shutdown](https://github.com/project-chip/connectedhomeip/blob/131b13c8b5ccb49585069c743b530310301deddd/src/app/server/Server.cpp#L346)


#### Change overview
This PR adds shutdown calls for the modules that had some formal shutdown method. It also reversely orders them according to initialization sequence.