### PR TITLE
Fix K32W061 issues

### DIFF
--- a/examples/lighting-app/nxp/k32w/k32w0/main/include/app_config.h
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/include/app_config.h
@@ -34,8 +34,8 @@
 
 #define APP_BUTTON_PUSH 1
 
-#define SYSTEM_STATE_LED LED2
-#define LIGHT_STATE_LED LED1
+#define SYSTEM_STATE_LED LED1
+#define LIGHT_STATE_LED LED2
 
 // Time it takes for the light to switch on/off
 #define ACTUATOR_MOVEMENT_PERIOS_MS 50

--- a/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.cpp
@@ -45,7 +45,7 @@ KeyValueStoreManagerImpl KeyValueStoreManagerImpl::sInstance;
 
 uint16_t GetStringKeyId(const char * key, uint16_t * freeId)
 {
-    CHIP_ERROR err                    = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    CHIP_ERROR err                    = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     uint8_t keyId                     = 0;
     uint8_t pdmIdKvsKey               = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVSKey;
     bool bFreeIdxFound                = false;
@@ -100,6 +100,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     }
 
 exit:
+    ConvertError(err);
     return err;
 }
 
@@ -159,12 +160,13 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
     }
 
 exit:
+    ConvertError(err);
     return err;
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
 {
-    CHIP_ERROR err         = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    CHIP_ERROR err         = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     uint8_t pdmIdKvsKey    = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVSKey;
     uint8_t pdmIdKvsValue  = chip::DeviceLayer::Internal::K32WConfig::kPDMId_KVSValue;
     uint8_t keyId          = 0;
@@ -205,7 +207,16 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
         }
     }
 exit:
+    ConvertError(err);
     return err;
+}
+
+void KeyValueStoreManagerImpl::ConvertError(CHIP_ERROR & err)
+{
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
 }
 
 } // namespace PersistedStorage

--- a/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/KeyValueStoreManagerImpl.h
@@ -47,6 +47,11 @@ private:
     friend KeyValueStoreManager & KeyValueStoreMgr();
     friend KeyValueStoreManagerImpl & KeyValueStoreMgrImpl();
 
+    // Reading config values uses the K32WConfig API, which returns CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND
+    // error if a key was not found. Convert this error to the correct error KeyValueStoreManagerImpl
+    // should return: CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND
+    void ConvertError(CHIP_ERROR & err);
+
     static KeyValueStoreManagerImpl sInstance;
 };
 


### PR DESCRIPTION
#### Problem
* invalid error code returned from KVS lead to failed initialization
* 
#### Change overview
* return correct error codes from KVS
* * invert D2 and D3 LED states

#### Testing
* manually testing using chip-tool
