### PR TITLE
iOS TvCasting app: Implemented commissioner discovery and UDC requests

### DIFF
--- a/config/ios/CHIPProjectConfig.h
+++ b/config/ios/CHIPProjectConfig.h
@@ -40,6 +40,8 @@
 
 #define CHIP_CONFIG_MAX_SOFTWARE_VERSION_LENGTH 128
 
+#ifndef CHIP_CONFIG_KVS_PATH
 #define CHIP_CONFIG_KVS_PATH "chip.store"
+#endif
 
 #endif /* CHIPPROJECTCONFIG_H */

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
@@ -15,6 +15,7 @@
  *    limitations under the License.
  */
 
+#import "DiscoveredNodeData.h"
 #import <Foundation/Foundation.h>
 
 #ifndef CastingServerBridge_h
@@ -24,8 +25,13 @@
 
 + (CastingServerBridge *)getSharedInstance;
 
-// TBD: placeholder will be replaced with true CastingServer functions
-- (int)add:(int)a secondNum:(int)b;
+- (bool)discoverCommissioners;
+
+- (DiscoveredNodeData *)getDiscoveredCommissioner:(int)index;
+
+- (bool)sendUserDirectedCommissioningRequest:(NSString *)commissionerIpAddress
+                            commissionerPort:(uint16_t)commissionerPort
+                           platformInterface:(unsigned int)platformInterface;
 
 @end
 

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
@@ -23,15 +23,20 @@
 
 @interface CastingServerBridge : NSObject
 
-+ (CastingServerBridge *)getSharedInstance;
++ (CastingServerBridge * _Nullable)getSharedInstance;
 
-- (bool)discoverCommissioners;
+- (void)discoverCommissioners:(dispatch_queue_t _Nonnull)clientQueue
+    discoveryRequestSentHandler:(nullable void (^)(bool))discoveryRequestSentHandler;
 
-- (DiscoveredNodeData *)getDiscoveredCommissioner:(int)index;
+- (void)getDiscoveredCommissioner:(int)index
+                      clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+    discoveredCommissionerHandler:(nullable void (^)(DiscoveredNodeData * _Nullable))discoveredCommissionerHandler;
 
-- (bool)sendUserDirectedCommissioningRequest:(NSString *)commissionerIpAddress
+- (void)sendUserDirectedCommissioningRequest:(NSString * _Nonnull)commissionerIpAddress
                             commissionerPort:(uint16_t)commissionerPort
-                           platformInterface:(unsigned int)platformInterface;
+                           platformInterface:(unsigned int)platformInterface
+                                 clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+                       udcRequestSentHandler:(nullable void (^)(bool))udcRequestSentHandler;
 
 @end
 

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeData.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeData.h
@@ -36,7 +36,7 @@
 
 @property uint16_t pairingHint;
 
-@property uint8_t * rotatingId;
+@property const uint8_t * rotatingId;
 
 @property size_t rotatingIdLen;
 
@@ -51,8 +51,6 @@
 @property NSMutableArray * ipAddresses;
 
 @property size_t numIPs;
-
-- (DiscoveredNodeData *)initWithChipDiscoveredNodeData:(void *)chipDiscoveredNodedata;
 
 - (DiscoveredNodeData *)initWithDeviceName:(NSString *)deviceName vendorId:(uint16_t)vendorId productId:(uint16_t)productId;
 

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeData.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeData.h
@@ -1,0 +1,61 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#ifndef DiscoveredNodeData_h
+#define DiscoveredNodeData_h
+
+@interface DiscoveredNodeData : NSObject
+
+@property NSString * deviceName;
+
+@property uint16_t vendorId;
+
+@property uint16_t productId;
+
+@property uint16_t deviceType;
+
+@property uint16_t longDiscriminator;
+
+@property uint8_t commissioningMode;
+
+@property uint16_t pairingHint;
+
+@property uint8_t * rotatingId;
+
+@property size_t rotatingIdLen;
+
+@property NSString * instanceName;
+
+@property uint16_t port;
+
+@property NSString * hostName;
+
+@property unsigned int platformInterface;
+
+@property NSMutableArray * ipAddresses;
+
+@property size_t numIPs;
+
+- (DiscoveredNodeData *)initWithChipDiscoveredNodeData:(void *)chipDiscoveredNodedata;
+
+- (DiscoveredNodeData *)initWithDeviceName:(NSString *)deviceName vendorId:(uint16_t)vendorId productId:(uint16_t)productId;
+
+@end
+
+#endif /* DiscoveredNodeData_h */

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeData.mm
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeData.mm
@@ -22,41 +22,6 @@
 
 @implementation DiscoveredNodeData
 
-- (DiscoveredNodeData *)initWithChipDiscoveredNodeData:(void *)chipDiscoveredNodedata
-{
-    self = [super init];
-    if (self) {
-        chip::Dnssd::DiscoveredNodeData * data = (chip::Dnssd::DiscoveredNodeData *) chipDiscoveredNodedata;
-
-        // from CommissionNodeData
-        _deviceType = data->commissionData.deviceType;
-        _vendorId = data->commissionData.vendorId;
-        _productId = data->commissionData.productId;
-        _longDiscriminator = data->commissionData.longDiscriminator;
-        _commissioningMode = data->commissionData.commissioningMode;
-        _pairingHint = data->commissionData.pairingHint;
-        _deviceName = [NSString stringWithCString:data->commissionData.deviceName encoding:NSASCIIStringEncoding];
-        _rotatingIdLen = data->commissionData.rotatingIdLen;
-        _rotatingId = data->commissionData.rotatingId;
-        _instanceName = [NSString stringWithCString:data->commissionData.instanceName encoding:NSASCIIStringEncoding];
-
-        // from CommonResolutionData
-        _port = data->resolutionData.port;
-        _hostName = [NSString stringWithCString:data->resolutionData.hostName encoding:NSASCIIStringEncoding];
-        _platformInterface = data->resolutionData.interfaceId.GetPlatformInterface();
-        _numIPs = data->resolutionData.numIPs;
-        if (data->resolutionData.numIPs > 0) {
-            _ipAddresses = [NSMutableArray new];
-        }
-        for (int i = 0; i < data->resolutionData.numIPs; i++) {
-            char addrCString[chip::Inet::IPAddress::kMaxStringLength];
-            data->resolutionData.ipAddress->ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
-            _ipAddresses[i] = [NSString stringWithCString:addrCString encoding:NSASCIIStringEncoding];
-        }
-    }
-    return self;
-}
-
 - (DiscoveredNodeData *)initWithDeviceName:(NSString *)deviceName vendorId:(uint16_t)vendorId productId:(uint16_t)productId
 {
     self = [super init];
@@ -71,6 +36,38 @@
 - (NSString *)description
 {
     return [NSString stringWithFormat:@"%@ with Product ID: %d and Vendor ID: %d", _deviceName, _productId, _vendorId];
+}
+
+- (BOOL)isEqualToDiscoveredNodeData:(DiscoveredNodeData *)other
+{
+    return [self.instanceName isEqualToString:other.instanceName];
+}
+
+- (BOOL)isEqual:(id)other
+{
+    if (other == nil) {
+        return NO;
+    }
+
+    if (self == other) {
+        return YES;
+    }
+
+    if (![other isKindOfClass:[DiscoveredNodeData class]]) {
+        return NO;
+    }
+
+    return [self isEqualToDiscoveredNodeData:(DiscoveredNodeData *) other];
+}
+
+- (NSUInteger)hash
+{
+    const NSUInteger prime = 31;
+    NSUInteger result = 1;
+
+    result = prime * result + [self.instanceName hash];
+
+    return result;
 }
 
 @end

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeData.mm
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeData.mm
@@ -1,0 +1,76 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "DiscoveredNodeData.h"
+#include <lib/dnssd/Resolver.h>
+
+@implementation DiscoveredNodeData
+
+- (DiscoveredNodeData *)initWithChipDiscoveredNodeData:(void *)chipDiscoveredNodedata
+{
+    self = [super init];
+    if (self) {
+        chip::Dnssd::DiscoveredNodeData * data = (chip::Dnssd::DiscoveredNodeData *) chipDiscoveredNodedata;
+
+        // from CommissionNodeData
+        _deviceType = data->commissionData.deviceType;
+        _vendorId = data->commissionData.vendorId;
+        _productId = data->commissionData.productId;
+        _longDiscriminator = data->commissionData.longDiscriminator;
+        _commissioningMode = data->commissionData.commissioningMode;
+        _pairingHint = data->commissionData.pairingHint;
+        _deviceName = [NSString stringWithCString:data->commissionData.deviceName encoding:NSASCIIStringEncoding];
+        _rotatingIdLen = data->commissionData.rotatingIdLen;
+        _rotatingId = data->commissionData.rotatingId;
+        _instanceName = [NSString stringWithCString:data->commissionData.instanceName encoding:NSASCIIStringEncoding];
+
+        // from CommonResolutionData
+        _port = data->resolutionData.port;
+        _hostName = [NSString stringWithCString:data->resolutionData.hostName encoding:NSASCIIStringEncoding];
+        _platformInterface = data->resolutionData.interfaceId.GetPlatformInterface();
+        _numIPs = data->resolutionData.numIPs;
+        if (data->resolutionData.numIPs > 0) {
+            _ipAddresses = [NSMutableArray new];
+        }
+        for (int i = 0; i < data->resolutionData.numIPs; i++) {
+            char addrCString[chip::Inet::IPAddress::kMaxStringLength];
+            data->resolutionData.ipAddress->ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
+            _ipAddresses[i] = [NSString stringWithCString:addrCString encoding:NSASCIIStringEncoding];
+        }
+    }
+    return self;
+}
+
+- (DiscoveredNodeData *)initWithDeviceName:(NSString *)deviceName vendorId:(uint16_t)vendorId productId:(uint16_t)productId
+{
+    self = [super init];
+    if (self) {
+        _deviceName = deviceName;
+        _vendorId = vendorId;
+        _productId = productId;
+    }
+    return self;
+}
+
+- (NSString *)description
+{
+    return [NSString stringWithFormat:@"%@ with Product ID: %d and Vendor ID: %d", _deviceName, _productId, _vendorId];
+}
+
+@end

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeDataConverter.hpp
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeDataConverter.hpp
@@ -1,0 +1,32 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "DiscoveredNodeData.h"
+#include <lib/dnssd/Resolver.h>
+
+#ifndef DiscoveredNodeDataConverter_h
+#define DiscoveredNodeDataConverter_h
+
+@interface DiscoveredNodeDataConverter : NSObject
+
++ (DiscoveredNodeData *)convertToObjC:(const chip::Dnssd::DiscoveredNodeData *)chipDiscoveredNodedata;
+
+@end
+
+#endif /* DiscoveredNodeDataConverter_h */

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeDataConverter.mm
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/DiscoveredNodeDataConverter.mm
@@ -1,0 +1,58 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#import <Foundation/Foundation.h>
+
+#import "DiscoveredNodeDataConverter.hpp"
+
+@implementation DiscoveredNodeDataConverter
+
++ (DiscoveredNodeData *)convertToObjC:(const chip::Dnssd::DiscoveredNodeData *)chipDiscoveredNodeData
+{
+    DiscoveredNodeData * objCDiscoveredNodeData = [DiscoveredNodeData new];
+
+    // from CommissionNodeData
+    objCDiscoveredNodeData.deviceType = chipDiscoveredNodeData->commissionData.deviceType;
+    objCDiscoveredNodeData.vendorId = chipDiscoveredNodeData->commissionData.vendorId;
+    objCDiscoveredNodeData.productId = chipDiscoveredNodeData->commissionData.productId;
+    objCDiscoveredNodeData.longDiscriminator = chipDiscoveredNodeData->commissionData.longDiscriminator;
+    objCDiscoveredNodeData.commissioningMode = chipDiscoveredNodeData->commissionData.commissioningMode;
+    objCDiscoveredNodeData.pairingHint = chipDiscoveredNodeData->commissionData.pairingHint;
+    objCDiscoveredNodeData.deviceName = [NSString stringWithCString:chipDiscoveredNodeData->commissionData.deviceName
+                                                           encoding:NSASCIIStringEncoding];
+    objCDiscoveredNodeData.rotatingIdLen = chipDiscoveredNodeData->commissionData.rotatingIdLen;
+    objCDiscoveredNodeData.rotatingId = chipDiscoveredNodeData->commissionData.rotatingId;
+    objCDiscoveredNodeData.instanceName = [NSString stringWithCString:chipDiscoveredNodeData->commissionData.instanceName
+                                                             encoding:NSASCIIStringEncoding];
+
+    // from CommonResolutionData
+    objCDiscoveredNodeData.port = chipDiscoveredNodeData->resolutionData.port;
+    objCDiscoveredNodeData.hostName = [NSString stringWithCString:chipDiscoveredNodeData->resolutionData.hostName
+                                                         encoding:NSASCIIStringEncoding];
+    objCDiscoveredNodeData.platformInterface = chipDiscoveredNodeData->resolutionData.interfaceId.GetPlatformInterface();
+    objCDiscoveredNodeData.numIPs = chipDiscoveredNodeData->resolutionData.numIPs;
+    if (chipDiscoveredNodeData->resolutionData.numIPs > 0) {
+        objCDiscoveredNodeData.ipAddresses = [NSMutableArray new];
+    }
+    for (int i = 0; i < chipDiscoveredNodeData->resolutionData.numIPs; i++) {
+        char addrCString[chip::Inet::IPAddress::kMaxStringLength];
+        chipDiscoveredNodeData->resolutionData.ipAddress->ToString(addrCString, chip::Inet::IPAddress::kMaxStringLength);
+        objCDiscoveredNodeData.ipAddresses[i] = [NSString stringWithCString:addrCString encoding:NSASCIIStringEncoding];
+    }
+    return objCDiscoveredNodeData;
+}
+
+@end

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		3C7507AF28529A5F00D7DB3A /* CommissioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507AE28529A5F00D7DB3A /* CommissioningView.swift */; };
 		3C7507B72853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507B62853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift */; };
 		3C7507B92853EFF000D7DB3A /* CommissioningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */; };
+		3C7507BC2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507BB2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm */; };
 		3C9ACC05284ABF4000718B2D /* libTvCastingCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */; };
 		3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */; };
 		3CC0E8FC2841DD3400EC6A18 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */; };
@@ -30,6 +31,8 @@
 		3C7507AE28529A5F00D7DB3A /* CommissioningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommissioningView.swift; sourceTree = "<group>"; };
 		3C7507B62853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommissionerDiscoveryViewModel.swift; sourceTree = "<group>"; };
 		3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommissioningViewModel.swift; sourceTree = "<group>"; };
+		3C7507BB2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DiscoveredNodeDataConverter.mm; sourceTree = "<group>"; };
+		3C7507BD2857A72A00D7DB3A /* DiscoveredNodeDataConverter.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DiscoveredNodeDataConverter.hpp; sourceTree = "<group>"; };
 		3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libTvCastingCommon.a; path = lib/libTvCastingCommon.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC0E8F62841DD3400EC6A18 /* TvCasting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TvCasting.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TvCastingApp.swift; sourceTree = "<group>"; };
@@ -115,6 +118,8 @@
 				3CC0E9092841DD7000EC6A18 /* CastingServerBridge.mm */,
 				3C7507A52851187500D7DB3A /* DiscoveredNodeData.h */,
 				3C7507A62851188500D7DB3A /* DiscoveredNodeData.mm */,
+				3C7507BB2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm */,
+				3C7507BD2857A72A00D7DB3A /* DiscoveredNodeDataConverter.hpp */,
 			);
 			path = MatterBridge;
 			sourceTree = "<group>";
@@ -230,6 +235,7 @@
 				3C7507AD285299DF00D7DB3A /* CommissionerDiscoveryView.swift in Sources */,
 				3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */,
 				3C7507B92853EFF000D7DB3A /* CommissioningViewModel.swift in Sources */,
+				3C7507BC2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm in Sources */,
 				3C7507A72851188500D7DB3A /* DiscoveredNodeData.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
@@ -8,6 +8,11 @@
 
 /* Begin PBXBuildFile section */
 		3C75075C284B080900D7DB3A /* libmbedtls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C75075B284B07E800D7DB3A /* libmbedtls.a */; settings = {ATTRIBUTES = (Required, ); }; };
+		3C7507A72851188500D7DB3A /* DiscoveredNodeData.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507A62851188500D7DB3A /* DiscoveredNodeData.mm */; };
+		3C7507AD285299DF00D7DB3A /* CommissionerDiscoveryView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507AC285299DF00D7DB3A /* CommissionerDiscoveryView.swift */; };
+		3C7507AF28529A5F00D7DB3A /* CommissioningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507AE28529A5F00D7DB3A /* CommissioningView.swift */; };
+		3C7507B72853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507B62853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift */; };
+		3C7507B92853EFF000D7DB3A /* CommissioningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */; };
 		3C9ACC05284ABF4000718B2D /* libTvCastingCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */; };
 		3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */; };
 		3CC0E8FC2841DD3400EC6A18 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */; };
@@ -19,6 +24,12 @@
 /* Begin PBXFileReference section */
 		3C75075B284B07E800D7DB3A /* libmbedtls.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedtls.a; path = lib/libmbedtls.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3C75075E284C1DF800D7DB3A /* TvCasting.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = TvCasting.entitlements; sourceTree = "<group>"; };
+		3C7507A52851187500D7DB3A /* DiscoveredNodeData.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = DiscoveredNodeData.h; sourceTree = "<group>"; };
+		3C7507A62851188500D7DB3A /* DiscoveredNodeData.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DiscoveredNodeData.mm; sourceTree = "<group>"; };
+		3C7507AC285299DF00D7DB3A /* CommissionerDiscoveryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommissionerDiscoveryView.swift; sourceTree = "<group>"; };
+		3C7507AE28529A5F00D7DB3A /* CommissioningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommissioningView.swift; sourceTree = "<group>"; };
+		3C7507B62853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommissionerDiscoveryViewModel.swift; sourceTree = "<group>"; };
+		3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommissioningViewModel.swift; sourceTree = "<group>"; };
 		3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libTvCastingCommon.a; path = lib/libTvCastingCommon.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC0E8F62841DD3400EC6A18 /* TvCasting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TvCasting.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TvCastingApp.swift; sourceTree = "<group>"; };
@@ -80,6 +91,10 @@
 				3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */,
 				3CC0E8FD2841DD3500EC6A18 /* Assets.xcassets */,
 				3CC0E8FF2841DD3500EC6A18 /* Preview Content */,
+				3C7507AC285299DF00D7DB3A /* CommissionerDiscoveryView.swift */,
+				3C7507B62853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift */,
+				3C7507AE28529A5F00D7DB3A /* CommissioningView.swift */,
+				3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */,
 			);
 			path = TvCasting;
 			sourceTree = "<group>";
@@ -95,9 +110,11 @@
 		3CC0E9072841DD4B00EC6A18 /* MatterBridge */ = {
 			isa = PBXGroup;
 			children = (
-				3CC0E9092841DD7000EC6A18 /* CastingServerBridge.mm */,
 				3CC0E9082841DD6F00EC6A18 /* TvCasting-Bridging-Header.h */,
 				3CC0E90B2841DD8500EC6A18 /* CastingServerBridge.h */,
+				3CC0E9092841DD7000EC6A18 /* CastingServerBridge.mm */,
+				3C7507A52851187500D7DB3A /* DiscoveredNodeData.h */,
+				3C7507A62851188500D7DB3A /* DiscoveredNodeData.mm */,
 			);
 			path = MatterBridge;
 			sourceTree = "<group>";
@@ -206,9 +223,14 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3C7507AF28529A5F00D7DB3A /* CommissioningView.swift in Sources */,
 				3CC0E90A2841DD7000EC6A18 /* CastingServerBridge.mm in Sources */,
+				3C7507B72853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift in Sources */,
 				3CC0E8FC2841DD3400EC6A18 /* ContentView.swift in Sources */,
+				3C7507AD285299DF00D7DB3A /* CommissionerDiscoveryView.swift in Sources */,
 				3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */,
+				3C7507B92853EFF000D7DB3A /* CommissioningViewModel.swift in Sources */,
+				3C7507A72851188500D7DB3A /* DiscoveredNodeData.mm in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryView.swift
@@ -32,27 +32,44 @@ struct CommissionerDiscoveryView: View {
                 destination: CommissioningView(_selectedCommissioner: nil),
                 label: {
                     Text("Skip to manual commissioning >>")
+                        .frame(width: 300, height: 30, alignment: .center)
+                        .border(Color.black, width: 1)
                 }
             ).background(Color.blue)
                 .foregroundColor(Color.white)
                 .padding()
             
-            Text("Select a commissioner TV...")
+            Button("Discover commissioners", action: viewModel.discoverAndUpdate)
+                .frame(width: 200, height: 30, alignment: .center)
+                .border(Color.black, width: 1)
+                .background(Color.blue)
+                .foregroundColor(Color.white)
+                .padding()
             
-            ForEach(viewModel.commissioners) { commissioner in
-                NavigationLink(
-                    destination: CommissioningView(_selectedCommissioner: commissioner),
-                    label: {
-                        Text(commissioner.description)
-                    }
-                ).background(Color.blue)
+            if(viewModel.discoveryRequestStatus == false)
+            {
+                Text("Failed to send discovery request")
+            }
+            else if(!viewModel.commissioners.isEmpty)
+            {
+                Text("Select a commissioner TV...")
+                ForEach(viewModel.commissioners) { commissioner in
+                    NavigationLink(
+                        destination: CommissioningView(_selectedCommissioner: commissioner),
+                        label: {
+                            Text(commissioner.description)
+                        }
+                    )
+                    .frame(width: 350, height: 50, alignment: .center)
+                    .border(Color.black, width: 1)
+                    .background(Color.blue)
                     .foregroundColor(Color.white)
                     .padding(1)
+                }
             }
         }
         .navigationTitle("TV Discovery")
         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)
-        .onAppear(perform: viewModel.discoverAndUpdate)
     }
 }
 

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryView.swift
@@ -1,0 +1,63 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import SwiftUI
+
+extension DiscoveredNodeData : Identifiable {
+    public var id: String {
+        instanceName
+    }
+}
+
+struct CommissionerDiscoveryView: View {
+    @StateObject var viewModel = CommissionerDiscoveryViewModel()
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            NavigationLink(
+                destination: CommissioningView(_selectedCommissioner: nil),
+                label: {
+                    Text("Skip to manual commissioning >>")
+                }
+            ).background(Color.blue)
+                .foregroundColor(Color.white)
+                .padding()
+            
+            Text("Select a commissioner TV...")
+            
+            ForEach(viewModel.commissioners) { commissioner in
+                NavigationLink(
+                    destination: CommissioningView(_selectedCommissioner: commissioner),
+                    label: {
+                        Text(commissioner.description)
+                    }
+                ).background(Color.blue)
+                    .foregroundColor(Color.white)
+                    .padding(1)
+            }
+        }
+        .navigationTitle("TV Discovery")
+        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)
+        .onAppear(perform: viewModel.discoverAndUpdate)
+    }
+}
+
+struct CommissionerDiscoveryView_Previews: PreviewProvider {
+    static var previews: some View {
+        CommissionerDiscoveryView()
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissionerDiscoveryViewModel.swift
@@ -1,0 +1,43 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import Foundation
+
+class CommissionerDiscoveryViewModel: ObservableObject {
+    @Published var commissioners: [DiscoveredNodeData] = []
+    func discoverAndUpdate() {
+        if(commissioners.isEmpty) {
+            CastingServerBridge.getSharedInstance().discoverCommissioners()
+            Task {
+                try? await Task.sleep(nanoseconds: 5_000_000_000)  // Wait for commissioners to respond
+                await updateCommissioners()
+            }
+        }
+    }
+    
+    private func updateCommissioners() async {
+        var i: Int32 = 0
+        while(CastingServerBridge.getSharedInstance().getDiscoveredCommissioner(i) != nil)
+        {
+            let commissioner = CastingServerBridge.getSharedInstance().getDiscoveredCommissioner(i)!
+            DispatchQueue.main.async {
+                self.commissioners.append(commissioner)
+            }
+            i += 1
+        }
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningView.swift
@@ -29,22 +29,35 @@ struct CommissioningView: View {
     
     var body: some View {
         VStack(alignment: .leading) {
-            if(viewModel.commisisoningWindowOpened) {
+            if(viewModel.commisisoningWindowOpened == true) {
                 Text("Commissioning window opened.")
                 
-                if(viewModel.udcRequestSent) {
-                    Text("Complete commissioning on " + (selectedCommissioner?.deviceName)!)
+                if(self.selectedCommissioner != nil)
+                {
+                    if(viewModel.udcRequestSent == true)
+                    {
+                        Text("Complete commissioning on " + (selectedCommissioner?.deviceName)!)
+                    }
+                    else if(viewModel.udcRequestSent == false) {
+                        Text("Could not send user directed commissioning request to " + (selectedCommissioner?.deviceName)! + "! Complete commissioning manually!")
+                            .foregroundColor(Color.red)
+                    }
                 }
                 else{
-                    Text("Complete commissioning with a commissioner manually")
+                    Text("Complete commissioning with a commissioner manually!")
                 }
                 
                 // TBD: actual values
                 Text("Onboarding PIN: ")
+                    .padding()
+                    .border(Color.black, width: 1)
                 Text("Discriminator: ")
+                    .padding()
+                    .border(Color.black, width: 1)
             }
-            else {
+            else if(viewModel.commisisoningWindowOpened == false) {
                 Text("Failed to open Commissioning window!")
+                    .foregroundColor(Color.red)
             }
         }
         .navigationTitle("Commissioning...")

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningView.swift
@@ -1,0 +1,62 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+import SwiftUI
+
+struct CommissioningView: View {
+    var selectedCommissioner: DiscoveredNodeData?
+    
+    @StateObject var viewModel = CommissioningViewModel();
+    
+    init(_selectedCommissioner: DiscoveredNodeData?) {
+        self.selectedCommissioner = _selectedCommissioner
+    }
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            if(viewModel.commisisoningWindowOpened) {
+                Text("Commissioning window opened.")
+                
+                if(viewModel.udcRequestSent) {
+                    Text("Complete commissioning on " + (selectedCommissioner?.deviceName)!)
+                }
+                else{
+                    Text("Complete commissioning with a commissioner manually")
+                }
+                
+                // TBD: actual values
+                Text("Onboarding PIN: ")
+                Text("Discriminator: ")
+            }
+            else {
+                Text("Failed to open Commissioning window!")
+            }
+        }
+        .navigationTitle("Commissioning...")
+        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)
+        .onAppear(perform: {
+            viewModel.prepareForCommissioning(selectedCommissioner: self.selectedCommissioner)
+        })
+    }
+}
+
+struct CommissioningView_Previews: PreviewProvider {
+    static var previews: some View {
+        CommissioningView(_selectedCommissioner: nil)
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
@@ -1,0 +1,47 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+import Foundation
+
+class CommissioningViewModel: ObservableObject {
+    @Published var udcRequestSent: Bool = false;
+    
+    @Published var commisisoningWindowOpened: Bool = false;
+    
+    func prepareForCommissioning(selectedCommissioner: DiscoveredNodeData?) {
+        // TBD: Call openBasicCommissioningWindow() and get Onboarding payload
+        
+        // Send User directed commissioning request if a commissioner was selected
+        if(selectedCommissioner != nil && selectedCommissioner!.numIPs > 0)
+        {
+            Task {
+                await sendUserDirectedCommissioningRequest(selectedCommissioner: selectedCommissioner)
+            }
+        }
+    }
+    
+    private func sendUserDirectedCommissioningRequest(selectedCommissioner: DiscoveredNodeData?) async {
+        let ipAddress: String = selectedCommissioner!.ipAddresses[0] as! String
+        let port: UInt16 = selectedCommissioner!.port
+        let platformInterface: UInt32 = selectedCommissioner!.platformInterface
+        
+        DispatchQueue.main.async {
+            self.udcRequestSent = CastingServerBridge.getSharedInstance().sendUserDirectedCommissioningRequest(ipAddress, commissionerPort: port, platformInterface: platformInterface)
+        }
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentView.swift
@@ -19,8 +19,9 @@ import SwiftUI
 
 struct ContentView: View {
     var body: some View {
-        Text("Hello tv-casting-common C++, from Objective-C, from Swift! Sum: " + String(CastingServerBridge.getSharedInstance().add(5, secondNum: 6)))
-            .padding()
+        NavigationView {
+                CommissionerDiscoveryView()
+        }
     }
 }
 

--- a/examples/tv-casting-app/darwin/TvCasting/chip_xcode_build_connector.sh
+++ b/examples/tv-casting-app/darwin/TvCasting/chip_xcode_build_connector.sh
@@ -107,7 +107,7 @@ declare -a args=(
 [[ $PLATFORM_FAMILY_NAME != macOS ]] && {
     args+=(
         'target_os="ios"'
-        'import("//config/ios/args.gni")'
+        'import("//examples/tv-casting-app/darwin/args.gni")'
     )
 }
 

--- a/examples/tv-casting-app/darwin/args.gni
+++ b/examples/tv-casting-app/darwin/args.gni
@@ -1,0 +1,31 @@
+# Copyright (c) 2020-2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/config/ios/args.gni")
+
+chip_device_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_project_config_include = "<CHIPProjectAppConfig.h>"
+chip_system_project_config_include = "<SystemProjectConfig.h>"
+
+chip_project_config_include_dirs +=
+    [ "${chip_root}/examples/tv-casting-app/tv-casting-common/include" ]
+chip_project_config_include_dirs += [ "${chip_root}/config/ios" ]
+
+chip_build_libshell = true
+
+chip_enable_additional_data_advertising = true
+
+chip_enable_rotating_device_id = true


### PR DESCRIPTION
#### Problem
The iOS TvCasting app does not support commissioner discovery or sending User directed commissioning requests. This PR addresses https://github.com/project-chip/connectedhomeip/issues/14561 and https://github.com/project-chip/connectedhomeip/issues/14560 

#### Change overview
1. New SwiftUI views and their respective view models for CommissionerDiscovery and Commissioning flows.
2. New methods in CastingServerBridge.h/mm to discover commissioners and send UDC requests that talk to CastingServer.cpp (in libTvCastingCommon.a). + CHIP app server initialization in CastingServerBridge.init()
3. Updates to build scripts so that tv-casting-common/CHIPProjectAppConfig.h overrides are picked up. Note the subsequent edit to config/ios/CHIPProjectConfig.h

_TBD: call to openBasicCommissioningWindow or show Onboarding payload will be added in future PR._

#### Testing
* Tested on the iPhone simulator in Xcode against a tv-app running on a RasPi and verified that the TV commissioner is discovered and shown to the user. 
* The user is able to click the button for the discovered commissioner and a UDC request is sent out from the iOS TvCasting app. 
* Screenshots below:

 <img src="https://user-images.githubusercontent.com/31142146/173491212-bd1f8cf7-de3b-4e76-bca4-4f78f3ac8179.png" width="278" height="600"> <img src="https://user-images.githubusercontent.com/31142146/173491231-6f68de08-8e25-4dd3-97e5-6c892e6a04bb.png" width="278" height="600"> 