### PR TITLE
Ignore expired identities for Darwin codesigning.

### DIFF
--- a/examples/all-clusters-app/linux/entitlements/codesign.py
+++ b/examples/all-clusters-app/linux/entitlements/codesign.py
@@ -34,7 +34,8 @@ def get_identity():
             "No valid identity has been found. Application will run without entitlements.")
         exit(0)
 
-    identity = re.search(r'\b[0-9a-fA-F]{40}\b', command_result)
+    command_result = command_result.replace("\\n", "\n")
+    identity = re.search(r'\b[0-9a-fA-F]{40}\b(?![^\n]*\(CSSMERR_TP_CERT_EXPIRED\))', command_result)
     if identity is None:
         print(
             "No valid identity has been found. Application will run without entitlements.")

--- a/examples/all-clusters-minimal-app/linux/entitlements/codesign.py
+++ b/examples/all-clusters-minimal-app/linux/entitlements/codesign.py
@@ -34,7 +34,8 @@ def get_identity():
             "No valid identity has been found. Application will run without entitlements.")
         exit(0)
 
-    identity = re.search(r'\b[0-9a-fA-F]{40}\b', command_result)
+    command_result = command_result.replace("\\n", "\n")
+    identity = re.search(r'\b[0-9a-fA-F]{40}\b(?![^\n]*\(CSSMERR_TP_CERT_EXPIRED\))', command_result)
     if identity is None:
         print(
             "No valid identity has been found. Application will run without entitlements.")

--- a/examples/darwin-framework-tool/entitlements/codesign.py
+++ b/examples/darwin-framework-tool/entitlements/codesign.py
@@ -34,7 +34,8 @@ def get_identity():
             "No valid identity has been found. Application will run without entitlements.")
         exit(0)
 
-    identity = re.search(r'\b[0-9a-fA-F]{40}\b', command_result)
+    command_result = command_result.replace("\\n", "\n")
+    identity = re.search(r'\b[0-9a-fA-F]{40}\b(?![^\n]*\(CSSMERR_TP_CERT_EXPIRED\))', command_result)
     if identity is None:
         print(
             "No valid identity has been found. Application will run without entitlements.")


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/19327

#### Problem
We try to use expired identities, then codesigning fails

#### Change overview
Skip over expired identities.

#### Testing
Checked that if I use other strings that appear in my identities instead of CSSMERR_TP_CERT_EXPIRED the right things are skipped.