### PR TITLE
[Thread] Fix crash on unsuccessful resolve

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -2385,10 +2385,16 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::FromOtDnsRespons
 template <class ImplClass>
 void GenericThreadStackManagerImpl_OpenThread<ImplClass>::DispatchResolve(intptr_t context)
 {
-    auto * dnsResult            = reinterpret_cast<DnsResult *>(context);
-    Inet::IPAddress * ipAddress = &(dnsResult->mMdnsService.mAddress.Value());
-    ThreadStackMgrImpl().mDnsResolveCallback(dnsResult->context, &(dnsResult->mMdnsService), Span<Inet::IPAddress>(ipAddress, 1),
-                                             dnsResult->error);
+    DnsResult * dnsResult         = reinterpret_cast<DnsResult *>(context);
+    Dnssd::DnssdService & service = dnsResult->mMdnsService;
+    Span<Inet::IPAddress> ipAddrs;
+
+    if (service.mAddress.HasValue())
+    {
+        ipAddrs = Span<Inet::IPAddress>(&service.mAddress.Value(), 1);
+    }
+
+    ThreadStackMgrImpl().mDnsResolveCallback(dnsResult->context, &service, ipAddrs, dnsResult->error);
     Platform::Delete<DnsResult>(dnsResult);
 }
 


### PR DESCRIPTION
#### Problem
OpenThread implementation of DNS-SD tries to access the optional IP address even if the address resolution has
failed and the optional object is empty.

#### Change overview
Pass an empty span up the stack if no address has been returned from OpenThread.

#### Testing
Verified that sending AnnounceOTAProvider with an invalid OTA Provider node ID no longer crashes.
