### PR TITLE
Make test cluster attributes and commands optional

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -144,112 +144,112 @@ limitations under the License.
     <define>TEST_CLUSTER</define>
     <description>The Test Cluster is meant to validate the generated code</description>
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="BOOLEAN" type="BOOLEAN" writable="true" default="false" optional="false">boolean</attribute>
-    <attribute side="server" code="0x0001" define="BITMAP8" type="Bitmap8MaskMap" writable="true" default="0" optional="false">bitmap8</attribute>
-    <attribute side="server" code="0x0002" define="BITMAP16" type="Bitmap16MaskMap" writable="true" default="0" optional="false">bitmap16</attribute>
-    <attribute side="server" code="0x0003" define="BITMAP32" type="Bitmap32MaskMap" writable="true" default="0" optional="false">bitmap32</attribute>
-    <attribute side="server" code="0x0004" define="BITMAP64" type="Bitmap64MaskMap" writable="true" default="0" optional="false">bitmap64</attribute>
-    <attribute side="server" code="0x0005" define="INT8U" type="INT8U" writable="true" default="0" optional="false">int8u</attribute>
-    <attribute side="server" code="0x0006" define="INT16U" type="INT16U" writable="true" default="0" optional="false">int16u</attribute>
-    <attribute side="server" code="0x0007" define="INT24U" type="INT24U" writable="true" default="0" optional="false">int24u</attribute>
-    <attribute side="server" code="0x0008" define="INT32U" type="INT32U" writable="true" default="0" optional="false">int32u</attribute>
-    <attribute side="server" code="0x0009" define="INT40U" type="INT40U" writable="true" default="0" optional="false">int40u</attribute>
-    <attribute side="server" code="0x000A" define="INT48U" type="INT48U" writable="true" default="0" optional="false">int48u</attribute>
-    <attribute side="server" code="0x000B" define="INT56U" type="INT56U" writable="true" default="0" optional="false">int56u</attribute>
-    <attribute side="server" code="0x000C" define="INT64U" type="INT64U" writable="true" default="0" optional="false">int64u</attribute>
-    <attribute side="server" code="0x000D" define="INT8S" type="INT8S" writable="true" default="0" optional="false">int8s</attribute>
-    <attribute side="server" code="0x000E" define="INT16S" type="INT16S" writable="true" default="0" optional="false">int16s</attribute>
-    <attribute side="server" code="0x000F" define="INT24S" type="INT24S" writable="true" default="0" optional="false">int24s</attribute>
-    <attribute side="server" code="0x0010" define="INT32S" type="INT32S" writable="true" default="0" optional="false">int32s</attribute>
-    <attribute side="server" code="0x0011" define="INT40S" type="INT40S" writable="true" default="0" optional="false">int40s</attribute>
-    <attribute side="server" code="0x0012" define="INT48S" type="INT48S" writable="true" default="0" optional="false">int48s</attribute>
-    <attribute side="server" code="0x0013" define="INT56S" type="INT56S" writable="true" default="0" optional="false">int56s</attribute>
-    <attribute side="server" code="0x0014" define="INT64S" type="INT64S" writable="true" default="0" optional="false">int64s</attribute>
-    <attribute side="server" code="0x0015" define="ENUM8" type="ENUM8" writable="true" default="0" optional="false">enum8</attribute>
-    <attribute side="server" code="0x0016" define="ENUM16" type="ENUM16" writable="true" default="0" optional="false">enum16</attribute>
-    <attribute side="server" code="0x0017" define="FLOAT_SINGLE" type="SINGLE" writable="true" default="0" optional="false">float_single</attribute>
-    <attribute side="server" code="0x0018" define="FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" optional="false">float_double</attribute>
-    <attribute side="server" code="0x0019" define="OCTET_STRING" type="OCTET_STRING" length="10" writable="true" optional="false">octet_string</attribute>
-    <attribute side="server" code="0x001A" define="LIST" type="ARRAY" entryType="INT8U" length="10" writable="true" optional="false">list_int8u</attribute>
-    <attribute side="server" code="0x001B" define="LIST_OCTET_STRING" type="ARRAY" entryType="OCTET_STRING" length="254" writable="true" optional="false">list_octet_string</attribute>
-    <attribute side="server" code="0x001C" define="LIST_STRUCT_OCTET_STRING" type="ARRAY" entryType="TestListStructOctet" length="254" writable="true" optional="false">list_struct_octet_string</attribute>
-    <attribute side="server" code="0x001D" define="LONG_OCTET_STRING" type="LONG_OCTET_STRING" length="1000" writable="true" optional="false">long_octet_string</attribute>
-    <attribute side="server" code="0x001E" define="CHAR_STRING" type="CHAR_STRING" length="10" writable="true" optional="false">char_string</attribute>
-    <attribute side="server" code="0x001F" define="LONG_CHAR_STRING" type="LONG_CHAR_STRING" length="1000" writable="true" optional="false">long_char_string</attribute>
-    <attribute side="server" code="0x0020" define="EPOCH_US" type="EPOCH_US" writable="true" optional="false">epoch_us</attribute>
-    <attribute side="server" code="0x0021" define="EPOCH_S" type="EPOCH_S" writable="true" optional="false">epoch_s</attribute>
+    <attribute side="server" code="0x0000" define="BOOLEAN" type="BOOLEAN" writable="true" default="false" optional="true">boolean</attribute>
+    <attribute side="server" code="0x0001" define="BITMAP8" type="Bitmap8MaskMap" writable="true" default="0" optional="true">bitmap8</attribute>
+    <attribute side="server" code="0x0002" define="BITMAP16" type="Bitmap16MaskMap" writable="true" default="0" optional="true">bitmap16</attribute>
+    <attribute side="server" code="0x0003" define="BITMAP32" type="Bitmap32MaskMap" writable="true" default="0" optional="true">bitmap32</attribute>
+    <attribute side="server" code="0x0004" define="BITMAP64" type="Bitmap64MaskMap" writable="true" default="0" optional="true">bitmap64</attribute>
+    <attribute side="server" code="0x0005" define="INT8U" type="INT8U" writable="true" default="0" optional="true">int8u</attribute>
+    <attribute side="server" code="0x0006" define="INT16U" type="INT16U" writable="true" default="0" optional="true">int16u</attribute>
+    <attribute side="server" code="0x0007" define="INT24U" type="INT24U" writable="true" default="0" optional="true">int24u</attribute>
+    <attribute side="server" code="0x0008" define="INT32U" type="INT32U" writable="true" default="0" optional="true">int32u</attribute>
+    <attribute side="server" code="0x0009" define="INT40U" type="INT40U" writable="true" default="0" optional="true">int40u</attribute>
+    <attribute side="server" code="0x000A" define="INT48U" type="INT48U" writable="true" default="0" optional="true">int48u</attribute>
+    <attribute side="server" code="0x000B" define="INT56U" type="INT56U" writable="true" default="0" optional="true">int56u</attribute>
+    <attribute side="server" code="0x000C" define="INT64U" type="INT64U" writable="true" default="0" optional="true">int64u</attribute>
+    <attribute side="server" code="0x000D" define="INT8S" type="INT8S" writable="true" default="0" optional="true">int8s</attribute>
+    <attribute side="server" code="0x000E" define="INT16S" type="INT16S" writable="true" default="0" optional="true">int16s</attribute>
+    <attribute side="server" code="0x000F" define="INT24S" type="INT24S" writable="true" default="0" optional="true">int24s</attribute>
+    <attribute side="server" code="0x0010" define="INT32S" type="INT32S" writable="true" default="0" optional="true">int32s</attribute>
+    <attribute side="server" code="0x0011" define="INT40S" type="INT40S" writable="true" default="0" optional="true">int40s</attribute>
+    <attribute side="server" code="0x0012" define="INT48S" type="INT48S" writable="true" default="0" optional="true">int48s</attribute>
+    <attribute side="server" code="0x0013" define="INT56S" type="INT56S" writable="true" default="0" optional="true">int56s</attribute>
+    <attribute side="server" code="0x0014" define="INT64S" type="INT64S" writable="true" default="0" optional="true">int64s</attribute>
+    <attribute side="server" code="0x0015" define="ENUM8" type="ENUM8" writable="true" default="0" optional="true">enum8</attribute>
+    <attribute side="server" code="0x0016" define="ENUM16" type="ENUM16" writable="true" default="0" optional="true">enum16</attribute>
+    <attribute side="server" code="0x0017" define="FLOAT_SINGLE" type="SINGLE" writable="true" default="0" optional="true">float_single</attribute>
+    <attribute side="server" code="0x0018" define="FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" optional="true">float_double</attribute>
+    <attribute side="server" code="0x0019" define="OCTET_STRING" type="OCTET_STRING" length="10" writable="true" optional="true">octet_string</attribute>
+    <attribute side="server" code="0x001A" define="LIST" type="ARRAY" entryType="INT8U" length="10" writable="true" optional="true">list_int8u</attribute>
+    <attribute side="server" code="0x001B" define="LIST_OCTET_STRING" type="ARRAY" entryType="OCTET_STRING" length="254" writable="true" optional="true">list_octet_string</attribute>
+    <attribute side="server" code="0x001C" define="LIST_STRUCT_OCTET_STRING" type="ARRAY" entryType="TestListStructOctet" length="254" writable="true" optional="true">list_struct_octet_string</attribute>
+    <attribute side="server" code="0x001D" define="LONG_OCTET_STRING" type="LONG_OCTET_STRING" length="1000" writable="true" optional="true">long_octet_string</attribute>
+    <attribute side="server" code="0x001E" define="CHAR_STRING" type="CHAR_STRING" length="10" writable="true" optional="true">char_string</attribute>
+    <attribute side="server" code="0x001F" define="LONG_CHAR_STRING" type="LONG_CHAR_STRING" length="1000" writable="true" optional="true">long_char_string</attribute>
+    <attribute side="server" code="0x0020" define="EPOCH_US" type="EPOCH_US" writable="true" optional="true">epoch_us</attribute>
+    <attribute side="server" code="0x0021" define="EPOCH_S" type="EPOCH_S" writable="true" optional="true">epoch_s</attribute>
     <attribute side="server" code="0x0022" define="TEST_VENDOR_ID" type="vendor_id"
-               writable="true" optional="false" default="0">vendor_id</attribute>
+               writable="true" optional="true" default="0">vendor_id</attribute>
     <attribute side="server" code="0x0023" define="LIST_OF_STRUCTS_WITH_OPTIONALS" type="ARRAY" entryType="NullablesAndOptionalsStruct"
-               writable="true" optional="false">list_nullables_and_optionals_struct</attribute>
-    <attribute side="server" code="0x0024" define="SIMPLE_ENUM" type="SimpleEnum" writable="true" optional="false">enum_attr</attribute>
-    <attribute side="server" code="0x0025" define="STRUCT" type="SimpleStruct" writable="true" optional="false">struct_attr</attribute>
-    <attribute side="server" code="0x0026" define="RANGE_RESTRICTED_INT8U" type="int8u" min="20" max="100" writable="true" optional="false" default="70">range_restricted_int8u</attribute>
-    <attribute side="server" code="0x0027" define="RANGE_RESTRICTED_INT8s" type="int8s" min="-40" max="50" writable="true" optional="false" default="-5">range_restricted_int8s</attribute>
-    <attribute side="server" code="0x0028" define="RANGE_RESTRICTED_INT16U" type="int16u" min="100" max="1000" writable="true" optional="false" default="200">range_restricted_int16u</attribute>
-    <attribute side="server" code="0x0029" define="RANGE_RESTRICTED_INT16s" type="int16s" min="-150" max="200" writable="true" optional="false" default="-5">range_restricted_int16s</attribute>
-    <attribute side="server" code="0x002A" define="LIST_LONG_OCTET_STRING" type="ARRAY" entryType="LONG_OCTET_STRING" length="1000" writable="true" optional="false">list_long_octet_string</attribute>
-    <attribute side="server" code="0x002B" define="LIST_FABRIC_SCOPED" type="ARRAY" entryType="TestFabricScoped" length="10" writable="true" optional="false">list_fabric_scoped</attribute>
+               writable="true" optional="true">list_nullables_and_optionals_struct</attribute>
+    <attribute side="server" code="0x0024" define="SIMPLE_ENUM" type="SimpleEnum" writable="true" optional="true">enum_attr</attribute>
+    <attribute side="server" code="0x0025" define="STRUCT" type="SimpleStruct" writable="true" optional="true">struct_attr</attribute>
+    <attribute side="server" code="0x0026" define="RANGE_RESTRICTED_INT8U" type="int8u" min="20" max="100" writable="true" optional="true" default="70">range_restricted_int8u</attribute>
+    <attribute side="server" code="0x0027" define="RANGE_RESTRICTED_INT8s" type="int8s" min="-40" max="50" writable="true" optional="true" default="-5">range_restricted_int8s</attribute>
+    <attribute side="server" code="0x0028" define="RANGE_RESTRICTED_INT16U" type="int16u" min="100" max="1000" writable="true" optional="true" default="200">range_restricted_int16u</attribute>
+    <attribute side="server" code="0x0029" define="RANGE_RESTRICTED_INT16s" type="int16s" min="-150" max="200" writable="true" optional="true" default="-5">range_restricted_int16s</attribute>
+    <attribute side="server" code="0x002A" define="LIST_LONG_OCTET_STRING" type="ARRAY" entryType="LONG_OCTET_STRING" length="1000" writable="true" optional="true">list_long_octet_string</attribute>
+    <attribute side="server" code="0x002B" define="LIST_FABRIC_SCOPED" type="ARRAY" entryType="TestFabricScoped" length="10" writable="true" optional="true">list_fabric_scoped</attribute>
     <attribute side="server" code="0x0030" define="TIMED_WRITE_BOOLEAN"
                type="BOOLEAN" writable="true" mustUseTimedWrite="true">timed_write_boolean</attribute>
     <!-- Reading/writing the following two attributes will respond with a
          general error or a cluster-specific error respectively -->
     <attribute side="server" code="0x0031" define="GENERAL_ERROR_BOOLEAN"
-               type="BOOLEAN" writable="true" optional="false">general_error_boolean</attribute>
+               type="BOOLEAN" writable="true" optional="true">general_error_boolean</attribute>
     <attribute side="server" code="0x0032" define="CLUSTER_ERROR_BOOLEAN"
-               type="BOOLEAN" writable="true" optional="false">cluster_error_boolean</attribute>
+               type="BOOLEAN" writable="true" optional="true">cluster_error_boolean</attribute>
 
-    <attribute side="server" code="0x4000" define="NULLABLE_BOOLEAN" type="BOOLEAN" writable="true" default="false" isNullable="true" optional="false">nullable_boolean</attribute>
-    <attribute side="server" code="0x4001" define="NULLABLE_BITMAP8" type="Bitmap8MaskMap" writable="true" default="0" isNullable="true" optional="false">nullable_bitmap8</attribute>
-    <attribute side="server" code="0x4002" define="NULLABLE_BITMAP16" type="Bitmap16MaskMap" writable="true" default="0" isNullable="true" optional="false">nullable_bitmap16</attribute>
-    <attribute side="server" code="0x4003" define="NULLABLE_BITMAP32" type="Bitmap32MaskMap" writable="true" default="0" isNullable="true" optional="false">nullable_bitmap32</attribute>
-    <attribute side="server" code="0x4004" define="NULLABLE_BITMAP64" type="Bitmap64MaskMap" writable="true" default="0" isNullable="true" optional="false">nullable_bitmap64</attribute>
-    <attribute side="server" code="0x4005" define="NULLABLE_INT8U" type="INT8U" writable="true" default="0" isNullable="true" optional="false">nullable_int8u</attribute>
-    <attribute side="server" code="0x4006" define="NULLABLE_INT16U" type="INT16U" writable="true" default="0" isNullable="true" optional="false">nullable_int16u</attribute>
-    <attribute side="server" code="0x4007" define="NULLABLE_INT24U" type="INT24U" writable="true" default="0" isNullable="true" optional="false">nullable_int24u</attribute>
-    <attribute side="server" code="0x4008" define="NULLABLE_INT32U" type="INT32U" writable="true" default="0" isNullable="true" optional="false">nullable_int32u</attribute>
-    <attribute side="server" code="0x4009" define="NULLABLE_INT40U" type="INT40U" writable="true" default="0" isNullable="true" optional="false">nullable_int40u</attribute>
-    <attribute side="server" code="0x400A" define="NULLABLE_INT48U" type="INT48U" writable="true" default="0" isNullable="true" optional="false">nullable_int48u</attribute>
-    <attribute side="server" code="0x400B" define="NULLABLE_INT56U" type="INT56U" writable="true" default="0" isNullable="true" optional="false">nullable_int56u</attribute>
-    <attribute side="server" code="0x400C" define="NULLABLE_INT64U" type="INT64U" writable="true" default="0" isNullable="true" optional="false">nullable_int64u</attribute>
-    <attribute side="server" code="0x400D" define="NULLABLE_INT8S" type="INT8S" writable="true" default="0" isNullable="true" optional="false">nullable_int8s</attribute>
-    <attribute side="server" code="0x400E" define="NULLABLE_INT16S" type="INT16S" writable="true" default="0" isNullable="true" optional="false">nullable_int16s</attribute>
-    <attribute side="server" code="0x400F" define="NULLABLE_INT24S" type="INT24S" writable="true" default="0" isNullable="true" optional="false">nullable_int24s</attribute>
-    <attribute side="server" code="0x4010" define="NULLABLE_INT32S" type="INT32S" writable="true" default="0" isNullable="true" optional="false">nullable_int32s</attribute>
-    <attribute side="server" code="0x4011" define="NULLABLE_INT40S" type="INT40S" writable="true" default="0" isNullable="true" optional="false">nullable_int40s</attribute>
-    <attribute side="server" code="0x4012" define="NULLABLE_INT48S" type="INT48S" writable="true" default="0" isNullable="true" optional="false">nullable_int48s</attribute>
-    <attribute side="server" code="0x4013" define="NULLABLE_INT56S" type="INT56S" writable="true" default="0" isNullable="true" optional="false">nullable_int56s</attribute>
-    <attribute side="server" code="0x4014" define="NULLABLE_INT64S" type="INT64S" writable="true" default="0" isNullable="true" optional="false">nullable_int64s</attribute>
-    <attribute side="server" code="0x4015" define="NULLABLE_ENUM8" type="ENUM8" writable="true" default="0" isNullable="true" optional="false">nullable_enum8</attribute>
-    <attribute side="server" code="0x4016" define="NULLABLE_ENUM16" type="ENUM16" writable="true" default="0" isNullable="true" optional="false">nullable_enum16</attribute>
-    <attribute side="server" code="0x4017" define="NULLABLE_FLOAT_SINGLE" type="SINGLE" writable="true" default="0" isNullable="true" optional="false">nullable_float_single</attribute>
-    <attribute side="server" code="0x4018" define="NULLABLE_FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" isNullable="true" optional="false">nullable_float_double</attribute>
-    <attribute side="server" code="0x4019" define="NULLABLE_OCTET_STRING" type="OCTET_STRING" length="10" writable="true" isNullable="true" optional="false">nullable_octet_string</attribute>
-    <attribute side="server" code="0x401E" define="NULLABLE_CHAR_STRING" type="CHAR_STRING" length="10" writable="true" isNullable="true" optional="false">nullable_char_string</attribute>
-    <attribute side="server" code="0x4024" define="NULLABLE_SIMPLE_ENUM" type="SimpleEnum" writable="true" isNullable="true" optional="false">nullable_enum_attr</attribute>
-    <attribute side="server" code="0x4025" define="NULLABLE_STRUCT" type="SimpleStruct" writable="true" isNullable="true" optional="false">nullable_struct</attribute>
-    <attribute side="server" code="0x4026" define="NULLABLE_RANGE_RESTRICTED_INT8U" type="int8u" min="20" max="100" writable="true" isNullable="true" optional="false" default="70">nullable_range_restricted_int8u</attribute>
-    <attribute side="server" code="0x4027" define="NULLABLE_RANGE_RESTRICTED_INT8s" type="int8s" min="-40" max="50" writable="true" isNullable="true" optional="false" default="-5">nullable_range_restricted_int8s</attribute>
-    <attribute side="server" code="0x4028" define="NULLABLE_RANGE_RESTRICTED_INT16U" type="int16u" min="100" max="1000" writable="true" isNullable="true" optional="false" default="200">nullable_range_restricted_int16u</attribute>
-    <attribute side="server" code="0x4029" define="NULLABLE_RANGE_RESTRICTED_INT16S" type="int16s" min="-150" max="200" writable="true" isNullable="true" optional="false" default="-5">nullable_range_restricted_int16s</attribute>
+    <attribute side="server" code="0x4000" define="NULLABLE_BOOLEAN" type="BOOLEAN" writable="true" default="false" isNullable="true" optional="true">nullable_boolean</attribute>
+    <attribute side="server" code="0x4001" define="NULLABLE_BITMAP8" type="Bitmap8MaskMap" writable="true" default="0" isNullable="true" optional="true">nullable_bitmap8</attribute>
+    <attribute side="server" code="0x4002" define="NULLABLE_BITMAP16" type="Bitmap16MaskMap" writable="true" default="0" isNullable="true" optional="true">nullable_bitmap16</attribute>
+    <attribute side="server" code="0x4003" define="NULLABLE_BITMAP32" type="Bitmap32MaskMap" writable="true" default="0" isNullable="true" optional="true">nullable_bitmap32</attribute>
+    <attribute side="server" code="0x4004" define="NULLABLE_BITMAP64" type="Bitmap64MaskMap" writable="true" default="0" isNullable="true" optional="true">nullable_bitmap64</attribute>
+    <attribute side="server" code="0x4005" define="NULLABLE_INT8U" type="INT8U" writable="true" default="0" isNullable="true" optional="true">nullable_int8u</attribute>
+    <attribute side="server" code="0x4006" define="NULLABLE_INT16U" type="INT16U" writable="true" default="0" isNullable="true" optional="true">nullable_int16u</attribute>
+    <attribute side="server" code="0x4007" define="NULLABLE_INT24U" type="INT24U" writable="true" default="0" isNullable="true" optional="true">nullable_int24u</attribute>
+    <attribute side="server" code="0x4008" define="NULLABLE_INT32U" type="INT32U" writable="true" default="0" isNullable="true" optional="true">nullable_int32u</attribute>
+    <attribute side="server" code="0x4009" define="NULLABLE_INT40U" type="INT40U" writable="true" default="0" isNullable="true" optional="true">nullable_int40u</attribute>
+    <attribute side="server" code="0x400A" define="NULLABLE_INT48U" type="INT48U" writable="true" default="0" isNullable="true" optional="true">nullable_int48u</attribute>
+    <attribute side="server" code="0x400B" define="NULLABLE_INT56U" type="INT56U" writable="true" default="0" isNullable="true" optional="true">nullable_int56u</attribute>
+    <attribute side="server" code="0x400C" define="NULLABLE_INT64U" type="INT64U" writable="true" default="0" isNullable="true" optional="true">nullable_int64u</attribute>
+    <attribute side="server" code="0x400D" define="NULLABLE_INT8S" type="INT8S" writable="true" default="0" isNullable="true" optional="true">nullable_int8s</attribute>
+    <attribute side="server" code="0x400E" define="NULLABLE_INT16S" type="INT16S" writable="true" default="0" isNullable="true" optional="true">nullable_int16s</attribute>
+    <attribute side="server" code="0x400F" define="NULLABLE_INT24S" type="INT24S" writable="true" default="0" isNullable="true" optional="true">nullable_int24s</attribute>
+    <attribute side="server" code="0x4010" define="NULLABLE_INT32S" type="INT32S" writable="true" default="0" isNullable="true" optional="true">nullable_int32s</attribute>
+    <attribute side="server" code="0x4011" define="NULLABLE_INT40S" type="INT40S" writable="true" default="0" isNullable="true" optional="true">nullable_int40s</attribute>
+    <attribute side="server" code="0x4012" define="NULLABLE_INT48S" type="INT48S" writable="true" default="0" isNullable="true" optional="true">nullable_int48s</attribute>
+    <attribute side="server" code="0x4013" define="NULLABLE_INT56S" type="INT56S" writable="true" default="0" isNullable="true" optional="true">nullable_int56s</attribute>
+    <attribute side="server" code="0x4014" define="NULLABLE_INT64S" type="INT64S" writable="true" default="0" isNullable="true" optional="true">nullable_int64s</attribute>
+    <attribute side="server" code="0x4015" define="NULLABLE_ENUM8" type="ENUM8" writable="true" default="0" isNullable="true" optional="true">nullable_enum8</attribute>
+    <attribute side="server" code="0x4016" define="NULLABLE_ENUM16" type="ENUM16" writable="true" default="0" isNullable="true" optional="true">nullable_enum16</attribute>
+    <attribute side="server" code="0x4017" define="NULLABLE_FLOAT_SINGLE" type="SINGLE" writable="true" default="0" isNullable="true" optional="true">nullable_float_single</attribute>
+    <attribute side="server" code="0x4018" define="NULLABLE_FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" isNullable="true" optional="true">nullable_float_double</attribute>
+    <attribute side="server" code="0x4019" define="NULLABLE_OCTET_STRING" type="OCTET_STRING" length="10" writable="true" isNullable="true" optional="true">nullable_octet_string</attribute>
+    <attribute side="server" code="0x401E" define="NULLABLE_CHAR_STRING" type="CHAR_STRING" length="10" writable="true" isNullable="true" optional="true">nullable_char_string</attribute>
+    <attribute side="server" code="0x4024" define="NULLABLE_SIMPLE_ENUM" type="SimpleEnum" writable="true" isNullable="true" optional="true">nullable_enum_attr</attribute>
+    <attribute side="server" code="0x4025" define="NULLABLE_STRUCT" type="SimpleStruct" writable="true" isNullable="true" optional="true">nullable_struct</attribute>
+    <attribute side="server" code="0x4026" define="NULLABLE_RANGE_RESTRICTED_INT8U" type="int8u" min="20" max="100" writable="true" isNullable="true" optional="true" default="70">nullable_range_restricted_int8u</attribute>
+    <attribute side="server" code="0x4027" define="NULLABLE_RANGE_RESTRICTED_INT8s" type="int8s" min="-40" max="50" writable="true" isNullable="true" optional="true" default="-5">nullable_range_restricted_int8s</attribute>
+    <attribute side="server" code="0x4028" define="NULLABLE_RANGE_RESTRICTED_INT16U" type="int16u" min="100" max="1000" writable="true" isNullable="true" optional="true" default="200">nullable_range_restricted_int16u</attribute>
+    <attribute side="server" code="0x4029" define="NULLABLE_RANGE_RESTRICTED_INT16S" type="int16s" min="-150" max="200" writable="true" isNullable="true" optional="true" default="-5">nullable_range_restricted_int16s</attribute>
 
     <!-- This attribute should not be enabled on the server side -->
-    <attribute side="server" code="0x00FF" define="UNSUPPORTED" type="BOOLEAN" writable="true" optional="false">unsupported</attribute>
+    <attribute side="server" code="0x00FF" define="UNSUPPORTED" type="BOOLEAN" writable="true" optional="true">unsupported</attribute>
 
     <!-- Test Commands -->
-    <command source="client" code="0x00" name="Test" optional="false">
+    <command source="client" code="0x00" name="Test" optional="true">
       <description>
         Simple command without any parameters and without a specific response
       </description>
     </command>
 
-    <command source="client" code="0x01" name="TestNotHandled" optional="false">
+    <command source="client" code="0x01" name="TestNotHandled" optional="true">
       <description>
         Simple command without any parameters and without a specific response not handled by the server
       </description>
     </command>
 
-    <command source="client" code="0x02" name="TestSpecific" response="TestSpecificResponse" optional="false">
+    <command source="client" code="0x02" name="TestSpecific" response="TestSpecificResponse" optional="true">
       <description>
         Simple command without any parameters and with a specific response
       </description>
@@ -261,7 +261,7 @@ limitations under the License.
       </description>
     </command>
 
-    <command source="client" code="0x04" name="TestAddArguments" response="TestAddArgumentsResponse" optional="false">
+    <command source="client" code="0x04" name="TestAddArguments" response="TestAddArgumentsResponse" optional="true">
       <description>
         Command that takes two arguments and returns their sum.
       </description>
@@ -269,14 +269,14 @@ limitations under the License.
       <arg name="arg2" type="INT8U"/>
     </command>
 
-    <command source="client" code="0x05" name="TestSimpleArgumentRequest" response="TestSimpleArgumentResponse" optional="false">
+    <command source="client" code="0x05" name="TestSimpleArgumentRequest" response="TestSimpleArgumentResponse" optional="true">
       <description>
         Command that takes an argument which is bool
       </description>
       <arg name="arg1" type="BOOLEAN"/>
     </command>
 
-    <command source="client" code="0x06" name="TestStructArrayArgumentRequest" response="TestStructArrayArgumentResponse" optional="false">
+    <command source="client" code="0x06" name="TestStructArrayArgumentRequest" response="TestStructArrayArgumentResponse" optional="true">
       <description>
         Command that takes various arguments that are arrays, including an array of structs which have a list member.
       </description>
@@ -289,7 +289,7 @@ limitations under the License.
     </command>
 
     <command source="client" code="0x07" name="TestStructArgumentRequest"
-             response="BooleanResponse" optional="false">
+             response="BooleanResponse" optional="true">
       <description>
         Command that takes an argument which is struct.  The response echoes the
         'b' field of the single arg.
@@ -298,7 +298,7 @@ limitations under the License.
     </command>
 
     <command source="client" code="0x08" name="TestNestedStructArgumentRequest"
-             response="BooleanResponse" optional="false">
+             response="BooleanResponse" optional="true">
       <description>
         Command that takes an argument which is nested struct.  The response
         echoes the 'b' field of ar1.c.
@@ -306,7 +306,7 @@ limitations under the License.
       <arg name="arg1" type="NestedStruct"/>
     </command>
 
-    <command source="client" code="0x09" name="TestListStructArgumentRequest" response="BooleanResponse" optional="false">
+    <command source="client" code="0x09" name="TestListStructArgumentRequest" response="BooleanResponse" optional="true">
       <description>
         Command that takes an argument which is a list of structs.  The response
         returns false if there is some struct in the list whose 'b' field is
@@ -315,7 +315,7 @@ limitations under the License.
       <arg name="arg1" type="SimpleStruct" array="true"/>
     </command>
 
-    <command source="client" code="0x0A" name="TestListInt8UArgumentRequest" response="BooleanResponse" optional="false">
+    <command source="client" code="0x0A" name="TestListInt8UArgumentRequest" response="BooleanResponse" optional="true">
       <description>
         Command that takes an argument which is a list of INT8U.  The response
         returns false if the list contains a 0 in it, true otherwise (including
@@ -324,7 +324,7 @@ limitations under the License.
       <arg name="arg1" type="INT8U" array="true"/>
     </command>
 
-    <command source="client" code="0x0B" name="TestNestedStructListArgumentRequest" response="BooleanResponse" optional="false">
+    <command source="client" code="0x0B" name="TestNestedStructListArgumentRequest" response="BooleanResponse" optional="true">
       <description>
         Command that takes an argument which is a Nested Struct List.  The
         response returns false if there is some struct in arg1 (either directly
@@ -334,7 +334,7 @@ limitations under the License.
       <arg name="arg1" type="NestedStructList"/>
     </command>
 
-    <command source="client" code="0x0C" name="TestListNestedStructListArgumentRequest" response="BooleanResponse" optional="false">
+    <command source="client" code="0x0C" name="TestListNestedStructListArgumentRequest" response="BooleanResponse" optional="true">
       <description>
         Command that takes an argument which is a list of Nested Struct List.
         The response returns false if there is some struct in arg1 (either
@@ -344,7 +344,7 @@ limitations under the License.
       <arg name="arg1" type="NestedStructList" array="true"/>
     </command>
 
-    <command source="client" code="0x0D" name="TestListInt8UReverseRequest" response="TestListInt8UReverseResponse" optional="false">
+    <command source="client" code="0x0D" name="TestListInt8UReverseRequest" response="TestListInt8UReverseResponse" optional="true">
       <description>
         Command that takes an argument which is a list of INT8U and expects a
         response that reverses the list.
@@ -352,7 +352,7 @@ limitations under the License.
       <arg name="arg1" type="INT8U" array="true"/>
     </command>
 
-    <command source="client" code="0x0E" name="TestEnumsRequest" response="TestEnumsResponse" optional="false">
+    <command source="client" code="0x0E" name="TestEnumsRequest" response="TestEnumsResponse" optional="true">
       <description>
         Command that sends a vendor id and an enum.  The server is expected to
         echo them back.
@@ -362,7 +362,7 @@ limitations under the License.
     </command>
 
     <command source="client" code="0x0F" name="TestNullableOptionalRequest"
-             optional="false" response="TestNullableOptionalResponse">
+             optional="true" response="TestNullableOptionalResponse">
       <description>
         Command that takes an argument which is nullable and optional.  The
         response returns a boolean indicating whether the argument was present,
@@ -373,7 +373,7 @@ limitations under the License.
     </command>
 
     <command source="client" code="0x10" name="TestComplexNullableOptionalRequest"
-             optional="false" response="TestComplexNullableOptionalResponse">
+             optional="true" response="TestComplexNullableOptionalResponse">
       <description>
         Command that takes various arguments which can be nullable and/or optional.  The
         response returns information about which things were received and what
@@ -398,7 +398,7 @@ limitations under the License.
     </command>
 
     <command source="client" code="0x11" name="SimpleStructEchoRequest"
-             response="SimpleStructResponse" optional="false">
+             response="SimpleStructResponse" optional="true">
       <description>
         Command that takes an argument which is a struct.  The response echoes
         the struct back.
@@ -407,14 +407,14 @@ limitations under the License.
     </command>
 
     <command source="client" code="0x12" name="TimedInvokeRequest"
-             mustUseTimedInvoke="true" optional="false">
+             mustUseTimedInvoke="true" optional="true">
       <description>
         Command that just responds with a success status if the timed invoke
         conditions are met.
       </description>
     </command>
 
-    <command source="client" code="0x13" name="TestSimpleOptionalArgumentRequest" optional="false">
+    <command source="client" code="0x13" name="TestSimpleOptionalArgumentRequest" optional="true">
       <description>
         Command that takes an optional argument which is bool. It responds with a success value if the optional is set to any value.
       </description>
@@ -422,7 +422,7 @@ limitations under the License.
     </command>
 
     <command source="client" code="0x14" name="TestEmitTestEventRequest"
-             optional="false" response="TestEmitTestEventResponse">
+             optional="true" response="TestEmitTestEventResponse">
       <description>
         Command that takes identical arguments to the fields of the TestEvent and logs the TestEvent to the buffer.  Command returns an event ID as the response.
       </description>
@@ -432,35 +432,35 @@ limitations under the License.
     </command>
 
     <command source="client" code="0x15" name="TestEmitTestFabricScopedEventRequest"
-             optional="false" response="TestEmitTestFabricScopedEventResponse">
+             optional="true" response="TestEmitTestFabricScopedEventResponse">
       <description>
         Command that takes identical arguments to the fields of the TestFabricScopedEvent and logs the TestFabricScopedEvent to the buffer.  Command returns an event ID as the response.
       </description>
       <arg name="arg1" type="INT8U"/>
     </command>
 
-    <command source="server" code="0x00" name="TestSpecificResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x00" name="TestSpecificResponse" optional="true" disableDefaultResponse="true">
       <description>
         Simple response for TestWithResponse with a simple return value
       </description>
       <arg name="returnValue" type="INT8U"/>
     </command>
 
-    <command source="server" code="0x01" name="TestAddArgumentsResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x01" name="TestAddArgumentsResponse" optional="true" disableDefaultResponse="true">
       <description>
         Response for TestAddArguments that returns the sum.
       </description>
       <arg name="returnValue" type="INT8U"/>
     </command>
 
-    <command source="server" code="0x02" name="TestSimpleArgumentResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x02" name="TestSimpleArgumentResponse" optional="true" disableDefaultResponse="true">
       <description>
         Simple response for TestSimpleArgumentRequest with a simple return value
       </description>
       <arg name="returnValue" type="BOOLEAN"/>
     </command>
 
-    <command source="server" code="0x03" name="TestStructArrayArgumentResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x03" name="TestStructArrayArgumentResponse" optional="true" disableDefaultResponse="true">
       <description>
         Response for TestStructArrayArgumentRequest with complicated return arguments
       </description>
@@ -472,14 +472,14 @@ limitations under the License.
       <arg name="arg6" type="BOOLEAN"/>
     </command>
 
-    <command source="server" code="0x04" name="TestListInt8UReverseResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x04" name="TestListInt8UReverseResponse" optional="true" disableDefaultResponse="true">
       <description>
         Response that delivers the reversed list of uint8.
       </description>
       <arg name="arg1" type="INT8U" array="true"/>
     </command>
 
-    <command source="server" code="0x05" name="TestEnumsResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x05" name="TestEnumsResponse" optional="true" disableDefaultResponse="true">
       <description>
         Response that delivers a vendor id and an enum..
       </description>
@@ -487,7 +487,7 @@ limitations under the License.
       <arg name="arg2" type="SimpleEnum"/>
     </command>
 
-    <command source="server" code="0x06" name="TestNullableOptionalResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x06" name="TestNullableOptionalResponse" optional="true" disableDefaultResponse="true">
       <description>
         Delivers information about the argument TestNullableOptionalRequest had,
         and the original value if there was one.
@@ -498,7 +498,7 @@ limitations under the License.
       <arg name="originalValue" type="INT8U" optional="true" isNullable="true"/>
     </command>
 
-    <command source="server" code="0x07" name="TestComplexNullableOptionalResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x07" name="TestComplexNullableOptionalResponse" optional="true" disableDefaultResponse="true">
       <description>
         Delivers information about the arguments TestComplexNullableOptionalRequest had.
       </description>
@@ -535,7 +535,7 @@ limitations under the License.
            optional="true"/>
     </command>
 
-    <command source="server" code="0x08" name="BooleanResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x08" name="BooleanResponse" optional="true" disableDefaultResponse="true">
       <description>
         Delivers a single boolean argument. What the argument means depends on
         what we're responding to.
@@ -543,7 +543,7 @@ limitations under the License.
       <arg name="value" type="BOOLEAN"/>
     </command>
 
-    <command source="server" code="0x09" name="SimpleStructResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x09" name="SimpleStructResponse" optional="true" disableDefaultResponse="true">
       <description>
         Command that returns a single argument which is a struct.  The contents
         of the struct depend on what we are responding to.
@@ -551,14 +551,14 @@ limitations under the License.
       <arg name="arg1" type="SimpleStruct"/>
     </command>
 
-    <command source="server" code="0x0A" name="TestEmitTestEventResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x0A" name="TestEmitTestEventResponse" optional="true" disableDefaultResponse="true">
       <description>
         Delivers the ID of an event in response to test command emitting fabric scoped events.
       </description>
       <arg name="value" type="INT64U"/>
     </command>
 
-    <command source="server" code="0x0B" name="TestEmitTestFabricScopedEventResponse" optional="false" disableDefaultResponse="true">
+    <command source="server" code="0x0B" name="TestEmitTestFabricScopedEventResponse" optional="true" disableDefaultResponse="true">
       <description>
         Delivers the ID of an event in response to test command emitting fabric scope events.
       </description>

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -144,112 +144,112 @@ limitations under the License.
     <define>TEST_CLUSTER</define>
     <description>The Test Cluster is meant to validate the generated code</description>
     <!-- Base data types -->
-    <attribute side="server" code="0x0000" define="BOOLEAN" type="BOOLEAN" writable="true" default="false" optional="true">boolean</attribute>
-    <attribute side="server" code="0x0001" define="BITMAP8" type="Bitmap8MaskMap" writable="true" default="0" optional="true">bitmap8</attribute>
-    <attribute side="server" code="0x0002" define="BITMAP16" type="Bitmap16MaskMap" writable="true" default="0" optional="true">bitmap16</attribute>
-    <attribute side="server" code="0x0003" define="BITMAP32" type="Bitmap32MaskMap" writable="true" default="0" optional="true">bitmap32</attribute>
-    <attribute side="server" code="0x0004" define="BITMAP64" type="Bitmap64MaskMap" writable="true" default="0" optional="true">bitmap64</attribute>
-    <attribute side="server" code="0x0005" define="INT8U" type="INT8U" writable="true" default="0" optional="true">int8u</attribute>
-    <attribute side="server" code="0x0006" define="INT16U" type="INT16U" writable="true" default="0" optional="true">int16u</attribute>
-    <attribute side="server" code="0x0007" define="INT24U" type="INT24U" writable="true" default="0" optional="true">int24u</attribute>
-    <attribute side="server" code="0x0008" define="INT32U" type="INT32U" writable="true" default="0" optional="true">int32u</attribute>
-    <attribute side="server" code="0x0009" define="INT40U" type="INT40U" writable="true" default="0" optional="true">int40u</attribute>
-    <attribute side="server" code="0x000A" define="INT48U" type="INT48U" writable="true" default="0" optional="true">int48u</attribute>
-    <attribute side="server" code="0x000B" define="INT56U" type="INT56U" writable="true" default="0" optional="true">int56u</attribute>
-    <attribute side="server" code="0x000C" define="INT64U" type="INT64U" writable="true" default="0" optional="true">int64u</attribute>
-    <attribute side="server" code="0x000D" define="INT8S" type="INT8S" writable="true" default="0" optional="true">int8s</attribute>
-    <attribute side="server" code="0x000E" define="INT16S" type="INT16S" writable="true" default="0" optional="true">int16s</attribute>
-    <attribute side="server" code="0x000F" define="INT24S" type="INT24S" writable="true" default="0" optional="true">int24s</attribute>
-    <attribute side="server" code="0x0010" define="INT32S" type="INT32S" writable="true" default="0" optional="true">int32s</attribute>
-    <attribute side="server" code="0x0011" define="INT40S" type="INT40S" writable="true" default="0" optional="true">int40s</attribute>
-    <attribute side="server" code="0x0012" define="INT48S" type="INT48S" writable="true" default="0" optional="true">int48s</attribute>
-    <attribute side="server" code="0x0013" define="INT56S" type="INT56S" writable="true" default="0" optional="true">int56s</attribute>
-    <attribute side="server" code="0x0014" define="INT64S" type="INT64S" writable="true" default="0" optional="true">int64s</attribute>
-    <attribute side="server" code="0x0015" define="ENUM8" type="ENUM8" writable="true" default="0" optional="true">enum8</attribute>
-    <attribute side="server" code="0x0016" define="ENUM16" type="ENUM16" writable="true" default="0" optional="true">enum16</attribute>
-    <attribute side="server" code="0x0017" define="FLOAT_SINGLE" type="SINGLE" writable="true" default="0" optional="true">float_single</attribute>
-    <attribute side="server" code="0x0018" define="FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" optional="true">float_double</attribute>
-    <attribute side="server" code="0x0019" define="OCTET_STRING" type="OCTET_STRING" length="10" writable="true" optional="true">octet_string</attribute>
-    <attribute side="server" code="0x001A" define="LIST" type="ARRAY" entryType="INT8U" length="10" writable="true" optional="true">list_int8u</attribute>
-    <attribute side="server" code="0x001B" define="LIST_OCTET_STRING" type="ARRAY" entryType="OCTET_STRING" length="254" writable="true" optional="true">list_octet_string</attribute>
-    <attribute side="server" code="0x001C" define="LIST_STRUCT_OCTET_STRING" type="ARRAY" entryType="TestListStructOctet" length="254" writable="true" optional="true">list_struct_octet_string</attribute>
-    <attribute side="server" code="0x001D" define="LONG_OCTET_STRING" type="LONG_OCTET_STRING" length="1000" writable="true" optional="true">long_octet_string</attribute>
-    <attribute side="server" code="0x001E" define="CHAR_STRING" type="CHAR_STRING" length="10" writable="true" optional="true">char_string</attribute>
-    <attribute side="server" code="0x001F" define="LONG_CHAR_STRING" type="LONG_CHAR_STRING" length="1000" writable="true" optional="true">long_char_string</attribute>
-    <attribute side="server" code="0x0020" define="EPOCH_US" type="EPOCH_US" writable="true" optional="true">epoch_us</attribute>
-    <attribute side="server" code="0x0021" define="EPOCH_S" type="EPOCH_S" writable="true" optional="true">epoch_s</attribute>
+    <attribute side="server" code="0x0000" define="BOOLEAN" type="BOOLEAN" writable="true" default="false" optional="false">boolean</attribute>
+    <attribute side="server" code="0x0001" define="BITMAP8" type="Bitmap8MaskMap" writable="true" default="0" optional="false">bitmap8</attribute>
+    <attribute side="server" code="0x0002" define="BITMAP16" type="Bitmap16MaskMap" writable="true" default="0" optional="false">bitmap16</attribute>
+    <attribute side="server" code="0x0003" define="BITMAP32" type="Bitmap32MaskMap" writable="true" default="0" optional="false">bitmap32</attribute>
+    <attribute side="server" code="0x0004" define="BITMAP64" type="Bitmap64MaskMap" writable="true" default="0" optional="false">bitmap64</attribute>
+    <attribute side="server" code="0x0005" define="INT8U" type="INT8U" writable="true" default="0" optional="false">int8u</attribute>
+    <attribute side="server" code="0x0006" define="INT16U" type="INT16U" writable="true" default="0" optional="false">int16u</attribute>
+    <attribute side="server" code="0x0007" define="INT24U" type="INT24U" writable="true" default="0" optional="false">int24u</attribute>
+    <attribute side="server" code="0x0008" define="INT32U" type="INT32U" writable="true" default="0" optional="false">int32u</attribute>
+    <attribute side="server" code="0x0009" define="INT40U" type="INT40U" writable="true" default="0" optional="false">int40u</attribute>
+    <attribute side="server" code="0x000A" define="INT48U" type="INT48U" writable="true" default="0" optional="false">int48u</attribute>
+    <attribute side="server" code="0x000B" define="INT56U" type="INT56U" writable="true" default="0" optional="false">int56u</attribute>
+    <attribute side="server" code="0x000C" define="INT64U" type="INT64U" writable="true" default="0" optional="false">int64u</attribute>
+    <attribute side="server" code="0x000D" define="INT8S" type="INT8S" writable="true" default="0" optional="false">int8s</attribute>
+    <attribute side="server" code="0x000E" define="INT16S" type="INT16S" writable="true" default="0" optional="false">int16s</attribute>
+    <attribute side="server" code="0x000F" define="INT24S" type="INT24S" writable="true" default="0" optional="false">int24s</attribute>
+    <attribute side="server" code="0x0010" define="INT32S" type="INT32S" writable="true" default="0" optional="false">int32s</attribute>
+    <attribute side="server" code="0x0011" define="INT40S" type="INT40S" writable="true" default="0" optional="false">int40s</attribute>
+    <attribute side="server" code="0x0012" define="INT48S" type="INT48S" writable="true" default="0" optional="false">int48s</attribute>
+    <attribute side="server" code="0x0013" define="INT56S" type="INT56S" writable="true" default="0" optional="false">int56s</attribute>
+    <attribute side="server" code="0x0014" define="INT64S" type="INT64S" writable="true" default="0" optional="false">int64s</attribute>
+    <attribute side="server" code="0x0015" define="ENUM8" type="ENUM8" writable="true" default="0" optional="false">enum8</attribute>
+    <attribute side="server" code="0x0016" define="ENUM16" type="ENUM16" writable="true" default="0" optional="false">enum16</attribute>
+    <attribute side="server" code="0x0017" define="FLOAT_SINGLE" type="SINGLE" writable="true" default="0" optional="false">float_single</attribute>
+    <attribute side="server" code="0x0018" define="FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" optional="false">float_double</attribute>
+    <attribute side="server" code="0x0019" define="OCTET_STRING" type="OCTET_STRING" length="10" writable="true" optional="false">octet_string</attribute>
+    <attribute side="server" code="0x001A" define="LIST" type="ARRAY" entryType="INT8U" length="10" writable="true" optional="false">list_int8u</attribute>
+    <attribute side="server" code="0x001B" define="LIST_OCTET_STRING" type="ARRAY" entryType="OCTET_STRING" length="254" writable="true" optional="false">list_octet_string</attribute>
+    <attribute side="server" code="0x001C" define="LIST_STRUCT_OCTET_STRING" type="ARRAY" entryType="TestListStructOctet" length="254" writable="true" optional="false">list_struct_octet_string</attribute>
+    <attribute side="server" code="0x001D" define="LONG_OCTET_STRING" type="LONG_OCTET_STRING" length="1000" writable="true" optional="false">long_octet_string</attribute>
+    <attribute side="server" code="0x001E" define="CHAR_STRING" type="CHAR_STRING" length="10" writable="true" optional="false">char_string</attribute>
+    <attribute side="server" code="0x001F" define="LONG_CHAR_STRING" type="LONG_CHAR_STRING" length="1000" writable="true" optional="false">long_char_string</attribute>
+    <attribute side="server" code="0x0020" define="EPOCH_US" type="EPOCH_US" writable="true" optional="false">epoch_us</attribute>
+    <attribute side="server" code="0x0021" define="EPOCH_S" type="EPOCH_S" writable="true" optional="false">epoch_s</attribute>
     <attribute side="server" code="0x0022" define="TEST_VENDOR_ID" type="vendor_id"
-               writable="true" optional="true" default="0">vendor_id</attribute>
+               writable="true" optional="false" default="0">vendor_id</attribute>
     <attribute side="server" code="0x0023" define="LIST_OF_STRUCTS_WITH_OPTIONALS" type="ARRAY" entryType="NullablesAndOptionalsStruct"
-               writable="true" optional="true">list_nullables_and_optionals_struct</attribute>
-    <attribute side="server" code="0x0024" define="SIMPLE_ENUM" type="SimpleEnum" writable="true" optional="true">enum_attr</attribute>
-    <attribute side="server" code="0x0025" define="STRUCT" type="SimpleStruct" writable="true" optional="true">struct_attr</attribute>
-    <attribute side="server" code="0x0026" define="RANGE_RESTRICTED_INT8U" type="int8u" min="20" max="100" writable="true" optional="true" default="70">range_restricted_int8u</attribute>
-    <attribute side="server" code="0x0027" define="RANGE_RESTRICTED_INT8s" type="int8s" min="-40" max="50" writable="true" optional="true" default="-5">range_restricted_int8s</attribute>
-    <attribute side="server" code="0x0028" define="RANGE_RESTRICTED_INT16U" type="int16u" min="100" max="1000" writable="true" optional="true" default="200">range_restricted_int16u</attribute>
-    <attribute side="server" code="0x0029" define="RANGE_RESTRICTED_INT16s" type="int16s" min="-150" max="200" writable="true" optional="true" default="-5">range_restricted_int16s</attribute>
-    <attribute side="server" code="0x002A" define="LIST_LONG_OCTET_STRING" type="ARRAY" entryType="LONG_OCTET_STRING" length="1000" writable="true" optional="true">list_long_octet_string</attribute>
-    <attribute side="server" code="0x002B" define="LIST_FABRIC_SCOPED" type="ARRAY" entryType="TestFabricScoped" length="10" writable="true" optional="true">list_fabric_scoped</attribute>
+               writable="true" optional="false">list_nullables_and_optionals_struct</attribute>
+    <attribute side="server" code="0x0024" define="SIMPLE_ENUM" type="SimpleEnum" writable="true" optional="false">enum_attr</attribute>
+    <attribute side="server" code="0x0025" define="STRUCT" type="SimpleStruct" writable="true" optional="false">struct_attr</attribute>
+    <attribute side="server" code="0x0026" define="RANGE_RESTRICTED_INT8U" type="int8u" min="20" max="100" writable="true" optional="false" default="70">range_restricted_int8u</attribute>
+    <attribute side="server" code="0x0027" define="RANGE_RESTRICTED_INT8s" type="int8s" min="-40" max="50" writable="true" optional="false" default="-5">range_restricted_int8s</attribute>
+    <attribute side="server" code="0x0028" define="RANGE_RESTRICTED_INT16U" type="int16u" min="100" max="1000" writable="true" optional="false" default="200">range_restricted_int16u</attribute>
+    <attribute side="server" code="0x0029" define="RANGE_RESTRICTED_INT16s" type="int16s" min="-150" max="200" writable="true" optional="false" default="-5">range_restricted_int16s</attribute>
+    <attribute side="server" code="0x002A" define="LIST_LONG_OCTET_STRING" type="ARRAY" entryType="LONG_OCTET_STRING" length="1000" writable="true" optional="false">list_long_octet_string</attribute>
+    <attribute side="server" code="0x002B" define="LIST_FABRIC_SCOPED" type="ARRAY" entryType="TestFabricScoped" length="10" writable="true" optional="false">list_fabric_scoped</attribute>
     <attribute side="server" code="0x0030" define="TIMED_WRITE_BOOLEAN"
                type="BOOLEAN" writable="true" mustUseTimedWrite="true">timed_write_boolean</attribute>
     <!-- Reading/writing the following two attributes will respond with a
          general error or a cluster-specific error respectively -->
     <attribute side="server" code="0x0031" define="GENERAL_ERROR_BOOLEAN"
-               type="BOOLEAN" writable="true" optional="true">general_error_boolean</attribute>
+               type="BOOLEAN" writable="true" optional="false">general_error_boolean</attribute>
     <attribute side="server" code="0x0032" define="CLUSTER_ERROR_BOOLEAN"
-               type="BOOLEAN" writable="true" optional="true">cluster_error_boolean</attribute>
+               type="BOOLEAN" writable="true" optional="false">cluster_error_boolean</attribute>
 
-    <attribute side="server" code="0x4000" define="NULLABLE_BOOLEAN" type="BOOLEAN" writable="true" default="false" isNullable="true" optional="true">nullable_boolean</attribute>
-    <attribute side="server" code="0x4001" define="NULLABLE_BITMAP8" type="Bitmap8MaskMap" writable="true" default="0" isNullable="true" optional="true">nullable_bitmap8</attribute>
-    <attribute side="server" code="0x4002" define="NULLABLE_BITMAP16" type="Bitmap16MaskMap" writable="true" default="0" isNullable="true" optional="true">nullable_bitmap16</attribute>
-    <attribute side="server" code="0x4003" define="NULLABLE_BITMAP32" type="Bitmap32MaskMap" writable="true" default="0" isNullable="true" optional="true">nullable_bitmap32</attribute>
-    <attribute side="server" code="0x4004" define="NULLABLE_BITMAP64" type="Bitmap64MaskMap" writable="true" default="0" isNullable="true" optional="true">nullable_bitmap64</attribute>
-    <attribute side="server" code="0x4005" define="NULLABLE_INT8U" type="INT8U" writable="true" default="0" isNullable="true" optional="true">nullable_int8u</attribute>
-    <attribute side="server" code="0x4006" define="NULLABLE_INT16U" type="INT16U" writable="true" default="0" isNullable="true" optional="true">nullable_int16u</attribute>
-    <attribute side="server" code="0x4007" define="NULLABLE_INT24U" type="INT24U" writable="true" default="0" isNullable="true" optional="true">nullable_int24u</attribute>
-    <attribute side="server" code="0x4008" define="NULLABLE_INT32U" type="INT32U" writable="true" default="0" isNullable="true" optional="true">nullable_int32u</attribute>
-    <attribute side="server" code="0x4009" define="NULLABLE_INT40U" type="INT40U" writable="true" default="0" isNullable="true" optional="true">nullable_int40u</attribute>
-    <attribute side="server" code="0x400A" define="NULLABLE_INT48U" type="INT48U" writable="true" default="0" isNullable="true" optional="true">nullable_int48u</attribute>
-    <attribute side="server" code="0x400B" define="NULLABLE_INT56U" type="INT56U" writable="true" default="0" isNullable="true" optional="true">nullable_int56u</attribute>
-    <attribute side="server" code="0x400C" define="NULLABLE_INT64U" type="INT64U" writable="true" default="0" isNullable="true" optional="true">nullable_int64u</attribute>
-    <attribute side="server" code="0x400D" define="NULLABLE_INT8S" type="INT8S" writable="true" default="0" isNullable="true" optional="true">nullable_int8s</attribute>
-    <attribute side="server" code="0x400E" define="NULLABLE_INT16S" type="INT16S" writable="true" default="0" isNullable="true" optional="true">nullable_int16s</attribute>
-    <attribute side="server" code="0x400F" define="NULLABLE_INT24S" type="INT24S" writable="true" default="0" isNullable="true" optional="true">nullable_int24s</attribute>
-    <attribute side="server" code="0x4010" define="NULLABLE_INT32S" type="INT32S" writable="true" default="0" isNullable="true" optional="true">nullable_int32s</attribute>
-    <attribute side="server" code="0x4011" define="NULLABLE_INT40S" type="INT40S" writable="true" default="0" isNullable="true" optional="true">nullable_int40s</attribute>
-    <attribute side="server" code="0x4012" define="NULLABLE_INT48S" type="INT48S" writable="true" default="0" isNullable="true" optional="true">nullable_int48s</attribute>
-    <attribute side="server" code="0x4013" define="NULLABLE_INT56S" type="INT56S" writable="true" default="0" isNullable="true" optional="true">nullable_int56s</attribute>
-    <attribute side="server" code="0x4014" define="NULLABLE_INT64S" type="INT64S" writable="true" default="0" isNullable="true" optional="true">nullable_int64s</attribute>
-    <attribute side="server" code="0x4015" define="NULLABLE_ENUM8" type="ENUM8" writable="true" default="0" isNullable="true" optional="true">nullable_enum8</attribute>
-    <attribute side="server" code="0x4016" define="NULLABLE_ENUM16" type="ENUM16" writable="true" default="0" isNullable="true" optional="true">nullable_enum16</attribute>
-    <attribute side="server" code="0x4017" define="NULLABLE_FLOAT_SINGLE" type="SINGLE" writable="true" default="0" isNullable="true" optional="true">nullable_float_single</attribute>
-    <attribute side="server" code="0x4018" define="NULLABLE_FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" isNullable="true" optional="true">nullable_float_double</attribute>
-    <attribute side="server" code="0x4019" define="NULLABLE_OCTET_STRING" type="OCTET_STRING" length="10" writable="true" isNullable="true" optional="true">nullable_octet_string</attribute>
-    <attribute side="server" code="0x401E" define="NULLABLE_CHAR_STRING" type="CHAR_STRING" length="10" writable="true" isNullable="true" optional="true">nullable_char_string</attribute>
-    <attribute side="server" code="0x4024" define="NULLABLE_SIMPLE_ENUM" type="SimpleEnum" writable="true" isNullable="true" optional="true">nullable_enum_attr</attribute>
-    <attribute side="server" code="0x4025" define="NULLABLE_STRUCT" type="SimpleStruct" writable="true" isNullable="true" optional="true">nullable_struct</attribute>
-    <attribute side="server" code="0x4026" define="NULLABLE_RANGE_RESTRICTED_INT8U" type="int8u" min="20" max="100" writable="true" isNullable="true" optional="true" default="70">nullable_range_restricted_int8u</attribute>
-    <attribute side="server" code="0x4027" define="NULLABLE_RANGE_RESTRICTED_INT8s" type="int8s" min="-40" max="50" writable="true" isNullable="true" optional="true" default="-5">nullable_range_restricted_int8s</attribute>
-    <attribute side="server" code="0x4028" define="NULLABLE_RANGE_RESTRICTED_INT16U" type="int16u" min="100" max="1000" writable="true" isNullable="true" optional="true" default="200">nullable_range_restricted_int16u</attribute>
-    <attribute side="server" code="0x4029" define="NULLABLE_RANGE_RESTRICTED_INT16S" type="int16s" min="-150" max="200" writable="true" isNullable="true" optional="true" default="-5">nullable_range_restricted_int16s</attribute>
+    <attribute side="server" code="0x4000" define="NULLABLE_BOOLEAN" type="BOOLEAN" writable="true" default="false" isNullable="true" optional="false">nullable_boolean</attribute>
+    <attribute side="server" code="0x4001" define="NULLABLE_BITMAP8" type="Bitmap8MaskMap" writable="true" default="0" isNullable="true" optional="false">nullable_bitmap8</attribute>
+    <attribute side="server" code="0x4002" define="NULLABLE_BITMAP16" type="Bitmap16MaskMap" writable="true" default="0" isNullable="true" optional="false">nullable_bitmap16</attribute>
+    <attribute side="server" code="0x4003" define="NULLABLE_BITMAP32" type="Bitmap32MaskMap" writable="true" default="0" isNullable="true" optional="false">nullable_bitmap32</attribute>
+    <attribute side="server" code="0x4004" define="NULLABLE_BITMAP64" type="Bitmap64MaskMap" writable="true" default="0" isNullable="true" optional="false">nullable_bitmap64</attribute>
+    <attribute side="server" code="0x4005" define="NULLABLE_INT8U" type="INT8U" writable="true" default="0" isNullable="true" optional="false">nullable_int8u</attribute>
+    <attribute side="server" code="0x4006" define="NULLABLE_INT16U" type="INT16U" writable="true" default="0" isNullable="true" optional="false">nullable_int16u</attribute>
+    <attribute side="server" code="0x4007" define="NULLABLE_INT24U" type="INT24U" writable="true" default="0" isNullable="true" optional="false">nullable_int24u</attribute>
+    <attribute side="server" code="0x4008" define="NULLABLE_INT32U" type="INT32U" writable="true" default="0" isNullable="true" optional="false">nullable_int32u</attribute>
+    <attribute side="server" code="0x4009" define="NULLABLE_INT40U" type="INT40U" writable="true" default="0" isNullable="true" optional="false">nullable_int40u</attribute>
+    <attribute side="server" code="0x400A" define="NULLABLE_INT48U" type="INT48U" writable="true" default="0" isNullable="true" optional="false">nullable_int48u</attribute>
+    <attribute side="server" code="0x400B" define="NULLABLE_INT56U" type="INT56U" writable="true" default="0" isNullable="true" optional="false">nullable_int56u</attribute>
+    <attribute side="server" code="0x400C" define="NULLABLE_INT64U" type="INT64U" writable="true" default="0" isNullable="true" optional="false">nullable_int64u</attribute>
+    <attribute side="server" code="0x400D" define="NULLABLE_INT8S" type="INT8S" writable="true" default="0" isNullable="true" optional="false">nullable_int8s</attribute>
+    <attribute side="server" code="0x400E" define="NULLABLE_INT16S" type="INT16S" writable="true" default="0" isNullable="true" optional="false">nullable_int16s</attribute>
+    <attribute side="server" code="0x400F" define="NULLABLE_INT24S" type="INT24S" writable="true" default="0" isNullable="true" optional="false">nullable_int24s</attribute>
+    <attribute side="server" code="0x4010" define="NULLABLE_INT32S" type="INT32S" writable="true" default="0" isNullable="true" optional="false">nullable_int32s</attribute>
+    <attribute side="server" code="0x4011" define="NULLABLE_INT40S" type="INT40S" writable="true" default="0" isNullable="true" optional="false">nullable_int40s</attribute>
+    <attribute side="server" code="0x4012" define="NULLABLE_INT48S" type="INT48S" writable="true" default="0" isNullable="true" optional="false">nullable_int48s</attribute>
+    <attribute side="server" code="0x4013" define="NULLABLE_INT56S" type="INT56S" writable="true" default="0" isNullable="true" optional="false">nullable_int56s</attribute>
+    <attribute side="server" code="0x4014" define="NULLABLE_INT64S" type="INT64S" writable="true" default="0" isNullable="true" optional="false">nullable_int64s</attribute>
+    <attribute side="server" code="0x4015" define="NULLABLE_ENUM8" type="ENUM8" writable="true" default="0" isNullable="true" optional="false">nullable_enum8</attribute>
+    <attribute side="server" code="0x4016" define="NULLABLE_ENUM16" type="ENUM16" writable="true" default="0" isNullable="true" optional="false">nullable_enum16</attribute>
+    <attribute side="server" code="0x4017" define="NULLABLE_FLOAT_SINGLE" type="SINGLE" writable="true" default="0" isNullable="true" optional="false">nullable_float_single</attribute>
+    <attribute side="server" code="0x4018" define="NULLABLE_FLOAT_DOUBLE" type="DOUBLE" writable="true" default="0" isNullable="true" optional="false">nullable_float_double</attribute>
+    <attribute side="server" code="0x4019" define="NULLABLE_OCTET_STRING" type="OCTET_STRING" length="10" writable="true" isNullable="true" optional="false">nullable_octet_string</attribute>
+    <attribute side="server" code="0x401E" define="NULLABLE_CHAR_STRING" type="CHAR_STRING" length="10" writable="true" isNullable="true" optional="false">nullable_char_string</attribute>
+    <attribute side="server" code="0x4024" define="NULLABLE_SIMPLE_ENUM" type="SimpleEnum" writable="true" isNullable="true" optional="false">nullable_enum_attr</attribute>
+    <attribute side="server" code="0x4025" define="NULLABLE_STRUCT" type="SimpleStruct" writable="true" isNullable="true" optional="false">nullable_struct</attribute>
+    <attribute side="server" code="0x4026" define="NULLABLE_RANGE_RESTRICTED_INT8U" type="int8u" min="20" max="100" writable="true" isNullable="true" optional="false" default="70">nullable_range_restricted_int8u</attribute>
+    <attribute side="server" code="0x4027" define="NULLABLE_RANGE_RESTRICTED_INT8s" type="int8s" min="-40" max="50" writable="true" isNullable="true" optional="false" default="-5">nullable_range_restricted_int8s</attribute>
+    <attribute side="server" code="0x4028" define="NULLABLE_RANGE_RESTRICTED_INT16U" type="int16u" min="100" max="1000" writable="true" isNullable="true" optional="false" default="200">nullable_range_restricted_int16u</attribute>
+    <attribute side="server" code="0x4029" define="NULLABLE_RANGE_RESTRICTED_INT16S" type="int16s" min="-150" max="200" writable="true" isNullable="true" optional="false" default="-5">nullable_range_restricted_int16s</attribute>
 
     <!-- This attribute should not be enabled on the server side -->
     <attribute side="server" code="0x00FF" define="UNSUPPORTED" type="BOOLEAN" writable="true" optional="true">unsupported</attribute>
 
     <!-- Test Commands -->
-    <command source="client" code="0x00" name="Test" optional="true">
+    <command source="client" code="0x00" name="Test" optional="false">
       <description>
         Simple command without any parameters and without a specific response
       </description>
     </command>
 
-    <command source="client" code="0x01" name="TestNotHandled" optional="true">
+    <command source="client" code="0x01" name="TestNotHandled" optional="false">
       <description>
         Simple command without any parameters and without a specific response not handled by the server
       </description>
     </command>
 
-    <command source="client" code="0x02" name="TestSpecific" response="TestSpecificResponse" optional="true">
+    <command source="client" code="0x02" name="TestSpecific" response="TestSpecificResponse" optional="false">
       <description>
         Simple command without any parameters and with a specific response
       </description>

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -33914,87 +33914,87 @@ class TestCluster(Cluster):
     def descriptor(cls) -> ClusterObjectDescriptor:
         return ClusterObjectDescriptor(
             Fields = [
-                ClusterObjectFieldDescriptor(Label="boolean", Tag=0x00000000, Type=typing.Optional[bool]),
-                ClusterObjectFieldDescriptor(Label="bitmap8", Tag=0x00000001, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="bitmap16", Tag=0x00000002, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="bitmap32", Tag=0x00000003, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="bitmap64", Tag=0x00000004, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int8u", Tag=0x00000005, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int16u", Tag=0x00000006, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int24u", Tag=0x00000007, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int32u", Tag=0x00000008, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int40u", Tag=0x00000009, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int48u", Tag=0x0000000A, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int56u", Tag=0x0000000B, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int64u", Tag=0x0000000C, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="int8s", Tag=0x0000000D, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="int16s", Tag=0x0000000E, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="int24s", Tag=0x0000000F, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="int32s", Tag=0x00000010, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="int40s", Tag=0x00000011, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="int48s", Tag=0x00000012, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="int56s", Tag=0x00000013, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="int64s", Tag=0x00000014, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="enum8", Tag=0x00000015, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="enum16", Tag=0x00000016, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="floatSingle", Tag=0x00000017, Type=typing.Optional[float32]),
-                ClusterObjectFieldDescriptor(Label="floatDouble", Tag=0x00000018, Type=typing.Optional[float]),
-                ClusterObjectFieldDescriptor(Label="octetString", Tag=0x00000019, Type=typing.Optional[bytes]),
-                ClusterObjectFieldDescriptor(Label="listInt8u", Tag=0x0000001A, Type=typing.Optional[typing.List[uint]]),
-                ClusterObjectFieldDescriptor(Label="listOctetString", Tag=0x0000001B, Type=typing.Optional[typing.List[bytes]]),
-                ClusterObjectFieldDescriptor(Label="listStructOctetString", Tag=0x0000001C, Type=typing.Optional[typing.List[TestCluster.Structs.TestListStructOctet]]),
-                ClusterObjectFieldDescriptor(Label="longOctetString", Tag=0x0000001D, Type=typing.Optional[bytes]),
-                ClusterObjectFieldDescriptor(Label="charString", Tag=0x0000001E, Type=typing.Optional[str]),
-                ClusterObjectFieldDescriptor(Label="longCharString", Tag=0x0000001F, Type=typing.Optional[str]),
-                ClusterObjectFieldDescriptor(Label="epochUs", Tag=0x00000020, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="epochS", Tag=0x00000021, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="vendorId", Tag=0x00000022, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="listNullablesAndOptionalsStruct", Tag=0x00000023, Type=typing.Optional[typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]]),
-                ClusterObjectFieldDescriptor(Label="enumAttr", Tag=0x00000024, Type=typing.Optional[TestCluster.Enums.SimpleEnum]),
-                ClusterObjectFieldDescriptor(Label="structAttr", Tag=0x00000025, Type=typing.Optional[TestCluster.Structs.SimpleStruct]),
-                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt8u", Tag=0x00000026, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt8s", Tag=0x00000027, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt16u", Tag=0x00000028, Type=typing.Optional[uint]),
-                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt16s", Tag=0x00000029, Type=typing.Optional[int]),
-                ClusterObjectFieldDescriptor(Label="listLongOctetString", Tag=0x0000002A, Type=typing.Optional[typing.List[bytes]]),
-                ClusterObjectFieldDescriptor(Label="listFabricScoped", Tag=0x0000002B, Type=typing.Optional[typing.List[TestCluster.Structs.TestFabricScoped]]),
+                ClusterObjectFieldDescriptor(Label="boolean", Tag=0x00000000, Type=bool),
+                ClusterObjectFieldDescriptor(Label="bitmap8", Tag=0x00000001, Type=uint),
+                ClusterObjectFieldDescriptor(Label="bitmap16", Tag=0x00000002, Type=uint),
+                ClusterObjectFieldDescriptor(Label="bitmap32", Tag=0x00000003, Type=uint),
+                ClusterObjectFieldDescriptor(Label="bitmap64", Tag=0x00000004, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int8u", Tag=0x00000005, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int16u", Tag=0x00000006, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int24u", Tag=0x00000007, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int32u", Tag=0x00000008, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int40u", Tag=0x00000009, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int48u", Tag=0x0000000A, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int56u", Tag=0x0000000B, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int64u", Tag=0x0000000C, Type=uint),
+                ClusterObjectFieldDescriptor(Label="int8s", Tag=0x0000000D, Type=int),
+                ClusterObjectFieldDescriptor(Label="int16s", Tag=0x0000000E, Type=int),
+                ClusterObjectFieldDescriptor(Label="int24s", Tag=0x0000000F, Type=int),
+                ClusterObjectFieldDescriptor(Label="int32s", Tag=0x00000010, Type=int),
+                ClusterObjectFieldDescriptor(Label="int40s", Tag=0x00000011, Type=int),
+                ClusterObjectFieldDescriptor(Label="int48s", Tag=0x00000012, Type=int),
+                ClusterObjectFieldDescriptor(Label="int56s", Tag=0x00000013, Type=int),
+                ClusterObjectFieldDescriptor(Label="int64s", Tag=0x00000014, Type=int),
+                ClusterObjectFieldDescriptor(Label="enum8", Tag=0x00000015, Type=uint),
+                ClusterObjectFieldDescriptor(Label="enum16", Tag=0x00000016, Type=uint),
+                ClusterObjectFieldDescriptor(Label="floatSingle", Tag=0x00000017, Type=float32),
+                ClusterObjectFieldDescriptor(Label="floatDouble", Tag=0x00000018, Type=float),
+                ClusterObjectFieldDescriptor(Label="octetString", Tag=0x00000019, Type=bytes),
+                ClusterObjectFieldDescriptor(Label="listInt8u", Tag=0x0000001A, Type=typing.List[uint]),
+                ClusterObjectFieldDescriptor(Label="listOctetString", Tag=0x0000001B, Type=typing.List[bytes]),
+                ClusterObjectFieldDescriptor(Label="listStructOctetString", Tag=0x0000001C, Type=typing.List[TestCluster.Structs.TestListStructOctet]),
+                ClusterObjectFieldDescriptor(Label="longOctetString", Tag=0x0000001D, Type=bytes),
+                ClusterObjectFieldDescriptor(Label="charString", Tag=0x0000001E, Type=str),
+                ClusterObjectFieldDescriptor(Label="longCharString", Tag=0x0000001F, Type=str),
+                ClusterObjectFieldDescriptor(Label="epochUs", Tag=0x00000020, Type=uint),
+                ClusterObjectFieldDescriptor(Label="epochS", Tag=0x00000021, Type=uint),
+                ClusterObjectFieldDescriptor(Label="vendorId", Tag=0x00000022, Type=uint),
+                ClusterObjectFieldDescriptor(Label="listNullablesAndOptionalsStruct", Tag=0x00000023, Type=typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]),
+                ClusterObjectFieldDescriptor(Label="enumAttr", Tag=0x00000024, Type=TestCluster.Enums.SimpleEnum),
+                ClusterObjectFieldDescriptor(Label="structAttr", Tag=0x00000025, Type=TestCluster.Structs.SimpleStruct),
+                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt8u", Tag=0x00000026, Type=uint),
+                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt8s", Tag=0x00000027, Type=int),
+                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt16u", Tag=0x00000028, Type=uint),
+                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt16s", Tag=0x00000029, Type=int),
+                ClusterObjectFieldDescriptor(Label="listLongOctetString", Tag=0x0000002A, Type=typing.List[bytes]),
+                ClusterObjectFieldDescriptor(Label="listFabricScoped", Tag=0x0000002B, Type=typing.List[TestCluster.Structs.TestFabricScoped]),
                 ClusterObjectFieldDescriptor(Label="timedWriteBoolean", Tag=0x00000030, Type=bool),
-                ClusterObjectFieldDescriptor(Label="generalErrorBoolean", Tag=0x00000031, Type=typing.Optional[bool]),
-                ClusterObjectFieldDescriptor(Label="clusterErrorBoolean", Tag=0x00000032, Type=typing.Optional[bool]),
+                ClusterObjectFieldDescriptor(Label="generalErrorBoolean", Tag=0x00000031, Type=bool),
+                ClusterObjectFieldDescriptor(Label="clusterErrorBoolean", Tag=0x00000032, Type=bool),
                 ClusterObjectFieldDescriptor(Label="unsupported", Tag=0x000000FF, Type=typing.Optional[bool]),
-                ClusterObjectFieldDescriptor(Label="nullableBoolean", Tag=0x00004000, Type=typing.Union[None, Nullable, bool]),
-                ClusterObjectFieldDescriptor(Label="nullableBitmap8", Tag=0x00004001, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableBitmap16", Tag=0x00004002, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableBitmap32", Tag=0x00004003, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableBitmap64", Tag=0x00004004, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt8u", Tag=0x00004005, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt16u", Tag=0x00004006, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt24u", Tag=0x00004007, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt32u", Tag=0x00004008, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt40u", Tag=0x00004009, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt48u", Tag=0x0000400A, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt56u", Tag=0x0000400B, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt64u", Tag=0x0000400C, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt8s", Tag=0x0000400D, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt16s", Tag=0x0000400E, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt24s", Tag=0x0000400F, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt32s", Tag=0x00004010, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt40s", Tag=0x00004011, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt48s", Tag=0x00004012, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt56s", Tag=0x00004013, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt64s", Tag=0x00004014, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableEnum8", Tag=0x00004015, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableEnum16", Tag=0x00004016, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableFloatSingle", Tag=0x00004017, Type=typing.Union[None, Nullable, float32]),
-                ClusterObjectFieldDescriptor(Label="nullableFloatDouble", Tag=0x00004018, Type=typing.Union[None, Nullable, float]),
-                ClusterObjectFieldDescriptor(Label="nullableOctetString", Tag=0x00004019, Type=typing.Union[None, Nullable, bytes]),
-                ClusterObjectFieldDescriptor(Label="nullableCharString", Tag=0x0000401E, Type=typing.Union[None, Nullable, str]),
-                ClusterObjectFieldDescriptor(Label="nullableEnumAttr", Tag=0x00004024, Type=typing.Union[None, Nullable, TestCluster.Enums.SimpleEnum]),
-                ClusterObjectFieldDescriptor(Label="nullableStruct", Tag=0x00004025, Type=typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]),
-                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt8u", Tag=0x00004026, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt8s", Tag=0x00004027, Type=typing.Union[None, Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt16u", Tag=0x00004028, Type=typing.Union[None, Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt16s", Tag=0x00004029, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableBoolean", Tag=0x00004000, Type=typing.Union[Nullable, bool]),
+                ClusterObjectFieldDescriptor(Label="nullableBitmap8", Tag=0x00004001, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableBitmap16", Tag=0x00004002, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableBitmap32", Tag=0x00004003, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableBitmap64", Tag=0x00004004, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt8u", Tag=0x00004005, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt16u", Tag=0x00004006, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt24u", Tag=0x00004007, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt32u", Tag=0x00004008, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt40u", Tag=0x00004009, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt48u", Tag=0x0000400A, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt56u", Tag=0x0000400B, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt64u", Tag=0x0000400C, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt8s", Tag=0x0000400D, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt16s", Tag=0x0000400E, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt24s", Tag=0x0000400F, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt32s", Tag=0x00004010, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt40s", Tag=0x00004011, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt48s", Tag=0x00004012, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt56s", Tag=0x00004013, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt64s", Tag=0x00004014, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableEnum8", Tag=0x00004015, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableEnum16", Tag=0x00004016, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableFloatSingle", Tag=0x00004017, Type=typing.Union[Nullable, float32]),
+                ClusterObjectFieldDescriptor(Label="nullableFloatDouble", Tag=0x00004018, Type=typing.Union[Nullable, float]),
+                ClusterObjectFieldDescriptor(Label="nullableOctetString", Tag=0x00004019, Type=typing.Union[Nullable, bytes]),
+                ClusterObjectFieldDescriptor(Label="nullableCharString", Tag=0x0000401E, Type=typing.Union[Nullable, str]),
+                ClusterObjectFieldDescriptor(Label="nullableEnumAttr", Tag=0x00004024, Type=typing.Union[Nullable, TestCluster.Enums.SimpleEnum]),
+                ClusterObjectFieldDescriptor(Label="nullableStruct", Tag=0x00004025, Type=typing.Union[Nullable, TestCluster.Structs.SimpleStruct]),
+                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt8u", Tag=0x00004026, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt8s", Tag=0x00004027, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt16u", Tag=0x00004028, Type=typing.Union[Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt16s", Tag=0x00004029, Type=typing.Union[Nullable, int]),
                 ClusterObjectFieldDescriptor(Label="generatedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="acceptedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="attributeList", Tag=0x0000FFFB, Type=typing.List[uint]),
@@ -34002,87 +34002,87 @@ class TestCluster(Cluster):
                 ClusterObjectFieldDescriptor(Label="clusterRevision", Tag=0x0000FFFD, Type=uint),
             ])
 
-    boolean: 'typing.Optional[bool]' = None
-    bitmap8: 'typing.Optional[uint]' = None
-    bitmap16: 'typing.Optional[uint]' = None
-    bitmap32: 'typing.Optional[uint]' = None
-    bitmap64: 'typing.Optional[uint]' = None
-    int8u: 'typing.Optional[uint]' = None
-    int16u: 'typing.Optional[uint]' = None
-    int24u: 'typing.Optional[uint]' = None
-    int32u: 'typing.Optional[uint]' = None
-    int40u: 'typing.Optional[uint]' = None
-    int48u: 'typing.Optional[uint]' = None
-    int56u: 'typing.Optional[uint]' = None
-    int64u: 'typing.Optional[uint]' = None
-    int8s: 'typing.Optional[int]' = None
-    int16s: 'typing.Optional[int]' = None
-    int24s: 'typing.Optional[int]' = None
-    int32s: 'typing.Optional[int]' = None
-    int40s: 'typing.Optional[int]' = None
-    int48s: 'typing.Optional[int]' = None
-    int56s: 'typing.Optional[int]' = None
-    int64s: 'typing.Optional[int]' = None
-    enum8: 'typing.Optional[uint]' = None
-    enum16: 'typing.Optional[uint]' = None
-    floatSingle: 'typing.Optional[float32]' = None
-    floatDouble: 'typing.Optional[float]' = None
-    octetString: 'typing.Optional[bytes]' = None
-    listInt8u: 'typing.Optional[typing.List[uint]]' = None
-    listOctetString: 'typing.Optional[typing.List[bytes]]' = None
-    listStructOctetString: 'typing.Optional[typing.List[TestCluster.Structs.TestListStructOctet]]' = None
-    longOctetString: 'typing.Optional[bytes]' = None
-    charString: 'typing.Optional[str]' = None
-    longCharString: 'typing.Optional[str]' = None
-    epochUs: 'typing.Optional[uint]' = None
-    epochS: 'typing.Optional[uint]' = None
-    vendorId: 'typing.Optional[uint]' = None
-    listNullablesAndOptionalsStruct: 'typing.Optional[typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]]' = None
-    enumAttr: 'typing.Optional[TestCluster.Enums.SimpleEnum]' = None
-    structAttr: 'typing.Optional[TestCluster.Structs.SimpleStruct]' = None
-    rangeRestrictedInt8u: 'typing.Optional[uint]' = None
-    rangeRestrictedInt8s: 'typing.Optional[int]' = None
-    rangeRestrictedInt16u: 'typing.Optional[uint]' = None
-    rangeRestrictedInt16s: 'typing.Optional[int]' = None
-    listLongOctetString: 'typing.Optional[typing.List[bytes]]' = None
-    listFabricScoped: 'typing.Optional[typing.List[TestCluster.Structs.TestFabricScoped]]' = None
+    boolean: 'bool' = None
+    bitmap8: 'uint' = None
+    bitmap16: 'uint' = None
+    bitmap32: 'uint' = None
+    bitmap64: 'uint' = None
+    int8u: 'uint' = None
+    int16u: 'uint' = None
+    int24u: 'uint' = None
+    int32u: 'uint' = None
+    int40u: 'uint' = None
+    int48u: 'uint' = None
+    int56u: 'uint' = None
+    int64u: 'uint' = None
+    int8s: 'int' = None
+    int16s: 'int' = None
+    int24s: 'int' = None
+    int32s: 'int' = None
+    int40s: 'int' = None
+    int48s: 'int' = None
+    int56s: 'int' = None
+    int64s: 'int' = None
+    enum8: 'uint' = None
+    enum16: 'uint' = None
+    floatSingle: 'float32' = None
+    floatDouble: 'float' = None
+    octetString: 'bytes' = None
+    listInt8u: 'typing.List[uint]' = None
+    listOctetString: 'typing.List[bytes]' = None
+    listStructOctetString: 'typing.List[TestCluster.Structs.TestListStructOctet]' = None
+    longOctetString: 'bytes' = None
+    charString: 'str' = None
+    longCharString: 'str' = None
+    epochUs: 'uint' = None
+    epochS: 'uint' = None
+    vendorId: 'uint' = None
+    listNullablesAndOptionalsStruct: 'typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]' = None
+    enumAttr: 'TestCluster.Enums.SimpleEnum' = None
+    structAttr: 'TestCluster.Structs.SimpleStruct' = None
+    rangeRestrictedInt8u: 'uint' = None
+    rangeRestrictedInt8s: 'int' = None
+    rangeRestrictedInt16u: 'uint' = None
+    rangeRestrictedInt16s: 'int' = None
+    listLongOctetString: 'typing.List[bytes]' = None
+    listFabricScoped: 'typing.List[TestCluster.Structs.TestFabricScoped]' = None
     timedWriteBoolean: 'bool' = None
-    generalErrorBoolean: 'typing.Optional[bool]' = None
-    clusterErrorBoolean: 'typing.Optional[bool]' = None
+    generalErrorBoolean: 'bool' = None
+    clusterErrorBoolean: 'bool' = None
     unsupported: 'typing.Optional[bool]' = None
-    nullableBoolean: 'typing.Union[None, Nullable, bool]' = None
-    nullableBitmap8: 'typing.Union[None, Nullable, uint]' = None
-    nullableBitmap16: 'typing.Union[None, Nullable, uint]' = None
-    nullableBitmap32: 'typing.Union[None, Nullable, uint]' = None
-    nullableBitmap64: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt8u: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt16u: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt24u: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt32u: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt40u: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt48u: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt56u: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt64u: 'typing.Union[None, Nullable, uint]' = None
-    nullableInt8s: 'typing.Union[None, Nullable, int]' = None
-    nullableInt16s: 'typing.Union[None, Nullable, int]' = None
-    nullableInt24s: 'typing.Union[None, Nullable, int]' = None
-    nullableInt32s: 'typing.Union[None, Nullable, int]' = None
-    nullableInt40s: 'typing.Union[None, Nullable, int]' = None
-    nullableInt48s: 'typing.Union[None, Nullable, int]' = None
-    nullableInt56s: 'typing.Union[None, Nullable, int]' = None
-    nullableInt64s: 'typing.Union[None, Nullable, int]' = None
-    nullableEnum8: 'typing.Union[None, Nullable, uint]' = None
-    nullableEnum16: 'typing.Union[None, Nullable, uint]' = None
-    nullableFloatSingle: 'typing.Union[None, Nullable, float32]' = None
-    nullableFloatDouble: 'typing.Union[None, Nullable, float]' = None
-    nullableOctetString: 'typing.Union[None, Nullable, bytes]' = None
-    nullableCharString: 'typing.Union[None, Nullable, str]' = None
-    nullableEnumAttr: 'typing.Union[None, Nullable, TestCluster.Enums.SimpleEnum]' = None
-    nullableStruct: 'typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]' = None
-    nullableRangeRestrictedInt8u: 'typing.Union[None, Nullable, uint]' = None
-    nullableRangeRestrictedInt8s: 'typing.Union[None, Nullable, int]' = None
-    nullableRangeRestrictedInt16u: 'typing.Union[None, Nullable, uint]' = None
-    nullableRangeRestrictedInt16s: 'typing.Union[None, Nullable, int]' = None
+    nullableBoolean: 'typing.Union[Nullable, bool]' = None
+    nullableBitmap8: 'typing.Union[Nullable, uint]' = None
+    nullableBitmap16: 'typing.Union[Nullable, uint]' = None
+    nullableBitmap32: 'typing.Union[Nullable, uint]' = None
+    nullableBitmap64: 'typing.Union[Nullable, uint]' = None
+    nullableInt8u: 'typing.Union[Nullable, uint]' = None
+    nullableInt16u: 'typing.Union[Nullable, uint]' = None
+    nullableInt24u: 'typing.Union[Nullable, uint]' = None
+    nullableInt32u: 'typing.Union[Nullable, uint]' = None
+    nullableInt40u: 'typing.Union[Nullable, uint]' = None
+    nullableInt48u: 'typing.Union[Nullable, uint]' = None
+    nullableInt56u: 'typing.Union[Nullable, uint]' = None
+    nullableInt64u: 'typing.Union[Nullable, uint]' = None
+    nullableInt8s: 'typing.Union[Nullable, int]' = None
+    nullableInt16s: 'typing.Union[Nullable, int]' = None
+    nullableInt24s: 'typing.Union[Nullable, int]' = None
+    nullableInt32s: 'typing.Union[Nullable, int]' = None
+    nullableInt40s: 'typing.Union[Nullable, int]' = None
+    nullableInt48s: 'typing.Union[Nullable, int]' = None
+    nullableInt56s: 'typing.Union[Nullable, int]' = None
+    nullableInt64s: 'typing.Union[Nullable, int]' = None
+    nullableEnum8: 'typing.Union[Nullable, uint]' = None
+    nullableEnum16: 'typing.Union[Nullable, uint]' = None
+    nullableFloatSingle: 'typing.Union[Nullable, float32]' = None
+    nullableFloatDouble: 'typing.Union[Nullable, float]' = None
+    nullableOctetString: 'typing.Union[Nullable, bytes]' = None
+    nullableCharString: 'typing.Union[Nullable, str]' = None
+    nullableEnumAttr: 'typing.Union[Nullable, TestCluster.Enums.SimpleEnum]' = None
+    nullableStruct: 'typing.Union[Nullable, TestCluster.Structs.SimpleStruct]' = None
+    nullableRangeRestrictedInt8u: 'typing.Union[Nullable, uint]' = None
+    nullableRangeRestrictedInt8s: 'typing.Union[Nullable, int]' = None
+    nullableRangeRestrictedInt16u: 'typing.Union[Nullable, uint]' = None
+    nullableRangeRestrictedInt16s: 'typing.Union[Nullable, int]' = None
     generatedCommandList: 'typing.List[uint]' = None
     acceptedCommandList: 'typing.List[uint]' = None
     attributeList: 'typing.List[uint]' = None
@@ -34876,9 +34876,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[bool])
+                return ClusterObjectFieldDescriptor(Type=bool)
 
-            value: 'typing.Optional[bool]' = None
+            value: 'bool' = False
 
         @dataclass
         class Bitmap8(ClusterAttributeDescriptor):
@@ -34892,9 +34892,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Bitmap16(ClusterAttributeDescriptor):
@@ -34908,9 +34908,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Bitmap32(ClusterAttributeDescriptor):
@@ -34924,9 +34924,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Bitmap64(ClusterAttributeDescriptor):
@@ -34940,9 +34940,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int8u(ClusterAttributeDescriptor):
@@ -34956,9 +34956,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int16u(ClusterAttributeDescriptor):
@@ -34972,9 +34972,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int24u(ClusterAttributeDescriptor):
@@ -34988,9 +34988,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int32u(ClusterAttributeDescriptor):
@@ -35004,9 +35004,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int40u(ClusterAttributeDescriptor):
@@ -35020,9 +35020,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int48u(ClusterAttributeDescriptor):
@@ -35036,9 +35036,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int56u(ClusterAttributeDescriptor):
@@ -35052,9 +35052,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int64u(ClusterAttributeDescriptor):
@@ -35068,9 +35068,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Int8s(ClusterAttributeDescriptor):
@@ -35084,9 +35084,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class Int16s(ClusterAttributeDescriptor):
@@ -35100,9 +35100,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class Int24s(ClusterAttributeDescriptor):
@@ -35116,9 +35116,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class Int32s(ClusterAttributeDescriptor):
@@ -35132,9 +35132,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class Int40s(ClusterAttributeDescriptor):
@@ -35148,9 +35148,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class Int48s(ClusterAttributeDescriptor):
@@ -35164,9 +35164,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class Int56s(ClusterAttributeDescriptor):
@@ -35180,9 +35180,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class Int64s(ClusterAttributeDescriptor):
@@ -35196,9 +35196,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class Enum8(ClusterAttributeDescriptor):
@@ -35212,9 +35212,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class Enum16(ClusterAttributeDescriptor):
@@ -35228,9 +35228,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class FloatSingle(ClusterAttributeDescriptor):
@@ -35244,9 +35244,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[float32])
+                return ClusterObjectFieldDescriptor(Type=float32)
 
-            value: 'typing.Optional[float32]' = None
+            value: 'float32' = 0.0
 
         @dataclass
         class FloatDouble(ClusterAttributeDescriptor):
@@ -35260,9 +35260,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[float])
+                return ClusterObjectFieldDescriptor(Type=float)
 
-            value: 'typing.Optional[float]' = None
+            value: 'float' = 0.0
 
         @dataclass
         class OctetString(ClusterAttributeDescriptor):
@@ -35276,9 +35276,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[bytes])
+                return ClusterObjectFieldDescriptor(Type=bytes)
 
-            value: 'typing.Optional[bytes]' = None
+            value: 'bytes' = b""
 
         @dataclass
         class ListInt8u(ClusterAttributeDescriptor):
@@ -35292,9 +35292,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[uint]])
+                return ClusterObjectFieldDescriptor(Type=typing.List[uint])
 
-            value: 'typing.Optional[typing.List[uint]]' = None
+            value: 'typing.List[uint]' = field(default_factory=lambda: [])
 
         @dataclass
         class ListOctetString(ClusterAttributeDescriptor):
@@ -35308,9 +35308,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[bytes]])
+                return ClusterObjectFieldDescriptor(Type=typing.List[bytes])
 
-            value: 'typing.Optional[typing.List[bytes]]' = None
+            value: 'typing.List[bytes]' = field(default_factory=lambda: [])
 
         @dataclass
         class ListStructOctetString(ClusterAttributeDescriptor):
@@ -35324,9 +35324,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[TestCluster.Structs.TestListStructOctet]])
+                return ClusterObjectFieldDescriptor(Type=typing.List[TestCluster.Structs.TestListStructOctet])
 
-            value: 'typing.Optional[typing.List[TestCluster.Structs.TestListStructOctet]]' = None
+            value: 'typing.List[TestCluster.Structs.TestListStructOctet]' = field(default_factory=lambda: [])
 
         @dataclass
         class LongOctetString(ClusterAttributeDescriptor):
@@ -35340,9 +35340,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[bytes])
+                return ClusterObjectFieldDescriptor(Type=bytes)
 
-            value: 'typing.Optional[bytes]' = None
+            value: 'bytes' = b""
 
         @dataclass
         class CharString(ClusterAttributeDescriptor):
@@ -35356,9 +35356,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[str])
+                return ClusterObjectFieldDescriptor(Type=str)
 
-            value: 'typing.Optional[str]' = None
+            value: 'str' = ""
 
         @dataclass
         class LongCharString(ClusterAttributeDescriptor):
@@ -35372,9 +35372,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[str])
+                return ClusterObjectFieldDescriptor(Type=str)
 
-            value: 'typing.Optional[str]' = None
+            value: 'str' = ""
 
         @dataclass
         class EpochUs(ClusterAttributeDescriptor):
@@ -35388,9 +35388,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class EpochS(ClusterAttributeDescriptor):
@@ -35404,9 +35404,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class VendorId(ClusterAttributeDescriptor):
@@ -35420,9 +35420,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class ListNullablesAndOptionalsStruct(ClusterAttributeDescriptor):
@@ -35436,9 +35436,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]])
+                return ClusterObjectFieldDescriptor(Type=typing.List[TestCluster.Structs.NullablesAndOptionalsStruct])
 
-            value: 'typing.Optional[typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]]' = None
+            value: 'typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]' = field(default_factory=lambda: [])
 
         @dataclass
         class EnumAttr(ClusterAttributeDescriptor):
@@ -35452,9 +35452,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[TestCluster.Enums.SimpleEnum])
+                return ClusterObjectFieldDescriptor(Type=TestCluster.Enums.SimpleEnum)
 
-            value: 'typing.Optional[TestCluster.Enums.SimpleEnum]' = None
+            value: 'TestCluster.Enums.SimpleEnum' = 0
 
         @dataclass
         class StructAttr(ClusterAttributeDescriptor):
@@ -35468,9 +35468,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[TestCluster.Structs.SimpleStruct])
+                return ClusterObjectFieldDescriptor(Type=TestCluster.Structs.SimpleStruct)
 
-            value: 'typing.Optional[TestCluster.Structs.SimpleStruct]' = None
+            value: 'TestCluster.Structs.SimpleStruct' = field(default_factory=lambda: TestCluster.Structs.SimpleStruct())
 
         @dataclass
         class RangeRestrictedInt8u(ClusterAttributeDescriptor):
@@ -35484,9 +35484,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class RangeRestrictedInt8s(ClusterAttributeDescriptor):
@@ -35500,9 +35500,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class RangeRestrictedInt16u(ClusterAttributeDescriptor):
@@ -35516,9 +35516,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
+                return ClusterObjectFieldDescriptor(Type=uint)
 
-            value: 'typing.Optional[uint]' = None
+            value: 'uint' = 0
 
         @dataclass
         class RangeRestrictedInt16s(ClusterAttributeDescriptor):
@@ -35532,9 +35532,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
+                return ClusterObjectFieldDescriptor(Type=int)
 
-            value: 'typing.Optional[int]' = None
+            value: 'int' = 0
 
         @dataclass
         class ListLongOctetString(ClusterAttributeDescriptor):
@@ -35548,9 +35548,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[bytes]])
+                return ClusterObjectFieldDescriptor(Type=typing.List[bytes])
 
-            value: 'typing.Optional[typing.List[bytes]]' = None
+            value: 'typing.List[bytes]' = field(default_factory=lambda: [])
 
         @dataclass
         class ListFabricScoped(ClusterAttributeDescriptor):
@@ -35564,9 +35564,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[TestCluster.Structs.TestFabricScoped]])
+                return ClusterObjectFieldDescriptor(Type=typing.List[TestCluster.Structs.TestFabricScoped])
 
-            value: 'typing.Optional[typing.List[TestCluster.Structs.TestFabricScoped]]' = None
+            value: 'typing.List[TestCluster.Structs.TestFabricScoped]' = field(default_factory=lambda: [])
 
         @dataclass
         class TimedWriteBoolean(ClusterAttributeDescriptor):
@@ -35600,9 +35600,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[bool])
+                return ClusterObjectFieldDescriptor(Type=bool)
 
-            value: 'typing.Optional[bool]' = None
+            value: 'bool' = False
 
         @dataclass
         class ClusterErrorBoolean(ClusterAttributeDescriptor):
@@ -35616,9 +35616,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Optional[bool])
+                return ClusterObjectFieldDescriptor(Type=bool)
 
-            value: 'typing.Optional[bool]' = None
+            value: 'bool' = False
 
         @dataclass
         class Unsupported(ClusterAttributeDescriptor):
@@ -35648,9 +35648,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, bool])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, bool])
 
-            value: 'typing.Union[None, Nullable, bool]' = None
+            value: 'typing.Union[Nullable, bool]' = NullValue
 
         @dataclass
         class NullableBitmap8(ClusterAttributeDescriptor):
@@ -35664,9 +35664,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableBitmap16(ClusterAttributeDescriptor):
@@ -35680,9 +35680,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableBitmap32(ClusterAttributeDescriptor):
@@ -35696,9 +35696,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableBitmap64(ClusterAttributeDescriptor):
@@ -35712,9 +35712,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt8u(ClusterAttributeDescriptor):
@@ -35728,9 +35728,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt16u(ClusterAttributeDescriptor):
@@ -35744,9 +35744,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt24u(ClusterAttributeDescriptor):
@@ -35760,9 +35760,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt32u(ClusterAttributeDescriptor):
@@ -35776,9 +35776,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt40u(ClusterAttributeDescriptor):
@@ -35792,9 +35792,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt48u(ClusterAttributeDescriptor):
@@ -35808,9 +35808,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt56u(ClusterAttributeDescriptor):
@@ -35824,9 +35824,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt64u(ClusterAttributeDescriptor):
@@ -35840,9 +35840,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableInt8s(ClusterAttributeDescriptor):
@@ -35856,9 +35856,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableInt16s(ClusterAttributeDescriptor):
@@ -35872,9 +35872,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableInt24s(ClusterAttributeDescriptor):
@@ -35888,9 +35888,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableInt32s(ClusterAttributeDescriptor):
@@ -35904,9 +35904,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableInt40s(ClusterAttributeDescriptor):
@@ -35920,9 +35920,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableInt48s(ClusterAttributeDescriptor):
@@ -35936,9 +35936,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableInt56s(ClusterAttributeDescriptor):
@@ -35952,9 +35952,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableInt64s(ClusterAttributeDescriptor):
@@ -35968,9 +35968,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableEnum8(ClusterAttributeDescriptor):
@@ -35984,9 +35984,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableEnum16(ClusterAttributeDescriptor):
@@ -36000,9 +36000,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableFloatSingle(ClusterAttributeDescriptor):
@@ -36016,9 +36016,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, float32])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, float32])
 
-            value: 'typing.Union[None, Nullable, float32]' = None
+            value: 'typing.Union[Nullable, float32]' = NullValue
 
         @dataclass
         class NullableFloatDouble(ClusterAttributeDescriptor):
@@ -36032,9 +36032,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, float])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, float])
 
-            value: 'typing.Union[None, Nullable, float]' = None
+            value: 'typing.Union[Nullable, float]' = NullValue
 
         @dataclass
         class NullableOctetString(ClusterAttributeDescriptor):
@@ -36048,9 +36048,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, bytes])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, bytes])
 
-            value: 'typing.Union[None, Nullable, bytes]' = None
+            value: 'typing.Union[Nullable, bytes]' = NullValue
 
         @dataclass
         class NullableCharString(ClusterAttributeDescriptor):
@@ -36064,9 +36064,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, str])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, str])
 
-            value: 'typing.Union[None, Nullable, str]' = None
+            value: 'typing.Union[Nullable, str]' = NullValue
 
         @dataclass
         class NullableEnumAttr(ClusterAttributeDescriptor):
@@ -36080,9 +36080,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, TestCluster.Enums.SimpleEnum])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, TestCluster.Enums.SimpleEnum])
 
-            value: 'typing.Union[None, Nullable, TestCluster.Enums.SimpleEnum]' = None
+            value: 'typing.Union[Nullable, TestCluster.Enums.SimpleEnum]' = NullValue
 
         @dataclass
         class NullableStruct(ClusterAttributeDescriptor):
@@ -36096,9 +36096,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, TestCluster.Structs.SimpleStruct])
 
-            value: 'typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]' = None
+            value: 'typing.Union[Nullable, TestCluster.Structs.SimpleStruct]' = NullValue
 
         @dataclass
         class NullableRangeRestrictedInt8u(ClusterAttributeDescriptor):
@@ -36112,9 +36112,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableRangeRestrictedInt8s(ClusterAttributeDescriptor):
@@ -36128,9 +36128,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class NullableRangeRestrictedInt16u(ClusterAttributeDescriptor):
@@ -36144,9 +36144,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
 
-            value: 'typing.Union[None, Nullable, uint]' = None
+            value: 'typing.Union[Nullable, uint]' = NullValue
 
         @dataclass
         class NullableRangeRestrictedInt16s(ClusterAttributeDescriptor):
@@ -36160,9 +36160,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
 
-            value: 'typing.Union[None, Nullable, int]' = None
+            value: 'typing.Union[Nullable, int]' = NullValue
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor):

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -33914,87 +33914,87 @@ class TestCluster(Cluster):
     def descriptor(cls) -> ClusterObjectDescriptor:
         return ClusterObjectDescriptor(
             Fields = [
-                ClusterObjectFieldDescriptor(Label="boolean", Tag=0x00000000, Type=bool),
-                ClusterObjectFieldDescriptor(Label="bitmap8", Tag=0x00000001, Type=uint),
-                ClusterObjectFieldDescriptor(Label="bitmap16", Tag=0x00000002, Type=uint),
-                ClusterObjectFieldDescriptor(Label="bitmap32", Tag=0x00000003, Type=uint),
-                ClusterObjectFieldDescriptor(Label="bitmap64", Tag=0x00000004, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int8u", Tag=0x00000005, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int16u", Tag=0x00000006, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int24u", Tag=0x00000007, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int32u", Tag=0x00000008, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int40u", Tag=0x00000009, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int48u", Tag=0x0000000A, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int56u", Tag=0x0000000B, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int64u", Tag=0x0000000C, Type=uint),
-                ClusterObjectFieldDescriptor(Label="int8s", Tag=0x0000000D, Type=int),
-                ClusterObjectFieldDescriptor(Label="int16s", Tag=0x0000000E, Type=int),
-                ClusterObjectFieldDescriptor(Label="int24s", Tag=0x0000000F, Type=int),
-                ClusterObjectFieldDescriptor(Label="int32s", Tag=0x00000010, Type=int),
-                ClusterObjectFieldDescriptor(Label="int40s", Tag=0x00000011, Type=int),
-                ClusterObjectFieldDescriptor(Label="int48s", Tag=0x00000012, Type=int),
-                ClusterObjectFieldDescriptor(Label="int56s", Tag=0x00000013, Type=int),
-                ClusterObjectFieldDescriptor(Label="int64s", Tag=0x00000014, Type=int),
-                ClusterObjectFieldDescriptor(Label="enum8", Tag=0x00000015, Type=uint),
-                ClusterObjectFieldDescriptor(Label="enum16", Tag=0x00000016, Type=uint),
-                ClusterObjectFieldDescriptor(Label="floatSingle", Tag=0x00000017, Type=float32),
-                ClusterObjectFieldDescriptor(Label="floatDouble", Tag=0x00000018, Type=float),
-                ClusterObjectFieldDescriptor(Label="octetString", Tag=0x00000019, Type=bytes),
-                ClusterObjectFieldDescriptor(Label="listInt8u", Tag=0x0000001A, Type=typing.List[uint]),
-                ClusterObjectFieldDescriptor(Label="listOctetString", Tag=0x0000001B, Type=typing.List[bytes]),
-                ClusterObjectFieldDescriptor(Label="listStructOctetString", Tag=0x0000001C, Type=typing.List[TestCluster.Structs.TestListStructOctet]),
-                ClusterObjectFieldDescriptor(Label="longOctetString", Tag=0x0000001D, Type=bytes),
-                ClusterObjectFieldDescriptor(Label="charString", Tag=0x0000001E, Type=str),
-                ClusterObjectFieldDescriptor(Label="longCharString", Tag=0x0000001F, Type=str),
-                ClusterObjectFieldDescriptor(Label="epochUs", Tag=0x00000020, Type=uint),
-                ClusterObjectFieldDescriptor(Label="epochS", Tag=0x00000021, Type=uint),
-                ClusterObjectFieldDescriptor(Label="vendorId", Tag=0x00000022, Type=uint),
-                ClusterObjectFieldDescriptor(Label="listNullablesAndOptionalsStruct", Tag=0x00000023, Type=typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]),
-                ClusterObjectFieldDescriptor(Label="enumAttr", Tag=0x00000024, Type=TestCluster.Enums.SimpleEnum),
-                ClusterObjectFieldDescriptor(Label="structAttr", Tag=0x00000025, Type=TestCluster.Structs.SimpleStruct),
-                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt8u", Tag=0x00000026, Type=uint),
-                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt8s", Tag=0x00000027, Type=int),
-                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt16u", Tag=0x00000028, Type=uint),
-                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt16s", Tag=0x00000029, Type=int),
-                ClusterObjectFieldDescriptor(Label="listLongOctetString", Tag=0x0000002A, Type=typing.List[bytes]),
-                ClusterObjectFieldDescriptor(Label="listFabricScoped", Tag=0x0000002B, Type=typing.List[TestCluster.Structs.TestFabricScoped]),
+                ClusterObjectFieldDescriptor(Label="boolean", Tag=0x00000000, Type=typing.Optional[bool]),
+                ClusterObjectFieldDescriptor(Label="bitmap8", Tag=0x00000001, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="bitmap16", Tag=0x00000002, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="bitmap32", Tag=0x00000003, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="bitmap64", Tag=0x00000004, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int8u", Tag=0x00000005, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int16u", Tag=0x00000006, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int24u", Tag=0x00000007, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int32u", Tag=0x00000008, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int40u", Tag=0x00000009, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int48u", Tag=0x0000000A, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int56u", Tag=0x0000000B, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int64u", Tag=0x0000000C, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="int8s", Tag=0x0000000D, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="int16s", Tag=0x0000000E, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="int24s", Tag=0x0000000F, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="int32s", Tag=0x00000010, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="int40s", Tag=0x00000011, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="int48s", Tag=0x00000012, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="int56s", Tag=0x00000013, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="int64s", Tag=0x00000014, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="enum8", Tag=0x00000015, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="enum16", Tag=0x00000016, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="floatSingle", Tag=0x00000017, Type=typing.Optional[float32]),
+                ClusterObjectFieldDescriptor(Label="floatDouble", Tag=0x00000018, Type=typing.Optional[float]),
+                ClusterObjectFieldDescriptor(Label="octetString", Tag=0x00000019, Type=typing.Optional[bytes]),
+                ClusterObjectFieldDescriptor(Label="listInt8u", Tag=0x0000001A, Type=typing.Optional[typing.List[uint]]),
+                ClusterObjectFieldDescriptor(Label="listOctetString", Tag=0x0000001B, Type=typing.Optional[typing.List[bytes]]),
+                ClusterObjectFieldDescriptor(Label="listStructOctetString", Tag=0x0000001C, Type=typing.Optional[typing.List[TestCluster.Structs.TestListStructOctet]]),
+                ClusterObjectFieldDescriptor(Label="longOctetString", Tag=0x0000001D, Type=typing.Optional[bytes]),
+                ClusterObjectFieldDescriptor(Label="charString", Tag=0x0000001E, Type=typing.Optional[str]),
+                ClusterObjectFieldDescriptor(Label="longCharString", Tag=0x0000001F, Type=typing.Optional[str]),
+                ClusterObjectFieldDescriptor(Label="epochUs", Tag=0x00000020, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="epochS", Tag=0x00000021, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="vendorId", Tag=0x00000022, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="listNullablesAndOptionalsStruct", Tag=0x00000023, Type=typing.Optional[typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]]),
+                ClusterObjectFieldDescriptor(Label="enumAttr", Tag=0x00000024, Type=typing.Optional[TestCluster.Enums.SimpleEnum]),
+                ClusterObjectFieldDescriptor(Label="structAttr", Tag=0x00000025, Type=typing.Optional[TestCluster.Structs.SimpleStruct]),
+                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt8u", Tag=0x00000026, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt8s", Tag=0x00000027, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt16u", Tag=0x00000028, Type=typing.Optional[uint]),
+                ClusterObjectFieldDescriptor(Label="rangeRestrictedInt16s", Tag=0x00000029, Type=typing.Optional[int]),
+                ClusterObjectFieldDescriptor(Label="listLongOctetString", Tag=0x0000002A, Type=typing.Optional[typing.List[bytes]]),
+                ClusterObjectFieldDescriptor(Label="listFabricScoped", Tag=0x0000002B, Type=typing.Optional[typing.List[TestCluster.Structs.TestFabricScoped]]),
                 ClusterObjectFieldDescriptor(Label="timedWriteBoolean", Tag=0x00000030, Type=bool),
-                ClusterObjectFieldDescriptor(Label="generalErrorBoolean", Tag=0x00000031, Type=bool),
-                ClusterObjectFieldDescriptor(Label="clusterErrorBoolean", Tag=0x00000032, Type=bool),
-                ClusterObjectFieldDescriptor(Label="unsupported", Tag=0x000000FF, Type=bool),
-                ClusterObjectFieldDescriptor(Label="nullableBoolean", Tag=0x00004000, Type=typing.Union[Nullable, bool]),
-                ClusterObjectFieldDescriptor(Label="nullableBitmap8", Tag=0x00004001, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableBitmap16", Tag=0x00004002, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableBitmap32", Tag=0x00004003, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableBitmap64", Tag=0x00004004, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt8u", Tag=0x00004005, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt16u", Tag=0x00004006, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt24u", Tag=0x00004007, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt32u", Tag=0x00004008, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt40u", Tag=0x00004009, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt48u", Tag=0x0000400A, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt56u", Tag=0x0000400B, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt64u", Tag=0x0000400C, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableInt8s", Tag=0x0000400D, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt16s", Tag=0x0000400E, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt24s", Tag=0x0000400F, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt32s", Tag=0x00004010, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt40s", Tag=0x00004011, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt48s", Tag=0x00004012, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt56s", Tag=0x00004013, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableInt64s", Tag=0x00004014, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableEnum8", Tag=0x00004015, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableEnum16", Tag=0x00004016, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableFloatSingle", Tag=0x00004017, Type=typing.Union[Nullable, float32]),
-                ClusterObjectFieldDescriptor(Label="nullableFloatDouble", Tag=0x00004018, Type=typing.Union[Nullable, float]),
-                ClusterObjectFieldDescriptor(Label="nullableOctetString", Tag=0x00004019, Type=typing.Union[Nullable, bytes]),
-                ClusterObjectFieldDescriptor(Label="nullableCharString", Tag=0x0000401E, Type=typing.Union[Nullable, str]),
-                ClusterObjectFieldDescriptor(Label="nullableEnumAttr", Tag=0x00004024, Type=typing.Union[Nullable, TestCluster.Enums.SimpleEnum]),
-                ClusterObjectFieldDescriptor(Label="nullableStruct", Tag=0x00004025, Type=typing.Union[Nullable, TestCluster.Structs.SimpleStruct]),
-                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt8u", Tag=0x00004026, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt8s", Tag=0x00004027, Type=typing.Union[Nullable, int]),
-                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt16u", Tag=0x00004028, Type=typing.Union[Nullable, uint]),
-                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt16s", Tag=0x00004029, Type=typing.Union[Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="generalErrorBoolean", Tag=0x00000031, Type=typing.Optional[bool]),
+                ClusterObjectFieldDescriptor(Label="clusterErrorBoolean", Tag=0x00000032, Type=typing.Optional[bool]),
+                ClusterObjectFieldDescriptor(Label="unsupported", Tag=0x000000FF, Type=typing.Optional[bool]),
+                ClusterObjectFieldDescriptor(Label="nullableBoolean", Tag=0x00004000, Type=typing.Union[None, Nullable, bool]),
+                ClusterObjectFieldDescriptor(Label="nullableBitmap8", Tag=0x00004001, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableBitmap16", Tag=0x00004002, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableBitmap32", Tag=0x00004003, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableBitmap64", Tag=0x00004004, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt8u", Tag=0x00004005, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt16u", Tag=0x00004006, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt24u", Tag=0x00004007, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt32u", Tag=0x00004008, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt40u", Tag=0x00004009, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt48u", Tag=0x0000400A, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt56u", Tag=0x0000400B, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt64u", Tag=0x0000400C, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableInt8s", Tag=0x0000400D, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt16s", Tag=0x0000400E, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt24s", Tag=0x0000400F, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt32s", Tag=0x00004010, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt40s", Tag=0x00004011, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt48s", Tag=0x00004012, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt56s", Tag=0x00004013, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableInt64s", Tag=0x00004014, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableEnum8", Tag=0x00004015, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableEnum16", Tag=0x00004016, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableFloatSingle", Tag=0x00004017, Type=typing.Union[None, Nullable, float32]),
+                ClusterObjectFieldDescriptor(Label="nullableFloatDouble", Tag=0x00004018, Type=typing.Union[None, Nullable, float]),
+                ClusterObjectFieldDescriptor(Label="nullableOctetString", Tag=0x00004019, Type=typing.Union[None, Nullable, bytes]),
+                ClusterObjectFieldDescriptor(Label="nullableCharString", Tag=0x0000401E, Type=typing.Union[None, Nullable, str]),
+                ClusterObjectFieldDescriptor(Label="nullableEnumAttr", Tag=0x00004024, Type=typing.Union[None, Nullable, TestCluster.Enums.SimpleEnum]),
+                ClusterObjectFieldDescriptor(Label="nullableStruct", Tag=0x00004025, Type=typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]),
+                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt8u", Tag=0x00004026, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt8s", Tag=0x00004027, Type=typing.Union[None, Nullable, int]),
+                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt16u", Tag=0x00004028, Type=typing.Union[None, Nullable, uint]),
+                ClusterObjectFieldDescriptor(Label="nullableRangeRestrictedInt16s", Tag=0x00004029, Type=typing.Union[None, Nullable, int]),
                 ClusterObjectFieldDescriptor(Label="generatedCommandList", Tag=0x0000FFF8, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="acceptedCommandList", Tag=0x0000FFF9, Type=typing.List[uint]),
                 ClusterObjectFieldDescriptor(Label="attributeList", Tag=0x0000FFFB, Type=typing.List[uint]),
@@ -34002,87 +34002,87 @@ class TestCluster(Cluster):
                 ClusterObjectFieldDescriptor(Label="clusterRevision", Tag=0x0000FFFD, Type=uint),
             ])
 
-    boolean: 'bool' = None
-    bitmap8: 'uint' = None
-    bitmap16: 'uint' = None
-    bitmap32: 'uint' = None
-    bitmap64: 'uint' = None
-    int8u: 'uint' = None
-    int16u: 'uint' = None
-    int24u: 'uint' = None
-    int32u: 'uint' = None
-    int40u: 'uint' = None
-    int48u: 'uint' = None
-    int56u: 'uint' = None
-    int64u: 'uint' = None
-    int8s: 'int' = None
-    int16s: 'int' = None
-    int24s: 'int' = None
-    int32s: 'int' = None
-    int40s: 'int' = None
-    int48s: 'int' = None
-    int56s: 'int' = None
-    int64s: 'int' = None
-    enum8: 'uint' = None
-    enum16: 'uint' = None
-    floatSingle: 'float32' = None
-    floatDouble: 'float' = None
-    octetString: 'bytes' = None
-    listInt8u: 'typing.List[uint]' = None
-    listOctetString: 'typing.List[bytes]' = None
-    listStructOctetString: 'typing.List[TestCluster.Structs.TestListStructOctet]' = None
-    longOctetString: 'bytes' = None
-    charString: 'str' = None
-    longCharString: 'str' = None
-    epochUs: 'uint' = None
-    epochS: 'uint' = None
-    vendorId: 'uint' = None
-    listNullablesAndOptionalsStruct: 'typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]' = None
-    enumAttr: 'TestCluster.Enums.SimpleEnum' = None
-    structAttr: 'TestCluster.Structs.SimpleStruct' = None
-    rangeRestrictedInt8u: 'uint' = None
-    rangeRestrictedInt8s: 'int' = None
-    rangeRestrictedInt16u: 'uint' = None
-    rangeRestrictedInt16s: 'int' = None
-    listLongOctetString: 'typing.List[bytes]' = None
-    listFabricScoped: 'typing.List[TestCluster.Structs.TestFabricScoped]' = None
+    boolean: 'typing.Optional[bool]' = None
+    bitmap8: 'typing.Optional[uint]' = None
+    bitmap16: 'typing.Optional[uint]' = None
+    bitmap32: 'typing.Optional[uint]' = None
+    bitmap64: 'typing.Optional[uint]' = None
+    int8u: 'typing.Optional[uint]' = None
+    int16u: 'typing.Optional[uint]' = None
+    int24u: 'typing.Optional[uint]' = None
+    int32u: 'typing.Optional[uint]' = None
+    int40u: 'typing.Optional[uint]' = None
+    int48u: 'typing.Optional[uint]' = None
+    int56u: 'typing.Optional[uint]' = None
+    int64u: 'typing.Optional[uint]' = None
+    int8s: 'typing.Optional[int]' = None
+    int16s: 'typing.Optional[int]' = None
+    int24s: 'typing.Optional[int]' = None
+    int32s: 'typing.Optional[int]' = None
+    int40s: 'typing.Optional[int]' = None
+    int48s: 'typing.Optional[int]' = None
+    int56s: 'typing.Optional[int]' = None
+    int64s: 'typing.Optional[int]' = None
+    enum8: 'typing.Optional[uint]' = None
+    enum16: 'typing.Optional[uint]' = None
+    floatSingle: 'typing.Optional[float32]' = None
+    floatDouble: 'typing.Optional[float]' = None
+    octetString: 'typing.Optional[bytes]' = None
+    listInt8u: 'typing.Optional[typing.List[uint]]' = None
+    listOctetString: 'typing.Optional[typing.List[bytes]]' = None
+    listStructOctetString: 'typing.Optional[typing.List[TestCluster.Structs.TestListStructOctet]]' = None
+    longOctetString: 'typing.Optional[bytes]' = None
+    charString: 'typing.Optional[str]' = None
+    longCharString: 'typing.Optional[str]' = None
+    epochUs: 'typing.Optional[uint]' = None
+    epochS: 'typing.Optional[uint]' = None
+    vendorId: 'typing.Optional[uint]' = None
+    listNullablesAndOptionalsStruct: 'typing.Optional[typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]]' = None
+    enumAttr: 'typing.Optional[TestCluster.Enums.SimpleEnum]' = None
+    structAttr: 'typing.Optional[TestCluster.Structs.SimpleStruct]' = None
+    rangeRestrictedInt8u: 'typing.Optional[uint]' = None
+    rangeRestrictedInt8s: 'typing.Optional[int]' = None
+    rangeRestrictedInt16u: 'typing.Optional[uint]' = None
+    rangeRestrictedInt16s: 'typing.Optional[int]' = None
+    listLongOctetString: 'typing.Optional[typing.List[bytes]]' = None
+    listFabricScoped: 'typing.Optional[typing.List[TestCluster.Structs.TestFabricScoped]]' = None
     timedWriteBoolean: 'bool' = None
-    generalErrorBoolean: 'bool' = None
-    clusterErrorBoolean: 'bool' = None
-    unsupported: 'bool' = None
-    nullableBoolean: 'typing.Union[Nullable, bool]' = None
-    nullableBitmap8: 'typing.Union[Nullable, uint]' = None
-    nullableBitmap16: 'typing.Union[Nullable, uint]' = None
-    nullableBitmap32: 'typing.Union[Nullable, uint]' = None
-    nullableBitmap64: 'typing.Union[Nullable, uint]' = None
-    nullableInt8u: 'typing.Union[Nullable, uint]' = None
-    nullableInt16u: 'typing.Union[Nullable, uint]' = None
-    nullableInt24u: 'typing.Union[Nullable, uint]' = None
-    nullableInt32u: 'typing.Union[Nullable, uint]' = None
-    nullableInt40u: 'typing.Union[Nullable, uint]' = None
-    nullableInt48u: 'typing.Union[Nullable, uint]' = None
-    nullableInt56u: 'typing.Union[Nullable, uint]' = None
-    nullableInt64u: 'typing.Union[Nullable, uint]' = None
-    nullableInt8s: 'typing.Union[Nullable, int]' = None
-    nullableInt16s: 'typing.Union[Nullable, int]' = None
-    nullableInt24s: 'typing.Union[Nullable, int]' = None
-    nullableInt32s: 'typing.Union[Nullable, int]' = None
-    nullableInt40s: 'typing.Union[Nullable, int]' = None
-    nullableInt48s: 'typing.Union[Nullable, int]' = None
-    nullableInt56s: 'typing.Union[Nullable, int]' = None
-    nullableInt64s: 'typing.Union[Nullable, int]' = None
-    nullableEnum8: 'typing.Union[Nullable, uint]' = None
-    nullableEnum16: 'typing.Union[Nullable, uint]' = None
-    nullableFloatSingle: 'typing.Union[Nullable, float32]' = None
-    nullableFloatDouble: 'typing.Union[Nullable, float]' = None
-    nullableOctetString: 'typing.Union[Nullable, bytes]' = None
-    nullableCharString: 'typing.Union[Nullable, str]' = None
-    nullableEnumAttr: 'typing.Union[Nullable, TestCluster.Enums.SimpleEnum]' = None
-    nullableStruct: 'typing.Union[Nullable, TestCluster.Structs.SimpleStruct]' = None
-    nullableRangeRestrictedInt8u: 'typing.Union[Nullable, uint]' = None
-    nullableRangeRestrictedInt8s: 'typing.Union[Nullable, int]' = None
-    nullableRangeRestrictedInt16u: 'typing.Union[Nullable, uint]' = None
-    nullableRangeRestrictedInt16s: 'typing.Union[Nullable, int]' = None
+    generalErrorBoolean: 'typing.Optional[bool]' = None
+    clusterErrorBoolean: 'typing.Optional[bool]' = None
+    unsupported: 'typing.Optional[bool]' = None
+    nullableBoolean: 'typing.Union[None, Nullable, bool]' = None
+    nullableBitmap8: 'typing.Union[None, Nullable, uint]' = None
+    nullableBitmap16: 'typing.Union[None, Nullable, uint]' = None
+    nullableBitmap32: 'typing.Union[None, Nullable, uint]' = None
+    nullableBitmap64: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt8u: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt16u: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt24u: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt32u: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt40u: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt48u: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt56u: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt64u: 'typing.Union[None, Nullable, uint]' = None
+    nullableInt8s: 'typing.Union[None, Nullable, int]' = None
+    nullableInt16s: 'typing.Union[None, Nullable, int]' = None
+    nullableInt24s: 'typing.Union[None, Nullable, int]' = None
+    nullableInt32s: 'typing.Union[None, Nullable, int]' = None
+    nullableInt40s: 'typing.Union[None, Nullable, int]' = None
+    nullableInt48s: 'typing.Union[None, Nullable, int]' = None
+    nullableInt56s: 'typing.Union[None, Nullable, int]' = None
+    nullableInt64s: 'typing.Union[None, Nullable, int]' = None
+    nullableEnum8: 'typing.Union[None, Nullable, uint]' = None
+    nullableEnum16: 'typing.Union[None, Nullable, uint]' = None
+    nullableFloatSingle: 'typing.Union[None, Nullable, float32]' = None
+    nullableFloatDouble: 'typing.Union[None, Nullable, float]' = None
+    nullableOctetString: 'typing.Union[None, Nullable, bytes]' = None
+    nullableCharString: 'typing.Union[None, Nullable, str]' = None
+    nullableEnumAttr: 'typing.Union[None, Nullable, TestCluster.Enums.SimpleEnum]' = None
+    nullableStruct: 'typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]' = None
+    nullableRangeRestrictedInt8u: 'typing.Union[None, Nullable, uint]' = None
+    nullableRangeRestrictedInt8s: 'typing.Union[None, Nullable, int]' = None
+    nullableRangeRestrictedInt16u: 'typing.Union[None, Nullable, uint]' = None
+    nullableRangeRestrictedInt16s: 'typing.Union[None, Nullable, int]' = None
     generatedCommandList: 'typing.List[uint]' = None
     acceptedCommandList: 'typing.List[uint]' = None
     attributeList: 'typing.List[uint]' = None
@@ -34876,9 +34876,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=bool)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[bool])
 
-            value: 'bool' = False
+            value: 'typing.Optional[bool]' = None
 
         @dataclass
         class Bitmap8(ClusterAttributeDescriptor):
@@ -34892,9 +34892,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Bitmap16(ClusterAttributeDescriptor):
@@ -34908,9 +34908,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Bitmap32(ClusterAttributeDescriptor):
@@ -34924,9 +34924,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Bitmap64(ClusterAttributeDescriptor):
@@ -34940,9 +34940,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int8u(ClusterAttributeDescriptor):
@@ -34956,9 +34956,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int16u(ClusterAttributeDescriptor):
@@ -34972,9 +34972,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int24u(ClusterAttributeDescriptor):
@@ -34988,9 +34988,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int32u(ClusterAttributeDescriptor):
@@ -35004,9 +35004,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int40u(ClusterAttributeDescriptor):
@@ -35020,9 +35020,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int48u(ClusterAttributeDescriptor):
@@ -35036,9 +35036,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int56u(ClusterAttributeDescriptor):
@@ -35052,9 +35052,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int64u(ClusterAttributeDescriptor):
@@ -35068,9 +35068,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Int8s(ClusterAttributeDescriptor):
@@ -35084,9 +35084,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class Int16s(ClusterAttributeDescriptor):
@@ -35100,9 +35100,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class Int24s(ClusterAttributeDescriptor):
@@ -35116,9 +35116,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class Int32s(ClusterAttributeDescriptor):
@@ -35132,9 +35132,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class Int40s(ClusterAttributeDescriptor):
@@ -35148,9 +35148,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class Int48s(ClusterAttributeDescriptor):
@@ -35164,9 +35164,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class Int56s(ClusterAttributeDescriptor):
@@ -35180,9 +35180,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class Int64s(ClusterAttributeDescriptor):
@@ -35196,9 +35196,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class Enum8(ClusterAttributeDescriptor):
@@ -35212,9 +35212,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class Enum16(ClusterAttributeDescriptor):
@@ -35228,9 +35228,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class FloatSingle(ClusterAttributeDescriptor):
@@ -35244,9 +35244,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=float32)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[float32])
 
-            value: 'float32' = 0.0
+            value: 'typing.Optional[float32]' = None
 
         @dataclass
         class FloatDouble(ClusterAttributeDescriptor):
@@ -35260,9 +35260,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=float)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[float])
 
-            value: 'float' = 0.0
+            value: 'typing.Optional[float]' = None
 
         @dataclass
         class OctetString(ClusterAttributeDescriptor):
@@ -35276,9 +35276,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=bytes)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[bytes])
 
-            value: 'bytes' = b""
+            value: 'typing.Optional[bytes]' = None
 
         @dataclass
         class ListInt8u(ClusterAttributeDescriptor):
@@ -35292,9 +35292,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.List[uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[uint]])
 
-            value: 'typing.List[uint]' = field(default_factory=lambda: [])
+            value: 'typing.Optional[typing.List[uint]]' = None
 
         @dataclass
         class ListOctetString(ClusterAttributeDescriptor):
@@ -35308,9 +35308,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.List[bytes])
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[bytes]])
 
-            value: 'typing.List[bytes]' = field(default_factory=lambda: [])
+            value: 'typing.Optional[typing.List[bytes]]' = None
 
         @dataclass
         class ListStructOctetString(ClusterAttributeDescriptor):
@@ -35324,9 +35324,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.List[TestCluster.Structs.TestListStructOctet])
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[TestCluster.Structs.TestListStructOctet]])
 
-            value: 'typing.List[TestCluster.Structs.TestListStructOctet]' = field(default_factory=lambda: [])
+            value: 'typing.Optional[typing.List[TestCluster.Structs.TestListStructOctet]]' = None
 
         @dataclass
         class LongOctetString(ClusterAttributeDescriptor):
@@ -35340,9 +35340,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=bytes)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[bytes])
 
-            value: 'bytes' = b""
+            value: 'typing.Optional[bytes]' = None
 
         @dataclass
         class CharString(ClusterAttributeDescriptor):
@@ -35356,9 +35356,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=str)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[str])
 
-            value: 'str' = ""
+            value: 'typing.Optional[str]' = None
 
         @dataclass
         class LongCharString(ClusterAttributeDescriptor):
@@ -35372,9 +35372,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=str)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[str])
 
-            value: 'str' = ""
+            value: 'typing.Optional[str]' = None
 
         @dataclass
         class EpochUs(ClusterAttributeDescriptor):
@@ -35388,9 +35388,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class EpochS(ClusterAttributeDescriptor):
@@ -35404,9 +35404,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class VendorId(ClusterAttributeDescriptor):
@@ -35420,9 +35420,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class ListNullablesAndOptionalsStruct(ClusterAttributeDescriptor):
@@ -35436,9 +35436,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.List[TestCluster.Structs.NullablesAndOptionalsStruct])
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]])
 
-            value: 'typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]' = field(default_factory=lambda: [])
+            value: 'typing.Optional[typing.List[TestCluster.Structs.NullablesAndOptionalsStruct]]' = None
 
         @dataclass
         class EnumAttr(ClusterAttributeDescriptor):
@@ -35452,9 +35452,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=TestCluster.Enums.SimpleEnum)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[TestCluster.Enums.SimpleEnum])
 
-            value: 'TestCluster.Enums.SimpleEnum' = 0
+            value: 'typing.Optional[TestCluster.Enums.SimpleEnum]' = None
 
         @dataclass
         class StructAttr(ClusterAttributeDescriptor):
@@ -35468,9 +35468,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=TestCluster.Structs.SimpleStruct)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[TestCluster.Structs.SimpleStruct])
 
-            value: 'TestCluster.Structs.SimpleStruct' = field(default_factory=lambda: TestCluster.Structs.SimpleStruct())
+            value: 'typing.Optional[TestCluster.Structs.SimpleStruct]' = None
 
         @dataclass
         class RangeRestrictedInt8u(ClusterAttributeDescriptor):
@@ -35484,9 +35484,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class RangeRestrictedInt8s(ClusterAttributeDescriptor):
@@ -35500,9 +35500,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class RangeRestrictedInt16u(ClusterAttributeDescriptor):
@@ -35516,9 +35516,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=uint)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[uint])
 
-            value: 'uint' = 0
+            value: 'typing.Optional[uint]' = None
 
         @dataclass
         class RangeRestrictedInt16s(ClusterAttributeDescriptor):
@@ -35532,9 +35532,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=int)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[int])
 
-            value: 'int' = 0
+            value: 'typing.Optional[int]' = None
 
         @dataclass
         class ListLongOctetString(ClusterAttributeDescriptor):
@@ -35548,9 +35548,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.List[bytes])
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[bytes]])
 
-            value: 'typing.List[bytes]' = field(default_factory=lambda: [])
+            value: 'typing.Optional[typing.List[bytes]]' = None
 
         @dataclass
         class ListFabricScoped(ClusterAttributeDescriptor):
@@ -35564,9 +35564,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.List[TestCluster.Structs.TestFabricScoped])
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[typing.List[TestCluster.Structs.TestFabricScoped]])
 
-            value: 'typing.List[TestCluster.Structs.TestFabricScoped]' = field(default_factory=lambda: [])
+            value: 'typing.Optional[typing.List[TestCluster.Structs.TestFabricScoped]]' = None
 
         @dataclass
         class TimedWriteBoolean(ClusterAttributeDescriptor):
@@ -35600,9 +35600,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=bool)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[bool])
 
-            value: 'bool' = False
+            value: 'typing.Optional[bool]' = None
 
         @dataclass
         class ClusterErrorBoolean(ClusterAttributeDescriptor):
@@ -35616,9 +35616,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=bool)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[bool])
 
-            value: 'bool' = False
+            value: 'typing.Optional[bool]' = None
 
         @dataclass
         class Unsupported(ClusterAttributeDescriptor):
@@ -35632,9 +35632,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=bool)
+                return ClusterObjectFieldDescriptor(Type=typing.Optional[bool])
 
-            value: 'bool' = False
+            value: 'typing.Optional[bool]' = None
 
         @dataclass
         class NullableBoolean(ClusterAttributeDescriptor):
@@ -35648,9 +35648,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, bool])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, bool])
 
-            value: 'typing.Union[Nullable, bool]' = NullValue
+            value: 'typing.Union[None, Nullable, bool]' = None
 
         @dataclass
         class NullableBitmap8(ClusterAttributeDescriptor):
@@ -35664,9 +35664,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableBitmap16(ClusterAttributeDescriptor):
@@ -35680,9 +35680,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableBitmap32(ClusterAttributeDescriptor):
@@ -35696,9 +35696,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableBitmap64(ClusterAttributeDescriptor):
@@ -35712,9 +35712,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt8u(ClusterAttributeDescriptor):
@@ -35728,9 +35728,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt16u(ClusterAttributeDescriptor):
@@ -35744,9 +35744,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt24u(ClusterAttributeDescriptor):
@@ -35760,9 +35760,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt32u(ClusterAttributeDescriptor):
@@ -35776,9 +35776,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt40u(ClusterAttributeDescriptor):
@@ -35792,9 +35792,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt48u(ClusterAttributeDescriptor):
@@ -35808,9 +35808,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt56u(ClusterAttributeDescriptor):
@@ -35824,9 +35824,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt64u(ClusterAttributeDescriptor):
@@ -35840,9 +35840,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableInt8s(ClusterAttributeDescriptor):
@@ -35856,9 +35856,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableInt16s(ClusterAttributeDescriptor):
@@ -35872,9 +35872,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableInt24s(ClusterAttributeDescriptor):
@@ -35888,9 +35888,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableInt32s(ClusterAttributeDescriptor):
@@ -35904,9 +35904,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableInt40s(ClusterAttributeDescriptor):
@@ -35920,9 +35920,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableInt48s(ClusterAttributeDescriptor):
@@ -35936,9 +35936,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableInt56s(ClusterAttributeDescriptor):
@@ -35952,9 +35952,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableInt64s(ClusterAttributeDescriptor):
@@ -35968,9 +35968,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableEnum8(ClusterAttributeDescriptor):
@@ -35984,9 +35984,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableEnum16(ClusterAttributeDescriptor):
@@ -36000,9 +36000,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableFloatSingle(ClusterAttributeDescriptor):
@@ -36016,9 +36016,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, float32])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, float32])
 
-            value: 'typing.Union[Nullable, float32]' = NullValue
+            value: 'typing.Union[None, Nullable, float32]' = None
 
         @dataclass
         class NullableFloatDouble(ClusterAttributeDescriptor):
@@ -36032,9 +36032,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, float])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, float])
 
-            value: 'typing.Union[Nullable, float]' = NullValue
+            value: 'typing.Union[None, Nullable, float]' = None
 
         @dataclass
         class NullableOctetString(ClusterAttributeDescriptor):
@@ -36048,9 +36048,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, bytes])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, bytes])
 
-            value: 'typing.Union[Nullable, bytes]' = NullValue
+            value: 'typing.Union[None, Nullable, bytes]' = None
 
         @dataclass
         class NullableCharString(ClusterAttributeDescriptor):
@@ -36064,9 +36064,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, str])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, str])
 
-            value: 'typing.Union[Nullable, str]' = NullValue
+            value: 'typing.Union[None, Nullable, str]' = None
 
         @dataclass
         class NullableEnumAttr(ClusterAttributeDescriptor):
@@ -36080,9 +36080,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, TestCluster.Enums.SimpleEnum])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, TestCluster.Enums.SimpleEnum])
 
-            value: 'typing.Union[Nullable, TestCluster.Enums.SimpleEnum]' = NullValue
+            value: 'typing.Union[None, Nullable, TestCluster.Enums.SimpleEnum]' = None
 
         @dataclass
         class NullableStruct(ClusterAttributeDescriptor):
@@ -36096,9 +36096,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, TestCluster.Structs.SimpleStruct])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct])
 
-            value: 'typing.Union[Nullable, TestCluster.Structs.SimpleStruct]' = NullValue
+            value: 'typing.Union[None, Nullable, TestCluster.Structs.SimpleStruct]' = None
 
         @dataclass
         class NullableRangeRestrictedInt8u(ClusterAttributeDescriptor):
@@ -36112,9 +36112,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableRangeRestrictedInt8s(ClusterAttributeDescriptor):
@@ -36128,9 +36128,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class NullableRangeRestrictedInt16u(ClusterAttributeDescriptor):
@@ -36144,9 +36144,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, uint])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, uint])
 
-            value: 'typing.Union[Nullable, uint]' = NullValue
+            value: 'typing.Union[None, Nullable, uint]' = None
 
         @dataclass
         class NullableRangeRestrictedInt16s(ClusterAttributeDescriptor):
@@ -36160,9 +36160,9 @@ class TestCluster(Cluster):
 
             @ChipUtility.classproperty
             def attribute_type(cls) -> ClusterObjectFieldDescriptor:
-                return ClusterObjectFieldDescriptor(Type=typing.Union[Nullable, int])
+                return ClusterObjectFieldDescriptor(Type=typing.Union[None, Nullable, int])
 
-            value: 'typing.Union[Nullable, int]' = NullValue
+            value: 'typing.Union[None, Nullable, int]' = None
 
         @dataclass
         class GeneratedCommandList(ClusterAttributeDescriptor):


### PR DESCRIPTION
#### Problem
`./scripts/idl_lint.py examples/all-clusters-app/all-clusters-common/all-clusters-app.matter` complains about unimplemented test cluster features, specifically the `unsupported` attribute as well as some commands (TestSimpleArgument, TestStructArrayArgument and TestComplexNullableOption)

#### Change overview
Mark all elements of test cluster as optional that were optional=false.

Some remained mandatory, but this allows us for now to catch unexpected usages (e.g. tv-casting-app.matter will complain about TestCluster::timed_write_boolean but that should be fine as  test-cluster is not expected there).

#### Testing
ZAP generation should not find differences.
Ran `idl_lint.py` on all-clusters and saw no complaints regarding test cluster.