### PR TITLE
[chip-tool] Stop the command on pairing failure

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -147,6 +147,7 @@ void PairingCommand::OnStatusUpdate(DevicePairingDelegate::Status status)
         break;
     case DevicePairingDelegate::Status::SecurePairingFailed:
         ChipLogError(chipTool, "Secure Pairing Failed");
+        SetCommandExitStatus(CHIP_ERROR_INCORRECT_STATE);
         break;
     }
 }


### PR DESCRIPTION
#### Problem

Looking at #19138 I found that `chip-tool` does not ends the command on pairing failure. That's not the cause of the issue in #19138 but that is still a problem.

#### Change overview
 * Call `SetCommandExitStatus`
