### PR TITLE
[chip-cert] Updated Tool To Generate Invalid Operational Certificates.

### DIFF
--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -27,6 +27,7 @@
 #define __STDC_FORMAT_MACROS
 
 #include "chip-cert.h"
+#include <lib/core/CHIPEncoding.h>
 #include <lib/support/BytesToHex.h>
 
 #include <string>
@@ -34,8 +35,9 @@
 using namespace chip;
 using namespace chip::Credentials;
 using namespace chip::ASN1;
+using namespace chip::TLV;
 
-bool ToolChipDN::SetCertSubjectDN(X509 * cert) const
+bool ToolChipDN::SetCertName(X509_NAME * name) const
 {
     bool res         = true;
     uint8_t rdnCount = RDNCount();
@@ -77,8 +79,8 @@ bool ToolChipDN::SetCertSubjectDN(X509 * cert) const
                                                       Encoding::HexFlags::kUppercase) == CHIP_NO_ERROR,
                                 false);
 
-            if (!X509_NAME_add_entry_by_NID(X509_get_subject_name(cert), attrNID, MBSTRING_UTF8,
-                                            reinterpret_cast<uint8_t *>(chipAttrStr), sizeof(chipAttrStr), -1, 0))
+            if (!X509_NAME_add_entry_by_NID(name, attrNID, MBSTRING_UTF8, reinterpret_cast<uint8_t *>(chipAttrStr),
+                                            sizeof(chipAttrStr), -1, 0))
             {
                 ReportOpenSSLErrorAndExit("X509_NAME_add_entry_by_NID", res = false);
             }
@@ -90,15 +92,15 @@ bool ToolChipDN::SetCertSubjectDN(X509 * cert) const
                                                       Encoding::HexFlags::kUppercase) == CHIP_NO_ERROR,
                                 false);
 
-            if (!X509_NAME_add_entry_by_NID(X509_get_subject_name(cert), attrNID, MBSTRING_UTF8,
-                                            reinterpret_cast<uint8_t *>(chipAttrStr), sizeof(chipAttrStr), -1, 0))
+            if (!X509_NAME_add_entry_by_NID(name, attrNID, MBSTRING_UTF8, reinterpret_cast<uint8_t *>(chipAttrStr),
+                                            sizeof(chipAttrStr), -1, 0))
             {
                 ReportOpenSSLErrorAndExit("X509_NAME_add_entry_by_NID", res = false);
             }
         }
         else
         {
-            if (!X509_NAME_add_entry_by_NID(X509_get_subject_name(cert), attrNID, MBSTRING_UTF8,
+            if (!X509_NAME_add_entry_by_NID(name, attrNID, MBSTRING_UTF8,
                                             reinterpret_cast<uint8_t *>(const_cast<char *>(rdn[i].mString.data())),
                                             static_cast<int>(rdn[i].mString.size()), -1, 0))
             {
@@ -247,9 +249,10 @@ bool SetCertTimeField(ASN1_TIME * asn1Time, const struct tm & value)
     return true;
 }
 
-bool SetValidityTime(X509 * cert, const struct tm & validFrom, uint32_t validDays)
+bool SetValidityTime(X509 * cert, const struct tm & validFrom, uint32_t validDays, CertStructConfig & certConfig)
 {
     bool res = true;
+    struct tm validFromLocal;
     struct tm validTo;
     time_t validToTime;
 
@@ -283,13 +286,30 @@ bool SetValidityTime(X509 * cert, const struct tm & validFrom, uint32_t validDay
         localtime_r(&validToTime, &validTo);
     }
 
+    if (certConfig.IsValidityCorrect())
+    {
+        validFromLocal = validFrom;
+    }
+    else
+    {
+        // Switch values if error flag is set.
+        validFromLocal = validTo;
+        validTo        = validFrom;
+    }
+
     // Set the certificate's notBefore date.
-    res = SetCertTimeField(X509_get_notBefore(cert), validFrom);
-    VerifyTrueOrExit(res);
+    if (certConfig.IsValidityNotBeforePresent())
+    {
+        res = SetCertTimeField(X509_get_notBefore(cert), validFromLocal);
+        VerifyTrueOrExit(res);
+    }
 
     // Set the certificate's notAfter date.
-    res = SetCertTimeField(X509_get_notAfter(cert), validTo);
-    VerifyTrueOrExit(res);
+    if (certConfig.IsValidityNotAfterPresent())
+    {
+        res = SetCertTimeField(X509_get_notAfter(cert), validTo);
+        VerifyTrueOrExit(res);
+    }
 
 exit:
     return true;
@@ -308,6 +328,104 @@ bool AddExtension(X509 * cert, int extNID, const char * extStr)
 
 exit:
     return res;
+}
+
+bool SetBasicConstraintsExtension(X509 * cert, bool isCA, int pathLen, CertStructConfig & certConfig)
+{
+    if (!certConfig.IsExtensionBasicPresent())
+    {
+        return true;
+    }
+
+    std::string basicConstraintsExt;
+
+    if (certConfig.IsExtensionBasicCriticalPresent() && certConfig.IsExtensionBasicCritical())
+    {
+        basicConstraintsExt += "critical";
+    }
+
+    if (certConfig.IsExtensionBasicCAPresent())
+    {
+        if (!basicConstraintsExt.empty())
+        {
+            basicConstraintsExt += ",";
+        }
+        if ((certConfig.IsExtensionBasicCACorrect() && !isCA) || (!certConfig.IsExtensionBasicCACorrect() && isCA))
+        {
+            basicConstraintsExt += "CA:FALSE";
+        }
+        else
+        {
+            basicConstraintsExt += "CA:TRUE";
+        }
+    }
+
+    if (pathLen != kPathLength_NotSpecified)
+    {
+        if (!basicConstraintsExt.empty())
+        {
+            basicConstraintsExt += ",";
+        }
+        basicConstraintsExt.append("pathlen:" + std::to_string(pathLen));
+    }
+
+    return AddExtension(cert, NID_basic_constraints, basicConstraintsExt.c_str());
+}
+
+bool SetKeyUsageExtension(X509 * cert, bool isCA, CertStructConfig & certConfig)
+{
+    if (!certConfig.IsExtensionKeyUsagePresent())
+    {
+        return true;
+    }
+
+    std::string keyUsageExt;
+
+    if (certConfig.IsExtensionKeyUsageCriticalPresent() && certConfig.IsExtensionKeyUsageCritical())
+    {
+        keyUsageExt += "critical";
+    }
+
+    if ((certConfig.IsExtensionKeyUsageDigitalSigCorrect() && !isCA) ||
+        (!certConfig.IsExtensionKeyUsageDigitalSigCorrect() && isCA))
+    {
+        if (!keyUsageExt.empty())
+        {
+            keyUsageExt += ",";
+        }
+        keyUsageExt += "digitalSignature";
+    }
+
+    if ((certConfig.IsExtensionKeyUsageKeyCertSignCorrect() && isCA) ||
+        (!certConfig.IsExtensionKeyUsageKeyCertSignCorrect() && !isCA))
+    {
+        if (!keyUsageExt.empty())
+        {
+            keyUsageExt += ",";
+        }
+        keyUsageExt += "keyCertSign";
+    }
+
+    if ((certConfig.IsExtensionKeyUsageCRLSignCorrect() && isCA) || (!certConfig.IsExtensionKeyUsageCRLSignCorrect() && !isCA))
+    {
+        if (!keyUsageExt.empty())
+        {
+            keyUsageExt += ",";
+        }
+        keyUsageExt += "cRLSign";
+    }
+
+    // In test mode only: just add an extra extension flag to prevent empty extantion.
+    if (certConfig.IsErrorTestCaseEnabled() && (keyUsageExt.empty() || (keyUsageExt.compare("critical") == 0)))
+    {
+        if (!keyUsageExt.empty())
+        {
+            keyUsageExt += ",";
+        }
+        keyUsageExt += "keyEncipherment";
+    }
+
+    return AddExtension(cert, NID_key_usage, keyUsageExt.c_str());
 }
 
 /** The key identifier field is derived from the public key using method (1) per RFC5280 (section 4.2.1.2):
@@ -605,11 +723,52 @@ exit:
     return res;
 }
 
+bool WriteChipCert(const char * fileName, const ByteSpan & chipCert, CertFormat certFmt)
+{
+    bool res                    = true;
+    FILE * file                 = nullptr;
+    const uint8_t * certToWrite = nullptr;
+    size_t certToWriteLen       = 0;
+    uint32_t chipCertBase64Len  = BASE64_ENCODED_LEN(static_cast<uint32_t>(chipCert.size()));
+    std::unique_ptr<uint8_t[]> chipCertBase64(new uint8_t[chipCertBase64Len]);
+
+    VerifyOrReturnError(certFmt == kCertFormat_Chip_Raw || certFmt == kCertFormat_Chip_Base64, false);
+
+    if (certFmt == kCertFormat_Chip_Base64)
+    {
+        res = Base64Encode(chipCert.data(), static_cast<uint32_t>(chipCert.size()), chipCertBase64.get(), chipCertBase64Len,
+                           chipCertBase64Len);
+        VerifyTrueOrExit(res);
+
+        certToWrite    = chipCertBase64.get();
+        certToWriteLen = chipCertBase64Len;
+    }
+    else
+    {
+        certToWrite    = chipCert.data();
+        certToWriteLen = chipCert.size();
+    }
+
+    res = OpenFile(fileName, file, true);
+    VerifyTrueOrExit(res);
+
+    if (fwrite(certToWrite, 1, certToWriteLen, file) != certToWriteLen)
+    {
+        fprintf(stderr, "Unable to write to %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
+        ExitNow(res = false);
+    }
+
+exit:
+    CloseFile(file);
+    return res;
+}
+
 bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey, const struct tm & validFrom,
               uint32_t validDays, int pathLen, const FutureExtension * futureExts, uint8_t futureExtsCount, X509 * newCert,
-              EVP_PKEY * newKey)
+              EVP_PKEY * newKey, CertStructConfig & certConfig)
 {
-    bool res = true;
+    bool res  = true;
+    bool isCA = (certType != kCertType_Node);
 
     VerifyOrExit(subjectDN != nullptr, res = false);
     VerifyOrExit(caCert != nullptr, res = false);
@@ -618,17 +777,38 @@ bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP
     VerifyOrExit(newKey != nullptr, res = false);
 
     // Set the certificate version (must be 2, a.k.a. v3).
-    if (!X509_set_version(newCert, 2))
+    if (!X509_set_version(newCert, certConfig.GetCertVersion()))
     {
         ReportOpenSSLErrorAndExit("X509_set_version", res = false);
     }
 
     // Generate a serial number for the cert.
-    res = SetCertSerialNumber(newCert);
-    VerifyTrueOrExit(res);
+    if (certConfig.IsSerialNumberPresent())
+    {
+        res = SetCertSerialNumber(newCert);
+        VerifyTrueOrExit(res);
+    }
+
+    // Set the issuer name for the certificate. In the case of a self-signed cert, this will be
+    // the new cert's subject name.
+    if (certConfig.IsIssuerPresent())
+    {
+        if (certType == kCertType_Root)
+        {
+            res = subjectDN->SetCertIssuerDN(newCert);
+            VerifyTrueOrExit(res);
+        }
+        else
+        {
+            if (!X509_set_issuer_name(newCert, X509_get_subject_name(caCert)))
+            {
+                ReportOpenSSLErrorAndExit("X509_set_issuer_name", res = false);
+            }
+        }
+    }
 
     // Set the certificate validity time.
-    res = SetValidityTime(newCert, validFrom, validDays);
+    res = SetValidityTime(newCert, validFrom, validDays, certConfig);
     VerifyTrueOrExit(res);
 
     // Set the certificate's public key.
@@ -637,65 +817,81 @@ bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP
         ReportOpenSSLErrorAndExit("X509_set_pubkey", res = false);
     }
 
-    // Set certificate subject DN.
-    res = subjectDN->SetCertSubjectDN(newCert);
-    VerifyTrueOrExit(res);
-
-    // Set the issuer name for the certificate. In the case of a self-signed cert, this will be
-    // the new cert's subject name.
-    if (!X509_set_issuer_name(newCert, X509_get_subject_name(caCert)))
+    // Injuct error into public key value.
+    if (certConfig.IsPublicKeyError())
     {
-        ReportOpenSSLErrorAndExit("X509_set_issuer_name", res = false);
+        ASN1_BIT_STRING * pk = X509_get0_pubkey_bitstr(newCert);
+        pk->data[CertStructConfig::kPublicKeyErrorByte] ^= 0xFF;
     }
 
-    // Add basic constraints certificate extensions.
+    // Set certificate subject DN.
+    if (certConfig.IsSubjectPresent())
     {
-        std::string basicConstraintsExt;
-
-        if (certType == kCertType_Node || certType == kCertType_FirmwareSigning)
-        {
-            basicConstraintsExt = "critical,CA:FALSE";
-        }
-        else
-        {
-            basicConstraintsExt = "critical,CA:TRUE";
-        }
-
-        if (pathLen != kPathLength_NotSpecified)
-        {
-            basicConstraintsExt.append(",pathlen:" + std::to_string(pathLen));
-        }
-
-        res = AddExtension(newCert, NID_basic_constraints, basicConstraintsExt.c_str());
+        res = subjectDN->SetCertSubjectDN(newCert);
         VerifyTrueOrExit(res);
     }
 
-    // Add the appropriate certificate extensions.
-    if (certType == kCertType_Node)
+    // Add basic constraints certificate extensions.
+    if (certConfig.IsExtensionBasicPathLenPresent() || !certConfig.IsExtensionBasicCAPresent())
     {
-        res = AddExtension(newCert, NID_key_usage, "critical,digitalSignature") &&
-            AddExtension(newCert, NID_ext_key_usage, "critical,clientAuth,serverAuth");
+        pathLen = certConfig.GetExtensionBasicPathLenValue(certType);
     }
-    else if (certType == kCertType_FirmwareSigning)
-    {
-        res = AddExtension(newCert, NID_key_usage, "critical,digitalSignature") &&
-            AddExtension(newCert, NID_ext_key_usage, "critical,codeSigning");
-    }
-    else if (certType == kCertType_ICA || certType == kCertType_Root)
-    {
-        res = AddExtension(newCert, NID_key_usage, "critical,keyCertSign,cRLSign");
-    }
+    res = SetBasicConstraintsExtension(newCert, isCA, pathLen, certConfig);
     VerifyTrueOrExit(res);
 
-    // Add a subject key id extension for the certificate.
-    res = AddSubjectKeyId(newCert);
+    // Add key usage certificate extensions.
+    res = SetKeyUsageExtension(newCert, isCA, certConfig);
     VerifyTrueOrExit(res);
+
+    // Add extended key usage certificate extensions.
+    if (!certConfig.IsExtensionExtendedKeyUsageMissing())
+    {
+        if (certType == kCertType_Node)
+        {
+            res = AddExtension(newCert, NID_ext_key_usage, "critical,clientAuth,serverAuth");
+            VerifyTrueOrExit(res);
+        }
+        else if (certType == kCertType_FirmwareSigning)
+        {
+            res = AddExtension(newCert, NID_ext_key_usage, "critical,codeSigning");
+            VerifyTrueOrExit(res);
+        }
+    }
+
+    // Add a subject key id extension for the certificate.
+    if (certConfig.IsExtensionSKIDPresent())
+    {
+        res = AddSubjectKeyId(newCert);
+        VerifyTrueOrExit(res);
+    }
 
     // Add the authority key id extension from the signing certificate. For self-signed cert's this will
     // be the same as new cert's subject key id extension.
-    res = AddAuthorityKeyId(newCert, caCert);
-    VerifyTrueOrExit(res);
+    if (certConfig.IsExtensionAKIDPresent())
+    {
+        if ((certType == kCertType_Root) && !certConfig.IsExtensionSKIDPresent())
+        {
+            res = AddSubjectKeyId(newCert);
+            VerifyTrueOrExit(res);
+            res = AddAuthorityKeyId(newCert, newCert);
+            VerifyTrueOrExit(res);
 
+            // Remove that temporary added subject key id
+            int authKeyIdExtLoc = X509_get_ext_by_NID(newCert, NID_subject_key_identifier, -1);
+            if (authKeyIdExtLoc != -1)
+            {
+                if (X509_delete_ext(newCert, authKeyIdExtLoc) == nullptr)
+                {
+                    ReportOpenSSLErrorAndExit("X509_delete_ext", res = false);
+                }
+            }
+        }
+        else
+        {
+            res = AddAuthorityKeyId(newCert, caCert);
+            VerifyTrueOrExit(res);
+        }
+    }
     for (uint8_t i = 0; i < futureExtsCount; i++)
     {
         res = AddExtension(newCert, futureExts[i].nid, futureExts[i].info);
@@ -703,13 +899,273 @@ bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP
     }
 
     // Sign the new certificate.
-    if (!X509_sign(newCert, caKey, EVP_sha256()))
+    if (!X509_sign(newCert, caKey, certConfig.GetSignatureAlgorithmDER()))
     {
         ReportOpenSSLErrorAndExit("X509_sign", res = false);
     }
 
+    // Injuct error into signature value.
+    if (certConfig.IsSignatureError())
+    {
+        const ASN1_BIT_STRING * sig = nullptr;
+        X509_get0_signature(&sig, nullptr, newCert);
+        sig->data[20] ^= 0xFF;
+    }
+
 exit:
     return res;
+}
+
+CHIP_ERROR MakeCertChipTLV(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey,
+                           const struct tm & validFrom, uint32_t validDays, int pathLen, const FutureExtension * futureExts,
+                           uint8_t futureExtsCount, X509 * x509Cert, EVP_PKEY * newKey, CertStructConfig & certConfig,
+                           MutableByteSpan & chipCert)
+{
+    TLVWriter writer;
+    TLVType containerType;
+    TLVType containerType2;
+    TLVType containerType3;
+    uint8_t subjectPubkey[chip::Crypto::CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES] = { 0 };
+    uint8_t issuerPubkey[chip::Crypto::CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES]  = { 0 };
+    uint8_t keyid[chip::Crypto::kSHA1_Hash_Length]                         = { 0 };
+    bool isCA;
+
+    VerifyOrReturnError(subjectDN != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(caCert != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(caKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(x509Cert != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(newKey != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
+    isCA = (certType == kCertType_ICA || certType == kCertType_Root);
+
+    uint8_t * p = subjectPubkey;
+    VerifyOrReturnError(i2o_ECPublicKey(EVP_PKEY_get0_EC_KEY(newKey), &p) == chip::Crypto::CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+
+    p = issuerPubkey;
+    VerifyOrReturnError(i2o_ECPublicKey(EVP_PKEY_get0_EC_KEY(caKey), &p) == chip::Crypto::CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES,
+                        CHIP_ERROR_INVALID_ARGUMENT);
+
+    writer.Init(chipCert);
+
+    ReturnErrorOnFailure(writer.StartContainer(AnonymousTag(), kTLVType_Structure, containerType));
+
+    // serial number
+    if (certConfig.IsSerialNumberPresent())
+    {
+        ASN1_INTEGER * asn1Integer = X509_get_serialNumber(x509Cert);
+        uint64_t serialNumber;
+        uint8_t serialNumberArray[sizeof(uint64_t)];
+        VerifyOrReturnError(1 == ASN1_INTEGER_get_uint64(&serialNumber, asn1Integer), CHIP_ERROR_INVALID_ARGUMENT);
+        Encoding::BigEndian::Put64(serialNumberArray, serialNumber);
+        ReturnErrorOnFailure(writer.PutBytes(ContextTag(kTag_SerialNumber), serialNumberArray, sizeof(serialNumberArray)));
+    }
+
+    // signature algorithm
+    ReturnErrorOnFailure(writer.Put(ContextTag(kTag_SignatureAlgorithm), certConfig.GetSignatureAlgorithmTLVEnum()));
+
+    // issuer Name
+    if (certConfig.IsIssuerPresent())
+    {
+        if (certType == kCertType_Root)
+        {
+            ReturnErrorOnFailure(subjectDN->EncodeToTLV(writer, ContextTag(kTag_Issuer)));
+        }
+        else
+        {
+            uint8_t caChipCertBuf[kMaxCHIPCertLength];
+            MutableByteSpan caChipCert(caChipCertBuf);
+            VerifyOrReturnError(true == X509ToChipCert(caCert, caChipCert), CHIP_ERROR_INVALID_ARGUMENT);
+            ChipDN issuerDN;
+            ReturnErrorOnFailure(ExtractSubjectDNFromChipCert(caChipCert, issuerDN));
+            ReturnErrorOnFailure(issuerDN.EncodeToTLV(writer, ContextTag(kTag_Issuer)));
+        }
+    }
+
+    // validity
+    uint32_t validFromChipEpoch;
+    uint32_t validToChipEpoch;
+
+    VerifyOrReturnError(true ==
+                            CalendarToChipEpochTime(
+                                static_cast<uint16_t>(validFrom.tm_year + 1900), static_cast<uint8_t>(validFrom.tm_mon + 1),
+                                static_cast<uint8_t>(validFrom.tm_mday), static_cast<uint8_t>(validFrom.tm_hour),
+                                static_cast<uint8_t>(validFrom.tm_min), static_cast<uint8_t>(validFrom.tm_sec), validFromChipEpoch),
+                        CHIP_ERROR_INVALID_ARGUMENT);
+    if (validDays == kCertValidDays_NoWellDefinedExpiration)
+    {
+        validToChipEpoch = 0;
+    }
+    else
+    {
+        VerifyOrReturnError(CanCastTo<uint32_t>(validFromChipEpoch + validDays * kSecondsPerDay - 1), CHIP_ERROR_INVALID_ARGUMENT);
+        validToChipEpoch = validFromChipEpoch + validDays * kSecondsPerDay - 1;
+    }
+    if (!certConfig.IsValidityCorrect())
+    {
+        uint32_t validTemp = validFromChipEpoch;
+        validFromChipEpoch = validToChipEpoch;
+        validToChipEpoch   = validTemp;
+    }
+    if (certConfig.IsValidityNotBeforePresent())
+    {
+        ReturnErrorOnFailure(writer.Put(ContextTag(kTag_NotBefore), validFromChipEpoch));
+    }
+    if (certConfig.IsValidityNotAfterPresent())
+    {
+        ReturnErrorOnFailure(writer.Put(ContextTag(kTag_NotAfter), validToChipEpoch));
+    }
+
+    // subject Name
+    if (certConfig.IsSubjectPresent())
+    {
+        ReturnErrorOnFailure(subjectDN->EncodeToTLV(writer, ContextTag(kTag_Subject)));
+    }
+
+    // public key algorithm
+    ReturnErrorOnFailure(writer.Put(ContextTag(kTag_PublicKeyAlgorithm), GetOIDEnum(kOID_PubKeyAlgo_ECPublicKey)));
+
+    // public key curve Id
+    uint8_t ecCurveEnum = certConfig.IsSigCurveWrong() ? 0x02 : GetOIDEnum(kOID_EllipticCurve_prime256v1);
+    ReturnErrorOnFailure(writer.Put(ContextTag(kTag_EllipticCurveIdentifier), ecCurveEnum));
+
+    // public key
+    if (certConfig.IsPublicKeyError())
+    {
+        subjectPubkey[CertStructConfig::kPublicKeyErrorByte] ^= 0xFF;
+    }
+    ReturnErrorOnFailure(
+        writer.PutBytes(ContextTag(kTag_EllipticCurvePublicKey), subjectPubkey, chip::Crypto::CHIP_CRYPTO_PUBLIC_KEY_SIZE_BYTES));
+
+    // extensions
+    ReturnErrorOnFailure(writer.StartContainer(ContextTag(kTag_Extensions), kTLVType_List, containerType2));
+    {
+        if (isCA)
+        {
+            // basic constraints
+            if (certConfig.IsExtensionBasicPresent())
+            {
+                ReturnErrorOnFailure(writer.StartContainer(ContextTag(kTag_BasicConstraints), kTLVType_Structure, containerType3));
+                if (certConfig.IsExtensionBasicCAPresent())
+                {
+                    ReturnErrorOnFailure(writer.PutBoolean(ContextTag(kTag_BasicConstraints_IsCA),
+                                                           certConfig.IsExtensionBasicCACorrect() ? true : false));
+                }
+                // TODO
+                if (pathLen != kPathLength_NotSpecified)
+                {
+                    ReturnErrorOnFailure(
+                        writer.Put(ContextTag(kTag_BasicConstraints_PathLenConstraint), static_cast<uint8_t>(pathLen)));
+                }
+                ReturnErrorOnFailure(writer.EndContainer(containerType3));
+            }
+
+            // key usage
+            if (certConfig.IsExtensionKeyUsagePresent())
+            {
+                BitFlags<KeyUsageFlags> keyUsage;
+                if (!certConfig.IsExtensionKeyUsageDigitalSigCorrect())
+                {
+                    keyUsage.Set(KeyUsageFlags::kDigitalSignature);
+                }
+                if (certConfig.IsExtensionKeyUsageKeyCertSignCorrect())
+                {
+                    keyUsage.Set(KeyUsageFlags::kKeyCertSign);
+                }
+                if (certConfig.IsExtensionKeyUsageCRLSignCorrect())
+                {
+                    keyUsage.Set(KeyUsageFlags::kCRLSign);
+                }
+                ReturnErrorOnFailure(writer.Put(ContextTag(kTag_KeyUsage), keyUsage.Raw()));
+            }
+        }
+        else
+        {
+            // basic constraints
+            if (certConfig.IsExtensionBasicPresent())
+            {
+                ReturnErrorOnFailure(writer.StartContainer(ContextTag(kTag_BasicConstraints), kTLVType_Structure, containerType3));
+                ReturnErrorOnFailure(writer.PutBoolean(ContextTag(kTag_BasicConstraints_IsCA), false));
+                ReturnErrorOnFailure(writer.EndContainer(containerType3));
+            }
+
+            // key usage
+            if (certConfig.IsExtensionKeyUsagePresent())
+            {
+                BitFlags<KeyUsageFlags> keyUsage;
+                if (certConfig.IsExtensionKeyUsageDigitalSigCorrect())
+                {
+                    keyUsage.Set(KeyUsageFlags::kDigitalSignature);
+                }
+                if (!certConfig.IsExtensionKeyUsageKeyCertSignCorrect())
+                {
+                    keyUsage.Set(KeyUsageFlags::kKeyCertSign);
+                }
+                if (!certConfig.IsExtensionKeyUsageCRLSignCorrect())
+                {
+                    keyUsage.Set(KeyUsageFlags::kCRLSign);
+                }
+                ReturnErrorOnFailure(writer.Put(ContextTag(kTag_KeyUsage), keyUsage));
+            }
+
+            // extended key usage
+            if (!certConfig.IsExtensionExtendedKeyUsageMissing() && (certType == kCertType_Node))
+            {
+                ReturnErrorOnFailure(writer.StartContainer(ContextTag(kTag_ExtendedKeyUsage), kTLVType_Array, containerType3));
+                if (certType == kCertType_Node)
+                {
+                    ReturnErrorOnFailure(writer.Put(AnonymousTag(), GetOIDEnum(kOID_KeyPurpose_ClientAuth)));
+                    ReturnErrorOnFailure(writer.Put(AnonymousTag(), GetOIDEnum(kOID_KeyPurpose_ServerAuth)));
+                }
+                else if (certType == kCertType_FirmwareSigning)
+                {
+                    ReturnErrorOnFailure(writer.Put(AnonymousTag(), GetOIDEnum(kOID_KeyPurpose_CodeSigning)));
+                }
+                ReturnErrorOnFailure(writer.EndContainer(containerType3));
+            }
+        }
+
+        // subject key identifier
+        if (certConfig.IsExtensionSKIDPresent())
+        {
+            ReturnErrorOnFailure(Crypto::Hash_SHA1(subjectPubkey, sizeof(subjectPubkey), keyid));
+            ReturnErrorOnFailure(writer.Put(ContextTag(kTag_SubjectKeyIdentifier), ByteSpan(keyid)));
+        }
+
+        // authority key identifier
+        if (certConfig.IsExtensionAKIDPresent())
+        {
+            ReturnErrorOnFailure(Crypto::Hash_SHA1(issuerPubkey, sizeof(issuerPubkey), keyid));
+            ReturnErrorOnFailure(writer.Put(ContextTag(kTag_AuthorityKeyIdentifier), ByteSpan(keyid)));
+        }
+
+        for (uint8_t i = 0; i < futureExtsCount; i++)
+        {
+            ReturnErrorOnFailure(
+                writer.Put(ContextTag(kTag_FutureExtension),
+                           ByteSpan(reinterpret_cast<const uint8_t *>(futureExts[i].info), strlen(futureExts[i].info))));
+        }
+    }
+    ReturnErrorOnFailure(writer.EndContainer(containerType2));
+
+    // signature
+    const ASN1_BIT_STRING * asn1Signature = nullptr;
+    X509_get0_signature(&asn1Signature, nullptr, x509Cert);
+
+    uint8_t signatureRawBuf[chip::Crypto::kP256_ECDSA_Signature_Length_Raw];
+    MutableByteSpan signatureRaw(signatureRawBuf);
+    ReturnErrorOnFailure(chip::Crypto::EcdsaAsn1SignatureToRaw(
+        chip::Crypto::kP256_FE_Length, ByteSpan(asn1Signature->data, static_cast<size_t>(asn1Signature->length)), signatureRaw));
+
+    ReturnErrorOnFailure(writer.Put(ContextTag(kTag_ECDSASignature), signatureRaw));
+
+    ReturnErrorOnFailure(writer.EndContainer(containerType));
+
+    ReturnErrorOnFailure(writer.Finalize());
+
+    chipCert.reduce_size(writer.GetLengthWritten());
+
+    return CHIP_NO_ERROR;
 }
 
 bool ResignCert(X509 * cert, X509 * caCert, EVP_PKEY * caKey)
@@ -749,11 +1205,13 @@ exit:
 
 bool MakeAttCert(AttCertType attCertType, const char * subjectCN, uint16_t subjectVID, uint16_t subjectPID,
                  bool encodeVIDandPIDasCN, X509 * caCert, EVP_PKEY * caKey, const struct tm & validFrom, uint32_t validDays,
-                 X509 * newCert, EVP_PKEY * newKey, AttCertStructConfig & certConfig)
+                 X509 * newCert, EVP_PKEY * newKey, CertStructConfig & certConfig)
 {
     bool res     = true;
     uint16_t vid = certConfig.IsSubjectVIDMismatch() ? static_cast<uint16_t>(subjectVID + 1) : subjectVID;
     uint16_t pid = certConfig.IsSubjectPIDMismatch() ? static_cast<uint16_t>(subjectPID + 1) : subjectPID;
+    bool isCA    = (attCertType != kAttCertType_DAC);
+    int pathLen  = kPathLength_NotSpecified;
 
     VerifyOrReturnError(subjectCN != nullptr, false);
     VerifyOrReturnError(caCert != nullptr, false);
@@ -771,7 +1229,7 @@ bool MakeAttCert(AttCertType attCertType, const char * subjectCN, uint16_t subje
     VerifyTrueOrExit(res);
 
     // Set the certificate validity time.
-    res = SetValidityTime(newCert, validFrom, validDays);
+    res = SetValidityTime(newCert, validFrom, validDays, certConfig);
     VerifyTrueOrExit(res);
 
     // Set the certificate's public key.
@@ -889,103 +1347,17 @@ bool MakeAttCert(AttCertType attCertType, const char * subjectCN, uint16_t subje
         ReportOpenSSLErrorAndExit("X509_set_issuer_name", res = false);
     }
 
-    if (certConfig.IsExtensionBasicPresent())
+    // Add basic constraints certificate extensions.
+    if (certConfig.IsExtensionBasicPathLenPresent(attCertType) || !certConfig.IsExtensionBasicCAPresent())
     {
-        std::string basicConstraintsExt;
-
-        if (certConfig.IsExtensionBasicCriticalPresent())
-        {
-            if (certConfig.IsExtensionBasicCritical())
-            {
-                basicConstraintsExt += "critical";
-            }
-        }
-
-        if (certConfig.IsExtensionBasicCAPresent())
-        {
-            if (!basicConstraintsExt.empty())
-            {
-                basicConstraintsExt += ",";
-            }
-            if ((certConfig.IsExtensionBasicCACorrect() && attCertType == kAttCertType_DAC) ||
-                (!certConfig.IsExtensionBasicCACorrect() && attCertType != kAttCertType_DAC))
-            {
-                basicConstraintsExt += "CA:FALSE";
-            }
-            else
-            {
-                basicConstraintsExt += "CA:TRUE";
-            }
-        }
-
-        if (certConfig.IsExtensionBasicPathLenPresent(attCertType) || !certConfig.IsExtensionBasicCAPresent())
-        {
-            if (!basicConstraintsExt.empty())
-            {
-                basicConstraintsExt += ",";
-            }
-            basicConstraintsExt.append("pathlen:" + std::to_string(certConfig.GetExtensionBasicPathLenValue(attCertType)));
-        }
-
-        res = AddExtension(newCert, NID_basic_constraints, basicConstraintsExt.c_str());
-        VerifyTrueOrExit(res);
+        pathLen = certConfig.GetExtensionBasicPathLenValue(attCertType);
     }
+    res = SetBasicConstraintsExtension(newCert, isCA, pathLen, certConfig);
+    VerifyTrueOrExit(res);
 
-    if (certConfig.IsExtensionKeyUsagePresent())
-    {
-        std::string keyUsageExt;
-
-        if (certConfig.IsExtensionKeyUsageCriticalPresent())
-        {
-            if (certConfig.IsExtensionKeyUsageCritical())
-            {
-                keyUsageExt += "critical";
-            }
-        }
-
-        if ((certConfig.IsExtensionKeyUsageDigitalSigCorrect() && attCertType == kAttCertType_DAC) ||
-            (!certConfig.IsExtensionKeyUsageDigitalSigCorrect() && attCertType != kAttCertType_DAC))
-        {
-            if (!keyUsageExt.empty())
-            {
-                keyUsageExt += ",";
-            }
-            keyUsageExt += "digitalSignature";
-        }
-
-        if ((certConfig.IsExtensionKeyUsageKeyCertSignCorrect() && attCertType != kAttCertType_DAC) ||
-            (!certConfig.IsExtensionKeyUsageKeyCertSignCorrect() && attCertType == kAttCertType_DAC))
-        {
-            if (!keyUsageExt.empty())
-            {
-                keyUsageExt += ",";
-            }
-            keyUsageExt += "keyCertSign";
-        }
-
-        if ((certConfig.IsExtensionKeyUsageCRLSignCorrect() && attCertType != kAttCertType_DAC) ||
-            (!certConfig.IsExtensionKeyUsageCRLSignCorrect() && attCertType == kAttCertType_DAC))
-        {
-            if (!keyUsageExt.empty())
-            {
-                keyUsageExt += ",";
-            }
-            keyUsageExt += "cRLSign";
-        }
-
-        // In test mode only: just add an extra extension flag to prevent empty extantion.
-        if (certConfig.IsErrorTestCaseEnabled() && (keyUsageExt.empty() || (keyUsageExt.compare("critical") == 0)))
-        {
-            if (!keyUsageExt.empty())
-            {
-                keyUsageExt += ",";
-            }
-            keyUsageExt += "keyEncipherment";
-        }
-
-        res = AddExtension(newCert, NID_key_usage, keyUsageExt.c_str());
-        VerifyTrueOrExit(res);
-    }
+    // Add key usage certificate extensions.
+    res = SetKeyUsageExtension(newCert, isCA, certConfig);
+    VerifyTrueOrExit(res);
 
     if (certConfig.IsExtensionSKIDPresent())
     {
@@ -1023,7 +1395,7 @@ bool MakeAttCert(AttCertType attCertType, const char * subjectCN, uint16_t subje
     }
 
     // Sign the new certificate.
-    if (!X509_sign(newCert, caKey, certConfig.GetSignatureAlgorithm()))
+    if (!X509_sign(newCert, caKey, certConfig.GetSignatureAlgorithmDER()))
     {
         ReportOpenSSLErrorAndExit("X509_sign", res = false);
     }

--- a/src/tools/chip-cert/Cmd_GenAttCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenAttCert.cpp
@@ -173,7 +173,7 @@ const char * const gCmdOptionHelp =
     "           ext-authority-info-access        - Certificate will include optional Authority Information Access extension.\n"
     "           ext-subject-alt-name             - Certificate will include optional Subject Alternative Name extension.\n"
     "\n"
-#endif
+#endif // CHIP_CONFIG_INTERNAL_FLAG_GENERATE_DA_TEST_CASES
     ;
 
 OptionSet gCmdOptions =
@@ -211,7 +211,7 @@ const char * gOutCertFileName = nullptr;
 const char * gOutKeyFileName  = nullptr;
 uint32_t gValidDays           = kCertValidDays_Undefined;
 struct tm gValidFrom;
-AttCertStructConfig gCertConfig;
+CertStructConfig gCertConfig;
 
 bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
 {
@@ -400,7 +400,7 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
             return false;
         }
         break;
-#endif
+#endif // CHIP_CONFIG_INTERNAL_FLAG_GENERATE_DA_TEST_CASES
     default:
         PrintArgError("%s: Unhandled option: %s\n", progName, name);
         return false;

--- a/src/tools/chip-cert/Cmd_GenCD.cpp
+++ b/src/tools/chip-cert/Cmd_GenCD.cpp
@@ -1115,7 +1115,6 @@ bool Cmd_GenCD(int argc, char * argv[])
         fprintf(stderr, "Please specify the file name for the signed Certification Declaration using the --out option.\n");
         return false;
     }
-    fprintf(stderr, "gSignedCDFileName = %s\n", gSignedCDFileName);
 
     if (strcmp(gSignedCDFileName, "-") != 0 && access(gSignedCDFileName, R_OK) == 0)
     {


### PR DESCRIPTION
#### Problem
Need APIs to generate invalid conditions when sending AddTrusted, AddNOC, UpdateNOC commands.

Ticket: #19068 

#### Change overview
- Updated current code to inject errors into operational certs in DER/PEM format.
- New code to generate CHIP TLV encoded certificates with injected errors.
- It can generate invalid NOC, ICAC, and RCAC.

#### Testing
Verified manually that the tool generates normal/valid operational certificates as before.
Verified manually that invalid certificates can be properly generated.