### PR TITLE
[chip-trace-decoder] Use the right message parser for status response

### DIFF
--- a/examples/common/tracing/decoder/interaction_model/Decoder.cpp
+++ b/examples/common/tracing/decoder/interaction_model/Decoder.cpp
@@ -135,7 +135,7 @@ CHIP_ERROR DecodeStatusResponse(TLV::TLVReader & reader, bool decode)
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
     if (decode)
     {
-        app::InvokeRequestMessage::Parser parser;
+        app::StatusResponseMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
         return parser.CheckSchemaValidity();
     }


### PR DESCRIPTION
#### Problem

I made a typo when landing #18893 and status response does not use the right message parser when trying to see how #18800 can be done.

#### Change overview
 * Use the correct message parser

#### Testing
It was tested on a trace from a subscriptions that contains status responses...