### PR TITLE
SoftwareDiagnostics::Watermark support based on implementation flags

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2928,6 +2928,10 @@ server cluster Scenes = 5 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -2425,6 +2425,10 @@ server cluster Scenes = 5 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   info event SoftwareFault = 0 {
     SoftwareFaultStruct softwareFault = 0;
   }

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -834,6 +834,10 @@ server cluster OperationalCredentials = 62 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -1376,6 +1376,10 @@ client cluster Scenes = 5 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1358,6 +1358,10 @@ server cluster OperationalCredentials = 62 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -1569,6 +1569,10 @@ server cluster PowerSourceConfiguration = 46 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -2085,6 +2085,10 @@ server cluster Scenes = 5 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -2085,6 +2085,10 @@ server cluster Scenes = 5 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -1065,6 +1065,10 @@ client cluster PumpConfigurationAndControl = 512 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -632,6 +632,10 @@ server cluster OperationalCredentials = 62 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   info event SoftwareFault = 0 {
     SoftwareFaultStruct softwareFault = 0;
   }

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -977,6 +977,10 @@ server cluster Scenes = 5 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -1716,6 +1716,10 @@ server cluster RelativeHumidityMeasurement = 1029 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1770,6 +1770,10 @@ server cluster Scenes = 5 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -1120,6 +1120,10 @@ client cluster Scenes = 5 {
 }
 
 server cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -63,21 +63,26 @@ CHIP_ERROR SoftwareDiagosticsAttrAccess::Read(const ConcreteReadAttributePath & 
 
     switch (aPath.mAttributeId)
     {
-    case CurrentHeapFree::Id: {
+    case CurrentHeapFree::Id:
         return ReadIfSupported(&DiagnosticDataProvider::GetCurrentHeapFree, aEncoder);
-    }
-    case CurrentHeapUsed::Id: {
+    case CurrentHeapUsed::Id:
         return ReadIfSupported(&DiagnosticDataProvider::GetCurrentHeapUsed, aEncoder);
-    }
-    case CurrentHeapHighWatermark::Id: {
+    case CurrentHeapHighWatermark::Id:
         return ReadIfSupported(&DiagnosticDataProvider::GetCurrentHeapHighWatermark, aEncoder);
-    }
-    case ThreadMetrics::Id: {
+    case ThreadMetrics::Id:
         return ReadThreadMetrics(aEncoder);
+    case Clusters::Globals::Attributes::FeatureMap::Id: {
+        BitFlags<SoftwareDiagnosticsFeature> features;
+
+        if (DeviceLayer::GetDiagnosticDataProvider().SupportsWatermarks())
+        {
+            features.Set(SoftwareDiagnosticsFeature::kWaterMarks);
+        }
+
+        return aEncoder.Encode(features);
     }
-    default: {
+    default:
         break;
-    }
     }
     return CHIP_NO_ERROR;
 }

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -49,6 +49,7 @@ limitations under the License.
     </event>    
   </cluster>
   <bitmap name="SoftwareDiagnosticsFeature" type="BITMAP32">
+    <cluster code="0x0034"/>
     <field name="WaterMarks" mask="0x1"/>
   </bitmap>   
 </configurator>

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -164,8 +164,9 @@
         ],
         "Software Diagnostics": [
             "CurrentHeapFree",
-            "CurrentHeapUsed",
             "CurrentHeapHighWatermark",
+            "CurrentHeapUsed",
+            "FeatureMap",
             "ThreadMetrics"
         ],
         "Test Cluster": [

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -3362,6 +3362,10 @@ client cluster Scenes = 5 {
 }
 
 client cluster SoftwareDiagnostics = 52 {
+  bitmap SoftwareDiagnosticsFeature : BITMAP32 {
+    kWaterMarks = 0x1;
+  }
+
   struct ThreadMetrics {
     int64u id = 0;
     char_string<8> name = 1;

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPClustersObjc.h
@@ -21610,6 +21610,10 @@ typedef NS_ENUM(uint8_t, CHIPGeneralDiagnosticsRadioFaultType) {
     CHIPGeneralDiagnosticsRadioFaultTypeEthernetFault = 0x06,
 };
 
+typedef NS_OPTIONS(uint32_t, CHIPSoftwareDiagnosticsFeature) {
+    CHIPSoftwareDiagnosticsFeatureWaterMarks = 0x1,
+};
+
 typedef NS_ENUM(uint8_t, CHIPThreadNetworkDiagnosticsNetworkFault) {
     CHIPThreadNetworkDiagnosticsNetworkFaultUnspecified = 0x00,
     CHIPThreadNetworkDiagnosticsNetworkFaultLinkDown = 0x01,

--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -177,6 +177,10 @@ public:
     /**
      * Software Diagnostics methods.
      */
+
+    /// Feature support - this returns support gor GetCurrentHeapHighWatermark and ResetWatermarks()
+    virtual bool SupportsWatermarks() { return false; }
+
     virtual CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree);
     virtual CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed);
     virtual CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark);

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.h
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.h
@@ -40,6 +40,7 @@ public:
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
 
     // ===== Methods that implement the DiagnosticDataProvider abstract interface.
+    bool SupportsWatermarks() override { return true; }
     CHIP_ERROR ResetWatermarks() override;
 };
 

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.h
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.h
@@ -39,6 +39,7 @@ public:
 
     // ===== Methods that implement the PlatformManager abstract interface.
 
+    bool SupportsWatermarks() override { return true; }
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -39,6 +39,7 @@ public:
 
     // ===== Methods that implement the DiagnosticDataProvider abstract interface.
 
+    bool SupportsWatermarks() override { return true; }
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -755,6 +755,12 @@ using RadioFaultType                  = EmberAfRadioFaultType;
 } // namespace GeneralDiagnostics
 
 namespace SoftwareDiagnostics {
+
+// Bitmap for SoftwareDiagnosticsFeature
+enum class SoftwareDiagnosticsFeature : uint32_t
+{
+    kWaterMarks = 0x1,
+};
 } // namespace SoftwareDiagnostics
 
 namespace ThreadNetworkDiagnostics {


### PR DESCRIPTION
#### Problem
Not all platforms support ResetWatermark, but we always claim they do.

#### Change overview
- add the featuremap for software diagnostics as a codegen item
- make the diagnostics impl class return a `watermark supported` bool, override it to true for efr32, linux and darwin
- make the impl of the cluster set the feature flags based on the `supported` flag

Fixes #19160 

#### Testing
Flashed NRF all clusters app, observed feature map  0.
Flashed EFR32 light app, observed feature map 1 (and reset-watermarks returns success).

Script used:

```sh
#!/usr/bin/env bash

set -ex

function finish {
  echo "STATUS: $?"
}

trap finish EXIT

export NODEID=$RANDOM

export THREAD_CRED=hex:ADD_YOUR_CREDENTIALS_HERE
export CHIP_TOOL="$HOME/devel/connectedhomeip/out/linux-x64-chip-tool/chip-tool"

log_file="run_log_$(date +'%Y-%m-%d_%H-%M-%S').txt"
rm -f /tmp/chip_*

echo "NODE ID USED: $NODEID" | tee $log_file

echo "=============================================================" >>$log_file
echo $CHIP_TOOL pairing ble-thread $NODEID $THREAD_CRED 20202021 3840 | tee -a $log_file
$CHIP_TOOL pairing ble-thread $NODEID $THREAD_CRED 20202021 3840 >>$log_file 2>&1

echo "=============================================================" >>$log_file
echo $CHIP_TOOL softwarediagnostics read feature-map $NODEID 0 | tee -a $log_file
$CHIP_TOOL softwarediagnostics read feature-map $NODEID 0  2>&1 | tee -a $log_file | grep 'FeatureMap:'

echo "=============================================================" >>$log_file
echo $CHIP_TOOL softwarediagnostics read current-heap-high-watermark $NODEID 0 | tee -a $log_file
$CHIP_TOOL softwarediagnostics read current-heap-high-watermark $NODEID 0  2>&1 | tee -a $log_file | grep 'CurrentHeapHighWatermark:'

echo "=============================================================" >>$log_file
echo $CHIP_TOOL softwarediagnostics reset-watermarks $NODEID 0 | tee -a $log_file
$CHIP_TOOL softwarediagnostics reset-watermarks $NODEID 0  2>&1 | tee -a $log_file | grep -A 3 'StatusIB'
```

