### PR TITLE
Fix typos in build script for constants of app types

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -140,7 +140,7 @@ class HostApp(Enum):
             yield 'controller/python'  # Directory containing WHL files
         elif self == HostApp.NL_TEST_RUNNER:
             yield 'chip_nl_test_runner_wheels'
-        elif self == HostApp.LIGHTING:
+        elif self == HostApp.LIGHT:
             yield 'chip-lighting-app'
             yield 'chip-lighting-app.map'
         elif self == HostApp.TV_CASTING_APP:

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -143,10 +143,10 @@ class HostApp(Enum):
         elif self == HostApp.LIGHT:
             yield 'chip-lighting-app'
             yield 'chip-lighting-app.map'
-        elif self == HostApp.TV_CASTING_APP:
+        elif self == HostApp.TV_CASTING:
             yield 'chip-tv-casting-app'
             yield 'chip-tv-casting-app.map'
-        elif self == HostApp.BRIDGE_APP:
+        elif self == HostApp.BRIDGE:
             yield 'chip-bridge-app'
             yield 'chip-bridge-app.map'
         else:


### PR DESCRIPTION
#### Problem
After #18136 generating app artifacts fails for some apps due to typos in constant names

#### Change overview
Fix the names.

#### Testing
Compiled light app with artifact generation.