### PR TITLE
[Tizen] Fix array size for DNS-SD type name

### DIFF
--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -44,7 +44,7 @@ struct GenericContext
 struct RegisterContext : public GenericContext
 {
     dnssd_service_h service;
-    char type[kDnssdTypeMaxSize + kDnssdProtocolTextMaxSize + 1];
+    char type[kDnssdTypeAndProtocolMaxSize + 1];
     char name[Common::kInstanceNameMaxLength + 1];
     uint16_t port;
     uint32_t interfaceId;
@@ -64,7 +64,7 @@ struct RegisterContext : public GenericContext
 struct BrowseContext : public GenericContext
 {
     dnssd_browser_h browser;
-    char type[kDnssdTypeMaxSize + kDnssdProtocolTextMaxSize + 1];
+    char type[kDnssdTypeAndProtocolMaxSize + 1];
     uint32_t interfaceId;
 
     std::vector<DnssdService> services;
@@ -89,7 +89,7 @@ struct BrowseContext : public GenericContext
 struct ResolveContext : public GenericContext
 {
     dnssd_service_h service;
-    char type[kDnssdTypeMaxSize + kDnssdProtocolTextMaxSize + 1];
+    char type[kDnssdTypeAndProtocolMaxSize + 1];
     char name[Common::kInstanceNameMaxLength + 1];
     uint32_t interfaceId;
     bool isResolving;


### PR DESCRIPTION
#### Problem

The array for storing DNS-SD type and protocol is too small - it does not account for dot (.) in between.

#### Change overview

- use predefined constant for type and protocol

#### Testing

Make sure that commissioned device registers UDP service properly.

Before:
```
D/CHIP    (11540): DL: DNSsd OnRegister
D/CHIP    (11540): DL: DNSsd OnRegister name: 325A438EB5A2B5FE, type: _matterc._ud, port: 5540, interfaceId: 0
```

After:
```
D/CHIP    (11661): DL: DNSsd OnRegister
D/CHIP    (11661): DL: DNSsd OnRegister name: 4F078B16F7018E39, type: _matterc._udp, port: 5540, interfaceId: 0
```