### PR TITLE
[thread] use MLE Discovery mechanism instead of active scanning

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -388,17 +388,34 @@ template <class ImplClass>
 CHIP_ERROR
 GenericThreadStackManagerImpl_OpenThread<ImplClass>::_StartThreadScan(NetworkCommissioning::ThreadDriver::ScanCallback * callback)
 {
+    CHIP_ERROR error = CHIP_NO_ERROR;
+
     // If there is another ongoing scan request, reject the new one.
     VerifyOrReturnError(mpScanCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);
+
     mpScanCallback = callback;
-    CHIP_ERROR err = MapOpenThreadError(otLinkActiveScan(mOTInst, 0, /* all channels */
-                                                         0,          /* default value `kScanDurationDefault` = 300 ms. */
-                                                         _OnNetworkScanFinished, this));
-    if (err != CHIP_NO_ERROR)
+
+    Impl()->LockThreadStack();
+
+    // Ensure that IPv6 interface is up when MLE Discovery is performed.
+    if (!otIp6IsEnabled(mOTInst))
+    {
+        SuccessOrExit(error = MapOpenThreadError(otIp6SetEnabled(mOTInst, true)));
+    }
+
+    error = MapOpenThreadError(otThreadDiscover(mOTInst, 0,                       /* all channels */
+                                                OT_PANID_BROADCAST, false, false, /* disable PAN ID, EUI64 and Joiner filtering */
+                                                _OnNetworkScanFinished, this));
+
+exit:
+    Impl()->UnlockThreadStack();
+
+    if (error != CHIP_NO_ERROR)
     {
         mpScanCallback = nullptr;
     }
-    return err;
+
+    return error;
 }
 
 template <class ImplClass>
@@ -412,6 +429,12 @@ void GenericThreadStackManagerImpl_OpenThread<ImplClass>::_OnNetworkScanFinished
 {
     if (aResult == nullptr) // scan completed
     {
+        // If Thread scanning was done before commissioning, turn off the IPv6 interface.
+        if (otThreadGetDeviceRole(mOTInst) == OT_DEVICE_ROLE_DISABLED && !otDatasetIsCommissioned(mOTInst))
+        {
+            otIp6SetEnabled(mOTInst, false);
+        }
+
         if (mpScanCallback != nullptr)
         {
             DeviceLayer::SystemLayer().ScheduleLambda([this]() {


### PR DESCRIPTION
#### Problem
The current implementation of `ScanNetworks` command for Thread uses legacy 15.4 active scanning. This mechanism does not provide parameters such as Thread Network name or Extended PAN Id.

#### Change overview
Use `MLE Discovery` to trigger Thread scanning. Simple API change, the result callback has the same type.

#### Testing
Tested manually on nRF Connect platform that `ScanNetworkResponse` includes Network Name and Extended Pan ID over Thread network by executing `./chip-tool networkcommissioning scan-networks 1111 0` 

```
[1654725420.491720][119922:119927] CHIP:TOO:   ScanNetworksResponse: {
[1654725420.491797][119922:119927] CHIP:TOO:     networkingStatus: 0
[1654725420.491870][119922:119927] CHIP:TOO:     threadScanResults: 1 entries
[1654725420.491954][119922:119927] CHIP:TOO:       [1]: {
[1654725420.492005][119922:119927] CHIP:TOO:         PanId: 41209
[1654725420.492054][119922:119927] CHIP:TOO:         ExtendedPanId: 2944460015548818066
[1654725420.492103][119922:119927] CHIP:TOO:         NetworkName: OpenThread-a0f9
[1654725420.492149][119922:119927] CHIP:TOO:         Channel: 21
[1654725420.492195][119922:119927] CHIP:TOO:         Version: 3
[1654725420.492244][119922:119927] CHIP:TOO:         ExtendedAddress: 82B8FBEB54F3DAC3
[1654725420.492291][119922:119927] CHIP:TOO:         Rssi: -66
[1654725420.492337][119922:119927] CHIP:TOO:         Lqi: 108
[1654725420.492385][119922:119927] CHIP:TOO:        }
[1654725420.492437][119922:119927] CHIP:TOO:    }
```

Additionally modified `chip-tool` locally to send the `ScanNetworks` command during BLE commissioning, before Thread interface is brought up.

```
[1654725369.517185][119903:119909] CHIP:DMG: InvokeResponseMessage =
[1654725369.517235][119903:119909] CHIP:DMG: {
[1654725369.517305][119903:119909] CHIP:DMG: 	suppressResponse = false, 
[1654725369.517357][119903:119909] CHIP:DMG: 	InvokeResponseIBs =
[1654725369.517450][119903:119909] CHIP:DMG: 	[
[1654725369.517502][119903:119909] CHIP:DMG: 		InvokeResponseIB =
[1654725369.517607][119903:119909] CHIP:DMG: 		{
[1654725369.517680][119903:119909] CHIP:DMG: 			CommandDataIB =
[1654725369.517749][119903:119909] CHIP:DMG: 			{
[1654725369.517829][119903:119909] CHIP:DMG: 				CommandPathIB =
[1654725369.517900][119903:119909] CHIP:DMG: 				{
[1654725369.517989][119903:119909] CHIP:DMG: 					EndpointId = 0x0,
[1654725369.518069][119903:119909] CHIP:DMG: 					ClusterId = 0x31,
[1654725369.518212][119903:119909] CHIP:DMG: 					CommandId = 0x1,
[1654725369.518303][119903:119909] CHIP:DMG: 				},
[1654725369.518377][119903:119909] CHIP:DMG: 				
[1654725369.518455][119903:119909] CHIP:DMG: 				CommandFields = 
[1654725369.518524][119903:119909] CHIP:DMG: 				{
[1654725369.518613][119903:119909] CHIP:DMG: 					0x0 = 0, 
[1654725369.518702][119903:119909] CHIP:DMG: 					0x3 = [
[1654725369.518781][119903:119909] CHIP:DMG: 						
[1654725369.518878][119903:119909] CHIP:DMG: 						{
[1654725369.518959][119903:119909] CHIP:DMG: 							0x0 = 41209, 
[1654725369.519050][119903:119909] CHIP:DMG: 							0x1 = 2944460015548818066, 
[1654725369.519137][119903:119909] CHIP:DMG: 							0x2 = "OpenThread-a0f9", 
[1654725369.519224][119903:119909] CHIP:DMG: 							0x3 = 21, 
[1654725369.519307][119903:119909] CHIP:DMG: 							0x4 = 3, 
[1654725369.519387][119903:119909] CHIP:DMG: 							0x5 = [
[1654725369.519477][119903:119909] CHIP:DMG: 								0x82, 0xb8, 0xfb, 0xeb, 0x54, 0xf3, 0xda, 0xc3, 
[1654725369.519557][119903:119909] CHIP:DMG: 						]
[1654725369.519631][119903:119909] CHIP:DMG: 							0x6 = -67, 
[1654725369.519755][119903:119909] CHIP:DMG: 							0x7 = 104, 
[1654725369.519835][119903:119909] CHIP:DMG: 						},
[1654725369.519930][119903:119909] CHIP:DMG: 					],
[1654725369.520020][119903:119909] CHIP:DMG: 				},
[1654725369.520091][119903:119909] CHIP:DMG: 			},
[1654725369.520188][119903:119909] CHIP:DMG: 			
[1654725369.520261][119903:119909] CHIP:DMG: 		},
[1654725369.520340][119903:119909] CHIP:DMG: 		
[1654725369.520406][119903:119909] CHIP:DMG: 	],
[1654725369.520473][119903:119909] CHIP:DMG: 	
[1654725369.520515][119903:119909] CHIP:DMG: 	InteractionModelRevision = 1
[1654725369.520555][119903:119909] CHIP:DMG: },
```

