### PR TITLE
Use monotonic clock for measuring intervals in tests.

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -119,7 +119,7 @@ class App:
     def __waitFor(self, waitForString, server_process, outpipe):
         logging.debug('Waiting for %s' % waitForString)
 
-        start_time = time.time()
+        start_time = time.monotonic()
         ready, self.lastLogIndex = outpipe.CapturedLogContains(
             waitForString, self.lastLogIndex)
         while not ready:
@@ -128,7 +128,7 @@ class App:
                             (waitForString, server_process.returncode))
                 logging.error(died_str)
                 raise Exception(died_str)
-            if time.time() - start_time > 10:
+            if time.monotonic() - start_time > 10:
                 raise Exception('Timeout while waiting for %s' % waitForString)
             time.sleep(0.1)
             ready, self.lastLogIndex = outpipe.CapturedLogContains(

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -235,14 +235,14 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
     for i in range(iterations):
         logging.info("Starting iteration %d" % (i+1))
         for test in context.obj.tests:
-            test_start = time.time()
+            test_start = time.monotonic()
             try:
                 test.Run(runner, apps_register, paths, pics_file)
-                test_end = time.time()
+                test_end = time.monotonic()
                 logging.info('%-20s - Completed in %0.2f seconds' %
                              (test.name, (test_end - test_start)))
             except Exception:
-                test_end = time.time()
+                test_end = time.monotonic()
                 logging.exception('%s - FAILED in %0.2f seconds' %
                                   (test.name, (test_end - test_start)))
                 apps_register.uninit()


### PR DESCRIPTION
This way we won't get spurious timeouts from clock changes.

#### Problem
Wall clock being used for measuring time intervals.

#### Change overview
Use monotonic clock.

#### Testing
Ran tests locally.