### PR TITLE
[nrfconnect] Fixed a timer issue on WindowApp

### DIFF
--- a/examples/window-app/nrfconnect/README.md
+++ b/examples/window-app/nrfconnect/README.md
@@ -111,6 +111,20 @@ requests to start sending the update packages.
 An OTA Requestor is a node that wants to download a new firmware image and sends
 requests to an OTA Provider to start the update process.
 
+#### Simple Management Protocol
+
+Simple Management Protocol (SMP) is a basic transfer encoding that is used for
+device management purposes, including application image management. SMP supports
+using different transports, such as Bluetooth LE, UDP, or serial USB/UART.
+
+In this example, the Matter device runs the SMP Server to download the
+application update image using the Bluetooth LE transport.
+
+See the
+[Building with Device Firmware Upgrade support](#building-with-device-firmware-upgrade-support)
+section to learn how to enable SMP and use it for the DFU purpose in this
+example.
+
 #### Bootloader
 
 MCUboot is a secure bootloader used for swapping firmware images of different
@@ -393,6 +407,14 @@ For example, use the following command for `nrf52840dk_nrf52840`:
 ### Building with Device Firmware Upgrade support
 
 Support for DFU using Matter OTA is enabled by default.
+
+To enable DFU over Bluetooth LE, run the following command with _build-target_
+replaced with the build target name of the Nordic Semiconductor kit you are
+using (for example `nrf52840dk_nrf52840`):
+
+    ```
+    $ west build -b build-target -- -DCONFIG_CHIP_DFU_OVER_BT_SMP=y
+    ```
 
 To completely disable support for DFU, run the following command with
 _build-target_ replaced with the build target name of the Nordic Semiconductor

--- a/examples/window-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
+++ b/examples/window-app/nrfconnect/boards/nrf52840dk_nrf52840.overlay
@@ -18,7 +18,10 @@
 	chosen {
 		nordic,pm-ext-flash = &mx25r64;
 	};
+};
 
+
+/ {
 	/*
 	* In some default configurations within the nRF Connect SDK,
 	* e.g. on nRF52840, the chosen zephyr,entropy node is &cryptocell.
@@ -30,9 +33,8 @@
 	};
 
 	/*
-	* By default, PWM module is only configured for led0 (LED1 on the board).
-	* The window-app, however, uses LED2 to show the state of the window cover,
-	* by using the LED's brightness level.
+	* Configure LED2 and LED3 to show the state of the
+	* window cover,by using the LED's brightness level.
 	*/
 	aliases {
 		pwm-led1 = &pwm_led1;
@@ -40,7 +42,6 @@
 	};
 
 	pwmleds {
-		compatible = "pwm-leds";
 		pwm_led1: pwm_led_1 {
 			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
@@ -82,14 +83,14 @@
 &pinctrl {
 	pwm0_default_alt: pwm0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT1, 0, 29)>, <NRF_PSEL(PWM_OUT2, 0, 30)>;
+			psels = <NRF_PSEL(PWM_OUT1, 0, 14)>, <NRF_PSEL(PWM_OUT2, 0, 15)>;
 			nordic,invert;
 		};
 	};
 
 	pwm0_sleep_alt: pwm0_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT1, 0, 29)>, <NRF_PSEL(PWM_OUT2, 0, 30)>;
+			psels = <NRF_PSEL(PWM_OUT1, 0, 14)>, <NRF_PSEL(PWM_OUT2, 0, 15)>;
 			low-power-enable;
 		};
 	};

--- a/examples/window-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
+++ b/examples/window-app/nrfconnect/boards/nrf5340dk_nrf5340_cpuapp.overlay
@@ -20,9 +20,8 @@
 	};
 
 	/*
-	* By default, PWM module is only configured for led0 (LED1 on the board).
-	* The lighting-app, however, uses LED2 to show the state of the lighting,
-	* including its brightness level.
+	* Configure LED2 and LED3 to show the state of the
+	* window cover,by using the LED's brightness level.
 	*/
 	aliases {
 		pwm-led1 = &pwm_led1;
@@ -30,6 +29,7 @@
 	};
 
 	pwmleds {
+		compatible = "pwm-leds";
 		pwm_led1: pwm_led_1 {
 			pwms = <&pwm0 1 PWM_MSEC(20) PWM_POLARITY_INVERTED>;
 		};
@@ -81,8 +81,8 @@
 			};
 		};
 	};
-
 };
+
 
 /* Disable unused peripherals to reduce power consumption */
 &adc {
@@ -110,14 +110,14 @@
 &pinctrl {
 	pwm0_default_alt: pwm0_default_alt {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT1, 0, 14)>, <NRF_PSEL(PWM_OUT2, 0, 15)>;
+			psels = <NRF_PSEL(PWM_OUT1, 0, 29)>, <NRF_PSEL(PWM_OUT2, 0, 30)>;
 			nordic,invert;
 		};
 	};
 
 	pwm0_sleep_alt: pwm0_sleep_alt {
 		group1 {
-			psels = <NRF_PSEL(PWM_OUT1, 0, 14)>, <NRF_PSEL(PWM_OUT2, 0, 15)>;
+			psels = <NRF_PSEL(PWM_OUT1, 0, 29)>, <NRF_PSEL(PWM_OUT2, 0, 30)>;
 			low-power-enable;
 		};
 	};

--- a/examples/window-app/nrfconnect/main/include/WindowCovering.h
+++ b/examples/window-app/nrfconnect/main/include/WindowCovering.h
@@ -69,7 +69,7 @@ private:
     static chip::Percent100ths CalculateSingleStep(MoveType aMoveType);
     static void DriveCurrentLiftPosition(intptr_t);
     static void DriveCurrentTiltPosition(intptr_t);
-    static void MoveTimerTimeoutCallback(k_timer * aTimer);
+    static void MoveTimerTimeoutCallback(chip::System::Layer * systemLayer, void * appState);
     static void DoPostAttributeChange(intptr_t aArg);
 
     MoveType mCurrentUIMoveType;


### PR DESCRIPTION
#### Problem
Nrfconnect WindowApp example fell into a hard fault
after receiving `windowcovering` commands from a chip-tool.

#### Change overview
Moved the application timer's invocation to SystemLayer because previously,
it was called from an ISR context, and it caused a hard fault.
Added also DFU SMP to the WindowApp example and set proper pins to PWM.

#### Testing
Tested manually on nrf53 and nrf52
