### PR TITLE
[Infineon] Fix CYW30739 GetNetworkInterfaces and MatterPostAttributeChangeCallback methods.

### DIFF
--- a/examples/lighting-app/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/cyw30739/src/ZclCallbacks.cpp
@@ -64,9 +64,16 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
         }
         break;
     case Identify::Id:
-        ChipLogProgress(Zcl, "Identify attribute ID: " ChipLogFormatMEI " Type: %u Value: %u, length %u",
-                        ChipLogValueMEI(attributePath.mClusterId), type, *value, size);
-        return;
+        if (attributePath.mAttributeId == Identify::Attributes::IdentifyTime::Id)
+        {
+            uint16_t identifyTime;
+            if (EMBER_ZCL_STATUS_SUCCESS == Identify::Attributes::IdentifyTime::Get(attributePath.mEndpointId, &identifyTime))
+            {
+                ChipLogProgress(Zcl, "IdentifyTime %u", identifyTime);
+                return;
+            }
+        }
+        break;
     default:
         printf("Unhandled cluster ID: 0x%04lx\n", attributePath.mClusterId);
         return;

--- a/src/platform/CYW30739/DiagnosticDataProviderImpl.h
+++ b/src/platform/CYW30739/DiagnosticDataProviderImpl.h
@@ -44,8 +44,20 @@ public:
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_THREAD */
+
+private:
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
+    struct ThreadNetworkInterface : public NetworkInterface
+    {
+        ~ThreadNetworkInterface() = delete;
+
+        uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
+    };
+#endif /* CHIP_DEVICE_CONFIG_ENABLE_THREAD */
 };
 
 } // namespace DeviceLayer


### PR DESCRIPTION
#### Problem
See reviews in https://github.com/project-chip/connectedhomeip/pull/18733

#### Change overview
* Fix returning a dangling pointer for the CYW30739 GetNetworkInterfaces method.
* Use the accessor to read IdentifyTime for CYW30739.

#### Testing
* chip-tool generaldiagnostics read network-interfaces ...
* chip-tool identify identify ...
