### PR TITLE
[Tizen] Fix memory out-of-bound reads when logging

### DIFF
--- a/examples/lighting-app/tizen/tizen-manifest.xml
+++ b/examples/lighting-app/tizen/tizen-manifest.xml
@@ -9,6 +9,9 @@
         <privilege>http://tizen.org/privilege/internet</privilege>
         <privilege>http://tizen.org/privilege/network.get</privilege>
     </privileges>
+    <feature name="http://tizen.org/feature/network.bluetooth">true</feature>
+    <feature name="http://tizen.org/feature/network.bluetooth.le">true</feature>
     <feature name="http://tizen.org/feature/network.bluetooth.le.gatt.server">true</feature>
+    <feature name="http://tizen.org/feature/network.service_discovery.dnssd">true</feature>
     <feature name="http://tizen.org/feature/network.wifi">true</feature>
 </manifest>

--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
@@ -132,7 +132,7 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     memcpy(wifiConfig.passkey, key, keyLen);
     wifiConfig.security = WFX_SEC_WPA2;
 
-    ChipLogProgress(NetworkProvisioning, "Setting up connetion for WiFi SSID: %s", wifiConfig.ssid);
+    ChipLogProgress(NetworkProvisioning, "Setting up connection for WiFi SSID: %.*s", static_cast<int>(ssidLen), ssid);
     // Configure the WFX WiFi interface.
     wfx_set_wifi_provision(&wifiConfig);
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -190,7 +190,7 @@ void BLEManagerImpl::WriteValueRequestedCb(const char * remoteAddress, int reque
     ret = bt_gatt_server_send_response(requestId, BT_GATT_REQUEST_TYPE_WRITE, offset, 0x00, nullptr, 0);
     VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_server_send_response() failed. ret: %d", ret));
 
-    sInstance.HandleC1CharWriteEvent(conn, (const uint8_t *) value, len);
+    sInstance.HandleC1CharWriteEvent(conn, reinterpret_cast<const uint8_t *>(value), len);
 }
 
 void BLEManagerImpl::NotificationStateChangedCb(bool notify, bt_gatt_server_h server, bt_gatt_h gattHandle, void * userData)
@@ -240,7 +240,7 @@ void BLEManagerImpl::CharacteristicNotificationCb(bt_gatt_h characteristic, char
     VerifyOrReturn(conn->gattCharC2Handle == characteristic, ChipLogError(DeviceLayer, "Gatt characteristic handle did not match"));
 
     ChipLogProgress(DeviceLayer, "Notification Received from CHIP peripheral [%s]", conn->peerAddr);
-    sInstance.HandleRXCharChanged(conn, (const uint8_t *) value, len);
+    sInstance.HandleRXCharChanged(conn, reinterpret_cast<const uint8_t *>(value), len);
 }
 
 void BLEManagerImpl::IndicationConfirmationCb(int result, const char * remoteAddress, bt_gatt_server_h server,
@@ -419,7 +419,7 @@ gboolean BLEManagerImpl::ConnectChipThing(gpointer userData)
 {
     int ret = BT_ERROR_NONE;
 
-    char * address = (char *) userData;
+    char * address = reinterpret_cast<char *>(userData);
     ChipLogProgress(DeviceLayer, "ConnectRequest: Addr [%s]", address);
 
     ret = bt_gatt_client_create(address, &sInstance.mGattClient);
@@ -450,7 +450,7 @@ void BLEManagerImpl::ConnectHandler(const char * address)
 
 void BLEManagerImpl::OnChipDeviceScanned(void * device, const chip::Ble::ChipBLEDeviceIdentificationInfo & info)
 {
-    bt_adapter_le_device_scan_result_info_s * deviceInfo = (bt_adapter_le_device_scan_result_info_s *) device;
+    auto deviceInfo = reinterpret_cast<bt_adapter_le_device_scan_result_info_s *>(device);
     VerifyOrReturn(deviceInfo != nullptr, ChipLogError(DeviceLayer, "Invalid Device Info"));
 
     ChipLogProgress(DeviceLayer, "New device scanned: %s", deviceInfo->remote_address);
@@ -1242,7 +1242,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
     conn = static_cast<BLEConnection *>(g_hash_table_lookup(sInstance.mConnectionMap, conn->peerAddr));
     VerifyOrExit(conn != nullptr, ChipLogError(DeviceLayer, "Failed to find connection info"));
 
-    ret = bt_gatt_set_value(mGattCharC2Handle, (const char *) pBuf->Start(), pBuf->DataLength());
+    ret = bt_gatt_set_value(mGattCharC2Handle, reinterpret_cast<const char *>(pBuf->Start()), pBuf->DataLength());
     VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed. ret: %d", ret));
 
     ChipLogProgress(DeviceLayer, "Sending indication for CHIPoBLE RX characteristic (con %s, len %u)", conn->peerAddr,
@@ -1277,7 +1277,7 @@ bool BLEManagerImpl::SendWriteRequest(BLE_CONNECTION_OBJECT conId, const Ble::Ch
                  ChipLogError(DeviceLayer, "SendWriteRequest() called with invalid characteristic ID"));
     VerifyOrExit(conn->gattCharC1Handle != nullptr, ChipLogError(DeviceLayer, "Char C1 is null"));
 
-    ret = bt_gatt_set_value(conn->gattCharC1Handle, (const char *) pBuf->Start(), pBuf->DataLength());
+    ret = bt_gatt_set_value(conn->gattCharC1Handle, reinterpret_cast<const char *>(pBuf->Start()), pBuf->DataLength());
     VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_set_value() failed. ret: %d", ret));
 
     ChipLogProgress(DeviceLayer, "Sending Write Request for CHIPoBLE TX characteristic (con %s, len %u)", conn->peerAddr,

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -160,7 +160,7 @@ static void __ReadValueRequestedCb(const char * remoteAddress, int requestId, bt
     ret = bt_gatt_get_value(gattHandle, &value, &len);
     VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_gatt_get_value() failed. ret: %d", ret));
 
-    ChipLogProgress(DeviceLayer, "Read Value: %s(len: %d)", value, len);
+    ChipLogProgress(DeviceLayer, "Read Value (len: %d): %.*s", len, len, value);
 
     ret = bt_gatt_server_send_response(requestId, BT_GATT_REQUEST_TYPE_READ, offset, 0x00, value, len);
     g_free(value);
@@ -181,8 +181,8 @@ void BLEManagerImpl::WriteValueRequestedCb(const char * remoteAddress, int reque
     VerifyOrReturn(__GetAttInfo(gattHandle, &uuid, &type) == BT_ERROR_NONE,
                    ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from GATT handle"));
 
-    ChipLogProgress(DeviceLayer, "Write Requested on %s(%s)", __ConvertAttTypeToStr(type), uuid);
-    ChipLogProgress(DeviceLayer, "Write Value: %s(len: %d)", value, len);
+    ChipLogProgress(DeviceLayer, "Write Requested on %s: %s", __ConvertAttTypeToStr(type), uuid);
+    ChipLogProgress(DeviceLayer, "Write Value (len: %d): %.*s ", len, len, value);
     g_free(uuid);
 
     ret = bt_gatt_set_value(gattHandle, value, len);
@@ -215,7 +215,7 @@ void BLEManagerImpl::NotificationStateChangedCb(bool notify, bt_gatt_server_h se
     VerifyOrReturn(__GetAttInfo(gattHandle, &uuid, &type) == BT_ERROR_NONE,
                    ChipLogError(DeviceLayer, "Failed to fetch GATT Attribute from GATT handle"));
 
-    ChipLogProgress(DeviceLayer, "Notification State Changed %d on %s(%s)", notify, __ConvertAttTypeToStr(type), uuid);
+    ChipLogProgress(DeviceLayer, "Notification State Changed %d on %s: %s", notify, __ConvertAttTypeToStr(type), uuid);
     g_free(uuid);
     sInstance.NotifyBLESubscribed(notify ? true : false, conn);
 }

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -129,7 +129,7 @@ static int __GetAttInfo(bt_gatt_h gattHandle, char ** uuid, bt_gatt_type_e * typ
     return bt_gatt_get_uuid(gattHandle, uuid);
 }
 
-static const char * __ConvertAttTypeToStr(int type)
+static constexpr const char * __ConvertAttTypeToStr(bt_gatt_type_e type)
 {
     switch (type)
     {
@@ -140,7 +140,7 @@ static const char * __ConvertAttTypeToStr(int type)
     case BT_GATT_TYPE_DESCRIPTOR:
         return "Descriptor";
     default:
-        return nullptr;
+        return "(unknown)";
     }
 }
 

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -56,13 +56,12 @@ std::unique_ptr<ChipDeviceScanner> ChipDeviceScanner::Create(ChipDeviceScannerDe
     return std::make_unique<ChipDeviceScanner>(delegate);
 }
 
-static void __CleanupServiceData(bt_adapter_le_service_data_s * dataList, int count)
+static void __CleanupServiceData(bt_adapter_le_service_data_s * dataList, size_t count)
 {
-    int i;
-    if (!dataList || count == 0)
-        return;
+    VerifyOrReturn(dataList != nullptr);
+    VerifyOrReturn(count != 0);
 
-    for (i = 0; i < count; i++)
+    for (size_t i = 0; i < count; i++)
     {
         g_free(dataList[i].service_uuid);
         g_free(dataList[i].service_data);
@@ -70,44 +69,34 @@ static void __CleanupServiceData(bt_adapter_le_service_data_s * dataList, int co
     g_free(dataList);
 }
 
-static void __PrintLEScanData(bt_adapter_le_service_data_s * dataList, int idx)
+static void __PrintLEScanData(bt_adapter_le_service_data_s * dataList, size_t idx)
 {
-    int i = 0;
-    if (!dataList)
-        return;
+    VerifyOrReturn(dataList != nullptr);
 
     // Print Service UUID in the Service Data
-    ChipLogProgress(DeviceLayer, "======Service UUID========\n");
-    ChipLogProgress(DeviceLayer, "        UUID[%s]\n", dataList[idx].service_uuid);
-
-    ChipLogProgress(DeviceLayer, "Service Data Length::[%d]\n", dataList[idx].service_data_len);
+    ChipLogDetail(DeviceLayer, "======Service UUID========");
+    ChipLogDetail(DeviceLayer, "Service UUID::[%s]", dataList[idx].service_uuid);
 
     // Print Service Data
-    if (dataList[idx].service_data_len > 0)
-        ChipLogProgress(DeviceLayer, "=====Service Data====\n");
-
-    for (i = 0; i < dataList[idx].service_data_len; i++)
-    {
-        ChipLogProgress(DeviceLayer, "Service Data[%d] = [0x%x]\n", i, dataList[idx].service_data[i]);
-    }
+    ChipLogDetail(DeviceLayer, "======Service Data========");
+    ChipLogDetail(DeviceLayer, "Service Data Length::[%d]", dataList[idx].service_data_len);
+    ChipLogByteSpan(DeviceLayer, ByteSpan(reinterpret_cast<uint8_t *>(dataList[idx].service_data), dataList[idx].service_data_len));
 }
 
 static bool __IsChipThingDevice(bt_adapter_le_device_scan_result_info_s * info,
                                 chip::Ble::ChipBLEDeviceIdentificationInfo & aDeviceInfo)
 {
+    VerifyOrReturnError(info != nullptr, false);
+
     int count                               = 0;
     bt_adapter_le_service_data_s * dataList = nullptr;
     bool isChipDevice                       = false;
-
-    if (!info)
-        return false;
 
     ChipLogProgress(DeviceLayer, "Is [%s] ChipThingDevice ?: Check now", info->remote_address);
 
     if (bt_adapter_le_get_scan_result_service_data_list(info, BT_ADAPTER_LE_PACKET_ADVERTISING, &dataList, &count) == BT_ERROR_NONE)
     {
-        int i;
-        for (i = 0; i < count; i++)
+        for (int i = 0; i < count; i++)
         {
             if (g_strcmp0(dataList[i].service_uuid, chip_service_uuid) == 0 ||
                 g_strcmp0(dataList[i].service_uuid, chip_service_uuid_short) == 0)
@@ -127,11 +116,10 @@ static bool __IsChipThingDevice(bt_adapter_le_device_scan_result_info_s * info,
 
 void ChipDeviceScanner::LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * info, void * userData)
 {
+    VerifyOrReturn(info != nullptr);
+
     auto self = reinterpret_cast<ChipDeviceScanner *>(userData);
     chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
-
-    if (!info)
-        return;
 
     ChipLogProgress(DeviceLayer, "LE Device Reported!! remote addr [%s]", info->remote_address);
 

--- a/src/platform/Tizen/ChipDeviceScanner.cpp
+++ b/src/platform/Tizen/ChipDeviceScanner.cpp
@@ -127,7 +127,7 @@ static bool __IsChipThingDevice(bt_adapter_le_device_scan_result_info_s * info,
 
 void ChipDeviceScanner::LeScanResultCb(int result, bt_adapter_le_device_scan_result_info_s * info, void * userData)
 {
-    ChipDeviceScanner * self = (ChipDeviceScanner *) userData;
+    auto self = reinterpret_cast<ChipDeviceScanner *>(userData);
     chip::Ble::ChipBLEDeviceIdentificationInfo deviceInfo;
 
     if (!info)
@@ -148,7 +148,7 @@ void ChipDeviceScanner::LeScanResultCb(int result, bt_adapter_le_device_scan_res
 
 gboolean ChipDeviceScanner::TimerExpiredCb(gpointer userData)
 {
-    ChipDeviceScanner * self = (ChipDeviceScanner *) userData;
+    auto self = reinterpret_cast<ChipDeviceScanner *>(userData);
     ChipLogProgress(DeviceLayer, "Scan Timer expired!!");
     self->StopChipScan();
     return G_SOURCE_REMOVE;
@@ -156,8 +156,8 @@ gboolean ChipDeviceScanner::TimerExpiredCb(gpointer userData)
 
 gboolean ChipDeviceScanner::TriggerScan(GMainLoop * mainLoop, gpointer userData)
 {
-    ChipDeviceScanner * self = (ChipDeviceScanner *) userData;
-    int ret                  = BT_ERROR_NONE;
+    auto self = reinterpret_cast<ChipDeviceScanner *>(userData);
+    int ret   = BT_ERROR_NONE;
     GSource * idleSource;
 
     self->mAsyncLoop = mainLoop;

--- a/src/platform/Tizen/ChipDeviceScanner.h
+++ b/src/platform/Tizen/ChipDeviceScanner.h
@@ -57,7 +57,7 @@ struct ScanFilterData
     char address[CHIP_TIZEN_BLE_ADDRESS_STRING_LEN];
     char service_uuid[CHIP_TIZEN_BLE_SERVICE_UUID_STRING_LEN];
     char service_data[CHIP_TIZEN_BLE_SERVICE_DATA_MAX_LEN];
-    int service_data_len;
+    unsigned int service_data_len;
 };
 
 // Receives callbacks when chip devices are being scanned

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -64,13 +64,13 @@ bool CheckForSuccess(GenericContext * context, int err, const char * func, bool 
 {
     if (context == nullptr)
     {
-        ChipLogError(DeviceLayer, "%s (Dnssd context is null)", func);
+        ChipLogError(DeviceLayer, "DNSsd %s (context is null)", func);
         return false;
     }
 
     if (err != DNSSD_ERROR_NONE)
     {
-        ChipLogError(DeviceLayer, "%s Err(%d)", func, err);
+        ChipLogError(DeviceLayer, "DNSsd %s Err(%d)", func, err);
         if (useCallback)
         {
             switch (context->contextType)
@@ -108,7 +108,7 @@ CHIP_ERROR Initialize()
 
 CHIP_ERROR UpdateTXTRecord(dnssd_service_h service, TextEntry * textEntries, size_t textEntrySize)
 {
-    ChipLogProgress(DeviceLayer, "%s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
 
     // TODO
     return CHIP_NO_ERROR;
@@ -116,7 +116,7 @@ CHIP_ERROR UpdateTXTRecord(dnssd_service_h service, TextEntry * textEntries, siz
 
 void OnRegister(dnssd_error_e error, dnssd_service_h service, void * data)
 {
-    ChipLogDetail(DeviceLayer, "Dnssd: %s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     auto rCtx = reinterpret_cast<RegisterContext *>(data);
     auto loop = reinterpret_cast<GMainLoop *>(rCtx->context);
 
@@ -124,13 +124,13 @@ void OnRegister(dnssd_error_e error, dnssd_service_h service, void * data)
 
     VerifyOrReturn(CheckForSuccess(rCtx, static_cast<int>(error), __func__));
     rCtx->isRegistered = true;
-    ChipLogDetail(DeviceLayer, "Dnssd: %s name: %s, type: %s, port: %u, interfaceId: %u", __func__, rCtx->name, rCtx->type,
+    ChipLogDetail(DeviceLayer, "DNSsd %s name: %s, type: %s, port: %u, interfaceId: %u", __func__, rCtx->name, rCtx->type,
                   rCtx->port, rCtx->interfaceId);
 }
 
 gboolean RegisterAsync(GMainLoop * mainLoop, gpointer userData)
 {
-    ChipLogProgress(DeviceLayer, "%s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
 
     auto rCtx     = reinterpret_cast<RegisterContext *>(userData);
     rCtx->context = mainLoop;
@@ -162,7 +162,7 @@ CHIP_ERROR RegisterService(const char * type, const char * name, uint16_t port, 
         return UpdateTXTRecord(context->service, textEntries, textEntrySize);
     }
 
-    ChipLogProgress(DeviceLayer, "%s type: %s, name: %s, port: %u, interfaceId: %u", __func__, type, name, port, interfaceId);
+    ChipLogProgress(DeviceLayer, "DNSsd %s type: %s, name: %s, port: %u, interfaceId: %u", __func__, type, name, port, interfaceId);
 
     context = chip::Platform::New<RegisterContext>();
 
@@ -214,7 +214,7 @@ CHIP_ERROR UnregisterAllServices()
 
 void OnBrowseAdd(BrowseContext * context, dnssd_service_h service, const char * type, const char * name, uint32_t interfaceId)
 {
-    ChipLogDetail(DeviceLayer, "Dnssd: %s  type: %s, name: %s", __func__, type, name);
+    ChipLogDetail(DeviceLayer, "DNSsd %s type: %s, name: %s", __func__, type, name);
 
     char * tokens  = strdup(type);
     char * regtype = strtok(tokens, ".");
@@ -234,7 +234,7 @@ void OnBrowseAdd(BrowseContext * context, dnssd_service_h service, const char * 
 
 void OnBrowseRemove(BrowseContext * context, dnssd_service_h service, const char * type, const char * name, uint32_t interfaceId)
 {
-    ChipLogDetail(DeviceLayer, "Dnssd: %s  type: %s, name: %s, interfaceId: %u", __func__, type, name, interfaceId);
+    ChipLogDetail(DeviceLayer, "DNSsd %s type: %s, name: %s, interfaceId: %u", __func__, type, name, interfaceId);
 
     auto it = std::remove_if(
         context->services.begin(), context->services.end(), [name, type, interfaceId](const DnssdService & mdnsService) {
@@ -254,7 +254,7 @@ void StopBrowse(BrowseContext * context)
 
 void OnBrowse(dnssd_service_state_e state, dnssd_service_h service, void * data)
 {
-    ChipLogDetail(DeviceLayer, "Dnssd: %s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     auto bCtx = reinterpret_cast<BrowseContext *>(data);
     auto loop = reinterpret_cast<GMainLoop *>(bCtx->context);
 
@@ -277,7 +277,7 @@ void OnBrowse(dnssd_service_state_e state, dnssd_service_h service, void * data)
     interfaceId = if_nametoindex(ifaceName);
     VerifyOrExit(interfaceId > 0, );
 
-    ChipLogDetail(DeviceLayer, "Dnssd: %s type: %s, name: %s, interfaceId: %u", __func__, type, name, interfaceId);
+    ChipLogDetail(DeviceLayer, "DNSsd %s type: %s, name: %s, interfaceId: %u", __func__, type, name, interfaceId);
 
     if (state == DNSSD_SERVICE_STATE_AVAILABLE)
     {
@@ -309,7 +309,7 @@ exit:
 
 gboolean BrowseAsync(GMainLoop * mainLoop, gpointer userData)
 {
-    ChipLogProgress(DeviceLayer, "%s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
 
     BrowseContext * bCtx = reinterpret_cast<BrowseContext *>(userData);
     bCtx->context        = mainLoop;
@@ -363,7 +363,7 @@ void ConvertTxtRecords(unsigned short txtLen, uint8_t * txtRecord, std::vector<T
 {
     if (txtLen <= 1)
     {
-        ChipLogDetail(DeviceLayer, "Dnssd: %s No TXT records", __func__);
+        ChipLogDetail(DeviceLayer, "DNSsd %s: No TXT records", __func__);
         return;
     }
 
@@ -377,7 +377,7 @@ void ConvertTxtRecords(unsigned short txtLen, uint8_t * txtRecord, std::vector<T
         const uint8_t * const end = ptr + 1 + ptr[0];
         if (end > max)
         {
-            ChipLogError(DeviceLayer, "Dnssd: %s Invalid TXT data", __func__);
+            ChipLogError(DeviceLayer, "DNSsd %s: Invalid TXT data", __func__);
             return;
         }
 
@@ -405,7 +405,7 @@ void ConvertTxtRecords(unsigned short txtLen, uint8_t * txtRecord, std::vector<T
 
 void OnResolve(dnssd_error_e result, dnssd_service_h service, void * data)
 {
-    ChipLogDetail(DeviceLayer, "Dnssd: %s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     auto rCtx = reinterpret_cast<ResolveContext *>(data);
     auto loop = reinterpret_cast<GMainLoop *>(rCtx->context);
 
@@ -455,7 +455,7 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * data)
     }
 #endif
 
-    ChipLogDetail(DeviceLayer, "Dnssd: %s ipv4: %s, ipv6: %s, valid: %d", __func__, ipv4, ipv6, validIP);
+    ChipLogDetail(DeviceLayer, "DNSsd %s ipv4: %s, ipv6: %s, valid: %d", __func__, ipv4, ipv6, validIP);
 
     if (validIP)
     {
@@ -476,7 +476,7 @@ exit:
 
 gboolean ResolveAsync(GMainLoop * mainLoop, gpointer userData)
 {
-    ChipLogProgress(DeviceLayer, "Dnssd %s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
 
     ResolveContext * rCtx = reinterpret_cast<ResolveContext *>(userData);
     rCtx->context         = mainLoop;
@@ -491,7 +491,7 @@ gboolean ResolveAsync(GMainLoop * mainLoop, gpointer userData)
 
 CHIP_ERROR Resolve(uint32_t interfaceId, const char * type, const char * name, DnssdResolveCallback callback, void * context)
 {
-    ChipLogProgress(DeviceLayer, "Dnssd %s type: %s, name: %s, interfaceId: %u", __func__, type, name, interfaceId);
+    ChipLogDetail(DeviceLayer, "DNSsd %s type: %s, name: %s, interfaceId: %u", __func__, type, name, interfaceId);
 
     ResolveContext * rCtx = chip::Platform::New<ResolveContext>(type, name, interfaceId, callback, context);
 
@@ -621,7 +621,7 @@ CHIP_ERROR DnssdContexts::Add(ResolveContext * context, dnssd_service_h service)
 
 CHIP_ERROR DnssdContexts::Remove(GenericContext * context)
 {
-    ChipLogProgress(DeviceLayer, "Dnssd %s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     auto iter = mContexts.cbegin();
     while (iter != mContexts.end())
     {
@@ -638,7 +638,7 @@ CHIP_ERROR DnssdContexts::Remove(GenericContext * context)
 
 CHIP_ERROR DnssdContexts::Remove(const char * type, const char * name, uint16_t port, uint32_t interfaceId)
 {
-    ChipLogProgress(DeviceLayer, "Dnssd %s type: %s, name %s, port: %u, interfaceId: %u", __func__, type, name, port, interfaceId);
+    ChipLogDetail(DeviceLayer, "DNSsd %s type: %s, name %s, port: %u, interfaceId: %u", __func__, type, name, port, interfaceId);
     for (auto iter = mContexts.begin(); iter != mContexts.end(); ++iter)
     {
         if ((*iter)->contextType == ContextType::Register)
@@ -658,7 +658,7 @@ CHIP_ERROR DnssdContexts::Remove(const char * type, const char * name, uint16_t 
 
 CHIP_ERROR DnssdContexts::Remove(ContextType type)
 {
-    ChipLogProgress(DeviceLayer, "Dnssd %s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     bool found = false;
 
     auto iter = mContexts.cbegin();
@@ -700,7 +700,7 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback successCallback, DnssdAsyncRet
     VerifyOrReturnError(successCallback != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(errorCallback != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    ChipLogProgress(DeviceLayer, "Dnssd: %s", __func__);
+    ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     CHIP_ERROR err = Initialize();
     if (err == CHIP_NO_ERROR)
     {
@@ -720,7 +720,7 @@ CHIP_ERROR ChipDnssdShutdown()
 
 CHIP_ERROR ChipDnssdSetHostname(const char * hostname)
 {
-    ChipLogProgress(DeviceLayer, "Dnssd: hostname %s", hostname);
+    ChipLogProgress(DeviceLayer, "DNSsd: hostname: %s", hostname);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -117,8 +117,8 @@ CHIP_ERROR UpdateTXTRecord(dnssd_service_h service, TextEntry * textEntries, siz
 void OnRegister(dnssd_error_e error, dnssd_service_h service, void * data)
 {
     ChipLogDetail(DeviceLayer, "Dnssd: %s", __func__);
-    RegisterContext * rCtx = reinterpret_cast<RegisterContext *>(data);
-    GMainLoop * loop       = (GMainLoop *) rCtx->context;
+    auto rCtx = reinterpret_cast<RegisterContext *>(data);
+    auto loop = reinterpret_cast<GMainLoop *>(rCtx->context);
 
     g_main_loop_quit(loop);
 
@@ -132,8 +132,8 @@ gboolean RegisterAsync(GMainLoop * mainLoop, gpointer userData)
 {
     ChipLogProgress(DeviceLayer, "%s", __func__);
 
-    RegisterContext * rCtx = reinterpret_cast<RegisterContext *>(userData);
-    rCtx->context          = mainLoop;
+    auto rCtx     = reinterpret_cast<RegisterContext *>(userData);
+    rCtx->context = mainLoop;
 
     int ret = dnssd_register_local_service(rCtx->service, OnRegister, rCtx);
     VerifyOrReturnError(CheckForSuccess(rCtx, ret, __func__), false);
@@ -255,8 +255,8 @@ void StopBrowse(BrowseContext * context)
 void OnBrowse(dnssd_service_state_e state, dnssd_service_h service, void * data)
 {
     ChipLogDetail(DeviceLayer, "Dnssd: %s", __func__);
-    BrowseContext * bCtx = reinterpret_cast<BrowseContext *>(data);
-    GMainLoop * loop     = (GMainLoop *) bCtx->context;
+    auto bCtx = reinterpret_cast<BrowseContext *>(data);
+    auto loop = reinterpret_cast<GMainLoop *>(bCtx->context);
 
     // Always stop browsing
     g_main_loop_quit(loop);
@@ -406,8 +406,8 @@ void ConvertTxtRecords(unsigned short txtLen, uint8_t * txtRecord, std::vector<T
 void OnResolve(dnssd_error_e result, dnssd_service_h service, void * data)
 {
     ChipLogDetail(DeviceLayer, "Dnssd: %s", __func__);
-    ResolveContext * rCtx = reinterpret_cast<ResolveContext *>(data);
-    GMainLoop * loop      = (GMainLoop *) rCtx->context;
+    auto rCtx = reinterpret_cast<ResolveContext *>(data);
+    auto loop = reinterpret_cast<GMainLoop *>(rCtx->context);
 
     g_main_loop_quit(loop);
 
@@ -434,7 +434,7 @@ void OnResolve(dnssd_error_e result, dnssd_service_h service, void * data)
     ret = dnssd_service_get_port(service, &port);
     VerifyOrExit(CheckForSuccess(rCtx, ret, __func__, true), );
 
-    ret = dnssd_service_get_all_txt_record(service, &txtLen, (void **) &txtRecord);
+    ret = dnssd_service_get_all_txt_record(service, &txtLen, reinterpret_cast<void **>(&txtRecord));
     ConvertTxtRecords(txtLen, txtRecord, textEntries);
     g_free(txtRecord);
 

--- a/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
@@ -143,7 +143,8 @@ void TizenWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callb
 
     ChipLogProgress(NetworkProvisioning, "TizenNetworkCommissioningDelegate: SSID: %s", (char *) mStagingNetwork.ssid);
 
-    err = WiFiMgr().Connect((const char *) mStagingNetwork.ssid, (const char *) mStagingNetwork.credentials, callback);
+    err = WiFiMgr().Connect(reinterpret_cast<char *>(mStagingNetwork.ssid), reinterpret_cast<char *>(mStagingNetwork.credentials),
+                            callback);
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Tizen/NetworkCommissioningWiFiDriver.cpp
@@ -80,20 +80,7 @@ CHIP_ERROR TizenWiFiDriver::RevertConfiguration()
 
 bool TizenWiFiDriver::NetworkMatch(const WiFiNetwork & network, ByteSpan networkId)
 {
-    if (networkId.size() != network.ssidLen)
-    {
-        ChipLogProgress(NetworkProvisioning, "ssidLen is mismatched. network.ssidLen: %u, networkId.size(): %u", network.ssidLen,
-                        networkId.size());
-        return false;
-    }
-    if (memcmp(networkId.data(), network.ssid, network.ssidLen) != 0)
-    {
-        ChipLogProgress(NetworkProvisioning, "ssid is mismatched. network.ssid: %s, networkId.data(): %s", network.ssid,
-                        networkId.data());
-        return false;
-    }
-
-    return true;
+    return networkId.size() == network.ssidLen && memcmp(networkId.data(), network.ssid, network.ssidLen) == 0;
 }
 
 Status TizenWiFiDriver::AddOrUpdateNetwork(ByteSpan ssid, ByteSpan credentials, MutableCharSpan & outDebugText,
@@ -141,7 +128,8 @@ void TizenWiFiDriver::ConnectNetwork(ByteSpan networkId, ConnectCallback * callb
 
     VerifyOrExit(NetworkMatch(mStagingNetwork, networkId), networkingStatus = Status::kNetworkIDNotFound);
 
-    ChipLogProgress(NetworkProvisioning, "TizenNetworkCommissioningDelegate: SSID: %s", (char *) mStagingNetwork.ssid);
+    ChipLogProgress(NetworkProvisioning, "TizenNetworkCommissioningDelegate: SSID: %.*s",
+                    static_cast<int>(sizeof(mStagingNetwork.ssid)), reinterpret_cast<char *>(mStagingNetwork.ssid));
 
     err = WiFiMgr().Connect(reinterpret_cast<char *>(mStagingNetwork.ssid), reinterpret_cast<char *>(mStagingNetwork.credentials),
                             callback);

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -493,7 +493,7 @@ CHIP_ERROR ThreadStackManagerImpl::_AddSrpService(const char * aInstanceName, co
                                                   const Span<const Dnssd::TextEntry> & aTxtEntries, uint32_t aLeaseInterval,
                                                   uint32_t aKeyLeaseInterval)
 {
-    ChipLogProgress(DeviceLayer, "%s +", __FUNCTION__);
+    ChipLogDetail(DeviceLayer, "%s +", __func__);
     CHIP_ERROR error = CHIP_NO_ERROR;
     int threadErr    = THREAD_ERROR_NONE;
 

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -25,7 +25,7 @@
 #include "WiFiManager.h"
 
 namespace {
-const char * __WiFiDeviceStateToStr(wifi_manager_device_state_e state)
+static constexpr const char * __WiFiDeviceStateToStr(wifi_manager_device_state_e state)
 {
     switch (state)
     {
@@ -38,7 +38,7 @@ const char * __WiFiDeviceStateToStr(wifi_manager_device_state_e state)
     }
 }
 
-const char * __WiFiScanStateToStr(wifi_manager_scan_state_e state)
+static constexpr const char * __WiFiScanStateToStr(wifi_manager_scan_state_e state)
 {
     switch (state)
     {
@@ -51,7 +51,7 @@ const char * __WiFiScanStateToStr(wifi_manager_scan_state_e state)
     }
 }
 
-const char * __WiFiConnectionStateToStr(wifi_manager_connection_state_e state)
+static constexpr const char * __WiFiConnectionStateToStr(wifi_manager_connection_state_e state)
 {
     switch (state)
     {
@@ -70,7 +70,7 @@ const char * __WiFiConnectionStateToStr(wifi_manager_connection_state_e state)
     }
 }
 
-const char * __WiFiIPConflictStateToStr(wifi_manager_ip_conflict_state_e state)
+static constexpr const char * __WiFiIPConflictStateToStr(wifi_manager_ip_conflict_state_e state)
 {
     switch (state)
     {
@@ -83,7 +83,7 @@ const char * __WiFiIPConflictStateToStr(wifi_manager_ip_conflict_state_e state)
     }
 }
 
-const char * __WiFiModuleStateToStr(wifi_manager_module_state_e state)
+static constexpr const char * __WiFiModuleStateToStr(wifi_manager_module_state_e state)
 {
     switch (state)
     {
@@ -96,7 +96,7 @@ const char * __WiFiModuleStateToStr(wifi_manager_module_state_e state)
     }
 }
 
-const char * __WiFiSecurityTypeToStr(wifi_manager_security_type_e type)
+static constexpr const char * __WiFiSecurityTypeToStr(wifi_manager_security_type_e type)
 {
     switch (type)
     {

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -170,7 +170,7 @@ void WiFiManager::_IPConflictCb(char * mac, wifi_manager_ip_conflict_state_e ipC
 
 void WiFiManager::_ActivateCb(wifi_manager_error_e wifiErr, void * userData)
 {
-    GMainLoop * loop = (GMainLoop *) userData;
+    auto loop = reinterpret_cast<GMainLoop *>(userData);
 
     if (wifiErr == WIFI_MANAGER_ERROR_NONE)
     {
@@ -186,7 +186,7 @@ void WiFiManager::_ActivateCb(wifi_manager_error_e wifiErr, void * userData)
 
 void WiFiManager::_DeactivateCb(wifi_manager_error_e wifiErr, void * userData)
 {
-    GMainLoop * loop = (GMainLoop *) userData;
+    auto loop = reinterpret_cast<GMainLoop *>(userData);
 
     if (wifiErr == WIFI_MANAGER_ERROR_NONE)
     {
@@ -202,7 +202,7 @@ void WiFiManager::_DeactivateCb(wifi_manager_error_e wifiErr, void * userData)
 
 void WiFiManager::_ScanFinishedCb(wifi_manager_error_e wifiErr, void * userData)
 {
-    GMainLoop * loop          = (GMainLoop *) userData;
+    auto loop                 = reinterpret_cast<GMainLoop *>(userData);
     wifi_manager_ap_h foundAp = nullptr;
 
     if (wifiErr == WIFI_MANAGER_ERROR_NONE)
@@ -225,11 +225,11 @@ void WiFiManager::_ScanFinishedCb(wifi_manager_error_e wifiErr, void * userData)
 
 bool WiFiManager::_FoundAPCb(wifi_manager_ap_h ap, void * userData)
 {
-    bool cbRet                   = true;
-    int wifiErr                  = WIFI_MANAGER_ERROR_NONE;
-    char * essid                 = nullptr;
-    bool isPassphraseRequired    = false;
-    wifi_manager_ap_h * clonedAp = (wifi_manager_ap_h *) userData;
+    bool cbRet                = true;
+    int wifiErr               = WIFI_MANAGER_ERROR_NONE;
+    char * essid              = nullptr;
+    bool isPassphraseRequired = false;
+    auto clonedAp             = reinterpret_cast<wifi_manager_ap_h *>(userData);
 
     wifiErr = wifi_manager_ap_get_essid(ap, &essid);
     VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE,
@@ -262,7 +262,7 @@ exit:
 
 void WiFiManager::_ConnectedCb(wifi_manager_error_e wifiErr, void * userData)
 {
-    GMainLoop * loop = (GMainLoop *) userData;
+    auto loop = reinterpret_cast<GMainLoop *>(userData);
 
     if (wifiErr == WIFI_MANAGER_ERROR_NONE)
     {

--- a/src/platform/Tizen/WiFiManager.cpp
+++ b/src/platform/Tizen/WiFiManager.cpp
@@ -665,8 +665,8 @@ CHIP_ERROR WiFiManager::Connect(const char * ssid, const char * key,
     bool dbusAsyncErr         = false;
     wifi_manager_ap_h foundAp = nullptr;
 
-    g_strlcpy(sInstance.mWiFiSSID, ssid, kMaxWiFiSSIDLength + 1);
-    g_strlcpy(sInstance.mWiFiKey, key, kMaxWiFiKeyLength + 1);
+    g_strlcpy(sInstance.mWiFiSSID, ssid, sizeof(sInstance.mWiFiSSID));
+    g_strlcpy(sInstance.mWiFiKey, key, sizeof(sInstance.mWiFiKey));
 
     wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, &isWiFiActivated);
     VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE, err = CHIP_ERROR_INCORRECT_STATE;
@@ -705,7 +705,7 @@ CHIP_ERROR WiFiManager::Disconnect(const char * ssid)
     bool isWiFiActivated      = false;
     wifi_manager_ap_h foundAp = nullptr;
 
-    g_strlcpy(sInstance.mWiFiSSID, ssid, kMaxWiFiSSIDLength + 1);
+    g_strlcpy(sInstance.mWiFiSSID, ssid, sizeof(sInstance.mWiFiSSID));
 
     wifiErr = wifi_manager_is_activated(sInstance.mWiFiManagerHandle, &isWiFiActivated);
     VerifyOrExit(wifiErr == WIFI_MANAGER_ERROR_NONE, err = CHIP_ERROR_INCORRECT_STATE;


### PR DESCRIPTION
#### Problem

Various issues in Tizen platform code (mostly using non-string data in logging functions with `%s` specifier).

Fixes #15777

#### Change overview

- Use C++ casting instead of strongest C casting
- Do not log hex data byte by byte - use ChipLogByteSpan
- Use "%.*s" specifier when logging non-string data
- Small cleanups in Tizen DNSsd logging - move some debug logs to "detail" level

#### Testing

Testing whether network pairing will still work.

On DUT:
```
app_launcher -s org.tizen.matter.example.lighting vendor-id 65521 product-id 32769 discriminator 42 passcode 1234
```

On host:
```
./out/linux-x64-chip-tool/chip-tool pairing onnetwork 1 1234
```
