### PR TITLE
platform/Zephyr: Correct return value handling of bt_id_create()

### DIFF
--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -125,7 +125,7 @@ CHIP_ERROR InitRandomStaticAddress()
 
     error = bt_id_create(&addr, nullptr);
 
-    if (error)
+    if (error < 0)
     {
         ChipLogError(DeviceLayer, "Failed to create BLE identity: %d", error);
         return System::MapErrorZephyr(error);


### PR DESCRIPTION

#### Problem

platform/Zephyr: Correct return value handling of bt_id_create()

The identifier returned by bt_id_create() will be GT/EQ to 0 on successful

Reference manual page:
https://github.com/zephyrproject-rtos/zephyr/blob/main/include/zephyr/bluetooth/bluetooth.h#L278-L281

#### Change overview

The identifier returned by bt_id_create() will be GT/EQ to 0 on successful

#### Testing

Zephyr platform ble test