### PR TITLE
Fix service remove marked as removed by Avahi

### DIFF
--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -654,9 +654,10 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
         ChipLogProgress(DeviceLayer, "Avahi browse: remove");
         if (strcmp("local", domain) == 0)
         {
-            std::remove_if(context->mServices.begin(), context->mServices.end(), [name, type](const DnssdService & service) {
-                return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol);
-            });
+            context->mServices.erase(
+                std::remove_if(context->mServices.begin(), context->mServices.end(), [name, type](const DnssdService & service) {
+                    return strcmp(name, service.mName) == 0 && type == GetFullType(service.mType, service.mProtocol);
+                }));
         }
         break;
     case AVAHI_BROWSER_CACHE_EXHAUSTED:


### PR DESCRIPTION
#### Problem

Services marked for removal are not removed from the list (std::remove_if does not erase elements).

#### Change overview

- properly implement removal using std::remove_if and erase

#### Testing

Trivial change, but tested with:

```
gn gen --check --fail-on-unused-args --export-compile-commands --root=/home/a.bokowy/connectedhomeip/examples/chip-tool /home/a.bokowy/connectedhomeip/out/linux-x64-chip-tool "--args=chip_mdns=\"platform\""
ninja -C out/linux-x64-chip-tool
```