### PR TITLE
Respect maximum log level in esp32 pw_hdlc logger

### DIFF
--- a/examples/platform/esp32/PigweedLogger.cpp
+++ b/examples/platform/esp32/PigweedLogger.cpp
@@ -90,8 +90,9 @@ extern "C" void __wrap_esp_log_write(esp_log_level_t level, const char * tag, co
 {
     va_list v;
     va_start(v, format);
+
 #ifndef CONFIG_LOG_DEFAULT_LEVEL_NONE
-    if (uartInitialised)
+    if (uartInitialised && level <= CONFIG_LOG_MAXIMUM_LEVEL)
     {
         char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
         size_t len = vsnprintf(formattedMsg, sizeof formattedMsg, format, v);
@@ -102,6 +103,7 @@ extern "C" void __wrap_esp_log_write(esp_log_level_t level, const char * tag, co
         PigweedLogger::putString(formattedMsg, len);
     }
 #endif
+
     va_end(v);
 }
 


### PR DESCRIPTION
Enabling HDLC & RPC causes a significant increase in logs verbosity on
ESP32 which may cause bottlenecks (even causing commissioning to fail).

Respect the maximum log level to suppress these extra logs.

It would be more efficient to check this at the logging call sites, but
using a platform specific level limit is not easily supported with the
matter logging stack (instead, there are separate build time toggles
such as CHIP_DETAIL_LOGGING).

(cherry picked from commit 809f30a7dc6df830d49acc14e197147ae8c1330a)