### PR TITLE
[chip-tool] Support double quotes for arguments with spaces in interactive mode

### DIFF
--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -19,9 +19,9 @@
 #include "InteractiveCommands.h"
 
 #include <iomanip>
-#include <sstream>
 #include <readline/history.h>
 #include <readline/readline.h>
+#include <sstream>
 
 char kInteractiveModeName[]                            = "";
 constexpr const char * kInteractiveModePrompt          = ">>> ";
@@ -107,7 +107,8 @@ bool InteractiveStartCommand::ParseCommand(char * command)
     std::string arg;
 
     std::stringstream ss(command);
-    while (ss >> std::quoted(arg)) {
+    while (ss >> std::quoted(arg))
+    {
         if (argsCount == kInteractiveModeArgumentsMaxLength)
         {
             gIsCommandRunning = true;
@@ -116,8 +117,8 @@ bool InteractiveStartCommand::ParseCommand(char * command)
             return true;
         }
 
-	char* carg = new char[ arg.size() ];
-	strcpy(carg, arg.c_str() );
+        char * carg = new char[arg.size()];
+        strcpy(carg, arg.c_str());
         args[argsCount++] = carg;
     }
 

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -18,6 +18,8 @@
 
 #include "InteractiveCommands.h"
 
+#include <iomanip>
+#include <sstream>
 #include <readline/history.h>
 #include <readline/readline.h>
 
@@ -102,10 +104,10 @@ bool InteractiveStartCommand::ParseCommand(char * command)
     char * args[kInteractiveModeArgumentsMaxLength];
     args[0]       = kInteractiveModeName;
     int argsCount = 1;
+    std::string arg;
 
-    char * token = strtok(command, " ");
-    while (token != nullptr)
-    {
+    std::stringstream ss(command);
+    while (ss >> std::quoted(arg)) {
         if (argsCount == kInteractiveModeArgumentsMaxLength)
         {
             gIsCommandRunning = true;
@@ -114,14 +116,18 @@ bool InteractiveStartCommand::ParseCommand(char * command)
             return true;
         }
 
-        args[argsCount++] = token;
-        token             = strtok(nullptr, " ");
+	char* carg = new char[ arg.size() ];
+	strcpy(carg, arg.c_str() );
+        args[argsCount++] = carg;
     }
 
     ClearLine();
     gIsCommandRunning = true;
     mHandler->RunInteractive(argsCount, args);
     gIsCommandRunning = false;
+
+    while (--argsCount)
+        delete[] args[argsCount];
 
     return true;
 }

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -117,7 +117,7 @@ bool InteractiveStartCommand::ParseCommand(char * command)
             return true;
         }
 
-        char * carg = new char[arg.size()];
+        char * carg = new char[arg.size() + 1];
         strcpy(carg, arg.c_str());
         args[argsCount++] = carg;
     }

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -127,6 +127,7 @@ bool InteractiveStartCommand::ParseCommand(char * command)
     mHandler->RunInteractive(argsCount, args);
     gIsCommandRunning = false;
 
+    // Do not delete arg[0]
     while (--argsCount)
         delete[] args[argsCount];
 


### PR DESCRIPTION
#### Problem
Trying to pair with an SSID with spaces in `chip-tool interactive` mode doesn't work as spaces are used as argument delimiter and quotes are not supported.

#### Change overview
Add support for quotes.

#### Testing
Tested using `chip-tool interactive start` then `pairing ble-wifi` to commission to a SSID with spaces.