### PR TITLE
Fix IM protocol msg type doxygen header

### DIFF
--- a/src/protocols/interaction_model/Constants.h
+++ b/src/protocols/interaction_model/Constants.h
@@ -50,7 +50,7 @@ namespace InteractionModel {
 constexpr uint16_t kVersion = 0;
 
 /**
- * SecureChannel Protocol Message Types
+ * Interaction Model Protocol Message Types
  */
 enum class MsgType : uint8_t
 {


### PR DESCRIPTION
#### Problem
Doxygen Header specifies the message type constants for IM protocol as Secure Channel

#### Change overview
Correct the header

#### Testing
Minor doc fix, no testing required
