### PR TITLE
Synchronize recommended extension list with devcontainer extensions list

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -23,23 +23,23 @@
     "remoteUser": "vscode",
     // Add the IDs of extensions you want installed when the container is created in the array below.
     "extensions": [
-        "ms-azuretools.vscode-docker",
-        "xaver.clang-format",
-        "github.vscode-pull-request-github",
-        "maelvalais.autoconf",
-        "yzhang.markdown-all-in-one",
-        "eamodio.gitlens",
-        "yuichinukiyama.vscode-preview-server",
         "aaron-bond.better-comments",
-        "foxundermoon.shell-format",
+        "christian-kohler.path-intellisense",
+        "eamodio.gitlens",
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode",
-        "redhat.vscode-yaml",
-        "christian-kohler.path-intellisense",
+        "foxundermoon.shell-format",
+        "github.vscode-pull-request-github",
         "knisterpeter.vscode-github",
-        "npclaudiu.vscode-gn",
+        "maelvalais.autoconf",
         "marus25.cortex-debug",
-        "msedge-dev.gnls"
+        "ms-azuretools.vscode-docker",
+        "msedge-dev.gnls",
+        "npclaudiu.vscode-gn",
+        "redhat.vscode-yaml",
+        "xaver.clang-format",
+        "yuichinukiyama.vscode-preview-server",
+        "yzhang.markdown-all-in-one"
     ],
     // Use 'settings' to set *default* container specific settings.json values on container create.
     // You can edit these settings after create using File > Preferences > Settings > Remote.

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -3,7 +3,25 @@
     // Extension identifier format: ${publisher}.${name}. Example: vscode.csharp
 
     // List of extensions which should be recommended for users of this workspace.
-    "recommendations": ["marus25.cortex-debug"],
+    "recommendations": [
+        "ms-azuretools.vscode-docker",
+        "xaver.clang-format",
+        "github.vscode-pull-request-github",
+        "maelvalais.autoconf",
+        "yzhang.markdown-all-in-one",
+        "eamodio.gitlens",
+        "yuichinukiyama.vscode-preview-server",
+        "aaron-bond.better-comments",
+        "foxundermoon.shell-format",
+        "editorconfig.editorconfig",
+        "esbenp.prettier-vscode",
+        "redhat.vscode-yaml",
+        "christian-kohler.path-intellisense",
+        "knisterpeter.vscode-github",
+        "npclaudiu.vscode-gn",
+        "marus25.cortex-debug",
+        "msedge-dev.gnls"
+    ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []
 }

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,23 +4,23 @@
 
     // List of extensions which should be recommended for users of this workspace.
     "recommendations": [
-        "ms-azuretools.vscode-docker",
-        "xaver.clang-format",
-        "github.vscode-pull-request-github",
-        "maelvalais.autoconf",
-        "yzhang.markdown-all-in-one",
-        "eamodio.gitlens",
-        "yuichinukiyama.vscode-preview-server",
         "aaron-bond.better-comments",
-        "foxundermoon.shell-format",
+        "christian-kohler.path-intellisense",
+        "eamodio.gitlens",
         "editorconfig.editorconfig",
         "esbenp.prettier-vscode",
-        "redhat.vscode-yaml",
-        "christian-kohler.path-intellisense",
+        "foxundermoon.shell-format",
+        "github.vscode-pull-request-github",
         "knisterpeter.vscode-github",
-        "npclaudiu.vscode-gn",
+        "maelvalais.autoconf",
         "marus25.cortex-debug",
-        "msedge-dev.gnls"
+        "ms-azuretools.vscode-docker",
+        "msedge-dev.gnls",
+        "npclaudiu.vscode-gn",
+        "redhat.vscode-yaml",
+        "xaver.clang-format",
+        "yuichinukiyama.vscode-preview-server",
+        "yzhang.markdown-all-in-one"
     ],
     // List of extensions recommended by VS Code that should not be recommended for users of this workspace.
     "unwantedRecommendations": []


### PR DESCRIPTION
#### Problem
Recommended extensions list contains the only cortex-debug extension. 

What is being fixed?  Examples:
* synchronize recommended extension list with devcontainer extensions

#### Testing
Open vscode and install recommended extensions. 
