### PR TITLE
Stop using com.zigbee.chip in Darwin queue names.

### DIFF
--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -406,7 +406,7 @@
     [super viewDidLoad];
     [self setupUI];
 
-    dispatch_queue_t callbackQueue = dispatch_queue_create("com.zigbee.chip.qrcodevc.callback", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.csa.matter.qrcodevc.callback", DISPATCH_QUEUE_SERIAL);
     self.chipController = InitializeCHIP();
     [self.chipController setPairingDelegate:self queue:callbackQueue];
 
@@ -776,7 +776,7 @@
 - (void)_restartMatterStack
 {
     self.chipController = CHIPRestartController(self.chipController);
-    dispatch_queue_t callbackQueue = dispatch_queue_create("com.zigbee.chip.qrcodevc.callback", DISPATCH_QUEUE_SERIAL);
+    dispatch_queue_t callbackQueue = dispatch_queue_create("com.csa.matter.qrcodevc.callback", DISPATCH_QUEUE_SERIAL);
     [self.chipController setPairingDelegate:self queue:callbackQueue];
 }
 

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -19,7 +19,7 @@
 
 CHIPPersistentStorageDelegateBridge::CHIPPersistentStorageDelegateBridge(id<CHIPPersistentStorageDelegate> delegate)
     : mDelegate(delegate)
-    , mWorkQueue(dispatch_queue_create("com.zigbee.chip.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL))
+    , mWorkQueue(dispatch_queue_create("com.csa.matter.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL))
 {
 }
 

--- a/src/platform/Darwin/Logging.cpp
+++ b/src/platform/Darwin/Logging.cpp
@@ -31,7 +31,7 @@ void ENFORCE_FORMAT(3, 0) LogV(const char * module, uint8_t category, const char
     char formattedMsg[CHIP_CONFIG_LOG_MESSAGE_MAX_SIZE];
     int32_t prefixLen   = snprintf(formattedMsg, sizeof(formattedMsg), "[%ld] [%lld:%lld] CHIP: [%s] ", ms, (long long) getpid(),
                                  (long long) ktid, module);
-    static os_log_t log = os_log_create("com.zigbee.chip", "all");
+    static os_log_t log = os_log_create("com.csa.matter", "all");
     if (prefixLen < 0)
     {
         // This should not happen

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -26,7 +26,7 @@
 #include <dispatch/dispatch.h>
 #include <platform/internal/GenericPlatformManagerImpl.h>
 
-static constexpr const char * const CHIP_CONTROLLER_QUEUE = "com.zigbee.chip.framework.controller.workqueue";
+static constexpr const char * const CHIP_CONTROLLER_QUEUE = "com.csa.matter.framework.controller.workqueue";
 
 namespace chip {
 namespace DeviceLayer {


### PR DESCRIPTION
Use com.csa.matter instead.

#### Problem
See above.

#### Change overview
See above.

#### Testing
No behavior changes.