### PR TITLE
Fix WebOS Storage default config crash

### DIFF
--- a/src/platform/webos/CHIPWebOSStorageIni.cpp
+++ b/src/platform/webos/CHIPWebOSStorageIni.cpp
@@ -43,24 +43,6 @@ CHIP_ERROR ChipLinuxStorageIni::Init()
     return RemoveAll();
 }
 
-CHIP_ERROR ChipLinuxStorageIni::GetDefaultSection(std::map<std::string, std::string> & section)
-{
-    CHIP_ERROR retval = CHIP_NO_ERROR;
-
-    auto it = mConfigStore.sections.find("DEFAULT");
-
-    if (it != mConfigStore.sections.end())
-    {
-        section = mConfigStore.sections["DEFAULT"];
-    }
-    else
-    {
-        retval = CHIP_ERROR_KEY_NOT_FOUND;
-    }
-
-    return retval;
-}
-
 CHIP_ERROR ChipLinuxStorageIni::AddConfig(const std::string & configFile)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
@@ -125,12 +107,12 @@ CHIP_ERROR ChipLinuxStorageIni::CommitConfig(const std::string & configFile)
 CHIP_ERROR ChipLinuxStorageIni::GetUInt16Value(const char * key, uint16_t & val)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
-    std::map<std::string, std::string> section;
 
-    retval = GetDefaultSection(section);
+    auto isConfigFind = mConfigStore.sections.find("DEFAULT");
 
-    if (retval == CHIP_NO_ERROR)
+    if (isConfigFind != mConfigStore.sections.end())
     {
+        std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
         auto it = section.find(key);
 
         if (it != section.end())
@@ -152,12 +134,11 @@ CHIP_ERROR ChipLinuxStorageIni::GetUInt16Value(const char * key, uint16_t & val)
 CHIP_ERROR ChipLinuxStorageIni::GetUIntValue(const char * key, uint32_t & val)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
-    std::map<std::string, std::string> section;
+    auto isConfigFind = mConfigStore.sections.find("DEFAULT");
 
-    retval = GetDefaultSection(section);
-
-    if (retval == CHIP_NO_ERROR)
+    if (isConfigFind != mConfigStore.sections.end())
     {
+        std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
         auto it = section.find(key);
 
         if (it != section.end())
@@ -179,12 +160,11 @@ CHIP_ERROR ChipLinuxStorageIni::GetUIntValue(const char * key, uint32_t & val)
 CHIP_ERROR ChipLinuxStorageIni::GetUInt64Value(const char * key, uint64_t & val)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
-    std::map<std::string, std::string> section;
+    auto isConfigFind = mConfigStore.sections.find("DEFAULT");
 
-    retval = GetDefaultSection(section);
-
-    if (retval == CHIP_NO_ERROR)
+    if (isConfigFind != mConfigStore.sections.end())
     {
+        std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
         auto it = section.find(key);
 
         if (it != section.end())
@@ -206,12 +186,11 @@ CHIP_ERROR ChipLinuxStorageIni::GetUInt64Value(const char * key, uint64_t & val)
 CHIP_ERROR ChipLinuxStorageIni::GetStringValue(const char * key, char * buf, size_t bufSize, size_t & outLen)
 {
     CHIP_ERROR retval = CHIP_NO_ERROR;
-    std::map<std::string, std::string> section;
+    auto isConfigFind = mConfigStore.sections.find("DEFAULT");
 
-    retval = GetDefaultSection(section);
-
-    if (retval == CHIP_NO_ERROR)
+    if (isConfigFind != mConfigStore.sections.end())
     {
+        std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
         auto it = section.find(key);
 
         if (it != section.end())
@@ -251,12 +230,13 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobDataAndLengths(const char * key,
                                                             size_t & encodedDataLen, size_t & decodedDataLen)
 {
     size_t encodedDataPaddingLen = 0;
-    std::map<std::string, std::string> section;
-    CHIP_ERROR err = GetDefaultSection(section);
-    if (err != CHIP_NO_ERROR)
+    auto isConfigFind = mConfigStore.sections.find("DEFAULT");
+
+    if (isConfigFind == mConfigStore.sections.end())
     {
-        return err;
+        return CHIP_ERROR_KEY_NOT_FOUND;
     }
+    std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
 
     auto it = section.find(key);
     if (it == section.end())
@@ -333,11 +313,12 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobValue(const char * key, uint8_t * d
 
 bool ChipLinuxStorageIni::HasValue(const char * key)
 {
-    std::map<std::string, std::string> section;
+    auto isConfigFind = mConfigStore.sections.find("DEFAULT");
 
-    if (GetDefaultSection(section) != CHIP_NO_ERROR)
+    if (isConfigFind == mConfigStore.sections.end())
         return false;
 
+    std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
     auto it = section.find(key);
 
     return it != section.end();

--- a/src/platform/webos/CHIPWebOSStorageIni.cpp
+++ b/src/platform/webos/CHIPWebOSStorageIni.cpp
@@ -113,7 +113,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetUInt16Value(const char * key, uint16_t & val)
     if (isConfigFind != mConfigStore.sections.end())
     {
         std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
-        auto it = section.find(key);
+        auto it                                      = section.find(key);
 
         if (it != section.end())
         {
@@ -139,7 +139,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetUIntValue(const char * key, uint32_t & val)
     if (isConfigFind != mConfigStore.sections.end())
     {
         std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
-        auto it = section.find(key);
+        auto it                                      = section.find(key);
 
         if (it != section.end())
         {
@@ -165,7 +165,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetUInt64Value(const char * key, uint64_t & val)
     if (isConfigFind != mConfigStore.sections.end())
     {
         std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
-        auto it = section.find(key);
+        auto it                                      = section.find(key);
 
         if (it != section.end())
         {
@@ -191,7 +191,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetStringValue(const char * key, char * buf, siz
     if (isConfigFind != mConfigStore.sections.end())
     {
         std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
-        auto it = section.find(key);
+        auto it                                      = section.find(key);
 
         if (it != section.end())
         {
@@ -230,7 +230,7 @@ CHIP_ERROR ChipLinuxStorageIni::GetBinaryBlobDataAndLengths(const char * key,
                                                             size_t & encodedDataLen, size_t & decodedDataLen)
 {
     size_t encodedDataPaddingLen = 0;
-    auto isConfigFind = mConfigStore.sections.find("DEFAULT");
+    auto isConfigFind            = mConfigStore.sections.find("DEFAULT");
 
     if (isConfigFind == mConfigStore.sections.end())
     {
@@ -319,7 +319,7 @@ bool ChipLinuxStorageIni::HasValue(const char * key)
         return false;
 
     std::map<std::string, std::string> & section = mConfigStore.sections["DEFAULT"];
-    auto it = section.find(key);
+    auto it                                      = section.find(key);
 
     return it != section.end();
 }

--- a/src/platform/webos/CHIPWebOSStorageIni.h
+++ b/src/platform/webos/CHIPWebOSStorageIni.h
@@ -52,7 +52,6 @@ protected:
     CHIP_ERROR RemoveAll();
 
 private:
-    CHIP_ERROR GetDefaultSection(std::map<std::string, std::string> & section);
     CHIP_ERROR GetBinaryBlobDataAndLengths(const char * key, chip::Platform::ScopedMemoryBuffer<char> & encodedData,
                                            size_t & encodedDataLen, size_t & decodedDataLen);
     inipp::Ini<char> mConfigStore;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fix crash when "section.find(key)" (Using another build tool / script)

#### Change overview
This issue is related map class initialize / deinitialize.

After "std::map<std::string, std::string> section;" line, map class is initialized.
(https://github.com/project-chip/connectedhomeip/blob/master/src/platform/webos/CHIPWebOSStorageIni.cpp#L336)
But, after "section = mConfigStore.sections["DEFAULT"];" line, previous map class object is lost.
(https://github.com/project-chip/connectedhomeip/blob/master/src/platform/webos/CHIPWebOSStorageIni.cpp#L54)

End of local function, map object is going to deinitialize and delete this allocation.

#### Testing
How was this tested? (at least one bullet point required)
* Tested by repeating read/write of Config in Chiptool.
