### PR TITLE
Add better mandatory cluster rules in matterlint

### DIFF
--- a/scripts/rules.matterlint
+++ b/scripts/rules.matterlint
@@ -79,9 +79,25 @@ all endpoints {
 
 endpoint 0 {
   // Identifiers for clusters are loaded from XML files
+  // The required clusters are from the spec for RootNode (section 2.1.5 at the moment):
+
   require server cluster Basic;
+  require server cluster AccessControl;
   require server cluster GroupKeyManagement;
-  require server cluster NetworkCommissioning;
   require server cluster GeneralCommissioning;
-  require server cluster OTASoftwareUpdateRequestor;
+  require server cluster AdministratorCommissioning;
+  require server cluster OperationalCredentials;
+  require server cluster GeneralDiagnostics;
+
+  // Required only if !CustomNetworkConfig. For now assume yes for matter examples
+  require server cluster NetworkCommissioning;
+
+  // If Ethernet
+  // require server cluster EthernetNetworkDiagnostics;
+
+  // If WiFi
+  // require server cluster WiFiNetworkDiagnostics;
+
+  // If Thread
+  // require server cluster ThreadNetworkDiagnostics;
 }

--- a/scripts/rules.matterlint
+++ b/scripts/rules.matterlint
@@ -89,8 +89,8 @@ endpoint 0 {
   require server cluster OperationalCredentials;
   require server cluster GeneralDiagnostics;
 
-  // Required only if !CustomNetworkConfig. For now assume yes for matter examples
-  require server cluster NetworkCommissioning;
+  // Required only if !CustomNetworkConfig. 
+  // require server cluster NetworkCommissioning;
 
   // If Ethernet
   // require server cluster EthernetNetworkDiagnostics;


### PR DESCRIPTION
#### Problem
Update mandatory clusters for endpoint 0 (which should always be a root node) based on the spec:
  - added a few mandatory clusters
  - removed OTA requirement (I do not see it as mandatory in the spec)
  
#### Testing
`./scripts/lint_idl.py` still runs and outputs results (it parses, saw lint errors on various scripts)