### PR TITLE
[Infineon] Pre-SVE week01 fixes for CYW30739

### DIFF
--- a/examples/lighting-app/cyw30739/BUILD.gn
+++ b/examples/lighting-app/cyw30739/BUILD.gn
@@ -55,6 +55,7 @@ cyw30739_executable("lighting_app") {
   deps = [
     ":sdk",
     "${chip_root}/examples/lighting-app/lighting-common",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/examples/shell/shell_common:shell_common",
     "${chip_root}/src/lib",
   ]

--- a/examples/lighting-app/cyw30739/src/main.cpp
+++ b/examples/lighting-app/cyw30739/src/main.cpp
@@ -21,6 +21,7 @@
 #include <AppShellCommands.h>
 #include <ButtonHandler.h>
 #include <ChipShellCollection.h>
+#include <DeviceInfoProviderImpl.h>
 #include <LightingManager.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
 #include <OTAConfig.h>
@@ -42,6 +43,7 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::Shell;
 
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 static void InitApp(intptr_t args);
 static void EventHandler(const ChipDeviceEvent * event, intptr_t arg);
 static void HandleThreadStateChangeEvent(const ChipDeviceEvent * event);
@@ -153,6 +155,8 @@ void InitApp(intptr_t args)
     chip::Server::GetInstance().Init(initParams);
 
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     LightMgr().Init();
     LightMgr().SetCallbacks(LightManagerCallback, NULL);

--- a/examples/lock-app/cyw30739/BUILD.gn
+++ b/examples/lock-app/cyw30739/BUILD.gn
@@ -55,6 +55,7 @@ cyw30739_executable("lock_app") {
   deps = [
     ":sdk",
     "${chip_root}/examples/lock-app/lock-common",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/examples/shell/shell_common:shell_common",
     "${chip_root}/src/lib",
   ]

--- a/examples/lock-app/cyw30739/src/main.cpp
+++ b/examples/lock-app/cyw30739/src/main.cpp
@@ -21,6 +21,7 @@
 #include <AppShellCommands.h>
 #include <ButtonHandler.h>
 #include <ChipShellCollection.h>
+#include <DeviceInfoProviderImpl.h>
 #include <LockManager.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-objects.h>
@@ -53,6 +54,7 @@ using namespace ::chip::Shell;
 
 wiced_bool_t syncClusterToButtonAction = false;
 
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 static void InitApp(intptr_t args);
 static void EventHandler(const ChipDeviceEvent * event, intptr_t arg);
 static void HandleThreadStateChangeEvent(const ChipDeviceEvent * event);
@@ -169,6 +171,8 @@ void InitApp(intptr_t args)
     chip::Server::GetInstance().Init(initParams);
 
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initial lock state
     chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state;

--- a/src/lwip/cyw30739/lwipopts.h
+++ b/src/lwip/cyw30739/lwipopts.h
@@ -77,7 +77,7 @@
 #define PBUF_POOL_BUFSIZE 1356
 
 /* Network Interfaces options */
-#define PBUF_POOL_SIZE 8
+#define PBUF_POOL_SIZE 10
 
 /* LOOPIF options */
 

--- a/src/platform/CYW30739/CYW30739Config.h
+++ b/src/platform/CYW30739/CYW30739Config.h
@@ -78,12 +78,13 @@ public:
     static constexpr Key kConfigKey_LockUserName       = CYW30739ConfigKey(kChipConfig_KeyBase, 0x0d);
     static constexpr Key kConfigKey_CredentialData     = CYW30739ConfigKey(kChipConfig_KeyBase, 0x0e);
     static constexpr Key kConfigKey_UserCredentials    = CYW30739ConfigKey(kChipConfig_KeyBase, 0x0f);
+    static constexpr Key kConfigKey_BootReason         = CYW30739ConfigKey(kChipConfig_KeyBase, 0x10);
 
     // Set key id limits for each group.
     static constexpr Key kMinConfigKey_ChipFactory = CYW30739ConfigKey(kChipFactory_KeyBase, 0x00);
     static constexpr Key kMaxConfigKey_ChipFactory = CYW30739ConfigKey(kChipFactory_KeyBase, 0x0a);
     static constexpr Key kMinConfigKey_ChipConfig  = CYW30739ConfigKey(kChipConfig_KeyBase, 0x00);
-    static constexpr Key kMaxConfigKey_ChipConfig  = CYW30739ConfigKey(kChipConfig_KeyBase, 0x0f);
+    static constexpr Key kMaxConfigKey_ChipConfig  = CYW30739ConfigKey(kChipConfig_KeyBase, 0x10);
 
     static CHIP_ERROR Init(void);
 

--- a/src/platform/CYW30739/ConfigurationManagerImpl.cpp
+++ b/src/platform/CYW30739/ConfigurationManagerImpl.cpp
@@ -26,10 +26,10 @@
 
 #include <platform/internal/GenericConfigurationManagerImpl.ipp>
 
+#include <hal/wiced_hal_wdog.h>
 #include <platform/CYW30739/CYW30739Config.h>
 #include <platform/ConfigurationManager.h>
-
-#include <hal/wiced_hal_wdog.h>
+#include <platform/DiagnosticDataProvider.h>
 #include <platform/KeyValueStoreManager.h>
 
 namespace chip {
@@ -62,6 +62,12 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
         SuccessOrExit(err);
     }
 
+    if (!CYW30739Config::ConfigValueExists(CYW30739Config::kConfigKey_BootReason))
+    {
+        err = StoreBootReason(to_underlying(BootReasonType::kUnspecified));
+        SuccessOrExit(err);
+    }
+
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<CYW30739Config>::Init();
     SuccessOrExit(err);
@@ -78,6 +84,16 @@ CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
 CHIP_ERROR ConfigurationManagerImpl::StoreRebootCount(uint32_t rebootCount)
 {
     return WriteConfigValue(CYW30739Config::kConfigKey_RebootCount, rebootCount);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
+{
+    return ReadConfigValue(CYW30739Config::kConfigKey_BootReason, bootReason);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreBootReason(uint32_t bootReason)
+{
+    return WriteConfigValue(CYW30739Config::kConfigKey_BootReason, bootReason);
 }
 
 bool ConfigurationManagerImpl::CanFactoryReset(void)

--- a/src/platform/CYW30739/ConfigurationManagerImpl.h
+++ b/src/platform/CYW30739/ConfigurationManagerImpl.h
@@ -41,6 +41,8 @@ public:
     static ConfigurationManagerImpl & GetDefaultInstance();
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount) override;
     CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
+    CHIP_ERROR GetBootReason(uint32_t & bootReason) override;
+    CHIP_ERROR StoreBootReason(uint32_t bootReason) override;
 
 private:
     // ===== Members that implement the ConfigurationManager public interface.

--- a/src/platform/CYW30739/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/CYW30739/DiagnosticDataProviderImpl.cpp
@@ -81,6 +81,20 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetRebootCount(uint16_t & rebootCount)
     return err;
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
+{
+    uint32_t reason = 0;
+    CHIP_ERROR err  = ConfigurationMgr().GetBootReason(reason);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(reason <= UINT8_MAX, CHIP_ERROR_INVALID_INTEGER_VALUE);
+        bootReason = static_cast<BootReasonType>(reason);
+    }
+
+    return err;
+}
+
 CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** netifpp)
 {
     NetworkInterface * ifp = Platform::New<NetworkInterface>();

--- a/src/platform/CYW30739/DiagnosticDataProviderImpl.h
+++ b/src/platform/CYW30739/DiagnosticDataProviderImpl.h
@@ -43,6 +43,7 @@ public:
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 };


### PR DESCRIPTION
#### Problem
* CYW30739 has missed platform implementations.
* CYW30739 sometimes runs out of packet buffers.

#### Change overview
* Implement LCFG.C.A0000(ActiveLocale) and LCFG.C.A0001(SupportedLocales) for TC-LO-2.1
* Implement DGGEN.S.E03(BootReason) for TC-DGGEN-2.2
* Increase lwip packet buffer size to 10.

#### Testing
Running chip-tool instructions for the corresponding TCs.