### PR TITLE
docs: remove installation of python on Linux

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -43,7 +43,7 @@ On Debian-based Linux distributions such as Ubuntu, these dependencies can be
 satisfied with the following:
 
 ```
-sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev \
+sudo apt-get install git gcc g++ pkg-config libssl-dev libdbus-1-dev \
      libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev \
      python3-pip unzip libgirepository1.0-dev libcairo2-dev libreadline-dev
 ```


### PR DESCRIPTION
Debian-based distributions already included python, so it does not need
to be installed again.

Additionally, on Ubuntu 22.04 on Raspberry Pi, there is no package named
"python", causing this command to fail.

#### Problem
What is being fixed?  Examples:
* Docs included unnecessary step
* Docs include step that does not work on some platforms and distributions

#### Change overview
Removed 'python' from prerequisites to be installed.

#### Testing
* Tested on Ubuntu 22.04 on Raspberry Pi by running apt-get install without 'python' in the list.
