### PR TITLE
Add API to invalid sessions/exchanges for UpdateNOC command

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -325,7 +325,7 @@ ExchangeContext::~ExchangeContext()
     VerifyOrDie(mExchangeMgr != nullptr && GetReferenceCount() == 0);
     VerifyOrDie(!IsAckPending());
 
-    if (IsAutoReleaseSession() && mSession)
+    if (ReleaseSessionOnDestruction() && mSession)
         mSession->AsSecureSession()->MarkForRemoval();
 
 #if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -325,6 +325,9 @@ ExchangeContext::~ExchangeContext()
     VerifyOrDie(mExchangeMgr != nullptr && GetReferenceCount() == 0);
     VerifyOrDie(!IsAckPending());
 
+    if (IsAutoReleaseSession() && mSession)
+        mSession->AsSecureSession()->MarkForRemoval();
+
 #if CONFIG_DEVICE_LAYER && CHIP_DEVICE_CONFIG_ENABLE_SED
     // Make sure that the exchange withdraws the request for Sleepy End Device active mode.
     UpdateSEDIntervalMode(false);

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -376,26 +376,12 @@ void ExchangeManager::CloseAllContextsForDelegate(const ExchangeDelegate * deleg
     });
 }
 
-void ExchangeManager::AbortExchangeForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * exception)
+void ExchangeManager::AbortExchangesForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * deferred)
 {
     mContextPool.ForEachActiveObject([&](auto * ec) {
         if (ec->HasSessionHandle() && ec->GetSessionHandle()->GetPeer().GetFabricIndex() == fabricIndex)
         {
-            if (ec == exception)
-                ec->SetAutoReleaseSession();
-            else
-                ec->Abort();
-        }
-        return Loop::Continue;
-    });
-}
-
-void ExchangeManager::AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * exception)
-{
-    mContextPool.ForEachActiveObject([&](auto * ec) {
-        if (ec->HasSessionHandle() && ec->GetSessionHandle()->GetPeer() == node)
-        {
-            if (ec == exception)
+            if (ec == deferred)
                 ec->SetAutoReleaseSession();
             else
                 ec->Abort();

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -379,7 +379,7 @@ void ExchangeManager::CloseAllContextsForDelegate(const ExchangeDelegate * deleg
 void ExchangeManager::AbortExchangesForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * deferred)
 {
     mContextPool.ForEachActiveObject([&](auto * ec) {
-        if (ec->HasSessionHandle() && ec->GetSessionHandle()->GetPeer().GetFabricIndex() == fabricIndex)
+        if (ec->HasSessionHandle() && ec->GetSessionHandle()->GetFabricIndex() == fabricIndex)
         {
             if (ec == deferred)
                 ec->SetAutoReleaseSession();

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -376,12 +376,15 @@ void ExchangeManager::CloseAllContextsForDelegate(const ExchangeDelegate * deleg
     });
 }
 
-void ExchangeManager::AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * stay)
+void ExchangeManager::AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * exception)
 {
     mContextPool.ForEachActiveObject([&](auto * ec) {
-        if (ec != stay && ec->HasSessionHandle() && ec->GetSessionHandle()->GetPeer() == node)
+        if (ec->HasSessionHandle() && ec->GetSessionHandle()->GetPeer() == node)
         {
-            ec->Abort();
+            if (ec == exception)
+                ec->SetAutoReleaseSession();
+            else
+                ec->Abort();
         }
         return Loop::Continue;
     });

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -376,6 +376,20 @@ void ExchangeManager::CloseAllContextsForDelegate(const ExchangeDelegate * deleg
     });
 }
 
+void ExchangeManager::AbortExchangeForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * exception)
+{
+    mContextPool.ForEachActiveObject([&](auto * ec) {
+        if (ec->HasSessionHandle() && ec->GetSessionHandle()->GetPeer().GetFabricIndex() == fabricIndex)
+        {
+            if (ec == exception)
+                ec->SetAutoReleaseSession();
+            else
+                ec->Abort();
+        }
+        return Loop::Continue;
+    });
+}
+
 void ExchangeManager::AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * exception)
 {
     mContextPool.ForEachActiveObject([&](auto * ec) {

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -378,6 +378,8 @@ void ExchangeManager::CloseAllContextsForDelegate(const ExchangeDelegate * deleg
 
 void ExchangeManager::AbortExchangesForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * deferred)
 {
+    VerifyOrDie(deferred->HasSessionHandle() && deferred->GetSessionHandle()->IsSecureSession());
+
     mContextPool.ForEachActiveObject([&](auto * ec) {
         if (ec->HasSessionHandle() && ec->GetSessionHandle()->GetFabricIndex() == fabricIndex)
         {
@@ -388,6 +390,8 @@ void ExchangeManager::AbortExchangesForFabricExceptOne(FabricIndex fabricIndex, 
         }
         return Loop::Continue;
     });
+
+    mSessionManager->ReleaseSessionsForFabricExceptOne(fabricIndex, deferred->GetSessionHandle());
 }
 
 } // namespace Messaging

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -376,5 +376,16 @@ void ExchangeManager::CloseAllContextsForDelegate(const ExchangeDelegate * deleg
     });
 }
 
+void ExchangeManager::AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * stay)
+{
+    mContextPool.ForEachActiveObject([&](auto * ec) {
+        if (ec != stay && ec->HasSessionHandle() && ec->GetSessionHandle()->GetPeer() == node)
+        {
+            ec->Abort();
+        }
+        return Loop::Continue;
+    });
+}
+
 } // namespace Messaging
 } // namespace chip

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -183,9 +183,9 @@ public:
      */
     void CloseAllContextsForDelegate(const ExchangeDelegate * delegate);
 
-    // This 2 APIs are used by UpdateNOC command, to invalid all exchanges except the given one.
-    void AbortExchangeForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * exception);
-    void AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * exception);
+    // This API is used by UpdateNOC command, to abort all exchanges except the given one, whose abort is deferred until UpdateNOC
+    // command finishing its work.
+    void AbortExchangesForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * deferred);
 
     SessionManager * GetSessionManager() const { return mSessionManager; }
 

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -183,8 +183,9 @@ public:
      */
     void CloseAllContextsForDelegate(const ExchangeDelegate * delegate);
 
-    // This API is used by UpdateNOC command, to invalid all exchanges except the given one.
-    void AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * stay);
+    // This 2 APIs are used by UpdateNOC command, to invalid all exchanges except the given one.
+    void AbortExchangeForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * exception);
+    void AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * exception);
 
     SessionManager * GetSessionManager() const { return mSessionManager; }
 

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -183,9 +183,8 @@ public:
      */
     void CloseAllContextsForDelegate(const ExchangeDelegate * delegate);
 
-    // This API is used by commands that need to shut down all existing exchanges on 
-    // a fabric but need to make sure the response to the command still goes out on the exchange
-    // the command came in on.  This API flags that one exchange to shut down its session
+    // This API is used by commands that need to shut down all existing exchanges on a fabric but need to make sure the response to
+    // the command still goes out on the exchange the command came in on.  This API flags that one exchange to shut down its session
     // when it's done.
     void AbortExchangesForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * deferred);
 

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -183,8 +183,10 @@ public:
      */
     void CloseAllContextsForDelegate(const ExchangeDelegate * delegate);
 
-    // This API is used by UpdateNOC command, to abort all exchanges except the given one, whose abort is deferred until UpdateNOC
-    // command finishing its work.
+    // This API is used by commands that need to shut down all existing exchanges on 
+    // a fabric but need to make sure the response to the command still goes out on the exchange
+    // the command came in on.  This API flags that one exchange to shut down its session
+    // when it's done.
     void AbortExchangesForFabricExceptOne(FabricIndex fabricIndex, ExchangeContext * deferred);
 
     SessionManager * GetSessionManager() const { return mSessionManager; }

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -183,6 +183,9 @@ public:
      */
     void CloseAllContextsForDelegate(const ExchangeDelegate * delegate);
 
+    // This API is used by UpdateNOC command, to invalid all exchanges except the given one.
+    void AbortExchangeForNodeExceptOne(const ScopedNodeId & node, ExchangeContext * stay);
+
     SessionManager * GetSessionManager() const { return mSessionManager; }
 
     ReliableMessageMgr * GetReliableMessageMgr() { return &mReliableMessageMgr; };

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -121,8 +121,13 @@ public:
     /// Determine whether this exchange is requesting Sleepy End Device active mode
     bool IsRequestingActiveMode() const;
 
+
     /// Determine whether this exchange is a EphemeralExchange for replying a StandaloneAck
     bool IsEphemeralExchange() const;
+
+    // For UpdateNOC command, I'm the last exchange, I must release the session when finishing my work.
+    void SetAutoReleaseSession();
+    bool IsAutoReleaseSession();
 
     /**
      * Get the reliable message manager that corresponds to this reliable
@@ -162,8 +167,12 @@ protected:
         /// When set, signifies that the exchange is requesting Sleepy End Device active mode.
         kFlagActiveMode = (1u << 8),
 
+
         /// When set, signifies that the exchange created sorely for replying a StandaloneAck
         kFlagEphemeralExchange = (1u << 9),
+
+        /// When set, automatically release the session when finishing its work. Used by UpdateNOC command
+        kFlagAutoReleaseSession = (1u << 10),
     };
 
     BitFlags<Flags> mFlags; // Internal state flags
@@ -243,6 +252,16 @@ inline void ReliableMessageContext::SetRequestingActiveMode(bool activeMode)
 inline bool ReliableMessageContext::IsEphemeralExchange() const
 {
     return mFlags.Has(Flags::kFlagEphemeralExchange);
+}
+
+inline void ReliableMessageContext::SetAutoReleaseSession()
+{
+    mFlags.Set(Flags::kFlagAutoReleaseSession, true);
+}
+
+inline bool ReliableMessageContext::IsAutoReleaseSession()
+{
+    return mFlags.Has(Flags::kFlagAutoReleaseSession);
 }
 
 } // namespace Messaging

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -258,7 +258,7 @@ inline void ReliableMessageContext::SetAutoReleaseSession()
     mFlags.Set(Flags::kFlagAutoReleaseSession, true);
 }
 
-inline bool ReliableMessageContext::IsAutoReleaseSession()
+inline bool ReliableMessageContext::ReleaseSessionOnDestruction()
 {
     return mFlags.Has(Flags::kFlagAutoReleaseSession);
 }

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -124,9 +124,10 @@ public:
     /// Determine whether this exchange is a EphemeralExchange for replying a StandaloneAck
     bool IsEphemeralExchange() const;
 
-    // For UpdateNOC command, I'm the last exchange, I must release the session when finishing my work.
+    // If SetAutoReleaseSession() is called, this exchange must be using a SecureSession, and should
+    // evict it when the exchange is done with all its work (including any MRP traffic).
     void SetAutoReleaseSession();
-    bool IsAutoReleaseSession();
+    bool ReleaseSessionOnDestruction();
 
     /**
      * Get the reliable message manager that corresponds to this reliable
@@ -169,7 +170,7 @@ protected:
         /// When set, signifies that the exchange created sorely for replying a StandaloneAck
         kFlagEphemeralExchange = (1u << 9),
 
-        /// When set, automatically release the session when finishing its work. Used by UpdateNOC command
+        /// When set, automatically release the session when this exchange is destroyed.
         kFlagAutoReleaseSession = (1u << 10),
     };
 

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -121,7 +121,6 @@ public:
     /// Determine whether this exchange is requesting Sleepy End Device active mode
     bool IsRequestingActiveMode() const;
 
-
     /// Determine whether this exchange is a EphemeralExchange for replying a StandaloneAck
     bool IsEphemeralExchange() const;
 
@@ -166,7 +165,6 @@ protected:
 
         /// When set, signifies that the exchange is requesting Sleepy End Device active mode.
         kFlagActiveMode = (1u << 8),
-
 
         /// When set, signifies that the exchange created sorely for replying a StandaloneAck
         kFlagEphemeralExchange = (1u << 9),

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -50,9 +50,9 @@ void SecureSession::MarkForRemoval()
     }
 }
 
-void SecureSession::MarkForInactive()
+void SecureSession::MarkInactive()
 {
-    ChipLogDetail(Inet, "SecureSession[%p]: MarkForInactive Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
+    ChipLogDetail(Inet, "SecureSession[%p]: MarkInactive Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
                   mLocalSessionId);
     ReferenceCountedHandle<Transport::Session> ref(*this);
     switch (mState)

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -39,10 +39,32 @@ void SecureSession::MarkForRemoval()
         NotifySessionReleased();
         return;
     case State::kActive:
+    case State::kInactive:
         Release(); // Decrease the ref which is retained at Activate
         mState = State::kPendingRemoval;
         NotifySessionReleased();
         return;
+    case State::kPendingRemoval:
+        // Do nothing
+        return;
+    }
+}
+
+void SecureSession::MarkForInactive()
+{
+    ChipLogDetail(Inet, "SecureSession[%p]: MarkForInactive Type:%d LSID:%d", this, to_underlying(mSecureSessionType),
+                  mLocalSessionId);
+    ReferenceCountedHandle<Transport::Session> ref(*this);
+    switch (mState)
+    {
+    case State::kPairing:
+        VerifyOrDie(false);
+        return;
+    case State::kActive:
+        // By setting this state, IsActiveSession() will return false, which prevent creating new exchanges.
+        mState = State::kInactive;
+        return;
+    case State::kInactive:
     case State::kPendingRemoval:
         // Do nothing
         return;

--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -61,7 +61,7 @@ void SecureSession::MarkForInactive()
         VerifyOrDie(false);
         return;
     case State::kActive:
-        // By setting this state, IsActiveSession() will return false, which prevent creating new exchanges.
+        // By setting this state, IsActiveSession() will return false, which prevents creating new exchanges.
         mState = State::kInactive;
         return;
     case State::kInactive:

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -145,7 +145,7 @@ public:
     void MarkForRemoval();
 
     // Used to prevent any new exchange created on the session while the existing exchanges finish their work.
-    void MarkForInactive();
+    void MarkInactive();
 
     Session::SessionType GetSessionType() const override { return Session::SessionType::kSecure; }
 #if CHIP_PROGRESS_LOGGING
@@ -254,7 +254,7 @@ private:
         kPendingRemoval = 3,
 
         // The session is still functional, but it can't yield any new exchanges,
-        // This is meant to be used in conjunction with 
+        // This is meant to be used in conjunction with
         // ExchangeManager::AbortExchangesForFabricExceptOne, with the one
         // exceptional exchange handling moving this session out of this state when
         // it finishes whatever it needs the session for.

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -144,6 +144,9 @@ public:
     /// @brief Mark as pending removal, all holders to this session will be cleared, and disallow future grab
     void MarkForRemoval();
 
+    // Used by UpdateNOC command to prevent any new exchange created on the session.
+    void MarkForInactive();
+
     Session::SessionType GetSessionType() const override { return Session::SessionType::kSecure; }
 #if CHIP_PROGRESS_LOGGING
     const char * GetSessionTypeString() const override { return "secure"; };
@@ -249,6 +252,11 @@ private:
         // grab this session, when all SessionHandles go out of scope, the
         // session object will be released automatically.
         kPendingRemoval = 3,
+
+        // For UpdateNOC command, the session still functional, but it can't
+        // yield any new exchanges, the last exchange running UpdateNOC command
+        // will close the session soon.
+        kInactive = 4,
     };
 
     friend class SecureSessionDeleter;

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -144,7 +144,7 @@ public:
     /// @brief Mark as pending removal, all holders to this session will be cleared, and disallow future grab
     void MarkForRemoval();
 
-    // Used by UpdateNOC command to prevent any new exchange created on the session.
+    // Used to prevent any new exchange created on the session while the existing exchanges finish their work.
     void MarkForInactive();
 
     Session::SessionType GetSessionType() const override { return Session::SessionType::kSecure; }
@@ -253,9 +253,11 @@ private:
         // session object will be released automatically.
         kPendingRemoval = 3,
 
-        // For UpdateNOC command, the session still functional, but it can't
-        // yield any new exchanges, the last exchange running UpdateNOC command
-        // will close the session soon.
+        // The session is still functional, but it can't yield any new exchanges,
+        // This is meant to be used in conjunction with 
+        // ExchangeManager::AbortExchangesForFabricExceptOne, with the one
+        // exceptional exchange handling moving this session out of this state when
+        // it finishes whatever it needs the session for.
         kInactive = 4,
     };
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -389,11 +389,14 @@ void SessionManager::ExpireAllPASEPairings()
 
 void SessionManager::ReleaseSessionsForFabricExceptOne(FabricIndex fabricIndex, const SessionHandle & deferred)
 {
+    VerifyOrDie(deferred->IsSecureSession());
+    SecureSession * deferredSecureSession = deferred->AsSecureSession();
+
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetPeer().GetFabricIndex() == fabricIndex)
         {
-            if (session == deferred->AsSecureSession())
-                session->MarkForInactive();
+            if (session == deferredSecureSession)
+                session->MarkInactive();
             else
                 session->MarkForRemoval();
         }

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -387,7 +387,7 @@ void SessionManager::ExpireAllPASEPairings()
     });
 }
 
-void SessionManager::ReleaseSessionForFabricExceptOne(FabricIndex fabricIndex, const SessionHandle & exception)
+void SessionManager::ReleaseSessionsForFabricExceptOne(FabricIndex fabricIndex, const SessionHandle & deferred)
 {
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetPeer().GetFabricIndex() == fabricIndex)

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -387,6 +387,17 @@ void SessionManager::ExpireAllPASEPairings()
     });
 }
 
+void SessionManager::ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & stay)
+{
+    mSecureSessions.ForEachSession([&](auto session) {
+        if (session->GetPeer() == node && session != stay->AsSecureSession())
+        {
+            session->MarkForRemoval();
+        }
+        return Loop::Continue;
+    });
+}
+
 Optional<SessionHandle> SessionManager::AllocateSession(SecureSession::Type secureSessionType,
                                                         const ScopedNodeId & sessionEvictionHint)
 {

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -387,6 +387,20 @@ void SessionManager::ExpireAllPASEPairings()
     });
 }
 
+void SessionManager::ReleaseSessionForFabricExceptOne(FabricIndex fabricIndex, const SessionHandle & exception)
+{
+    mSecureSessions.ForEachSession([&](auto session) {
+        if (session->GetPeer().GetFabricIndex() == fabricIndex)
+        {
+            if (session == exception->AsSecureSession())
+                session->MarkForInactive();
+            else
+                session->MarkForRemoval();
+        }
+        return Loop::Continue;
+    });
+}
+
 void SessionManager::ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & exception)
 {
     mSecureSessions.ForEachSession([&](auto session) {

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -392,21 +392,7 @@ void SessionManager::ReleaseSessionsForFabricExceptOne(FabricIndex fabricIndex, 
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetPeer().GetFabricIndex() == fabricIndex)
         {
-            if (session == exception->AsSecureSession())
-                session->MarkForInactive();
-            else
-                session->MarkForRemoval();
-        }
-        return Loop::Continue;
-    });
-}
-
-void SessionManager::ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & exception)
-{
-    mSecureSessions.ForEachSession([&](auto session) {
-        if (session->GetPeer() == node)
-        {
-            if (session == exception->AsSecureSession())
+            if (session == deferred->AsSecureSession())
                 session->MarkForInactive();
             else
                 session->MarkForRemoval();

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -387,12 +387,15 @@ void SessionManager::ExpireAllPASEPairings()
     });
 }
 
-void SessionManager::ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & stay)
+void SessionManager::ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & exception)
 {
     mSecureSessions.ForEachSession([&](auto session) {
-        if (session->GetPeer() == node && session != stay->AsSecureSession())
+        if (session->GetPeer() == node)
         {
-            session->MarkForRemoval();
+            if (session == exception->AsSecureSession())
+                session->MarkForInactive();
+            else
+                session->MarkForRemoval();
         }
         return Loop::Continue;
     });

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -177,7 +177,8 @@ public:
     void ExpireAllPASEPairings();
 
     // This API is used by UpdateNOC command, to invalid all sessions except the given one.
-    void ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & stay);
+    void ReleaseSessionForFabricExceptOne(FabricIndex fabricIndex, const SessionHandle & exception);
+    void ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & exception);
 
     /**
      * @brief

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -176,8 +176,9 @@ public:
     void ExpireAllPairingsForFabric(FabricIndex fabric);
     void ExpireAllPASEPairings();
 
-    // This API is used by UpdateNOC command, to invalidate all sessions except the given one, whose release is deferred until
-    // UpdateNOC command finishing its work.
+    // This API is used by commands that need to release all existing sessions on a fabric but need to make sure the response to the
+    // command still goes out on the exchange the command came in on. This API flags that the release of the session used by the
+    // exchange is deferred until the exchange is done.
     void ReleaseSessionsForFabricExceptOne(FabricIndex fabricIndex, const SessionHandle & deferred);
 
     /**

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -176,6 +176,9 @@ public:
     void ExpireAllPairingsForFabric(FabricIndex fabric);
     void ExpireAllPASEPairings();
 
+    // This API is used by UpdateNOC command, to invalid all sessions except the given one.
+    void ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & stay);
+
     /**
      * @brief
      *   Return the System Layer pointer used by current SessionManager.

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -176,9 +176,9 @@ public:
     void ExpireAllPairingsForFabric(FabricIndex fabric);
     void ExpireAllPASEPairings();
 
-    // This API is used by UpdateNOC command, to invalid all sessions except the given one.
-    void ReleaseSessionForFabricExceptOne(FabricIndex fabricIndex, const SessionHandle & exception);
-    void ReleaseSessionForNodeExceptOne(const ScopedNodeId & node, const SessionHandle & exception);
+    // This API is used by UpdateNOC command, to invalidate all sessions except the given one, whose release is deferred until
+    // UpdateNOC command finishing its work.
+    void ReleaseSessionsForFabricExceptOne(FabricIndex fabricIndex, const SessionHandle & deferred);
 
     /**
      * @brief


### PR DESCRIPTION
#### Problem
Per spec:

> All internal data reflecting the prior operational identifier of the Node within the Fabric SHALL be revoked and removed, to an outcome equivalent to the disappearance of the prior Node, except for the ongoing CASE session context, which SHALL temporarily remain valid until the NOCResponse has been successfully delivered or until the next transport-layer error, so that the response can be received by the Administrator invoking the command.

#### Change overview
Add API required by UpdateNOC command
* ReleaseSessionForNodeExceptOne: invalid all sessions except one which is used by UpdateNOC command
* AbortExchangeForNodeExceptOne: invalid all exchanges except one which is used by UpdateNOC command


Follow ups:
* [ ] Ensure preventing creating new session for the fabric

#### Testing
These APIs should be tested by UpdateNOC feature.