### PR TITLE
[Zephyr] Support heap watermark for non-default malloc

### DIFF
--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -114,6 +114,15 @@ inline DiagnosticDataProviderImpl::DiagnosticDataProviderImpl() : mBootReason(De
     ChipLogDetail(DeviceLayer, "Boot reason: %u", static_cast<uint16_t>(mBootReason));
 }
 
+bool DiagnosticDataProviderImpl::SupportsWatermarks()
+{
+#ifdef CONFIG_CHIP_MALLOC_SYS_HEAP
+    return true;
+#else
+    return false;
+#endif
+}
+
 CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapFree(uint64_t & currentHeapFree)
 {
 #ifdef CONFIG_CHIP_MALLOC_SYS_HEAP
@@ -153,14 +162,17 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     Malloc::Stats stats;
     ReturnErrorOnFailure(Malloc::GetStats(stats));
 
-    // TODO: use the maximum usage once that is implemented in Zephyr
-    currentHeapHighWatermark = stats.used;
+    currentHeapHighWatermark = stats.maxUsed;
     return CHIP_NO_ERROR;
-#elif CHIP_DEVICE_CONFIG_HEAP_STATISTICS_MALLINFO
-    // ARM newlib does not provide a way to obtain the peak heap usage, so for now just return
-    // the amount of memory allocated from the system which should be an upper bound of the peak
-    // usage provided that the heap is not very fragmented.
-    currentHeapHighWatermark = mallinfo().arena;
+#else
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
+{
+#ifdef CONFIG_CHIP_MALLOC_SYS_HEAP
+    Malloc::ResetMaxStats();
     return CHIP_NO_ERROR;
 #else
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.h
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.h
@@ -39,9 +39,11 @@ public:
 
     // ===== Methods that implement the PlatformManager abstract interface.
 
+    bool SupportsWatermarks() override;
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
+    CHIP_ERROR ResetWatermarks() override;
 
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;

--- a/src/platform/Zephyr/SysHeapMalloc.cpp
+++ b/src/platform/Zephyr/SysHeapMalloc.cpp
@@ -136,8 +136,14 @@ CHIP_ERROR GetStats(Stats & stats)
 
     stats.free = sysHeapStats.free_bytes;
     stats.used = sysHeapStats.allocated_bytes;
+    stats.maxUsed = sysHeapStats.max_allocated_bytes;
 
     return CHIP_NO_ERROR;
+}
+
+void ResetMaxStats()
+{
+    (void) sys_heap_runtime_stats_reset_max(&sHeap);
 }
 
 #endif // CONFIG_SYS_HEAP_RUNTIME_STATS

--- a/src/platform/Zephyr/SysHeapMalloc.cpp
+++ b/src/platform/Zephyr/SysHeapMalloc.cpp
@@ -134,8 +134,8 @@ CHIP_ERROR GetStats(Stats & stats)
     sys_heap_runtime_stats sysHeapStats;
     ReturnErrorOnFailure(System::MapErrorZephyr(sys_heap_runtime_stats_get(&sHeap, &sysHeapStats)));
 
-    stats.free = sysHeapStats.free_bytes;
-    stats.used = sysHeapStats.allocated_bytes;
+    stats.free    = sysHeapStats.free_bytes;
+    stats.used    = sysHeapStats.allocated_bytes;
     stats.maxUsed = sysHeapStats.max_allocated_bytes;
 
     return CHIP_NO_ERROR;

--- a/src/platform/Zephyr/SysHeapMalloc.h
+++ b/src/platform/Zephyr/SysHeapMalloc.h
@@ -27,6 +27,7 @@ struct Stats
 {
     size_t free;
     size_t used;
+    size_t maxUsed;
 };
 
 void * Malloc(size_t size);
@@ -34,6 +35,7 @@ void * Calloc(size_t num, size_t size);
 void * Realloc(void * mem, size_t size);
 void Free(void * mem);
 CHIP_ERROR GetStats(Stats & stats);
+void ResetMaxStats();
 
 } // namespace Malloc
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem
Zephyr platform doesn't support Heap Watermark feature because the default newlib libc malloc doesn't provide such statistic. However, the feature can be supported if non-default malloc is used.

#### Change overview
When non-default malloc implementation, based on Zephyr's sys_heap is used, support CurrentHeapHighWatermark attribute
and ResetWatermarks command.

#### Testing
Verified that both the attribute and command work properly when nRF Connect all-clusters-app is built with `-DCONFIG_CHIP_MALLOC_SYS_HEAP=y`. Also, verified that FeatureMap is initialized correctly in that case.
