### PR TITLE
Fix out-of-bounds heap memory read

### DIFF
--- a/src/lib/support/CHIPMemString.h
+++ b/src/lib/support/CHIPMemString.h
@@ -171,7 +171,10 @@ public:
     ScopedMemoryString(const char * string, size_t length)
     {
         size_t lengthWithNull = length + 1;
-        CopyString(Alloc(lengthWithNull).Get(), lengthWithNull, string);
+
+        // We must convert the source string to a CharSpan, so we call the
+        // version of CopyString that handles unterminated strings.
+        CopyString(Alloc(lengthWithNull).Get(), lengthWithNull, CharSpan(string, length));
     }
 };
 


### PR DESCRIPTION
#### Problem
CopyString copies one byte past the end of a non-terminated source string, then overwrites it with nul.

The version of CopyString taking a const char* source expects it to be nul terminated.  When called from ScopedMemoryString() the destination buffer is always one byte larger than the source, and the source may not be terminated. 
 The result is a one-byte out-of-bounds memory read in CopyString().

#### Change overview
This change modifies ScopedMemoryString() to wrap the source string in a CharSpan, so it calls the version of CopyString that handles unterminated source strings.

#### Testing
`ninja -v -k 0 check`