### PR TITLE
Add support for validating mandatory commands in matter idl

### DIFF
--- a/scripts/idl/lint/lint_rules_parser.py
+++ b/scripts/idl/lint/lint_rules_parser.py
@@ -69,9 +69,17 @@ def DecodeClusterFromXml(element: xml.etree.ElementTree.Element):
             if 'optional' in attr.attrib and attr.attrib['optional'] == 'true':
                 continue
 
+            # when introducing access controls, the content of attributes may either be:
+            # <attribute ...>myName</attribute>
+            # or
+            # <attribute ...><description>myName</description><access .../>...</attribute>
+            attr_name = attr.text
+            if attr.find('description') is not None:
+                attr_name=attr.find('description').text
+
             required_attributes.append(
                 RequiredAttribute(
-                    name=attr.text,
+                    name=attr_name,
                     code=parseNumberString(attr.attrib['code'])
                 ))
 

--- a/scripts/idl/lint/lint_rules_parser.py
+++ b/scripts/idl/lint/lint_rules_parser.py
@@ -186,11 +186,11 @@ class LintRulesTransformer(Transformer):
 
         return parseNumberString(tokens[0].value)
 
-    @ v_args(inline=True)
+    @v_args(inline=True)
     def negative_integer(self, value):
         return -value
 
-    @ v_args(inline=True)
+    @v_args(inline=True)
     def integer(self, value):
         return value
 
@@ -219,24 +219,24 @@ class LintRulesTransformer(Transformer):
 
         return Discard
 
-    @ v_args(inline=True)
+    @v_args(inline=True)
     def load_xml(self, path):
         if not os.path.isabs(path):
             path = os.path.abspath(os.path.join(os.path.dirname(self.file_name), path))
 
         self.context.LoadXml(path)
 
-    @ v_args(inline=True)
+    @v_args(inline=True)
     def required_global_attribute(self, name, code):
         return AttributeRequirement(code=code, name=name)
 
-    @ v_args(inline=True)
+    @v_args(inline=True)
     def specific_endpoint_rule(self, code, *names):
         for name in names:
             self.context.RequireClusterInEndpoint(name, code)
         return Discard
 
-    @ v_args(inline=True)
+    @v_args(inline=True)
     def required_server_cluster(self, id):
         return id
 
@@ -273,13 +273,13 @@ if __name__ == '__main__':
         'fatal': logging.FATAL,
     }
 
-    @ click.command()
-    @ click.option(
+    @click.command()
+    @click.option(
         '--log-level',
         default='INFO',
         type=click.Choice(__LOG_LEVELS__.keys(), case_sensitive=False),
         help='Determines the verbosity of script output.')
-    @ click.argument('filename')
+    @click.argument('filename')
     def main(log_level, filename=None):
         coloredlogs.install(level=__LOG_LEVELS__[
                             log_level], fmt='%(asctime)s %(levelname)-7s %(message)s')

--- a/scripts/idl/lint/lint_rules_parser.py
+++ b/scripts/idl/lint/lint_rules_parser.py
@@ -75,7 +75,7 @@ def DecodeClusterFromXml(element: xml.etree.ElementTree.Element):
             # <attribute ...><description>myName</description><access .../>...</attribute>
             attr_name = attr.text
             if attr.find('description') is not None:
-                attr_name=attr.find('description').text
+                attr_name = attr.find('description').text
 
             required_attributes.append(
                 RequiredAttribute(

--- a/scripts/idl/lint/lint_rules_parser.py
+++ b/scripts/idl/lint/lint_rules_parser.py
@@ -99,7 +99,7 @@ def ClustersInXmlFile(path: str):
     logging.info("Loading XML from %s" % path)
 
     # root is expected to be just a "configurator" object
-    configurator=xml.etree.ElementTree.parse(path).getroot()
+    configurator = xml.etree.ElementTree.parse(path).getroot()
     for child in configurator:
         if child.tag != 'cluster':
             continue
@@ -116,11 +116,11 @@ class LintRulesContext:
     """
 
     def __init__(self):
-        self._required_attributes_rule=RequiredAttributesRule("Required attributes")
-        self._required_commands_rule=RequiredCommandsRule("Required commands")
+        self._required_attributes_rule = RequiredAttributesRule("Required attributes")
+        self._required_commands_rule = RequiredCommandsRule("Required commands")
 
         # Map cluster names to the underlying code
-        self._cluster_codes: Mapping[str, int]={}
+        self._cluster_codes: Mapping[str, int] = {}
 
     def GetLinterRules(self):
         return [self._required_attributes_rule, self._required_commands_rule]
@@ -148,12 +148,12 @@ class LintRulesContext:
            as needed.
         """
         for cluster in ClustersInXmlFile(path):
-            decoded=DecodeClusterFromXml(cluster)
+            decoded = DecodeClusterFromXml(cluster)
 
             if not decoded:
                 continue
 
-            self._cluster_codes[decoded.name]=decoded.code
+            self._cluster_codes[decoded.name] = decoded.code
 
             for attr in decoded.required_attributes:
                 self._required_attributes_rule.RequireAttribute(AttributeRequirement(
@@ -168,7 +168,6 @@ class LintRulesContext:
                     ))
 
 
-
 class LintRulesTransformer(Transformer):
     """
     A transformer capable to transform data parsed by Lark according to
@@ -176,8 +175,8 @@ class LintRulesTransformer(Transformer):
     """
 
     def __init__(self, file_name: str):
-        self.context=LintRulesContext()
-        self.file_name=file_name
+        self.context = LintRulesContext()
+        self.file_name = file_name
 
     def positive_integer(self, tokens):
         """Numbers in the grammar are integers or hex numbers.
@@ -223,7 +222,7 @@ class LintRulesTransformer(Transformer):
     @ v_args(inline=True)
     def load_xml(self, path):
         if not os.path.isabs(path):
-            path=os.path.abspath(os.path.join(os.path.dirname(self.file_name), path))
+            path = os.path.abspath(os.path.join(os.path.dirname(self.file_name), path))
 
         self.context.LoadXml(path)
 
@@ -244,11 +243,11 @@ class LintRulesTransformer(Transformer):
 
 class Parser:
     def __init__(self, parser, file_name: str):
-        self.parser=parser
-        self.file_name=file_name
+        self.parser = parser
+        self.file_name = file_name
 
     def parse(self):
-        data=LintRulesTransformer(self.file_name).transform(self.parser.parse(open(self.file_name, "rt").read()))
+        data = LintRulesTransformer(self.file_name).transform(self.parser.parse(open(self.file_name, "rt").read()))
         return data
 
 
@@ -267,7 +266,7 @@ if __name__ == '__main__':
 
     # Supported log levels, mapping string values required for argument
     # parsing into logging constants
-    __LOG_LEVELS__={
+    __LOG_LEVELS__ = {
         'debug': logging.DEBUG,
         'info': logging.INFO,
         'warn': logging.WARN,
@@ -286,7 +285,7 @@ if __name__ == '__main__':
                             log_level], fmt='%(asctime)s %(levelname)-7s %(message)s')
 
         logging.info("Starting to parse ...")
-        data=CreateParser(filename).parse()
+        data = CreateParser(filename).parse()
         logging.info("Parse completed")
 
         logging.info("Data:")

--- a/scripts/idl/lint/types.py
+++ b/scripts/idl/lint/types.py
@@ -222,7 +222,7 @@ class RequiredCommandsRule(ErrorAccumulatingRule):
 
         if self._mandatory_commands:
             result += "  mandatory_commands:\n"
-            for key,value in self._mandatory_commands.items():
+            for key, value in self._mandatory_commands.items():
                 result += "    - cluster %d:\n" % key
                 for requirement in value:
                     result += "        - %r\n" % requirement
@@ -253,6 +253,7 @@ class RequiredCommandsRule(ErrorAccumulatingRule):
                     continue  # command exists
 
                 self._AddLintError(
-                    "Cluster %s does not define mandatory command %s(%d)" % (cluster.name, requirement.command_name, requirement.command_code),
+                    "Cluster %s does not define mandatory command %s(%d)" % (
+                        cluster.name, requirement.command_name, requirement.command_code),
                     self._ParseLocation(cluster.parse_meta)
                 )

--- a/scripts/idl/lint/types.py
+++ b/scripts/idl/lint/types.py
@@ -71,16 +71,45 @@ class AttributeRequirement:
 @dataclass
 class ClusterRequirement:
     endpoint_id: int
-    cluster_id: int
+    cluster_code: int
     cluster_name: str
 
 
-class RequiredAttributesRule(LintRule):
+class ErrorAccumulatingRule(LintRule):
+    """Contains a lint error list and helps helpers to add to such a list of rules."""
+
     def __init__(self, name):
-        super(RequiredAttributesRule, self).__init__(name)
+        super(ErrorAccumulatingRule, self).__init__(name)
         self._lint_errors = []
         self._idl = None
 
+    def _AddLintError(self, text, location):
+        self._lint_errors.append(LintError("%s: %s" % (self.name, text), location))
+
+    def _ParseLocation(self, meta: Optional[ParseMetaData]) -> Optional[LocationInFile]:
+        """Create a location in the current file that is being parsed. """
+        if not meta or not self._idl.parse_file_name:
+            return None
+        return LocationInFile(self._idl.parse_file_name, meta)
+
+    def LintIdl(self, idl: Idl) -> List[LintError]:
+        self._idl = idl
+        self._lint_errors = []
+        self._LintImpl()
+        return self._lint_errors
+
+    @abstractmethod
+    def _LintImpl(self):
+        """Implements actual linting of the IDL.
+
+        Uses the underlying _idl for validation.
+        """
+        pass
+
+
+class RequiredAttributesRule(ErrorAccumulatingRule):
+    def __init__(self, name):
+        super(RequiredAttributesRule, self).__init__(name)
         # Map attribute code to name
         self._mandatory_attributes: List[AttributeRequirement] = []
         self._mandatory_clusters: List[ClusterRequirement] = []
@@ -93,6 +122,11 @@ class RequiredAttributesRule(LintRule):
             for attr in self._mandatory_attributes:
                 result += "    - %r\n" % attr
 
+        if self._mandatory_clusters:
+            result += "  mandatory_clusters:\n"
+            for cluster in self._mandatory_clusters:
+                result += "    - %r\n" % cluster
+
         result += "}"
         return result
 
@@ -102,15 +136,6 @@ class RequiredAttributesRule(LintRule):
 
     def RequireClusterInEndpoint(self, requirement: ClusterRequirement):
         self._mandatory_clusters.append(requirement)
-
-    def _ParseLocation(self, meta: Optional[ParseMetaData]) -> Optional[LocationInFile]:
-        """Create a location in the current file that is being parsed. """
-        if not meta or not self._idl.parse_file_name:
-            return None
-        return LocationInFile(self._idl.parse_file_name, meta)
-
-    def _AddLintError(self, text, location):
-        self._lint_errors.append(LintError("%s: %s" % (self.name, text), location))
 
     def _ServerClusterDefinition(self, name: str, location: Optional[LocationInFile]):
         """Finds the server cluster definition with the given name.
@@ -173,12 +198,61 @@ class RequiredAttributesRule(LintRule):
                 if requirement.endpoint_id != endpoint.number:
                     continue
 
-                if requirement.cluster_id not in cluster_codes:
+                if requirement.cluster_code not in cluster_codes:
                     self._AddLintError("Endpoint %d does not expose cluster %s (%d)" %
-                                       (requirement.endpoint_id, requirement.cluster_name, requirement.cluster_id), location=None)
+                                       (requirement.endpoint_id, requirement.cluster_name, requirement.cluster_code), location=None)
 
-    def LintIdl(self, idl: Idl) -> List[LintError]:
-        self._idl = idl
-        self._lint_errors = []
-        self._LintImpl()
-        return self._lint_errors
+
+@dataclass
+class ClusterCommandRequirement:
+    cluster_code: int
+    command_code: int
+    command_name: str
+
+
+class RequiredCommandsRule(ErrorAccumulatingRule):
+    def __init__(self, name):
+        super(RequiredCommandsRule, self).__init__(name)
+
+        # Maps cluster id to mandatory cluster requirement
+        self._mandatory_commands: Maping[int, List[ClusterCommandRequirement]] = {}
+
+    def __repr__(self):
+        result = "RequiredCommandsRule{\n"
+
+        if self._mandatory_commands:
+            result += "  mandatory_commands:\n"
+            for key,value in self._mandatory_commands.items():
+                result += "    - cluster %d:\n" % key
+                for requirement in value:
+                    result += "        - %r\n" % requirement
+
+        result += "}"
+        return result
+
+    def RequireCommand(self, cmd: ClusterCommandRequirement):
+        """Mark a command required"""
+
+        if cmd.cluster_code in self._mandatory_commands:
+            self._mandatory_commands[cmd.cluster_code].append(cmd)
+        else:
+            self._mandatory_commands[cmd.cluster_code] = [cmd]
+
+    def _LintImpl(self):
+        for cluster in self._idl.clusters:
+            if cluster.side != ClusterSide.SERVER:
+                continue  # only validate server-side:
+
+            if cluster.code not in self._mandatory_commands:
+                continue  # no known mandatory commands
+
+            defined_commands = set([c.code for c in cluster.commands])
+
+            for requirement in self._mandatory_commands[cluster.code]:
+                if requirement.command_code in defined_commands:
+                    continue  # command exists
+
+                self._AddLintError(
+                    "Cluster %s does not define mandatory command %s(%d)" % (cluster.name, requirement.command_name, requirement.command_code),
+                    self._ParseLocation(cluster.parse_meta)
+                )


### PR DESCRIPTION
#### Problem
Mandatory commands may not be present in our codegen. Make it easier to detect them.

#### Change overview
Some split in rule parsers - one for attributes and one for required commands.
Implement 'required commands' logic in XML reading and validation.

Also fixed a bug in finding attribute naming: if access control is available, name is not "text" but rather a sub-element named description. Found via `./scripts/idl/lint/lint_rules_parser.py ./scripts/rules.matterlint 2>&1 | less`

#### Testing
Manually run, see some missing commands:

```sh
> ./scripts/idl_lint.py examples/all-clusters-app/all-clusters-common/all-clusters-app.matter 2>&1 | tail -n 5

2022-06-02 12:21:13 ERROR   ERROR: Required commands: Cluster TestCluster does not define mandatory command TestSimpleArgumentRequest(5) at examples/all-clusters-app/all-clusters-common/all-clusters-app.matter:3027:1
2022-06-02 12:21:13 ERROR   ERROR: Required commands: Cluster TestCluster does not define mandatory command TestStructArrayArgumentRequest(6) at examples/all-clusters-app/all-clusters-common/all-clusters-app.matter:3027:1
2022-06-02 12:21:13 ERROR   ERROR: Required commands: Cluster TestCluster does not define mandatory command TestComplexNullableOptionalRequest(16) at examples/all-clusters-app/all-clusters-common/all-clusters-app.matter:3027:1
2022-06-02 12:21:13 ERROR   ERROR: Required commands: Cluster Thermostat does not define mandatory command SetpointRaiseLower(0) at examples/all-clusters-app/all-clusters-common/all-clusters-app.matter:3339:1
2022-06-02 12:21:13 ERROR   Found 20 lint errors
```
