### PR TITLE
[Tizen] Properly manage resources in main loop class

### DIFF
--- a/src/platform/Tizen/MainLoop.h
+++ b/src/platform/Tizen/MainLoop.h
@@ -32,8 +32,12 @@ typedef gboolean (*initFn_t)(gpointer userData);
 typedef gboolean (*asyncFn_t)(GMainLoop * mainLoop, gpointer userData);
 typedef void (*timeoutFn_t)(gpointer userData);
 
-struct LoopData
+class LoopData
 {
+public:
+    LoopData();
+    ~LoopData();
+
     // Thread which governs glib main event loop
     std::thread mThread;
     // Objects for running glib main event loop

--- a/src/platform/Tizen/MainLoop.h
+++ b/src/platform/Tizen/MainLoop.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <memory>
 #include <thread>
 
 #include <lib/core/CHIPError.h>
@@ -55,12 +56,11 @@ public:
 private:
     MainLoop() = default;
 
-    void DeleteData(LoopData * loopData);
     static gboolean ThreadTimeout(gpointer userData);
-    static void ThreadMainHandler(LoopData * loopData);
-    static void ThreadAsyncHandler(LoopData * loopData);
+    static void ThreadMainHandler(std::shared_ptr<LoopData> loopData);
+    static void ThreadAsyncHandler(std::shared_ptr<LoopData> loopData);
 
-    std::vector<LoopData *> mLoopData;
+    std::vector<std::shared_ptr<LoopData>> mLoopData;
 };
 
 } // namespace Internal

--- a/src/platform/Tizen/MainLoop.h
+++ b/src/platform/Tizen/MainLoop.h
@@ -29,29 +29,27 @@ typedef gboolean (*initFn_t)(gpointer userData);
 typedef gboolean (*asyncFn_t)(GMainLoop * mainLoop, gpointer userData);
 typedef void (*timeoutFn_t)(gpointer userData);
 
-class LoopData
+struct LoopData
 {
-public:
-    LoopData() : mMainContext(NULL), mMainLoop(NULL), mThread(NULL), mTimeoutFn(NULL), mTimeoutUserData(NULL) {}
-
-    GMainContext * mMainContext;
-    GMainLoop * mMainLoop;
-    GThread * mThread;
-    timeoutFn_t mTimeoutFn;
-    gpointer mTimeoutUserData;
+    GMainContext * mMainContext = nullptr;
+    GMainLoop * mMainLoop       = nullptr;
+    GThread * mThread           = nullptr;
+    timeoutFn_t mTimeoutFn      = nullptr;
+    gpointer mTimeoutUserData   = nullptr;
 };
 
 class MainLoop
 {
 public:
-    bool Init(initFn_t initFn, gpointer userData = NULL);
+    bool Init(initFn_t initFn, gpointer userData = nullptr);
     void Deinit(void);
-    bool AsyncRequest(asyncFn_t asyncFn, gpointer asyncUserData = NULL, guint interval = 0, timeoutFn_t timeoutFn = NULL,
-                      gpointer timeoutUserData = NULL);
+    bool AsyncRequest(asyncFn_t asyncFn, gpointer asyncUserData = nullptr, guint interval = 0, timeoutFn_t timeoutFn = nullptr,
+                      gpointer timeoutUserData = nullptr);
     static MainLoop & Instance(void);
 
 private:
-    MainLoop() {}
+    MainLoop() = default;
+
     void DeleteData(LoopData * loopData);
     static gboolean ThreadTimeout(gpointer userData);
     void SetThreadTimeout(LoopData * loopData, guint interval);

--- a/src/platform/Tizen/MainLoop.h
+++ b/src/platform/Tizen/MainLoop.h
@@ -57,8 +57,7 @@ private:
     MainLoop() = default;
 
     static gboolean ThreadTimeout(gpointer userData);
-    static void ThreadMainHandler(std::shared_ptr<LoopData> loopData);
-    static void ThreadAsyncHandler(std::shared_ptr<LoopData> loopData);
+    static void ThreadHandler(std::shared_ptr<LoopData> loopData);
 
     std::vector<std::shared_ptr<LoopData>> mLoopData;
 };


### PR DESCRIPTION
#### Problem

The MainLoop class has poor resource management. First of all it leaks not jointed threads. Also, it handles memory in an explicit way which is error prone.

#### Change overview

- use C++ threads for running main-loop handlers
- manage loopData objects using shared pointers and RAII
- change logging level to "detail" for logging debug-only information
- remove code redundancy

#### Testing

Unfortunately, there is no easy way to debug/test thread resources leaking, however, I can post some stats from /proc file system.


status filed | old-code | new-code
-|-|-
VmPeak | 146108 kB | 121604 kB
VmSize | 146108 kB | 121528 kB
VmData |116516 kB | 91940 kB
VmPTE |   148 kB | 112 kB
Threads | 10 | 10

Number of allocated private mappings (every thread has a private mapping which is unmapped upon proper thread exit via join/detach) using command like this `grep -- '---p' /proc/$(pgrep chip-lighting)/maps |wc -l`:

perm | old-code | new-code
-|-|-
---p | 88 | 84

And in fact there was around 4 non-joined threads.
