### PR TITLE
Remove incorrect checks for unicast commands in groups cluster.

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -134,13 +134,6 @@ bool emberAfGroupsClusterAddGroupCallback(app::CommandHandler * commandObj, cons
     auto fabricIndex = commandObj->GetAccessingFabricIndex();
     Groups::Commands::AddGroupResponse::Type response;
 
-    // For all networks, Add Group commands are only responded to when
-    // they are addressed to a single device.
-    if (emberAfCurrentCommand()->type != EMBER_INCOMING_UNICAST && emberAfCurrentCommand()->type != EMBER_INCOMING_UNICAST_REPLY)
-    {
-        return true;
-    }
-
     response.groupId = commandData.groupId;
     response.status  = GroupAdd(fabricIndex, commandPath.mEndpointId, commandData.groupId, commandData.groupName);
     commandObj->AddResponse(commandPath, response);
@@ -157,11 +150,6 @@ bool emberAfGroupsClusterViewGroupCallback(app::CommandHandler * commandObj, con
     Groups::Commands::ViewGroupResponse::Type response;
     CHIP_ERROR err       = CHIP_NO_ERROR;
     EmberAfStatus status = EMBER_ZCL_STATUS_NOT_FOUND;
-
-    if (emberAfCurrentCommand()->type != EMBER_INCOMING_UNICAST && emberAfCurrentCommand()->type != EMBER_INCOMING_UNICAST_REPLY)
-    {
-        return true;
-    }
 
     VerifyOrExit(IsFabricGroupId(groupId), status = EMBER_ZCL_STATUS_INVALID_VALUE);
     VerifyOrExit(nullptr != provider, status = EMBER_ZCL_STATUS_FAILURE);
@@ -292,13 +280,6 @@ bool emberAfGroupsClusterRemoveGroupCallback(app::CommandHandler * commandObj, c
 {
     auto fabricIndex = commandObj->GetAccessingFabricIndex();
     Groups::Commands::RemoveGroupResponse::Type response;
-
-    // For all networks, Remove Group commands are only responded to when
-    // they are addressed to a single device.
-    if (emberAfCurrentCommand()->type != EMBER_INCOMING_UNICAST && emberAfCurrentCommand()->type != EMBER_INCOMING_UNICAST_REPLY)
-    {
-        return true;
-    }
 
 #ifdef EMBER_AF_PLUGIN_SCENES
     // If a group is, removed the scenes associated with that group SHOULD be removed.


### PR DESCRIPTION
In the original Silicon Labs code, these checks happened _after_ the actual
action of the command had taken place, and only affected the sending of the
response.  But the groups cluster edits have now placed the actual work of the
command after these checks, which makes the resulting behavior not
spec-compliant.

Since we don't send a response on the CommandHandler level if the incoming
command was not unicast, we can just remove these checks altogether.  The
behavior they are meant to achieve is handled by CommandHandler.

#### Problem
Groups cluster commands sent over groupcast are incorrectly no-opped.

#### Change overview
Remove the incorrect code.

#### Testing
Need to come up with some tests, but a bit hard to do on Mac because groupcast is broken there....