### PR TITLE
[nrfconnect] Fixed auto relock attribute and Lock Operation event

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -59,7 +59,6 @@ namespace {
 
 constexpr int kFactoryResetTriggerTimeout      = 3000;
 constexpr int kFactoryResetCancelWindowTimeout = 3000;
-constexpr int kExtDiscoveryTimeoutSecs         = 20;
 constexpr int kAppEventQueueSize               = 10;
 constexpr uint8_t kButtonPushEvent             = 1;
 constexpr uint8_t kButtonReleaseEvent          = 0;
@@ -170,7 +169,6 @@ CHIP_ERROR AppTask::Init()
 
     // Initialize CHIP server
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-    chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(kExtDiscoveryTimeoutSecs);
 
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();


### PR DESCRIPTION
#### Problem
There are two issues with the nrfconnect door lock:
* It has auto-relock-time value set to 60, while it should be 0
* It emits Lock Operation event on init, while no operation was done.

#### Change overview
* Set auto relock time to 0
* Added invoking lock/unlock operation only if lock state is not null (uninitialized)
* By the way of this change aligned lighting app extended discovery timeout to other nrfconnect examples

#### Testing
Manual testing was done.
