### PR TITLE
[Tizen] Error handling refactoring for DNS-SD impl

### DIFF
--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -54,7 +54,7 @@ std::string GetFullType(const char * type, DnssdServiceProtocol protocol)
 
 void RemoveContext(GenericContext * context)
 {
-    if (DnssdContexts::GetInstance().Remove(context) == CHIP_ERROR_KEY_NOT_FOUND)
+    if (DnssdTizen::GetInstance().Remove(context) == CHIP_ERROR_KEY_NOT_FOUND)
     {
         chip::Platform::Delete(context);
     }
@@ -156,7 +156,7 @@ CHIP_ERROR RegisterService(const char * type, const char * name, uint16_t port, 
         return CHIP_ERROR_INTERNAL;
     }
 
-    auto context = DnssdContexts::GetInstance().Get(type, name, port, interfaceId);
+    auto context = DnssdTizen::GetInstance().Get(type, name, port, interfaceId);
     if (context != nullptr)
     {
         return UpdateTXTRecord(context->service, textEntries, textEntrySize);
@@ -194,7 +194,7 @@ CHIP_ERROR RegisterService(const char * type, const char * name, uint16_t port, 
         VerifyOrReturnError(CheckForSuccess(context, ret, __func__), CHIP_ERROR_INTERNAL);
     }
 
-    DnssdContexts::GetInstance().Add(context, service, type, name, port, interfaceId);
+    DnssdTizen::GetInstance().Add(context, service, type, name, port, interfaceId);
     if (MainLoop::Instance().AsyncRequest(RegisterAsync, context) == false)
     {
         chip::Platform::Delete(context);
@@ -206,7 +206,7 @@ CHIP_ERROR RegisterService(const char * type, const char * name, uint16_t port, 
 
 CHIP_ERROR UnregisterAllServices()
 {
-    CHIP_ERROR err = DnssdContexts::GetInstance().Remove(ContextType::Register);
+    CHIP_ERROR err = DnssdTizen::GetInstance().Remove(ContextType::Register);
     if (err == CHIP_ERROR_KEY_NOT_FOUND)
         err = CHIP_NO_ERROR;
     return err;
@@ -249,7 +249,7 @@ void OnBrowseRemove(BrowseContext * context, dnssd_service_h service, const char
 
 void StopBrowse(BrowseContext * context)
 {
-    DnssdContexts::GetInstance().Remove(context);
+    DnssdTizen::GetInstance().Remove(context);
 }
 
 void OnBrowse(dnssd_service_state_e state, dnssd_service_h service, void * data)
@@ -336,7 +336,7 @@ gboolean BrowseAsync(GMainLoop * mainLoop, gpointer userData)
 
     VerifyOrReturnError(CheckForSuccess(bCtx, ret, __func__, true), false);
     bCtx->isBrowsing = true;
-    DnssdContexts::GetInstance().Add(bCtx, browser);
+    DnssdTizen::GetInstance().Add(bCtx, browser);
 
     return true;
 }
@@ -356,7 +356,7 @@ CHIP_ERROR Browse(uint32_t interfaceId, const char * type, DnssdServiceProtocol 
 
 void StopResolve(ResolveContext * context)
 {
-    DnssdContexts::GetInstance().Remove(context);
+    DnssdTizen::GetInstance().Remove(context);
 }
 
 void ConvertTxtRecords(unsigned short txtLen, uint8_t * txtRecord, std::vector<TextEntry> & textEntries)
@@ -517,7 +517,7 @@ CHIP_ERROR Resolve(uint32_t interfaceId, const char * type, const char * name, D
 
     VerifyOrReturnError(CheckForSuccess(rCtx, ret, __func__, true), CHIP_ERROR_INTERNAL);
 
-    DnssdContexts::GetInstance().Add(rCtx, service);
+    DnssdTizen::GetInstance().Add(rCtx, service);
     if (MainLoop::Instance().AsyncRequest(ResolveAsync, rCtx) == false)
     {
         chip::Platform::Delete(rCtx);
@@ -532,9 +532,9 @@ CHIP_ERROR Resolve(uint32_t interfaceId, const char * type, const char * name, D
 namespace chip {
 namespace Dnssd {
 
-DnssdContexts DnssdContexts::sInstance;
+DnssdTizen DnssdTizen::sInstance;
 
-void DnssdContexts::Delete(GenericContext * context)
+void DnssdTizen::Delete(GenericContext * context)
 {
     switch (context->contextType)
     {
@@ -575,7 +575,7 @@ void DnssdContexts::Delete(GenericContext * context)
     chip::Platform::Delete(context);
 }
 
-DnssdContexts::~DnssdContexts()
+DnssdTizen::~DnssdTizen()
 {
     auto iter = mContexts.cbegin();
     while (iter != mContexts.cend())
@@ -585,8 +585,8 @@ DnssdContexts::~DnssdContexts()
     }
 }
 
-CHIP_ERROR DnssdContexts::Add(RegisterContext * context, dnssd_service_h service, const char * type, const char * name,
-                              uint16_t port, uint32_t interfaceId)
+CHIP_ERROR DnssdTizen::Add(RegisterContext * context, dnssd_service_h service, const char * type, const char * name, uint16_t port,
+                           uint32_t interfaceId)
 {
     VerifyOrReturnError(context != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(service != 0, CHIP_ERROR_INVALID_ARGUMENT);
@@ -602,7 +602,7 @@ CHIP_ERROR DnssdContexts::Add(RegisterContext * context, dnssd_service_h service
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DnssdContexts::Add(BrowseContext * context, dnssd_browser_h browser)
+CHIP_ERROR DnssdTizen::Add(BrowseContext * context, dnssd_browser_h browser)
 {
     VerifyOrReturnError(context != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(browser != 0, CHIP_ERROR_INVALID_ARGUMENT);
@@ -611,7 +611,7 @@ CHIP_ERROR DnssdContexts::Add(BrowseContext * context, dnssd_browser_h browser)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DnssdContexts::Add(ResolveContext * context, dnssd_service_h service)
+CHIP_ERROR DnssdTizen::Add(ResolveContext * context, dnssd_service_h service)
 {
     VerifyOrReturnError(context != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     context->service = service;
@@ -619,7 +619,7 @@ CHIP_ERROR DnssdContexts::Add(ResolveContext * context, dnssd_service_h service)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DnssdContexts::Remove(GenericContext * context)
+CHIP_ERROR DnssdTizen::Remove(GenericContext * context)
 {
     ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     auto iter = mContexts.cbegin();
@@ -636,7 +636,7 @@ CHIP_ERROR DnssdContexts::Remove(GenericContext * context)
     return CHIP_ERROR_KEY_NOT_FOUND;
 }
 
-CHIP_ERROR DnssdContexts::Remove(const char * type, const char * name, uint16_t port, uint32_t interfaceId)
+CHIP_ERROR DnssdTizen::Remove(const char * type, const char * name, uint16_t port, uint32_t interfaceId)
 {
     ChipLogDetail(DeviceLayer, "DNSsd %s type: %s, name %s, port: %u, interfaceId: %u", __func__, type, name, port, interfaceId);
     for (auto iter = mContexts.begin(); iter != mContexts.end(); ++iter)
@@ -656,7 +656,7 @@ CHIP_ERROR DnssdContexts::Remove(const char * type, const char * name, uint16_t 
     return CHIP_ERROR_KEY_NOT_FOUND;
 }
 
-CHIP_ERROR DnssdContexts::Remove(ContextType type)
+CHIP_ERROR DnssdTizen::Remove(ContextType type)
 {
     ChipLogDetail(DeviceLayer, "DNSsd %s", __func__);
     bool found = false;
@@ -678,7 +678,7 @@ CHIP_ERROR DnssdContexts::Remove(ContextType type)
     return found ? CHIP_NO_ERROR : CHIP_ERROR_KEY_NOT_FOUND;
 }
 
-RegisterContext * DnssdContexts::Get(const char * type, const char * name, uint16_t port, uint32_t interfaceId)
+RegisterContext * DnssdTizen::Get(const char * type, const char * name, uint16_t port, uint32_t interfaceId)
 {
     for (auto iter = mContexts.begin(); iter != mContexts.end(); ++iter)
     {

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -90,7 +90,6 @@ void OnRegister(dnssd_error_e result, dnssd_service_h service, void * data)
         return;
     }
 
-    rCtx->mIsRegistered = true;
     rCtx->mCallback(rCtx->mCbContext, rCtx->mType, CHIP_NO_ERROR);
 }
 
@@ -105,6 +104,7 @@ gboolean RegisterAsync(GMainLoop * mainLoop, gpointer userData)
     VerifyOrReturnError(ret == DNSSD_ERROR_NONE,
                         (ChipLogError(DeviceLayer, "dnssd_register_local_service() failed. ret: %d", ret), false));
 
+    rCtx->mIsRegistered = true;
     return true;
 }
 

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -769,17 +769,5 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
     return Resolve(interfaceId.GetPlatformInterface(), regtype.c_str(), service->mName, callback, context);
 }
 
-void GetDnssdTimeout(timeval & timeout)
-{
-    // Do nothing
-    // Tizen DNS-SD API adds I/O events to GMainContext, so MainLoop::AsyncRequest will be used for DNS-SD operations
-}
-
-void HandleDnssdTimeout()
-{
-    // Do nothing
-    // Tizen DNS-SD API adds I/O events to GMainContext, so MainLoop::AsyncRequest will be used for DNS-SD operations
-}
-
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -108,13 +108,12 @@ struct ResolveContext : public GenericContext
     }
 };
 
-class DnssdContexts
+class DnssdTizen
 {
 public:
-    DnssdContexts(const DnssdContexts &) = delete;
-    DnssdContexts & operator=(const DnssdContexts &) = delete;
-    ~DnssdContexts();
-    static DnssdContexts & GetInstance() { return sInstance; }
+    DnssdTizen(const DnssdTizen &) = delete;
+    DnssdTizen & operator=(const DnssdTizen &) = delete;
+    ~DnssdTizen();
 
     CHIP_ERROR Add(RegisterContext * context, dnssd_service_h service, const char * type, const char * name, uint16_t port,
                    uint32_t interfaceId);
@@ -125,9 +124,11 @@ public:
     CHIP_ERROR Remove(ContextType type);
     RegisterContext * Get(const char * type, const char * name, uint16_t port, uint32_t interfaceId);
 
+    static DnssdTizen & GetInstance() { return sInstance; }
+
 private:
-    DnssdContexts(){};
-    static DnssdContexts sInstance;
+    DnssdTizen(){};
+    static DnssdTizen sInstance;
 
     void Delete(GenericContext * context);
     std::vector<GenericContext *> mContexts;

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -46,6 +46,7 @@ struct GenericContext
     GMainLoop * mMainLoop = nullptr;
 
     explicit GenericContext(ContextType contextType) : mContextType(contextType) {}
+    virtual ~GenericContext() = default;
 };
 
 struct RegisterContext : public GenericContext
@@ -64,7 +65,7 @@ struct RegisterContext : public GenericContext
 
     RegisterContext(DnssdTizen * instance, const char * type, const DnssdService & service, DnssdPublishCallback callback,
                     void * context);
-    ~RegisterContext();
+    ~RegisterContext() override;
 };
 
 struct BrowseContext : public GenericContext
@@ -82,6 +83,7 @@ struct BrowseContext : public GenericContext
 
     BrowseContext(DnssdServiceProtocol cbContextProtocol, const char * bType, uint32_t interfaceId, DnssdBrowseCallback callback,
                   void * context);
+    ~BrowseContext() override;
 };
 
 struct ResolveContext : public GenericContext
@@ -97,6 +99,7 @@ struct ResolveContext : public GenericContext
     bool mIsResolving              = false;
 
     ResolveContext(const char * rType, const char * rName, uint32_t interfaceId, DnssdResolveCallback callback, void * context);
+    ~ResolveContext() override;
 };
 
 class DnssdTizen
@@ -128,8 +131,6 @@ public:
 private:
     DnssdTizen() = default;
     static DnssdTizen sInstance;
-
-    void Delete(GenericContext * context);
 
     std::mutex mMutex;
     std::vector<GenericContext *> mContexts;

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -47,7 +47,9 @@ struct GenericContext
     GMainLoop * mMainLoop = nullptr;
 
     GenericContext(ContextType contextType, DnssdTizen * instance) : mContextType(contextType), mInstance(instance) {}
-    virtual ~GenericContext() = default;
+    virtual ~GenericContext() { MainLoopQuit(); };
+
+    void MainLoopQuit();
 };
 
 struct RegisterContext : public GenericContext

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -70,8 +70,9 @@ struct RegisterContext : public GenericContext
 
 struct BrowseContext : public GenericContext
 {
-    DnssdServiceProtocol mProtocol;
+    DnssdTizen * mInstance;
     char mType[kDnssdTypeAndProtocolMaxSize + 1];
+    DnssdServiceProtocol mProtocol;
     uint32_t mInterfaceId;
 
     DnssdBrowseCallback mCallback;
@@ -81,8 +82,8 @@ struct BrowseContext : public GenericContext
     std::vector<DnssdService> mServices;
     bool mIsBrowsing = false;
 
-    BrowseContext(DnssdServiceProtocol cbContextProtocol, const char * bType, uint32_t interfaceId, DnssdBrowseCallback callback,
-                  void * context);
+    BrowseContext(DnssdTizen * instance, const char * type, DnssdServiceProtocol protocol, uint32_t interfaceId,
+                  DnssdBrowseCallback callback, void * context);
     ~BrowseContext() override;
 };
 
@@ -122,9 +123,10 @@ public:
     CHIP_ERROR Resolve(const DnssdService & browseResult, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                        void * context);
 
-    CHIP_ERROR Add(BrowseContext * context, dnssd_browser_h browser);
     CHIP_ERROR Add(ResolveContext * context, dnssd_service_h service);
     CHIP_ERROR Remove(GenericContext * context);
+
+    CHIP_ERROR RemoveContext(GenericContext * context);
 
     static DnssdTizen & GetInstance() { return sInstance; }
 
@@ -134,6 +136,7 @@ private:
 
     std::mutex mMutex;
     std::vector<GenericContext *> mContexts;
+    std::set<std::shared_ptr<BrowseContext>> mBrowseContexts;
     std::set<std::shared_ptr<RegisterContext>> mRegisteredServices;
 };
 

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -115,6 +115,9 @@ public:
     DnssdTizen & operator=(const DnssdTizen &) = delete;
     ~DnssdTizen();
 
+    CHIP_ERROR Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context);
+    CHIP_ERROR Shutdown();
+
     CHIP_ERROR Add(RegisterContext * context, dnssd_service_h service, const char * type, const char * name, uint16_t port,
                    uint32_t interfaceId);
     CHIP_ERROR Add(BrowseContext * context, dnssd_browser_h browser);
@@ -127,7 +130,7 @@ public:
     static DnssdTizen & GetInstance() { return sInstance; }
 
 private:
-    DnssdTizen(){};
+    DnssdTizen() = default;
     static DnssdTizen sInstance;
 
     void Delete(GenericContext * context);

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -126,6 +126,12 @@ public:
     CHIP_ERROR UnregisterService(dnssd_service_h serviceHandle);
     CHIP_ERROR UnregisterAllServices();
 
+    CHIP_ERROR Browse(const char * type, DnssdServiceProtocol protocol, chip::Inet::IPAddressType addressType,
+                      chip::Inet::InterfaceId interface, DnssdBrowseCallback callback, void * context);
+
+    CHIP_ERROR Resolve(const DnssdService & browseResult, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
+                       void * context);
+
     CHIP_ERROR Add(BrowseContext * context, dnssd_browser_h browser);
     CHIP_ERROR Add(ResolveContext * context, dnssd_service_h service);
     CHIP_ERROR Remove(GenericContext * context);

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -89,6 +89,7 @@ struct BrowseContext : public GenericContext
 
 struct ResolveContext : public GenericContext
 {
+    DnssdTizen * mInstance;
     char mName[Common::kInstanceNameMaxLength + 1];
     char mType[kDnssdTypeAndProtocolMaxSize + 1];
     uint32_t mInterfaceId;
@@ -99,7 +100,8 @@ struct ResolveContext : public GenericContext
     dnssd_service_h mServiceHandle = 0;
     bool mIsResolving              = false;
 
-    ResolveContext(const char * rType, const char * rName, uint32_t interfaceId, DnssdResolveCallback callback, void * context);
+    ResolveContext(DnssdTizen * instance, const char * name, const char * type, uint32_t interfaceId, DnssdResolveCallback callback,
+                   void * context);
     ~ResolveContext() override;
 };
 
@@ -108,7 +110,6 @@ class DnssdTizen
 public:
     DnssdTizen(const DnssdTizen &) = delete;
     DnssdTizen & operator=(const DnssdTizen &) = delete;
-    ~DnssdTizen();
 
     CHIP_ERROR Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context);
     CHIP_ERROR Shutdown();
@@ -123,9 +124,6 @@ public:
     CHIP_ERROR Resolve(const DnssdService & browseResult, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                        void * context);
 
-    CHIP_ERROR Add(ResolveContext * context, dnssd_service_h service);
-    CHIP_ERROR Remove(GenericContext * context);
-
     CHIP_ERROR RemoveContext(GenericContext * context);
 
     static DnssdTizen & GetInstance() { return sInstance; }
@@ -135,8 +133,8 @@ private:
     static DnssdTizen sInstance;
 
     std::mutex mMutex;
-    std::vector<GenericContext *> mContexts;
     std::set<std::shared_ptr<BrowseContext>> mBrowseContexts;
+    std::set<std::shared_ptr<ResolveContext>> mResolveContexts;
     std::set<std::shared_ptr<RegisterContext>> mRegisteredServices;
 };
 


### PR DESCRIPTION
#### Problem

The implementation of the mDNS has very poor error handling and memory management. Also, mDNS callbacks are not always called when they should be and in two cases the context which should be passed to the callback function is wrong.... And lastly there is a bug which causes 100% CPU utilization when running already commissioned application.

What is being fixed?

- fix CPU 100%
- fixed many potential memory leaks during error handling
- call Dnssd*Callback callbacks always during success and failure
- always pass proper context to callback functions (the one received in the ChipDnssd* calls)
- protect mContexts access with a mutex (context is added in one thread and removed in other)
- in some cases async threads were not quit (application had 10-11 threads after startup, now it has 8 threads)

#### Change overview

- renamed DnssdContexts to DnssdTizen (so it will handle not only contexts but it will contain implementations entry points for mDNS handling)
- proper shutdown function for DNS-SD service
- support case when we would like to update already registered mDNS service
- mark service as registered just after registering it (ChipDnssdRemoveServices() might be called before the Tizen Native API callback will be called, so we will end up with unregistered service)
- manage context using smart pointers and polymorphism - no explicit ::New() and ::Delete()

#### Testing

1. Tested lighting-app commissioning and onoff cluster with chip-tool from Linux controller.

   On Target:
   ```
   app_launcher -s org.tizen.matter.example.lighting discriminator 42 passcode 1234
   ```
   On Linux:
   ```
   ./out/linux-x64-chip-tool/chip-tool pairing onnetwork 1 1234
   ./out/linux-x64-chip-tool/chip-tool onoff on 1 1
   ```

2. Running chip-tool on Tizen to check whether mDNS browsing and resolving works correctly (in order to build chip-tool for Tizen, build-chip-tizen dockerfile changes from PR #19043 are required).

   On Linux:
   ```
   ./out/linux-x64-light/chip-lighting-app --passcode 4321 --discriminator 11
   ```
   On Target:
   ```
   /opt/usr/apps/chip-tool pairing onnetwork 1 4321
   ```