### PR TITLE
Fix dangling entries in host.py builder

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -140,13 +140,10 @@ class HostApp(Enum):
             yield 'controller/python'  # Directory containing WHL files
         elif self == HostApp.NL_TEST_RUNNER:
             yield 'chip_nl_test_runner_wheels'
-        elif self == HostApp.LIGHTING:
-            yield 'chip-lighting-app'
-            yield 'chip-lighting-app.map'
-        elif self == HostApp.TV_CASTING_APP:
+        elif self == HostApp.TV_CASTING:
             yield 'chip-tv-casting-app'
             yield 'chip-tv-casting-app.map'
-        elif self == HostApp.BRIDGE_APP:
+        elif self == HostApp.BRIDGE:
             yield 'chip-bridge-app'
             yield 'chip-bridge-app.map'
         else:


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Incorrect dangling entries in the host.py OutputNames class.

#### Change overview
Removed LIGHTING (duplicate of LIGHT) and renamed TV_CASTING and BRIDGE to their appropriate names.

#### Testing
Built tv-casting-app, tv-app, light, and bridge using build_examples.py.
