### PR TITLE
Assert that message send/receive is thread-synchronized properly.

### DIFF
--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -42,6 +42,7 @@
 #include <messaging/EphemeralExchangeDispatch.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/ExchangeMgr.h>
+#include <platform/LockTracker.h>
 #include <protocols/Protocols.h>
 #include <protocols/secure_channel/Constants.h>
 
@@ -132,6 +133,10 @@ void ExchangeContext::UpdateSEDIntervalMode(bool activeMode)
 CHIP_ERROR ExchangeContext::SendMessage(Protocols::Id protocolId, uint8_t msgType, PacketBufferHandle && msgBuf,
                                         const SendFlags & sendFlags)
 {
+    // This is the first point all outgoing messages funnel through.  Ensure
+    // that our message sends are all synchronized correctly.
+    assertChipStackLockedByCurrentThread();
+
     bool isStandaloneAck =
         (protocolId == Protocols::SecureChannel::Id) && msgType == to_underlying(Protocols::SecureChannel::MsgType::StandaloneAck);
     if (!isStandaloneAck)

--- a/src/transport/TransportMgrBase.cpp
+++ b/src/transport/TransportMgrBase.cpp
@@ -17,6 +17,7 @@
 #include <transport/TransportMgrBase.h>
 
 #include <lib/support/CodeUtils.h>
+#include <platform/LockTracker.h>
 #include <transport/TransportMgr.h>
 #include <transport/raw/Base.h>
 
@@ -57,6 +58,10 @@ CHIP_ERROR TransportMgrBase::MulticastGroupJoinLeave(const Transport::PeerAddres
 
 void TransportMgrBase::HandleMessageReceived(const Transport::PeerAddress & peerAddress, System::PacketBufferHandle && msg)
 {
+    // This is the first point all incoming messages funnel through.  Ensure
+    // that our message receipts are all synchronized correctly.
+    assertChipStackLockedByCurrentThread();
+
     if (msg->HasChainedBuffer())
     {
         // Something in the lower levels messed up.


### PR DESCRIPTION
Sending and receiving of messages needs to happen with the Matter lock
held (i.e. either on the Matter thread, or on some other thread after
it takes the lock).  Add asserts to that effect to catch accidental
misuse, which can lead to data races and data corruption.

#### Problem
We can end up with races like in https://github.com/project-chip/connectedhomeip/issues/18327 and not realize it.

#### Change overview
Add asserts that will hopefully catch some races.

#### Testing
No behavior changes; CI will tell us if we have these problems in the most basic cases.