### PR TITLE
Addressing issue #19620

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CGEN_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CGEN_2_1.yaml
@@ -72,21 +72,19 @@ tests:
           the BasicCommissioningInfo attribute has the following field:
           FailSafeExpiryLengthSeconds field value is within a duration range of
           0 to 65535"
-      verification: |
-          ./chip-tool generalcommissioning read basic-commissioning-info 1 0
-          [1651131078.723121][4686:4691] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0030 Attribute 0x0000_0001 DataVersion: 3151774872
-          55555555555555555555
-          [1651131078.723431][4686:4691] CHIP:EM: Sending Standalone Ack for MessageCounter:2959333 on exchange 17319
-      disabled: true
+      command: "readAttribute"
+      attribute: "BasicCommissioningInfo"
+
+    - label: "Step 6 TC-CGEN-2.1"
       cluster: "LogCommands"
       command: "UserPrompt"
-      PICS: PICS_USER_PROMPT
       arguments:
           values:
               - name: "message"
-                value: "Please enter 'y' for success"
-              - name: "expectedValue"
-                value: "y"
+                value:
+                    "Step 6 is implicitly validating the
+                    attribute(BasicCommissioningInfo) constraints, as long as
+                    the payload is being parsed successfully"
 
     - label: "TH1 reads SupportsConcurrentConnection attribute from the DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_CGEN_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CGEN_2_1.yaml
@@ -35,7 +35,8 @@ tests:
       command: "readAttribute"
       attribute: "Breadcrumb"
       response:
-          value: 0
+          constraints:
+              type: uint64
 
     - label: "TH1 writes the BreadCrumb attribute as 1 to the DUT"
       command: "writeAttribute"
@@ -66,12 +67,30 @@ tests:
               maxValue: 2
 
     #Issue 17997
-    - label: "TH1 reads BasicCommissioningInfo attribute from DUT"
+    - label:
+          "TH1 reads BasicCommissioningInfo attribute from DUT and Verify that
+          the BasicCommissioningInfo attribute has the following field:
+          FailSafeExpiryLengthSeconds field value is within a duration range of
+          0 to 65535"
+      verification: |
+          ./chip-tool generalcommissioning read basic-commissioning-info 1 0
+          [1651131078.723121][4686:4691] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0030 Attribute 0x0000_0001 DataVersion: 3151774872
+          55555555555555555555
+          [1651131078.723431][4686:4691] CHIP:EM: Sending Standalone Ack for MessageCounter:2959333 on exchange 17319
+      disabled: true
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_USER_PROMPT
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' for success"
+              - name: "expectedValue"
+                value: "y"
+
+    - label: "TH1 reads SupportsConcurrentConnection attribute from the DUT"
       command: "readAttribute"
-      attribute: "BasicCommissioningInfo"
+      attribute: "SupportsConcurrentConnection"
       response:
-          value:
-              {
-                  FailSafeExpiryLengthSeconds: 60,
-                  MaxCumulativeFailsafeSeconds: 900,
-              }
+          constraints:
+              type: bool

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -13774,7 +13774,7 @@ private:
             {
                 uint64_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("breadcrumb", value, 0ULL));
+                VerifyOrReturn(CheckConstraintType("value", "", "uint64"));
             }
             break;
         case 2:
@@ -13809,12 +13809,9 @@ private:
         case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfo::DecodableType value;
+                bool value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(
-                    CheckValue("basicCommissioningInfo.failSafeExpiryLengthSeconds", value.failSafeExpiryLengthSeconds, 60U));
-                VerifyOrReturn(
-                    CheckValue("basicCommissioningInfo.maxCumulativeFailsafeSeconds", value.maxCumulativeFailsafeSeconds, 900U));
+                VerifyOrReturn(CheckConstraintType("value", "", "bool"));
             }
             break;
         default:
@@ -13868,9 +13865,9 @@ private:
                                  GeneralCommissioning::Attributes::LocationCapability::Id, true, chip::NullOptional);
         }
         case 6: {
-            LogStep(6, "TH1 reads BasicCommissioningInfo attribute from DUT");
+            LogStep(6, "TH1 reads SupportsConcurrentConnection attribute from the DUT");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), GeneralCommissioning::Id,
-                                 GeneralCommissioning::Attributes::BasicCommissioningInfo::Id, true, chip::NullOptional);
+                                 GeneralCommissioning::Attributes::SupportsConcurrentConnection::Id, true, chip::NullOptional);
         }
         }
         return CHIP_NO_ERROR;

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -13732,7 +13732,7 @@ private:
 class Test_TC_CGEN_2_1Suite : public TestCommand
 {
 public:
-    Test_TC_CGEN_2_1Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CGEN_2_1", 7, credsIssuerConfig)
+    Test_TC_CGEN_2_1Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_CGEN_2_1", 9, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -13809,6 +13809,17 @@ private:
         case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
+                chip::app::Clusters::GeneralCommissioning::Structs::BasicCommissioningInfo::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+            }
+            break;
+        case 7:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 8:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
                 bool value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckConstraintType("value", "", "bool"));
@@ -13865,7 +13876,24 @@ private:
                                  GeneralCommissioning::Attributes::LocationCapability::Id, true, chip::NullOptional);
         }
         case 6: {
-            LogStep(6, "TH1 reads SupportsConcurrentConnection attribute from the DUT");
+            LogStep(6,
+                    "TH1 reads BasicCommissioningInfo attribute from DUT and Verify that the BasicCommissioningInfo attribute has "
+                    "the following field: FailSafeExpiryLengthSeconds field value is within a duration range of 0 to 65535");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(0), GeneralCommissioning::Id,
+                                 GeneralCommissioning::Attributes::BasicCommissioningInfo::Id, true, chip::NullOptional);
+        }
+        case 7: {
+            LogStep(7, "Step 6 TC-CGEN-2.1");
+            ListFreer listFreer;
+            chip::app::Clusters::LogCommands::Commands::UserPrompt::Type value;
+            value.message =
+                chip::Span<const char>("Step 6 is implicitly validating the attribute(BasicCommissioningInfo) constraints, as long "
+                                       "as the payload is being parsed successfullygarbage: not in length on purpose",
+                                       134);
+            return UserPrompt(kIdentityAlpha, value);
+        }
+        case 8: {
+            LogStep(8, "TH1 reads SupportsConcurrentConnection attribute from the DUT");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), GeneralCommissioning::Id,
                                  GeneralCommissioning::Attributes::SupportsConcurrentConnection::Id, true, chip::NullOptional);
         }


### PR DESCRIPTION
Summary:
Modified Test TC-CGEN-2.1 as per latest testplan 
we don't have a way to check the range within a struct value in yaml (https://github.com/project-chip/connectedhomeip/issues/17997) for step 6 updated as manual user prompt just for this step for the user to validate its within the range
Addressing issue https://github.com/project-chip/connectedhomeip/issues/19620
Added auto generated files

Attached execution logs for reference:
[Execution_log.txt](https://github.com/project-chip/connectedhomeip/files/8916827/Execution_log.txt)