### PR TITLE
Add logging to debug `SecureSession` ref-counting

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -655,6 +655,17 @@
 #endif // CHIP_CONFIG_PEER_CONNECTION_POOL_SIZE
 
 /**
+ * @def CHIP_CONFIG_SECURE_SESSION_REFCOUNT_LOGGING
+ *
+ * @brief This enables logging of changes to the underlying reference count of
+ * SecureSession objects.
+ *
+ */
+#ifndef CHIP_CONFIG_SECURE_SESSION_REFCOUNT_LOGGING
+#define CHIP_CONFIG_SECURE_SESSION_REFCOUNT_LOGGING 0
+#endif
+
+/**
  *  @def CHIP_CONFIG_MAX_FABRICS
  *
  *  @brief

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -182,7 +182,8 @@ CASESession::ListenForSessionEstablishment(SessionManager & sessionManager, Fabr
     mSessionResumptionStorage = sessionResumptionStorage;
     mLocalMRPConfig           = mrpConfig;
 
-    ChipLogDetail(SecureChannel, "Waiting for Sigma1 msg");
+    ChipLogDetail(SecureChannel, "Allocated SecureSession (%p) - waiting for Sigma1 msg",
+                  mSecureSessionHolder.Get().Value()->AsSecureSession());
 
     return CHIP_NO_ERROR;
 }

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -28,7 +28,7 @@ void SecureSessionDeleter::Release(SecureSession * entry)
 
 void SecureSession::MarkForRemoval()
 {
-    ChipLogDetail(Inet, "SecureSession MarkForRemoval %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
+    ChipLogDetail(Inet, "SecureSession[%p]: MarkForRemoval Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
                   mLocalSessionId);
     ReferenceCountedHandle<Transport::Session> ref(*this);
     switch (mState)
@@ -75,6 +75,24 @@ Access::SubjectDescriptor SecureSession::GetSubjectDescriptor() const
         VerifyOrDie(false);
     }
     return subjectDescriptor;
+}
+
+void SecureSession::Retain()
+{
+#if CHIP_CONFIG_SECURE_SESSION_REFCOUNT_LOGGING
+    ChipLogProgress(SecureChannel, "SecureSession[%p]: ++ %d -> %d", this, GetReferenceCount(), GetReferenceCount() + 1);
+#endif
+
+    ReferenceCounted<SecureSession, SecureSessionDeleter, 0, uint16_t>::Retain();
+}
+
+void SecureSession::Release()
+{
+#if CHIP_CONFIG_SECURE_SESSION_REFCOUNT_LOGGING
+    ChipLogProgress(SecureChannel, "SecureSession[%p]: -- %d -> %d", this, GetReferenceCount(), GetReferenceCount() - 1);
+#endif
+
+    ReferenceCounted<SecureSession, SecureSessionDeleter, 0, uint16_t>::Release();
 }
 
 } // namespace Transport

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -75,7 +75,7 @@ public:
     {
         Retain(); // Put the test session in Active state
         SetFabricIndex(fabric);
-        ChipLogDetail(Inet, "SecureSession Allocated for test %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
+        ChipLogDetail(Inet, "SecureSession[%p]: Allocated for Test Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
                       mLocalSessionId);
     }
 
@@ -88,7 +88,8 @@ public:
     SecureSession(SecureSessionTable & table, Type secureSessionType, uint16_t localSessionId) :
         mTable(table), mState(State::kPairing), mSecureSessionType(secureSessionType), mLocalSessionId(localSessionId)
     {
-        ChipLogDetail(Inet, "SecureSession Allocated %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType), mLocalSessionId);
+        ChipLogDetail(Inet, "SecureSession[%p]: Allocated Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
+                      mLocalSessionId);
     }
 
     /**
@@ -120,11 +121,13 @@ public:
 
         Retain();
         mState = State::kActive;
-        ChipLogDetail(Inet, "SecureSession Active %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType), mLocalSessionId);
+        ChipLogDetail(Inet, "SecureSession[%p]: Activated - Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
+                      mLocalSessionId);
     }
     ~SecureSession() override
     {
-        ChipLogDetail(Inet, "SecureSession Released %p Type:%d LSID:%d", this, to_underlying(mSecureSessionType), mLocalSessionId);
+        ChipLogDetail(Inet, "SecureSession[%p]: Released - Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
+                      mLocalSessionId);
     }
 
     SecureSession(SecureSession &&)      = delete;
@@ -132,8 +135,8 @@ public:
     SecureSession & operator=(const SecureSession &) = delete;
     SecureSession & operator=(SecureSession &&) = delete;
 
-    void Retain() override { ReferenceCounted<SecureSession, SecureSessionDeleter, 0, uint16_t>::Retain(); }
-    void Release() override { ReferenceCounted<SecureSession, SecureSessionDeleter, 0, uint16_t>::Release(); }
+    void Retain() override;
+    void Release() override;
 
     bool IsActiveSession() const override { return mState == State::kActive; }
     bool IsPairing() const { return mState == State::kPairing; }


### PR DESCRIPTION
#### Problem

When debugging or verifying `SecureSession` lifetime and allocation behaviors/issues, it's useful to quickly log the evolution of the ref-count on any given `SecureSession` object to see where it may be getting held-up, or prematurely free'ed.

### Solution

Add a `CHIP_CONFIG_SECURE_SESSION_REFCOUNT_LOGGING` define to `CHIPConfig.h` that when enabled, adds extra ref-count evolution prints.