### PR TITLE
doc: nrf_connect: rework OT RCP dongle guide

### DIFF
--- a/docs/guides/openthread_border_router_pi.md
+++ b/docs/guides/openthread_border_router_pi.md
@@ -20,13 +20,14 @@ released by Google is an open-source implementation of the Thread Border Router.
 
 ## Tutorials
 
-Follow the [CodeLab tutorial on openthread.io](https://openthread.io/codelabs/openthread-border-router)
-to set up your OpenThread Border Router on a Raspberry Pi 3 or Raspberry Pi 4 device.
-Ubuntu and debian hosts are also supported.
-The CodeLab uses Nordic Semiconductor's nRF52840 DK as the Border Router RCP
-device.
+Follow the
+[CodeLab tutorial on openthread.io](https://openthread.io/codelabs/openthread-border-router)
+to set up your OpenThread Border Router on a Raspberry Pi 3 or Raspberry Pi 4
+device. Ubuntu and debian hosts are also supported. The CodeLab uses Nordic
+Semiconductor's nRF52840 DK as the Border Router RCP device.
 
 -   See [this guide](./openthread_rcp_nrf_dongle.md) for configuring the
     nRF52840 Dongle as an RCP device.
--   See [this guide](https://www.silabs.com/documents/public/application-notes/an1256-using-sl-rcp-with-openthread-border-router.pdf)
+-   See
+    [this guide](https://www.silabs.com/documents/public/application-notes/an1256-using-sl-rcp-with-openthread-border-router.pdf)
     for creating Silicon Labs RCP devices.

--- a/docs/guides/openthread_border_router_pi.md
+++ b/docs/guides/openthread_border_router_pi.md
@@ -18,18 +18,15 @@ functions:
 [OpenThread Border Router](https://openthread.io/guides/border-router) (OTBR)
 released by Google is an open-source implementation of the Thread Border Router.
 
-## Setup
+## Tutorials
 
-**Follow [this CodeLab](https://openthread.io/codelabs/openthread-border-router)
-to set up your OpenThread Border Router on a Raspberry Pi 3/4 device!**
-
-> Ubuntu and debian hosts are also supported!
-
+Follow the [CodeLab tutorial on openthread.io](https://openthread.io/codelabs/openthread-border-router)
+to set up your OpenThread Border Router on a Raspberry Pi 3 or Raspberry Pi 4 device.
+Ubuntu and debian hosts are also supported.
 The CodeLab uses Nordic Semiconductor's nRF52840 DK as the Border Router RCP
 device.
 
--   See this [guide](./openthread_rcp_nrf_dongle.md) for configuring the
+-   See [this guide](./openthread_rcp_nrf_dongle.md) for configuring the
     nRF52840 Dongle as an RCP device.
--   See this
-    [guide](https://www.silabs.com/documents/public/application-notes/an1256-using-sl-rcp-with-openthread-border-router.pdf)
+-   See [this guide](https://www.silabs.com/documents/public/application-notes/an1256-using-sl-rcp-with-openthread-border-router.pdf)
     for creating Silicon Labs RCP devices.

--- a/docs/guides/openthread_rcp_nrf_dongle.md
+++ b/docs/guides/openthread_rcp_nrf_dongle.md
@@ -12,13 +12,15 @@ Once programmed, the dongle can be used for
 
 ## Requirements
 
-You need to set up the [nRF Connect SDK](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/index.html)
+You need to set up the
+[nRF Connect SDK](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/index.html)
 to build and program the OpenThread Radio Co-Processor to the nRF52840 Dongle.
-Read the [nRF Connect SDK Getting started](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html)
+Read the
+[nRF Connect SDK Getting started](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html)
 documentation for more information.
 
 ## Building and programming the RCP firmware onto an nRF52840 Dongle
 
-After you set up the nRF Connect SDK, follow the steps
-in the [Configuring a radio co-processor](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_thread_tools.html#configuring-a-radio-co-processor)
+After you set up the nRF Connect SDK, follow the steps in the
+[Configuring a radio co-processor](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_thread_tools.html#configuring-a-radio-co-processor)
 section for the nRF52840 Dongle (USB transport).

--- a/docs/guides/openthread_rcp_nrf_dongle.md
+++ b/docs/guides/openthread_rcp_nrf_dongle.md
@@ -10,66 +10,15 @@ You can build and program
 Once programmed, the dongle can be used for
 [configuring Thread network on a Linux machine](./openthread_border_router_pi.md).
 
+## Requirements
+
+You need to set up the [nRF Connect SDK](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/index.html)
+to build and program the OpenThread Radio Co-Processor to the nRF52840 Dongle.
+Read the [nRF Connect SDK Getting started](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/getting_started.html)
+documentation for more information.
+
 ## Building and programming the RCP firmware onto an nRF52840 Dongle
 
-Run the following commands to build and program the RCP firmware onto an
-nRF52840 Dongle:
-
-1.  Clone the OpenThread nRF528xx platform repository into the current
-    directory:
-
-        ```
-        git clone --recursive https://github.com/openthread/ot-nrf528xx.git
-        ```
-
-2.  Enter the _ot-nrf528xx_ directory:
-
-        ```
-        cd ot-nrf528xx
-        ```
-
-3.  Install OpenThread dependencies:
-
-        ```
-        ./script/bootstrap
-        ```
-
-4.  Build OpenThread for the nRF52840 Dongle:
-
-         $ script/build nrf52840 USB_trans -DOT_BOOTLOADER=USB -DOT_THREAD_VERSION=1.2
-
-    This creates an RCP image at `build/bin/ot-rcp`.
-
-5.  Convert the RCP image to the `.hex` format:
-
-        ```
-        arm-none-eabi-objcopy -O ihex build/bin/ot-rcp build/bin/ot-rcp.hex
-        ```
-
-6.  Install
-    [nRF Util](https://www.nordicsemi.com/Software-and-tools/Development-Tools/nRF-Util):
-
-        ```
-        python3 -m pip install -U nrfutil
-        ```
-
-7.  Generate the RCP firmware package:
-
-        ```
-        nrfutil pkg generate --hw-version 52 --sd-req=0x00 \
-            --application build/bin/ot-rcp.hex \
-            --application-version 1 build/bin/ot-rcp.zip
-        ```
-
-8.  Connect the nRF52840 Dongle to the USB port.
-
-9.  Press the **Reset** button on the dongle to put it into the DFU mode. Red
-    LED on the dongle starts blinking.
-
-10. To install the RCP firmware package onto the dongle, run the following
-    command, with `/dev/ttyACM0` replaced with the device node name of your
-    nRF52840 Dongle:
-
-        ```
-        nrfutil dfu usb-serial -pkg build/bin/ot-rcp.zip -p /dev/ttyACM0
-        ```
+After you set up the nRF Connect SDK, follow the steps
+in the [Configuring a radio co-processor](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/ug_thread_tools.html#configuring-a-radio-co-processor)
+section for the nRF52840 Dongle (USB transport).


### PR DESCRIPTION
Edited the nRF Connect OpenThread RCP dongle guide.
Made minor style edits to OT border router page.

Signed-off-by: Grzegorz Ferenc <Grzegorz.Ferenc@nordicsemi.no>

----

#### Problem
Fix outdated information about setting up RCP on nRF52840 Dongle.

#### Change overview
Removed bare-metal RCP instructions for more recent NCS-based RCP instructions.
Edited the Setup OpenThread Border Router on Raspberry Pi for style to make links more clear
and remove non-technical emotionally-marked forms with exclamation marks and too much formatting.

#### Testing
Doc changes only.
