### PR TITLE
Add build_overrides/pigweed_environment.gni

### DIFF
--- a/build_overrides/pigweed_environment.gni
+++ b/build_overrides/pigweed_environment.gni
@@ -1,0 +1,13 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.


### PR DESCRIPTION
#### Problem
A fresh build complains missing `build_overrides/pigweed_environment.gni` file.

#### Change overview
Add an empty file to satisfy it.

#### Testing
Not needed.