### PR TITLE
Convert CharSpan to C++ String for proper comparison.

### DIFF
--- a/src/app/tests/suites/commands/log/LogCommands.cpp
+++ b/src/app/tests/suites/commands/log/LogCommands.cpp
@@ -34,7 +34,7 @@ CHIP_ERROR LogCommands::UserPrompt(const char * identity,
     {
         std::string line;
         std::getline(std::cin, line);
-        if (line != value.expectedValue.Value().data())
+        if (line != std::string(value.expectedValue.Value().data(), value.expectedValue.Value().size()))
         {
             return ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT);
         }


### PR DESCRIPTION
#### Problem
When comparing CharSpan to C++ String, we need to convert CharSpan to a string and then do the comparison. 
* Fix incorrect comparison in UserPrompt.
* Fixes #19475 

#### Change overview
- Convert CharSpan to C++ string using the correct size and then do the comparison. 

#### Testing
* Validated that the input now correctly accepts the value given. 