### PR TITLE
[Tizen] Handle relaunching event

### DIFF
--- a/examples/platform/tizen/TizenServiceAppMain.cpp
+++ b/examples/platform/tizen/TizenServiceAppMain.cpp
@@ -84,13 +84,16 @@ void TizenServiceAppMain::AppTerminated()
 void TizenServiceAppMain::AppControl(app_control_h app_control)
 {
     ChipLogProgress(NotSpecified, "Tizen app control");
-
-    mLinuxArgs.Parse(mArgc > 0 ? mArgv[0] : nullptr, app_control);
-    if (ChipLinuxAppInit(mLinuxArgs.argc(), const_cast<char **>(mLinuxArgs.argv())) != 0)
+    if (!initialized)
     {
-        service_app_exit();
-        return;
-    }
+        mLinuxArgs.Parse(mArgc > 0 ? mArgv[0] : nullptr, app_control);
+        if (ChipLinuxAppInit(mLinuxArgs.argc(), const_cast<char **>(mLinuxArgs.argv())) != 0)
+        {
+            service_app_exit();
+            return;
+        }
 
-    mLinuxThread = std::thread(ChipLinuxAppMainLoop);
+        mLinuxThread = std::thread(ChipLinuxAppMainLoop);
+        initialized  = true;
+    }
 }

--- a/examples/platform/tizen/TizenServiceAppMain.h
+++ b/examples/platform/tizen/TizenServiceAppMain.h
@@ -44,4 +44,5 @@ private:
     char ** mArgv = nullptr;
     OptionsProxy mLinuxArgs;
     std::thread mLinuxThread;
+    bool initialized = false;
 };


### PR DESCRIPTION
#### Problem
Can't relaunch the lighting app on the Tizen device. 

#### Change overview
Check the current app state and omit initialization. 

#### Testing
Call two times command below:
```sh
app_launcher --start=org.tizen.matter.example.lighting discriminator 43 wifi true
```