### PR TITLE
docs: fix title and add link for building guide

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -86,7 +86,8 @@ architectures on a micro SD card. This release will have bluez 5.55 or newer
 which is required for BLE functionality.
 
 Boot the SD card, login with the default user account "ubuntu" and password
-"ubuntu", then proceed with "How to install prerequisites on Linux".
+"ubuntu", then proceed with
+[Installing prerequisites on Linux](#installing-prerequisites-on-linux).
 
 Finally, install some Raspberry Pi specific dependencies:
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Documentation

#### Change overview
Documentation has slightly incorrect reference to another section. On the first read, I didn't understand that it was referring to the previous section of the docs. Added an intradocument link to make it easier on the user.

#### Testing
* Tested by pushing to my fork and verifying that it looks good and the link works.
