### PR TITLE
Chef - Preserve returncode in stateful_shell

### DIFF
--- a/examples/chef/stateful_shell.py
+++ b/examples/chef/stateful_shell.py
@@ -92,8 +92,8 @@ class StatefulShell:
             redirect = ""
 
         command_with_state = (
-            f"OLDPWD={self.env.get('OLDPWD', '')}; {cmd} {redirect};"
-            f" env -0 > {self.envfile_path}")
+            f"OLDPWD={self.env.get('OLDPWD', '')}; {cmd} {redirect}; RETCODE=$?;"
+            f" env -0 > {self.envfile_path}; exit $RETCODE")
         with subprocess.Popen(
             [command_with_state],
             env=self.env, cwd=self.cwd,
@@ -114,7 +114,9 @@ class StatefulShell:
 
         if raise_on_returncode and returncode != 0:
             raise RuntimeError(
-                f"Error. Return code is not 0. It is: {returncode}")
+                "Error. Nonzero return code."
+                f"\nReturncode: {returncode}"
+                f"\nCmd: {cmd}")
 
         if return_cmd_output:
             with open(self.cmd_output_path, encoding="latin1") as f:


### PR DESCRIPTION
#### Problem
* Stateful shell is not preserving the returncode correctly.

#### Change overview
* Preserve the return code of the command passed to `stateful_shell`

#### Testing
Tested with:
```
import stateful_shell

shell = stateful_shell.StatefulShell()
shell.run_cmd("not_real_cmd", raise_on_returncode=True)  # Correctly raises an error with returncode 127
```