### PR TITLE
Fix broken Chef NRF build caused by #18955

### DIFF
--- a/examples/chef/nrfconnect/CMakeLists.txt
+++ b/examples/chef/nrfconnect/CMakeLists.txt
@@ -122,6 +122,7 @@ set(PIGWEED_ROOT "${CHIP_ROOT}/third_party/pigweed/repo")
 include(${PIGWEED_ROOT}/pw_build/pigweed.cmake)
 include(${PIGWEED_ROOT}/pw_protobuf_compiler/proto.cmake)
 
+pw_set_module_config(pw_rpc_CONFIG pw_rpc.disable_global_mutex_config)
 pw_set_backend(pw_log pw_log_basic)
 pw_set_backend(pw_assert pw_assert_log)
 pw_set_backend(pw_sys_io pw_sys_io.nrfconnect)


### PR DESCRIPTION
#### Problem
Chef NRF build was broken by #18955

This PR will unblock #18859 which is currently blocked due to failing NRF build - the other platform builds are currently passing (efr32, esp32, and linux). After Chef CI gets merged, future changes will trigger builds for the various platforms and alert authors of breaking changes.

#### Change overview
- Disable global mutex config for pw RPC  (18955)

#### Testing
Able to successfully build NRF on master:
```
./chef.py -zbcefr -d lighting-app -t nrfconnect
```