### PR TITLE
Remove test_zap_file_parser.py from sources as it is already in tests

### DIFF
--- a/examples/chef/BUILD.gn
+++ b/examples/chef/BUILD.gn
@@ -32,7 +32,6 @@ pw_python_package("chef") {
     "constants.py",
     "sample_app_util/__init__.py",
     "sample_app_util/sample_app_util.py",
-    "sample_app_util/test_zap_file_parser.py",
     "sample_app_util/zap_file_parser.py",
     "stateful_shell.py",
   ]


### PR DESCRIPTION
#### Problem
`gn gen out/host` followed by ninja complains about multiple rules for test_zap_file_parser.py.

This is because this file appears in both tests and sources.

Fixes #19517 

#### Change overview
Remove the file from sources.

#### Testing

```
gn gen out/host
ninja -C out/host
```