### PR TITLE
Make darwin-framework-tool subscribe-by-id pay attention to the "wait" argument.

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
@@ -154,6 +154,11 @@ public:
         return CHIP_NO_ERROR;
     }
 
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mWait ? UINT16_MAX : 10);
+    }
+
 protected:
     chip::Optional<bool> mKeepSubscriptions;
     chip::Optional<bool> mFabricFiltered;

--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -231,12 +231,6 @@ public:
 
         return CHIP_NO_ERROR;
     }
-
-    chip::System::Clock::Timeout GetWaitDuration() const override
-    {
-        return chip::System::Clock::Seconds16(mWait ? UINT16_MAX : 10);
-    }
-
 };
 
 {{/if}}


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/19426

#### Problem
See #19426.

#### Change overview
Moves the "wait forever" implementation up into the SubscribeAttribute superclass.

#### Testing
Ran the commands from #19246.