### PR TITLE
Revert "Fix alignment when using PacketBuffer reserve space"

### DIFF
--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -471,7 +471,16 @@ struct netif * UDPEndPointImplLwIP::FindNetifFromInterfaceId(InterfaceId aInterf
 
 IPPacketInfo * UDPEndPointImplLwIP::GetPacketInfo(const System::PacketBufferHandle & aBuffer)
 {
-    return aBuffer->GetReserve<IPPacketInfo>();
+    if (!aBuffer->EnsureReservedSize(sizeof(IPPacketInfo) + 3))
+    {
+        return nullptr;
+    }
+
+    uintptr_t lStart           = (uintptr_t) aBuffer->Start();
+    uintptr_t lPacketInfoStart = lStart - sizeof(IPPacketInfo);
+
+    // Align to a 4-byte boundary
+    return reinterpret_cast<IPPacketInfo *>(lPacketInfoStart & ~(sizeof(uint32_t) - 1));
 }
 
 } // namespace Inet

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -401,46 +401,6 @@ bool PacketBuffer::EnsureReservedSize(uint16_t aReservedSize)
     return true;
 }
 
-uint8_t * PacketBuffer::GetReserve(uint16_t aSize, uint16_t aAlignmentMask)
-{
-    // This private utility method requires that `aAlignmentMask` be one less than a power-of-two alignment. This requirement
-    // is satisfied when aAlignmentMask=alignof(T)-1 for some type T, as passed by the public GetReserve<T>().
-
-    // Computing `reserveStart` can't overflow because a valid PacketBuffer must be larger than kStructureSize.
-    const uintptr_t reserveStart = reinterpret_cast<uintptr_t>(this) + kStructureSize;
-    if (reserveStart + aSize < reserveStart)
-    {
-        // Overflow here means the requested size can't possibly fit.
-        return nullptr;
-    }
-
-    const uintptr_t requestStart = (reserveStart + aAlignmentMask) & ~aAlignmentMask;
-    if (requestStart < reserveStart)
-    {
-        // Overflow here means the request can't be satisfied because the alignment is too large.
-        return nullptr;
-    }
-
-    // This cast is safe because the difference is at most `aAlignmentMask`.
-    const uint16_t reserveAlignmentOffset = static_cast<uint16_t>(requestStart - reserveStart);
-
-    // This cast is not safe in itself, but the result is checked.
-    const uint16_t requestSize = static_cast<uint16_t>(reserveAlignmentOffset + aSize);
-    if (requestSize < aSize)
-    {
-        // Overflow here means the requested size can't possibly fit.
-        return nullptr;
-    }
-
-    if (!EnsureReservedSize(requestSize))
-    {
-        // The requested size is too large for the available space.
-        return nullptr;
-    }
-
-    return reinterpret_cast<uint8_t *>(requestStart);
-}
-
 bool PacketBuffer::AlignPayload(uint16_t aAlignBytes)
 {
     if (aAlignBytes == 0)

--- a/src/system/SystemPacketBuffer.h
+++ b/src/system/SystemPacketBuffer.h
@@ -116,7 +116,7 @@ private:
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     static constexpr uint16_t kStructureSize = LWIP_MEM_ALIGN_SIZE(sizeof(struct ::pbuf));
 #else  // CHIP_SYSTEM_CONFIG_USE_LWIP
-    static constexpr uint16_t kStructureSize = CHIP_SYSTEM_ALIGN_SIZE(sizeof(::chip::System::pbuf), alignof(::chip::System::pbuf));
+    static constexpr uint16_t kStructureSize         = CHIP_SYSTEM_ALIGN_SIZE(sizeof(::chip::System::pbuf), 4u);
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
 
 public:
@@ -289,23 +289,6 @@ public:
     CHECK_RETURN_VALUE bool EnsureReservedSize(uint16_t aReservedSize);
 
     /**
-     * Get a pointer to reserved space.
-     *
-     *  Returns a pointer to space in the packet buffer with size and alignment suitable for type T. Payload data is
-     *  moved if necessary to increase the reserve. Due to alignment and padding, the returned space is not necessarily
-     *  adjacent to either the packet buffer header or to the payload.
-     *
-     *  @return \c pointer to the requested reserve if available, \c nullptr if there's not enough room in the buffer.
-     */
-    template <typename T>
-    T * GetReserve()
-    {
-        static_assert(sizeof(T) <= UINT16_MAX, "type too large");
-        static_assert(alignof(T) <= UINT16_MAX, "alignment too large");
-        return reinterpret_cast<T *>(GetReserve(static_cast<uint16_t>(sizeof(T)), static_cast<uint16_t>(alignof(T) - 1)));
-    }
-
-    /**
      * Align the buffer payload on the specified bytes boundary.
      *
      *  Moving the payload in the buffer forward if necessary.
@@ -390,7 +373,6 @@ private:
     static void InternalCheck(const PacketBuffer * buffer);
 #endif
 
-    uint8_t * GetReserve(uint16_t aSize, uint16_t aAlignmentMask);
     void AddRef();
     bool HasSoleOwnership() const { return (this->ref == 1); }
     static void Free(PacketBuffer * aPacket);


### PR DESCRIPTION
Reverts project-chip/connectedhomeip#19244

Fixes  #19289 M5 board cannot be paired due to continuous crash and rebooting