### PR TITLE
Chef - Fix Chef CI and add unit tests for stateful_shell.py

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -162,6 +162,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     if (chip_link_tests) {
       deps = [
         "//:fake_platform_tests",
+        "//examples/chef:chef.tests",
         "//scripts/build:build_examples.tests",
         "//scripts/idl:idl.tests",
         "//src:tests_run",

--- a/examples/chef/BUILD.gn
+++ b/examples/chef/BUILD.gn
@@ -1,0 +1,32 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+import("//build_overrides/pigweed.gni")
+import("$dir_pw_build/python.gni")
+
+pw_python_package("chef") {
+  setup = [ "setup.py" ]
+
+  sources = [
+    "__init__.py",
+    "chef.py",
+    "constants.py",
+    "stateful_shell.py",
+  ]
+
+  tests = [ "test_stateful_shell.py" ]
+}

--- a/examples/chef/setup.py
+++ b/examples/chef/setup.py
@@ -1,0 +1,28 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+"""The chef package."""
+
+import setuptools  # type: ignore
+
+setuptools.setup(
+    name='chef',
+    version='0.0.1',
+    author='Project CHIP Authors',
+    description='Build custom sample apps for supported platforms',
+    packages=setuptools.find_packages(),
+    package_data={'chef': ['py.typed']},
+    zip_safe=False,
+)

--- a/examples/chef/test_stateful_shell.py
+++ b/examples/chef/test_stateful_shell.py
@@ -1,0 +1,48 @@
+"""Tests for stateful_shell.py
+
+Usage:
+python -m unittest
+"""
+
+import unittest
+
+import stateful_shell
+
+
+class TestStatefulShell(unittest.TestCase):
+    """Testcases for stateful_shell.py."""
+
+    def setUp(self):
+        """Prepares stateful shell instance for tests."""
+        self.shell = stateful_shell.StatefulShell()
+
+    def test_cmd_output(self):
+        """Tests shell command output."""
+        resp = self.shell.run_cmd("echo test123", return_cmd_output=True).strip()
+        self.assertEqual(resp, "test123")
+
+    def test_set_env_in_shell(self):
+        """Tests setting env variables in shell."""
+        self.shell.run_cmd("export TESTVAR=123")
+        self.assertEqual(self.shell.env["TESTVAR"], "123")
+
+    def test_set_env_outside_shell(self):
+        """Tests setting env variables outside shell call."""
+        self.shell.env["TESTVAR"] = "1234"
+        resp = self.shell.run_cmd("echo $TESTVAR", return_cmd_output=True).strip()
+        self.assertEqual(resp, "1234")
+
+    def test_env_var_set_get(self):
+        """Tests setting and getting env vars between calls."""
+        self.shell.run_cmd("export TESTVAR=123")
+        resp = self.shell.run_cmd("echo $TESTVAR", return_cmd_output=True).strip()
+        self.assertEqual(resp, "123")
+
+    def test_raise_on_returncode(self):
+        """Tests raising errors when returncode is nonzero."""
+        with self.assertRaises(RuntimeError):
+            self.shell.run_cmd("invalid_cmd > /dev/null 2>&1", raise_on_returncode=True)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#### Problem
- There are no unit tests for stateful_shell.py
- There is a race condition in stateful_shell.py which depends on `tee`
- Chef CI failures may be caused by the race condition mentioned above.
- `macos-latest` refers to MacOS 11 which doesn't support `env -0` used in stateful_shell.py.

#### Change overview
- Add unit tests for stateful_shell.py
- Fix race condition due to use of `tee` in stateful_shell.py
- Support MacOS 11 by removing `env -0` usage. This is needed for github actions that rely on `macos-latest`.

#### Testing
Tested unit tests with:
`python -m unittest`
Tested ninja integration with:
```
gn gen out
ninja -C out examples/chef:chef.tests
```

CI handles the rest.