### PR TITLE
Groups cluster: GroupInfo is now removed from the GroupTable whenever…

### DIFF
--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -223,6 +223,35 @@ tests:
                         EpochStartTime2: 2110002,
                     }
 
+    - label: "Remove Group 1"
+      cluster: "Groups"
+      endpoint: 1
+      command: "RemoveGroup"
+      arguments:
+          values:
+              - name: "groupId"
+                value: 0x0101
+      response:
+          values:
+              - name: "status"
+                value: 0
+              - name: "groupId"
+                value: 0x0101
+
+    - label: "Read GroupTable 2"
+      command: "readAttribute"
+      attribute: "GroupTable"
+      response:
+          value:
+              [
+                  {
+                      FabricIndex: 1,
+                      GroupId: 0x0102,
+                      endpoints: [1],
+                      GroupName: "Group #2",
+                  },
+              ]
+
     - label: "Remove All"
       cluster: "Groups"
       endpoint: 1

--- a/src/credentials/GroupDataProviderImpl.cpp
+++ b/src/credentials/GroupDataProviderImpl.cpp
@@ -1187,11 +1187,15 @@ CHIP_ERROR GroupDataProviderImpl::RemoveEndpoint(chip::FabricIndex fabric_index,
         prev.next = endpoint.next;
         ReturnErrorOnFailure(prev.Save(mStorage));
     }
-    if (group.endpoint_count > 0)
+
+    if (group.endpoint_count > 1)
     {
         group.endpoint_count--;
+        return group.Save(mStorage);
     }
-    return group.Save(mStorage);
+
+    // No more endpoints, remove the group
+    return RemoveGroupInfoAt(fabric_index, group.index);
 }
 
 CHIP_ERROR GroupDataProviderImpl::RemoveEndpoint(chip::FabricIndex fabric_index, chip::EndpointId endpoint_id)

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -65137,7 +65137,7 @@ class TestGroupKeyManagementClusterSuite : public TestCommand
 {
 public:
     TestGroupKeyManagementClusterSuite(CredentialIssuerCommands * credsIssuerConfig) :
-        TestCommand("TestGroupKeyManagementCluster", 18, credsIssuerConfig)
+        TestCommand("TestGroupKeyManagementCluster", 20, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -65318,11 +65318,40 @@ private:
             break;
         case 15:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 0));
+
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
+            }
             break;
         case 16:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::DecodableList<
+                    chip::app::Clusters::GroupKeyManagement::Structs::GroupInfoMapStruct::DecodableType>
+                    value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                {
+                    auto iter_0 = value.begin();
+                    VerifyOrReturn(CheckNextListItemDecodes<decltype(value)>("groupTable", iter_0, 0));
+                    VerifyOrReturn(CheckValue("groupTable[0].groupId", iter_0.GetValue().groupId, 258U));
+                    VerifyOrReturn(CheckValuePresent("groupTable[0].groupName", iter_0.GetValue().groupName));
+                    VerifyOrReturn(CheckValueAsString("groupTable[0].groupName.Value()", iter_0.GetValue().groupName.Value(),
+                                                      chip::CharSpan("Group #2", 8)));
+                    VerifyOrReturn(CheckValue("groupTable[0].fabricIndex", iter_0.GetValue().fabricIndex, 1));
+                    VerifyOrReturn(CheckNoMoreListItems<decltype(value)>("groupTable", iter_0, 1));
+                }
+            }
             break;
         case 17:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 18:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 19:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
             break;
         default:
@@ -65540,7 +65569,22 @@ private:
             );
         }
         case 15: {
-            LogStep(15, "Remove All");
+            LogStep(15, "Remove Group 1");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::RemoveGroup::Type value;
+            value.groupId = 257U;
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::RemoveGroup::Id, value,
+                               chip::NullOptional
+
+            );
+        }
+        case 16: {
+            LogStep(16, "Read GroupTable 2");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(0), GroupKeyManagement::Id,
+                                 GroupKeyManagement::Attributes::GroupTable::Id, true, chip::NullOptional);
+        }
+        case 17: {
+            LogStep(17, "Remove All");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::RemoveAllGroups::Id, value,
@@ -65548,8 +65592,8 @@ private:
 
             );
         }
-        case 16: {
-            LogStep(16, "KeySet Remove 2");
+        case 18: {
+            LogStep(18, "KeySet Remove 2");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetRemove::Type value;
             value.groupKeySetID = 418U;
@@ -65558,8 +65602,8 @@ private:
 
             );
         }
-        case 17: {
-            LogStep(17, "KeySet Read (also removed)");
+        case 19: {
+            LogStep(19, "KeySet Read (also removed)");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetRead::Type value;
             value.groupKeySetID = 418U;


### PR DESCRIPTION
GroupInfo is now removed from the GroupTable when the last endpoint is removed from the group.

#### Problem
Groups are not removed from GroupTable even after RemoveGroup command gets Success response.
* Fixes [#18892](https://github.com/project-chip/connectedhomeip/issues/18892)

#### Change overview
* Now GroupDataProviderImpl::RemoveEndpoint also removes the GroupInfo if the last endpoint is removed.
* Test added to TestGroupKeyManagementCluster.yaml to check for the new behaviour.

#### Testing
Groups and GroupKeyManagement cluster YAML tests executed successfully.
