### PR TITLE
[hotfix]bump ca-certificate version in cirque docker to recover cirque CI

### DIFF
--- a/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
@@ -18,7 +18,7 @@ RUN apt-get update \
   && apt-get install --no-install-recommends -y \
   avahi-daemon=0.7-4ubuntu7.1 \
   avahi-utils=0.7-4ubuntu7.1 \
-  ca-certificates=20210119~20.04.2 \
+  ca-certificates=20211016~20.04.1 \
   dhcpcd5=7.1.0-2build1 \
   gdb=9.2-0ubuntu1~20.04.1 \
   git=1:2.25.1-1ubuntu3.4 \


### PR DESCRIPTION
#### Problem
ubuntu focal upstream upgrade ca-certificate version, which breaks cirque CI.

#### Change overview
update ca-certificate version

#### Testing
CI runs
