### PR TITLE
Move apps build timeout from 30 to 45 minutes. Darwin builds keep tim…

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,7 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Apps
-              timeout-minutes: 30
+              timeout-minutes: 45
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \


### PR DESCRIPTION
…ing out

#### Problem
Darwin builds timeout, makes PRs  and master red in CI

#### Change overview
Timeout increase: 30min to 45min

#### Testing
N/A - CI will validate, this is a trivial change.