### PR TITLE
Inject a certificate validity policy that accounts for unavailability of wall clock time

### DIFF
--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -30,6 +30,7 @@
 #include <app/server/AppDelegate.h>
 #include <app/server/CommissioningWindowManager.h>
 #include <app/server/DefaultAclStorage.h>
+#include <credentials/CertificateValidityPolicy.h>
 #include <credentials/FabricTable.h>
 #include <credentials/GroupDataProvider.h>
 #include <credentials/GroupDataProviderImpl.h>
@@ -114,6 +115,42 @@ struct ServerInitParams
     TestEventTriggerDelegate * testEventTriggerDelegate = nullptr;
 };
 
+class IgnoreCertificateValidityPolicy : public Credentials::CertificateValidityPolicy
+{
+public:
+    IgnoreCertificateValidityPolicy() {}
+
+    /**
+     * @brief
+     *
+     * This certificate validity policy does not validate NotBefore or
+     * NotAfter to accommodate platforms that may have wall clock time, but
+     * where it is unreliable.
+     *
+     * Last Known Good Time is also not considered in this policy.
+     *
+     * @param cert CHIP Certificate for which we are evaluating validity
+     * @param depth the depth of the certificate in the chain, where the leaf is at depth 0
+     * @return CHIP_NO_ERROR if CHIPCert should accept the certificate; an appropriate CHIP_ERROR if it should be rejected
+     */
+    CHIP_ERROR ApplyCertificateValidityPolicy(const Credentials::ChipCertificateData * cert, uint8_t depth,
+                                              Credentials::CertificateValidityResult result) override
+    {
+        switch (result)
+        {
+        case Credentials::CertificateValidityResult::kValid:
+        case Credentials::CertificateValidityResult::kNotYetValid:
+        case Credentials::CertificateValidityResult::kExpired:
+        case Credentials::CertificateValidityResult::kNotExpiredAtLastKnownGoodTime:
+        case Credentials::CertificateValidityResult::kExpiredAtLastKnownGoodTime:
+        case Credentials::CertificateValidityResult::kTimeUnknown:
+            return CHIP_NO_ERROR;
+        default:
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+    }
+};
+
 /**
  * Transitional version of ServerInitParams to assist SDK integrators in
  * transitioning to injecting product/platform-owned resources. This version
@@ -162,6 +199,8 @@ struct CommonCaseDeviceServerInitParams : public ServerInitParams
     {
         static chip::KvsPersistentStorageDelegate sKvsPersistenStorageDelegate;
         static chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
+        static IgnoreCertificateValidityPolicy sDefaultCertValidityPolicy;
+
 #if CHIP_CONFIG_ENABLE_SESSION_RESUMPTION
         static chip::SimpleSessionResumptionStorage sSessionResumptionStorage;
 #endif
@@ -189,6 +228,10 @@ struct CommonCaseDeviceServerInitParams : public ServerInitParams
 
         // Inject ACL storage. (Don't initialize it.)
         this->aclStorage = &sAclStorage;
+
+        // Inject certificate validation policy compatible with non-wall-clock-time-synced
+        // embedded systems.
+        this->certificateValidityPolicy = &sDefaultCertValidityPolicy;
 
         return CHIP_NO_ERROR;
     }

--- a/src/platform/Ameba/SystemTimeSupport.cpp
+++ b/src/platform/Ameba/SystemTimeSupport.cpp
@@ -65,6 +65,7 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & curTime)
     // TODO(19081): This platform does not properly error out if wall clock has
     //              not been set.  For now, short circuit this.
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#if 0
     time_t seconds;
     struct rtkTimeVal tv;
 
@@ -81,6 +82,7 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & curTime)
     curTime = Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
 
     return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)

--- a/src/platform/Ameba/SystemTimeSupport.cpp
+++ b/src/platform/Ameba/SystemTimeSupport.cpp
@@ -62,6 +62,9 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64(void)
 
 CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & curTime)
 {
+    // TODO(19081): This platform does not properly error out if wall clock has
+    //              not been set.  For now, short circuit this.
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     time_t seconds;
     struct rtkTimeVal tv;
 
@@ -105,6 +108,9 @@ CHIP_ERROR InitClock_RealTime()
         Clock::Microseconds64((static_cast<uint64_t>(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD) * UINT64_C(1000000)));
     // Use CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD as the initial value of RealTime.
     // Then the RealTime obtained from GetClock_RealTime will be always valid.
+    //
+    // TODO(19081): This is broken because it causes the platform to report
+    //              that it does have wall clock time when it actually doesn't.
     return System::SystemClock().SetClock_RealTime(curTime);
 }
 

--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -53,6 +53,7 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
     // TODO(19081): This platform does not properly error out if wall clock has
     //              not been set.  For now, short circuit this.
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#if 0
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
     {
@@ -69,6 +70,7 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
     static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
     aCurTime = Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
     return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)

--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -122,12 +122,14 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
     // TODO(19081): This platform does not properly error out if wall clock has
     //              not been set.  For now, short circuit this.
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#if 0
     if (sBootTimeUS == 0)
     {
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
     }
     aCurTime = Clock::Microseconds64(sBootTimeUS + GetClock_Monotonic());
     return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Clock::Milliseconds64 & aCurTime)

--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -119,6 +119,9 @@ uint64_t GetClock_MonotonicHiRes(void)
 
 CHIP_ERROR ClockImpl::GetClock_RealTime(Clock::Microseconds64 & aCurTime)
 {
+    // TODO(19081): This platform does not properly error out if wall clock has
+    //              not been set.  For now, short circuit this.
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     if (sBootTimeUS == 0)
     {
         return CHIP_ERROR_REAL_TIME_NOT_SYNCED;
@@ -157,6 +160,9 @@ CHIP_ERROR InitClock_RealTime()
         Clock::Microseconds64((static_cast<uint64_t>(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD) * UINT64_C(1000000)));
     // Use CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD as the initial value of RealTime.
     // Then the RealTime obtained from GetClock_RealTime will be always valid.
+    //
+    // TODO(19081): This is broken because it causes the platform to report
+    //              that it does have wall clock time when it actually doesn't.
     return System::SystemClock().SetClock_RealTime(curTime);
 }
 

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -73,6 +73,9 @@ Milliseconds64 ClockImpl::GetMonotonicMilliseconds64()
 
 CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
 {
+    // TODO(19081): This platform does not properly error out if wall clock has
+    //              not been set.  For now, short circuit this.
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
     {
@@ -124,6 +127,9 @@ CHIP_ERROR InitClock_RealTime()
         Clock::Microseconds64((static_cast<uint64_t>(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD) * UINT64_C(1000000)));
     // Use CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD as the initial value of RealTime.
     // Then the RealTime obtained from GetClock_RealTime will be always valid.
+    //
+    // TODO(19081): This is broken because it causes the platform to report
+    //              that it does have wall clock time when it actually doesn't.
     return System::SystemClock().SetClock_RealTime(curTime);
 }
 

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -76,6 +76,7 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
     // TODO(19081): This platform does not properly error out if wall clock has
     //              not been set.  For now, short circuit this.
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#if 0
     struct timeval tv;
     if (gettimeofday(&tv, nullptr) != 0)
     {
@@ -92,6 +93,7 @@ CHIP_ERROR ClockImpl::GetClock_RealTime(Microseconds64 & aCurTime)
     static_assert(CHIP_SYSTEM_CONFIG_VALID_REAL_TIME_THRESHOLD >= 0, "We might be letting through negative tv_sec values!");
     aCurTime = Microseconds64((static_cast<uint64_t>(tv.tv_sec) * UINT64_C(1000000)) + static_cast<uint64_t>(tv.tv_usec));
     return CHIP_NO_ERROR;
+#endif
 }
 
 CHIP_ERROR ClockImpl::GetClock_RealTimeMS(Milliseconds64 & aCurTime)


### PR DESCRIPTION
#### Problem

Most of our in-tree example server platforms do not have wall clock time.
But to complicate matters, most are also reporting that they _do_ have wall
clock time through the GetClock_RealTime interface.  With #19119, this is
now breaking CASE on these platforms.

#### Change overview

This commit does two things: first, where in-tree example platforms are seen
by inspection to be giving obviously incorrect time, GetClock_RealTime now
returns an error.  Second, a default policy is injected from the server code
that ignores NotBefore / NotAfter validation.  This prevents NotBefore / NotAfter
certificate validation breakages in other server implementations, whether in tree
or out of tree, and is pragmatic in that it recognizes that many server-oriented
nodes may not have access to a reliable time source.

Fixes #19459

#### Testing

* Tested commissioning on EFR32 to verify the fix
* Tested commissioning on ESP32 to verify no regressions
* Instrumented ESP32 to inject an incorrect wall clock time outside of the certificate validity period and verified that the new policy in Server.h could tolerate this