### PR TITLE
IntrusiveList: Add auto-unlink mode

### DIFF
--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -66,7 +66,7 @@ public:
 /// Implementations extend this class with implementation-specific data like
 /// storing the 'last known good address' and 'scores' or any additional data
 /// required to figure out when a resolve is ok.
-class NodeLookupHandleBase : public IntrusiveListNodeBase
+class NodeLookupHandleBase : public IntrusiveListNodeBase<>
 {
 public:
     NodeLookupHandleBase() {}

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -105,7 +105,7 @@ constexpr size_t kMaxOperationalRecords = 6;
 /// Represents an allocated operational responder.
 ///
 /// Wraps a QueryResponderAllocator.
-class OperationalQueryAllocator : public chip::IntrusiveListNodeBase
+class OperationalQueryAllocator : public chip::IntrusiveListNodeBase<>
 {
 public:
     using Allocator = QueryResponderAllocator<kMaxOperationalRecords>;

--- a/src/lib/support/tests/TestIntrusiveList.cpp
+++ b/src/lib/support/tests/TestIntrusiveList.cpp
@@ -27,7 +27,7 @@ namespace {
 
 using namespace chip;
 
-class ListNode : public IntrusiveListNodeBase
+class ListNode : public IntrusiveListNodeBase<>
 {
 };
 
@@ -191,6 +191,35 @@ void TestMoveList(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+class ListNodeAutoUnlink : public IntrusiveListNodeBase<IntrusiveMode::AutoUnlink>
+{
+};
+
+void TestAutoUnlink(nlTestSuite * inSuite, void * inContext)
+{
+    IntrusiveList<ListNodeAutoUnlink, IntrusiveMode::AutoUnlink> list;
+
+    // Test case 1: Test node->Unlink()
+    {
+        ListNodeAutoUnlink a;
+        NL_TEST_ASSERT(inSuite, !list.Contains(&a));
+        list.PushBack(&a);
+        NL_TEST_ASSERT(inSuite, list.Contains(&a));
+        a.Unlink();
+        NL_TEST_ASSERT(inSuite, !list.Contains(&a));
+        NL_TEST_ASSERT(inSuite, list.Empty());
+    }
+
+    // Test case 2: The node is automatically removed when goes out of scope
+    {
+        ListNodeAutoUnlink a;
+        NL_TEST_ASSERT(inSuite, !list.Contains(&a));
+        list.PushBack(&a);
+        NL_TEST_ASSERT(inSuite, list.Contains(&a));
+    }
+    NL_TEST_ASSERT(inSuite, list.Empty());
+}
+
 int Setup(void * inContext)
 {
     return SUCCESS;
@@ -212,6 +241,7 @@ static const nlTest sTests[] = {
     NL_TEST_DEF_FN(TestContains),            //
     NL_TEST_DEF_FN(TestReplaceNode),         //
     NL_TEST_DEF_FN(TestMoveList),            //
+    NL_TEST_DEF_FN(TestAutoUnlink),          //
     NL_TEST_SENTINEL(),                      //
 };
 

--- a/src/transport/SessionHolder.h
+++ b/src/transport/SessionHolder.h
@@ -28,7 +28,7 @@ namespace chip {
  *    released when the underlying session is released. One must verify it is available before use. The object can be
  *    created using SessionHandle.Grab()
  */
-class SessionHolder : public SessionDelegate, public IntrusiveListNodeBase
+class SessionHolder : public SessionDelegate, public IntrusiveListNodeBase<>
 {
 public:
     SessionHolder() {}


### PR DESCRIPTION
#### Problem
Current it is a abort when destructing a list node which is belonged to a list. This may be to restrictive for some use-cases.

#### Change overview
Add a auto-unlink mode where the node is removed from the list when destructing, and provide a function for node to remove itself from the list w/o going through list API.

**Note**: this feature is inspired by Boost.Intrusive auto-unlink mode

#### Testing
Add unit test-cases for the new feature and API.