### PR TITLE
[Testing] Add a command line option to generate the CSR with an existing keypair instead of a new one

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -298,6 +298,9 @@ void ChipLinuxAppMainLoop()
 
     initParams.interfaceId = LinuxDeviceOptions::GetInstance().interfaceId;
 
+    LinuxDeviceOptions::GetInstance().mCSRResponseOptions.operationalKeyStore.Init(initParams.persistentStorageDelegate);
+    initParams.operationalKeystore = &LinuxDeviceOptions::GetInstance().mCSRResponseOptions.operationalKeyStore;
+
     // Init ZCL Data Model and CHIP App Server
     Server::GetInstance().Init(initParams);
 

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -298,8 +298,12 @@ void ChipLinuxAppMainLoop()
 
     initParams.interfaceId = LinuxDeviceOptions::GetInstance().interfaceId;
 
-    LinuxDeviceOptions::GetInstance().mCSRResponseOptions.operationalKeyStore.Init(initParams.persistentStorageDelegate);
-    initParams.operationalKeystore = &LinuxDeviceOptions::GetInstance().mCSRResponseOptions.operationalKeyStore;
+    if (LinuxDeviceOptions::GetInstance().mCSRResponseOptions.csrExistingKeyPair)
+    {
+        LinuxDeviceOptions::GetInstance().mCSRResponseOptions.badCsrOperationalKeyStoreForTest.Init(
+            initParams.persistentStorageDelegate);
+        initParams.operationalKeystore = &LinuxDeviceOptions::GetInstance().mCSRResponseOptions.badCsrOperationalKeyStoreForTest;
+    }
 
     // Init ZCL Data Model and CHIP App Server
     Server::GetInstance().Init(initParams);

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -41,6 +41,8 @@ source_set("app-main") {
     "Options.h",
     "testing/CustomCSRResponse.cpp",
     "testing/CustomCSRResponse.h",
+    "testing/CustomCSRResponseOperationalKeyStore.cpp",
+    "testing/CustomCSRResponseOperationalKeyStore.h",
   ]
 
   defines = []

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -69,6 +69,7 @@ enum
     kOptionCSRResponseNOCSRElementsTooLong              = 0x101b,
     kOptionCSRResponseAttestationSignatureIncorrectType = 0x101c,
     kOptionCSRResponseAttestationSignatureInvalid       = 0x101d,
+    kOptionCSRResponseCSRExistingKeyPair                = 0x101e,
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -106,6 +107,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "trace_decode", kArgumentRequired, kDeviceOption_TraceDecode },
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
     { "cert_error_csr_incorrect_type", kNoArgument, kOptionCSRResponseCSRIncorrectType },
+    { "cert_error_csr_existing_keypair", kNoArgument, kOptionCSRResponseCSRExistingKeyPair },
     { "cert_error_csr_nonce_incorrect_type", kNoArgument, kOptionCSRResponseCSRNonceIncorrectType },
     { "cert_error_csr_nonce_too_long", kNoArgument, kOptionCSRResponseCSRNonceTooLong },
     { "cert_error_csr_nonce_invalid", kNoArgument, kOptionCSRResponseCSRNonceInvalid },
@@ -199,6 +201,8 @@ const char * sDeviceOptionHelp =
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
     "  --cert_error_csr_incorrect_type\n"
     "       Configure the CSRResponse to be built with an invalid CSR type.\n"
+    "  --cert_error_csr_existing_keypair\n"
+    "       Configure the CSRResponse to be built with a CSR where the keypair already exists.\n"
     "  --cert_error_csr_nonce_incorrect_type\n"
     "       Configure the CSRResponse to be built with an invalid CSRNonce type.\n"
     "  --cert_error_csr_nonce_too_long\n"
@@ -416,6 +420,9 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
 
     case kOptionCSRResponseCSRIncorrectType:
         LinuxDeviceOptions::GetInstance().mCSRResponseOptions.csrIncorrectType = true;
+        break;
+    case kOptionCSRResponseCSRExistingKeyPair:
+        LinuxDeviceOptions::GetInstance().mCSRResponseOptions.csrExistingKeyPair = true;
         break;
     case kOptionCSRResponseCSRNonceIncorrectType:
         LinuxDeviceOptions::GetInstance().mCSRResponseOptions.csrNonceIncorrectType = true;

--- a/examples/platform/linux/testing/CustomCSRResponse.cpp
+++ b/examples/platform/linux/testing/CustomCSRResponse.cpp
@@ -147,9 +147,9 @@ namespace DataModel {
 template <>
 CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag, const CSRResponse::Type & responseData)
 {
-    auto tag1    = TLV::ContextTag(to_underlying(CSRResponse::Fields::kNOCSRElements));
-    auto tag2    = TLV::ContextTag(to_underlying(CSRResponse::Fields::kAttestationSignature));
-    auto options = LinuxDeviceOptions::GetInstance().mCSRResponseOptions;
+    auto tag1      = TLV::ContextTag(to_underlying(CSRResponse::Fields::kNOCSRElements));
+    auto tag2      = TLV::ContextTag(to_underlying(CSRResponse::Fields::kAttestationSignature));
+    auto & options = LinuxDeviceOptions::GetInstance().mCSRResponseOptions;
 
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));

--- a/examples/platform/linux/testing/CustomCSRResponse.h
+++ b/examples/platform/linux/testing/CustomCSRResponse.h
@@ -30,7 +30,7 @@ struct CSRResponseOptions
     bool nocsrElementsTooLong              = false;
     bool attestationSignatureIncorrectType = false;
     bool attestationSignatureInvalid       = false;
-    CustomCSRResponseOperationalKeyStore operationalKeyStore;
+    CustomCSRResponseOperationalKeyStore badCsrOperationalKeyStoreForTest;
 };
 
 } // namespace chip

--- a/examples/platform/linux/testing/CustomCSRResponse.h
+++ b/examples/platform/linux/testing/CustomCSRResponse.h
@@ -21,6 +21,7 @@ namespace chip {
 struct CSRResponseOptions
 {
     bool csrIncorrectType                  = false;
+    bool csrExistingKeyPair                = false;
     bool csrNonceIncorrectType             = false;
     bool csrNonceTooLong                   = false;
     bool csrNonceInvalid                   = false;

--- a/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.cpp
+++ b/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.cpp
@@ -18,12 +18,114 @@
 
 #include "CustomCSRResponseOperationalKeyStore.h"
 
+#include <credentials/FabricTable.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
+
 namespace chip {
+
+namespace {
+// Tags for our operational keypair storage.
+constexpr TLV::Tag kOpKeyVersionTag = TLV::ContextTag(0);
+constexpr TLV::Tag kOpKeyDataTag    = TLV::ContextTag(1);
+
+constexpr size_t OpKeyTLVMaxSize()
+{
+    // Version and serialized key
+    return TLV::EstimateStructOverhead(sizeof(uint16_t), Crypto::P256SerializedKeypair::Capacity());
+}
+} // namespace
 
 CHIP_ERROR CustomCSRResponseOperationalKeyStore::NewOpKeypairForFabric(FabricIndex fabricIndex,
                                                                        MutableByteSpan & outCertificateSigningRequest)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    if (fabricIndex == 1)
+    {
+        return PersistentStorageOperationalKeystore::NewOpKeypairForFabric(fabricIndex, outCertificateSigningRequest);
+    }
+
+    return ReuseOpKeypair(fabricIndex, outCertificateSigningRequest);
+}
+
+CHIP_ERROR CustomCSRResponseOperationalKeyStore::ReuseOpKeypair(FabricIndex fabricIndex, MutableByteSpan & outCSR)
+{
+    //
+    // DO NOT COPY THIS METHOD - IT IS FOR TESTING PURPOSES ONLY
+    //
+
+    VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+    // Replace previous pending keypair, if any was previously allocated
+    ResetPendingKey();
+
+    mPendingKeypair = Platform::New<Crypto::P256Keypair>();
+    VerifyOrReturnError(mPendingKeypair != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    // Scope 1: Load up the keypair data from storage
+    {
+        // Use a CapacityBoundBuffer to get RAII secret data clearing on scope exit.
+        Crypto::CapacityBoundBuffer<OpKeyTLVMaxSize()> buf;
+
+        // Load up the operational key structure from storage
+        uint16_t size = static_cast<uint16_t>(buf.Capacity());
+        DefaultStorageKeyAllocator keyAlloc;
+
+        // In order to retrieve a keypair that has already been registered, assume the device
+        // as already been commissioned and fabric index 1 is the registered fabric.
+        CHIP_ERROR err = mStorage->SyncGetKeyValue(keyAlloc.FabricOpKey(1 /* fabricIndex */), buf.Bytes(), size);
+        if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+        {
+            err = CHIP_ERROR_INVALID_FABRIC_INDEX;
+        }
+        ReturnErrorOnFailure(err);
+        buf.SetLength(static_cast<size_t>(size));
+
+        // Read-out the operational key TLV entry.
+        TLV::ContiguousBufferTLVReader reader;
+        reader.Init(buf.Bytes(), buf.Length());
+
+        ReturnErrorOnFailure(reader.Next(TLV::kTLVType_Structure, TLV::AnonymousTag()));
+        TLV::TLVType containerType;
+        ReturnErrorOnFailure(reader.EnterContainer(containerType));
+
+        ReturnErrorOnFailure(reader.Next(kOpKeyVersionTag));
+        uint16_t opKeyVersion;
+        ReturnErrorOnFailure(reader.Get(opKeyVersion));
+
+        ReturnErrorOnFailure(reader.Next(kOpKeyDataTag));
+        {
+            ByteSpan keyData;
+            Crypto::P256SerializedKeypair serializedOpKey;
+            ReturnErrorOnFailure(reader.GetByteView(keyData));
+
+            // Unfortunately, we have to copy the data into a P256SerializedKeypair.
+            VerifyOrReturnError(keyData.size() <= serializedOpKey.Capacity(), CHIP_ERROR_BUFFER_TOO_SMALL);
+
+            // Before doing anything with the key, validate format further.
+            ReturnErrorOnFailure(reader.ExitContainer(containerType));
+            ReturnErrorOnFailure(reader.VerifyEndOfContainer());
+
+            memcpy(serializedOpKey.Bytes(), keyData.data(), keyData.size());
+            serializedOpKey.SetLength(keyData.size());
+
+            // Load-up key material
+            // WARNING: This makes use of the raw key bits
+            ReturnErrorOnFailure(mPendingKeypair->Deserialize(serializedOpKey));
+        }
+    }
+
+    size_t outCSRLength = outCSR.size();
+    CHIP_ERROR err      = mPendingKeypair->NewCertificateSigningRequest(outCSR.data(), outCSRLength);
+    if (CHIP_NO_ERROR != err)
+    {
+        ResetPendingKey();
+        return err;
+    }
+
+    outCSR.reduce_size(outCSRLength);
+    mPendingFabricIndex = fabricIndex;
+
+    return CHIP_NO_ERROR;
 }
 
 } // namespace chip

--- a/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.cpp
+++ b/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.cpp
@@ -20,17 +20,10 @@
 
 namespace chip {
 
-struct CSRResponseOptions
+CHIP_ERROR CustomCSRResponseOperationalKeyStore::NewOpKeypairForFabric(FabricIndex fabricIndex,
+                                                                       MutableByteSpan & outCertificateSigningRequest)
 {
-    bool csrIncorrectType                  = false;
-    bool csrExistingKeyPair                = false;
-    bool csrNonceIncorrectType             = false;
-    bool csrNonceTooLong                   = false;
-    bool csrNonceInvalid                   = false;
-    bool nocsrElementsTooLong              = false;
-    bool attestationSignatureIncorrectType = false;
-    bool attestationSignatureInvalid       = false;
-    CustomCSRResponseOperationalKeyStore operationalKeyStore;
-};
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
 
 } // namespace chip

--- a/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.h
+++ b/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.h
@@ -26,6 +26,9 @@ class CustomCSRResponseOperationalKeyStore : public PersistentStorageOperational
 {
 public:
     CHIP_ERROR NewOpKeypairForFabric(FabricIndex fabricIndex, MutableByteSpan & outCertificateSigningRequest) override;
+
+private:
+    CHIP_ERROR ReuseOpKeypair(FabricIndex fabricIndex, MutableByteSpan & outCertificateSigningRequest);
 };
 
 } // namespace chip

--- a/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.h
+++ b/examples/platform/linux/testing/CustomCSRResponseOperationalKeyStore.h
@@ -16,21 +16,16 @@
  *    limitations under the License.
  */
 
-#include "CustomCSRResponseOperationalKeyStore.h"
+#pragma once
+
+#include <crypto/PersistentStorageOperationalKeystore.h>
 
 namespace chip {
 
-struct CSRResponseOptions
+class CustomCSRResponseOperationalKeyStore : public PersistentStorageOperationalKeystore
 {
-    bool csrIncorrectType                  = false;
-    bool csrExistingKeyPair                = false;
-    bool csrNonceIncorrectType             = false;
-    bool csrNonceTooLong                   = false;
-    bool csrNonceInvalid                   = false;
-    bool nocsrElementsTooLong              = false;
-    bool attestationSignatureIncorrectType = false;
-    bool attestationSignatureInvalid       = false;
-    CustomCSRResponseOperationalKeyStore operationalKeyStore;
+public:
+    CHIP_ERROR NewOpKeypairForFabric(FabricIndex fabricIndex, MutableByteSpan & outCertificateSigningRequest) override;
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem

The last part of https://github.com/project-chip/connectedhomeip/issues/14404 requires to use a CSR that contains an already existing public key.
This PR add the ability to test this last step by reusing the keypair of the previous commissioned fabric. It means that the test needs to have commissioned one fabric first.

#### Change overview
 * The last step of #14404 which is a way to test that the CSR does not contain a previous public key.
 

Warning: The first 2 commits of this PR are #19461 which contains all the other steps required by 14404. Please ignore those while reviewing or do that in #19461 ;) 