### PR TITLE
Fix timed invoke for commands with no fields in darwin-framework-tool.

### DIFF
--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -56,7 +56,7 @@ public:
         uint16_t __block responsesNeeded = repeatCount;
         while (repeatCount--)
         {
-            [cluster {{asLowerCamelCase name}}With{{#if (hasArguments)}}Params:params completionHandler:{{else}}CompletionHandler:{{/if}}
+            [cluster {{asLowerCamelCase name}}WithParams:params completionHandler:
             {{#if hasSpecificResponse}}
                 ^(CHIP{{asUpperCamelCase clusterName}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable values, NSError * _Nullable error) {
                     NSLog(@"Values: %@", values);


### PR DESCRIPTION
For commands with no fields we were ignoring the params struct we
allocated.

Fixes https://github.com/project-chip/connectedhomeip/issues/19427

#### Problem
See #19427

#### Change overview
See above: use the params that have the timed interaction bits in them.

#### Testing
Ran command from #19427, verified that now we get a timed invoke.