### PR TITLE
Overrides rendezvousInformation with the value that came from the com…

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -182,6 +182,11 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions)
                                                    LinuxDeviceOptions::GetInstance());
     SuccessOrExit(err);
 
+    if (LinuxDeviceOptions::GetInstance().payload.rendezvousInformation.HasAny())
+    {
+        rendezvousFlags = LinuxDeviceOptions::GetInstance().payload.rendezvousInformation;
+    }
+
     err = GetPayloadContents(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);
     SuccessOrExit(err);
 
@@ -289,7 +294,6 @@ void ChipLinuxAppMainLoop()
     // use a different service port to make testing possible with other sample devices running on same host
     initParams.operationalServicePort        = LinuxDeviceOptions::GetInstance().securedDevicePort;
     initParams.userDirectedCommissioningPort = LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort;
-    ;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
     initParams.interfaceId = LinuxDeviceOptions::GetInstance().interfaceId;


### PR DESCRIPTION
…mand line

#### Problem
What is being fixed?  Examples:
* '--capabilities' option for Linux apps does nothing, and always use the value which is based on some build-time defines.

* Fixes #18995

#### Change overview
Overrides rendezvousInformation with the value that came from the command line

#### Testing
How was this tested? (at least one bullet point required)
* launch chip-all-clusters-app with '--capabilities' option
`  ./chip-all-clusters-app --capabilities 3`
* confirm the rendezvousInformation is overwritten by the value from the command line