### PR TITLE
[Tizen] Vscode compile commands support 

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,7 +38,8 @@
         "christian-kohler.path-intellisense",
         "knisterpeter.vscode-github",
         "npclaudiu.vscode-gn",
-        "marus25.cortex-debug"
+        "marus25.cortex-debug",
+        "msedge-dev.gnls"
     ],
     // Use 'settings' to set *default* container specific settings.json values on container create.
     // You can edit these settings after create using File > Preferences > Settings > Remote.

--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -89,6 +89,7 @@
             "cppStandard": "gnu++14",
             "intelliSenseMode": "gcc-arm",
             "compilerPath": "/opt/tizen-sdk/tools/arm-linux-gnueabi-gcc-9.2/bin/arm-linux-gnueabi-gcc",
+            "compileCommands": "${workspaceFolder}/out/debug/compile_commands.tizen_arm.json",
             "browse": {
                 "path": ["${workspaceFolder}/out/debug/"],
                 "limitSymbolsToIncludedHeaders": true

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -178,6 +178,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     # Enable building for Android.
     enable_android_builds = false
 
+    # Enable building for Tizen.
+    enable_tizen_builds = false
+
     # Set this to true to enable TI builds by default.
     enable_ti_simplelink_builds = false
 
@@ -284,6 +287,8 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     enable_bl602_lighting_app_build = enable_bl602_builds
 
     enable_fake_tests = enable_default_builds && host_os == "linux"
+
+    enable_tizen_lighting_app = enable_tizen_builds
   }
 
   if (enable_host_clang_build) {
@@ -468,6 +473,12 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     }
   }
 
+  if (enable_tizen_lighting_app) {
+    group("tizen_lighting_app") {
+      deps = [ "${chip_root}/examples/lighting-app/tizen/(${chip_root}/build/toolchain/tizen:tizen_arm)" ]
+    }
+  }
+
   group("default") {
     deps = []
     if (enable_host_clang_build) {
@@ -486,6 +497,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         ":android_x64",
         ":android_x86",
       ]
+    }
+    if (enable_tizen_builds) {
+      deps += [ ":tizen_lighting_app" ]
     }
     if (enable_standalone_chip_cert_build) {
       deps += [ ":standalone_chip_cert" ]

--- a/build/config/sysroot.gni
+++ b/build/config/sysroot.gni
@@ -26,6 +26,8 @@ if (sysroot_platform_config == "") {
     sysroot_platform_config = "${build_root}/config/webos/webos_sysroot.gni"
   } else if (is_clang && current_cpu == "arm" && current_os == "freertos") {
     sysroot_platform_config = "${build_root}/toolchain/arm/arm_sysroot.gni"
+  } else if (current_os == "tizen") {
+    sysroot_platform_config = "${build_root}/config/tizen/tizen_sysroot.gni"
   }
 }
 

--- a/build/config/tizen/tizen_sysroot.gni
+++ b/build/config/tizen/tizen_sysroot.gni
@@ -1,4 +1,4 @@
-# Copyright (c) 2020 Project CHIP Authors
+# Copyright (c) 2022 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-declare_args() {
-  # Location of The Tizen sysroot
-  tizen_sdk_sysroot = ""
+import("//build_overrides/build.gni")
+import("${build_root}/config/tizen/config.gni")
 
-  # Location of the Tizen SDK.
-  tizen_sdk_root = ""
-}
+sysroot = tizen_sdk_sysroot

--- a/examples/lighting-app/tizen/README.md
+++ b/examples/lighting-app/tizen/README.md
@@ -15,7 +15,7 @@ gn gen --check \
 	--fail-on-unused-args \
 	--export-compile-commands \
 	--root=$PW_PROJECT_ROOT/examples/lighting-app/tizen \
-	"--args=target_os=\"tizen\" target_cpu=\"arm\" tizen_sdk_root=\"$TIZEN_SDK_ROOT\" sysroot=\"$TIZEN_SDK_SYSROOT\"" \
+	"--args=target_os=\"tizen\" target_cpu=\"arm\" tizen_sdk_root=\"$TIZEN_SDK_ROOT\" tizen_sdk_sysroot=\"$TIZEN_SDK_SYSROOT\"" \
 	$PW_PROJECT_ROOT/out/tizen-arm-light
 ```
 

--- a/gn_build.sh
+++ b/gn_build.sh
@@ -192,6 +192,20 @@ fi
 
 echo
 
+tizen_sdk_args=""
+
+if [[ -d "${TIZEN_SDK_ROOT}" && -d "${TIZEN_SDK_SYSROOT}" ]]; then
+    tizen_sdk_args+="tizen_sdk_root=\"$TIZEN_SDK_ROOT\" tizen_sdk_sysroot=\"$TIZEN_SDK_SYSROOT\""
+    extra_args+=" $tizen_sdk_args enable_tizen_builds=true"
+else
+    echo
+    echo "Hint: Set \$TIZEN_SDK_ROOT and \$TIZEN_SDK_SYSROOT to enable building for Tizen"
+    echo "      Required Tizen SDK can be obtained from"
+    echo "      https://developer.tizen.org/development/tizen-studio/download"
+fi
+
+echo
+
 _chip_banner "Build: GN configure"
 
 gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args "$CHIP_ROOT/out/debug" --args='target_os="all"'"$extra_args$user_args"

--- a/scripts/build/builders/tizen.py
+++ b/scripts/build/builders/tizen.py
@@ -105,7 +105,7 @@ class TizenBuilder(GnBuilder):
             'target_os="tizen"',
             'target_cpu="%s"' % self.board.TargetCpuName(),
             'tizen_sdk_root="%s"' % os.environ['TIZEN_SDK_ROOT'],
-            'sysroot="%s"' % os.environ['TIZEN_SDK_SYSROOT'],
+            'tizen_sdk_sysroot="%s"' % os.environ['TIZEN_SDK_SYSROOT'],
         ]
 
     def _generate_flashbundle(self):

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -1117,28 +1117,28 @@ source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-light-switch -b tlsr9518adk80d {root}/examples/light-switch-app/telink'
 
 # Generating tizen-arm-light
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light
 
 # Generating tizen-arm-light-asan
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-asan
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-asan
 
 # Generating tizen-arm-light-no-ble
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_config_network_layer_ble=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-ble
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_config_network_layer_ble=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-ble
 
 # Generating tizen-arm-light-no-ble-asan
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_config_network_layer_ble=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-ble-asan
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_config_network_layer_ble=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-ble-asan
 
 # Generating tizen-arm-light-no-ble-no-wifi
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_config_network_layer_ble=false chip_enable_wifi=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-ble-no-wifi
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_config_network_layer_ble=false chip_enable_wifi=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-ble-no-wifi
 
 # Generating tizen-arm-light-no-ble-no-wifi-asan
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_config_network_layer_ble=false chip_enable_wifi=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-ble-no-wifi-asan
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_config_network_layer_ble=false chip_enable_wifi=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-ble-no-wifi-asan
 
 # Generating tizen-arm-light-no-wifi
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_enable_wifi=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-wifi
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_enable_wifi=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-wifi
 
 # Generating tizen-arm-light-no-wifi-asan
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_enable_wifi=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-wifi-asan
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=chip_enable_wifi=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light-no-wifi-asan
 
 # Building ameba-amebad-all-clusters
 ninja -C {out}/ameba-amebad-all-clusters

--- a/scripts/helpers/update_compile_commands.sh
+++ b/scripts/helpers/update_compile_commands.sh
@@ -40,3 +40,6 @@ mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_co
 
 gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=efr32_lock_app
 mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_commands.efr32.json"
+
+gn --root="$CHIP_ROOT" gen "$CHIP_ROOT/out/debug" --export-compile-commands=tizen_lighting_app
+mv "$CHIP_ROOT/out/debug/compile_commands.json" "$CHIP_ROOT/out/debug/compile_commands.tizen_arm.json"

--- a/third_party/tizen/tizen_sdk.gni
+++ b/third_party/tizen/tizen_sdk.gni
@@ -63,7 +63,7 @@ template("tizen_sdk_package") {
   # Output directory where packaging will occur. We need a separate directory
   # for this, because Tizen Studio CLI scans "res" (resources), "shared" and
   # "lib" directories for items to pack. In our case it could include in the
-  # TPK package libraries available in ${root_build_dir}/lib directory.
+  # TPK package libraries available in ${root_out_dir}/lib directory.
   tizen_package_dir = "${root_build_dir}/package"
   tizen_package_out_dir = "${tizen_package_dir}/out"
 
@@ -94,7 +94,7 @@ template("tizen_sdk_package") {
   if (manifest_apps["service"] != "") {
     dependencies += [ ":${target_name}:app:service" ]
     copy("${target_name}:app:service") {
-      sources = [ root_build_dir + "/" + manifest_apps["service"] ]
+      sources = [ root_out_dir + "/" + manifest_apps["service"] ]
       outputs = [ "${tizen_package_out_dir}/{{source_file_part}}" ]
       deps = invoker.deps
     }


### PR DESCRIPTION
#### Problem
There is no support for compiling database in vscode for Tizen

#### Change overview
* fix tizen SDK config to use tizen_sdk_sysroot instead of sysroot arg
* fix lighting-app app to use root_out_dir instead of root_build_dir
* generate compile commands in update_compile_commands.sh
* update vscode config for tizen

#### Testing
Build unified build with tizen enabled:
```sh
gn gen out/debug \
    --args="\
    target_os=\"all\" \
    tizen_sdk_root=\"$TIZEN_SDK_ROOT\" \
    tizen_sdk_sysroot=\"$TIZEN_SDK_SYSROOT\" \
    enable_tizen_builds=true"

ninja -C out/debug
scripts/helpers/update_compile_commands.sh
```

