### PR TITLE
Add handling of CloseSession messages.

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -202,6 +202,9 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     err = mMessageCounterManager.Init(&mExchangeMgr);
     SuccessOrExit(err);
 
+    err = mUnsolicitedStatusHandler.Init(&mExchangeMgr);
+    SuccessOrExit(err);
+
     err = chip::app::InteractionModelEngine::GetInstance()->Init(&mExchangeMgr, &GetFabricTable());
     SuccessOrExit(err);
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -46,6 +46,7 @@
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <protocols/secure_channel/PASESession.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
+#include <protocols/secure_channel/UnsolicitedStatusHandler.h>
 #if CHIP_CONFIG_ENABLE_SESSION_RESUMPTION
 #include <protocols/secure_channel/SimpleSessionResumptionStorage.h>
 #endif
@@ -452,6 +453,7 @@ private:
     CASEClientPool<CHIP_CONFIG_DEVICE_MAX_ACTIVE_CASE_CLIENTS> mCASEClientPool;
     OperationalDeviceProxyPool<CHIP_CONFIG_DEVICE_MAX_ACTIVE_DEVICES> mDevicePool;
 
+    Protocols::SecureChannel::UnsolicitedStatusHandler mUnsolicitedStatusHandler;
     Messaging::ExchangeManager mExchangeMgr;
     FabricTable mFabrics;
     secure_channel::MessageCounterManager mMessageCounterManager;

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -154,6 +154,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     SimpleSessionResumptionStorage * sessionResumptionStorage = chip::Platform::New<SimpleSessionResumptionStorage>();
     stateParams.sessionResumptionStorage                      = sessionResumptionStorage;
     stateParams.certificateValidityPolicy                     = params.certificateValidityPolicy;
+    stateParams.unsolicitedStatusHandler                      = Platform::New<Protocols::SecureChannel::UnsolicitedStatusHandler>();
     stateParams.exchangeMgr                                   = chip::Platform::New<Messaging::ExchangeManager>();
     stateParams.messageCounterManager                         = chip::Platform::New<secure_channel::MessageCounterManager>();
     stateParams.groupDataProvider                             = params.groupDataProvider;
@@ -179,6 +180,7 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
                                                       stateParams.fabricTable));
     ReturnErrorOnFailure(stateParams.exchangeMgr->Init(stateParams.sessionMgr));
     ReturnErrorOnFailure(stateParams.messageCounterManager->Init(stateParams.exchangeMgr));
+    ReturnErrorOnFailure(stateParams.unsolicitedStatusHandler->Init(stateParams.exchangeMgr));
 
     InitDataModelHandler(stateParams.exchangeMgr);
 
@@ -422,6 +424,12 @@ CHIP_ERROR DeviceControllerSystemState::Shutdown()
     {
         chip::Platform::Delete(mExchangeMgr);
         mExchangeMgr = nullptr;
+    }
+
+    if (mUnsolicitedStatusHandler != nullptr)
+    {
+        Platform::Delete(mUnsolicitedStatusHandler);
+        mUnsolicitedStatusHandler = nullptr;
     }
 
     if (mSessionMgr != nullptr)

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -36,6 +36,7 @@
 #include <lib/core/CHIPConfig.h>
 #include <protocols/secure_channel/CASEServer.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
+#include <protocols/secure_channel/UnsolicitedStatusHandler.h>
 
 #include <transport/TransportMgr.h>
 #include <transport/raw/UDP.h>
@@ -82,17 +83,18 @@ struct DeviceControllerSystemStateParams
 
     // Params that will be deallocated via Platform::Delete in
     // DeviceControllerSystemState::Shutdown.
-    DeviceTransportMgr * transportMgr                                  = nullptr;
-    SessionResumptionStorage * sessionResumptionStorage                = nullptr;
-    Credentials::CertificateValidityPolicy * certificateValidityPolicy = nullptr;
-    SessionManager * sessionMgr                                        = nullptr;
-    Messaging::ExchangeManager * exchangeMgr                           = nullptr;
-    secure_channel::MessageCounterManager * messageCounterManager      = nullptr;
-    CASEServer * caseServer                                            = nullptr;
-    CASESessionManager * caseSessionManager                            = nullptr;
-    OperationalDevicePool * operationalDevicePool                      = nullptr;
-    CASEClientPool * caseClientPool                                    = nullptr;
-    FabricTable::Delegate * fabricTableDelegate                        = nullptr;
+    DeviceTransportMgr * transportMgr                                             = nullptr;
+    SessionResumptionStorage * sessionResumptionStorage                           = nullptr;
+    Credentials::CertificateValidityPolicy * certificateValidityPolicy            = nullptr;
+    SessionManager * sessionMgr                                                   = nullptr;
+    Protocols::SecureChannel::UnsolicitedStatusHandler * unsolicitedStatusHandler = nullptr;
+    Messaging::ExchangeManager * exchangeMgr                                      = nullptr;
+    secure_channel::MessageCounterManager * messageCounterManager                 = nullptr;
+    CASEServer * caseServer                                                       = nullptr;
+    CASESessionManager * caseSessionManager                                       = nullptr;
+    OperationalDevicePool * operationalDevicePool                                 = nullptr;
+    CASEClientPool * caseClientPool                                               = nullptr;
+    FabricTable::Delegate * fabricTableDelegate                                   = nullptr;
 };
 
 // A representation of the internal state maintained by the DeviceControllerFactory
@@ -108,10 +110,11 @@ public:
     DeviceControllerSystemState(DeviceControllerSystemStateParams params) :
         mSystemLayer(params.systemLayer), mTCPEndPointManager(params.tcpEndPointManager),
         mUDPEndPointManager(params.udpEndPointManager), mTransportMgr(params.transportMgr), mSessionMgr(params.sessionMgr),
-        mExchangeMgr(params.exchangeMgr), mMessageCounterManager(params.messageCounterManager), mFabrics(params.fabricTable),
-        mCASEServer(params.caseServer), mCASESessionManager(params.caseSessionManager),
-        mOperationalDevicePool(params.operationalDevicePool), mCASEClientPool(params.caseClientPool),
-        mGroupDataProvider(params.groupDataProvider), mFabricTableDelegate(params.fabricTableDelegate)
+        mUnsolicitedStatusHandler(params.unsolicitedStatusHandler), mExchangeMgr(params.exchangeMgr),
+        mMessageCounterManager(params.messageCounterManager), mFabrics(params.fabricTable), mCASEServer(params.caseServer),
+        mCASESessionManager(params.caseSessionManager), mOperationalDevicePool(params.operationalDevicePool),
+        mCASEClientPool(params.caseClientPool), mGroupDataProvider(params.groupDataProvider),
+        mFabricTableDelegate(params.fabricTableDelegate)
     {
 #if CONFIG_NETWORK_LAYER_BLE
         mBleLayer = params.bleLayer;
@@ -143,8 +146,9 @@ public:
     bool IsInitialized()
     {
         return mSystemLayer != nullptr && mUDPEndPointManager != nullptr && mTransportMgr != nullptr && mSessionMgr != nullptr &&
-            mExchangeMgr != nullptr && mMessageCounterManager != nullptr && mFabrics != nullptr && mCASESessionManager != nullptr &&
-            mOperationalDevicePool != nullptr && mCASEClientPool != nullptr && mGroupDataProvider != nullptr;
+            mUnsolicitedStatusHandler != nullptr && mExchangeMgr != nullptr && mMessageCounterManager != nullptr &&
+            mFabrics != nullptr && mCASESessionManager != nullptr && mOperationalDevicePool != nullptr &&
+            mCASEClientPool != nullptr && mGroupDataProvider != nullptr;
     };
 
     System::Layer * SystemLayer() const { return mSystemLayer; };
@@ -171,17 +175,18 @@ private:
 #if CONFIG_NETWORK_LAYER_BLE
     Ble::BleLayer * mBleLayer = nullptr;
 #endif
-    DeviceTransportMgr * mTransportMgr                             = nullptr;
-    SessionManager * mSessionMgr                                   = nullptr;
-    Messaging::ExchangeManager * mExchangeMgr                      = nullptr;
-    secure_channel::MessageCounterManager * mMessageCounterManager = nullptr;
-    FabricTable * mFabrics                                         = nullptr;
-    CASEServer * mCASEServer                                       = nullptr;
-    CASESessionManager * mCASESessionManager                       = nullptr;
-    OperationalDevicePool * mOperationalDevicePool                 = nullptr;
-    CASEClientPool * mCASEClientPool                               = nullptr;
-    Credentials::GroupDataProvider * mGroupDataProvider            = nullptr;
-    FabricTable::Delegate * mFabricTableDelegate                   = nullptr;
+    DeviceTransportMgr * mTransportMgr                                             = nullptr;
+    SessionManager * mSessionMgr                                                   = nullptr;
+    Protocols::SecureChannel::UnsolicitedStatusHandler * mUnsolicitedStatusHandler = nullptr;
+    Messaging::ExchangeManager * mExchangeMgr                                      = nullptr;
+    secure_channel::MessageCounterManager * mMessageCounterManager                 = nullptr;
+    FabricTable * mFabrics                                                         = nullptr;
+    CASEServer * mCASEServer                                                       = nullptr;
+    CASESessionManager * mCASESessionManager                                       = nullptr;
+    OperationalDevicePool * mOperationalDevicePool                                 = nullptr;
+    CASEClientPool * mCASEClientPool                                               = nullptr;
+    Credentials::GroupDataProvider * mGroupDataProvider                            = nullptr;
+    FabricTable::Delegate * mFabricTableDelegate                                   = nullptr;
 
     // If mTempFabricTable is not null, it was created during
     // DeviceControllerFactory::InitSystemState and needs to be

--- a/src/protocols/secure_channel/BUILD.gn
+++ b/src/protocols/secure_channel/BUILD.gn
@@ -25,6 +25,8 @@ static_library("secure_channel") {
     "SimpleSessionResumptionStorage.h",
     "StatusReport.cpp",
     "StatusReport.h",
+    "UnsolicitedStatusHandler.cpp",
+    "UnsolicitedStatusHandler.h",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/protocols/secure_channel/UnsolicitedStatusHandler.cpp
+++ b/src/protocols/secure_channel/UnsolicitedStatusHandler.cpp
@@ -1,0 +1,73 @@
+/**
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "UnsolicitedStatusHandler.h"
+#include <lib/support/TypeTraits.h>
+#include <protocols/secure_channel/Constants.h>
+#include <protocols/secure_channel/StatusReport.h>
+
+using namespace chip;
+using namespace chip::Protocols;
+using namespace chip::Protocols::SecureChannel;
+using namespace chip::Messaging;
+
+CHIP_ERROR UnsolicitedStatusHandler::Init(ExchangeManager * exchangeManager)
+{
+    return exchangeManager->RegisterUnsolicitedMessageHandlerForType(SecureChannel::Id, to_underlying(MsgType::StatusReport), this);
+}
+
+CHIP_ERROR UnsolicitedStatusHandler::OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                                       System::PacketBufferHandle && payload)
+{
+    if (!payloadHeader.HasMessageType(MsgType::StatusReport))
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    auto session = ec->GetSessionHandle();
+    if (!session->IsSecureSession())
+    {
+        // Nothing to do here.  We only care about CloseSession on secure
+        // sessions.
+        return CHIP_NO_ERROR;
+    }
+
+    StatusReport report;
+    ReturnErrorOnFailure(report.Parse(std::move(payload)));
+
+    if (report.GetGeneralCode() == GeneralStatusCode::kSuccess && report.GetProtocolCode() == kProtocolCodeCloseSession)
+    {
+        ChipLogProgress(ExchangeManager, "Received CloseSession status message, closing session");
+        session->AsSecureSession()->MarkForRemoval();
+        return CHIP_NO_ERROR;
+    }
+
+    // Just ignore this message.
+    return CHIP_NO_ERROR;
+}
+
+void UnsolicitedStatusHandler::OnResponseTimeout(ExchangeContext * ec)
+{
+    // We should never get here, since we never send messages ourselves.
+}
+
+CHIP_ERROR UnsolicitedStatusHandler::OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader,
+                                                                  ExchangeDelegate *& newDelegate)
+{
+    newDelegate = this;
+    return CHIP_NO_ERROR;
+}

--- a/src/protocols/secure_channel/UnsolicitedStatusHandler.h
+++ b/src/protocols/secure_channel/UnsolicitedStatusHandler.h
@@ -1,0 +1,44 @@
+/**
+ *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <messaging/ExchangeDelegate.h>
+#include <messaging/ExchangeMgr.h>
+
+namespace chip {
+namespace Protocols {
+namespace SecureChannel {
+
+class UnsolicitedStatusHandler : public Messaging::ExchangeDelegate, public Messaging::UnsolicitedMessageHandler
+{
+public:
+    CHIP_ERROR Init(Messaging::ExchangeManager * exchangeManager);
+
+protected:
+    // ExchangeDelegate
+    CHIP_ERROR OnMessageReceived(Messaging::ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                 System::PacketBufferHandle && payload) override;
+    void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
+
+    // UnsolicitedMessageHandler
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override;
+};
+
+} // namespace SecureChannel
+} // namespace Protocols
+} // namespace chip


### PR DESCRIPTION
To handle a CloseSession status message, we need something with access
to SecureChannel::StatusReport.  That means it can't live in
src/transport or src/messaging, so can't be handled by the session
manager or exchange manager automatically.

So unfortunate as it is, add yet another thing that needs to be
initialized and initialize it once we have an initialized exchange
manager.

Fixes https://github.com/project-chip/connectedhomeip/issues/16839

#### Problem
CloseSession not implemented.

#### Change overview
Implement it.

#### Testing
Used the chip-tool command from #19641 in interactive mode and made sure that both PASE and CASE sessions get closed.