### PR TITLE
Add darwin-framework-tool support for min/max constraints with saved variables

### DIFF
--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -325,6 +325,38 @@ protected:
         return CheckConstraintNotValue(itemName, currentValue, @(expected));
     }
 
+    using ConstraintsChecker::CheckConstraintMinValue;
+
+    // Used when the minValue is a saved variable, since ConstraintsChecker does
+    // not expect Core Foundation types.
+    template <typename T, std::enable_if_t<std::is_signed<T>::value, int> = 0>
+    bool CheckConstraintMinValue(const char * _Nonnull itemName, T current, const NSNumber * _Nonnull expected)
+    {
+        return ConstraintsChecker::CheckConstraintMinValue(itemName, current, [expected longLongValue]);
+    }
+
+    template <typename T, std::enable_if_t<!std::is_signed<T>::value, int> = 0>
+    bool CheckConstraintMinValue(const char * _Nonnull itemName, T current, const NSNumber * _Nonnull expected)
+    {
+        return ConstraintsChecker::CheckConstraintMinValue(itemName, current, [expected unsignedLongLongValue]);
+    }
+
+    using ConstraintsChecker::CheckConstraintMaxValue;
+
+    // Used when the maxValue is a saved variable, since ConstraintsChecker does
+    // not expect Core Foundation types.
+    template <typename T, std::enable_if_t<std::is_signed<T>::value, int> = 0>
+    bool CheckConstraintMaxValue(const char * _Nonnull itemName, T current, const NSNumber * _Nonnull expected)
+    {
+        return ConstraintsChecker::CheckConstraintMaxValue(itemName, current, [expected longLongValue]);
+    }
+
+    template <typename T, std::enable_if_t<!std::is_signed<T>::value, int> = 0>
+    bool CheckConstraintMaxValue(const char * _Nonnull itemName, T current, const NSNumber * _Nonnull expected)
+    {
+        return ConstraintsChecker::CheckConstraintMaxValue(itemName, current, [expected unsignedLongLongValue]);
+    }
+
     bool CheckValueAsString(const char * _Nonnull itemName, const id _Nonnull current, const NSString * _Nonnull expected)
     {
         NSString * data = current;

--- a/src/app/tests/suites/include/ConstraintsChecker.h
+++ b/src/app/tests/suites/include/ConstraintsChecker.h
@@ -189,7 +189,7 @@ protected:
         return true;
     }
 
-    template <typename T, typename U, std::enable_if_t<!std::is_enum<T>::value, int> = 0>
+    template <typename T, typename U, std::enable_if_t<!std::is_enum<T>::value && !std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMinValue(const char * itemName, T current, U expected)
     {
         if (current < expected)
@@ -201,13 +201,13 @@ protected:
         return true;
     }
 
-    template <typename T, typename U, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+    template <typename T, typename U, std::enable_if_t<std::is_enum<T>::value && !std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMinValue(const char * itemName, T current, U expected)
     {
         return CheckConstraintMinValue(itemName, chip::to_underlying(current), expected);
     }
 
-    template <typename T, typename U>
+    template <typename T, typename U, std::enable_if_t<!std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMinValue(const char * itemName, chip::BitFlags<T> current, U expected)
     {
         if (current.Raw() < expected)
@@ -219,7 +219,7 @@ protected:
         return true;
     }
 
-    template <typename T, typename U>
+    template <typename T, typename U, std::enable_if_t<!std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMinValue(const char * itemName, chip::BitMask<T> current, U expected)
     {
         if (current.Raw() < expected)
@@ -231,7 +231,7 @@ protected:
         return true;
     }
 
-    template <typename T, typename U>
+    template <typename T, typename U, std::enable_if_t<!std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMinValue(const char * itemName, const chip::app::DataModel::Nullable<T> & current, U expected)
     {
         if (current.IsNull())
@@ -252,7 +252,7 @@ protected:
         return CheckConstraintMinValue(itemName, current, expected.Value());
     }
 
-    template <typename T, typename U, std::enable_if_t<!std::is_enum<T>::value, int> = 0>
+    template <typename T, typename U, std::enable_if_t<!std::is_enum<T>::value && !std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMaxValue(const char * itemName, T current, U expected)
     {
         if (current > expected)
@@ -264,13 +264,13 @@ protected:
         return true;
     }
 
-    template <typename T, typename U, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+    template <typename T, typename U, std::enable_if_t<std::is_enum<T>::value && !std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMaxValue(const char * itemName, T current, U expected)
     {
         return CheckConstraintMaxValue(itemName, chip::to_underlying(current), expected);
     }
 
-    template <typename T, typename U>
+    template <typename T, typename U, std::enable_if_t<!std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMaxValue(const char * itemName, chip::BitFlags<T> current, U expected)
     {
         if (current.Raw() > expected)
@@ -282,7 +282,7 @@ protected:
         return true;
     }
 
-    template <typename T, typename U>
+    template <typename T, typename U, std::enable_if_t<!std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMaxValue(const char * itemName, chip::BitMask<T> current, U expected)
     {
         if (current.Raw() > expected)
@@ -294,7 +294,7 @@ protected:
         return true;
     }
 
-    template <typename T, typename U>
+    template <typename T, typename U, std::enable_if_t<!std::is_pointer<U>::value, int> = 0>
     bool CheckConstraintMaxValue(const char * itemName, const chip::app::DataModel::Nullable<T> & current, U expected)
     {
         if (current.IsNull())


### PR DESCRIPTION
Adds support for having the expected value in a min/max constraint be
a saveAs value in darwin-framework-tool.

Fixes https://github.com/project-chip/connectedhomeip/issues/19110

#### Problem
See above.

#### Change overview
See above.

#### Testing
Checks that the generated code from #19110 compiles.