### PR TITLE
Make darwin-framework-tool constraint handling handle optionals correctly

### DIFF
--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -250,14 +250,6 @@ protected:
         return ConstraintsChecker::CheckConstraintIsHexString(itemName, value, expectHexString);
     }
 
-    bool CheckConstraintNotValue(
-        const char * _Nonnull itemName, const NSString * _Nonnull current, const NSString * _Nonnull expected)
-    {
-        const chip::CharSpan currentValue([current UTF8String], [current lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
-        const chip::CharSpan expectedValue([expected UTF8String], [expected lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
-        return ConstraintsChecker::CheckConstraintNotValue(itemName, currentValue, expectedValue);
-    }
-
     template <typename T> bool CheckConstraintContains(const char * _Nonnull itemName, const NSArray * _Nonnull current, T expected)
     {
         for (id currentElement in current) {
@@ -283,8 +275,31 @@ protected:
         return true;
     }
 
-    bool CheckConstraintNotValue(const char * _Nonnull itemName, const NSData * _Nonnull current, const NSData * _Nonnull expected)
+    bool CheckConstraintNotValue(
+        const char * _Nonnull itemName, const NSString * _Nullable current, const NSString * _Nullable expected)
     {
+        if (current == nil && expected == nil) {
+            Exit(std::string(itemName) + " got unexpected value. Both values are nil.");
+            return false;
+        }
+        if ((current == nil) != (expected == nil)) {
+            return true;
+        }
+        const chip::CharSpan currentValue([current UTF8String], [current lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
+        const chip::CharSpan expectedValue([expected UTF8String], [expected lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
+        return ConstraintsChecker::CheckConstraintNotValue(itemName, currentValue, expectedValue);
+    }
+
+    bool CheckConstraintNotValue(
+        const char * _Nonnull itemName, const NSData * _Nullable current, const NSData * _Nullable expected)
+    {
+        if (current == nil && expected == nil) {
+            Exit(std::string(itemName) + " got unexpected value. Both values are nil.");
+            return false;
+        }
+        if ((current == nil) != (expected == nil)) {
+            return true;
+        }
         const chip::ByteSpan currentValue(static_cast<const uint8_t *>([current bytes]), [current length]);
         const chip::ByteSpan expectedValue(static_cast<const uint8_t *>([expected bytes]), [expected length]);
         return ConstraintsChecker::CheckConstraintNotValue(itemName, currentValue, expectedValue);
@@ -308,7 +323,7 @@ protected:
     }
 
     template <typename T>
-    bool CheckConstraintNotValue(const char * _Nonnull itemName, const NSNumber * _Nonnull current, T expected)
+    bool CheckConstraintNotValue(const char * _Nonnull itemName, const NSNumber * _Nullable current, T expected)
     {
         return CheckConstraintNotValue(itemName, current, @(expected));
     }
@@ -349,6 +364,21 @@ protected:
     bool CheckConstraintMaxValue(const char * _Nonnull itemName, T current, const NSNumber * _Nonnull expected)
     {
         return ConstraintsChecker::CheckConstraintMaxValue(itemName, current, [expected unsignedLongLongValue]);
+    }
+
+    bool CheckConstraintHasValue(const char * _Nonnull itemName, id _Nullable current, bool shouldHaveValue)
+    {
+        if (shouldHaveValue && (current == nil)) {
+            Exit(std::string(itemName) + " expected to have a value but doesn't");
+            return false;
+        }
+
+        if (!shouldHaveValue && (current != nil)) {
+            Exit(std::string(itemName) + " not expected to have a value but does");
+            return false;
+        }
+
+        return true;
     }
 
     bool CheckValueAsString(const char * _Nonnull itemName, const id _Nonnull current, const NSString * _Nonnull expected)

--- a/examples/darwin-framework-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt
@@ -1,5 +1,13 @@
 {{#if hasExpectedConstraints}}
     {{~#*inline "item"}}{{asLowerCamelCase name}}{{/inline}}
+
+    {{~#if isOptional}}
+        {{~#if (hasProperty expectedConstraints "hasValue")}}VerifyOrReturn(CheckConstraintHasValue("{{>item}}", {{>actualValue}}, {{expectedConstraints.hasValue}}));{{/if}}
+        if ({{>actualValue}} != nil) {
+    {{else if isNullable}}
+        if ({{>actualValue}} != nil) {
+    {{/if}}
+
     {{#if (hasProperty expectedConstraints "type")}}VerifyOrReturn(CheckConstraintType("{{>item}}", "", "{{expectedConstraints.type}}"));{{/if}}
 
     {{~#if (hasProperty expectedConstraints "format")}}VerifyOrReturn(CheckConstraintFormat("{{>item}}", "", "{{expectedConstraints.format}}"));{{/if}}
@@ -19,49 +27,36 @@
     {{~#if (hasProperty expectedConstraints "maxLength")}}VerifyOrReturn(CheckConstraintMaxLength("{{>item}}", [{{>actualValue}} length], {{expectedConstraints.maxLength}}));{{/if}}
 
     {{~#if (hasProperty expectedConstraints "minValue")}}
-    if ({{>actualValue}} != nil)
-    {
-        VerifyOrReturn(CheckConstraintMinValue<{{chipType}}>("{{>item}}", [{{>actualValue}} {{asObjectiveCNumberType "" type true}}Value], {{asTypedLiteral expectedConstraints.minValue type}}));
-    }
+    VerifyOrReturn(CheckConstraintMinValue<{{chipType}}>("{{>item}}", [{{>actualValue}} {{asObjectiveCNumberType "" type true}}Value], {{asTypedLiteral expectedConstraints.minValue type}}));
     {{/if}}
 
     {{~#if (hasProperty expectedConstraints "maxValue")}}
-    if ({{>actualValue}} != nil)
-    {
-        VerifyOrReturn(CheckConstraintMaxValue<{{chipType}}>("{{>item}}", [{{>actualValue}} {{asObjectiveCNumberType "" type true}}Value], {{asTypedLiteral expectedConstraints.maxValue type}}));
-    }
+    VerifyOrReturn(CheckConstraintMaxValue<{{chipType}}>("{{>item}}", [{{>actualValue}} {{asObjectiveCNumberType "" type true}}Value], {{asTypedLiteral expectedConstraints.maxValue type}}));
     {{/if}}
 
     {{~#if (hasProperty expectedConstraints "contains")}}
-    if ({{>actualValue}} != nil)
-    {
-        {{#chip_tests_iterate_expected_list expectedConstraints.contains}}
-    VerifyOrReturn(CheckConstraintContains("{{asLowerCamelCase name}}", {{>actualValue}}, {{asTypedLiteral value type}}));
-        {{/chip_tests_iterate_expected_list}}
-    }
+      {{#chip_tests_iterate_expected_list expectedConstraints.contains}}
+        VerifyOrReturn(CheckConstraintContains("{{asLowerCamelCase name}}", {{>actualValue}}, {{asTypedLiteral value type}}));
+      {{/chip_tests_iterate_expected_list}}
     {{/if}}
 
     {{~#if (hasProperty expectedConstraints "excludes")}}
-    if ({{>actualValue}} != nil)
-    {
-        {{#chip_tests_iterate_expected_list expectedConstraints.excludes}}
-    VerifyOrReturn(CheckConstraintExcludes("{{asLowerCamelCase name}}", {{>actualValue}}, {{asTypedLiteral value type}}));
-        {{/chip_tests_iterate_expected_list}}
-    }
+      {{#chip_tests_iterate_expected_list expectedConstraints.excludes}}
+        VerifyOrReturn(CheckConstraintExcludes("{{asLowerCamelCase name}}", {{>actualValue}}, {{asTypedLiteral value type}}));
+      {{/chip_tests_iterate_expected_list}}
+    {{/if}}
+
+    {{~#if isOptional}}
+      }
+    {{else if isNullable}}
+      }
     {{/if}}
 
     {{~#if (hasProperty expectedConstraints "notValue")}}
         {{#if (isLiteralNull expectedConstraints.notValue)}}
-    VerifyOrReturn(CheckValueNonNull("{{>item}}", {{>actualValue}}));
+          VerifyOrReturn(CheckValueNonNull("{{>item}}", {{>actualValue}}));
         {{else}}
-    if ({{>actualValue}} != nil)
-    {
-            {{#if (isString type)}}
-        VerifyOrReturn(CheckConstraintNotValue("{{>item}}", {{>actualValue}}, {{asTypedLiteral expectedConstraints.notValue type}}));
-            {{else}}
-        VerifyOrReturn(CheckConstraintNotValue("{{>item}}", {{>actualValue}}, {{asTypedLiteral expectedConstraints.notValue type}}));
-            {{/if}}
-    }
+          VerifyOrReturn(CheckConstraintNotValue("{{>item}}", {{>actualValue}}, {{asTypedLiteral expectedConstraints.notValue type}}));
         {{/if}}
     {{/if}}
 {{/if}}


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/19151

#### Problem
No support for "hasValue" constraint, unclear handling of the cases when an optional has no value.

#### Change overview
* Add hasValue support.
* For optionals and nullables, do an up-front check for nil around all constraints except "notValue".
* For "notValue" handle nullables and optionals properly for all cases, not just the "notValue: null" case.

#### Testing
Should not have behavior changes so far, just better checking for things.