### PR TITLE
RPC: Add RPC to set temporary spake values

### DIFF
--- a/examples/common/pigweed/protos/device_service.options
+++ b/examples/common/pigweed/protos/device_service.options
@@ -2,3 +2,5 @@ chip.rpc.DeviceInfo.serial_number max_size:32  // length defined in chip spec 8.
 chip.rpc.DeviceState.fabric_info max_count:2
 chip.rpc.PairingInfo.qr_code max_size:256
 chip.rpc.PairingInfo.qr_code_url max_size:256
+chip.rpc.SpakeInfo.verifier max_size:97  // kSpake2p_VerifierSerialized_Length
+chip.rpc.SpakeInfo.salt max_size:32      // kSpake2p_Max_PBKDF_Salt_Length

--- a/examples/common/pigweed/protos/device_service.proto
+++ b/examples/common/pigweed/protos/device_service.proto
@@ -11,6 +11,12 @@ message PairingInfo {
   string qr_code_url = 4;
 }
 
+message SpakeInfo {
+  optional bytes verifier = 1;
+  optional bytes salt = 2;
+  optional uint32 iteration_count = 3;
+}
+
 // type lengths defined in chip spec 8.2.3.1
 message DeviceInfo {
   uint32 vendor_id = 1;
@@ -43,4 +49,6 @@ service Device {
   rpc SetPairingState(PairingState) returns (pw.protobuf.Empty){}
   rpc GetPairingState(pw.protobuf.Empty) returns (PairingState){}
   rpc SetPairingInfo(PairingInfo) returns (pw.protobuf.Empty){}
+  rpc GetSpakeInfo(pw.protobuf.Empty) returns (SpakeInfo){}
+  rpc SetSpakeInfo(SpakeInfo) returns (pw.protobuf.Empty){}
 }

--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -55,7 +55,7 @@ public:
             setupPasscode = mPasscodeOverride.value();
             return CHIP_NO_ERROR;
         }
-        else if (mCommissionableDataProvider)
+        if (mCommissionableDataProvider)
         {
             return mCommissionableDataProvider->GetSetupPasscode(setupPasscode);
         }
@@ -82,7 +82,7 @@ public:
             setupDiscriminator = mDiscriminatorOverride.value();
             return CHIP_NO_ERROR;
         }
-        else if (mCommissionableDataProvider)
+        if (mCommissionableDataProvider)
         {
             return mCommissionableDataProvider->GetSetupDiscriminator(setupDiscriminator);
         }
@@ -104,7 +104,7 @@ public:
             iterationCount = mIterationCountOverride.value();
             return CHIP_NO_ERROR;
         }
-        else if (mCommissionableDataProvider)
+        if (mCommissionableDataProvider)
         {
             return mCommissionableDataProvider->GetSpake2pIterationCount(iterationCount);
         }
@@ -131,7 +131,7 @@ public:
             saltBuf.reduce_size(mSaltOverride.value().size());
             return CHIP_NO_ERROR;
         }
-        else if (mCommissionableDataProvider)
+        if (mCommissionableDataProvider)
         {
             return mCommissionableDataProvider->GetSpake2pSalt(saltBuf);
         }
@@ -164,7 +164,7 @@ public:
             verifierBuf.reduce_size(mVerifierOverride.value().size());
             return CHIP_NO_ERROR;
         }
-        else if (mCommissionableDataProvider)
+        if (mCommissionableDataProvider)
         {
             return mCommissionableDataProvider->GetSpake2pVerifier(verifierBuf, outVerifierLen);
         }

--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -26,6 +26,7 @@
 #include "app/server/Server.h"
 #include "credentials/FabricTable.h"
 #include "device_service/device_service.rpc.pb.h"
+#include "platform/CommissionableDataProvider.h"
 #include "platform/ConfigurationManager.h"
 #include "platform/DiagnosticDataProvider.h"
 #include "platform/PlatformManager.h"
@@ -34,6 +35,175 @@
 
 namespace chip {
 namespace rpc {
+
+namespace Internal {
+// This class supports changing the commissionable data provider values at
+// runtime using the RPCs.
+// This class is LazyInit after getting or setting any of it's values. After
+// this the class wraps the original CommissionableDataProvider, returning the
+// original values for anything which has not been overwritten.
+//
+// NOTE: Values written do not persist across a reboot.
+class CommissionableDataProviderRpcWrapper : public DeviceLayer::CommissionableDataProvider
+{
+public:
+    CHIP_ERROR GetSetupPasscode(uint32_t & setupPasscode) override
+    {
+        LazyInit();
+        if (mPasscodeOverride.has_value())
+        {
+            setupPasscode = mPasscodeOverride.value();
+            return CHIP_NO_ERROR;
+        }
+        else if (mCommissionableDataProvider)
+        {
+            return mCommissionableDataProvider->GetSetupPasscode(setupPasscode);
+        }
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    // NOTE: Changing the passcode will not change the verifier or anything else
+    // this just changes the value returned from GetSetupPasscode.
+    // Using this is completely optional, and only really useful for test
+    // automation which can read the configured passcode for commissioning
+    // after it is changed.
+    CHIP_ERROR SetSetupPasscode(uint32_t setupPasscode) override
+    {
+        LazyInit();
+        mPasscodeOverride = setupPasscode;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetSetupDiscriminator(uint16_t & setupDiscriminator) override
+    {
+        LazyInit();
+        if (mDiscriminatorOverride.has_value())
+        {
+            setupDiscriminator = mDiscriminatorOverride.value();
+            return CHIP_NO_ERROR;
+        }
+        else if (mCommissionableDataProvider)
+        {
+            return mCommissionableDataProvider->GetSetupDiscriminator(setupDiscriminator);
+        }
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    CHIP_ERROR SetSetupDiscriminator(uint16_t setupDiscriminator) override
+    {
+        LazyInit();
+        mDiscriminatorOverride = setupDiscriminator;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetSpake2pIterationCount(uint32_t & iterationCount) override
+    {
+        LazyInit();
+        if (mIterationCountOverride.has_value())
+        {
+            iterationCount = mIterationCountOverride.value();
+            return CHIP_NO_ERROR;
+        }
+        else if (mCommissionableDataProvider)
+        {
+            return mCommissionableDataProvider->GetSpake2pIterationCount(iterationCount);
+        }
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    CHIP_ERROR SetSpake2pIterationCount(uint32_t iterationCount)
+    {
+        LazyInit();
+        mIterationCountOverride = iterationCount;
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetSpake2pSalt(MutableByteSpan & saltBuf) override
+    {
+        LazyInit();
+        if (mSaltOverride.has_value())
+        {
+            if (mSaltOverride.value().size() > saltBuf.size())
+            {
+                return CHIP_ERROR_BUFFER_TOO_SMALL;
+            }
+            std::copy(mSaltOverride.value().begin(), mSaltOverride.value().end(), saltBuf.begin());
+            saltBuf.reduce_size(mSaltOverride.value().size());
+            return CHIP_NO_ERROR;
+        }
+        else if (mCommissionableDataProvider)
+        {
+            return mCommissionableDataProvider->GetSpake2pSalt(saltBuf);
+        }
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    CHIP_ERROR SetSpake2pSalt(ByteSpan saltBuf)
+    {
+        LazyInit();
+        if (sizeof(mSaltBuf) < saltBuf.size())
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        std::copy(saltBuf.begin(), saltBuf.end(), mSaltBuf);
+        mSaltOverride = ByteSpan(mSaltBuf, saltBuf.size());
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR GetSpake2pVerifier(MutableByteSpan & verifierBuf, size_t & outVerifierLen) override
+    {
+        LazyInit();
+        if (mVerifierOverride.has_value())
+        {
+            outVerifierLen = mVerifierOverride.value().size();
+            if (mVerifierOverride.value().size() > verifierBuf.size())
+            {
+                return CHIP_ERROR_BUFFER_TOO_SMALL;
+            }
+            std::copy(mVerifierOverride.value().begin(), mVerifierOverride.value().end(), verifierBuf.begin());
+            verifierBuf.reduce_size(mVerifierOverride.value().size());
+            return CHIP_NO_ERROR;
+        }
+        else if (mCommissionableDataProvider)
+        {
+            return mCommissionableDataProvider->GetSpake2pVerifier(verifierBuf, outVerifierLen);
+        }
+
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    CHIP_ERROR SetSpake2pVerifier(ByteSpan verifierBuf)
+    {
+        LazyInit();
+        if (sizeof(mVerifierBuf) < verifierBuf.size())
+        {
+            return CHIP_ERROR_BUFFER_TOO_SMALL;
+        }
+        std::copy(verifierBuf.begin(), verifierBuf.end(), mVerifierBuf);
+        mVerifierOverride = ByteSpan(mVerifierBuf, verifierBuf.size());
+        return CHIP_NO_ERROR;
+    }
+
+private:
+    std::optional<uint16_t> mDiscriminatorOverride;
+    std::optional<uint32_t> mPasscodeOverride;
+    Spake2pVerifierSerialized mVerifierBuf;
+    std::optional<ByteSpan> mVerifierOverride;
+    uint8_t mSaltBuf[kSpake2p_Max_PBKDF_Salt_Length];
+    std::optional<ByteSpan> mSaltOverride;
+    std::optional<uint32_t> mIterationCountOverride;
+    DeviceLayer::CommissionableDataProvider * mCommissionableDataProvider = nullptr;
+
+    void LazyInit()
+    {
+        if (!mCommissionableDataProvider)
+        {
+            mCommissionableDataProvider = DeviceLayer::GetCommissionableDataProvider();
+            DeviceLayer::SetCommissionableDataProvider(this);
+        }
+    }
+};
+} // namespace Internal
 
 class Device : public pw_rpc::nanopb::Device::Service<Device>
 {
@@ -174,15 +344,65 @@ public:
         return pw::OkStatus();
     }
 
+    virtual pw::Status GetSpakeInfo(const pw_protobuf_Empty & request, chip_rpc_SpakeInfo & response)
+    {
+        size_t serializedVerifierLen = 0;
+        MutableByteSpan verifierSpan{ response.verifier.bytes };
+        if (DeviceLayer::GetCommissionableDataProvider()->GetSpake2pVerifier(verifierSpan, serializedVerifierLen) == CHIP_NO_ERROR)
+        {
+            response.verifier.size = verifierSpan.size();
+            response.has_verifier  = true;
+        }
+
+        MutableByteSpan saltSpan{ response.salt.bytes };
+        if (DeviceLayer::GetCommissionableDataProvider()->GetSpake2pSalt(saltSpan) == CHIP_NO_ERROR)
+        {
+            response.salt.size = saltSpan.size();
+            response.has_salt  = true;
+        }
+
+        if (DeviceLayer::GetCommissionableDataProvider()->GetSpake2pIterationCount(response.iteration_count) == CHIP_NO_ERROR)
+        {
+            response.has_iteration_count = true;
+        }
+
+        return pw::OkStatus();
+    }
+
+    virtual pw::Status SetSpakeInfo(const chip_rpc_SpakeInfo & request, pw_protobuf_Empty & response)
+    {
+        if (request.has_salt)
+        {
+            mCommissionableDataProvider.SetSpake2pSalt(ByteSpan(request.salt.bytes, request.salt.size));
+        }
+        if (request.has_iteration_count)
+        {
+            mCommissionableDataProvider.SetSpake2pIterationCount(request.iteration_count);
+        }
+        if (request.has_verifier)
+        {
+            mCommissionableDataProvider.SetSpake2pVerifier(ByteSpan(request.verifier.bytes, request.verifier.size));
+        }
+        return pw::OkStatus();
+    }
+
+    // NOTE: Changing the passcode will not change the verifier or anything else
+    // this just changes the value returned from GetSetupPasscode.
+    // Using this is completely optional, and only really useful for test
+    // automation which can read the configured passcode for commissioning
+    // after it is changed.
     virtual pw::Status SetPairingInfo(const chip_rpc_PairingInfo & request, pw_protobuf_Empty & response)
     {
-        if (DeviceLayer::GetCommissionableDataProvider()->SetSetupPasscode(request.code) != CHIP_NO_ERROR ||
-            DeviceLayer::GetCommissionableDataProvider()->SetSetupDiscriminator(request.discriminator) != CHIP_NO_ERROR)
+        if (mCommissionableDataProvider.SetSetupPasscode(request.code) != CHIP_NO_ERROR ||
+            mCommissionableDataProvider.SetSetupDiscriminator(request.discriminator) != CHIP_NO_ERROR)
         {
             return pw::Status::Unknown();
         }
         return pw::OkStatus();
     }
+
+private:
+    Internal::CommissionableDataProviderRpcWrapper mCommissionableDataProvider;
 };
 
 } // namespace rpc


### PR DESCRIPTION
#### Problem
There are currently no RPCs to set the verifier, salt and iteration count. This is needed for testing devices with values other then the default passcode. 

#### Change overview
Add new RPCs to the Device RPC service which allows setting and getting the verifier, salt, and iteration count.

When setting these values the current commissionable data provider gets wrapped by a new one which returns the set values for anything which has been set, and returns the original values for everything else.

NOTE: These values do not persist across reboot.

#### Testing
Changed the pass code and commissioned an m5stack all-clusters app:

Calculated new spake values:
```
$ out/host/spake2p gen-verifier --pin-code 11223344 --iteration-count 1234 --salt "SaltySalt123456789" -o -
Index,PIN Code,Iteration Count,Salt,Verifier
0,11223344,1234,U2FsdHlTYWx0MTIzNDU2Nzg5,/Ea84aj+TE6uSOibxpfXmOFMKZxRmNXeAQ29iZz64nEE/n8mIecmgtwDgYCXWJBkyRy0Dx3YKzMZ9XFUxvTrweNCqIXp7458hiCjYeDcWm3kLZmrWi1SZwCLNm99yDNqyA==
```

Started console: 
```chip-console -d /dev/ttyUSB0```

In console configured the new values:
```
>>> import base64

>>> rpcs.chip.rpc.Device.FactoryReset()
(Status.OK, pw.protobuf.Empty())

>>> rpcs.chip.rpc.Device.SetPairingState(pairing_enabled=False)
(Status.OK, pw.protobuf.Empty())

>>> rpcs.chip.rpc.Device.SetPairingInfo(discriminator=55,code=11223344)
(Status.OK, pw.protobuf.Empty())

>>> v =base64.b64decode("/Ea84aj+TE6uSOibxpfXmOFMKZxRmNXeAQ29iZz64nEE/n8mIecmgtwDgYCXWJBkyRy0Dx3YKzMZ9XFUxvTrweNCqIXp7458hiCjYeDcWm3kLZmrWi1SZwCLNm99yDNqyA==")

>>> s =base64.b64decode("U2FsdHlTYWx0MTIzNDU2Nzg5")

>>> rpcs.chip.rpc.Device.SetSpakeInfo(salt=s, iteration_count=1234, verifier=v)
(Status.OK, pw.protobuf.Empty())

>>> rpcs.chip.rpc.Device.SetPairingState(pairing_enabled=True)
(Status.OK, pw.protobuf.Empty())

>>> rpcs.chip.rpc.Device.GetSpakeInfo()
(Status.OK, chip.rpc.SpakeInfo(verifier=b'\xFC\x46\xBC\xE1\xA8\xFE\x4C\x4E\xAE\x48\xE8\x9B\xC6\x97\xD7\x98\xE1\x4C\x29\x9C\x51\x98\xD5\xDE\x01\x0D\xBD\x89\x9C\xFA\xE2\x71\x04\xFE\x7F\x26\x21\xE7\x26\x82\xDC\x03\x81\x80\x97\x58\x90\x64\xC9\x1C\xB4\x0F\x1D\xD8\x2B\x33\x19\xF5\x71\x54\xC6\xF4\xEB\xC1\xE3\x42\xA8\x85\xE9\xEF\x8E\x7C\x86\x20\xA3\x61\xE0\xDC\x5A\x6D\xE4\x2D\x99\xAB\x5A\x2D\x52\x67\x00\x8B\x36\x6F\x7D\xC8\x33\x6A\xC8', salt=b'SaltySalt123456789', iteration_count=1234))

>>> rpcs.chip.rpc.Device.GetDeviceInfo()
(Status.OK, chip.rpc.DeviceInfo(vendor_id=65521, product_id=32769, software_version=1, serial_number='TEST_SN', pairing_info=chip.rpc.PairingInfo(code=11223344, discriminator=55, qr_code='MT:-24J0MBW1703R340900', qr_code_url='https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0MBW1703R340900')))
```

Commissioned device using chip-tool:
```
out/debug/chip-tool pairing ble-wifi $node_id $ssid $pass 11223344 55
```
