### PR TITLE
Align the ThreadMetrics struct with the spec.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -2930,10 +2930,10 @@ server cluster Scenes = 5 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -836,10 +836,10 @@ server cluster OperationalCredentials = 62 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -1378,10 +1378,10 @@ client cluster Scenes = 5 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -1360,10 +1360,10 @@ server cluster OperationalCredentials = 62 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -1571,10 +1571,10 @@ server cluster PowerSourceConfiguration = 46 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -2087,10 +2087,10 @@ server cluster Scenes = 5 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -2087,10 +2087,10 @@ server cluster Scenes = 5 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -1067,10 +1067,10 @@ client cluster PumpConfigurationAndControl = 512 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -979,10 +979,10 @@ server cluster Scenes = 5 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -1718,10 +1718,10 @@ server cluster RelativeHumidityMeasurement = 1029 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1772,10 +1772,10 @@ server cluster Scenes = 5 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -1122,10 +1122,10 @@ client cluster Scenes = 5 {
 server cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -19,10 +19,10 @@ limitations under the License.
   <struct name="ThreadMetrics">
     <cluster code="0x0034"/>
     <item name="Id" type="INT64U"/>
-    <item name="Name" type="CHAR_STRING" length="8"/>
-    <item name="StackFreeCurrent" type="INT32U"/>
-    <item name="StackFreeMinimum" type="INT32U"/>
-    <item name="StackSize" type="INT32U"/>
+    <item name="Name" type="CHAR_STRING" length="8" optional="true"/>
+    <item name="StackFreeCurrent" type="INT32U" optional="true"/>
+    <item name="StackFreeMinimum" type="INT32U" optional="true"/>
+    <item name="StackSize" type="INT32U" optional="true"/>
   </struct>
   <struct name="SoftwareFaultStruct">
     <cluster code="0x0034"/>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -3364,10 +3364,10 @@ client cluster Scenes = 5 {
 client cluster SoftwareDiagnostics = 52 {
   struct ThreadMetrics {
     int64u id = 0;
-    char_string<8> name = 1;
-    int32u stackFreeCurrent = 2;
-    int32u stackFreeMinimum = 3;
-    int32u stackSize = 4;
+    optional char_string<8> name = 1;
+    optional int32u stackFreeCurrent = 2;
+    optional int32u stackFreeMinimum = 3;
+    optional int32u stackSize = 4;
   }
 
   info event SoftwareFault = 0 {

--- a/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPAttributeTLVValueDecoder.cpp
@@ -12557,25 +12557,67 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                 chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
                     newElement_0_idClassName.c_str(), newElement_0_idCtorSignature.c_str(), entry_0.id, newElement_0_id);
                 jobject newElement_0_name;
-                newElement_0_name = env->NewStringUTF(std::string(entry_0.name.data(), entry_0.name.size()).c_str());
+                if (!entry_0.name.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_name);
+                }
+                else
+                {
+                    jobject newElement_0_nameInsideOptional;
+                    newElement_0_nameInsideOptional =
+                        env->NewStringUTF(std::string(entry_0.name.Value().data(), entry_0.name.Value().size()).c_str());
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_nameInsideOptional, newElement_0_name);
+                }
                 jobject newElement_0_stackFreeCurrent;
-                std::string newElement_0_stackFreeCurrentClassName     = "java/lang/Long";
-                std::string newElement_0_stackFreeCurrentCtorSignature = "(J)V";
-                chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
-                    newElement_0_stackFreeCurrentClassName.c_str(), newElement_0_stackFreeCurrentCtorSignature.c_str(),
-                    entry_0.stackFreeCurrent, newElement_0_stackFreeCurrent);
+                if (!entry_0.stackFreeCurrent.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_stackFreeCurrent);
+                }
+                else
+                {
+                    jobject newElement_0_stackFreeCurrentInsideOptional;
+                    std::string newElement_0_stackFreeCurrentInsideOptionalClassName     = "java/lang/Long";
+                    std::string newElement_0_stackFreeCurrentInsideOptionalCtorSignature = "(J)V";
+                    chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+                        newElement_0_stackFreeCurrentInsideOptionalClassName.c_str(),
+                        newElement_0_stackFreeCurrentInsideOptionalCtorSignature.c_str(), entry_0.stackFreeCurrent.Value(),
+                        newElement_0_stackFreeCurrentInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_stackFreeCurrentInsideOptional,
+                                                                      newElement_0_stackFreeCurrent);
+                }
                 jobject newElement_0_stackFreeMinimum;
-                std::string newElement_0_stackFreeMinimumClassName     = "java/lang/Long";
-                std::string newElement_0_stackFreeMinimumCtorSignature = "(J)V";
-                chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
-                    newElement_0_stackFreeMinimumClassName.c_str(), newElement_0_stackFreeMinimumCtorSignature.c_str(),
-                    entry_0.stackFreeMinimum, newElement_0_stackFreeMinimum);
+                if (!entry_0.stackFreeMinimum.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_stackFreeMinimum);
+                }
+                else
+                {
+                    jobject newElement_0_stackFreeMinimumInsideOptional;
+                    std::string newElement_0_stackFreeMinimumInsideOptionalClassName     = "java/lang/Long";
+                    std::string newElement_0_stackFreeMinimumInsideOptionalCtorSignature = "(J)V";
+                    chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+                        newElement_0_stackFreeMinimumInsideOptionalClassName.c_str(),
+                        newElement_0_stackFreeMinimumInsideOptionalCtorSignature.c_str(), entry_0.stackFreeMinimum.Value(),
+                        newElement_0_stackFreeMinimumInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_stackFreeMinimumInsideOptional,
+                                                                      newElement_0_stackFreeMinimum);
+                }
                 jobject newElement_0_stackSize;
-                std::string newElement_0_stackSizeClassName     = "java/lang/Long";
-                std::string newElement_0_stackSizeCtorSignature = "(J)V";
-                chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0_stackSizeClassName.c_str(),
-                                                                               newElement_0_stackSizeCtorSignature.c_str(),
-                                                                               entry_0.stackSize, newElement_0_stackSize);
+                if (!entry_0.stackSize.HasValue())
+                {
+                    chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_stackSize);
+                }
+                else
+                {
+                    jobject newElement_0_stackSizeInsideOptional;
+                    std::string newElement_0_stackSizeInsideOptionalClassName     = "java/lang/Long";
+                    std::string newElement_0_stackSizeInsideOptionalCtorSignature = "(J)V";
+                    chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+                        newElement_0_stackSizeInsideOptionalClassName.c_str(),
+                        newElement_0_stackSizeInsideOptionalCtorSignature.c_str(), entry_0.stackSize.Value(),
+                        newElement_0_stackSizeInsideOptional);
+                    chip::JniReferences::GetInstance().CreateOptional(newElement_0_stackSizeInsideOptional, newElement_0_stackSize);
+                }
 
                 jclass threadMetricsStructClass;
                 err = chip::JniReferences::GetInstance().GetClassRef(
@@ -12585,9 +12627,9 @@ jobject DecodeAttributeValue(const app::ConcreteAttributePath & aPath, TLV::TLVR
                     ChipLogError(Zcl, "Could not find class ChipStructs$SoftwareDiagnosticsClusterThreadMetrics");
                     return nullptr;
                 }
-                jmethodID threadMetricsStructCtor =
-                    env->GetMethodID(threadMetricsStructClass, "<init>",
-                                     "(Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
+                jmethodID threadMetricsStructCtor = env->GetMethodID(
+                    threadMetricsStructClass, "<init>",
+                    "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
                 if (threadMetricsStructCtor == nullptr)
                 {
                     ChipLogError(Zcl, "Could not find ChipStructs$SoftwareDiagnosticsClusterThreadMetrics constructor");

--- a/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
+++ b/src/controller/java/zap-generated/CHIPReadCallbacks.cpp
@@ -18850,25 +18850,66 @@ void CHIPSoftwareDiagnosticsThreadMetricsAttributeCallback::CallbackFn(
         chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>(
             newElement_0_idClassName.c_str(), newElement_0_idCtorSignature.c_str(), entry_0.id, newElement_0_id);
         jobject newElement_0_name;
-        newElement_0_name = env->NewStringUTF(std::string(entry_0.name.data(), entry_0.name.size()).c_str());
+        if (!entry_0.name.HasValue())
+        {
+            chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_name);
+        }
+        else
+        {
+            jobject newElement_0_nameInsideOptional;
+            newElement_0_nameInsideOptional =
+                env->NewStringUTF(std::string(entry_0.name.Value().data(), entry_0.name.Value().size()).c_str());
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_nameInsideOptional, newElement_0_name);
+        }
         jobject newElement_0_stackFreeCurrent;
-        std::string newElement_0_stackFreeCurrentClassName     = "java/lang/Long";
-        std::string newElement_0_stackFreeCurrentCtorSignature = "(J)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0_stackFreeCurrentClassName.c_str(),
-                                                                       newElement_0_stackFreeCurrentCtorSignature.c_str(),
-                                                                       entry_0.stackFreeCurrent, newElement_0_stackFreeCurrent);
+        if (!entry_0.stackFreeCurrent.HasValue())
+        {
+            chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_stackFreeCurrent);
+        }
+        else
+        {
+            jobject newElement_0_stackFreeCurrentInsideOptional;
+            std::string newElement_0_stackFreeCurrentInsideOptionalClassName     = "java/lang/Long";
+            std::string newElement_0_stackFreeCurrentInsideOptionalCtorSignature = "(J)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+                newElement_0_stackFreeCurrentInsideOptionalClassName.c_str(),
+                newElement_0_stackFreeCurrentInsideOptionalCtorSignature.c_str(), entry_0.stackFreeCurrent.Value(),
+                newElement_0_stackFreeCurrentInsideOptional);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_stackFreeCurrentInsideOptional,
+                                                              newElement_0_stackFreeCurrent);
+        }
         jobject newElement_0_stackFreeMinimum;
-        std::string newElement_0_stackFreeMinimumClassName     = "java/lang/Long";
-        std::string newElement_0_stackFreeMinimumCtorSignature = "(J)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0_stackFreeMinimumClassName.c_str(),
-                                                                       newElement_0_stackFreeMinimumCtorSignature.c_str(),
-                                                                       entry_0.stackFreeMinimum, newElement_0_stackFreeMinimum);
+        if (!entry_0.stackFreeMinimum.HasValue())
+        {
+            chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_stackFreeMinimum);
+        }
+        else
+        {
+            jobject newElement_0_stackFreeMinimumInsideOptional;
+            std::string newElement_0_stackFreeMinimumInsideOptionalClassName     = "java/lang/Long";
+            std::string newElement_0_stackFreeMinimumInsideOptionalCtorSignature = "(J)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+                newElement_0_stackFreeMinimumInsideOptionalClassName.c_str(),
+                newElement_0_stackFreeMinimumInsideOptionalCtorSignature.c_str(), entry_0.stackFreeMinimum.Value(),
+                newElement_0_stackFreeMinimumInsideOptional);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_stackFreeMinimumInsideOptional,
+                                                              newElement_0_stackFreeMinimum);
+        }
         jobject newElement_0_stackSize;
-        std::string newElement_0_stackSizeClassName     = "java/lang/Long";
-        std::string newElement_0_stackSizeCtorSignature = "(J)V";
-        chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(newElement_0_stackSizeClassName.c_str(),
-                                                                       newElement_0_stackSizeCtorSignature.c_str(),
-                                                                       entry_0.stackSize, newElement_0_stackSize);
+        if (!entry_0.stackSize.HasValue())
+        {
+            chip::JniReferences::GetInstance().CreateOptional(nullptr, newElement_0_stackSize);
+        }
+        else
+        {
+            jobject newElement_0_stackSizeInsideOptional;
+            std::string newElement_0_stackSizeInsideOptionalClassName     = "java/lang/Long";
+            std::string newElement_0_stackSizeInsideOptionalCtorSignature = "(J)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint32_t>(
+                newElement_0_stackSizeInsideOptionalClassName.c_str(), newElement_0_stackSizeInsideOptionalCtorSignature.c_str(),
+                entry_0.stackSize.Value(), newElement_0_stackSizeInsideOptional);
+            chip::JniReferences::GetInstance().CreateOptional(newElement_0_stackSizeInsideOptional, newElement_0_stackSize);
+        }
 
         jclass threadMetricsStructClass;
         err = chip::JniReferences::GetInstance().GetClassRef(
@@ -18880,7 +18921,7 @@ void CHIPSoftwareDiagnosticsThreadMetricsAttributeCallback::CallbackFn(
         }
         jmethodID threadMetricsStructCtor =
             env->GetMethodID(threadMetricsStructClass, "<init>",
-                             "(Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Long;Ljava/lang/Long;Ljava/lang/Long;)V");
+                             "(Ljava/lang/Long;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V");
         if (threadMetricsStructCtor == nullptr)
         {
             ChipLogError(Zcl, "Could not find ChipStructs$SoftwareDiagnosticsClusterThreadMetrics constructor");

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
@@ -1449,13 +1449,17 @@ public class ChipStructs {
 
   public static class SoftwareDiagnosticsClusterThreadMetrics {
     public Long id;
-    public String name;
-    public Long stackFreeCurrent;
-    public Long stackFreeMinimum;
-    public Long stackSize;
+    public Optional<String> name;
+    public Optional<Long> stackFreeCurrent;
+    public Optional<Long> stackFreeMinimum;
+    public Optional<Long> stackSize;
 
     public SoftwareDiagnosticsClusterThreadMetrics(
-        Long id, String name, Long stackFreeCurrent, Long stackFreeMinimum, Long stackSize) {
+        Long id,
+        Optional<String> name,
+        Optional<Long> stackFreeCurrent,
+        Optional<Long> stackFreeMinimum,
+        Optional<Long> stackSize) {
       this.id = id;
       this.name = name;
       this.stackFreeCurrent = stackFreeCurrent;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -10738,17 +10738,17 @@ class SoftwareDiagnostics(Cluster):
                 return ClusterObjectDescriptor(
                     Fields = [
                             ClusterObjectFieldDescriptor(Label="id", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="stackFreeCurrent", Tag=2, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="stackFreeMinimum", Tag=3, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="stackSize", Tag=4, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="stackFreeCurrent", Tag=2, Type=typing.Optional[uint]),
+                            ClusterObjectFieldDescriptor(Label="stackFreeMinimum", Tag=3, Type=typing.Optional[uint]),
+                            ClusterObjectFieldDescriptor(Label="stackSize", Tag=4, Type=typing.Optional[uint]),
                     ])
 
             id: 'uint' = 0
-            name: 'str' = ""
-            stackFreeCurrent: 'uint' = 0
-            stackFreeMinimum: 'uint' = 0
-            stackSize: 'uint' = 0
+            name: 'typing.Optional[str]' = None
+            stackFreeCurrent: 'typing.Optional[uint]' = None
+            stackFreeMinimum: 'typing.Optional[uint]' = None
+            stackSize: 'typing.Optional[uint]' = None
 
 
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPAttributeTLVValueDecoder.mm
@@ -12101,12 +12101,28 @@ id CHIPDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader 
                     CHIPSoftwareDiagnosticsClusterThreadMetrics * newElement_0;
                     newElement_0 = [CHIPSoftwareDiagnosticsClusterThreadMetrics new];
                     newElement_0.id = [NSNumber numberWithUnsignedLongLong:entry_0.id];
-                    newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                                 length:entry_0.name.size()
-                                                               encoding:NSUTF8StringEncoding];
-                    newElement_0.stackFreeCurrent = [NSNumber numberWithUnsignedInt:entry_0.stackFreeCurrent];
-                    newElement_0.stackFreeMinimum = [NSNumber numberWithUnsignedInt:entry_0.stackFreeMinimum];
-                    newElement_0.stackSize = [NSNumber numberWithUnsignedInt:entry_0.stackSize];
+                    if (entry_0.name.HasValue()) {
+                        newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
+                                                                     length:entry_0.name.Value().size()
+                                                                   encoding:NSUTF8StringEncoding];
+                    } else {
+                        newElement_0.name = nil;
+                    }
+                    if (entry_0.stackFreeCurrent.HasValue()) {
+                        newElement_0.stackFreeCurrent = [NSNumber numberWithUnsignedInt:entry_0.stackFreeCurrent.Value()];
+                    } else {
+                        newElement_0.stackFreeCurrent = nil;
+                    }
+                    if (entry_0.stackFreeMinimum.HasValue()) {
+                        newElement_0.stackFreeMinimum = [NSNumber numberWithUnsignedInt:entry_0.stackFreeMinimum.Value()];
+                    } else {
+                        newElement_0.stackFreeMinimum = nil;
+                    }
+                    if (entry_0.stackSize.HasValue()) {
+                        newElement_0.stackSize = [NSNumber numberWithUnsignedInt:entry_0.stackSize.Value()];
+                    } else {
+                        newElement_0.stackSize = nil;
+                    }
                     [array_0 addObject:newElement_0];
                 }
                 CHIP_ERROR err = iter_0.GetStatus();

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPCallbackBridge.mm
@@ -8560,12 +8560,28 @@ void CHIPSoftwareDiagnosticsThreadMetricsListAttributeCallbackBridge::OnSuccessF
             CHIPSoftwareDiagnosticsClusterThreadMetrics * newElement_0;
             newElement_0 = [CHIPSoftwareDiagnosticsClusterThreadMetrics new];
             newElement_0.id = [NSNumber numberWithUnsignedLongLong:entry_0.id];
-            newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.data()
-                                                         length:entry_0.name.size()
-                                                       encoding:NSUTF8StringEncoding];
-            newElement_0.stackFreeCurrent = [NSNumber numberWithUnsignedInt:entry_0.stackFreeCurrent];
-            newElement_0.stackFreeMinimum = [NSNumber numberWithUnsignedInt:entry_0.stackFreeMinimum];
-            newElement_0.stackSize = [NSNumber numberWithUnsignedInt:entry_0.stackSize];
+            if (entry_0.name.HasValue()) {
+                newElement_0.name = [[NSString alloc] initWithBytes:entry_0.name.Value().data()
+                                                             length:entry_0.name.Value().size()
+                                                           encoding:NSUTF8StringEncoding];
+            } else {
+                newElement_0.name = nil;
+            }
+            if (entry_0.stackFreeCurrent.HasValue()) {
+                newElement_0.stackFreeCurrent = [NSNumber numberWithUnsignedInt:entry_0.stackFreeCurrent.Value()];
+            } else {
+                newElement_0.stackFreeCurrent = nil;
+            }
+            if (entry_0.stackFreeMinimum.HasValue()) {
+                newElement_0.stackFreeMinimum = [NSNumber numberWithUnsignedInt:entry_0.stackFreeMinimum.Value()];
+            } else {
+                newElement_0.stackFreeMinimum = nil;
+            }
+            if (entry_0.stackSize.HasValue()) {
+                newElement_0.stackSize = [NSNumber numberWithUnsignedInt:entry_0.stackSize.Value()];
+            } else {
+                newElement_0.stackSize = nil;
+            }
             [array_0 addObject:newElement_0];
         }
         CHIP_ERROR err = iter_0.GetStatus();

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
@@ -281,10 +281,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface CHIPSoftwareDiagnosticsClusterThreadMetrics : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull id;
-@property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSNumber * _Nonnull stackFreeCurrent;
-@property (strong, nonatomic) NSNumber * _Nonnull stackFreeMinimum;
-@property (strong, nonatomic) NSNumber * _Nonnull stackSize;
+@property (strong, nonatomic) NSString * _Nullable name;
+@property (strong, nonatomic) NSNumber * _Nullable stackFreeCurrent;
+@property (strong, nonatomic) NSNumber * _Nullable stackFreeMinimum;
+@property (strong, nonatomic) NSNumber * _Nullable stackSize;
 - (instancetype)init;
 @end
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
@@ -928,13 +928,13 @@ NS_ASSUME_NONNULL_BEGIN
 
         _id = @(0);
 
-        _name = @"";
+        _name = nil;
 
-        _stackFreeCurrent = @(0);
+        _stackFreeCurrent = nil;
 
-        _stackFreeMinimum = @(0);
+        _stackFreeMinimum = nil;
 
-        _stackSize = @(0);
+        _stackSize = nil;
     }
     return self;
 }

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -303,13 +303,11 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
 
             strncpy(thread->NameBuf, entry->d_name, kMaxThreadNameLength);
             thread->NameBuf[kMaxThreadNameLength] = '\0';
-            thread->name                          = CharSpan::fromCharString(thread->NameBuf);
-            thread->id                            = atoi(entry->d_name);
+            thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+            thread->id = atoi(entry->d_name);
 
-            // TODO: Get stack info of each thread
-            thread->stackFreeCurrent = 0;
-            thread->stackFreeMinimum = 0;
-            thread->stackSize        = 0;
+            // TODO: Get stack info of each thread: thread->stackFreeCurrent,
+            // thread->stackFreeMinimum, thread->stackSize.
 
             thread->Next = head;
             head         = thread;

--- a/src/platform/cc13x2_26x2/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc13x2_26x2/DiagnosticDataProviderImpl.cpp
@@ -87,13 +87,13 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
 
             strncpy(thread->NameBuf, taskStatusArray[x].pcTaskName, kMaxThreadNameLength - 1);
             thread->NameBuf[kMaxThreadNameLength] = '\0';
-            thread->name                          = CharSpan(thread->NameBuf, strlen(thread->NameBuf));
-            thread->id                            = taskStatusArray[x].xTaskNumber;
+            thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+            thread->id = taskStatusArray[x].xTaskNumber;
 
-            thread->stackFreeMinimum = taskStatusArray[x].usStackHighWaterMark;
+            thread->stackFreeMinimum.Emplace(taskStatusArray[x].usStackHighWaterMark);
             /* Unsupported metrics */
-            thread->stackSize        = 0;
-            thread->stackFreeCurrent = 0;
+            // thread->stackSize
+            // thread->stackFreeCurrent
 
             thread->Next = head;
             head         = thread;

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -290,13 +290,11 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
 
             strncpy(thread->NameBuf, entry->d_name, kMaxThreadNameLength);
             thread->NameBuf[kMaxThreadNameLength] = '\0';
-            thread->name                          = CharSpan::fromCharString(thread->NameBuf);
-            thread->id                            = atoi(entry->d_name);
+            thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+            thread->id = atoi(entry->d_name);
 
-            // TODO: Get stack info of each thread
-            thread->stackFreeCurrent = 0;
-            thread->stackFreeMinimum = 0;
-            thread->stackSize        = 0;
+            // TODO: Get stack info of each thread: thread->stackFreeCurrent,
+            // thread->stackFreeMinimum, thread->stackSize.
 
             thread->Next = head;
             head         = thread;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -11216,10 +11216,10 @@ struct Type
 {
 public:
     uint64_t id = static_cast<uint64_t>(0);
-    chip::CharSpan name;
-    uint32_t stackFreeCurrent = static_cast<uint32_t>(0);
-    uint32_t stackFreeMinimum = static_cast<uint32_t>(0);
-    uint32_t stackSize        = static_cast<uint32_t>(0);
+    Optional<chip::CharSpan> name;
+    Optional<uint32_t> stackFreeCurrent;
+    Optional<uint32_t> stackFreeMinimum;
+    Optional<uint32_t> stackSize;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
@@ -2183,29 +2183,34 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
     VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
 
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ThreadMetrics.id", "id", value.isMember("id")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ThreadMetrics.name", "name", value.isMember("name")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ThreadMetrics.stackFreeCurrent", "stackFreeCurrent",
-                                                                  value.isMember("stackFreeCurrent")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("ThreadMetrics.stackFreeMinimum", "stackFreeMinimum",
-                                                                  value.isMember("stackFreeMinimum")));
-    ReturnErrorOnFailure(
-        ComplexArgumentParser::EnsureMemberExist("ThreadMetrics.stackSize", "stackSize", value.isMember("stackSize")));
 
     char labelWithMember[kMaxLabelLength];
     snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "id");
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.id, value["id"]));
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "name");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.name, value["name"]));
+    if (value.isMember("name"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "name");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.name, value["name"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "stackFreeCurrent");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.stackFreeCurrent, value["stackFreeCurrent"]));
+    if (value.isMember("stackFreeCurrent"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "stackFreeCurrent");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.stackFreeCurrent, value["stackFreeCurrent"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "stackFreeMinimum");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.stackFreeMinimum, value["stackFreeMinimum"]));
+    if (value.isMember("stackFreeMinimum"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "stackFreeMinimum");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.stackFreeMinimum, value["stackFreeMinimum"]));
+    }
 
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "stackSize");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.stackSize, value["stackSize"]));
+    if (value.isMember("stackSize"))
+    {
+        snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "stackSize");
+        ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.stackSize, value["stackSize"]));
+    }
 
     return CHIP_NO_ERROR;
 }

--- a/zzz_generated/darwin-framework-tool/zap-generated/cluster/CHIPTestClustersObjc.mm
+++ b/zzz_generated/darwin-framework-tool/zap-generated/cluster/CHIPTestClustersObjc.mm
@@ -16738,10 +16738,22 @@ using namespace chip::app::Clusters;
                         }
                         auto element_0 = (CHIPSoftwareDiagnosticsClusterThreadMetrics *) value[i_0];
                         listHolder_0->mList[i_0].id = element_0.id.unsignedLongLongValue;
-                        listHolder_0->mList[i_0].name = [self asCharSpan:element_0.name];
-                        listHolder_0->mList[i_0].stackFreeCurrent = element_0.stackFreeCurrent.unsignedIntValue;
-                        listHolder_0->mList[i_0].stackFreeMinimum = element_0.stackFreeMinimum.unsignedIntValue;
-                        listHolder_0->mList[i_0].stackSize = element_0.stackSize.unsignedIntValue;
+                        if (element_0.name != nil) {
+                            auto & definedValue_2 = listHolder_0->mList[i_0].name.Emplace();
+                            definedValue_2 = [self asCharSpan:element_0.name];
+                        }
+                        if (element_0.stackFreeCurrent != nil) {
+                            auto & definedValue_2 = listHolder_0->mList[i_0].stackFreeCurrent.Emplace();
+                            definedValue_2 = element_0.stackFreeCurrent.unsignedIntValue;
+                        }
+                        if (element_0.stackFreeMinimum != nil) {
+                            auto & definedValue_2 = listHolder_0->mList[i_0].stackFreeMinimum.Emplace();
+                            definedValue_2 = element_0.stackFreeMinimum.unsignedIntValue;
+                        }
+                        if (element_0.stackSize != nil) {
+                            auto & definedValue_2 = listHolder_0->mList[i_0].stackSize.Emplace();
+                            definedValue_2 = element_0.stackSize.unsignedIntValue;
+                        }
                     }
                     cppValue = ListType_0(listHolder_0->mList, value.count);
                 } else {


### PR DESCRIPTION
The optional fields should be optional instead of forcing consumers to
provide garbage values.

#### Problem
Struct definition does not match spec.

#### Change overview
Make them match.

#### Testing
Looked at the generated code.