### PR TITLE
iOS tv-casting-app: Building, linking and calling libTvCastingCommon.a

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -135,6 +135,10 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         "${chip_root}/src/setup_payload/java",
       ]
     }
+
+    if (build_tv_casting_common_a) {
+      deps += [ "${chip_root}/examples/tv-casting-app/tv-casting-common:tvCastingCommon" ]
+    }
   }
 
   if (chip_build_tools) {

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
@@ -22,6 +22,9 @@
 
 @interface CastingServerBridge : NSObject
 
++ (CastingServerBridge *)getSharedInstance;
+
+// TBD: placeholder will be replaced with true CastingServer functions
 - (int)add:(int)a secondNum:(int)b;
 
 @end

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.mm
@@ -16,9 +16,44 @@
  */
 
 #import "CastingServerBridge.h"
+#import "CastingServer.h"
+
+#include <lib/support/CHIPMem.h>
+#include <platform/PlatformManager.h>
 
 @implementation CastingServerBridge
 
++ (CastingServerBridge *)getSharedInstance
+{
+    static CastingServerBridge * instance = nil;
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        instance = [[self alloc] init];
+    });
+    return instance;
+}
+
+- (instancetype)init
+{
+    if (self = [super init]) {
+        CHIP_ERROR err = chip::Platform::MemoryInit();
+        if (err != CHIP_NO_ERROR) {
+            ChipLogError(AppServer, "MemoryInit failed: %s", ErrorStr(err));
+            return nil;
+        }
+
+        err = chip::DeviceLayer::PlatformMgr().InitChipStack();
+        if (err != CHIP_NO_ERROR) {
+            ChipLogError(AppServer, "InitChipStack failed: %s", ErrorStr(err));
+            return nil;
+        }
+
+        CastingServer::GetInstance()->Init();
+    }
+    return self;
+}
+
+// TBD: placeholder will be replaced with true CastingServer functions
 - (int)add:(int)a secondNum:(int)b
 {
     return a + b;

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		3C75075C284B080900D7DB3A /* libmbedtls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C75075B284B07E800D7DB3A /* libmbedtls.a */; settings = {ATTRIBUTES = (Required, ); }; };
+		3C9ACC05284ABF4000718B2D /* libTvCastingCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */; };
 		3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */; };
 		3CC0E8FC2841DD3400EC6A18 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */; };
 		3CC0E8FE2841DD3500EC6A18 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3CC0E8FD2841DD3500EC6A18 /* Assets.xcassets */; };
@@ -15,6 +17,9 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		3C75075B284B07E800D7DB3A /* libmbedtls.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedtls.a; path = lib/libmbedtls.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C75075E284C1DF800D7DB3A /* TvCasting.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TvCasting.entitlements; sourceTree = "<group>"; };
+		3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libTvCastingCommon.a; path = lib/libTvCastingCommon.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC0E8F62841DD3400EC6A18 /* TvCasting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TvCasting.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TvCastingApp.swift; sourceTree = "<group>"; };
 		3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -31,12 +36,23 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C9ACC05284ABF4000718B2D /* libTvCastingCommon.a in Frameworks */,
+				3C75075C284B080900D7DB3A /* libmbedtls.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		3C9ACC02284ABBD600718B2D /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				3C75075B284B07E800D7DB3A /* libmbedtls.a */,
+				3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
 		3CC0E8ED2841DD3400EC6A18 = {
 			isa = PBXGroup;
 			children = (
@@ -44,6 +60,7 @@
 				3CC0E8F82841DD3400EC6A18 /* TvCasting */,
 				3CC0E9072841DD4B00EC6A18 /* MatterBridge */,
 				3CC0E8F72841DD3400EC6A18 /* Products */,
+				3C9ACC02284ABBD600718B2D /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -58,6 +75,7 @@
 		3CC0E8F82841DD3400EC6A18 /* TvCasting */ = {
 			isa = PBXGroup;
 			children = (
+				3C75075E284C1DF800D7DB3A /* TvCasting.entitlements */,
 				3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */,
 				3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */,
 				3CC0E8FD2841DD3500EC6A18 /* Assets.xcassets */,
@@ -86,11 +104,23 @@
 		};
 /* End PBXGroup section */
 
+/* Begin PBXHeadersBuildPhase section */
+		3C75075D284BD20000D7DB3A /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXHeadersBuildPhase section */
+
 /* Begin PBXNativeTarget section */
 		3CC0E8F52841DD3400EC6A18 /* TvCasting */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 3CC0E9042841DD3500EC6A18 /* Build configuration list for PBXNativeTarget "TvCasting" */;
 			buildPhases = (
+				3C9ACC012849D55B00718B2D /* Run Script */,
+				3C75075D284BD20000D7DB3A /* Headers */,
 				3CC0E8F22841DD3400EC6A18 /* Sources */,
 				3CC0E8F32841DD3400EC6A18 /* Frameworks */,
 				3CC0E8F42841DD3400EC6A18 /* Resources */,
@@ -150,6 +180,27 @@
 		};
 /* End PBXResourcesBuildPhase section */
 
+/* Begin PBXShellScriptBuildPhase section */
+		3C9ACC012849D55B00718B2D /* Run Script */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "./chip_xcode_build_connector.sh\n";
+		};
+/* End PBXShellScriptBuildPhase section */
+
 /* Begin PBXSourcesBuildPhase section */
 		3CC0E8F22841DD3400EC6A18 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
@@ -206,7 +257,9 @@
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_OPTIMIZATION_LEVEL = 0;
 				GCC_PREPROCESSOR_DEFINITIONS = (
+					CHIP_HAVE_CONFIG_H,
 					"DEBUG=1",
+					"CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
 					"$(inherited)",
 				);
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -264,6 +317,7 @@
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = CHIP_HAVE_CONFIG_H;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
 				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
 				GCC_WARN_UNDECLARED_SELECTOR = YES;
@@ -285,12 +339,40 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CHIP_ROOT = "$(PROJECT_DIR)/../../../..";
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = TvCasting/TvCasting.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TvCasting/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_PREVIEWS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					CHIP_HAVE_CONFIG_H,
+					"CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
+					"DEBUG=1",
+					"$(inherited)",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${CHIP_ROOT}/examples/tv-casting-app/tv-casting-common/include",
+					"$(CHIP_ROOT)/src",
+					"$(CHIP_ROOT)/src/include",
+					"$(CHIP_ROOT)/src/lib",
+					"$(CHIP_ROOT)/src/app",
+					"$(CHIP_ROOT)/config/ios",
+					"$(CHIP_ROOT)/src/darwin/Framework/CHIP/",
+					"$(CHIP_ROOT)/src/app/util",
+					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
+					"$(CHIP_ROOT)/third_party/nlio/repo/include",
+					"$(TEMP_DIR)/out/gen/include",
+					"$(CHIP_ROOT)/zzz_generated/",
+					"$(CHIP_ROOT)/zzz_generated/app-common",
+					"$(CHIP_ROOT)/zzz_generated/controller-clusters",
+				);
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -300,9 +382,37 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = "$(TEMP_DIR)/out/lib";
 				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-Wformat",
+					"-Wformat-nonliteral",
+					"-Wformat-security",
+				);
+				"OTHER_LDFLAGS[arch=*]" = (
+					"-framework",
+					CoreData,
+					"-framework",
+					Foundation,
+					"-framework",
+					CoreBluetooth,
+					"-lnetwork",
+					"-Wl,-unexported_symbol,\"__Z*\"",
+				);
+				"OTHER_LDFLAGS[sdk=macosx*]" = (
+					"-framework",
+					IOKit,
+					"-lnetwork",
+					"-framework",
+					CoreBluetooth,
+					"-framework",
+					CoreData,
+					"-Wl,-unexported_symbol,\"__Z*\"",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.matter.TvCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "MatterBridge/TvCasting-Bridging-Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
@@ -316,12 +426,39 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CHIP_ROOT = "$(PROJECT_DIR)/../../../..";
 				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_ENTITLEMENTS = TvCasting/TvCasting.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"TvCasting/Preview Content\"";
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				ENABLE_PREVIEWS = YES;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					CHIP_HAVE_CONFIG_H,
+					"CHIP_ADDRESS_RESOLVE_IMPL_INCLUDE_HEADER=<lib/address_resolve/AddressResolve_DefaultImpl.h>",
+					"$(inherited)",
+				);
 				GENERATE_INFOPLIST_FILE = YES;
+				HEADER_SEARCH_PATHS = (
+					"${CHIP_ROOT}/examples/tv-casting-app/tv-casting-common/include",
+					"$(CHIP_ROOT)/src",
+					"$(CHIP_ROOT)/src/include",
+					"$(CHIP_ROOT)/src/lib",
+					"$(CHIP_ROOT)/src/app",
+					"$(CHIP_ROOT)/config/ios",
+					"$(CHIP_ROOT)/src/darwin/Framework/CHIP/",
+					"$(CHIP_ROOT)/src/app/util",
+					"$(CHIP_ROOT)/third_party/nlassert/repo/include",
+					"$(CHIP_ROOT)/third_party/nlio/repo/include",
+					"$(TEMP_DIR)/out/gen/include",
+					"$(CHIP_ROOT)/zzz_generated/",
+					"$(CHIP_ROOT)/zzz_generated/app-common",
+					"$(CHIP_ROOT)/zzz_generated/controller-clusters",
+				);
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
@@ -331,9 +468,17 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
+				LIBRARY_SEARCH_PATHS = "$(TEMP_DIR)/out/lib";
 				MARKETING_VERSION = 1.0;
+				ONLY_ACTIVE_ARCH = YES;
+				OTHER_CFLAGS = (
+					"-Wformat",
+					"-Wformat-nonliteral",
+					"-Wformat-security",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.matter.TvCasting;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SUPPORTED_PLATFORMS = "iphonesimulator iphoneos";
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "MatterBridge/TvCasting-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentView.swift
@@ -19,7 +19,7 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("Hello Objective-C from Swift! " + String(CastingServerBridge().add(5, secondNum: 6)))
+        Text("Hello tv-casting-common C++, from Objective-C, from Swift! Sum: " + String(CastingServerBridge.getSharedInstance().add(5, secondNum: 6)))
             .padding()
     }
 }

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCasting.entitlements
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/TvCasting.entitlements
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+</dict>
+</plist>

--- a/examples/tv-casting-app/darwin/TvCasting/chip_xcode_build_connector.sh
+++ b/examples/tv-casting-app/darwin/TvCasting/chip_xcode_build_connector.sh
@@ -1,0 +1,162 @@
+#!/usr/bin/env bash
+
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# This script connects Xcode's "Run Script" build phase to a build of CHIP for Apple's environments.
+#
+# Conventions used in this script:
+#  * Variables in upper case supplied by Xcode (or other executor), are exported to subprocesses, or
+#      are upper-case elsewhere in CHIP scripts (e.g. CHIP_ROOT is only used locally,
+#      but is all uppper). Variables defined herein and used locally are lower-case
+#
+
+here=$(cd "${0%/*}" && pwd)
+me=${0##*/}
+
+CHIP_ROOT=$(cd "$here/../../../.." && pwd)
+
+die() {
+    echo "$me: *** ERROR: $*"
+    exit 1
+}
+
+# lotsa debug output :-)
+set -ex
+
+# helpful debugging, save off environment that Xcode gives us, can source it to
+#  retry/repro failures from a bash terminal
+mkdir -p "$TEMP_DIR"
+export >"$TEMP_DIR/env.sh"
+
+declare -a defines=()
+# lots of environment variables passed by Xcode to this script
+read -r -a defines <<<"$GCC_PREPROCESSOR_DEFINITIONS"
+
+declare target_defines=
+for define in "${defines[@]}"; do
+
+    # skip over those that GN does for us
+    case "$define" in
+        CHIP_HAVE_CONFIG_H)
+            continue
+            ;;
+    esac
+    target_defines+=,\"${define//\"/\\\"}\"
+done
+target_defines=[${target_defines:1}]
+
+declare target_cpu=
+case $PLATFORM_PREFERRED_ARCH in
+    i386)
+        target_cpu=x86
+        ;;
+    x86_64)
+        target_cpu=x64
+        ;;
+    armv7)
+        target_cpu=arm
+        ;;
+    arm64)
+        target_cpu=arm64
+        ;;
+    *)
+        echo >&2
+        ;;
+esac
+
+declare target_cflags='"-target","'"$PLATFORM_PREFERRED_ARCH"'-'"$LLVM_TARGET_TRIPLE_VENDOR"'-'"$LLVM_TARGET_TRIPLE_OS_VERSION"'"'
+
+read -r -a archs <<<"$ARCHS"
+
+for arch in "${archs[@]}"; do
+    target_cflags+=',"-arch","'"$arch"'"'
+done
+
+[[ $ENABLE_BITCODE == YES ]] && {
+    target_cflags+=',"-flto"'
+}
+
+declare -a args=(
+    'default_configs_cosmetic=[]' # suppress colorization
+    'chip_crypto="mbedtls"'
+    'chip_build_tools=false'
+    'chip_build_tests=false'
+    'target_cpu="'"$target_cpu"'"'
+    'target_defines='"$target_defines"
+    'target_cflags=['"$target_cflags"']'
+    'build_tv_casting_common_a=true'
+)
+
+[[ $CONFIGURATION != Debug* ]] && args+='is_debug=true'
+
+[[ $PLATFORM_FAMILY_NAME != macOS ]] && {
+    args+=(
+        'target_os="ios"'
+        'import("//config/ios/args.gni")'
+    )
+}
+
+[[ $PLATFORM_FAMILY_NAME == macOS ]] && {
+    args+=(
+        'target_os="mac"'
+    )
+}
+
+# search current (or $2) and its parent directories until
+#  a name match is found, which is output on stdout
+find_in_ancestors() {
+    declare to_find="${1}"
+    declare dir="${2:-$(pwd)}"
+
+    while [[ ! -e ${dir}/${to_find} && -n ${dir} ]]; do
+        dir=${dir%/*}
+    done
+
+    if [[ ! -e ${dir}/${to_find} ]]; then
+        printf 'error: find_in_ancestors: %s not found\n' "$to_find" >&2
+        return 1
+    fi
+    printf '%s\n' "$dir/$to_find"
+}
+
+# actual build stuff
+(
+    cd "$CHIP_ROOT" # pushd and popd because we need the env vars from activate
+
+    if ENV=$(find_in_ancestors chip_xcode_build_connector_env.sh 2>/dev/null); then
+        . "$ENV"
+    fi
+
+    # there are environments where these bits are unwanted, unnecessary, or impossible
+    [[ -n $CHIP_NO_SUBMODULES ]] || git submodule update --init
+    if [[ -z $CHIP_NO_ACTIVATE ]]; then
+        # first run bootstrap/activate in an external env to build everything
+        env -i PW_ENVSETUP_NO_BANNER=1 PW_ENVSETUP_QUIET=1 bash -c '. scripts/activate.sh'
+        set +ex
+        # now source activate for env vars
+        PW_ENVSETUP_NO_BANNER=1 PW_ENVSETUP_QUIET=1 . scripts/activate.sh
+        set -ex
+    fi
+
+    # put build intermediates in TEMP_DIR
+    cd "$TEMP_DIR"
+
+    # gnerate and build
+    gn --root="$CHIP_ROOT" gen --check out --args="${args[*]}"
+    ninja -v -C out
+)

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -15,6 +15,7 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/src/app/chip_data_model.gni")
+import("${chip_root}/src/lib/lib.gni")
 
 config("config") {
   include_dirs = [
@@ -62,4 +63,16 @@ chip_data_model("tv-casting-common") {
       [ "${chip_root}/examples/tv-casting-app/tv-casting-common/include" ]
 
   is_server = true
+}
+
+static_library("tvCastingCommon") {
+  public_deps = [ "${chip_root}/examples/tv-casting-app/tv-casting-common" ]
+
+  cflags = [ "-Wconversion" ]
+
+  output_name = "libTvCastingCommon"
+
+  output_dir = "${root_out_dir}/lib"
+
+  complete_static_lib = true
 }

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -149,6 +149,9 @@ declare_args() {
   # If true, disables KVS implementation for the platform.  May not be
   # supported on all platforms.
   chip_disable_platform_kvs = false
+
+  # If true, builds the tv-casting-common static lib
+  build_tv_casting_common_a = false
 }
 
 assert(chip_disable_platform_kvs == false || chip_device_platform == "darwin",


### PR DESCRIPTION
#### Problem
iOS TvCasting app could not call into the tv-casting-common C++ logic that is shared across other platforms (Linux, android, etc). This PR establishes a way to leverage that shared logic (i.e. CastingServer.cpp) 

#### Change overview
1. Updates to project.pbxproj with a plugged in chip_xcode_build_connector.sh, customized for the iOS TvCasting app. Also, updates to BUILD.gn so static lib libTvCastingCommon.a can be built when the appropriate build arg is passed in to gn.
2. Initialization of ChipStack and CastingServer via CastingServerBridge.mm (see the over-riden init() function). 
3. Added a getSharedInstance() function to CastingServerBridge to allow reusing the same instance across the app.

#### Testing
Built and tested on iPhone simulator to verify that the CastingServer is initialized (via logs).