### PR TITLE
Fix OnOff cmd OffWithEffect action order

### DIFF
--- a/examples/lighting-app/efr32/include/LightingManager.h
+++ b/examples/lighting-app/efr32/include/LightingManager.h
@@ -25,6 +25,7 @@
 
 #include "FreeRTOS.h"
 #include "timers.h" // provides FreeRTOS timer support
+#include <app/clusters/on-off-server/on-off-server.h>
 
 #include <lib/core/CHIPError.h>
 
@@ -58,6 +59,8 @@ public:
     typedef void (*Callback_fn_completed)(Action_t);
     void SetCallbacks(Callback_fn_initiated aActionInitiated_CB, Callback_fn_completed aActionCompleted_CB);
 
+    static void OnTriggerOffWithEffect(OnOffEffect * effect);
+
 private:
     friend LightingManager & LightMgr(void);
     State_t mState;
@@ -68,6 +71,7 @@ private:
     bool mAutoTurnOff;
     uint32_t mAutoTurnOffDuration;
     bool mAutoTurnOffTimerArmed;
+    bool mOffEffectArmed;
 
     void CancelTimer(void);
     void StartTimer(uint32_t aTimeoutMs);
@@ -75,6 +79,7 @@ private:
     static void TimerEventHandler(TimerHandle_t xTimer);
     static void AutoTurnOffTimerEventHandler(AppEvent * aEvent);
     static void ActuatorMovementTimerEventHandler(AppEvent * aEvent);
+    static void OffEffectTimerEventHandler(AppEvent * aEvent);
 
     static LightingManager sLight;
 };

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -160,52 +160,6 @@ Identify gIdentify = {
     OnTriggerIdentifyEffect,
 };
 
-/**********************************************************
- * OffWithEffect Callbacks
- *********************************************************/
-
-void OnTriggerOffWithEffect(OnOffEffect * effect)
-{
-    chip::app::Clusters::OnOff::OnOffEffectIdentifier effectId = effect->mEffectIdentifier;
-    uint8_t effectVariant                                      = effect->mEffectVariant;
-
-    // Uses print outs until we can support the effects
-    if (effectId == EMBER_ZCL_ON_OFF_EFFECT_IDENTIFIER_DELAYED_ALL_OFF)
-    {
-        if (effectVariant == EMBER_ZCL_ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_FADE_TO_OFF_IN_0P8_SECONDS)
-        {
-            ChipLogProgress(Zcl, "EMBER_ZCL_ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_FADE_TO_OFF_IN_0P8_SECONDS");
-        }
-        else if (effectVariant == EMBER_ZCL_ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_NO_FADE)
-        {
-            ChipLogProgress(Zcl, "EMBER_ZCL_ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_NO_FADE");
-        }
-        else if (effectVariant ==
-                 EMBER_ZCL_ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_50_PERCENT_DIM_DOWN_IN_0P8_SECONDS_THEN_FADE_TO_OFF_IN_12_SECONDS)
-        {
-            ChipLogProgress(Zcl,
-                            "EMBER_ZCL_ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_50_PERCENT_DIM_DOWN_IN_0P8_SECONDS_THEN_FADE_TO_OFF_"
-                            "IN_12_SECONDS");
-        }
-    }
-    else if (effectId == EMBER_ZCL_ON_OFF_EFFECT_IDENTIFIER_DYING_LIGHT)
-    {
-        if (effectVariant ==
-            EMBER_ZCL_ON_OFF_DYING_LIGHT_EFFECT_VARIANT_20_PERCENTER_DIM_UP_IN_0P5_SECONDS_THEN_FADE_TO_OFF_IN_1_SECOND)
-        {
-            ChipLogProgress(
-                Zcl, "EMBER_ZCL_ON_OFF_DYING_LIGHT_EFFECT_VARIANT_20_PERCENTER_DIM_UP_IN_0P5_SECONDS_THEN_FADE_TO_OFF_IN_1_SECOND");
-        }
-    }
-}
-
-OnOffEffect gEffect = {
-    chip::EndpointId{ 1 },
-    OnTriggerOffWithEffect,
-    EMBER_ZCL_ON_OFF_EFFECT_IDENTIFIER_DELAYED_ALL_OFF,
-    static_cast<uint8_t>(EMBER_ZCL_ON_OFF_DELAYED_ALL_OFF_EFFECT_VARIANT_FADE_TO_OFF_IN_0P8_SECONDS),
-};
-
 } // namespace
 
 using namespace chip::TLV;

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -383,13 +383,7 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
 #endif // EMBER_AF_PLUGIN_SCENES
 
             OnOff::Attributes::GlobalSceneControl::Set(endpoint, false);
-
-            status = setOnOffValue(endpoint, Commands::Off::Id, false);
             Attributes::OnTime::Set(endpoint, 0);
-        }
-        else
-        {
-            status = setOnOffValue(endpoint, Commands::Off::Id, false);
         }
 
         // Only apply effect if OnOff is on
@@ -405,6 +399,8 @@ bool OnOffServer::offWithEffectCommand(app::CommandHandler * commandObj, const a
                 effect->mOffWithEffectTrigger(effect);
             }
         }
+
+        status = setOnOffValue(endpoint, Commands::Off::Id, false);
     }
     else
     {


### PR DESCRIPTION
#### Problem
fixes #15991

#### Change overview
- Call the OffEffect callback before setting the attribute OnOff to false
- Basic application implementation that can deal with executing the off effect as a demo of how it can be done. (efr32 dev board currently does not handle dimming of the physical led)

#### Testing
Build and commission the lighting app on efr32
`send chip-tool onoff off-with-effect <0|1>  <0|1|2> <node> 1`

