### PR TITLE
Revert "Make MemoryInit and MemoryShutdown Platform APIs threadsafe (#18854)"

### DIFF
--- a/src/lib/support/CHIPMem.cpp
+++ b/src/lib/support/CHIPMem.cpp
@@ -26,7 +26,6 @@
 #include <lib/core/CHIPConfig.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CHIPPlatformMemory.h>
-#include <system/SystemMutex.h>
 
 #include <atomic>
 #include <stdlib.h>
@@ -37,51 +36,31 @@ namespace Platform {
 extern CHIP_ERROR MemoryAllocatorInit(void * buf, size_t bufSize);
 extern void MemoryAllocatorShutdown();
 
-#if !CHIP_SYSTEM_CONFIG_NO_LOCKING
-static chip::System::Mutex gMemoryLock;
-#endif
-static int memoryInitializationCount{ 0 };
+static std::atomic_int memoryInitializationCount{ 0 };
 
 CHIP_ERROR MemoryInit(void * buf, size_t bufSize)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-#if !CHIP_SYSTEM_CONFIG_NO_LOCKING
-    gMemoryLock.Lock();
-#endif
-    do
+    if (memoryInitializationCount++ > 0)
     {
-        if (memoryInitializationCount++ > 0)
-        {
-            // Already initialized
-            break;
-        }
-        // Initialize the allocator.
-        err = MemoryAllocatorInit(buf, bufSize);
-        if (err != CHIP_NO_ERROR)
-        {
-            break;
-        }
-        // Here we do things like mbedtls_platform_set_calloc_free(), depending on configuration.
-    } while (0);
-#if !CHIP_SYSTEM_CONFIG_NO_LOCKING
-    gMemoryLock.Unlock();
-#endif
+        return CHIP_NO_ERROR;
+    }
+    // Initialize the allocator.
+    CHIP_ERROR err = MemoryAllocatorInit(buf, bufSize);
+    if (err != CHIP_NO_ERROR)
+    {
+        return err;
+    }
+    // Here we do things like mbedtls_platform_set_calloc_free(), depending on configuration.
     return err;
 }
 
 void MemoryShutdown()
 {
-#if !CHIP_SYSTEM_CONFIG_NO_LOCKING
-    gMemoryLock.Lock();
-#endif
     if ((memoryInitializationCount > 0) && (--memoryInitializationCount == 0))
     {
         // Here we undo things like mbedtls_platform_set_calloc_free()
         MemoryAllocatorShutdown();
     }
-#if !CHIP_SYSTEM_CONFIG_NO_LOCKING
-    gMemoryLock.Unlock();
-#endif
 }
 
 } // namespace Platform

--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -46,7 +46,6 @@ namespace Platform {
  * This function is platform specific and might be empty in certain cases.
  * For example, this function is doing nothing when the C Standard Library malloc()
  * and free() functions are used for memory allocation.
- * Note- The MemoryInit and MemoryShutdown APIs are thread-safe, unless CHIP_SYSTEM_CONFIG_NO_LOCKING is enabled
  *
  * @param[in]  buf      A pointer to a dedicated memory buffer, which should be used as
  *                      a memory pool for CHIP memory allocation.
@@ -74,7 +73,6 @@ extern CHIP_ERROR MemoryInit(void * buf = nullptr, size_t bufSize = 0);
  * This function can be an empty call if there is no need to release resources. For example,
  * this is the case when the C Standard Library malloc() and free() functions are used
  * for memory allocation.
- * Note- The MemoryInit and MemoryShutdown APIs are thread-safe, unless CHIP_SYSTEM_CONFIG_NO_LOCKING is enabled
  *
  */
 extern void MemoryShutdown();


### PR DESCRIPTION
This reverts commit 19d826a3f95362ab4898b61be36d66d4f5602511.

The PR causes esp32 to boot-loop.

Fixes https://github.com/project-chip/connectedhomeip/issues/19142

#### Problem
See above.

#### Change overview
See above.

#### Testing
Verified boot-loop is fixed.