### PR TITLE
Improve fallback to next discovered thing in SetUpCodePairer.

### DIFF
--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -147,4 +147,8 @@ ALLOW: Dict[str, Set[str]] = {
 
     # Uses platform-define to switch between list and array
     'src/lib/dnssd/minimal_mdns/ResponseSender.h': {'list'},
+
+    # Not really for embedded consumers; uses std::queue to keep track
+    # of a list of discovered things.
+    'src/controller/SetUpCodePairer.h': {'queue'},
 }


### PR DESCRIPTION
Discovery fallback in SetUpCodePairer had a few limitations:

1. It only supported one discovered thing per transport.  For DNS-SD this is a
   poor match for how things actually work.  The fix for that is to move from a
   fixed-size array indexed by transport to an std::queue.

2. It did not support continuing DNS-SD discovery once BLE found something, even
   if it turned out we had the wrong passcode for the BLE thing.  The fix for
   that is to not cancel discovery unless one of three things happens:

   a) We successfully establish PASE.
   b) We hit our discovery timeout.
   c) We are asked to discover something else.

3. It notified failure on failure to establish PASE to a discovered thing, even
   if there were other things already discovered, or waiting to be discovered.
   This would cause consumers to assume discovery had completely failed, if we
   happened to have a discriminator collision when doing DNS-SD discovery.  The
   fix for that is to hold off on propagating failure notifications until
   discovery times out.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Tested that if I provide an incorrect PIN in my pairing code we now try all the discovered things, then wait for discovery timeout, before failing out from `chip-tool pairing code` on ToT (where it stops the command once a failure is reported).