### PR TITLE
Disable tizen builds from build all tests: tizen does not compile in …

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -18,7 +18,7 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob '*' --skip-target-glob '*-tests' build
+              --target-glob '*' --skip-target-glob '{tizen-*,*-tests}' build
               --create-archives /workspace/artifacts/
       id: CompileAll
       waitFor:


### PR DESCRIPTION
…the vscode image

#### Problem

Dockerfile for tizen has a lot of configuration steps not mirrored in the vscode image. This results in:

```
INFO    No package 'capi-appfw-service-application' found
```

#### Change overview
Disable tizen builds in cloudbuild.

#### Testing
Tested glob manually. Actual validation will happen in cloudbuild.