### PR TITLE
Go back to browsing by discriminator, not by commissioning mode.

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -146,26 +146,9 @@ CHIP_ERROR SetUpCodePairer::StartDiscoverOverIP(SetupPayload & payload)
                                                       : Dnssd::DiscoveryFilterType::kLongDiscriminator;
     currentFilter.code =
         payload.isShortDiscriminator ? static_cast<uint16_t>((payload.discriminator >> 8) & 0x0F) : payload.discriminator;
-
-    // We're going to ensure that anything we discover matches currentFilter
-    // before we use it, which will do our discriminator checks for us.
-    //
-    // We are using an mdns continuous query for some PTR record to discover
-    // devices.  If the PTR record we use is for one of the discriminator-based
-    // subtypes (based on currentFilter), then we can run into a problem where
-    // we discover a (possibly stale) advertisement for a non-commissionable
-    // (CM=0) node and ignore it, and then when it becomes commissionable we
-    // don't notice because that just updates the TXT record to CM=1 and does
-    // not touch the PTR record we are querying for.
-    //
-    // So instead we query the PTR record for the "_CM" subtype, which will get
-    // added when a node enters commissioning mode.
-    Dnssd::DiscoveryFilter filter;
-    filter.type = Dnssd::DiscoveryFilterType::kCommissioningMode;
-
     // Handle possibly-sync callbacks.
     mWaitingForDiscovery[kIPTransport] = true;
-    CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(filter);
+    CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(currentFilter);
     if (err != CHIP_NO_ERROR)
     {
         mWaitingForDiscovery[kIPTransport] = false;


### PR DESCRIPTION
This reverts commit a689c84318e637836d747c0627f377420ec33587.

Now that we always register a new instance name when opening a new
commissioning window the problem PR #17356 was trying to work around
no longer applies.  On the other hand, the new setup introduced a new
problem: if there are multiple things advertising the _CM subtype
(i.e. multiple things in comissioning mode at once), then we might
find the first several (however much fits in a DNS packet) and then
platform mdns will stop delivering results, per
https://github.com/project-chip/connectedhomeip/issues/19194 (which is
about Darwin, but other platforms have similar issues).

If we browse by discrimnator instead, the chance of multiple results
is much lower, and hence the chance of finding the thing we care about
is much higher.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Tested with multiple commissionables around and the right one was discovered now.