### PR TITLE
RPC: Add software version string to device info

### DIFF
--- a/examples/common/pigweed/protos/device_service.options
+++ b/examples/common/pigweed/protos/device_service.options
@@ -1,4 +1,5 @@
-chip.rpc.DeviceInfo.serial_number max_size:32  // length defined in chip spec 8.2.3.1
+chip.rpc.DeviceInfo.serial_number max_size:32  // length defined in chip spec 11.1.6.1
+chip.rpc.DeviceInfo.software_version_string max_size:64  // length defined in chip spec 11.1.6.1
 chip.rpc.DeviceState.fabric_info max_count:2
 chip.rpc.PairingInfo.qr_code max_size:256
 chip.rpc.PairingInfo.qr_code_url max_size:256

--- a/examples/common/pigweed/protos/device_service.proto
+++ b/examples/common/pigweed/protos/device_service.proto
@@ -24,6 +24,7 @@ message DeviceInfo {
   uint32 software_version = 3;
   string serial_number = 4;
   PairingInfo pairing_info = 5;
+  string software_version_string = 6;
 }
 
 message FabricInfo {

--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -311,6 +311,13 @@ public:
             response.software_version = CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION;
         }
 
+        if (DeviceLayer::ConfigurationMgr().GetSoftwareVersionString(response.software_version_string,
+                                                                     sizeof(response.software_version_string)) != CHIP_NO_ERROR)
+        {
+            snprintf(response.software_version_string, sizeof(response.software_version_string),
+                     CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
+        }
+
         uint32_t code;
         if (DeviceLayer::GetCommissionableDataProvider()->GetSetupPasscode(code) == CHIP_NO_ERROR)
         {
@@ -325,7 +332,7 @@ public:
             response.has_pairing_info           = true;
         }
 
-        if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetSerialNumber(response.serial_number, sizeof(response.serial_number)) ==
+        if (DeviceLayer::GetDeviceInstanceInfoProvider()->GetSerialNumber(response.serial_number, sizeof(response.serial_number)) !=
             CHIP_NO_ERROR)
         {
             snprintf(response.serial_number, sizeof(response.serial_number), CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER);


### PR DESCRIPTION
Add the software version string value to the device info RPC.

#### Problem
The value of software version string is need for some test automation.

#### Change overview
Add the value to the GetDeviceInfo RPC in the Device RPC service.

#### Testing
Tested on esp all-clusters app.
