### PR TITLE
[tlv] Disable 64-bit lengths. NCC-E003350-GH4

### DIFF
--- a/src/lib/core/CHIPTLVReader.cpp
+++ b/src/lib/core/CHIPTLVReader.cpp
@@ -731,6 +731,7 @@ CHIP_ERROR TLVReader::ReadElement()
         break;
     case kTLVFieldSize_8Byte:
         mElemLenOrVal = LittleEndian::Read64(p);
+        VerifyOrReturnError(!TLVTypeHasLength(elemType) || (mElemLenOrVal <= UINT32_MAX), CHIP_ERROR_NOT_IMPLEMENTED);
         break;
     }
 


### PR DESCRIPTION
#### Problem
Fix #19340

TLV support for 64-bit lengths is impractical.
Few if any Matter devices will have >4GB buffers to support even one such element.

NCC-E003350-GH4

#### Change overview
Return ERROR_NOT_IMPLEMENTED when provided 64-bit length exceeds max 32-bit length.
This prevents potential buffer overflow attacks.

#### Testing
CI
Need to add or verify existence of test cases for the new behaviors:
- [ ] TLV with 64-bit length <= UINT32_MAX (expect success) -- may exist
- [ ] TLV with 64-bit length > UINT32_MAX (expect error) -- probably need to add
