### PR TITLE
Update existing example app to support switch cluster event

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -25,6 +25,7 @@
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/clusters/software-diagnostics-server/software-diagnostics-server.h>
+#include <app/clusters/switch-server/switch-server.h>
 #include <app/server/Server.h>
 #include <app/util/af.h>
 #include <lib/support/CHIPMem.h>
@@ -147,6 +148,52 @@ void HandleGeneralFaultEvent(intptr_t arg)
     }
 }
 
+/**
+ * Should be called when a switch operation takes place on the Node.
+ */
+void HandleSwitchEvent(intptr_t arg)
+{
+    uint32_t eventId = static_cast<uint32_t>(arg);
+
+    EndpointId endpoint      = 1;
+    uint8_t newPosition      = 20;
+    uint8_t previousPosition = 10;
+    uint8_t count            = 3;
+
+    if (eventId == Clusters::Switch::Events::SwitchLatched::Id)
+    {
+        Clusters::SwitchServer::Instance().OnSwitchLatch(endpoint, newPosition);
+    }
+    else if (eventId == Clusters::Switch::Events::InitialPress::Id)
+    {
+        Clusters::SwitchServer::Instance().OnInitialPress(endpoint, newPosition);
+    }
+    else if (eventId == Clusters::Switch::Events::LongPress::Id)
+    {
+        Clusters::SwitchServer::Instance().OnLongPress(endpoint, newPosition);
+    }
+    else if (eventId == Clusters::Switch::Events::ShortRelease::Id)
+    {
+        Clusters::SwitchServer::Instance().OnShortRelease(endpoint, previousPosition);
+    }
+    else if (eventId == Clusters::Switch::Events::LongRelease::Id)
+    {
+        Clusters::SwitchServer::Instance().OnLongRelease(endpoint, previousPosition);
+    }
+    else if (eventId == Clusters::Switch::Events::MultiPressOngoing::Id)
+    {
+        Clusters::SwitchServer::Instance().OnMultiPressOngoing(endpoint, newPosition, count);
+    }
+    else if (eventId == Clusters::Switch::Events::MultiPressComplete::Id)
+    {
+        Clusters::SwitchServer::Instance().OnMultiPressComplete(endpoint, newPosition, count);
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Unknow event ID:%d", eventId);
+    }
+}
+
 // when the shell is enabled, don't intercept signals since it prevents the user from
 // using expected commands like CTRL-C to quit the application. (see issue #17845)
 // We should stop using signals for those faults, and move to a different notification
@@ -223,6 +270,42 @@ void OnGeneralFaultSignalHandler(int signum)
     PlatformMgr().ScheduleWork(HandleGeneralFaultEvent, static_cast<intptr_t>(eventId));
 }
 
+void OnSwitchSignalHandler(int signum)
+{
+    ChipLogDetail(DeviceLayer, "Caught signal %d", signum);
+
+    uint32_t eventId;
+    switch (signum)
+    {
+    case SIGTSTP:
+        eventId = Clusters::Switch::Events::SwitchLatched::Id;
+        break;
+    case SIGSTOP:
+        eventId = Clusters::Switch::Events::InitialPress::Id;
+        break;
+    case SIGTTOU:
+        eventId = Clusters::Switch::Events::LongPress::Id;
+        break;
+    case SIGWINCH:
+        eventId = Clusters::Switch::Events::ShortRelease::Id;
+        break;
+    case SIGQUIT:
+        eventId = Clusters::Switch::Events::LongRelease::Id;
+        break;
+    case SIGFPE:
+        eventId = Clusters::Switch::Events::MultiPressOngoing::Id;
+        break;
+    case SIGPIPE:
+        eventId = Clusters::Switch::Events::MultiPressComplete::Id;
+        break;
+    default:
+        ChipLogError(NotSpecified, "Unhandled signal: Should never happens");
+        chipDie();
+        break;
+    }
+
+    PlatformMgr().ScheduleWork(HandleSwitchEvent, static_cast<intptr_t>(eventId));
+}
 void SetupSignalHandlers()
 {
     // sigaction is not used here because Tsan interceptors seems to
@@ -238,6 +321,13 @@ void SetupSignalHandlers()
     signal(SIGUSR2, OnGeneralFaultSignalHandler);
     signal(SIGHUP, OnGeneralFaultSignalHandler);
     signal(SIGTTIN, OnGeneralFaultSignalHandler);
+    signal(SIGTSTP, OnSwitchSignalHandler);
+    signal(SIGSTOP, OnSwitchSignalHandler);
+    signal(SIGTTOU, OnSwitchSignalHandler);
+    signal(SIGWINCH, OnSwitchSignalHandler);
+    signal(SIGQUIT, OnSwitchSignalHandler);
+    signal(SIGFPE, OnSwitchSignalHandler);
+    signal(SIGPIPE, OnSwitchSignalHandler);
 }
 #endif // !defined(ENABLE_CHIP_SHELL)
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* switch cluster event APIs have been moved from platform layer to app domain, currently, CSG does not have a way to validate these events.

* Fixes #19007

#### Change overview
Update existing example app to support switch cluster event.

Please note, this change is still using the signal to trigger the events, #19114 is created to migrate to use pipe to send those events, but this is still under discussion with CSG on which client we should use to send those pipe command and what command format should look like .....and CSG need to update the related test cases accordingly.

#### Testing
How was this tested? (at least one bullet point required)
* On Server Side:
```
sudo rm -rf /tmp/chip_*
./chip-all-clusters-app
```

* Open an new terminal and send the signal:
```
yufengwang@yufengwang:~$ ps -A | grep chip
3336771 pts/4    00:00:00 chip-all-cluste
yufengwang@yufengwang:~$ kill -SIGTSTP 3336771
```

* Confirm the SwitchLatch event is logged from the server log. 
```
[1654880643.204103][3336771:3336771] CHIP:ZCL: SwitchServer: OnSwitchLatch
[1654880643.204151][3336771:3336771] CHIP:EVL: LogEvent event number: 0x0000000000080001 priority: 1, endpoint id:  0x1 cluster id: 0x0000_003B event id: 0x0 Sys timestamp: 0x0000000056B86A93
```





