### PR TITLE
[Groups] Fix error code in Groups server

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -95,7 +95,7 @@ static EmberAfStatus GroupAdd(FabricIndex fabricIndex, EndpointId endpointId, Gr
 
     ChipLogDetail(Zcl, "ERR: Failed to add mapping (end:%d, group:0x%x), err:%" CHIP_ERROR_FORMAT, endpointId, groupId,
                   err.Format());
-    return EMBER_ZCL_STATUS_INSUFFICIENT_SPACE;
+    return EMBER_ZCL_STATUS_RESOURCE_EXHAUSTED;
 }
 
 static EmberAfStatus GroupRemove(FabricIndex fabricIndex, EndpointId endpointId, GroupId groupId)


### PR DESCRIPTION
#### Problem
As per Application cluster spec section 1.3.7.6.1 

```
5. The server verifies that the node has free entries in the Group Table. If there are no free entries
in the Group Table, the status SHALL be RESOURCE_EXHAUSTED and the server continues from
step 7.
```

#### Change overview
Changed the error code in the implementation

#### Testing
Unit Test
