### PR TITLE
Fix comments around X.509/RFC5280 99991231235959Z time value

### DIFF
--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -740,12 +740,6 @@ CHIP_ERROR ExtractPublicKeyFromChipCert(const ByteSpan & chipCert, P256PublicKey
  * Extract Not Before Time from a chip certificate in ByteSpan TLV-encoded form.
  * Output format is seconds referenced from the CHIP epoch.
  *
- * Special value 0 corresponds to the X.509/RFC5280 defined special time value
- * 99991231235959Z meaning 'no well-defined expiration date'.  However, as a
- * NotBefore time, this does not require special handling when comparing to
- * a CHIP epoch time source, as 0 (the epoch) is also the earliest representable
- * uint32 time.
-
  * This does not perform any sort of validation on the certificate structure
  * other than parsing it.
  *


### PR DESCRIPTION
#### Problem

X.509/RFC5280 defines the special time 99991231235959Z to mean 'no
well-defined expiration date'.  Comments in the code implied this was
also relevant for NotBefore, but it's not.  This is only a NotAfter
concept.

#### Change overview

In spite of the misleading comments, the code does have reasonable behavior for both the NotBefore and NotAfter cases.  This commit amends comments to spell out exactly what this behavior is.

#### Testing

Tested to build without error.