### PR TITLE
[IM] Fix handling of invalid attribute path in WriteHandler

### DIFF
--- a/src/app/ConcreteAttributePath.h
+++ b/src/app/ConcreteAttributePath.h
@@ -127,6 +127,13 @@ struct ConcreteDataAttributePath : public ConcreteAttributePath
         mListIndex = aListIndex;
     }
 
+    bool IsValid() const
+    {
+        return IsValidEndpointId(mEndpointId) && IsValidClusterId(mClusterId) && IsValidAttributeId(mAttributeId);
+    }
+
+    bool IsValidForGroupWrites() const { return IsValidClusterId(mClusterId) && IsValidAttributeId(mAttributeId); }
+
     bool IsListOperation() const { return mListOp != ListOperation::NotList; }
     bool IsListItemOperation() const { return ((mListOp != ListOperation::NotList) && (mListOp != ListOperation::ReplaceAll)); }
 

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -321,12 +321,7 @@ CHIP_ERROR WriteHandler::ProcessAttributeDataIBs(TLV::TLVReader & aAttributeData
         err = element.GetData(&dataReader);
         SuccessOrExit(err);
 
-        if (!dataAttributePath.IsValid())
-        {
-            err = AddStatus(dataAttributePath, StatusIB(Status::InvalidAction));
-            SuccessOrExit(err);
-            continue;
-        }
+        VerifyOrExit(dataAttributePath.IsValid(), err = CHIP_IM_GLOBAL_STATUS(InvalidAction));
 
         const auto attributeMetadata = GetAttributeMetadata(dataAttributePath);
         bool currentAttributeIsList  = (attributeMetadata != nullptr && attributeMetadata->attributeType == kListAttributeType);
@@ -440,10 +435,7 @@ CHIP_ERROR WriteHandler::ProcessGroupAttributeDataIBs(TLV::TLVReader & aAttribut
         err = element.GetData(&dataReader);
         SuccessOrExit(err);
 
-        if (!dataAttributePath.IsValidForGroupWrites())
-        {
-            continue;
-        }
+        VerifyOrExit(dataAttributePath.IsValidForGroupWrites(), err = CHIP_IM_GLOBAL_STATUS(InvalidAction));
 
         if (!dataAttributePath.IsListOperation() && dataReader.GetType() == TLV::TLVType::kTLVType_Array)
         {

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -157,7 +157,6 @@ private:
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
                                  System::PacketBufferHandle && aPayload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
-    Protocols::InteractionModel::Status VerifyAttributeDataIBs(const TLV::TLVReader & aAttributeDataIBsReader, bool aIsGroupAction);
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponseMessage::Builder mWriteResponseBuilder;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -157,7 +157,7 @@ private:
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
                                  System::PacketBufferHandle && aPayload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
-    CHIP_ERROR VerifyAttributeDataIBs(const TLV::TLVReader & aAttributeDataIBsReader, bool aIsGroupAction);
+    Protocols::InteractionModel::Status VerifyAttributeDataIBs(const TLV::TLVReader & aAttributeDataIBsReader, bool aIsGroupAction);
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponseMessage::Builder mWriteResponseBuilder;

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -157,6 +157,7 @@ private:
     CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
                                  System::PacketBufferHandle && aPayload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
+    CHIP_ERROR VerifyAttributeDataIBs(const TLV::TLVReader & aAttributeDataIBsReader, bool aIsGroupAction);
 
     Messaging::ExchangeContext * mpExchangeCtx = nullptr;
     WriteResponseMessage::Builder mWriteResponseBuilder;

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -572,21 +572,15 @@ void TestWriteInteraction::TestWriteInvalidPath(nlTestSuite * apSuite, void * ap
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     {
-        TestWriteClientCallback callback;
-        app::WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
+        NL_TEST_ASSERT(apSuite, ConcreteDataAttributePath(0, 1, 2).IsValid());
+        NL_TEST_ASSERT(apSuite, !ConcreteDataAttributePath(kInvalidEndpointId, 1, 2).IsValid());
+        NL_TEST_ASSERT(apSuite, !ConcreteDataAttributePath(0, kInvalidClusterId, 2).IsValid());
+        NL_TEST_ASSERT(apSuite, !ConcreteDataAttributePath(0, 1, kInvalidAttributeId).IsValid());
 
-        NL_TEST_ASSERT(apSuite,
-                       writeClient.EncodeAttribute(AttributePathParams(kInvalidEndpointId, 1, 2), (bool) true) == CHIP_NO_ERROR);
-
-        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 0 && callback.mOnErrorCalled == 0 && callback.mOnDoneCalled == 0);
-
-        err = writeClient.SendWriteRequest(ctx.GetSessionBobToAlice());
-        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-        ctx.DrainAndServiceIO();
-
-        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 0 && callback.mOnErrorCalled == 1 && callback.mOnDoneCalled == 1);
-        NL_TEST_ASSERT(apSuite, callback.mError == CHIP_IM_GLOBAL_STATUS(InvalidAction));
+        NL_TEST_ASSERT(apSuite, ConcreteDataAttributePath(0, 1, 2).IsValidForGroupWrites());
+        NL_TEST_ASSERT(apSuite, ConcreteDataAttributePath(kInvalidEndpointId, 1, 2).IsValidForGroupWrites());
+        NL_TEST_ASSERT(apSuite, !ConcreteDataAttributePath(0, kInvalidClusterId, 2).IsValidForGroupWrites());
+        NL_TEST_ASSERT(apSuite, !ConcreteDataAttributePath(0, 1, kInvalidAttributeId).IsValidForGroupWrites());
     }
 
     {
@@ -604,8 +598,8 @@ void TestWriteInteraction::TestWriteInvalidPath(nlTestSuite * apSuite, void * ap
 
         ctx.DrainAndServiceIO();
 
-        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 0 && callback.mOnErrorCalled == 1 && callback.mOnDoneCalled == 1);
-        NL_TEST_ASSERT(apSuite, callback.mError == CHIP_IM_GLOBAL_STATUS(InvalidAction));
+        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 1 && callback.mOnErrorCalled == 0 && callback.mOnDoneCalled == 1);
+        NL_TEST_ASSERT(apSuite, callback.mStatus.mStatus == Protocols::InteractionModel::Status::InvalidAction);
     }
 
     {
@@ -623,8 +617,8 @@ void TestWriteInteraction::TestWriteInvalidPath(nlTestSuite * apSuite, void * ap
 
         ctx.DrainAndServiceIO();
 
-        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 0 && callback.mOnErrorCalled == 1 && callback.mOnDoneCalled == 1);
-        NL_TEST_ASSERT(apSuite, callback.mError == CHIP_IM_GLOBAL_STATUS(InvalidAction));
+        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 1 && callback.mOnErrorCalled == 0 && callback.mOnDoneCalled == 1);
+        NL_TEST_ASSERT(apSuite, callback.mStatus.mStatus == Protocols::InteractionModel::Status::InvalidAction);
     }
 
     // By now we should have closed all exchanges and sent all pending acks, so

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -598,8 +598,8 @@ void TestWriteInteraction::TestWriteInvalidPath(nlTestSuite * apSuite, void * ap
 
         ctx.DrainAndServiceIO();
 
-        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 1 && callback.mOnErrorCalled == 0 && callback.mOnDoneCalled == 1);
-        NL_TEST_ASSERT(apSuite, callback.mStatus.mStatus == Protocols::InteractionModel::Status::InvalidAction);
+        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 0 && callback.mOnErrorCalled == 1 && callback.mOnDoneCalled == 1);
+        NL_TEST_ASSERT(apSuite, callback.mError == CHIP_IM_GLOBAL_STATUS(InvalidAction));
     }
 
     {
@@ -617,8 +617,8 @@ void TestWriteInteraction::TestWriteInvalidPath(nlTestSuite * apSuite, void * ap
 
         ctx.DrainAndServiceIO();
 
-        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 1 && callback.mOnErrorCalled == 0 && callback.mOnDoneCalled == 1);
-        NL_TEST_ASSERT(apSuite, callback.mStatus.mStatus == Protocols::InteractionModel::Status::InvalidAction);
+        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 0 && callback.mOnErrorCalled == 1 && callback.mOnDoneCalled == 1);
+        NL_TEST_ASSERT(apSuite, callback.mError == CHIP_IM_GLOBAL_STATUS(InvalidAction));
     }
 
     // By now we should have closed all exchanges and sent all pending acks, so

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -576,6 +576,24 @@ void TestWriteInteraction::TestWriteInvalidPath(nlTestSuite * apSuite, void * ap
         app::WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
 
         NL_TEST_ASSERT(apSuite,
+                       writeClient.EncodeAttribute(AttributePathParams(kInvalidEndpointId, 1, 2), (bool) true) == CHIP_NO_ERROR);
+
+        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 0 && callback.mOnErrorCalled == 0 && callback.mOnDoneCalled == 0);
+
+        err = writeClient.SendWriteRequest(ctx.GetSessionBobToAlice());
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+
+        NL_TEST_ASSERT(apSuite, callback.mOnSuccessCalled == 0 && callback.mOnErrorCalled == 1 && callback.mOnDoneCalled == 1);
+        NL_TEST_ASSERT(apSuite, callback.mError == CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+
+    {
+        TestWriteClientCallback callback;
+        app::WriteClient writeClient(engine->GetExchangeManager(), &callback, Optional<uint16_t>::Missing());
+
+        NL_TEST_ASSERT(apSuite,
                        writeClient.EncodeAttribute(AttributePathParams(1 /* endpoint id */, kInvalidClusterId, 2), (bool) true) ==
                            CHIP_NO_ERROR);
 


### PR DESCRIPTION
#### Problem

Fixes #19000 

#### Change overview

- Adds `VerifyAttributeDataIBs` for checking invalid attribute data ibs, and reject it if it contains invalid attribute path.

Per spec, the WriteInteraction SHALL be terminated, so we should have a separate function for checking the write requests instead of check it when processing (and writing) the attribute data ibs.

#### Testing
- Added unit test
