### PR TITLE
[Ameba] Use default DeviceInfoProviders for Ameba

### DIFF
--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -141,6 +141,8 @@ list(
     ${chip_dir}/examples/all-clusters-app/ameba/main/Globals.cpp
     ${chip_dir}/examples/all-clusters-app/ameba/main/LEDWidget.cpp
     ${chip_dir}/examples/all-clusters-app/ameba/main/DsoHack.cpp
+
+    ${chip_dir}/examples/providers/DeviceInfoProviderImpl.cpp
 )
 
 add_library(
@@ -181,6 +183,7 @@ target_include_directories(
     ${chip_dir}/examples/all-clusters-app/all-clusters-common/include
     ${chip_dir}/examples/all-clusters-app/ameba/main/include
     ${chip_dir}/examples/platform/ameba
+    ${chip_dir}/examples/providers
     ${chip_dir_output}/gen/include
     ${chip_dir}/src/include/
     ${chip_dir}/src/lib/

--- a/examples/all-clusters-app/ameba/main/chipinterface.cpp
+++ b/examples/all-clusters-app/ameba/main/chipinterface.cpp
@@ -22,6 +22,7 @@
 #include "Globals.h"
 #include "LEDWidget.h"
 #include "chip_porting.h"
+#include <DeviceInfoProviderImpl.h>
 #include <lwip_netconf.h>
 
 #include <app/clusters/identify-server/identify-server.h>
@@ -89,6 +90,7 @@ Identify gIdentify1 = {
 #endif
 
 static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 static void InitServer(intptr_t context)
 {
@@ -96,6 +98,8 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     initParams.InitializeStaticResourcesBeforeServerInit();
     chip::Server::GetInstance().Init(initParams);
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -37,6 +37,8 @@ list(
     ${chip_dir}/examples/lighting-app/ameba/main/Globals.cpp
     ${chip_dir}/examples/lighting-app/ameba/main/LEDWidget.cpp
     ${chip_dir}/examples/lighting-app/ameba/main/DsoHack.cpp
+
+    ${chip_dir}/examples/providers/DeviceInfoProviderImpl.cpp
 )
 
 add_library(
@@ -61,6 +63,7 @@ target_include_directories(
     ${chip_dir}/examples/lighting-app/lighting-common/include
     ${chip_dir}/examples/lighting-app/ameba/main/include
     ${chip_dir}/examples/platform/ameba
+    ${chip_dir}/examples/providers
     ${chip_dir_output}/gen/include
     ${chip_dir}/src/include/
     ${chip_dir}/src/lib/

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -22,6 +22,7 @@
 #include "Globals.h"
 #include "LEDWidget.h"
 #include "Server.h"
+#include <DeviceInfoProviderImpl.h>
 
 #include "chip_porting.h"
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -74,6 +75,7 @@ void NetWorkCommissioningInstInit()
 #endif
 
 static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 void OnIdentifyStart(Identify *)
 {
@@ -117,6 +119,8 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     chip::Server::GetInstance().Init(initParams);
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/ota-requestor-app/ameba/chip_main.cmake
+++ b/examples/ota-requestor-app/ameba/chip_main.cmake
@@ -28,6 +28,8 @@ list(
     ${chip_dir}/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
     ${chip_dir}/src/app/clusters/ota-requestor/ota-requestor-server.cpp
     ${chip_dir}/examples/platform/ameba/ota/OTAInitializer.cpp
+
+    ${chip_dir}/examples/providers/DeviceInfoProviderImpl.cpp
 )
 
 add_library(
@@ -62,6 +64,7 @@ target_include_directories(
     ${chip_dir}/src/app/clusters/ota-requestor
     ${chip_dir}/examples/ota-requestor-app/ameba/main/include
     ${chip_dir}/examples/platform/ameba
+    ${chip_dir}/examples/providers
     ${sdk_root}/component/soc/realtek/amebad/fwlib/include
 )
 

--- a/examples/ota-requestor-app/ameba/main/chipinterface.cpp
+++ b/examples/ota-requestor-app/ameba/main/chipinterface.cpp
@@ -20,6 +20,7 @@
 #include "CHIPDeviceManager.h"
 #include "DeviceCallbacks.h"
 #include "chip_porting.h"
+#include <DeviceInfoProviderImpl.h>
 
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/Server.h>
@@ -73,6 +74,7 @@ void NetWorkCommissioningInstInit()
 }
 
 static DeviceCallbacks EchoCallbacks;
+chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 static void InitServer(intptr_t context)
 {
@@ -80,6 +82,8 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     chip::Server::GetInstance().Init(initParams);
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());


### PR DESCRIPTION
#### Problem
Ameba does not have DeviceInfoProviders

#### Change overview
Let Ameba use the default DeviceInfoProviders for the time being
Added to all-clusters-app, lighting-app, ota-requestor-app

