### PR TITLE
StandaloneAck handling: Untangle code path for UMH and StandaloneAck

### DIFF
--- a/src/messaging/EphemeralExchangeDispatch.h
+++ b/src/messaging/EphemeralExchangeDispatch.h
@@ -14,13 +14,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *      This file defines Application Channel class. The object of this
- *      class can be used by CHIP data model cluster applications to send
- *      and receive messages. The messages are encrypted using session keys.
- */
-
 #pragma once
 
 #include <messaging/ExchangeMessageDispatch.h>
@@ -46,7 +39,7 @@ protected:
     {
         // Only permit StandaloneAck
         return (protocol == Protocols::SecureChannel::Id &&
-                type == static_cast<uint8_t>(Protocols::SecureChannel::MsgType::StandaloneAck));
+                type == to_underlying(Protocols::SecureChannel::MsgType::StandaloneAck));
     }
 
     bool IsEncryptionRequired() const override

--- a/src/messaging/EphemeralExchangeDispatch.h
+++ b/src/messaging/EphemeralExchangeDispatch.h
@@ -29,17 +29,17 @@
 namespace chip {
 namespace Messaging {
 
-class StandaloneExchangeDispatch : public ExchangeMessageDispatch
+class EphemeralExchangeDispatch : public ExchangeMessageDispatch
 {
 public:
     static ExchangeMessageDispatch & Instance()
     {
-        static StandaloneExchangeDispatch instance;
+        static EphemeralExchangeDispatch instance;
         return instance;
     }
 
-    StandaloneExchangeDispatch() {}
-    ~StandaloneExchangeDispatch() override {}
+    EphemeralExchangeDispatch() {}
+    ~EphemeralExchangeDispatch() override {}
 
 protected:
     bool MessagePermitted(Protocols::Id protocol, uint8_t type) override

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -39,9 +39,9 @@
 #include <lib/support/TypeTraits.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ApplicationExchangeDispatch.h>
+#include <messaging/EphemeralExchangeDispatch.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
-#include <messaging/StandaloneExchangeDispatch.h>
 #include <protocols/Protocols.h>
 #include <protocols/secure_channel/Constants.h>
 
@@ -291,8 +291,8 @@ void ExchangeContextDeletor::Release(ExchangeContext * ec)
 }
 
 ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, const SessionHandle & session, bool Initiator,
-                                 ExchangeDelegate * delegate, bool isStandaloneExchange) :
-    mDispatch(GetMessageDispatch(isStandaloneExchange, delegate)),
+                                 ExchangeDelegate * delegate, bool isEphemeralExchange) :
+    mDispatch(GetMessageDispatch(isEphemeralExchange, delegate)),
     mSession(*this)
 {
     VerifyOrDie(mExchangeMgr == nullptr);
@@ -301,7 +301,7 @@ ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, cons
     mExchangeId  = ExchangeId;
     mSession.Grab(session);
     mFlags.Set(Flags::kFlagInitiator, Initiator);
-    mFlags.Set(Flags::kFlagStandaloneExchange, isStandaloneExchange);
+    mFlags.Set(Flags::kFlagEphemeralExchange, isEphemeralExchange);
     mDelegate = delegate;
 
     SetAckPending(false);
@@ -496,9 +496,9 @@ CHIP_ERROR ExchangeContext::HandleMessage(uint32_t messageCounter, const Payload
         return CHIP_NO_ERROR;
     }
 
-    if (IsStandaloneExchange())
+    if (IsEphemeralExchange())
     {
-        // The StandaloneExchange has done its job, since StandaloneAck is sent in previous FlushAcks() call.
+        // The EphemeralExchange has done its job, since StandaloneAck is sent in previous FlushAcks() call.
         return CHIP_NO_ERROR;
     }
 
@@ -535,10 +535,10 @@ void ExchangeContext::MessageHandled()
     Close();
 }
 
-ExchangeMessageDispatch & ExchangeContext::GetMessageDispatch(bool isStandaloneExchange, ExchangeDelegate * delegate)
+ExchangeMessageDispatch & ExchangeContext::GetMessageDispatch(bool isEphemeralExchange, ExchangeDelegate * delegate)
 {
-    if (isStandaloneExchange)
-        return StandaloneExchangeDispatch::Instance();
+    if (isEphemeralExchange)
+        return EphemeralExchangeDispatch::Instance();
 
     if (delegate != nullptr)
         return delegate->GetMessageDispatch();

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -66,7 +66,7 @@ public:
     typedef System::Clock::Timeout Timeout; // Type used to express the timeout in this ExchangeContext
 
     ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, const SessionHandle & session, bool Initiator,
-                    ExchangeDelegate * delegate, bool isStandaloneExchange = false);
+                    ExchangeDelegate * delegate, bool isEphemeralExchange = false);
 
     ~ExchangeContext() override;
 
@@ -272,7 +272,7 @@ private:
      */
     void UpdateSEDIntervalMode(bool activeMode);
 
-    static ExchangeMessageDispatch & GetMessageDispatch(bool isStandaloneExchange, ExchangeDelegate * delegate);
+    static ExchangeMessageDispatch & GetMessageDispatch(bool isEphemeralExchange, ExchangeDelegate * delegate);
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -66,7 +66,7 @@ public:
     typedef System::Clock::Timeout Timeout; // Type used to express the timeout in this ExchangeContext
 
     ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, const SessionHandle & session, bool Initiator,
-                    ExchangeDelegate * delegate);
+                    ExchangeDelegate * delegate, bool isStandaloneExchange = false);
 
     ~ExchangeContext() override;
 
@@ -153,8 +153,6 @@ public:
     ExchangeManager * GetExchangeMgr() const { return mExchangeMgr; }
 
     ReliableMessageContext * GetReliableMessageContext() { return static_cast<ReliableMessageContext *>(this); };
-
-    ExchangeMessageDispatch & GetMessageDispatch() { return mDispatch; }
 
     SessionHandle GetSessionHandle() const
     {
@@ -273,6 +271,8 @@ private:
      * exchange nor other component requests the active mode.
      */
     void UpdateSEDIntervalMode(bool activeMode);
+
+    static ExchangeMessageDispatch & GetMessageDispatch(bool isStandaloneExchange, ExchangeDelegate * delegate);
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -240,6 +240,8 @@ private:
 
     void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, const SessionHandle & session,
                            DuplicateMessage isDuplicate, System::PacketBufferHandle && msgBuf) override;
+    void ReplyStandaloneAck(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, const SessionHandle & session,
+                            MessageFlags msgFlags, System::PacketBufferHandle && msgBuf);
 };
 
 } // namespace Messaging

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -240,8 +240,8 @@ private:
 
     void OnMessageReceived(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, const SessionHandle & session,
                            DuplicateMessage isDuplicate, System::PacketBufferHandle && msgBuf) override;
-    void ReplyStandaloneAck(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader, const SessionHandle & session,
-                            MessageFlags msgFlags, System::PacketBufferHandle && msgBuf);
+    void SendStandaloneAckIfNeeded(const PacketHeader & packetHeader, const PayloadHeader & payloadHeader,
+                                   const SessionHandle & session, MessageFlags msgFlags, System::PacketBufferHandle && msgBuf);
 };
 
 } // namespace Messaging

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -121,8 +121,8 @@ public:
     /// Determine whether this exchange is requesting Sleepy End Device active mode
     bool IsRequestingActiveMode() const;
 
-    /// Determine whether this exchange is a StandaloneExchange for replying a StandaloneAck
-    bool IsStandaloneExchange() const;
+    /// Determine whether this exchange is a EphemeralExchange for replying a StandaloneAck
+    bool IsEphemeralExchange() const;
 
     /**
      * Get the reliable message manager that corresponds to this reliable
@@ -163,7 +163,7 @@ protected:
         kFlagActiveMode = (1u << 8),
 
         /// When set, signifies that the exchange created sorely for replying a StandaloneAck
-        kFlagStandaloneExchange = (1u << 9),
+        kFlagEphemeralExchange = (1u << 9),
     };
 
     BitFlags<Flags> mFlags; // Internal state flags
@@ -240,9 +240,9 @@ inline void ReliableMessageContext::SetRequestingActiveMode(bool activeMode)
     mFlags.Set(Flags::kFlagActiveMode, activeMode);
 }
 
-inline bool ReliableMessageContext::IsStandaloneExchange() const
+inline bool ReliableMessageContext::IsEphemeralExchange() const
 {
-    return mFlags.Has(Flags::kFlagStandaloneExchange);
+    return mFlags.Has(Flags::kFlagEphemeralExchange);
 }
 
 } // namespace Messaging

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -121,6 +121,9 @@ public:
     /// Determine whether this exchange is requesting Sleepy End Device active mode
     bool IsRequestingActiveMode() const;
 
+    /// Determine whether this exchange is a StandaloneExchange for replying a StandaloneAck
+    bool IsStandaloneExchange() const;
+
     /**
      * Get the reliable message manager that corresponds to this reliable
      * message context.
@@ -158,6 +161,9 @@ protected:
 
         /// When set, signifies that the exchange is requesting Sleepy End Device active mode.
         kFlagActiveMode = (1u << 8),
+
+        /// When set, signifies that the exchange created sorely for replying a StandaloneAck
+        kFlagStandaloneExchange = (1u << 9),
     };
 
     BitFlags<Flags> mFlags; // Internal state flags
@@ -232,6 +238,11 @@ inline void ReliableMessageContext::SetMessageNotAcked(bool messageNotAcked)
 inline void ReliableMessageContext::SetRequestingActiveMode(bool activeMode)
 {
     mFlags.Set(Flags::kFlagActiveMode, activeMode);
+}
+
+inline bool ReliableMessageContext::IsStandaloneExchange() const
+{
+    return mFlags.Has(Flags::kFlagStandaloneExchange);
 }
 
 } // namespace Messaging

--- a/src/messaging/StandaloneExchangeDispatch.h
+++ b/src/messaging/StandaloneExchangeDispatch.h
@@ -1,0 +1,61 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines Application Channel class. The object of this
+ *      class can be used by CHIP data model cluster applications to send
+ *      and receive messages. The messages are encrypted using session keys.
+ */
+
+#pragma once
+
+#include <messaging/ExchangeMessageDispatch.h>
+#include <protocols/secure_channel/Constants.h>
+
+namespace chip {
+namespace Messaging {
+
+class StandaloneExchangeDispatch : public ExchangeMessageDispatch
+{
+public:
+    static ExchangeMessageDispatch & Instance()
+    {
+        static StandaloneExchangeDispatch instance;
+        return instance;
+    }
+
+    StandaloneExchangeDispatch() {}
+    ~StandaloneExchangeDispatch() override {}
+
+protected:
+    bool MessagePermitted(Protocols::Id protocol, uint8_t type) override
+    {
+        // Only permit StandaloneAck
+        return (protocol == Protocols::SecureChannel::Id &&
+                type == static_cast<uint8_t>(Protocols::SecureChannel::MsgType::StandaloneAck));
+    }
+
+    bool IsEncryptionRequired() const override
+    {
+        // This function should not be called at all
+        VerifyOrDie(false);
+        return false;
+    }
+};
+
+} // namespace Messaging
+} // namespace chip


### PR DESCRIPTION
#### Problem
The original implementation in PR #19398 is too tricky

#### Change overview
* Untangle code path for UMH and StandaloneAck
  * Revert UMH path, but only for UMH != nullptr case
  * Add a new branch for generating StandaloneAck
* Add `EpheremalExchangeDispatch` for helping generating StandaloneAck
* Add `kFlagEpheremalExchange` flag for exchange, to help go through StandaloneAck processing

Although the code is a bit tedious, but the logic is more clear, and more robust.

#### Testing
Reusing current unit-tests for regression