### PR TITLE
Resolve identify all clusters #19060

### DIFF
--- a/examples/all-clusters-app/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/BUILD.gn
@@ -37,6 +37,7 @@ ti_sysconfig("sysconfig") {
   sources = [ "${project_dir}/chip.syscfg" ]
 
   outputs = [
+    "ti_devices_config.c",
     "ti_radio_config.c",
     "ti_radio_config.h",
     "ti_drivers_config.c",

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/args.gni
@@ -26,14 +26,13 @@ ti_simplelink_board = "LP_CC2652R7"
 optimize_debug_level = "s"
 lwip_debug = false
 
-#optimize_for_size=true
 chip_enable_ota_requestor = false
 
 # Disable FTD Build for all-clusters app to save Flash
 chip_openthread_ftd = false
 
 # Disable CHIP Logging
-chip_progress_logging = false
+#chip_progress_logging = false
 chip_detail_logging = false
 chip_automation_logging = false
 

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/chip.syscfg
@@ -89,8 +89,7 @@ for(var setting in ccfgSettings)
     CCFG[setting] = ccfgSettings[setting];
 }
 
-// Disable CCFG generation, this is added by the BIM project
-CCFG.enableCodeGeneration = false;
+CCFG.enableCodeGeneration = true;
 
 /* NVS */
 NVS1.$name                      = "CONFIG_NVSINTERNAL";

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/main/ClusterManager.cpp
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/main/ClusterManager.cpp
@@ -132,13 +132,13 @@ void ClusterManager::OnColorControlAttributeChangeCallback(EndpointId endpointId
         {
             hue = *value;
             /* Read Current Saturation value when Attribute change callback for HUE Attribute */
-	    app::Clusters::ColorControl::Attributes::CurrentSaturation::Get(endpointId, &saturation);
+            app::Clusters::ColorControl::Attributes::CurrentSaturation::Get(endpointId, &saturation);
         }
         else
         {
             saturation = *value;
             /* Read Current Hue value when Attribute change callback for SATURATION Attribute */
-	    app::Clusters::ColorControl::Attributes::CurrentHue::Get(endpointId, &hue);
+            app::Clusters::ColorControl::Attributes::CurrentHue::Get(endpointId, &hue);
         }
         PLAT_LOG("Color Control triggered: Hue: %d Saturation: %d", hue, saturation);
     }

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/main/ClusterManager.cpp
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/main/ClusterManager.cpp
@@ -34,7 +34,6 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 using namespace ::chip::DeviceLayer;
-using namespace ::chip::app::Clusters;
 
 constexpr uint32_t kIdentifyTimerDelayMS     = 250;
 constexpr uint32_t kIdentifyTimerDelayPerSec = 4;
@@ -43,6 +42,45 @@ ClusterManager ClusterManager::sCluster;
 #define ENDPOINT_ID_0 (0)
 #define ENDPOINT_ID_1 (1)
 #define ENDPOINT_ID_2 (2)
+
+void OnIdentifyTriggerEffect(Identify * identify)
+{
+    switch (identify->mCurrentEffectIdentifier)
+    {
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
+        PLAT_LOG("EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
+        PLAT_LOG("EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
+        PLAT_LOG("EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
+        PLAT_LOG("EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE");
+        break;
+    default:
+        PLAT_LOG("No identifier effect");
+        break;
+    }
+    return;
+}
+
+Identify gIdentify0 = {
+    chip::EndpointId{ 0 },
+    [](Identify *) { PLAT_LOG("onIdentifyStart"); },
+    [](Identify *) { PLAT_LOG("onIdentifyStop"); },
+    EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
+    OnIdentifyTriggerEffect,
+};
+
+Identify gIdentify1 = {
+    chip::EndpointId{ 1 },
+    [](Identify *) { PLAT_LOG("onIdentifyStart"); },
+    [](Identify *) { PLAT_LOG("onIdentifyStop"); },
+    EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
+    OnIdentifyTriggerEffect,
+};
 
 void ClusterManager::OnOnOffPostAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
 {
@@ -94,13 +132,13 @@ void ClusterManager::OnColorControlAttributeChangeCallback(EndpointId endpointId
         {
             hue = *value;
             /* Read Current Saturation value when Attribute change callback for HUE Attribute */
-            ColorControl::Attributes::CurrentSaturation::Get(endpointId, &saturation);
+	    app::Clusters::ColorControl::Attributes::CurrentSaturation::Get(endpointId, &saturation);
         }
         else
         {
             saturation = *value;
             /* Read Current Hue value when Attribute change callback for SATURATION Attribute */
-            ColorControl::Attributes::CurrentHue::Get(endpointId, &hue);
+	    app::Clusters::ColorControl::Attributes::CurrentHue::Get(endpointId, &hue);
         }
         PLAT_LOG("Color Control triggered: Hue: %d Saturation: %d", hue, saturation);
     }
@@ -111,7 +149,7 @@ exit:
 void ClusterManager::OnIdentifyPostAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint16_t size,
                                                            uint8_t * value)
 {
-    if (attributeId == Identify::Attributes::IdentifyTime::Id && size == 2)
+    if (attributeId == app::Clusters::Identify::Attributes::IdentifyTime::Id && size == 2)
     {
         uint16_t identifyTime;
         memcpy(&identifyTime, value, size);

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/BUILD.gn
@@ -37,6 +37,7 @@ ti_sysconfig("sysconfig") {
   sources = [ "${project_dir}/chip.syscfg" ]
 
   outputs = [
+    "ti_devices_config.c",
     "ti_radio_config.c",
     "ti_radio_config.h",
     "ti_drivers_config.c",

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/args.gni
@@ -26,14 +26,13 @@ ti_simplelink_board = "LP_CC2652R7"
 optimize_debug_level = "s"
 lwip_debug = false
 
-#optimize_for_size=true
 chip_enable_ota_requestor = false
 
 # Disable FTD Build for all-clusters app to save Flash
 chip_openthread_ftd = false
 
 # Disable CHIP Logging
-chip_progress_logging = false
+#chip_progress_logging = false
 chip_detail_logging = false
 chip_automation_logging = false
 

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/chip.syscfg
@@ -89,8 +89,7 @@ for(var setting in ccfgSettings)
     CCFG[setting] = ccfgSettings[setting];
 }
 
-// Disable CCFG generation, this is added by the BIM project
-CCFG.enableCodeGeneration = false;
+CCFG.enableCodeGeneration = true;
 
 /* NVS */
 NVS1.$name                      = "CONFIG_NVSINTERNAL";

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/main/ClusterManager.cpp
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/main/ClusterManager.cpp
@@ -132,13 +132,13 @@ void ClusterManager::OnColorControlAttributeChangeCallback(EndpointId endpointId
         {
             hue = *value;
             /* Read Current Saturation value when Attribute change callback for HUE Attribute */
-	    app::Clusters::ColorControl::Attributes::CurrentSaturation::Get(endpointId, &saturation);
+            app::Clusters::ColorControl::Attributes::CurrentSaturation::Get(endpointId, &saturation);
         }
         else
         {
             saturation = *value;
             /* Read Current Hue value when Attribute change callback for SATURATION Attribute */
-	    app::Clusters::ColorControl::Attributes::CurrentHue::Get(endpointId, &hue);
+            app::Clusters::ColorControl::Attributes::CurrentHue::Get(endpointId, &hue);
         }
         PLAT_LOG("Color Control triggered: Hue: %d Saturation: %d", hue, saturation);
     }

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/main/ClusterManager.cpp
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/main/ClusterManager.cpp
@@ -34,7 +34,6 @@ using namespace ::chip;
 using namespace ::chip::Inet;
 using namespace ::chip::System;
 using namespace ::chip::DeviceLayer;
-using namespace ::chip::app::Clusters;
 
 constexpr uint32_t kIdentifyTimerDelayMS     = 250;
 constexpr uint32_t kIdentifyTimerDelayPerSec = 4;
@@ -43,6 +42,45 @@ ClusterManager ClusterManager::sCluster;
 #define ENDPOINT_ID_0 (0)
 #define ENDPOINT_ID_1 (1)
 #define ENDPOINT_ID_2 (2)
+
+void OnIdentifyTriggerEffect(Identify * identify)
+{
+    switch (identify->mCurrentEffectIdentifier)
+    {
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
+        PLAT_LOG("EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
+        PLAT_LOG("EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
+        PLAT_LOG("EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
+        PLAT_LOG("EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE");
+        break;
+    default:
+        PLAT_LOG("No identifier effect");
+        break;
+    }
+    return;
+}
+
+Identify gIdentify0 = {
+    chip::EndpointId{ 0 },
+    [](Identify *) { PLAT_LOG("onIdentifyStart"); },
+    [](Identify *) { PLAT_LOG("onIdentifyStop"); },
+    EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
+    OnIdentifyTriggerEffect,
+};
+
+Identify gIdentify1 = {
+    chip::EndpointId{ 1 },
+    [](Identify *) { PLAT_LOG("onIdentifyStart"); },
+    [](Identify *) { PLAT_LOG("onIdentifyStop"); },
+    EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
+    OnIdentifyTriggerEffect,
+};
 
 void ClusterManager::OnOnOffPostAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint8_t * value)
 {
@@ -94,13 +132,13 @@ void ClusterManager::OnColorControlAttributeChangeCallback(EndpointId endpointId
         {
             hue = *value;
             /* Read Current Saturation value when Attribute change callback for HUE Attribute */
-            ColorControl::Attributes::CurrentSaturation::Get(endpointId, &saturation);
+	    app::Clusters::ColorControl::Attributes::CurrentSaturation::Get(endpointId, &saturation);
         }
         else
         {
             saturation = *value;
             /* Read Current Hue value when Attribute change callback for SATURATION Attribute */
-            ColorControl::Attributes::CurrentHue::Get(endpointId, &hue);
+	    app::Clusters::ColorControl::Attributes::CurrentHue::Get(endpointId, &hue);
         }
         PLAT_LOG("Color Control triggered: Hue: %d Saturation: %d", hue, saturation);
     }
@@ -111,7 +149,7 @@ exit:
 void ClusterManager::OnIdentifyPostAttributeChangeCallback(EndpointId endpointId, AttributeId attributeId, uint16_t size,
                                                            uint8_t * value)
 {
-    if (attributeId == Identify::Attributes::IdentifyTime::Id && size == 2)
+    if (attributeId == app::Clusters::Identify::Attributes::IdentifyTime::Id && size == 2)
     {
         uint16_t identifyTime;
         memcpy(&identifyTime, value, size);

--- a/examples/shell/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/shell/cc13x2x7_26x2x7/BUILD.gn
@@ -36,6 +36,7 @@ ti_sysconfig("sysconfig") {
   sources = [ "chip.syscfg" ]
 
   outputs = [
+    "ti_devices_config.c",
     "ti_radio_config.c",
     "ti_radio_config.h",
     "ti_drivers_config.c",

--- a/examples/shell/cc13x2x7_26x2x7/args.gni
+++ b/examples/shell/cc13x2x7_26x2x7/args.gni
@@ -31,7 +31,7 @@ chip_enable_ota_requestor = false
 chip_openthread_ftd = false
 
 # Disable CHIP Logging
-chip_progress_logging = false
+#chip_progress_logging = false
 chip_detail_logging = false
 chip_automation_logging = false
 

--- a/examples/shell/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/shell/cc13x2x7_26x2x7/chip.syscfg
@@ -69,8 +69,7 @@ for(var setting in ccfgSettings)
     CCFG[setting] = ccfgSettings[setting];
 }
 
-// Disable CCFG generation, this is added by the BIM project
-CCFG.enableCodeGeneration = false;
+CCFG.enableCodeGeneration = true;
 
 /* NVS */
 NVS1.$name                      = "CONFIG_NVSINTERNAL";

--- a/examples/shell/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/shell/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -96,7 +96,7 @@ CHIP_ERROR AppTask::Init()
             ;
     }
 
-    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_Router);
+    ret = ConnectivityMgr().SetThreadDeviceType(ConnectivityManager::kThreadDeviceType_MinimalEndDevice);
     if (ret != CHIP_NO_ERROR)
     {
         while (1)


### PR DESCRIPTION
#### Problem
All clusters & Shell applications crash on startup
Identify cluster fails to implement certain attributes in all clusters application

#### Change overview
* Resolve shell and all-clusters application crashes
* Add support for identify cluster stubs for all clusters app

#### Testing
Verified builds for shell, all clusters app (Min)
Verified shell example is able to boot
Verified all clusters identify cluster is working as expected in TC_I_2_3.
[tc_I_2_3.log](https://github.com/project-chip/connectedhomeip/files/8847746/tc_I_2_3.log)


