### PR TITLE
Add code-wifi and code-thread commands

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/Commands.h
+++ b/examples/darwin-framework-tool/commands/pairing/Commands.h
@@ -27,6 +27,18 @@ public:
     PairCode() : PairingCommandBridge("code", PairingMode::Code, PairingNetworkType::None) {}
 };
 
+class PairCodeWifi : public PairingCommandBridge
+{
+public:
+    PairCodeWifi() : PairingCommandBridge("code-wifi", PairingMode::Code, PairingNetworkType::WiFi) {}
+};
+
+class PairCodeThread : public PairingCommandBridge
+{
+public:
+    PairCodeThread() : PairingCommandBridge("code-thread", PairingMode::Code, PairingNetworkType::Thread) {}
+};
+
 class PairWithIPAddress : public PairingCommandBridge
 {
 public:
@@ -56,9 +68,10 @@ void registerCommandsPairing(Commands & commands)
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<PairCode>(),    make_unique<PairWithIPAddress>(),
-        make_unique<PairBleWiFi>(), make_unique<PairBleThread>(),
-        make_unique<Unpair>(),      make_unique<OpenCommissioningWindowCommand>(),
+        make_unique<PairCode>(),     make_unique<PairWithIPAddress>(),
+        make_unique<PairCodeWifi>(), make_unique<PairCodeThread>(),
+        make_unique<PairBleWiFi>(),  make_unique<PairBleThread>(),
+        make_unique<Unpair>(),       make_unique<OpenCommissioningWindowCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);


### PR DESCRIPTION
#### Problem
Currently Darwin-framework-tool has no way of performing paring to thread or wifi using the SetupQRCode or ManualCode.

#### Change overview
- Add command to do pairing with Thread and Wifi using SetupQRCode and ManualCode by passing wifi or thread credentials.

#### Testing
- Build
- Commissioned device successfully with code-thread command
