### PR TITLE
[Ameba] SoftwareDiagnostic update

### DIFF
--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -25,7 +25,6 @@
 
 #include <crypto/CHIPCryptoPAL.h>
 #include <platform/Ameba/DiagnosticDataProviderImpl.h>
-#include <platform/DiagnosticDataProvider.h>
 
 #include <lwip_netconf.h>
 
@@ -54,6 +53,70 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
 {
     currentHeapHighWatermark = xPortGetTotalHeapSize() - xPortGetMinimumEverFreeHeapSize();
     return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
+{
+    // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the
+    // value of the CurrentHeapUsed.
+
+    xPortResetHeapMinimumEverFreeHeapSize();
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadMetricsOut)
+{
+    /* Obtain all available task information */
+    TaskStatus_t * taskStatusArray;
+    ThreadMetrics * head = nullptr;
+    unsigned long arraySize, x, dummy;
+
+    arraySize = uxTaskGetNumberOfTasks();
+
+    taskStatusArray = (TaskStatus_t *) pvPortMalloc(arraySize * sizeof(TaskStatus_t));
+
+    if (taskStatusArray != NULL)
+    {
+        /* Generate raw status information about each task. */
+        arraySize = uxTaskGetSystemState(taskStatusArray, arraySize, &dummy);
+        /* For each populated position in the taskStatusArray array,
+           format the raw data as human readable ASCII data. */
+
+        for (x = 0; x < arraySize; x++)
+        {
+            ThreadMetrics * thread = (ThreadMetrics *) pvPortMalloc(sizeof(ThreadMetrics));
+
+            strncpy(thread->NameBuf, taskStatusArray[x].pcTaskName, kMaxThreadNameLength - 1);
+            thread->NameBuf[kMaxThreadNameLength] = '\0';
+            thread->name                          = CharSpan(thread->NameBuf, strlen(thread->NameBuf));
+            thread->id                            = taskStatusArray[x].xTaskNumber;
+
+            thread->stackFreeMinimum = taskStatusArray[x].usStackHighWaterMark;
+            /* Unsupported metrics */
+            thread->stackSize        = 0;
+            thread->stackFreeCurrent = 0;
+
+            thread->Next = head;
+            head         = thread;
+        }
+
+        *threadMetricsOut = head;
+        /* The array is no longer needed, free the memory it consumes. */
+        vPortFree(taskStatusArray);
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void DiagnosticDataProviderImpl::ReleaseThreadMetrics(ThreadMetrics * threadMetrics)
+{
+    while (threadMetrics)
+    {
+        ThreadMetrics * del = threadMetrics;
+        threadMetrics       = threadMetrics->Next;
+        vPortFree(del);
+    }
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetRebootCount(uint16_t & rebootCount)

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -89,13 +89,13 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
 
             strncpy(thread->NameBuf, taskStatusArray[x].pcTaskName, kMaxThreadNameLength - 1);
             thread->NameBuf[kMaxThreadNameLength] = '\0';
-            thread->name                          = CharSpan(thread->NameBuf, strlen(thread->NameBuf));
-            thread->id                            = taskStatusArray[x].xTaskNumber;
+            thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+            thread->id = taskStatusArray[x].xTaskNumber;
 
-            thread->stackFreeMinimum = taskStatusArray[x].usStackHighWaterMark;
+            thread->stackFreeMinimum.Emplace(taskStatusArray[x].usStackHighWaterMark);
             /* Unsupported metrics */
-            thread->stackSize        = 0;
-            thread->stackFreeCurrent = 0;
+            // thread->stackSize;
+            // thread->stackFreeCurrent;
 
             thread->Next = head;
             head         = thread;

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.h
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.h
@@ -40,6 +40,9 @@ public:
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
+    CHIP_ERROR ResetWatermarks() override;
+    CHIP_ERROR GetThreadMetrics(ThreadMetrics ** threadMetricsOut) override;
+    void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
 
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;


### PR DESCRIPTION
#### Problem
Ameba doesn't have method to get thread metrics and reset watermark

#### Change overview
Implement GetThreadMetrics and ResetWatermarks

#### Testing
`./chip-tool softwarediagnostics read thread-metrics 1234 0`
`./chip-tool softwarediagnostics reset-watermarks 1234 0`
