### PR TITLE
[nrfconnect] Added handling Identify TriggerEffect command

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -29,6 +29,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/clusters/identify-server/identify-server.h>
 #include <app/util/attribute-storage.h>
 
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -62,6 +63,40 @@ UnusedLedsWrapper<3> sUnusedLeds{ { DK_LED2, DK_LED3, DK_LED4 } };
 k_timer sFunctionTimer;
 
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+
+constexpr EndpointId kIdentifyEndpointId = 1;
+
+void OnIdentifyTriggerEffect(Identify * identify)
+{
+    ChipLogProgress(Zcl, "OnIdentifyTriggerEffect");
+    switch (identify->mCurrentEffectIdentifier)
+    {
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
+        ChipLogProgress(Zcl, "Effect: EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
+        ChipLogProgress(Zcl, "Effect: EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
+        ChipLogProgress(Zcl, "Effect: EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
+        ChipLogProgress(Zcl, "Effect: EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE");
+        break;
+    default:
+        ChipLogProgress(Zcl, "Effect: No identifier effect");
+        break;
+    }
+    return;
+}
+
+Identify sIdentify = {
+    chip::EndpointId{ kIdentifyEndpointId },
+    [](Identify *) { ChipLogProgress(Zcl, "OnIdentifyStart"); },
+    [](Identify *) { ChipLogProgress(Zcl, "OnIdentifyStop"); },
+    EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_NONE,
+    OnIdentifyTriggerEffect,
+};
 
 } // namespace
 


### PR DESCRIPTION
#### Problem
All-clusters-app for nrfconnect doesn't support handling TriggerEffect command, despite it is enabled in the .zap
configuration.

#### Change overview
Added method that handles TriggerEffect callback.

#### Testing
Tested manually following the procedure from: https://github.com/project-chip/connectedhomeip/issues/19419.

Fixes: https://github.com/project-chip/connectedhomeip/issues/19419
