### PR TITLE
Fix the Segmentation fault if wifi name not initialized

### DIFF
--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -117,6 +117,12 @@ void PlatformManagerImpl::WiFIIPChangeListener()
                             continue;
                         }
 
+                        if (ConnectivityManagerImpl::GetWiFiIfName() == nullptr)
+                        {
+                            ChipLogDetail(DeviceLayer, "No wifi interface name. Ignoring IP update event.");
+                            continue;
+                        }
+
                         if (strcmp(name, ConnectivityManagerImpl::GetWiFiIfName()) != 0)
                         {
                             continue;


### PR DESCRIPTION
The WiFi name is configured when WiFi init successfuly.
Sometime, the WiFi interface is not up in some Linux platform and instead
the platform use ethernet like eth0.
In this condition, eth0 will have the IP update event and this update listerner
will be called.
On this condition, the GetWiFiIfName() will report a nullptr and cause a Segmentation fault.

This patch will ignore the event and prevent the Segmentation fault.

Signed-off-by: Haoran Wang <elven.wang@nxp.com>

