### PR TITLE
Infineon p6 all clusters update

### DIFF
--- a/examples/all-clusters-app/p6/src/AppTask.cpp
+++ b/examples/all-clusters-app/p6/src/AppTask.cpp
@@ -74,6 +74,9 @@ AppTask AppTask::sAppTask;
 namespace {
 app::Clusters::NetworkCommissioning::Instance
     sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::P6WiFiDriver::GetInstance()));
+
+constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
+
 } // namespace
 
 void NetWorkCommissioningInstInit()
@@ -87,6 +90,9 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     chip::Server::GetInstance().Init(initParams);
+
+    // We only have network commissioning on endpoint 0.
+    emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/all-clusters-minimal-app/p6/src/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/p6/src/AppTask.cpp
@@ -74,6 +74,9 @@ AppTask AppTask::sAppTask;
 namespace {
 app::Clusters::NetworkCommissioning::Instance
     sWiFiNetworkCommissioningInstance(0 /* Endpoint Id */, &(NetworkCommissioning::P6WiFiDriver::GetInstance()));
+
+constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
+
 } // namespace
 
 void NetWorkCommissioningInstInit()
@@ -87,6 +90,9 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     chip::Server::GetInstance().Init(initParams);
+
+    // We only have network commissioning on endpoint 0.
+    emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/src/platform/P6/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/P6/NetworkCommissioningWiFiDriver.cpp
@@ -160,7 +160,9 @@ void P6WiFiDriver::OnConnectWiFiNetwork()
     if (mpConnectCallback)
     {
         CommitConfiguration();
+        chip::DeviceLayer::PlatformMgr().LockChipStack();
         mpConnectCallback->OnResult(Status::kSuccess, CharSpan(), 0);
+        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
         mpConnectCallback = nullptr;
     }
 }
@@ -185,7 +187,9 @@ exit:
     {
         ChipLogError(NetworkProvisioning, "Failed to connect to WiFi network:%s", chip::ErrorStr(err));
         mpConnectCallback = nullptr;
+        chip::DeviceLayer::PlatformMgr().LockChipStack();
         callback->OnResult(networkingStatus, CharSpan(), 0);
+        chip::DeviceLayer::PlatformMgr().UnlockChipStack();
     }
 }
 


### PR DESCRIPTION
#### Problem
Fixed commissioning issue with all clusters; updated network commissioning wifi driver with needed lock/unlock sequences.


#### Change overview
Updated P6 all clusters and all clusters minimal apptask to support commissioning only on endpoint 0. Added necessary lock/unlock calls to P6 network commissioning wifi driver.

#### Testing
 Tested by commissioning both all clusters and all clusters minimal on P6 hardware.
