### PR TITLE
Allow commissioning window to work even if BLE advertising is not supported

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -359,6 +359,7 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
         // us from opening a commissioning window and advertising over IP.
         if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
         {
+            ChipLogProgress(AppServer, "BLE networking available but BLE advertising is not supported");
             err = CHIP_NO_ERROR;
         }
         ReturnErrorOnFailure(err);
@@ -415,7 +416,7 @@ CHIP_ERROR CommissioningWindowManager::StopAdvertisement(bool aShuttingDown)
         // Ignore errors from SetBLEAdvertisingEnabled (which could be due to
         // BLE advertising not being supported at all).  Our commissioning
         // window is now closed and we need to notify our delegate of that.
-        chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
+        (void) chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
     }
 #endif // CONFIG_NETWORK_LAYER_BLE
 

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -354,7 +354,14 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
 #if CONFIG_NETWORK_LAYER_BLE
     if (mIsBLE)
     {
-        ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true));
+        CHIP_ERROR err = chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(true);
+        // BLE advertising may just not be supported.  That should not prevent
+        // us from opening a commissioning window and advertising over IP.
+        if (err == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
+        {
+            err = CHIP_NO_ERROR;
+        }
+        ReturnErrorOnFailure(err);
     }
 #endif // CONFIG_NETWORK_LAYER_BLE
 
@@ -405,7 +412,10 @@ CHIP_ERROR CommissioningWindowManager::StopAdvertisement(bool aShuttingDown)
 #if CONFIG_NETWORK_LAYER_BLE
     if (mIsBLE)
     {
-        ReturnErrorOnFailure(chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false));
+        // Ignore errors from SetBLEAdvertisingEnabled (which could be due to
+        // BLE advertising not being supported at all).  Our commissioning
+        // window is now closed and we need to notify our delegate of that.
+        chip::DeviceLayer::ConnectivityMgr().SetBLEAdvertisingEnabled(false);
     }
 #endif // CONFIG_NETWORK_LAYER_BLE
 

--- a/src/include/platform/ConnectivityManager.h
+++ b/src/include/platform/ConnectivityManager.h
@@ -221,6 +221,12 @@ public:
     CHIPoBLEServiceMode GetCHIPoBLEServiceMode();
     CHIP_ERROR SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool IsBLEAdvertisingEnabled();
+    /**
+     * Enable or disable BLE advertising.
+     *
+     * @return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE if BLE advertising is not
+     * supported or other error on other failures.
+     */
     CHIP_ERROR SetBLEAdvertisingEnabled(bool val);
     bool IsBLEAdvertising();
     CHIP_ERROR SetBLEAdvertisingMode(BLEAdvertisingMode mode);


### PR DESCRIPTION
An application might be built against an CHIP library that has BLE support
compieled in (e.g. so it can do discovery over BLE) but does not support
commissionable advertising over BLE.  In that case, we should not fail to open a
commissioning window just because we can't advertise over BLE; we can still
advertise over DNS-SD.

#### Problem
Have to compile SDK with non-default flags to get a working example app on Mac.

#### Change overview
Fix things to not need that.

#### Testing
Compiled with `scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone` without disabling BLE and was able to commission the resulting example app over IP.