### PR TITLE
Remove direct operational certs access from FabricInfo

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -61,6 +61,7 @@ using namespace ::chip::Transport;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::OperationalCredentials;
+using namespace chip::Credentials;
 using namespace chip::Protocols::InteractionModel;
 
 namespace {
@@ -125,22 +126,28 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadNOCs(EndpointId endpoint, Attri
     auto accessingFabricIndex = aEncoder.AccessingFabricIndex();
 
     return aEncoder.EncodeList([accessingFabricIndex](const auto & encoder) -> CHIP_ERROR {
-        for (auto & fabricInfo : Server::GetInstance().GetFabricTable())
+        const auto & fabricTable = Server::GetInstance().GetFabricTable();
+        for (auto & fabricInfo : fabricTable)
         {
             Clusters::OperationalCredentials::Structs::NOCStruct::Type noc;
+            uint8_t nocBuf[kMaxCHIPCertLength];
+            uint8_t icacBuf[kMaxCHIPCertLength];
+            MutableByteSpan nocSpan{nocBuf};
+            MutableByteSpan icacSpan{icacBuf};
+            FabricIndex fabricIndex = fabricInfo.GetFabricIndex();
 
-            noc.fabricIndex = fabricInfo.GetFabricIndex();
+            noc.fabricIndex = fabricIndex;
 
-            if (accessingFabricIndex == fabricInfo.GetFabricIndex())
+            if (accessingFabricIndex == fabricIndex)
             {
-                ByteSpan icac;
 
-                ReturnErrorOnFailure(fabricInfo.GetNOCCert(noc.noc));
-                ReturnErrorOnFailure(fabricInfo.GetICACert(icac));
+                ReturnErrorOnFailure(fabricTable.GetNOCCert(fabricIndex, nocSpan));
+                ReturnErrorOnFailure(fabricTable.GetICACert(fabricIndex, icacSpan));
 
-                if (!icac.empty())
+                noc.noc = nocSpan;
+                if (!icacSpan.empty())
                 {
-                    noc.icac.SetNonNull(icac);
+                    noc.icac.SetNonNull(icacSpan);
                 }
             }
 
@@ -166,20 +173,23 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadCommissionedFabrics(EndpointId 
 CHIP_ERROR OperationalCredentialsAttrAccess::ReadFabricsList(EndpointId endpoint, AttributeValueEncoder & aEncoder)
 {
     return aEncoder.EncodeList([](const auto & encoder) -> CHIP_ERROR {
-        for (auto & fabricInfo : Server::GetInstance().GetFabricTable())
+        const auto & fabricTable = Server::GetInstance().GetFabricTable();
+
+        for (auto & fabricInfo : fabricTable)
         {
             Clusters::OperationalCredentials::Structs::FabricDescriptor::Type fabricDescriptor;
+            FabricIndex fabricIndex = fabricInfo.GetFabricIndex();
 
-            fabricDescriptor.fabricIndex = fabricInfo.GetFabricIndex();
+            fabricDescriptor.fabricIndex = fabricIndex;
             fabricDescriptor.nodeId      = fabricInfo.GetPeerId().GetNodeId();
             fabricDescriptor.vendorId    = static_cast<chip::VendorId>(fabricInfo.GetVendorId());
             fabricDescriptor.fabricId    = fabricInfo.GetFabricId();
 
             fabricDescriptor.label = fabricInfo.GetFabricLabel();
 
-            Credentials::P256PublicKeySpan pubKey;
-            ReturnErrorOnFailure(fabricInfo.GetRootPubkey(pubKey));
-            fabricDescriptor.rootPublicKey = pubKey;
+            Crypto::P256PublicKey pubKey;
+            ReturnErrorOnFailure(fabricTable.GetRootPubkey(fabricIndex, pubKey));
+            fabricDescriptor.rootPublicKey = ByteSpan{pubKey.ConstBytes(), pubKey.Length()};
 
             ReturnErrorOnFailure(encoder.Encode(fabricDescriptor));
         }
@@ -192,11 +202,14 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadRootCertificates(EndpointId end
 {
     // It is OK to have duplicates.
     return aEncoder.EncodeList([](const auto & encoder) -> CHIP_ERROR {
-        for (auto & fabricInfo : Server::GetInstance().GetFabricTable())
+        const auto & fabricTable = Server::GetInstance().GetFabricTable();
+
+        for (auto & fabricInfo : fabricTable)
         {
-            ByteSpan cert;
-            ReturnErrorOnFailure(fabricInfo.GetRootCert(cert));
-            ReturnErrorOnFailure(encoder.Encode(cert));
+            uint8_t certBuf[kMaxCHIPCertLength];
+            MutableByteSpan cert{certBuf};
+            ReturnErrorOnFailure(fabricTable.GetRootCert(fabricInfo.GetFabricIndex(), cert));
+            ReturnErrorOnFailure(encoder.Encode(ByteSpan{cert}));
         }
 
         return CHIP_NO_ERROR;
@@ -842,8 +855,7 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
 
     auto & fabricTable                = Server::GetInstance().GetFabricTable();
     FailSafeContext & failSafeContext = DeviceControlServer::DeviceControlSvr().GetFailSafeContext();
-    FabricInfo * fabric               = RetrieveCurrentFabric(commandObj);
-    ByteSpan rcac;
+    FabricInfo * fabricInfo           = RetrieveCurrentFabric(commandObj);
 
     VerifyOrExit(NOCValue.size() <= Credentials::kMaxCHIPCertLength, nonDefaultStatus = Status::InvalidCommand);
     VerifyOrExit(!ICACValue.HasValue() || ICACValue.Value().size() <= Credentials::kMaxCHIPCertLength,
@@ -858,8 +870,8 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
     VerifyOrExit(failSafeContext.IsCsrRequestForUpdateNoc(), nonDefaultStatus = Status::ConstraintError);
 
     // If current fabric is not available, command was invoked over PASE which is not legal
-    VerifyOrExit(fabric != nullptr, nocResponse = ConvertToNOCResponseStatus(CHIP_ERROR_INSUFFICIENT_PRIVILEGE));
-    fabricIndex = fabric->GetFabricIndex();
+    VerifyOrExit(fabricInfo != nullptr, nocResponse = ConvertToNOCResponseStatus(CHIP_ERROR_INSUFFICIENT_PRIVILEGE));
+    fabricIndex = fabricInfo->GetFabricIndex();
 
     // Initialize fields of gFabricBeingCommissioned:
     //  - the root certificate, fabric label, and vendor id are copied from the existing fabric record
@@ -868,16 +880,19 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
     // The remaining operation id and fabric id fields will be extracted from the new operational
     // credentials and set by following SetFabricInfo() call.
     {
-        err = fabric->GetRootCert(rcac);
+        uint8_t rcacBuf[kMaxCHIPCertLength];
+        MutableByteSpan rcac{rcacBuf};
+
+        err = fabricTable.GetRootCert(fabricIndex, rcac);
         VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
         err = gFabricBeingCommissioned.SetRootCert(rcac);
         VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
-        err = gFabricBeingCommissioned.SetFabricLabel(fabric->GetFabricLabel());
+        err = gFabricBeingCommissioned.SetFabricLabel(fabricInfo->GetFabricLabel());
         VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
-        gFabricBeingCommissioned.SetVendorId(fabric->GetVendorId());
+        gFabricBeingCommissioned.SetVendorId(fabricInfo->GetVendorId());
 
         err = gFabricBeingCommissioned.SetNOCCert(NOCValue);
         VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -132,8 +132,8 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadNOCs(EndpointId endpoint, Attri
             Clusters::OperationalCredentials::Structs::NOCStruct::Type noc;
             uint8_t nocBuf[kMaxCHIPCertLength];
             uint8_t icacBuf[kMaxCHIPCertLength];
-            MutableByteSpan nocSpan{nocBuf};
-            MutableByteSpan icacSpan{icacBuf};
+            MutableByteSpan nocSpan{ nocBuf };
+            MutableByteSpan icacSpan{ icacBuf };
             FabricIndex fabricIndex = fabricInfo.GetFabricIndex();
 
             noc.fabricIndex = fabricIndex;
@@ -189,7 +189,7 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadFabricsList(EndpointId endpoint
 
             Crypto::P256PublicKey pubKey;
             ReturnErrorOnFailure(fabricTable.GetRootPubkey(fabricIndex, pubKey));
-            fabricDescriptor.rootPublicKey = ByteSpan{pubKey.ConstBytes(), pubKey.Length()};
+            fabricDescriptor.rootPublicKey = ByteSpan{ pubKey.ConstBytes(), pubKey.Length() };
 
             ReturnErrorOnFailure(encoder.Encode(fabricDescriptor));
         }
@@ -207,9 +207,9 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadRootCertificates(EndpointId end
         for (auto & fabricInfo : fabricTable)
         {
             uint8_t certBuf[kMaxCHIPCertLength];
-            MutableByteSpan cert{certBuf};
+            MutableByteSpan cert{ certBuf };
             ReturnErrorOnFailure(fabricTable.GetRootCert(fabricInfo.GetFabricIndex(), cert));
-            ReturnErrorOnFailure(encoder.Encode(ByteSpan{cert}));
+            ReturnErrorOnFailure(encoder.Encode(ByteSpan{ cert }));
         }
 
         return CHIP_NO_ERROR;
@@ -881,7 +881,7 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
     // credentials and set by following SetFabricInfo() call.
     {
         uint8_t rcacBuf[kMaxCHIPCertLength];
-        MutableByteSpan rcac{rcacBuf};
+        MutableByteSpan rcac{ rcacBuf };
 
         err = fabricTable.GetRootCert(fabricIndex, rcac);
         VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -141,8 +141,8 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadNOCs(EndpointId endpoint, Attri
             if (accessingFabricIndex == fabricIndex)
             {
 
-                ReturnErrorOnFailure(fabricTable.GetNOCCert(fabricIndex, nocSpan));
-                ReturnErrorOnFailure(fabricTable.GetICACert(fabricIndex, icacSpan));
+                ReturnErrorOnFailure(fabricTable.FetchNOCCert(fabricIndex, nocSpan));
+                ReturnErrorOnFailure(fabricTable.FetchICACert(fabricIndex, icacSpan));
 
                 noc.noc = nocSpan;
                 if (!icacSpan.empty())
@@ -188,7 +188,7 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadFabricsList(EndpointId endpoint
             fabricDescriptor.label = fabricInfo.GetFabricLabel();
 
             Crypto::P256PublicKey pubKey;
-            ReturnErrorOnFailure(fabricTable.GetRootPubkey(fabricIndex, pubKey));
+            ReturnErrorOnFailure(fabricTable.FetchRootPubkey(fabricIndex, pubKey));
             fabricDescriptor.rootPublicKey = ByteSpan{ pubKey.ConstBytes(), pubKey.Length() };
 
             ReturnErrorOnFailure(encoder.Encode(fabricDescriptor));
@@ -208,7 +208,7 @@ CHIP_ERROR OperationalCredentialsAttrAccess::ReadRootCertificates(EndpointId end
         {
             uint8_t certBuf[kMaxCHIPCertLength];
             MutableByteSpan cert{ certBuf };
-            ReturnErrorOnFailure(fabricTable.GetRootCert(fabricInfo.GetFabricIndex(), cert));
+            ReturnErrorOnFailure(fabricTable.FetchRootCert(fabricInfo.GetFabricIndex(), cert));
             ReturnErrorOnFailure(encoder.Encode(ByteSpan{ cert }));
         }
 
@@ -883,7 +883,7 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
         uint8_t rcacBuf[kMaxCHIPCertLength];
         MutableByteSpan rcac{ rcacBuf };
 
-        err = fabricTable.GetRootCert(fabricIndex, rcac);
+        err = fabricTable.FetchRootCert(fabricIndex, rcac);
         VerifyOrExit(err == CHIP_NO_ERROR, nocResponse = ConvertToNOCResponseStatus(err));
 
         err = gFabricBeingCommissioned.SetRootCert(rcac);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2008,20 +2008,20 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
     }
     break;
     case CommissioningStage::kSendTrustedRootCert: {
-        if (!params.FetchRootCert().HasValue() || !params.GetNoc().HasValue())
+        if (!params.GetRootCert().HasValue() || !params.GetNoc().HasValue())
         {
             ChipLogError(Controller, "No trusted root cert or NOC specified");
             CommissioningStageComplete(CHIP_ERROR_INVALID_ARGUMENT);
             return;
         }
-        CHIP_ERROR err = SendTrustedRootCertificate(proxy, params.FetchRootCert().Value(), timeout);
+        CHIP_ERROR err = SendTrustedRootCertificate(proxy, params.GetRootCert().Value(), timeout);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Error sending trusted root certificate: %s", err.AsString());
             CommissioningStageComplete(err);
             return;
         }
-        err = proxy->SetPeerId(params.FetchRootCert().Value(), params.GetNoc().Value());
+        err = proxy->SetPeerId(params.GetRootCert().Value(), params.GetNoc().Value());
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Error setting peer id: %s", err.AsString());

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -176,7 +176,7 @@ CHIP_ERROR DeviceController::InitControllerNOCChain(const ControllerInitParams &
     ReturnErrorOnFailure(ConvertX509CertToChipCert(params.controllerRCAC, chipCertSpan));
     ReturnErrorOnFailure(newFabric.SetRootCert(chipCertSpan));
     ReturnErrorOnFailure(Credentials::ExtractPublicKeyFromChipCert(chipCertSpan, rootPublicKeySpan));
-    Crypto::P256PublicKey rootPublicKey{rootPublicKeySpan};
+    Crypto::P256PublicKey rootPublicKey{ rootPublicKeySpan };
 
     if (params.controllerICAC.empty())
     {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -2008,20 +2008,20 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
     }
     break;
     case CommissioningStage::kSendTrustedRootCert: {
-        if (!params.GetRootCert().HasValue() || !params.GetNoc().HasValue())
+        if (!params.FetchRootCert().HasValue() || !params.GetNoc().HasValue())
         {
             ChipLogError(Controller, "No trusted root cert or NOC specified");
             CommissioningStageComplete(CHIP_ERROR_INVALID_ARGUMENT);
             return;
         }
-        CHIP_ERROR err = SendTrustedRootCertificate(proxy, params.GetRootCert().Value(), timeout);
+        CHIP_ERROR err = SendTrustedRootCertificate(proxy, params.FetchRootCert().Value(), timeout);
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Error sending trusted root certificate: %s", err.AsString());
             CommissioningStageComplete(err);
             return;
         }
-        err = proxy->SetPeerId(params.GetRootCert().Value(), params.GetNoc().Value());
+        err = proxy->SetPeerId(params.FetchRootCert().Value(), params.GetNoc().Value());
         if (err != CHIP_NO_ERROR)
         {
             ChipLogError(Controller, "Error setting peer id: %s", err.AsString());

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -149,7 +149,7 @@ CHIP_ERROR DeviceController::InitControllerNOCChain(const ControllerInitParams &
     FabricInfo newFabric;
     constexpr uint32_t chipCertAllocatedLen = kMaxCHIPCertLength;
     chip::Platform::ScopedMemoryBuffer<uint8_t> chipCert;
-    Credentials::P256PublicKeySpan rootPublicKey;
+    Credentials::P256PublicKeySpan rootPublicKeySpan;
     FabricId fabricId;
 
     // There are three possibilities here in terms of what happens with our
@@ -175,6 +175,8 @@ CHIP_ERROR DeviceController::InitControllerNOCChain(const ControllerInitParams &
 
     ReturnErrorOnFailure(ConvertX509CertToChipCert(params.controllerRCAC, chipCertSpan));
     ReturnErrorOnFailure(newFabric.SetRootCert(chipCertSpan));
+    ReturnErrorOnFailure(Credentials::ExtractPublicKeyFromChipCert(chipCertSpan, rootPublicKeySpan));
+    Crypto::P256PublicKey rootPublicKey{rootPublicKeySpan};
 
     if (params.controllerICAC.empty())
     {
@@ -194,7 +196,6 @@ CHIP_ERROR DeviceController::InitControllerNOCChain(const ControllerInitParams &
     ReturnErrorOnFailure(newFabric.SetNOCCert(chipCertSpan));
     ReturnErrorOnFailure(ExtractFabricIdFromCert(chipCertSpan, &fabricId));
 
-    ReturnErrorOnFailure(newFabric.GetRootPubkey(rootPublicKey));
     mFabricInfo = params.systemState->Fabrics()->FindFabric(rootPublicKey, fabricId);
     if (mFabricInfo != nullptr)
     {

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -240,6 +240,15 @@ public:
 
     FabricInfo * GetFabricInfo() { return mFabricInfo; }
 
+    const FabricTable * GetFabricTable() const
+    {
+        if (mSystemState == nullptr)
+        {
+            return nullptr;
+        }
+        return mSystemState->Fabrics();
+    }
+
     void ReleaseOperationalDevice(NodeId remoteDeviceId);
 
     OperationalCredentialsDelegate * GetOperationalCredentialsDelegate() { return mOperationalCredentialsDelegate; }

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -143,7 +143,7 @@ public:
     // The root certificate for the operational certificate chain. In the auto commissioner, this is set by by the kGenerateNOCChain
     // stage through the OperationalCredentialsDelegate.
     // This value must be set before calling PerformCommissioningStep for the kSendTrustedRootCert step.
-    const Optional<ByteSpan> FetchRootCert() const { return mRootCert; }
+    const Optional<ByteSpan> GetRootCert() const { return mRootCert; }
 
     // The node operational certificate for the node being commissioned. In the AutoCommissioner, this is set by by the
     // kGenerateNOCChain stage through the OperationalCredentialsDelegate.

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -143,7 +143,7 @@ public:
     // The root certificate for the operational certificate chain. In the auto commissioner, this is set by by the kGenerateNOCChain
     // stage through the OperationalCredentialsDelegate.
     // This value must be set before calling PerformCommissioningStep for the kSendTrustedRootCert step.
-    const Optional<ByteSpan> GetRootCert() const { return mRootCert; }
+    const Optional<ByteSpan> FetchRootCert() const { return mRootCert; }
 
     // The node operational certificate for the node being commissioned. In the AutoCommissioner, this is set by by the
     // kGenerateNOCChain stage through the OperationalCredentialsDelegate.

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -464,7 +464,7 @@ FabricTable::~FabricTable()
     }
 }
 
-FabricInfo * FabricTable::FindFabric(const Crypto::P256PublicKey &  rootPubKey, FabricId fabricId)
+FabricInfo * FabricTable::FindFabric(const Crypto::P256PublicKey & rootPubKey, FabricId fabricId)
 {
     for (auto & fabric : mStates)
     {
@@ -700,7 +700,7 @@ CHIP_ERROR FabricTable::AddNewFabric(FabricInfo & newFabric, FabricIndex * outpu
     FabricId fabricId;
     {
         uint8_t nocBuf[kMaxCHIPCertLength];
-        MutableByteSpan nocSpan{nocBuf};
+        MutableByteSpan nocSpan{ nocBuf };
         ReturnErrorOnFailure(newFabric.GetNOCCert(nocSpan));
         NodeId unused;
         ReturnErrorOnFailure(ExtractNodeIdFabricIdFromOpCert(nocSpan, &unused, &fabricId));
@@ -1018,7 +1018,7 @@ CHIP_ERROR FabricTable::SetLastKnownGoodChipEpochTime(System::Clock::Seconds32 l
         }
         {
             uint8_t rcacBuf[kMaxCHIPCertLength];
-            MutableByteSpan rcacSpan{rcacBuf};
+            MutableByteSpan rcacSpan{ rcacBuf };
             SuccessOrExit(err = fabric.GetRootCert(rcacSpan));
             chip::System::Clock::Seconds32 rcacNotBefore;
             SuccessOrExit(err = Credentials::ExtractNotBeforeFromChipCert(rcacSpan, rcacNotBefore));
@@ -1026,7 +1026,7 @@ CHIP_ERROR FabricTable::SetLastKnownGoodChipEpochTime(System::Clock::Seconds32 l
         }
         {
             uint8_t icacBuf[kMaxCHIPCertLength];
-            MutableByteSpan icacSpan{icacBuf};
+            MutableByteSpan icacSpan{ icacBuf };
             SuccessOrExit(err = fabric.GetICACert(icacSpan));
             if (!icacSpan.empty())
             {
@@ -1037,7 +1037,7 @@ CHIP_ERROR FabricTable::SetLastKnownGoodChipEpochTime(System::Clock::Seconds32 l
         }
         {
             uint8_t nocBuf[kMaxCHIPCertLength];
-            MutableByteSpan nocSpan{nocBuf};
+            MutableByteSpan nocSpan{ nocBuf };
             SuccessOrExit(err = fabric.GetNOCCert(nocSpan));
             chip::System::Clock::Seconds32 nocNotBefore;
             ReturnErrorOnFailure(Credentials::ExtractNotBeforeFromChipCert(nocSpan, nocNotBefore));

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -440,6 +440,18 @@ CHIP_ERROR FabricInfo::VerifyCredentials(const ByteSpan & noc, const ByteSpan & 
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR FabricInfo::GetRootPubkey(Crypto::P256PublicKey & publicKey) const
+{
+    P256PublicKeySpan publicKeySpan;
+    CHIP_ERROR err = Credentials::ExtractPublicKeyFromChipCert(mRootCert, publicKeySpan);
+    if (err == CHIP_NO_ERROR)
+    {
+        publicKey = P256PublicKey(publicKeySpan);
+    }
+
+    return err;
+}
+
 FabricTable::~FabricTable()
 {
     // Remove all links to every delegate
@@ -452,7 +464,7 @@ FabricTable::~FabricTable()
     }
 }
 
-FabricInfo * FabricTable::FindFabric(P256PublicKeySpan rootPubKey, FabricId fabricId)
+FabricInfo * FabricTable::FindFabric(const Crypto::P256PublicKey &  rootPubKey, FabricId fabricId)
 {
     for (auto & fabric : mStates)
     {
@@ -460,16 +472,17 @@ FabricInfo * FabricTable::FindFabric(P256PublicKeySpan rootPubKey, FabricId fabr
         {
             continue;
         }
-        P256PublicKeySpan candidatePubKey;
+        P256PublicKey candidatePubKey;
         if (fabric.GetRootPubkey(candidatePubKey) != CHIP_NO_ERROR)
         {
             continue;
         }
-        if (rootPubKey.data_equal(candidatePubKey) && fabricId == fabric.GetFabricId())
+        if (rootPubKey.Matches(candidatePubKey) && fabricId == fabric.GetFabricId())
         {
             return &fabric;
         }
     }
+
     return nullptr;
 }
 
@@ -524,6 +537,34 @@ FabricInfo * FabricTable::FindFabricWithCompressedId(CompressedFabricId fabricId
         }
     }
     return nullptr;
+}
+
+CHIP_ERROR FabricTable::GetRootCert(FabricIndex fabricIndex, MutableByteSpan & cert) const
+{
+    const FabricInfo * fabricInfo = FindFabricWithIndex(fabricIndex);
+    ReturnErrorCodeIf(fabricInfo == nullptr, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    return fabricInfo->GetRootCert(cert);
+}
+
+CHIP_ERROR FabricTable::GetICACert(FabricIndex fabricIndex, MutableByteSpan & cert) const
+{
+    const FabricInfo * fabricInfo = FindFabricWithIndex(fabricIndex);
+    ReturnErrorCodeIf(fabricInfo == nullptr, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    return fabricInfo->GetICACert(cert);
+}
+
+CHIP_ERROR FabricTable::GetNOCCert(FabricIndex fabricIndex, MutableByteSpan & cert) const
+{
+    const FabricInfo * fabricInfo = FindFabricWithIndex(fabricIndex);
+    ReturnErrorCodeIf(fabricInfo == nullptr, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    return fabricInfo->GetNOCCert(cert);
+}
+
+CHIP_ERROR FabricTable::GetRootPubkey(FabricIndex fabricIndex, Crypto::P256PublicKey & publicKey) const
+{
+    const FabricInfo * fabricInfo = FindFabricWithIndex(fabricIndex);
+    ReturnErrorCodeIf(fabricInfo == nullptr, CHIP_ERROR_INVALID_FABRIC_INDEX);
+    return fabricInfo->GetRootPubkey(publicKey);
 }
 
 CHIP_ERROR FabricTable::Store(FabricIndex fabricIndex)
@@ -658,19 +699,22 @@ CHIP_ERROR FabricTable::AddNewFabric(FabricInfo & newFabric, FabricIndex * outpu
     // comparison.
     FabricId fabricId;
     {
-        ByteSpan noc;
-        ReturnErrorOnFailure(newFabric.GetNOCCert(noc));
+        uint8_t nocBuf[kMaxCHIPCertLength];
+        MutableByteSpan nocSpan{nocBuf};
+        ReturnErrorOnFailure(newFabric.GetNOCCert(nocSpan));
         NodeId unused;
-        ReturnErrorOnFailure(ExtractNodeIdFabricIdFromOpCert(noc, &unused, &fabricId));
+        ReturnErrorOnFailure(ExtractNodeIdFabricIdFromOpCert(nocSpan, &unused, &fabricId));
     }
+
     for (auto & existingFabric : *this)
     {
         if (existingFabric.GetFabricId() == fabricId)
         {
-            P256PublicKeySpan existingRootKey, newRootKey;
+            P256PublicKey existingRootKey, newRootKey;
             ReturnErrorOnFailure(existingFabric.GetRootPubkey(existingRootKey));
             ReturnErrorOnFailure(newFabric.GetRootPubkey(newRootKey));
-            if (existingRootKey.data_equal(newRootKey))
+
+            if (existingRootKey.Matches(newRootKey))
             {
                 return CHIP_ERROR_FABRIC_EXISTS;
             }
@@ -973,27 +1017,30 @@ CHIP_ERROR FabricTable::SetLastKnownGoodChipEpochTime(System::Clock::Seconds32 l
             continue;
         }
         {
-            ByteSpan rcac;
-            SuccessOrExit(err = fabric.GetRootCert(rcac));
+            uint8_t rcacBuf[kMaxCHIPCertLength];
+            MutableByteSpan rcacSpan{rcacBuf};
+            SuccessOrExit(err = fabric.GetRootCert(rcacSpan));
             chip::System::Clock::Seconds32 rcacNotBefore;
-            SuccessOrExit(err = Credentials::ExtractNotBeforeFromChipCert(rcac, rcacNotBefore));
+            SuccessOrExit(err = Credentials::ExtractNotBeforeFromChipCert(rcacSpan, rcacNotBefore));
             latestNotBefore = rcacNotBefore > latestNotBefore ? rcacNotBefore : latestNotBefore;
         }
         {
-            ByteSpan icac;
-            SuccessOrExit(err = fabric.GetICACert(icac));
-            if (!icac.empty())
+            uint8_t icacBuf[kMaxCHIPCertLength];
+            MutableByteSpan icacSpan{icacBuf};
+            SuccessOrExit(err = fabric.GetICACert(icacSpan));
+            if (!icacSpan.empty())
             {
                 chip::System::Clock::Seconds32 icacNotBefore;
-                ReturnErrorOnFailure(Credentials::ExtractNotBeforeFromChipCert(icac, icacNotBefore));
+                ReturnErrorOnFailure(Credentials::ExtractNotBeforeFromChipCert(icacSpan, icacNotBefore));
                 latestNotBefore = icacNotBefore > latestNotBefore ? icacNotBefore : latestNotBefore;
             }
         }
         {
-            ByteSpan noc;
-            SuccessOrExit(err = fabric.GetNOCCert(noc));
+            uint8_t nocBuf[kMaxCHIPCertLength];
+            MutableByteSpan nocSpan{nocBuf};
+            SuccessOrExit(err = fabric.GetNOCCert(nocSpan));
             chip::System::Clock::Seconds32 nocNotBefore;
-            ReturnErrorOnFailure(Credentials::ExtractNotBeforeFromChipCert(noc, nocNotBefore));
+            ReturnErrorOnFailure(Credentials::ExtractNotBeforeFromChipCert(nocSpan, nocNotBefore));
             latestNotBefore = nocNotBefore > latestNotBefore ? nocNotBefore : latestNotBefore;
         }
     }

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -435,7 +435,7 @@ CHIP_ERROR FabricInfo::VerifyCredentials(const ByteSpan & noc, const ByteSpan & 
     }
 
     ReturnErrorOnFailure(GeneratePeerId(rcac, fabricId, nodeId, &nocPeerId));
-    nocPubkey = P256PublicKey(certificates.GetLastCert()[0].mPublicKey);
+    nocPubkey = certificates.GetLastCert()[0].mPublicKey;
 
     return CHIP_NO_ERROR;
 }
@@ -446,7 +446,7 @@ CHIP_ERROR FabricInfo::FetchRootPubkey(Crypto::P256PublicKey & outPublicKey) con
     CHIP_ERROR err = Credentials::ExtractPublicKeyFromChipCert(mRootCert, publicKeySpan);
     if (err == CHIP_NO_ERROR)
     {
-        outPublicKey = P256PublicKey(publicKeySpan);
+        outPublicKey = publicKeySpan;
     }
 
     return err;

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -203,29 +203,29 @@ protected:
      */
     CHIP_ERROR SignWithOpKeypair(ByteSpan message, Crypto::P256ECDSASignature & outSignature) const;
 
-    CHIP_ERROR GetRootCert(MutableByteSpan & cert) const
+    CHIP_ERROR FetchRootCert(MutableByteSpan & outCert) const
     {
         ReturnErrorCodeIf(mRootCert.empty(), CHIP_ERROR_INCORRECT_STATE);
-        return CopySpanToMutableSpan(mRootCert, cert);
+        return CopySpanToMutableSpan(mRootCert, outCert);
     }
 
-    CHIP_ERROR GetICACert(MutableByteSpan & cert) const
+    CHIP_ERROR FetchICACert(MutableByteSpan & outCert) const
     {
         if (mICACert.empty())
         {
-            cert.reduce_size(0);
+            outCert.reduce_size(0);
             return CHIP_NO_ERROR;
         }
-        return CopySpanToMutableSpan(mICACert, cert);
+        return CopySpanToMutableSpan(mICACert, outCert);
     }
 
-    CHIP_ERROR GetNOCCert(MutableByteSpan & cert) const
+    CHIP_ERROR FetchNOCCert(MutableByteSpan & outCert) const
     {
         ReturnErrorCodeIf(mNOCCert.empty(), CHIP_ERROR_INCORRECT_STATE);
-        return CopySpanToMutableSpan(mNOCCert, cert);
+        return CopySpanToMutableSpan(mNOCCert, outCert);
     }
 
-    CHIP_ERROR GetRootPubkey(Crypto::P256PublicKey & publicKey) const;
+    CHIP_ERROR FetchRootPubkey(Crypto::P256PublicKey & outPublicKey) const;
 
     static constexpr size_t MetadataTLVMaxSize()
     {
@@ -470,10 +470,10 @@ public:
     ConstFabricIterator begin() const { return cbegin(); }
     ConstFabricIterator end() const { return cend(); }
 
-    CHIP_ERROR GetRootCert(FabricIndex fabricIndex, MutableByteSpan & cert) const;
-    CHIP_ERROR GetICACert(FabricIndex fabricIndex, MutableByteSpan & cert) const;
-    CHIP_ERROR GetNOCCert(FabricIndex fabricIndex, MutableByteSpan & cert) const;
-    CHIP_ERROR GetRootPubkey(FabricIndex fabricIndex, Crypto::P256PublicKey & publicKey) const;
+    CHIP_ERROR FetchRootCert(FabricIndex fabricIndex, MutableByteSpan & outCert) const;
+    CHIP_ERROR FetchICACert(FabricIndex fabricIndex, MutableByteSpan & outCert) const;
+    CHIP_ERROR FetchNOCCert(FabricIndex fabricIndex, MutableByteSpan & outCert) const;
+    CHIP_ERROR FetchRootPubkey(FabricIndex fabricIndex, Crypto::P256PublicKey & outPublicKey) const;
 
     /**
      * @brief Sign a message with a given fabric's operational keypair. This is used for

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -50,15 +50,7 @@ static constexpr uint8_t kFabricLabelMaxLengthInBytes = 32;
 static_assert(kUndefinedFabricIndex < chip::kMinValidFabricIndex, "Undefined fabric index should not be valid");
 
 /**
- * Defines state of a pairing established by a fabric.
- * Node ID is only settable using the device operational credentials.
- *
- * Information contained within the state:
- *   - Fabric identification
- *   - Node Id assigned by the fabric to the device
- *   - Vendor Id
- *   - Fabric Id
- *   - Device operational credentials
+ * Provides access to the core metadata for a given fabric to which a node is joined.
  */
 class DLL_EXPORT FabricInfo
 {
@@ -133,9 +125,6 @@ public:
      */
     CHIP_ERROR SetExternallyOwnedOperationalKeypair(Crypto::P256Keypair * keyPair);
 
-    // TODO - Update these APIs to take ownership of the buffer, instead of copying
-    //        internally.
-    // TODO - Optimize persistent storage of NOC and Root Cert in FabricInfo.
     CHIP_ERROR SetRootCert(const chip::ByteSpan & cert) { return SetCert(mRootCert, cert); }
     CHIP_ERROR SetICACert(const chip::ByteSpan & cert) { return SetCert(mICACert, cert); }
     CHIP_ERROR SetICACert(const Optional<ByteSpan> & cert) { return SetICACert(cert.ValueOr(ByteSpan())); }
@@ -144,39 +133,6 @@ public:
     bool IsInitialized() const { return IsOperationalNodeId(mOperationalId.GetNodeId()); }
 
     bool HasOperationalKey() const { return mOperationalKey != nullptr; }
-
-    // TODO - Refactor storing and loading of fabric info from persistent storage.
-    //        The op cert array doesn't need to be in RAM except when it's being
-    //        transmitted to peer node during CASE session setup.
-    CHIP_ERROR GetRootCert(ByteSpan & cert) const
-    {
-        ReturnErrorCodeIf(mRootCert.empty(), CHIP_ERROR_INCORRECT_STATE);
-        cert = mRootCert;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetICACert(ByteSpan & cert) const
-    {
-        cert = mICACert;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetNOCCert(ByteSpan & cert) const
-    {
-        ReturnErrorCodeIf(mNOCCert.empty(), CHIP_ERROR_INCORRECT_STATE);
-        cert = mNOCCert;
-        return CHIP_NO_ERROR;
-    }
-
-    CHIP_ERROR GetTrustedRootId(Credentials::CertificateKeyId & skid) const
-    {
-        return Credentials::ExtractSKIDFromChipCert(mRootCert, skid);
-    }
-
-    CHIP_ERROR GetRootPubkey(Credentials::P256PublicKeySpan & publicKey) const
-    {
-        return Credentials::ExtractPublicKeyFromChipCert(mRootCert, publicKey);
-    }
 
     // Verifies credentials, using this fabric info's root certificate.
     CHIP_ERROR VerifyCredentials(const ByteSpan & noc, const ByteSpan & icac, Credentials::ValidationContext & context,
@@ -247,6 +203,30 @@ protected:
      */
     CHIP_ERROR SignWithOpKeypair(ByteSpan message, Crypto::P256ECDSASignature & outSignature) const;
 
+    CHIP_ERROR GetRootCert(MutableByteSpan & cert) const
+    {
+        ReturnErrorCodeIf(mRootCert.empty(), CHIP_ERROR_INCORRECT_STATE);
+        return CopySpanToMutableSpan(mRootCert, cert);
+    }
+
+    CHIP_ERROR GetICACert(MutableByteSpan & cert) const
+    {
+        if (mICACert.empty())
+        {
+            cert.reduce_size(0);
+            return CHIP_NO_ERROR;
+        }
+        return CopySpanToMutableSpan(mICACert, cert);
+    }
+
+    CHIP_ERROR GetNOCCert(MutableByteSpan & cert) const
+    {
+        ReturnErrorCodeIf(mNOCCert.empty(), CHIP_ERROR_INCORRECT_STATE);
+        return CopySpanToMutableSpan(mNOCCert, cert);
+    }
+
+    CHIP_ERROR GetRootPubkey(Crypto::P256PublicKey & publicKey) const;
+
     static constexpr size_t MetadataTLVMaxSize()
     {
         return TLV::EstimateStructOverhead(sizeof(VendorId), kFabricLabelMaxLengthInBytes);
@@ -269,6 +249,7 @@ protected:
     mutable Crypto::P256Keypair * mOperationalKey = nullptr;
 #endif
     bool mHasExternallyOwnedOperationalKey = false;
+    bool mHasExternallyOwnedCertificates = false;
 
     MutableByteSpan mRootCert;
     MutableByteSpan mICACert;
@@ -424,7 +405,7 @@ public:
      */
     CHIP_ERROR UpdateFabric(FabricIndex fabricIndex, FabricInfo & fabricInfo);
 
-    FabricInfo * FindFabric(Credentials::P256PublicKeySpan rootPubKey, FabricId fabricId);
+    FabricInfo * FindFabric(const Crypto::P256PublicKey & rootPubKey, FabricId fabricId);
     FabricInfo * FindFabricWithIndex(FabricIndex fabricIndex);
     const FabricInfo * FindFabricWithIndex(FabricIndex fabricIndex) const;
     FabricInfo * FindFabricWithCompressedId(CompressedFabricId fabricId);
@@ -488,6 +469,11 @@ public:
     ConstFabricIterator cend() const { return ConstFabricIterator(mStates, CHIP_CONFIG_MAX_FABRICS, CHIP_CONFIG_MAX_FABRICS); }
     ConstFabricIterator begin() const { return cbegin(); }
     ConstFabricIterator end() const { return cend(); }
+
+    CHIP_ERROR GetRootCert(FabricIndex fabricIndex, MutableByteSpan & cert) const;
+    CHIP_ERROR GetICACert(FabricIndex fabricIndex, MutableByteSpan & cert) const;
+    CHIP_ERROR GetNOCCert(FabricIndex fabricIndex, MutableByteSpan & cert) const;
+    CHIP_ERROR GetRootPubkey(FabricIndex fabricIndex, Crypto::P256PublicKey & publicKey) const;
 
     /**
      * @brief Sign a message with a given fabric's operational keypair. This is used for

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -249,7 +249,6 @@ protected:
     mutable Crypto::P256Keypair * mOperationalKey = nullptr;
 #endif
     bool mHasExternallyOwnedOperationalKey = false;
-    bool mHasExternallyOwnedCertificates   = false;
 
     MutableByteSpan mRootCert;
     MutableByteSpan mICACert;

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -249,7 +249,7 @@ protected:
     mutable Crypto::P256Keypair * mOperationalKey = nullptr;
 #endif
     bool mHasExternallyOwnedOperationalKey = false;
-    bool mHasExternallyOwnedCertificates = false;
+    bool mHasExternallyOwnedCertificates   = false;
 
     MutableByteSpan mRootCert;
     MutableByteSpan mICACert;

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -306,6 +306,14 @@ public:
         memcpy(&bytes[0], value.data(), N);
     }
 
+    template <size_t N>
+    P256PublicKey & operator=(const FixedByteSpan<N> & value)
+    {
+        static_assert(N == kP256_PublicKey_Length, "Can only initialize from proper sized byte span");
+        memcpy(&bytes[0], value.data(), N);
+        return *this;
+    }
+
     SupportedECPKeyTypes Type() const override { return SupportedECPKeyTypes::ECP256R1; }
     size_t Length() const override { return kP256_PublicKey_Length; }
     operator uint8_t *() override { return bytes; }

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -748,13 +748,19 @@ static NSString * const kErrorCommitPendingFabricData = @"Committing fabric data
         return CHIP_NO_ERROR;
     }
 
-    chip::Credentials::FabricTable * fabricTable = _cppCommissioner->GetFabricTable();
+    // "fabric" comes from a different fabric table for the moment, but it's a
+    // fabric table that is: (1) readonly, (2) has stack lifetime, and (3) uses
+    // the same storage as _cppCommissioner->GetFabricTable(), so it turns out
+    // that in practice they have the same fabric indices and this logic is OK.
+    //
+    // TODO: stop relying on that.
+    const chip::FabricTable * fabricTable = _cppCommissioner->GetFabricTable();
     if (!fabricTable) {
         // Surprising as well!
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    chip::Credentials::P256PublicKey ourRootPublicKey, otherRootPublicKey;
+    chip::Crypto::P256PublicKey ourRootPublicKey, otherRootPublicKey;
     ReturnErrorOnFailure(fabricTable->FetchRootPubkey(ourFabric->GetFabricIndex(), ourRootPublicKey));
     ReturnErrorOnFailure(fabricTable->FetchRootPubkey(fabric->GetFabricIndex(), otherRootPublicKey));
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -749,8 +749,8 @@ static NSString * const kErrorCommitPendingFabricData = @"Committing fabric data
     }
 
     chip::Credentials::P256PublicKey ourRootPublicKey, otherRootPublicKey;
-    ReturnErrorOnFailure(ourFabric->GetRootPubkey(ourRootPublicKey));
-    ReturnErrorOnFailure(fabric->GetRootPubkey(otherRootPublicKey));
+    ReturnErrorOnFailure(ourFabric->FetchRootPubkey(ourRootPublicKey));
+    ReturnErrorOnFailure(fabric->FetchRootPubkey(otherRootPublicKey));
 
     *isRunning = (ourRootPublicKey.Matches(otherRootPublicKey));
     return CHIP_NO_ERROR;

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -748,11 +748,11 @@ static NSString * const kErrorCommitPendingFabricData = @"Committing fabric data
         return CHIP_NO_ERROR;
     }
 
-    chip::Credentials::P256PublicKeySpan ourRootPublicKey, otherRootPublicKey;
+    chip::Credentials::P256PublicKey ourRootPublicKey, otherRootPublicKey;
     ReturnErrorOnFailure(ourFabric->GetRootPubkey(ourRootPublicKey));
     ReturnErrorOnFailure(fabric->GetRootPubkey(otherRootPublicKey));
 
-    *isRunning = (ourRootPublicKey.data_equal(otherRootPublicKey));
+    *isRunning = (ourRootPublicKey.Matches(otherRootPublicKey));
     return CHIP_NO_ERROR;
 }
 

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -748,9 +748,15 @@ static NSString * const kErrorCommitPendingFabricData = @"Committing fabric data
         return CHIP_NO_ERROR;
     }
 
+    chip::Credentials::FabricTable * fabricTable = _cppCommissioner->GetFabricTable();
+    if (!fabricTable) {
+        // Surprising as well!
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
     chip::Credentials::P256PublicKey ourRootPublicKey, otherRootPublicKey;
-    ReturnErrorOnFailure(ourFabric->FetchRootPubkey(ourRootPublicKey));
-    ReturnErrorOnFailure(fabric->FetchRootPubkey(otherRootPublicKey));
+    ReturnErrorOnFailure(fabricTable->FetchRootPubkey(ourFabric->GetFabricIndex(), ourRootPublicKey));
+    ReturnErrorOnFailure(fabricTable->FetchRootPubkey(fabric->GetFabricIndex(), otherRootPublicKey));
 
     *isRunning = (ourRootPublicKey.Matches(otherRootPublicKey));
     return CHIP_NO_ERROR;

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerStartupParams.mm
@@ -217,7 +217,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
         if (self.operationalKeypair == nil) {
             uint8_t nocBuf[Credentials::kMaxCHIPCertLength];
             MutableByteSpan noc(nocBuf);
-            CHIP_ERROR err = fabric->GetNOCCert(noc);
+            CHIP_ERROR err = fabric->FetchNOCCert(noc);
             if (err != CHIP_NO_ERROR) {
                 CHIP_LOG_ERROR("Failed to get existing NOC: %s", ErrorStr(err));
                 return nil;
@@ -240,7 +240,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
     {
         uint8_t icaBuf[Credentials::kMaxCHIPCertLength];
         MutableByteSpan icaCert(icaBuf);
-        CHIP_ERROR err = fabric->GetICACert(icaCert);
+        CHIP_ERROR err = fabric->FetchICACert(icaCert);
         if (err != CHIP_NO_ERROR) {
             CHIP_LOG_ERROR("Failed to get existing intermediate certificate: %s", ErrorStr(err));
             return nil;
@@ -282,7 +282,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
     {
         uint8_t rootBuf[Credentials::kMaxCHIPCertLength];
         MutableByteSpan rootCert(rootBuf);
-        CHIP_ERROR err = fabric->GetRootCert(rootCert);
+        CHIP_ERROR err = fabric->FetchRootCert(rootCert);
         if (err != CHIP_NO_ERROR) {
             CHIP_LOG_ERROR("Failed to get existing root certificate: %s", ErrorStr(err));
             return nil;

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerStartupParams.mm
@@ -217,7 +217,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
         if (self.operationalKeypair == nil) {
             uint8_t nocBuf[Credentials::kMaxCHIPCertLength];
             MutableByteSpan noc(nocBuf);
-            CHIP_ERROR err = fabric->FetchNOCCert(noc);
+            CHIP_ERROR err = fabricTable->FetchNOCCert(fabric->GetFabricIndex(), noc);
             if (err != CHIP_NO_ERROR) {
                 CHIP_LOG_ERROR("Failed to get existing NOC: %s", ErrorStr(err));
                 return nil;
@@ -240,7 +240,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
     {
         uint8_t icaBuf[Credentials::kMaxCHIPCertLength];
         MutableByteSpan icaCert(icaBuf);
-        CHIP_ERROR err = fabric->FetchICACert(icaCert);
+        CHIP_ERROR err = fabricTable->FetchICACert(fabric->GetFabricIndex(), icaCert);
         if (err != CHIP_NO_ERROR) {
             CHIP_LOG_ERROR("Failed to get existing intermediate certificate: %s", ErrorStr(err));
             return nil;
@@ -282,7 +282,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
     {
         uint8_t rootBuf[Credentials::kMaxCHIPCertLength];
         MutableByteSpan rootCert(rootBuf);
-        CHIP_ERROR err = fabric->FetchRootCert(rootCert);
+        CHIP_ERROR err = fabricTable->FetchRootCert(fabric->GetFabricIndex(), rootCert);
         if (err != CHIP_NO_ERROR) {
             CHIP_LOG_ERROR("Failed to get existing root certificate: %s", ErrorStr(err));
             return nil;

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerStartupParams.mm
@@ -215,7 +215,8 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
         self.nodeId = @(fabric->GetNodeId());
 
         if (self.operationalKeypair == nil) {
-            ByteSpan noc;
+            uint8_t nocBuf[Credentials::kMaxCHIPCertLength];
+            MutableByteSpan noc(nocBuf);
             CHIP_ERROR err = fabric->GetNOCCert(noc);
             if (err != CHIP_NO_ERROR) {
                 CHIP_LOG_ERROR("Failed to get existing NOC: %s", ErrorStr(err));
@@ -237,7 +238,8 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 
     NSData * oldIntermediateCert = nil;
     {
-        ByteSpan icaCert;
+        uint8_t icaBuf[Credentials::kMaxCHIPCertLength];
+        MutableByteSpan icaCert(icaBuf);
         CHIP_ERROR err = fabric->GetICACert(icaCert);
         if (err != CHIP_NO_ERROR) {
             CHIP_LOG_ERROR("Failed to get existing intermediate certificate: %s", ErrorStr(err));
@@ -278,7 +280,8 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 
     NSData * oldRootCert;
     {
-        ByteSpan rootCert;
+        uint8_t rootBuf[Credentials::kMaxCHIPCertLength];
+        MutableByteSpan rootCert(rootBuf);
         CHIP_ERROR err = fabric->GetRootCert(rootCert);
         if (err != CHIP_NO_ERROR) {
             CHIP_LOG_ERROR("Failed to get existing root certificate: %s", ErrorStr(err));

--- a/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPP256KeypairBridge.mm
@@ -161,7 +161,7 @@ CHIP_ERROR CHIPP256KeypairBridge::MatterPubKeyFromSecKeyRef(SecKeyRef pubkeyRef,
         return CHIP_ERROR_INTERNAL;
     }
     chip::FixedByteSpan<kP256_PublicKey_Length> pubkeyBytes((const uint8_t *) pubkeyData.bytes);
-    *matterPubKey = P256PublicKey(pubkeyBytes);
+    *matterPubKey = pubkeyBytes;
 
     return CHIP_NO_ERROR;
 }

--- a/src/darwin/Framework/CHIP/MatterControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MatterControllerFactory.mm
@@ -448,7 +448,7 @@ static NSString * const kErrorKeystoreInit = @"Init failure while initializing p
         }
     }
 
-    *fabric = fabricTable.FindFabric(Credentials::P256PublicKeySpan(pubKey.ConstBytes()), params.fabricId);
+    *fabric = fabricTable.FindFabric(pubKey, params.fabricId);
     return YES;
 }
 

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1065,10 +1065,10 @@ CHIP_ERROR CASESession::SendSigma3()
 
     ChipLogDetail(SecureChannel, "Sending Sigma3");
 
-    VerifyOrExit(icacBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(icacBuf.Alloc(kMaxCHIPCertLength), err = CHIP_ERROR_NO_MEMORY);
     icaCert = MutableByteSpan{ icacBuf.Get(), kMaxCHIPCertLength };
 
-    VerifyOrExit(nocBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
+    VerifyOrExit(nocBuf.Alloc(kMaxCHIPCertLength), err = CHIP_ERROR_NO_MEMORY);
     nocCert = MutableByteSpan{ nocBuf.Get(), kMaxCHIPCertLength };
 
     VerifyOrExit(mFabricsTable != nullptr, err = CHIP_ERROR_INCORRECT_STATE);

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -381,9 +381,9 @@ CHIP_ERROR CASESession::SendSigma1()
         ReturnErrorOnFailure(RecoverInitiatorIpk());
 
         FabricId fabricId = fabricInfo->GetFabricId();
-        uint8_t rootPubKeyBuf[Crypto::kP256_Point_Length];
-        Credentials::P256PublicKeySpan rootPubKeySpan(rootPubKeyBuf);
-        ReturnErrorOnFailure(fabricInfo->GetRootPubkey(rootPubKeySpan));
+        Crypto::P256PublicKey rootPubKey;
+        ReturnErrorOnFailure(mFabricsTable->GetRootPubkey(mFabricIndex, rootPubKey));
+        Credentials::P256PublicKeySpan rootPubKeySpan{rootPubKey.ConstBytes()};
 
         MutableByteSpan destinationIdSpan(destinationIdentifier);
         ReturnErrorOnFailure(GenerateCaseDestinationId(ByteSpan(mIPK), ByteSpan(mInitiatorRandom), rootPubKeySpan, fabricId,
@@ -457,9 +457,9 @@ CHIP_ERROR CASESession::FindLocalNodeFromDestionationId(const ByteSpan & destina
         // Basic data for candidate fabric, used to compute candidate destination identifiers
         FabricId fabricId = fabricInfo.GetFabricId();
         NodeId nodeId     = fabricInfo.GetNodeId();
-        uint8_t rootPubKeyBuf[Crypto::kP256_Point_Length];
-        Credentials::P256PublicKeySpan rootPubKeySpan(rootPubKeyBuf);
-        ReturnErrorOnFailure(fabricInfo.GetRootPubkey(rootPubKeySpan));
+        Crypto::P256PublicKey rootPubKey;
+        ReturnErrorOnFailure(mFabricsTable->GetRootPubkey(fabricInfo.GetFabricIndex(), rootPubKey));
+        Credentials::P256PublicKeySpan rootPubKeySpan{rootPubKey.ConstBytes()};
 
         // Get IPK operational group key set for current candidate fabric
         GroupDataProvider::KeySet ipkKeySet;
@@ -667,14 +667,18 @@ CHIP_ERROR CASESession::SendSigma2()
 
     VerifyOrReturnError(GetLocalSessionId().HasValue(), CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(mFabricsTable != nullptr, CHIP_ERROR_INCORRECT_STATE);
-    auto * fabricInfo = mFabricsTable->FindFabricWithIndex(mFabricIndex);
-    VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-    ByteSpan icaCert;
-    ReturnErrorOnFailure(fabricInfo->GetICACert(icaCert));
+    chip::Platform::ScopedMemoryBuffer<uint8_t> icacBuf;
+    VerifyOrReturnError(icacBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
 
-    ByteSpan nocCert;
-    ReturnErrorOnFailure(fabricInfo->GetNOCCert(nocCert));
+    chip::Platform::ScopedMemoryBuffer<uint8_t> nocBuf;
+    VerifyOrReturnError(nocBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
+
+    MutableByteSpan icaCert{icacBuf.Get(), kMaxCHIPCertLength};
+    ReturnErrorOnFailure(mFabricsTable->GetICACert(mFabricIndex, icaCert));
+
+    MutableByteSpan nocCert{nocBuf.Get(), kMaxCHIPCertLength};
+    ReturnErrorOnFailure(mFabricsTable->GetNOCCert(mFabricIndex, nocCert));
 
     // Fill in the random value
     uint8_t msg_rand[kSigmaParamRandomNumberSize];
@@ -701,7 +705,7 @@ CHIP_ERROR CASESession::SendSigma2()
 
     // Construct Sigma2 TBS Data
     size_t msg_r2_signed_len =
-        TLV::EstimateStructOverhead(nocCert.size(), icaCert.size(), kP256_PublicKey_Length, kP256_PublicKey_Length);
+        TLV::EstimateStructOverhead(kMaxCHIPCertLength, kMaxCHIPCertLength, kP256_PublicKey_Length, kP256_PublicKey_Length);
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> msg_R2_Signed;
     VerifyOrReturnError(msg_R2_Signed.Alloc(msg_r2_signed_len), CHIP_ERROR_NO_MEMORY);
@@ -732,6 +736,16 @@ CHIP_ERROR CASESession::SendSigma2()
     {
         ReturnErrorOnFailure(tlvWriter.Put(TLV::ContextTag(kTag_TBEData_SenderICAC), icaCert));
     }
+
+    // We are now done with ICAC and NOC certs so we can release the memory.
+    {
+        icacBuf.Free();
+        icaCert = MutableByteSpan{};
+
+        nocBuf.Free();
+        nocCert = MutableByteSpan{};
+    }
+
     ReturnErrorOnFailure(tlvWriter.PutBytes(TLV::ContextTag(kTag_TBEData_Signature), tbsData2Signature,
                                             static_cast<uint32_t>(tbsData2Signature.Length())));
 
@@ -1026,7 +1040,6 @@ CHIP_ERROR CASESession::SendSigma3()
 {
     MATTER_TRACE_EVENT_SCOPE("SendSigma3", "CASESession");
     CHIP_ERROR err          = CHIP_NO_ERROR;
-    FabricInfo * fabricInfo = nullptr;
 
     MutableByteSpan messageDigestSpan(mMessageDigest);
     System::PacketBufferHandle msg_R3;
@@ -1044,17 +1057,24 @@ CHIP_ERROR CASESession::SendSigma3()
 
     P256ECDSASignature tbsData3Signature;
 
+    chip::Platform::ScopedMemoryBuffer<uint8_t> icacBuf;
+    MutableByteSpan icaCert;
+
+    chip::Platform::ScopedMemoryBuffer<uint8_t> nocBuf;
+    MutableByteSpan nocCert;
+
     ChipLogDetail(SecureChannel, "Sending Sigma3");
 
-    ByteSpan icaCert;
-    ByteSpan nocCert;
+    VerifyOrExit(icacBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
+    icaCert = MutableByteSpan{icacBuf.Get(), kMaxCHIPCertLength};
+
+    VerifyOrExit(nocBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
+    nocCert = MutableByteSpan{nocBuf.Get(), kMaxCHIPCertLength};
 
     VerifyOrExit(mFabricsTable != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    fabricInfo = mFabricsTable->FindFabricWithIndex(mFabricIndex);
-    VerifyOrExit(fabricInfo != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    SuccessOrExit(err = fabricInfo->GetICACert(icaCert));
-    SuccessOrExit(err = fabricInfo->GetNOCCert(nocCert));
+    SuccessOrExit(err = mFabricsTable->GetICACert(mFabricIndex, icaCert));
+    SuccessOrExit(err = mFabricsTable->GetNOCCert(mFabricIndex, nocCert));
 
     // Prepare Sigma3 TBS Data Blob
     msg_r3_signed_len = TLV::EstimateStructOverhead(icaCert.size(), nocCert.size(), kP256_PublicKey_Length, kP256_PublicKey_Length);
@@ -1084,6 +1104,16 @@ CHIP_ERROR CASESession::SendSigma3()
         {
             SuccessOrExit(err = tlvWriter.Put(TLV::ContextTag(kTag_TBEData_SenderICAC), icaCert));
         }
+
+        // We are now done with ICAC and NOC certs so we can release the memory.
+        {
+            icacBuf.Free();
+            icaCert = MutableByteSpan{};
+
+            nocBuf.Free();
+            nocCert = MutableByteSpan{};
+        }
+
         SuccessOrExit(err = tlvWriter.PutBytes(TLV::ContextTag(kTag_TBEData_Signature), tbsData3Signature,
                                                static_cast<uint32_t>(tbsData3Signature.Length())));
         SuccessOrExit(err = tlvWriter.EndContainer(outerContainerType));

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -382,7 +382,7 @@ CHIP_ERROR CASESession::SendSigma1()
 
         FabricId fabricId = fabricInfo->GetFabricId();
         Crypto::P256PublicKey rootPubKey;
-        ReturnErrorOnFailure(mFabricsTable->GetRootPubkey(mFabricIndex, rootPubKey));
+        ReturnErrorOnFailure(mFabricsTable->FetchRootPubkey(mFabricIndex, rootPubKey));
         Credentials::P256PublicKeySpan rootPubKeySpan{ rootPubKey.ConstBytes() };
 
         MutableByteSpan destinationIdSpan(destinationIdentifier);
@@ -458,7 +458,7 @@ CHIP_ERROR CASESession::FindLocalNodeFromDestionationId(const ByteSpan & destina
         FabricId fabricId = fabricInfo.GetFabricId();
         NodeId nodeId     = fabricInfo.GetNodeId();
         Crypto::P256PublicKey rootPubKey;
-        ReturnErrorOnFailure(mFabricsTable->GetRootPubkey(fabricInfo.GetFabricIndex(), rootPubKey));
+        ReturnErrorOnFailure(mFabricsTable->FetchRootPubkey(fabricInfo.GetFabricIndex(), rootPubKey));
         Credentials::P256PublicKeySpan rootPubKeySpan{ rootPubKey.ConstBytes() };
 
         // Get IPK operational group key set for current candidate fabric
@@ -675,10 +675,10 @@ CHIP_ERROR CASESession::SendSigma2()
     VerifyOrReturnError(nocBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
 
     MutableByteSpan icaCert{ icacBuf.Get(), kMaxCHIPCertLength };
-    ReturnErrorOnFailure(mFabricsTable->GetICACert(mFabricIndex, icaCert));
+    ReturnErrorOnFailure(mFabricsTable->FetchICACert(mFabricIndex, icaCert));
 
     MutableByteSpan nocCert{ nocBuf.Get(), kMaxCHIPCertLength };
-    ReturnErrorOnFailure(mFabricsTable->GetNOCCert(mFabricIndex, nocCert));
+    ReturnErrorOnFailure(mFabricsTable->FetchNOCCert(mFabricIndex, nocCert));
 
     // Fill in the random value
     uint8_t msg_rand[kSigmaParamRandomNumberSize];
@@ -1073,8 +1073,8 @@ CHIP_ERROR CASESession::SendSigma3()
 
     VerifyOrExit(mFabricsTable != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 
-    SuccessOrExit(err = mFabricsTable->GetICACert(mFabricIndex, icaCert));
-    SuccessOrExit(err = mFabricsTable->GetNOCCert(mFabricIndex, nocCert));
+    SuccessOrExit(err = mFabricsTable->FetchICACert(mFabricIndex, icaCert));
+    SuccessOrExit(err = mFabricsTable->FetchNOCCert(mFabricIndex, nocCert));
 
     // Prepare Sigma3 TBS Data Blob
     msg_r3_signed_len = TLV::EstimateStructOverhead(icaCert.size(), nocCert.size(), kP256_PublicKey_Length, kP256_PublicKey_Length);

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -383,7 +383,7 @@ CHIP_ERROR CASESession::SendSigma1()
         FabricId fabricId = fabricInfo->GetFabricId();
         Crypto::P256PublicKey rootPubKey;
         ReturnErrorOnFailure(mFabricsTable->GetRootPubkey(mFabricIndex, rootPubKey));
-        Credentials::P256PublicKeySpan rootPubKeySpan{rootPubKey.ConstBytes()};
+        Credentials::P256PublicKeySpan rootPubKeySpan{ rootPubKey.ConstBytes() };
 
         MutableByteSpan destinationIdSpan(destinationIdentifier);
         ReturnErrorOnFailure(GenerateCaseDestinationId(ByteSpan(mIPK), ByteSpan(mInitiatorRandom), rootPubKeySpan, fabricId,
@@ -459,7 +459,7 @@ CHIP_ERROR CASESession::FindLocalNodeFromDestionationId(const ByteSpan & destina
         NodeId nodeId     = fabricInfo.GetNodeId();
         Crypto::P256PublicKey rootPubKey;
         ReturnErrorOnFailure(mFabricsTable->GetRootPubkey(fabricInfo.GetFabricIndex(), rootPubKey));
-        Credentials::P256PublicKeySpan rootPubKeySpan{rootPubKey.ConstBytes()};
+        Credentials::P256PublicKeySpan rootPubKeySpan{ rootPubKey.ConstBytes() };
 
         // Get IPK operational group key set for current candidate fabric
         GroupDataProvider::KeySet ipkKeySet;
@@ -674,10 +674,10 @@ CHIP_ERROR CASESession::SendSigma2()
     chip::Platform::ScopedMemoryBuffer<uint8_t> nocBuf;
     VerifyOrReturnError(nocBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
 
-    MutableByteSpan icaCert{icacBuf.Get(), kMaxCHIPCertLength};
+    MutableByteSpan icaCert{ icacBuf.Get(), kMaxCHIPCertLength };
     ReturnErrorOnFailure(mFabricsTable->GetICACert(mFabricIndex, icaCert));
 
-    MutableByteSpan nocCert{nocBuf.Get(), kMaxCHIPCertLength};
+    MutableByteSpan nocCert{ nocBuf.Get(), kMaxCHIPCertLength };
     ReturnErrorOnFailure(mFabricsTable->GetNOCCert(mFabricIndex, nocCert));
 
     // Fill in the random value
@@ -1039,7 +1039,7 @@ exit:
 CHIP_ERROR CASESession::SendSigma3()
 {
     MATTER_TRACE_EVENT_SCOPE("SendSigma3", "CASESession");
-    CHIP_ERROR err          = CHIP_NO_ERROR;
+    CHIP_ERROR err = CHIP_NO_ERROR;
 
     MutableByteSpan messageDigestSpan(mMessageDigest);
     System::PacketBufferHandle msg_R3;
@@ -1066,10 +1066,10 @@ CHIP_ERROR CASESession::SendSigma3()
     ChipLogDetail(SecureChannel, "Sending Sigma3");
 
     VerifyOrExit(icacBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
-    icaCert = MutableByteSpan{icacBuf.Get(), kMaxCHIPCertLength};
+    icaCert = MutableByteSpan{ icacBuf.Get(), kMaxCHIPCertLength };
 
     VerifyOrExit(nocBuf.Alloc(kMaxCHIPCertLength), CHIP_ERROR_NO_MEMORY);
-    nocCert = MutableByteSpan{nocBuf.Get(), kMaxCHIPCertLength};
+    nocCert = MutableByteSpan{ nocBuf.Get(), kMaxCHIPCertLength };
 
     VerifyOrExit(mFabricsTable != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
 


### PR DESCRIPTION
#### Problem
To support moving to non-permanent storage, need to ensure
there is never direct access to certificates from FabricInfo classes
outside the FabricTable which owns all validations. This prevents
dangling FabricInfo instances and enables the changes needed to
make the fail-safe work to spec for AddNOC, UpdateNOC and
AddTrustedRootCertificate.

Issue #15585
Issue #7695

#### Change overview
- Always go through the FabricTable, don't allow going directly via
  FabricInfo
- Updated CASESession to go through FabricTable also
- Getters for certs and root public key are now copying operations,
  rather than updating a ByteSpan to internally owned data (which
  may be stale!)
- First step towards moving to spec-compliant lifecycle for UpdateNOC
  with the same model as OperationalKeystore
- No functional changes, only structural changes

#### Testing
- Cert tests still pass
- Unit tests still pass
