### PR TITLE
Better handling for the multiple fabric tables live during controller startup

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController_Internal.h
@@ -33,7 +33,7 @@
 @class MatterControllerFactory;
 
 namespace chip {
-class FabricInfo;
+class FabricTable;
 } // namespace chip
 
 NS_ASSUME_NONNULL_BEGIN
@@ -66,16 +66,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithFactory:(MatterControllerFactory *)factory queue:(dispatch_queue_t)queue;
 
 /**
- * Check whether this controller is running on the given fabric.  The FabricInfo
- * might be from a one-off fabric table.  This method MUST be called from the
- * Matter work queue.
+ * Check whether this controller is running on the given fabric, as represented
+ * by the provided FabricTable and fabric index.  The provided fabric table may
+ * not be the same as the fabric table this controller is using. This method
+ * MUST be called from the Matter work queue.
  *
  * Might return failure, in which case we don't know whether it's running on the
  * given fabric.  Otherwise it will set *isRunning to the right boolean value.
  *
  * Only MatterControllerFactory should be calling this.
  */
-- (CHIP_ERROR)isRunningOnFabric:(chip::FabricInfo *)fabric isRunning:(BOOL *)isRunning;
+- (CHIP_ERROR)isRunningOnFabric:(chip::FabricTable *)fabricTable
+                    fabricIndex:(chip::FabricIndex)fabricIndex
+                      isRunning:(BOOL *)isRunning;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MatterControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MatterControllerFactory.mm
@@ -305,7 +305,8 @@ static NSString * const kErrorKeystoreInit = @"Init failure while initializing p
 
         for (CHIPDeviceController * existing in _controllers) {
             BOOL isRunning = YES; // assume the worst
-            if ([existing isRunningOnFabric:fabric isRunning:&isRunning] != CHIP_NO_ERROR) {
+            if ([existing isRunningOnFabric:&fabricTable fabricIndex:fabric->GetFabricIndex() isRunning:&isRunning]
+                != CHIP_NO_ERROR) {
                 CHIP_LOG_ERROR("Can't tell what fabric a controller is running on.  Not safe to start.");
                 return;
             }


### PR DESCRIPTION
We should be using fabric indices with the right fabric table, not
assuming they have matching fabric indices.

#### Problem
Fabric indices from one fabric table being used with a different fabric table.

#### Change overview
Stop doing that.

#### Testing
Darwin tests should verify that this generally works right.