### PR TITLE
[Infineon] Optimize CYW30739 key-value storage implementations.

### DIFF
--- a/src/platform/CYW30739/CYW30739Config.cpp
+++ b/src/platform/CYW30739/CYW30739Config.cpp
@@ -38,28 +38,27 @@ CHIP_ERROR CYW30739Config::Init()
 template <typename T>
 CHIP_ERROR CYW30739Config::ReadConfigValue(Key key, T & val)
 {
-    wiced_result_t result;
-    uint16_t read_count = wiced_hal_read_nvram(PLATFORM_NVRAM_VSID_MATTER_BASE + key, sizeof(val), (uint8_t *) &val, &result);
-    if (result != WICED_SUCCESS || read_count != sizeof(val))
-    {
-        read_count = wiced_hal_read_nvram_static(PLATFORM_NVRAM_SSID_MATTER_BASE + key, sizeof(val), &val, &result);
-    }
-    if (result == WICED_SUCCESS && read_count == sizeof(val))
-        return CHIP_NO_ERROR;
-    else
-        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    size_t read_count;
+    ReturnErrorOnFailure(ReadConfigValueBin(key, &val, sizeof(val), read_count));
+    VerifyOrReturnError(sizeof(val) == read_count, CHIP_ERROR_PERSISTED_STORAGE_FAILED);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR CYW30739Config::ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen)
 {
-    return ReadConfigValueBin(key, reinterpret_cast<uint8_t *>(buf), bufSize, outLen);
+    return ReadConfigValueBin(key, buf, bufSize, outLen);
 }
 
 CHIP_ERROR CYW30739Config::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen)
 {
+    return ReadConfigValueBin(key, static_cast<void *>(buf), bufSize, outLen);
+}
+
+CHIP_ERROR CYW30739Config::ReadConfigValueBin(Key key, void * buf, size_t bufSize, size_t & outLen)
+{
     wiced_result_t result;
     uint16_t read_count = wiced_hal_read_nvram(PLATFORM_NVRAM_VSID_MATTER_BASE + key, bufSize, (uint8_t *) buf, &result);
-    if (result != WICED_SUCCESS)
+    if (kMinConfigKey_ChipFactory <= key && key <= kMaxConfigKey_ChipFactory && result != WICED_SUCCESS)
     {
         read_count = wiced_hal_read_nvram_static(PLATFORM_NVRAM_SSID_MATTER_BASE + key, bufSize, buf, &result);
     }
@@ -68,8 +67,8 @@ CHIP_ERROR CYW30739Config::ReadConfigValueBin(Key key, uint8_t * buf, size_t buf
         outLen = read_count;
         return CHIP_NO_ERROR;
     }
-    else
-        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
 template CHIP_ERROR CYW30739Config::ReadConfigValue(Key key, bool & val);
@@ -98,10 +97,15 @@ CHIP_ERROR CYW30739Config::WriteConfigValueStr(Key key, const char * str)
 
 CHIP_ERROR CYW30739Config::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
-    return WriteConfigValueBin(key, reinterpret_cast<const uint8_t *>(str), strLen);
+    return WriteConfigValueBin(key, str, strLen);
 }
 
 CHIP_ERROR CYW30739Config::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
+{
+    return WriteConfigValueBin(key, static_cast<const void *>(data), dataLen);
+}
+
+CHIP_ERROR CYW30739Config::WriteConfigValueBin(Key key, const void * data, size_t dataLen)
 {
     /* Skip writing because the write API reports error result for zero length data. */
     if (dataLen == 0)
@@ -111,25 +115,33 @@ CHIP_ERROR CYW30739Config::WriteConfigValueBin(Key key, const uint8_t * data, si
     const uint16_t write_count = wiced_hal_write_nvram(PLATFORM_NVRAM_VSID_MATTER_BASE + key, dataLen, (uint8_t *) data, &result);
     if (result == WICED_SUCCESS && write_count == dataLen)
         return CHIP_NO_ERROR;
-    else
-        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+
+    ChipLogError(DeviceLayer, "%s wiced_hal_write_nvram %u", __func__, result);
+    return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+}
+
+CHIP_ERROR CYW30739Config::ClearConfigValue(Key key)
+{
+    wiced_result_t result;
+    wiced_hal_delete_nvram(PLATFORM_NVRAM_VSID_MATTER_BASE + key, &result);
+    if (result == WICED_SUCCESS)
+    {
+        return CHIP_NO_ERROR;
+    }
+
+    return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
 }
 
 bool CYW30739Config::ConfigValueExists(Key key)
 {
-    wiced_result_t result;
     uint8_t val;
-    wiced_hal_read_nvram(PLATFORM_NVRAM_VSID_MATTER_BASE + key, sizeof(val), &val, &result);
-    if (result != WICED_SUCCESS)
-        wiced_hal_read_nvram_static(PLATFORM_NVRAM_SSID_MATTER_BASE + key, 0, NULL, &result);
-    return result == WICED_SUCCESS;
+    return ChipError::IsSuccess(ReadConfigValue(key, val));
 }
 
 CHIP_ERROR CYW30739Config::FactoryResetConfig(void)
 {
-    wiced_result_t result;
     for (Key key = kMinConfigKey_ChipConfig; key <= kMaxConfigKey_ChipConfig; key++)
-        wiced_hal_delete_nvram(PLATFORM_NVRAM_VSID_MATTER_BASE + key, &result);
+        ClearConfigValue(key);
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/CYW30739/CYW30739Config.h
+++ b/src/platform/CYW30739/CYW30739Config.h
@@ -45,8 +45,10 @@ class CYW30739Config
 public:
     using Key = uint32_t;
 
-    static constexpr uint8_t kChipFactory_KeyBase = 0x00;
-    static constexpr uint8_t kChipConfig_KeyBase  = 0x01;
+    static constexpr uint8_t kChipFactory_KeyBase  = 0x00;
+    static constexpr uint8_t kChipConfig_KeyBase   = 0x01;
+    static constexpr uint8_t kChipKvsValue_KeyBase = 0x02;
+    static constexpr uint8_t kChipKvsKey_KeyBase   = 0x03;
 
     // Key definitions for well-known keys.
     // Factory config keys
@@ -94,11 +96,13 @@ public:
 
     static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen);
+    static CHIP_ERROR ReadConfigValueBin(Key key, void * buf, size_t bufSize, size_t & outLen);
     template <typename T>
     static CHIP_ERROR WriteConfigValue(Key key, T val);
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str);
     static CHIP_ERROR WriteConfigValueStr(Key key, const char * str, size_t strLen);
     static CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen);
+    static CHIP_ERROR WriteConfigValueBin(Key key, const void * data, size_t dataLen);
     static CHIP_ERROR ClearConfigValue(Key key);
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);

--- a/src/platform/CYW30739/PlatformManagerImpl.cpp
+++ b/src/platform/CYW30739/PlatformManagerImpl.cpp
@@ -42,7 +42,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     wiced_result_t result;
 
     // Initialize the configuration system.
-    err = Internal::CYW30739Config::Init();
+    err = PersistedStorage::KeyValueStoreMgrImpl().Init();
     SuccessOrExit(err);
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());


### PR DESCRIPTION
#### Problem
* The CYW30739 KeyValueStoreManagerImpl is using a key-ID table to map a string-based key to a number-based NVRAM ID.
* The CYW30739 KeyValueStoreManagerImpl writes the whole key-ID table to the flash when there is a key-ID changed in the table.
* The size of this table has been growing to a large size while the number of keys keeps increasing.
* Therefore, we have to change the implementation of CYW30739 KeyValueStoreManagerImpl to avoid writing such a big table to the flash.

#### Change overview
* Replace the heavy key-NvramID table with a light-weighted key-configID list.
* No longer stores the key-configID map information in a flash. The key-configID map information is stored in a run-time linked list which was one-time constructed from the existing key and value stored to the flash in the initialization procedure.
* KeyValueStoreManagerImpl class no longer calls WICED NVRAM APIs directly. It accesses the flash through the CYW30739Config methods.
* Add kChipKvsValue_KeyBase and kChipKvsKey_KeyBase configuration groups for KVS key and value NVRAM IDs. KVS configuration groups obsolete original PLATFORM_NVRAM_ID_ENTRY_INFO_STRING based and PLATFORM_NVRAM_ID_ENTRY_DATA_STRING based NVRAM IDs.
* Implement missing methods of CYW30739Config class.

#### Testing
chip-tool pairing.
