### PR TITLE
Fix "No command" logging during group command dispatch.

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -399,7 +399,7 @@ CHIP_ERROR CommandHandler::ProcessGroupCommandDataIB(CommandDataIB::Parser & aCo
         if (mpCallback->CommandExists(concretePath) != Protocols::InteractionModel::Status::Success)
         {
             ChipLogDetail(DataManagement, "No command " ChipLogFormatMEI " in Cluster " ChipLogFormatMEI " on Endpoint 0x%x",
-                          ChipLogValueMEI(mapping.endpoint_id), ChipLogValueMEI(clusterId), mapping.endpoint_id);
+                          ChipLogValueMEI(commandId), ChipLogValueMEI(clusterId), mapping.endpoint_id);
 
             continue;
         }


### PR DESCRIPTION
We were logging the endpoint id and claiming it's the command id.

#### Problem
See above.

#### Change overview
Log the right thing.

#### Testing
Sent group command, looked at the logs.