### PR TITLE
[Ameba] Update ameba SDK to expose xPortResetHeapMinimumEverFreeHeapSize API

### DIFF
--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -3,7 +3,7 @@ FROM connectedhomeip/chip-build:${VERSION}
 
 # Setup Ameba
 ARG AMEBA_DIR=/opt/ameba
-ARG TAG_NAME=ameba_update_2022_05_20
+ARG TAG_NAME=ameba_update_2022_06_06
 RUN set -x \
     && apt-get update \
     && mkdir ${AMEBA_DIR} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.78 Version bump reason: [Tizen] Fix environment variable order, add missing tizen dependencies
+0.5.79 Version bump reason: [Ameba] Update ameba SDK to expose xPortResetHeapMinimumEverFreeHeapSize API


### PR DESCRIPTION
#### Problem
Add reset-watermarks and read thread-metrics function.

#### Change overview

- Update chip-build-ameba/Dockerfile
- Update version
- Exposed xPortResetHeapMinimumEverFreeHeapSize FreeRTOS API to use for #19147

#### Testing
Tested docker build
