### PR TITLE
Enable "Application" read test.

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_MC_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MC_9_1.yaml
@@ -70,9 +70,7 @@ tests:
           constraints:
               type: uint16
 
-    #Issue 18103
     - label: "Reads the Application attribute"
-      PICS: PICS_SKIP_SAMPLE_APP
       command: "readAttribute"
       attribute: "Application"
       response:

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -20894,7 +20894,6 @@ private:
         }
         case 6: {
             LogStep(6, "Reads the Application attribute");
-            VerifyOrDo(!ShouldSkip("PICS_SKIP_SAMPLE_APP"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             return ReadAttribute(kIdentityAlpha, GetEndpoint(3), ApplicationBasic::Id,
                                  ApplicationBasic::Attributes::Application::Id, true, chip::NullOptional);
         }


### PR DESCRIPTION
This works now that we run MC tests against tv-app.

Fixes https://github.com/project-chip/connectedhomeip/issues/18103
Fixes https://github.com/project-chip/connectedhomeip/issues/14645

#### Problem
Test disabled unnecessarily.

#### Change overview
Enable it.

#### Testing
Ran locally, it passes.