### PR TITLE
[pump] PostEvents now called from ScheduleWork

### DIFF
--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -379,8 +379,8 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
     case AppEvent::kEventType_ButtonLeft:
         if (AppEvent::kAppEventButtonType_Clicked == aEvent->ButtonEvent.Type)
         {
-            // Post event for demonstration purposes, we must ensure that the 
-            // LogEvent is called in the right context which is the Matter mainloop 
+            // Post event for demonstration purposes, we must ensure that the
+            // LogEvent is called in the right context which is the Matter mainloop
             // thru ScheduleWork()
             chip::DeviceLayer::PlatformMgr().ScheduleWork(sAppTask.PostEvents, reinterpret_cast<intptr_t>(nullptr));
 

--- a/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -379,8 +379,10 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
     case AppEvent::kEventType_ButtonLeft:
         if (AppEvent::kAppEventButtonType_Clicked == aEvent->ButtonEvent.Type)
         {
-            // Post event for demonstration purposes
-            sAppTask.PostEvents();
+            // Post event for demonstration purposes, we must ensure that the 
+            // LogEvent is called in the right context which is the Matter mainloop 
+            // thru ScheduleWork()
+            chip::DeviceLayer::PlatformMgr().ScheduleWork(sAppTask.PostEvents, reinterpret_cast<intptr_t>(nullptr));
 
             // Toggle BLE advertisements
             if (!ConnectivityMgr().IsBLEAdvertisingEnabled())
@@ -608,7 +610,7 @@ void AppTask::UpdateCluster(intptr_t context)
     }
 }
 
-void AppTask::PostEvents()
+void AppTask::PostEvents(intptr_t context)
 {
     // Example on posting events - here we post the general fault event on endpoints with PCC Server enabled
     for (auto endpoint : EnabledEndpointsWithServerCluster(PumpConfigurationAndControl::Id))

--- a/examples/pump-app/cc13x2x7_26x2x7/main/include/AppTask.h
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/include/AppTask.h
@@ -64,7 +64,7 @@ private:
     static void ButtonLeftEventHandler(Button_Handle handle, Button_EventMask events);
     static void ButtonRightEventHandler(Button_Handle handle, Button_EventMask events);
     static void TimerEventHandler(void * p_context);
-    static void PostEvents();
+    static void PostEvents(intptr_t context);
 
     enum Function_t
     {


### PR DESCRIPTION
#### Problem
What is being fixed? 
* LogEvent was called directly from AppTask
* Fixes issue https://github.com/project-chip/connectedhomeip/issues/19304

#### Change overview
PostEvents is not called from ScheduleWork

#### Testing
How was this tested? (at least one bullet point required)
manually tested on cc2652r7 launchpad

