### PR TITLE
Fix merge conflict in CASESession.cpp

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -210,7 +210,7 @@ CHIP_ERROR CASESession::EstablishSession(SessionManager & sessionManager, Fabric
     auto * fabricInfo = fabricTable->FindFabricWithIndex(peerScopedNodeId.GetFabricIndex());
     ReturnErrorCodeIf(fabricInfo == nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
-    err = Init(sessionManager, policy, delegate, ScopedNodeId(peerNodeId, fabricIndex));
+    err = Init(sessionManager, policy, delegate, peerScopedNodeId);
 
     mRole = CryptoContext::SessionRole::kInitiator;
 


### PR DESCRIPTION
#### Problem
- Semantic merge conflict between #19277 and #19261
- One line mismatch

#### Change overview
- Fix the conflict

#### Testing
- Unit tests pass
- Integration tests pass
