### PR TITLE
Fix crash on read Networks when not connected

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1346,6 +1346,11 @@ CHIP_ERROR ConnectivityManagerImpl::GetConfiguredNetwork(NetworkCommissioning::N
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
     std::unique_ptr<GError, GErrorDeleter> err;
 
+    if (mWpaSupplicant.iface == nullptr) {
+        ChipLogDetail(DeviceLayer, "Wifi network not currently connected");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
     const gchar * networkPath = wpa_fi_w1_wpa_supplicant1_interface_get_current_network(mWpaSupplicant.iface);
 
     // wpa_supplicant DBus API: if network path of current network is "/", means no networks is currently selected.

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1346,7 +1346,8 @@ CHIP_ERROR ConnectivityManagerImpl::GetConfiguredNetwork(NetworkCommissioning::N
     std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
     std::unique_ptr<GError, GErrorDeleter> err;
 
-    if (mWpaSupplicant.iface == nullptr) {
+    if (mWpaSupplicant.iface == nullptr)
+    {
         ChipLogDetail(DeviceLayer, "Wifi network not currently connected");
         return CHIP_ERROR_INCORRECT_STATE;
     }


### PR DESCRIPTION
#### Problem
Crash when reading Networks attribute if no wifi network is connected.
This happens when running the example apps on linux with the wifi
feature enabled (--wifi) because the device is actually connected
via ethernet and wifi is not connected. This could happen in a prod
device if > 1 network type was supported.

Fixes #19585

#### Change overview
Add a check that the iface object is valid before dereferencing.

#### Testing
tested using chip-tool and all 'chip-all-clusters-app --wifi' on linux.
- armed failsafe
- called AddOrUpdateWifiNetwork
- read Networks attribute - no crash any more. Saw log.
