### PR TITLE
Make the chip-tool and darwin-framework-tool logging about pairing clearer

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -144,6 +144,7 @@ void PairingCommand::OnStatusUpdate(DevicePairingDelegate::Status status)
     {
     case DevicePairingDelegate::Status::SecurePairingSuccess:
         ChipLogProgress(chipTool, "Secure Pairing Success");
+        ChipLogProgress(chipTool, "CASE establishment successful");
         break;
     case DevicePairingDelegate::Status::SecurePairingFailed:
         ChipLogError(chipTool, "Secure Pairing Failed");
@@ -157,6 +158,7 @@ void PairingCommand::OnPairingComplete(CHIP_ERROR err)
     if (err == CHIP_NO_ERROR)
     {
         ChipLogProgress(chipTool, "Pairing Success");
+        ChipLogProgress(chipTool, "PASE establishment successful");
         if (mPairingMode == PairingMode::CodePaseOnly)
         {
             SetCommandExitStatus(err);

--- a/examples/darwin-framework-tool/commands/pairing/PairingDelegateBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/PairingDelegateBridge.mm
@@ -29,6 +29,7 @@
     switch (status) {
     case kSecurePairingSuccess:
         ChipLogProgress(chipTool, "Secure Pairing Success");
+        ChipLogProgress(chipTool, "CASE establishment successful");
         break;
     case kSecurePairingFailed:
         ChipLogError(chipTool, "Secure Pairing Failed");
@@ -42,10 +43,12 @@
 - (void)onPairingComplete:(NSError *)error
 {
     if (error != nil) {
+        ChipLogProgress(chipTool, "PASE establishment failed");
         _commandBridge->SetCommandExitStatus(error);
         return;
     }
-    ChipLogProgress(chipTool, "Pairing Complete");
+    ChipLogProgress(chipTool, "Pairing Success");
+    ChipLogProgress(chipTool, "PASE establishment successful");
     NSError * commissionError;
     [_commissioner commissionDevice:_deviceID commissioningParams:_params error:&commissionError];
     if (commissionError != nil) {


### PR DESCRIPTION
Make it clear whern PASE vs CASE is done.

Fixes https://github.com/project-chip/connectedhomeip/issues/19451

#### Problem
People being confused about when PASE is done.

#### Change overview
Make the logging clearer.

#### Testing
Looked at logs during commissioning.