### PR TITLE
Integrate Tinycrypt ECC operations

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -626,7 +626,6 @@ IlluminanceMeasurement
 IM
 imager
 imagetool
-ImageURI
 imageUri
 img
 Impl
@@ -728,6 +727,7 @@ libglib
 libical
 libncurses
 libreadline
+libs
 libsdl
 libshell
 libssl
@@ -895,6 +895,7 @@ NVM
 NVS
 nwk
 NXP
+NXPmicro
 objcopy
 OccupancySensing
 OctetString
@@ -1278,6 +1279,8 @@ timedInteractionTimeoutMs
 TimeFormatLocalization
 timeoutMs
 TimeSynchronization
+tinycrypt
+tinycryptbuildingsteps
 Tizen
 TKIP
 tlsr

--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -727,7 +727,6 @@ libglib
 libical
 libncurses
 libreadline
-libs
 libsdl
 libshell
 libssl
@@ -895,7 +894,6 @@ NVM
 NVS
 nwk
 NXP
-NXPmicro
 objcopy
 OccupancySensing
 OctetString
@@ -1280,7 +1278,6 @@ TimeFormatLocalization
 timeoutMs
 TimeSynchronization
 tinycrypt
-tinycryptbuildingsteps
 Tizen
 TKIP
 tlsr

--- a/.gitmodules
+++ b/.gitmodules
@@ -250,3 +250,4 @@
 	path = third_party/nxp/libs/mbedtls/repo
 	url = https://github.com/NXPmicro/mbedtls.git
 	branch = tinycrypt-mbedtls-2.28
+	platforms = k32w0

--- a/.gitmodules
+++ b/.gitmodules
@@ -246,3 +246,7 @@
 	url = https://github.com/bouffalolab/bl_iot_sdk_matter.git
 	branch = bl602_release
 	platforms = bl602
+[submodule "third_party/nxp/libs/mbedtls/repo"]
+	path = third_party/nxp/libs/mbedtls/repo
+	url = https://github.com/NXPmicro/mbedtls.git
+	branch = tinycrypt-mbedtls-2.28

--- a/build_overrides/mbedtls.gni
+++ b/build_overrides/mbedtls.gni
@@ -15,4 +15,5 @@
 declare_args() {
   # Root directory for mbedTLS.
   mbedtls_root = "//third_party/mbedtls"
+  mbedtls_repo = "//third_party/mbedtls"
 }

--- a/examples/build_overrides/mbedtls.gni
+++ b/examples/build_overrides/mbedtls.gni
@@ -15,4 +15,5 @@
 declare_args() {
   # Root directory for mbedTLS.
   mbedtls_root = "//third_party/connectedhomeip/third_party/mbedtls"
+  mbedtls_repo = "//third_party/connectedhomeip/third_party/mbedtls"
 }

--- a/examples/lighting-app/nxp/k32w/k32w0/README.md
+++ b/examples/lighting-app/nxp/k32w/k32w0/README.md
@@ -27,9 +27,15 @@ network.
     -   [Detokenizer script](#detokenizer)
     -   [Notes](#detokenizer-notes)
     -   [Known issues](#detokenizer-known-issues)
--   [OTA](#ota) - [Writing the SSBL](#ssbl) - [Writing the PSECT](#psect) -
-    [Writing the application](#appwrite) - [OTA Testing](#otatesting) -
-    [Known issues](#otaissues)
+-   [Tinycrypt ECC operations](#tinycrypt)
+    -    [Building steps](#tinycryptbuildingsteps)
+-   [OTA](#ota)
+    -    [Writing the SSBL](#ssbl)
+    -    [Writing the PSECT](#psect)
+    -    [Writing the application](#appwrite)
+    -    [OTA Testing](#otatesting)
+    -    [Known issues](#otaissues)
+
     </hr>
 
 <a name="intro"></a>
@@ -182,17 +188,16 @@ user@ubuntu:~/Desktop/git/connectedhomeip$ export NXP_K32W061_SDK_ROOT=/home/use
 user@ubuntu:~/Desktop/git/connectedhomeip$ ./third_party/nxp/k32w0_sdk/sdk_fixes/patch_k32w_sdk.sh
 user@ubuntu:~/Desktop/git/connectedhomeip$ source ./scripts/activate.sh
 user@ubuntu:~/Desktop/git/connectedhomeip$ cd examples/lighting-app/nxp/k32w/k32w0
-user@ubuntu:~/Desktop/git/connectedhomeip/examples/lighting-app/nxp/k32w/k32w0$ gn gen out/debug --args="k32w0_sdk_root=\"${NXP_K32W061_SDK_ROOT}\" chip_with_OM15082=1 chip_with_ot_cli=0 is_debug=false chip_crypto=\"mbedtls\" chip_with_se05x=0"
+user@ubuntu:~/Desktop/git/connectedhomeip/examples/lighting-app/nxp/k32w/k32w0$ gn gen out/debug --args="k32w0_sdk_root=\"${NXP_K32W061_SDK_ROOT}\" chip_with_OM15082=1 chip_with_ot_cli=0 is_debug=false chip_crypto=\"mbedtls\" chip_with_se05x=0 mbedtls_use_tinycrypt=true chip_pw_tokenizer_logging=true mbedtls_repo=\"//third_party/connectedhomeip/third_party/nxp/libs/mbedtls\""
 user@ubuntu:~/Desktop/git/connectedhomeip/examples/lighting-app/nxp/k32w/k32w0$ ninja -C out/debug
 user@ubuntu:~/Desktop/git/connectedhomeip/examples/lighting-app/nxp/k32w/k32w0$ $NXP_K32W061_SDK_ROOT/tools/imagetool/sign_images.sh out/debug/
 ```
 
     -   with Secure element
         Exactly the same steps as above but set chip_with_se05x=1 in the gn command
-        and add arguments chip_pw_tokenizer_logging=true chip_enable_ota_requestor=false
+        and add argument chip_enable_ota_requestor=false
 
-Note that options chip_pw_tokenizer_logging=true and
-chip_enable_ota_requestor=false are required for building with Secure Element.
+Note that option chip_enable_ota_requestor=false are required for building with Secure Element.
 These can be changed if building without Secure Element
 
 Note that "patch_k32w_sdk.sh" script must be run for patching the K32W061 SDK
@@ -299,6 +304,22 @@ If run, closed and rerun with the serial option on the same serial port, the
 detokenization script will get stuck and not show any logs. The solution is to
 unplug and plug the board and then rerun the script.
 
+<a name="tinycrypt"></a>
+
+## Tinycrypt ECC operations
+
+<a name="tinycryptbuildingsteps"></a>
+### Building steps
+
+
+Note: This solution is temporary.
+
+In order to use the tinycrypt ecc operations, use the following build arguments:
+
+- Build without Secure element (_chip_with_se05x=0_), with tinycrypt enabled (_mbedtls_use_tinycrypt=true_) and with the NXPmicro/mbedtls library (_mbedtls_repo=\"//third_party/connectedhomeip/third_party/nxp/libs/mbedtls\"_).
+
+To disable tinycrypt ecc operations, simply build without _mbedtls_use_tinycrypt=true_ and without _mbedtls_repo_.
+ 
 <a name="ota"></a>
 
 ## OTA

--- a/examples/lighting-app/nxp/k32w/k32w0/README.md
+++ b/examples/lighting-app/nxp/k32w/k32w0/README.md
@@ -28,13 +28,14 @@ network.
     -   [Notes](#detokenizer-notes)
     -   [Known issues](#detokenizer-known-issues)
 -   [Tinycrypt ECC operations](#tinycrypt)
-    -    [Building steps](#tinycryptbuildingsteps)
+    -   [Building steps](#tinycryptbuildingsteps)
 -   [OTA](#ota)
-    -    [Writing the SSBL](#ssbl)
-    -    [Writing the PSECT](#psect)
-    -    [Writing the application](#appwrite)
-    -    [OTA Testing](#otatesting)
-    -    [Known issues](#otaissues)
+
+    -   [Writing the SSBL](#ssbl)
+    -   [Writing the PSECT](#psect)
+    -   [Writing the application](#appwrite)
+    -   [OTA Testing](#otatesting)
+    -   [Known issues](#otaissues)
 
     </hr>
 
@@ -197,8 +198,8 @@ user@ubuntu:~/Desktop/git/connectedhomeip/examples/lighting-app/nxp/k32w/k32w0$ 
         Exactly the same steps as above but set chip_with_se05x=1 in the gn command
         and add argument chip_enable_ota_requestor=false
 
-Note that option chip_enable_ota_requestor=false are required for building with Secure Element.
-These can be changed if building without Secure Element
+Note that option chip_enable_ota_requestor=false are required for building with
+Secure Element. These can be changed if building without Secure Element
 
 Note that "patch_k32w_sdk.sh" script must be run for patching the K32W061 SDK
 2.6.4.
@@ -309,17 +310,20 @@ unplug and plug the board and then rerun the script.
 ## Tinycrypt ECC operations
 
 <a name="tinycryptbuildingsteps"></a>
-### Building steps
 
+### Building steps
 
 Note: This solution is temporary.
 
 In order to use the tinycrypt ecc operations, use the following build arguments:
 
-- Build without Secure element (_chip_with_se05x=0_), with tinycrypt enabled (_mbedtls_use_tinycrypt=true_) and with the NXPmicro/mbedtls library (_mbedtls_repo=\"//third_party/connectedhomeip/third_party/nxp/libs/mbedtls\"_).
+-   Build without Secure element (_chip_with_se05x=0_), with tinycrypt enabled
+    (_mbedtls_use_tinycrypt=true_) and with the NXPmicro/mbedtls library
+    (_mbedtls_repo=\"//third_party/connectedhomeip/third_party/nxp/libs/mbedtls\"_).
 
-To disable tinycrypt ecc operations, simply build without _mbedtls_use_tinycrypt=true_ and without _mbedtls_repo_.
- 
+To disable tinycrypt ecc operations, simply build without
+_mbedtls_use_tinycrypt=true_ and without _mbedtls_repo_.
+
 <a name="ota"></a>
 
 ## OTA

--- a/examples/lighting-app/nxp/k32w/k32w0/README.md
+++ b/examples/lighting-app/nxp/k32w/k32w0/README.md
@@ -28,7 +28,7 @@ network.
     -   [Notes](#detokenizer-notes)
     -   [Known issues](#detokenizer-known-issues)
 -   [Tinycrypt ECC operations](#tinycrypt)
-    -   [Building steps](#tinycryptbuildingsteps)
+    -   [Building steps](#tinycrypt-building-steps)
 -   [OTA](#ota)
 
     -   [Writing the SSBL](#ssbl)
@@ -309,7 +309,7 @@ unplug and plug the board and then rerun the script.
 
 ## Tinycrypt ECC operations
 
-<a name="tinycryptbuildingsteps"></a>
+<a name="tinycrypt-building-steps"></a>
 
 ### Building steps
 
@@ -318,8 +318,8 @@ Note: This solution is temporary.
 In order to use the tinycrypt ecc operations, use the following build arguments:
 
 -   Build without Secure element (_chip_with_se05x=0_), with tinycrypt enabled
-    (_mbedtls_use_tinycrypt=true_) and with the NXPmicro/mbedtls library
-    (_mbedtls_repo=\"//third_party/connectedhomeip/third_party/nxp/libs/mbedtls\"_).
+    (_mbedtls_use_tinycrypt=true_) and with the `NXPmicro/mbedtls` library
+    (_mbedtls_repo=`\"//third_party/connectedhomeip/third_party/nxp/libs/mbedtls\"`_).
 
 To disable tinycrypt ecc operations, simply build without
 _mbedtls_use_tinycrypt=true_ and without _mbedtls_repo_.

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -509,7 +509,7 @@ static int uecc_rng_wrapper(uint8_t * dest, unsigned int size)
 
 static int uECC_is_rng_set(void)
 {
-	return (uecc_rng_wrapper == uECC_get_rng()) ? 1 : 0;
+    return (uecc_rng_wrapper == uECC_get_rng()) ? 1 : 0;
 }
 
 #endif
@@ -665,7 +665,7 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, co
 
     const uint8_t * public_key = *this;
 
-    //Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
+    // Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
     result = uECC_verify(public_key + 1, hash, hash_length, Uint8::to_const_uchar(signature.ConstBytes()));
     VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INVALID_SIGNATURE);
 
@@ -738,7 +738,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
 
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
 
-    //Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
+    // Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
     result = uECC_shared_secret(remote_public_key.ConstBytes() + 1, keypair->private_key, Uint8::to_uchar(out_secret));
     VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
@@ -809,15 +809,15 @@ CHIP_ERROR P256Keypair::Initialize()
     Clear();
 
     mbedtls_uecc_keypair * keypair = to_keypair(&mKeypair);
-    if(!uECC_is_rng_set())
+    if (!uECC_is_rng_set())
     {
-    	uECC_set_rng(&uecc_rng_wrapper);
+        uECC_set_rng(&uecc_rng_wrapper);
     }
 
     result = uECC_make_key(keypair->public_key, keypair->private_key);
     VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
-    //Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
+    // Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
     Uint8::to_uchar(mPublicKey)[0] = 0x04;
     memcpy(Uint8::to_uchar(mPublicKey) + 1, keypair->public_key, 2 * NUM_ECC_BYTES);
 
@@ -929,12 +929,12 @@ CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
     Clear();
 
     mbedtls_uecc_keypair * keypair = to_keypair(&mKeypair);
-    if(!uECC_is_rng_set())
+    if (!uECC_is_rng_set())
     {
-    	uECC_set_rng(&uecc_rng_wrapper);
+        uECC_set_rng(&uecc_rng_wrapper);
     }
 
-    //Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
+    // Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
     memcpy(keypair->public_key, Uint8::to_uchar(input) + 1, 2 * NUM_ECC_BYTES);
     memcpy(keypair->private_key, Uint8::to_uchar(input) + mPublicKey.Length(), NUM_ECC_BYTES);
 
@@ -992,8 +992,8 @@ void P256Keypair::Clear()
     if (mInitialized)
     {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-    	mbedtls_uecc_keypair * keypair = to_keypair(&mKeypair);
-    	memset(keypair, 0, sizeof(mbedtls_uecc_keypair));
+        mbedtls_uecc_keypair * keypair = to_keypair(&mKeypair);
+        memset(keypair, 0, sizeof(mbedtls_uecc_keypair));
         mInitialized = false;
 #else
         mbedtls_ecp_keypair * keypair = to_keypair(&mKeypair);
@@ -1011,7 +1011,7 @@ P256Keypair::~P256Keypair()
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
-    int result = 0;
+    int result       = 0;
     size_t out_length;
 
     mbedtls_x509write_csr csr;
@@ -1019,7 +1019,7 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
 
     mbedtls_pk_context pk;
     pk.CHIP_CRYPTO_PAL_PRIVATE(pk_info) = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
-    pk.CHIP_CRYPTO_PAL_PRIVATE(pk_ctx) = to_keypair(&mKeypair);
+    pk.CHIP_CRYPTO_PAL_PRIVATE(pk_ctx)  = to_keypair(&mKeypair);
     VerifyOrExit(pk.CHIP_CRYPTO_PAL_PRIVATE(pk_info) != nullptr, error = CHIP_ERROR_INTERNAL);
 
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
@@ -1039,7 +1039,7 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
     VerifyOrExit(CanCastTo<size_t>(result), error = CHIP_ERROR_INTERNAL);
 
     out_length = static_cast<size_t>(result);
-    result = 0;
+    result     = 0;
     VerifyOrExit(out_length <= csr_length, error = CHIP_ERROR_INTERNAL);
 
     if (csr_length != out_length)
@@ -1182,9 +1182,9 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
 
     G = curve_G;
 
-    if(!uECC_is_rng_set())
+    if (!uECC_is_rng_set())
     {
-    	uECC_set_rng(&uecc_rng_wrapper);
+        uECC_set_rng(&uecc_rng_wrapper);
     }
 #else
     mbedtls_ecp_group_init(&context->curve);
@@ -1404,7 +1404,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const uint8_t * in, size_t i
 #if defined(MBEDTLS_USE_TINYCRYPT)
     uint8_t tmp[2 * NUM_ECC_BYTES];
 
-    //Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
+    // Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
     memcpy(tmp, in + 1, 2 * NUM_ECC_BYTES);
 
     uECC_vli_bytesToNative((uECC_word_t *) R, tmp, NUM_ECC_BYTES);
@@ -1426,7 +1426,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, uint8_t * o
     memset(out, 0, out_len);
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-    //Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
+    // Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
     out[0] = 0x04;
     uECC_vli_nativeToBytes(out + 1, NUM_ECC_BYTES, (uECC_word_t *) R);
     uECC_vli_nativeToBytes(out + NUM_ECC_BYTES + 1, NUM_ECC_BYTES, (uECC_word_t *) R + NUM_ECC_WORDS);
@@ -1544,7 +1544,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     result = EccPoint_mult_safer(L_tmp, curve_G, w1_bn);
     VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
-    //Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
+    // Fully padded raw uncompressed points expected, first byte is always 0x04 i.e uncompressed
     Lout[0] = 0x04;
     uECC_vli_nativeToBytes(Lout + 1, NUM_ECC_BYTES, L_tmp);
     uECC_vli_nativeToBytes(Lout + NUM_ECC_BYTES + 1, NUM_ECC_BYTES, L_tmp + NUM_ECC_WORDS);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -534,8 +534,6 @@ static inline const mbedtls_uecc_keypair * to_const_keypair(const P256KeypairCon
 
 #else
 
-#if defined(MBEDTLS_ECP_C)
-
 static inline mbedtls_ecp_keypair * to_keypair(P256KeypairContext * context)
 {
     return SafePointerCast<mbedtls_ecp_keypair *>(context);
@@ -546,7 +544,6 @@ static inline const mbedtls_ecp_keypair * to_const_keypair(const P256KeypairCont
     return SafePointerCast<const mbedtls_ecp_keypair *>(context);
 }
 
-#endif
 #endif
 
 CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_length, P256ECDSASignature & out_signature) const
@@ -586,10 +583,7 @@ CHIP_ERROR P256Keypair::ECDSA_sign_hash(const uint8_t * hash, const size_t hash_
 
 exit:
     return error;
-
-#else
-
-#if defined(MBEDTLS_ECDSA_C)
+#elif defined(MBEDTLS_ECDSA_C)
     VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(hash != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(hash_length == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
@@ -635,8 +629,6 @@ exit:
 #else
     return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
-
-#endif
 }
 
 CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, const size_t msg_length,
@@ -658,9 +650,7 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_msg_signature(const uint8_t * msg, cons
 CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, const size_t hash_length,
                                                         const P256ECDSASignature & signature) const
 {
-
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     VerifyOrReturnError(hash != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(hash_length == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(signature.Length() == kP256_ECDSA_Signature_Length_Raw, CHIP_ERROR_INVALID_ARGUMENT);
@@ -675,9 +665,7 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, co
 
 exit:
     return error;
-
-#else
-#if defined(MBEDTLS_ECDSA_C)
+#elif defined(MBEDTLS_ECDSA_C)
     VerifyOrReturnError(hash != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(hash_length == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(signature.Length() == kP256_ECDSA_Signature_Length_Raw, CHIP_ERROR_INVALID_ARGUMENT);
@@ -729,7 +717,6 @@ exit:
 #else
     return CHIP_ERROR_NOT_IMPLEMENTED;
 #endif
-#endif
 }
 
 CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
@@ -737,7 +724,6 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
 #if defined(MBEDTLS_ECDH_C)
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     CHIP_ERROR error     = CHIP_NO_ERROR;
     int result           = 0;
     size_t secret_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
@@ -755,9 +741,7 @@ exit:
     keypair = nullptr;
     _log_mbedTLS_error(result);
     return error;
-
 #else
-
     CHIP_ERROR error     = CHIP_NO_ERROR;
     int result           = 0;
     size_t secret_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
@@ -797,7 +781,6 @@ exit:
     mbedtls_ecp_point_free(&ecp_pubkey);
     _log_mbedTLS_error(result);
     return error;
-
 #endif
 
 #else
@@ -812,9 +795,7 @@ void ClearSecretData(uint8_t * buf, size_t len)
 
 CHIP_ERROR P256Keypair::Initialize()
 {
-
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result       = UECC_FAILURE;
 
@@ -835,7 +816,6 @@ CHIP_ERROR P256Keypair::Initialize()
 exit:
     _log_mbedTLS_error(result);
     return error;
-
 #else
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result = 0;
@@ -875,9 +855,7 @@ exit:
 
 CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
 {
-
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     const mbedtls_uecc_keypair * keypair = to_const_keypair(&mKeypair);
     size_t len                           = output.Length() == 0 ? output.Capacity() : output.Length();
     Encoding::BufferWriter bbuf(output, len);
@@ -901,7 +879,6 @@ exit:
     memset(privkey, 0, sizeof(privkey));
     _log_mbedTLS_error(result);
     return error;
-
 #else
     const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
     size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
@@ -928,15 +905,12 @@ exit:
     ClearSecretData(privkey, sizeof(privkey));
     _log_mbedTLS_error(result);
     return error;
-
 #endif
 }
 
 CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
 {
-
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     int result       = 0;
     CHIP_ERROR error = CHIP_NO_ERROR;
     Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
@@ -961,7 +935,6 @@ CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
 
 exit:
     return error;
-
 #else
     Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
 
@@ -1021,7 +994,6 @@ P256Keypair::~P256Keypair()
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     CHIP_ERROR error = CHIP_NO_ERROR;
 
     int result = 0;
@@ -1080,7 +1052,6 @@ exit:
 
     _log_mbedTLS_error(result);
     return error;
-
 #else
     CHIP_ERROR error = CHIP_NO_ERROR;
     int result = 0;
@@ -1194,7 +1165,6 @@ exit:
 typedef struct Spake2p_Context
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     const mbedtls_md_info_t * md_info;
     uECC_word_t M[2 * NUM_ECC_WORDS];
     uECC_word_t N[2 * NUM_ECC_WORDS];
@@ -1208,7 +1178,6 @@ typedef struct Spake2p_Context
     uECC_word_t w1[NUM_ECC_WORDS];
     uECC_word_t xy[NUM_ECC_WORDS];
     uECC_word_t tempbn[NUM_ECC_WORDS];
-
 #else
     mbedtls_ecp_group curve;
     const mbedtls_md_info_t * md_info;
@@ -1242,7 +1211,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     memset(context, 0, sizeof(Spake2p_Context));
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     M = context->M;
     N = context->N;
     X = context->X;
@@ -1257,7 +1225,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     tempbn = context->tempbn;
 
     G = curve_G;
-
 #else
     mbedtls_ecp_group_init(&context->curve);
     result = mbedtls_ecp_group_load(&context->curve, MBEDTLS_ECP_DP_SECP256R1);
@@ -1307,7 +1274,6 @@ void Spake2p_P256_SHA256_HKDF_HMAC::Clear()
     VerifyOrReturn(state != CHIP_SPAKE2P_STATE::PREINIT);
 
 #if !defined(MBEDTLS_USE_TINYCRYPT)
-
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     mbedtls_ecp_point_free(&context->M);
@@ -1382,14 +1348,11 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FELoad(const uint8_t * in, size_t in_l
     int result       = 0;
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     uECC_word_t tmp[2 * NUM_ECC_WORDS] = { 0 };
     uECC_vli_bytesToNative(tmp, in, NUM_ECC_BYTES);
 
     uECC_vli_mmod((uECC_word_t *) fe, tmp, curve_n);
-
 #else
-
     result = mbedtls_mpi_read_binary((mbedtls_mpi *) fe, Uint8::to_const_uchar(in), in_len);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
@@ -1405,10 +1368,8 @@ exit:
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEWrite(const void * fe, uint8_t * out, size_t out_len)
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     uECC_vli_nativeToBytes(out, NUM_ECC_BYTES, (const unsigned int *) fe);
 #else
-
     if (mbedtls_mpi_write_binary((const mbedtls_mpi *) fe, Uint8::to_uchar(out), out_len) != 0)
     {
         return CHIP_ERROR_INTERNAL;
@@ -1423,7 +1384,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEGenerate(void * fe)
     int result       = 0;
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     mbedtls_uecc_keypair keypair;
 
     uECC_set_rng(&uecc_rng_wrapper);
@@ -1435,7 +1395,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEGenerate(void * fe)
 
     uECC_vli_bytesToNative((uECC_word_t *) fe, keypair.private_key, NUM_ECC_BYTES);
 #else
-
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     result = mbedtls_ecp_gen_privkey(&context->curve, (mbedtls_mpi *) fe, CryptoRNG, nullptr);
@@ -1453,10 +1412,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEMul(void * fer, const void * fe1, co
     int result       = 0;
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     uECC_vli_modMult((uECC_word_t *) fer, (const uECC_word_t *) fe1, (const uECC_word_t *) fe2, (const uECC_word_t *) curve_n);
 #else
-
     result = mbedtls_mpi_mul_mpi((mbedtls_mpi *) fer, (const mbedtls_mpi *) fe1, (const mbedtls_mpi *) fe2);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
@@ -1472,7 +1429,6 @@ exit:
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const uint8_t * in, size_t in_len, void * R)
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     uint8_t tmp[2 * NUM_ECC_BYTES];
 
     memcpy(tmp, in + 1, 2 * NUM_ECC_BYTES);
@@ -1480,7 +1436,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const uint8_t * in, size_t i
     uECC_vli_bytesToNative((uECC_word_t *) R, tmp, NUM_ECC_BYTES);
     uECC_vli_bytesToNative((uECC_word_t *) R + NUM_ECC_WORDS, tmp + NUM_ECC_BYTES, NUM_ECC_BYTES);
 #else
-
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_point_read_binary(&context->curve, (mbedtls_ecp_point *) R, Uint8::to_const_uchar(in), in_len) != 0)
@@ -1497,12 +1452,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, uint8_t * o
     memset(out, 0, out_len);
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     out[0] = 0x04;
     uECC_vli_nativeToBytes(out + 1, NUM_ECC_BYTES, (uECC_word_t *) R);
     uECC_vli_nativeToBytes(out + NUM_ECC_BYTES + 1, NUM_ECC_BYTES, (uECC_word_t *) R + NUM_ECC_WORDS);
 #else
-
     size_t mbedtls_out_len = out_len;
 
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
@@ -1521,10 +1474,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
 {
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     if (EccPoint_mult_safer((uECC_word_t *) R, (const uECC_word_t *) P1, (const uECC_word_t *) fe1) != UECC_SUCCESS)
 #else
-
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_mul(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
@@ -1541,7 +1492,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
                                                       const void * fe2)
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     uECC_word_t R1[2 * NUM_ECC_WORDS];
     uECC_word_t R2[2 * NUM_ECC_WORDS];
     uECC_word_t z[NUM_ECC_WORDS];
@@ -1564,7 +1514,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
 
     memcpy((uECC_word_t *) R, R2, 2 * NUM_ECC_BYTES);
 #else
-
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_muladd(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
@@ -1580,13 +1529,11 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointInvert(void * R)
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     uECC_word_t tmp[NUM_ECC_WORDS] = { 0 };
 
     uECC_vli_sub(tmp, curve_p, (uECC_word_t *) R + NUM_ECC_WORDS);
     memcpy((uECC_word_t *) R + NUM_ECC_WORDS, tmp, NUM_ECC_BYTES);
 #else
-
     mbedtls_ecp_point * Rp = (mbedtls_ecp_point *) R;
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
@@ -1610,7 +1557,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     int result       = 0;
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     result = UECC_SUCCESS;
     uECC_word_t tmp[2 * NUM_ECC_WORDS];
     uECC_word_t w1_bn[NUM_ECC_WORDS];
@@ -1627,7 +1573,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     uECC_vli_nativeToBytes(Lout + 1, NUM_ECC_BYTES, L_tmp);
     uECC_vli_nativeToBytes(Lout + NUM_ECC_BYTES + 1, NUM_ECC_BYTES, L_tmp + NUM_ECC_WORDS);
 #else
-
     mbedtls_ecp_group curve;
     mbedtls_mpi w1_bn;
     mbedtls_ecp_point Ltemp;
@@ -1652,7 +1597,6 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
 
     result = mbedtls_ecp_point_write_binary(&curve, &Ltemp, MBEDTLS_ECP_PF_UNCOMPRESSED, L_len, Uint8::to_uchar(Lout), *L_len);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
-
 #endif
 
 exit:
@@ -1669,10 +1613,8 @@ exit:
 CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-
     if (uECC_valid_point((const uECC_word_t *) R) != 0)
 #else
-
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_check_pubkey(&context->curve, (mbedtls_ecp_point *) R) != 0)

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -96,7 +96,7 @@ static void _log_mbedTLS_error(int error_code)
 #if defined(MBEDTLS_USE_TINYCRYPT)
     if (error_code != 0 && error_code != UECC_SUCCESS)
 #else
-	if (error_code != 0)
+    if (error_code != 0)
 #endif
     {
 #if defined(MBEDTLS_ERROR_C)
@@ -498,13 +498,13 @@ static int CryptoRNG(void * ctxt, uint8_t * out_buffer, size_t out_length)
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-static int uecc_rng_wrapper(uint8_t *dest, unsigned int size)
+static int uecc_rng_wrapper(uint8_t * dest, unsigned int size)
 {
-	int ret;
+    int ret;
 
-	ret = CryptoRNG(NULL, dest, size);
+    ret = CryptoRNG(NULL, dest, size);
 
-	return (ret == 0)?size:0;
+    return (ret == 0) ? size : 0;
 }
 
 #endif
@@ -568,24 +568,24 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
 CHIP_ERROR P256Keypair::ECDSA_sign_hash(const uint8_t * hash, const size_t hash_length, P256ECDSASignature & out_signature) const
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-	VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
-	VerifyOrReturnError(hash != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-	VerifyOrReturnError(hash_length == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(hash != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(hash_length == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
 
-	CHIP_ERROR error = CHIP_NO_ERROR;
-	int result = UECC_FAILURE;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = UECC_FAILURE;
 
-	const mbedtls_uecc_keypair * keypair = to_const_keypair(&mKeypair);
+    const mbedtls_uecc_keypair * keypair = to_const_keypair(&mKeypair);
 
-	result = uECC_sign(keypair->private_key, hash, hash_length, out_signature.Bytes() );
+    result = uECC_sign(keypair->private_key, hash, hash_length, out_signature.Bytes());
 
-	VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
-	VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(out_signature.SetLength(kP256_ECDSA_Signature_Length_Raw) == CHIP_NO_ERROR, error = CHIP_ERROR_INTERNAL);
 
-	keypair		= nullptr;
+    keypair = nullptr;
 
 exit:
-	return error;
+    return error;
 
 #else
 
@@ -595,7 +595,7 @@ exit:
     VerifyOrReturnError(hash_length == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
 
     CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    int result = 0;
     mbedtls_mpi r, s;
     mbedtls_mpi_init(&r);
     mbedtls_mpi_init(&s);
@@ -661,20 +661,20 @@ CHIP_ERROR P256PublicKey::ECDSA_validate_hash_signature(const uint8_t * hash, co
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-	VerifyOrReturnError(hash != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-	VerifyOrReturnError(hash_length == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
-	VerifyOrReturnError(signature.Length() == kP256_ECDSA_Signature_Length_Raw, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(hash != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(hash_length == kSHA256_Hash_Length, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(signature.Length() == kP256_ECDSA_Signature_Length_Raw, CHIP_ERROR_INVALID_ARGUMENT);
 
-	CHIP_ERROR error = CHIP_NO_ERROR;
-	int result = UECC_FAILURE;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = UECC_FAILURE;
 
-	const uint8_t *public_key = *this;
+    const uint8_t * public_key = *this;
 
-	result = uECC_verify( public_key + 1, hash, hash_length, Uint8::to_const_uchar(signature.ConstBytes()) );
-	VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INVALID_SIGNATURE);
+    result = uECC_verify(public_key + 1, hash, hash_length, Uint8::to_const_uchar(signature.ConstBytes()));
+    VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INVALID_SIGNATURE);
 
 exit:
-	return error;
+    return error;
 
 #else
 #if defined(MBEDTLS_ECDSA_C)
@@ -683,7 +683,7 @@ exit:
     VerifyOrReturnError(signature.Length() == kP256_ECDSA_Signature_Length_Raw, CHIP_ERROR_INVALID_ARGUMENT);
 
     CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    int result = 0;
     mbedtls_mpi r, s;
 
     mbedtls_mpi_init(&r);
@@ -815,30 +815,30 @@ CHIP_ERROR P256Keypair::Initialize()
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-	CHIP_ERROR error = CHIP_NO_ERROR;
-	int result = UECC_FAILURE;
+    CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = UECC_FAILURE;
 
-	Clear();
+    Clear();
 
-	mbedtls_uecc_keypair * keypair = to_keypair(&mKeypair);
-	uECC_set_rng( &uecc_rng_wrapper );
+    mbedtls_uecc_keypair * keypair = to_keypair(&mKeypair);
+    uECC_set_rng(&uecc_rng_wrapper);
 
-	result = uECC_make_key( keypair->public_key, keypair->private_key);
-	VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    result = uECC_make_key(keypair->public_key, keypair->private_key);
+    VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
-	Uint8::to_uchar(mPublicKey)[0] = 0x04;
-	memcpy(Uint8::to_uchar(mPublicKey) + 1, keypair->public_key, 2*NUM_ECC_BYTES);
+    Uint8::to_uchar(mPublicKey)[0] = 0x04;
+    memcpy(Uint8::to_uchar(mPublicKey) + 1, keypair->public_key, 2 * NUM_ECC_BYTES);
 
-	keypair      = nullptr;
-	mInitialized = true;
+    keypair      = nullptr;
+    mInitialized = true;
 
 exit:
-	_log_mbedTLS_error(result);
-	return error;
+    _log_mbedTLS_error(result);
+    return error;
 
 #else
     CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    int result = 0;
 
     size_t pubkey_size = 0;
 
@@ -858,7 +858,7 @@ exit:
     VerifyOrExit(result == 0, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(pubkey_size == mPublicKey.Length(), error = CHIP_ERROR_INVALID_ARGUMENT);
 
-    keypair      = nullptr;
+    keypair = nullptr;
     mInitialized = true;
 
 exit:
@@ -879,7 +879,7 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
     const mbedtls_uecc_keypair * keypair = to_const_keypair(&mKeypair);
-    size_t len                          = output.Length() == 0 ? output.Capacity() : output.Length();
+    size_t len                           = output.Length() == 0 ? output.Capacity() : output.Length();
     Encoding::BufferWriter bbuf(output, len);
     uint8_t privkey[kP256_PrivateKey_Length];
     CHIP_ERROR error = CHIP_NO_ERROR;
@@ -898,17 +898,17 @@ CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
     output.SetLength(bbuf.Needed());
 
 exit:
-	memset(privkey, 0, sizeof(privkey));
+    memset(privkey, 0, sizeof(privkey));
     _log_mbedTLS_error(result);
     return error;
 
 #else
     const mbedtls_ecp_keypair * keypair = to_const_keypair(&mKeypair);
-    size_t len                          = output.Length() == 0 ? output.Capacity() : output.Length();
+    size_t len = output.Length() == 0 ? output.Capacity() : output.Length();
     Encoding::BufferWriter bbuf(output, len);
     uint8_t privkey[kP256_PrivateKey_Length];
     CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    int result = 0;
 
     bbuf.Put(mPublicKey, mPublicKey.Length());
 
@@ -937,35 +937,35 @@ CHIP_ERROR P256Keypair::Deserialize(P256SerializedKeypair & input)
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-	int result       = 0;
-	CHIP_ERROR error = CHIP_NO_ERROR;
+    int result       = 0;
+    CHIP_ERROR error = CHIP_NO_ERROR;
     Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
 
-	Clear();
+    Clear();
 
-	mbedtls_uecc_keypair * keypair = to_keypair(&mKeypair);
-	uECC_set_rng( &uecc_rng_wrapper );
+    mbedtls_uecc_keypair * keypair = to_keypair(&mKeypair);
+    uECC_set_rng(&uecc_rng_wrapper);
 
-	memcpy(keypair->public_key, Uint8::to_uchar(input) + 1, 2*NUM_ECC_BYTES);
-	memcpy(keypair->private_key, Uint8::to_uchar(input) + mPublicKey.Length(), NUM_ECC_BYTES);
+    memcpy(keypair->public_key, Uint8::to_uchar(input) + 1, 2 * NUM_ECC_BYTES);
+    memcpy(keypair->private_key, Uint8::to_uchar(input) + mPublicKey.Length(), NUM_ECC_BYTES);
 
-	keypair			= nullptr;
+    keypair = nullptr;
 
     VerifyOrExit(input.Length() == mPublicKey.Length() + kP256_PrivateKey_Length, error = CHIP_ERROR_INVALID_ARGUMENT);
     bbuf.Put((const uint8_t *) input, mPublicKey.Length());
     VerifyOrExit(bbuf.Fit(), error = CHIP_ERROR_NO_MEMORY);
 
-	mInitialized	= true;
+    mInitialized = true;
 
-	_log_mbedTLS_error(result);
+    _log_mbedTLS_error(result);
 
 exit:
-	return error;
+    return error;
 
 #else
     Encoding::BufferWriter bbuf(mPublicKey, mPublicKey.Length());
 
-    int result       = 0;
+    int result = 0;
     CHIP_ERROR error = CHIP_NO_ERROR;
 
     Clear();
@@ -1004,7 +1004,7 @@ void P256Keypair::Clear()
     if (mInitialized)
     {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-	mInitialized = false;
+        mInitialized = false;
 #else
         mbedtls_ecp_keypair * keypair = to_keypair(&mKeypair);
         mbedtls_ecp_keypair_free(keypair);
@@ -1031,59 +1031,59 @@ CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t &
     const mbedtls_uecc_keypair * keypair = to_const_keypair(&mKeypair);
 
     mbedtls_x509write_csr csr;
-	mbedtls_x509write_csr_init(&csr);
+    mbedtls_x509write_csr_init(&csr);
 
-	mbedtls_pk_context pk;
-	mbedtls_pk_init(&pk);
+    mbedtls_pk_context pk;
+    mbedtls_pk_init(&pk);
 
-	const mbedtls_pk_info_t * pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
-	VerifyOrExit(pk_info != nullptr, error = CHIP_ERROR_INTERNAL);
+    const mbedtls_pk_info_t * pk_info = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
+    VerifyOrExit(pk_info != nullptr, error = CHIP_ERROR_INTERNAL);
 
-	VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
 
-	result = mbedtls_pk_setup(&pk, pk_info);
-	VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    result = mbedtls_pk_setup(&pk, pk_info);
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-	memcpy(mbedtls_pk_uecc(pk), keypair, sizeof(mbedtls_uecc_keypair));
+    memcpy(mbedtls_pk_uecc(pk), keypair, sizeof(mbedtls_uecc_keypair));
 
-	mbedtls_x509write_csr_set_key(&csr, &pk);
+    mbedtls_x509write_csr_set_key(&csr, &pk);
 
-	mbedtls_x509write_csr_set_md_alg(&csr, MBEDTLS_MD_SHA256);
+    mbedtls_x509write_csr_set_md_alg(&csr, MBEDTLS_MD_SHA256);
 
-	// TODO: mbedTLS CSR parser fails if the subject name is not set (or if empty).
-	//       CHIP Spec doesn't specify the subject name that can be used.
-	//       Figure out the correct value and update this code.
-	result = mbedtls_x509write_csr_set_subject_name(&csr, "O=CSR");
-	VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
+    // TODO: mbedTLS CSR parser fails if the subject name is not set (or if empty).
+    //       CHIP Spec doesn't specify the subject name that can be used.
+    //       Figure out the correct value and update this code.
+    result = mbedtls_x509write_csr_set_subject_name(&csr, "O=CSR");
+    VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-	result = mbedtls_x509write_csr_der(&csr, out_csr, csr_length, CryptoRNG, nullptr);
-	VerifyOrExit(result > 0, error = CHIP_ERROR_INTERNAL);
+    result = mbedtls_x509write_csr_der(&csr, out_csr, csr_length, CryptoRNG, nullptr);
+    VerifyOrExit(result > 0, error = CHIP_ERROR_INTERNAL);
 
-	out_length = (size_t) result;
-	result     = 0;
-	VerifyOrExit(out_length <= csr_length, error = CHIP_ERROR_INTERNAL);
+    out_length = (size_t) result;
+    result     = 0;
+    VerifyOrExit(out_length <= csr_length, error = CHIP_ERROR_INTERNAL);
 
-	if (csr_length != out_length)
-	{
-		// mbedTLS API writes the CSR at the end of the provided buffer.
-		// Let's move it to the start of the buffer.
-		size_t offset = csr_length - out_length;
-		memmove(out_csr, &out_csr[offset], out_length);
-	}
+    if (csr_length != out_length)
+    {
+        // mbedTLS API writes the CSR at the end of the provided buffer.
+        // Let's move it to the start of the buffer.
+        size_t offset = csr_length - out_length;
+        memmove(out_csr, &out_csr[offset], out_length);
+    }
 
-	csr_length = out_length;
+    csr_length = out_length;
 
 exit:
-	mbedtls_x509write_csr_free(&csr);
+    mbedtls_x509write_csr_free(&csr);
 
-	mbedtls_pk_free(&pk);
+    mbedtls_pk_free(&pk);
 
-	_log_mbedTLS_error(result);
-	return error;
+    _log_mbedTLS_error(result);
+    return error;
 
 #else
     CHIP_ERROR error = CHIP_NO_ERROR;
-    int result       = 0;
+    int result = 0;
     size_t out_length;
 
     mbedtls_x509write_csr csr;
@@ -1091,7 +1091,7 @@ exit:
 
     mbedtls_pk_context pk;
     pk.CHIP_CRYPTO_PAL_PRIVATE(pk_info) = mbedtls_pk_info_from_type(MBEDTLS_PK_ECKEY);
-    pk.CHIP_CRYPTO_PAL_PRIVATE(pk_ctx)  = to_keypair(&mKeypair);
+    pk.CHIP_CRYPTO_PAL_PRIVATE(pk_ctx) = to_keypair(&mKeypair);
     VerifyOrExit(pk.CHIP_CRYPTO_PAL_PRIVATE(pk_info) != nullptr, error = CHIP_ERROR_INTERNAL);
 
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
@@ -1111,7 +1111,7 @@ exit:
     VerifyOrExit(CanCastTo<size_t>(result), error = CHIP_ERROR_INTERNAL);
 
     out_length = static_cast<size_t>(result);
-    result     = 0;
+    result = 0;
     VerifyOrExit(out_length <= csr_length, error = CHIP_ERROR_INTERNAL);
 
     if (csr_length != out_length)
@@ -1195,19 +1195,19 @@ typedef struct Spake2p_Context
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-	const mbedtls_md_info_t * md_info;
-	uECC_word_t M[2*NUM_ECC_WORDS];
-	uECC_word_t N[2*NUM_ECC_WORDS];
-	uECC_word_t X[2*NUM_ECC_WORDS];
-	uECC_word_t Y[2*NUM_ECC_WORDS];
-	uECC_word_t L[2*NUM_ECC_WORDS];
-	uECC_word_t Z[2*NUM_ECC_WORDS];
-	uECC_word_t V[2*NUM_ECC_WORDS];
+    const mbedtls_md_info_t * md_info;
+    uECC_word_t M[2 * NUM_ECC_WORDS];
+    uECC_word_t N[2 * NUM_ECC_WORDS];
+    uECC_word_t X[2 * NUM_ECC_WORDS];
+    uECC_word_t Y[2 * NUM_ECC_WORDS];
+    uECC_word_t L[2 * NUM_ECC_WORDS];
+    uECC_word_t Z[2 * NUM_ECC_WORDS];
+    uECC_word_t V[2 * NUM_ECC_WORDS];
 
-	uECC_word_t w0[NUM_ECC_WORDS];
-	uECC_word_t w1[NUM_ECC_WORDS];
-	uECC_word_t xy[NUM_ECC_WORDS];
-	uECC_word_t tempbn[NUM_ECC_WORDS];
+    uECC_word_t w0[NUM_ECC_WORDS];
+    uECC_word_t w1[NUM_ECC_WORDS];
+    uECC_word_t xy[NUM_ECC_WORDS];
+    uECC_word_t tempbn[NUM_ECC_WORDS];
 
 #else
     mbedtls_ecp_group curve;
@@ -1256,7 +1256,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     xy     = context->xy;
     tempbn = context->tempbn;
 
-    G		= curve_G;
+    G = curve_G;
 
 #else
     mbedtls_ecp_group_init(&context->curve);
@@ -1285,12 +1285,12 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     mbedtls_mpi_init(&context->w1);
     mbedtls_mpi_init(&context->xy);
     mbedtls_mpi_init(&context->tempbn);
-    w0     = &context->w0;
-    w1     = &context->w1;
-    xy     = &context->xy;
+    w0 = &context->w0;
+    w1 = &context->w1;
+    xy = &context->xy;
     tempbn = &context->tempbn;
 
-    G     = &context->curve.G;
+    G = &context->curve.G;
     order = &context->curve.N;
 #endif
 
@@ -1383,10 +1383,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FELoad(const uint8_t * in, size_t in_l
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-    uECC_word_t tmp[2*NUM_ECC_WORDS] = { 0 };
+    uECC_word_t tmp[2 * NUM_ECC_WORDS] = { 0 };
     uECC_vli_bytesToNative(tmp, in, NUM_ECC_BYTES);
 
-    uECC_vli_mmod((uECC_word_t*)fe, tmp, curve_n);
+    uECC_vli_mmod((uECC_word_t *) fe, tmp, curve_n);
 
 #else
 
@@ -1406,7 +1406,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEWrite(const void * fe, uint8_t * out
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-	uECC_vli_nativeToBytes(out, NUM_ECC_BYTES, (const unsigned int *)fe);
+    uECC_vli_nativeToBytes(out, NUM_ECC_BYTES, (const unsigned int *) fe);
 #else
 
     if (mbedtls_mpi_write_binary((const mbedtls_mpi *) fe, Uint8::to_uchar(out), out_len) != 0)
@@ -1426,17 +1426,17 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEGenerate(void * fe)
 
     mbedtls_uecc_keypair keypair;
 
-	uECC_set_rng( &uecc_rng_wrapper );
+    uECC_set_rng(&uecc_rng_wrapper);
 
-	result = UECC_FAILURE;
+    result = UECC_FAILURE;
 
-	result = uECC_make_key( keypair.public_key, keypair.private_key);
-	VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
+    result = uECC_make_key(keypair.public_key, keypair.private_key);
+    VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
-	uECC_vli_bytesToNative((uECC_word_t*)fe, keypair.private_key, NUM_ECC_BYTES);
+    uECC_vli_bytesToNative((uECC_word_t *) fe, keypair.private_key, NUM_ECC_BYTES);
 #else
 
-	Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     result = mbedtls_ecp_gen_privkey(&context->curve, (mbedtls_mpi *) fe, CryptoRNG, nullptr);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
@@ -1454,7 +1454,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::FEMul(void * fer, const void * fe1, co
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-    uECC_vli_modMult( (uECC_word_t*) fer, (const uECC_word_t*) fe1, (const uECC_word_t*) fe2, (const uECC_word_t*) curve_n);
+    uECC_vli_modMult((uECC_word_t *) fer, (const uECC_word_t *) fe1, (const uECC_word_t *) fe2, (const uECC_word_t *) curve_n);
 #else
 
     result = mbedtls_mpi_mul_mpi((mbedtls_mpi *) fer, (const mbedtls_mpi *) fe1, (const mbedtls_mpi *) fe2);
@@ -1473,12 +1473,12 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointLoad(const uint8_t * in, size_t i
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-    uint8_t tmp[2*NUM_ECC_BYTES];
+    uint8_t tmp[2 * NUM_ECC_BYTES];
 
-    memcpy(tmp, in + 1, 2*NUM_ECC_BYTES);
+    memcpy(tmp, in + 1, 2 * NUM_ECC_BYTES);
 
-    uECC_vli_bytesToNative((uECC_word_t*)R, tmp, NUM_ECC_BYTES);
-    uECC_vli_bytesToNative((uECC_word_t*)R + NUM_ECC_WORDS, tmp + NUM_ECC_BYTES, NUM_ECC_BYTES);
+    uECC_vli_bytesToNative((uECC_word_t *) R, tmp, NUM_ECC_BYTES);
+    uECC_vli_bytesToNative((uECC_word_t *) R + NUM_ECC_WORDS, tmp + NUM_ECC_BYTES, NUM_ECC_BYTES);
 #else
 
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
@@ -1499,8 +1499,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointWrite(const void * R, uint8_t * o
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
     out[0] = 0x04;
-    uECC_vli_nativeToBytes(out + 1, NUM_ECC_BYTES, (uECC_word_t*)R);
-    uECC_vli_nativeToBytes(out + NUM_ECC_BYTES + 1, NUM_ECC_BYTES, (uECC_word_t*)R + NUM_ECC_WORDS);
+    uECC_vli_nativeToBytes(out + 1, NUM_ECC_BYTES, (uECC_word_t *) R);
+    uECC_vli_nativeToBytes(out + NUM_ECC_BYTES + 1, NUM_ECC_BYTES, (uECC_word_t *) R + NUM_ECC_WORDS);
 #else
 
     size_t mbedtls_out_len = out_len;
@@ -1522,10 +1522,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointMul(void * R, const void * P1, co
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-    if(EccPoint_mult_safer((uECC_word_t*)R, (const uECC_word_t*)P1, (const uECC_word_t*)fe1) != UECC_SUCCESS)
+    if (EccPoint_mult_safer((uECC_word_t *) R, (const uECC_word_t *) P1, (const uECC_word_t *) fe1) != UECC_SUCCESS)
 #else
 
-	Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_mul(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
                         CryptoRNG, nullptr) != 0)
@@ -1542,30 +1542,30 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointAddMul(void * R, const void * P1,
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-    uECC_word_t R1[2*NUM_ECC_WORDS];
-    uECC_word_t R2[2*NUM_ECC_WORDS];
-	uECC_word_t z[NUM_ECC_WORDS];
+    uECC_word_t R1[2 * NUM_ECC_WORDS];
+    uECC_word_t R2[2 * NUM_ECC_WORDS];
+    uECC_word_t z[NUM_ECC_WORDS];
     uint8_t ret = UECC_SUCCESS;
 
-    if(EccPoint_mult_safer(R1, (const uECC_word_t*)P1, (const uECC_word_t*)fe1) != UECC_SUCCESS)
+    if (EccPoint_mult_safer(R1, (const uECC_word_t *) P1, (const uECC_word_t *) fe1) != UECC_SUCCESS)
     {
-	return CHIP_ERROR_INTERNAL;
+        return CHIP_ERROR_INTERNAL;
     }
 
-    if(EccPoint_mult_safer(R2, (const uECC_word_t*)P2, (const uECC_word_t*)fe2) != UECC_SUCCESS)
+    if (EccPoint_mult_safer(R2, (const uECC_word_t *) P2, (const uECC_word_t *) fe2) != UECC_SUCCESS)
     {
-	return CHIP_ERROR_INTERNAL;
+        return CHIP_ERROR_INTERNAL;
     }
 
-	uECC_vli_modSub(z, R2, R1, curve_p);
-	XYcZ_add(R1, R1 + NUM_ECC_WORDS, R2, R2 + NUM_ECC_WORDS);
-	uECC_vli_modInv(z, z, curve_p);
-	apply_z(R2, R2 + NUM_ECC_WORDS, z);
+    uECC_vli_modSub(z, R2, R1, curve_p);
+    XYcZ_add(R1, R1 + NUM_ECC_WORDS, R2, R2 + NUM_ECC_WORDS);
+    uECC_vli_modInv(z, z, curve_p);
+    apply_z(R2, R2 + NUM_ECC_WORDS, z);
 
-	memcpy((uECC_word_t*)R, R2, 2 * NUM_ECC_BYTES);
+    memcpy((uECC_word_t *) R, R2, 2 * NUM_ECC_BYTES);
 #else
 
-	Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_muladd(&context->curve, (mbedtls_ecp_point *) R, (const mbedtls_mpi *) fe1, (const mbedtls_ecp_point *) P1,
                            (const mbedtls_mpi *) fe2, (const mbedtls_ecp_point *) P2) != 0)
@@ -1581,13 +1581,13 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointInvert(void * R)
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-	uECC_word_t tmp[NUM_ECC_WORDS] = { 0 };
+    uECC_word_t tmp[NUM_ECC_WORDS] = { 0 };
 
-	uECC_vli_sub(tmp, curve_p, (uECC_word_t*)R + NUM_ECC_WORDS);
-	memcpy((uECC_word_t*)R + NUM_ECC_WORDS, tmp, NUM_ECC_BYTES);
+    uECC_vli_sub(tmp, curve_p, (uECC_word_t *) R + NUM_ECC_WORDS);
+    memcpy((uECC_word_t *) R + NUM_ECC_WORDS, tmp, NUM_ECC_BYTES);
 #else
 
-    mbedtls_ecp_point * Rp    = (mbedtls_ecp_point *) R;
+    mbedtls_ecp_point * Rp = (mbedtls_ecp_point *) R;
     Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_mpi_sub_mpi(&Rp->CHIP_CRYPTO_PAL_PRIVATE(Y), &context->curve.P, &Rp->CHIP_CRYPTO_PAL_PRIVATE(Y)) != 0)
@@ -1612,9 +1612,9 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
     result = UECC_SUCCESS;
-    uECC_word_t tmp[2*NUM_ECC_WORDS];
+    uECC_word_t tmp[2 * NUM_ECC_WORDS];
     uECC_word_t w1_bn[NUM_ECC_WORDS];
-    uECC_word_t L_tmp[2*NUM_ECC_WORDS];
+    uECC_word_t L_tmp[2 * NUM_ECC_WORDS];
 
     uECC_vli_bytesToNative(tmp, w1in, NUM_ECC_BYTES);
 
@@ -1624,8 +1624,8 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::ComputeL(uint8_t * Lout, size_t * L_le
     VerifyOrExit(result == UECC_SUCCESS, error = CHIP_ERROR_INTERNAL);
 
     Lout[0] = 0x04;
-    uECC_vli_nativeToBytes(Lout + 1, NUM_ECC_BYTES,L_tmp);
-    uECC_vli_nativeToBytes(Lout + NUM_ECC_BYTES + 1, NUM_ECC_BYTES,L_tmp + NUM_ECC_WORDS);
+    uECC_vli_nativeToBytes(Lout + 1, NUM_ECC_BYTES, L_tmp);
+    uECC_vli_nativeToBytes(Lout + NUM_ECC_BYTES + 1, NUM_ECC_BYTES, L_tmp + NUM_ECC_WORDS);
 #else
 
     mbedtls_ecp_group curve;
@@ -1670,10 +1670,10 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::PointIsValid(void * R)
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
 
-    if (uECC_valid_point((const uECC_word_t *)R) != 0)
+    if (uECC_valid_point((const uECC_word_t *) R) != 0)
 #else
 
-	Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
+    Spake2p_Context * context = to_inner_spake2p_context(&mSpake2pContext);
 
     if (mbedtls_ecp_check_pubkey(&context->curve, (mbedtls_ecp_point *) R) != 0)
 #endif

--- a/third_party/mbedtls/mbedtls.gni
+++ b/third_party/mbedtls/mbedtls.gni
@@ -17,7 +17,7 @@ import("//build_overrides/mbedtls.gni")
 template("mbedtls_target") {
   mbedtls_target_name = target_name
 
-  _mbedtls_root = "${mbedtls_root}/repo"
+  _mbedtls_root = "${mbedtls_repo}/repo"
 
   config("${mbedtls_target_name}_warnings") {
     cflags = [

--- a/third_party/nxp/k32w0_sdk/BUILD.gn
+++ b/third_party/nxp/k32w0_sdk/BUILD.gn
@@ -56,7 +56,7 @@ config("mbedtls_k32w0_config") {
   if (mbedtls_use_tinycrypt) {
     defines += [
       "MBEDTLS_USE_TINYCRYPT",
-      "MBEDTLS_OPTIMIZE_TINYCRYPT_ASM"
+      "MBEDTLS_OPTIMIZE_TINYCRYPT_ASM",
     ]
   }
 
@@ -73,8 +73,7 @@ mbedtls_target("mbedtls") {
     "${k32w0_sdk_root}/middleware/mbedtls/port/ksdk/ksdk_mbedtls.c",
   ]
 
-  if (mbedtls_use_tinycrypt)
-  {
+  if (mbedtls_use_tinycrypt) {
     sources += [
       "${mbedtls_repo}/repo/tinycrypt/ecc.c",
       "${mbedtls_repo}/repo/tinycrypt/ecc_dh.c",

--- a/third_party/nxp/k32w0_sdk/BUILD.gn
+++ b/third_party/nxp/k32w0_sdk/BUILD.gn
@@ -53,7 +53,18 @@ config("mbedtls_k32w0_config") {
     ]
   }
 
+  if (mbedtls_use_tinycrypt) {
+    defines += [
+      "MBEDTLS_USE_TINYCRYPT",
+      "MBEDTLS_OPTIMIZE_TINYCRYPT_ASM"
+    ]
+  }
+
   include_dirs = [ chip_root ]
+
+  if (mbedtls_use_tinycrypt) {
+    include_dirs += [ "${mbedtls_repo}/repo/include/tinycrypt" ]
+  }
 }
 
 mbedtls_target("mbedtls") {
@@ -61,6 +72,15 @@ mbedtls_target("mbedtls") {
     "${k32w0_sdk_root}/middleware/mbedtls/port/ksdk/aes_alt.c",
     "${k32w0_sdk_root}/middleware/mbedtls/port/ksdk/ksdk_mbedtls.c",
   ]
+
+  if (mbedtls_use_tinycrypt)
+  {
+    sources += [
+      "${mbedtls_repo}/repo/tinycrypt/ecc.c",
+      "${mbedtls_repo}/repo/tinycrypt/ecc_dh.c",
+      "${mbedtls_repo}/repo/tinycrypt/ecc_dsa.c",
+    ]
+  }
 
   public_configs = [ ":mbedtls_k32w0_config" ]
 

--- a/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
+++ b/third_party/nxp/k32w0_sdk/k32w0_sdk.gni
@@ -29,6 +29,7 @@ declare_args() {
   chip_with_OM15082 = 0
   chip_with_ot_cli = 0
   chip_with_low_power = 0
+  mbedtls_use_tinycrypt = false
 }
 
 assert(k32w0_sdk_root != "", "k32w0_sdk_root must be specified")


### PR DESCRIPTION
#### Problem
Mbedtls crypto ecc operations are slow
 
#### Change overview
Integrate Tinycrypt ecc operations.
Tinycrypt can decrease ecc oprations time (ecc make key, sign and verify) by a factor of 4.
This PR uses a external mbedtls library that has TinyCrypt integrated.

#### Testing
Tested on K32W061, lighting-app
gn gen out/debug --args="k32w0_sdk_root=\"${NXP_K32W061_SDK_ROOT}\" chip_with_OM15082=1 chip_with_ot_cli=0 is_debug=false chip_crypto=\"mbedtls\" chip_with_se05x=0 mbedtls_use_tinycrypt=true chip_pw_tokenizer_logging=true mbedtls_repo=\"//third_party/connectedhomeip/third_party/nxp/libs/mbedtls\""