### PR TITLE
Run init/free functions to the backup context for GetDigest.

### DIFF
--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -290,6 +290,7 @@ CHIP_ERROR Hash_SHA256_stream::GetDigest(MutableByteSpan & out_buffer)
 
     // Back-up context as we are about to finalize the hash to extract digest.
     mbedtls_sha256_context previous_ctx;
+    mbedtls_sha256_init(&previous_ctx);
     mbedtls_sha256_clone(&previous_ctx, context);
 
     // Pad + compute digest, then finalize context. It is restored next line to continue.
@@ -297,6 +298,7 @@ CHIP_ERROR Hash_SHA256_stream::GetDigest(MutableByteSpan & out_buffer)
 
     // Restore context prior to finalization.
     mbedtls_sha256_clone(context, &previous_ctx);
+    mbedtls_sha256_free(&previous_ctx);
 
     return result;
 }


### PR DESCRIPTION
#### Problem
CYW30739 platform specific SHA256 implementations need `mbedtls_sha256_init` and `mbedtls_sha256_free` functions called to do initialization and cleanup.

#### Change overview
* Call `mbedtls_sha256_init` before cloning the original context to the backup context.
* Call `mbedtls_sha256_free` after the backup context is no longer needed.

#### Testing
chip-tool pairing