### PR TITLE
Set chip_progress_logging = false for all-clusters for cc13x2 builds …

### DIFF
--- a/examples/all-clusters-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/args.gni
@@ -32,7 +32,7 @@ chip_enable_ota_requestor = false
 chip_openthread_ftd = false
 
 # Disable CHIP Logging
-#chip_progress_logging = false
+chip_progress_logging = false
 chip_detail_logging = false
 chip_automation_logging = false
 


### PR DESCRIPTION
…as it does not fit in flash

#### Problem
Compile error: out of flash on all clusters app:

https://github.com/project-chip/connectedhomeip/runs/6833066586?check_suite_focus=true

#### Change overview
Disable progress logging for all clusters app to save some flash space.

#### Testing
Local compile test.