### PR TITLE
[hotfix]Remove endpointid check for command path IB

### DIFF
--- a/src/app/MessageDef/CommandPathIB.cpp
+++ b/src/app/MessageDef/CommandPathIB.cpp
@@ -103,8 +103,7 @@ CHIP_ERROR CommandPathIB::Parser::CheckSchemaValidity() const
     if (CHIP_END_OF_TLV == err)
     {
         // check for required fields:
-        const uint16_t requiredFields =
-            (1 << to_underlying(Tag::kEndpointId)) | (1 << to_underlying(Tag::kCommandId)) | (1 << to_underlying(Tag::kClusterId));
+        const uint16_t requiredFields = (1 << to_underlying(Tag::kCommandId)) | (1 << to_underlying(Tag::kClusterId));
 
         err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_COMMAND_PATH_IB;
     }


### PR DESCRIPTION
#### Problem
Master CI is broken.
#19016 has accidentally added the endpointId check in CommandPathIB, group message don't have endpointId, so we need remove this check.

#### Change overview
Remove this endpointId check in CommandPathIB
#### Testing
CI pass
