### PR TITLE
Make minmdns advertiser send a TTL=0 record broadcast when services are removed.

### DIFF
--- a/examples/minimal-mdns/server.cpp
+++ b/examples/minimal-mdns/server.cpp
@@ -146,7 +146,7 @@ public:
 
     void OnQuery(const mdns::Minimal::QueryData & data) override
     {
-        if (mResponder->Respond(mMessageId, data, mCurrentSource) != CHIP_NO_ERROR)
+        if (mResponder->Respond(mMessageId, data, mCurrentSource, mdns::Minimal::ResponseConfiguration()) != CHIP_NO_ERROR)
         {
             printf("FAILED to respond!\n");
         }
@@ -166,6 +166,16 @@ private:
     const Inet::IPPacketInfo * mCurrentSource = nullptr;
     uint32_t mMessageId                       = 0;
 };
+
+mdns::Minimal::Server<10 /* endpoints */> gMdnsServer;
+
+void StopSignalHandler(int signal)
+{
+    gMdnsServer.Shutdown();
+
+    DeviceLayer::PlatformMgr().StopEventLoopTask();
+    DeviceLayer::PlatformMgr().Shutdown();
+}
 
 } // namespace
 
@@ -190,7 +200,6 @@ int main(int argc, char ** args)
 
     printf("Running on port %d using %s...\n", gOptions.listenPort, gOptions.enableIpV4 ? "IPv4 AND IPv6" : "IPv6 ONLY");
 
-    mdns::Minimal::Server<10 /* endpoints */> mdnsServer;
     mdns::Minimal::QueryResponder<16 /* maxRecords */> queryResponder;
 
     mdns::Minimal::QNamePart tcpServiceName[]       = { Dnssd::kOperationalServiceName, Dnssd::kOperationalProtocol,
@@ -249,21 +258,24 @@ int main(int argc, char ** args)
         queryResponder.AddResponder(&ipv4Responder);
     }
 
-    mdns::Minimal::ResponseSender responseSender(&mdnsServer);
+    mdns::Minimal::ResponseSender responseSender(&gMdnsServer);
     responseSender.AddQueryResponder(&queryResponder);
 
     ReplyDelegate delegate(&responseSender);
-    mdnsServer.SetDelegate(&delegate);
+    gMdnsServer.SetDelegate(&delegate);
 
     {
         MdnsExample::AllInterfaces allInterfaces(gOptions.enableIpV4);
 
-        if (mdnsServer.Listen(DeviceLayer::UDPEndPointManager(), &allInterfaces, gOptions.listenPort) != CHIP_NO_ERROR)
+        if (gMdnsServer.Listen(DeviceLayer::UDPEndPointManager(), &allInterfaces, gOptions.listenPort) != CHIP_NO_ERROR)
         {
             printf("Server failed to listen on all interfaces\n");
             return 1;
         }
     }
+
+    signal(SIGTERM, StopSignalHandler);
+    signal(SIGINT, StopSignalHandler);
 
     DeviceLayer::PlatformMgr().RunEventLoop();
 

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -357,6 +357,8 @@ CHIP_ERROR AdvertiserMinMdns::Init(chip::Inet::EndPointManager<chip::Inet::UDPEn
 
 void AdvertiserMinMdns::Shutdown()
 {
+    AdvertiseRecords(BroadcastAdvertiseType::kRemovingAll);
+
     GlobalMinimalMdnsServer::Server().Shutdown();
     mIsInitialized = false;
 }
@@ -427,10 +429,14 @@ OperationalQueryAllocator::Allocator * AdvertiserMinMdns::FindEmptyOperationalAl
 
 CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters & params)
 {
+
     char nameBuffer[Operational::kInstanceNameMaxLength + 1] = "";
 
     /// need to set server name
     ReturnErrorOnFailure(MakeInstanceName(nameBuffer, sizeof(nameBuffer), params.GetPeerId()));
+
+    // about to clear all records below, clear them
+    AdvertiseRecords(BroadcastAdvertiseType::kRemovingAll);
 
     QNamePart nameCheckParts[]  = { nameBuffer, kOperationalServiceName, kOperationalProtocol, kLocalDomain };
     FullQName nameCheck         = FullQName(nameCheckParts);
@@ -547,6 +553,9 @@ CHIP_ERROR AdvertiserMinMdns::UpdateCommissionableInstanceName()
 
 CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & params)
 {
+    // about to override a new advertising type
+    AdvertiseRecords(BroadcastAdvertiseType::kRemovingAll);
+
     if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
     {
         mQueryResponderAllocatorCommissionable.Clear();

--- a/src/lib/dnssd/minimal_mdns/Parser.h
+++ b/src/lib/dnssd/minimal_mdns/Parser.h
@@ -42,10 +42,12 @@ public:
     QClass GetClass() const { return mClass; }
     bool RequestedUnicastAnswer() const { return mAnswerViaUnicast; }
 
-    /// Boot advertisement is an internal query meant to advertise all available
-    /// services at device startup time.
-    bool IsBootAdvertising() const { return mIsBootAdvertising; }
-    void SetIsBootAdvertising(bool isBootAdvertising) { mIsBootAdvertising = isBootAdvertising; }
+    /// Internal broadcasts will advertise all available data and will not apply
+    /// an broadcast filtering. Intent is for paths such as:
+    ///   - boot time advertisement: advertise all servicese available
+    ///   - stop-time advertisement: advertise a TTL of 0 as services are removed
+    bool IsInternalBroadcast() const { return mIsInternalBroadcast; }
+    void SetIsInternalBroadcast(bool isInternalBroadcast) { mIsInternalBroadcast = isInternalBroadcast; }
 
     SerializedQNameIterator GetName() const { return mNameIterator; }
 
@@ -65,9 +67,9 @@ private:
     bool mAnswerViaUnicast = false;
     SerializedQNameIterator mNameIterator;
 
-    /// Flag as a boot-time internal query. This allows query replies
-    /// to be built accordingly.
-    bool mIsBootAdvertising = false;
+    /// Flag as a internal broadcast, controls repliy construction (e.g. no
+    /// filtering applied)
+    bool mIsInternalBroadcast = false;
 };
 
 class ResourceData

--- a/src/lib/dnssd/minimal_mdns/Parser.h
+++ b/src/lib/dnssd/minimal_mdns/Parser.h
@@ -43,8 +43,8 @@ public:
     bool RequestedUnicastAnswer() const { return mAnswerViaUnicast; }
 
     /// Internal broadcasts will advertise all available data and will not apply
-    /// an broadcast filtering. Intent is for paths such as:
-    ///   - boot time advertisement: advertise all servicese available
+    /// any broadcast filtering. Intent is for paths such as:
+    ///   - boot time advertisement: advertise all services available
     ///   - stop-time advertisement: advertise a TTL of 0 as services are removed
     bool IsInternalBroadcast() const { return mIsInternalBroadcast; }
     void SetIsInternalBroadcast(bool isInternalBroadcast) { mIsInternalBroadcast = isInternalBroadcast; }
@@ -67,7 +67,7 @@ private:
     bool mAnswerViaUnicast = false;
     SerializedQNameIterator mNameIterator;
 
-    /// Flag as a internal broadcast, controls repliy construction (e.g. no
+    /// Flag as an internal broadcast, controls reply construction (e.g. no
     /// filtering applied)
     bool mIsInternalBroadcast = false;
 };

--- a/src/lib/dnssd/minimal_mdns/QueryReplyFilter.h
+++ b/src/lib/dnssd/minimal_mdns/QueryReplyFilter.h
@@ -81,7 +81,7 @@ private:
 
     bool AcceptablePath(FullQName qname)
     {
-        if (mIgnoreNameMatch || mQueryData.IsBootAdvertising())
+        if (mIgnoreNameMatch || mQueryData.IsInternalBroadcast())
         {
             return true;
         }

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -100,7 +100,8 @@ bool ResponseSender::HasQueryResponders() const
     return false;
 }
 
-CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, const chip::Inet::IPPacketInfo * querySource)
+CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, const chip::Inet::IPPacketInfo * querySource,
+                                   const ResponseConfiguration & configuration)
 {
     mSendState.Reset(messageId, query, querySource);
 
@@ -116,8 +117,6 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
             }
         }
     }
-
-    const ResponseConfiguration defaultResponseConfiguration;
 
     // send all 'Answer' replies
     {
@@ -144,7 +143,7 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
             }
             for (auto it = (*responder)->begin(&responseFilter); it != (*responder)->end(); it++)
             {
-                it->responder->AddAllResponses(querySource, this, defaultResponseConfiguration);
+                it->responder->AddAllResponses(querySource, this, configuration);
                 ReturnErrorOnFailure(mSendState.GetError());
 
                 (*responder)->MarkAdditionalRepliesFor(it);
@@ -177,7 +176,7 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
             }
             for (auto it = (*responder)->begin(&responseFilter); it != (*responder)->end(); it++)
             {
-                it->responder->AddAllResponses(querySource, this, defaultResponseConfiguration);
+                it->responder->AddAllResponses(querySource, this, configuration);
                 ReturnErrorOnFailure(mSendState.GetError());
             }
         }

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.cpp
@@ -117,6 +117,8 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
         }
     }
 
+    const ResponseConfiguration defaultResponseConfiguration;
+
     // send all 'Answer' replies
     {
         const chip::System::Clock::Timestamp kTimeNow = chip::System::SystemClock().GetMonotonicTimestamp();
@@ -142,7 +144,7 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
             }
             for (auto it = (*responder)->begin(&responseFilter); it != (*responder)->end(); it++)
             {
-                it->responder->AddAllResponses(querySource, this);
+                it->responder->AddAllResponses(querySource, this, defaultResponseConfiguration);
                 ReturnErrorOnFailure(mSendState.GetError());
 
                 (*responder)->MarkAdditionalRepliesFor(it);
@@ -175,7 +177,7 @@ CHIP_ERROR ResponseSender::Respond(uint32_t messageId, const QueryData & query, 
             }
             for (auto it = (*responder)->begin(&responseFilter); it != (*responder)->end(); it++)
             {
-                it->responder->AddAllResponses(querySource, this);
+                it->responder->AddAllResponses(querySource, this, defaultResponseConfiguration);
                 ReturnErrorOnFailure(mSendState.GetError());
             }
         }

--- a/src/lib/dnssd/minimal_mdns/ResponseSender.h
+++ b/src/lib/dnssd/minimal_mdns/ResponseSender.h
@@ -112,7 +112,8 @@ public:
     bool HasQueryResponders() const;
 
     /// Send back the response to a particular query
-    CHIP_ERROR Respond(uint32_t messageId, const QueryData & query, const chip::Inet::IPPacketInfo * querySource);
+    CHIP_ERROR Respond(uint32_t messageId, const QueryData & query, const chip::Inet::IPPacketInfo * querySource,
+                       const ResponseConfiguration & configuration);
 
     // Implementation of ResponderDelegate
     void AddResponse(const ResourceRecord & record) override;

--- a/src/lib/dnssd/minimal_mdns/responders/IP.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/IP.cpp
@@ -21,19 +21,23 @@
 namespace mdns {
 namespace Minimal {
 
-void IPv4Responder::AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate)
+void IPv4Responder::AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                                    const ResponseConfiguration & configuration)
 {
     chip::Inet::IPAddress addr;
     for (chip::Inet::InterfaceAddressIterator it; it.HasCurrent(); it.Next())
     {
         if ((it.GetInterfaceId() == source->Interface) && (it.GetAddress(addr) == CHIP_NO_ERROR) && addr.IsIPv4())
         {
-            delegate->AddResponse(IPResourceRecord(GetQName(), addr));
+            IPResourceRecord record(GetQName(), addr);
+            configuration.Adjust(record);
+            delegate->AddResponse(record);
         }
     }
 }
 
-void IPv6Responder::AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate)
+void IPv6Responder::AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                                    const ResponseConfiguration & configuration)
 {
     for (chip::Inet::InterfaceAddressIterator it; it.HasCurrent(); it.Next())
     {
@@ -45,7 +49,9 @@ void IPv6Responder::AddAllResponses(const chip::Inet::IPPacketInfo * source, Res
         chip::Inet::IPAddress addr;
         if ((it.GetInterfaceId() == source->Interface) && (it.GetAddress(addr) == CHIP_NO_ERROR) && addr.IsIPv6())
         {
-            delegate->AddResponse(IPResourceRecord(GetQName(), addr));
+            IPResourceRecord record(GetQName(), addr);
+            configuration.Adjust(record);
+            delegate->AddResponse(record);
         }
     }
 }

--- a/src/lib/dnssd/minimal_mdns/responders/IP.h
+++ b/src/lib/dnssd/minimal_mdns/responders/IP.h
@@ -27,7 +27,8 @@ class IPv4Responder : public RecordResponder
 public:
     IPv4Responder(const FullQName & qname) : RecordResponder(QType::A, qname) {}
 
-    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override;
+    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                         const ResponseConfiguration & configuration) override;
 };
 
 class IPv6Responder : public RecordResponder
@@ -35,7 +36,8 @@ class IPv6Responder : public RecordResponder
 public:
     IPv6Responder(const FullQName & qname) : RecordResponder(QType::AAAA, qname) {}
 
-    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override;
+    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                         const ResponseConfiguration & configuration) override;
 };
 
 } // namespace Minimal

--- a/src/lib/dnssd/minimal_mdns/responders/Ptr.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Ptr.h
@@ -28,9 +28,12 @@ class PtrResponder : public RecordResponder
 public:
     PtrResponder(const FullQName & qname, const FullQName & target) : RecordResponder(QType::PTR, qname), mTarget(target) {}
 
-    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override
+    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                         const ResponseConfiguration & configuration) override
     {
-        delegate->AddResponse(PtrResourceRecord(GetQName(), mTarget));
+        PtrResourceRecord record(GetQName(), mTarget);
+        configuration.Adjust(record);
+        delegate->AddResponse(record);
     }
 
 private:

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.cpp
@@ -137,7 +137,8 @@ void QueryResponderBase::MarkAdditionalRepliesFor(QueryResponderIterator it)
     }
 }
 
-void QueryResponderBase::AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate)
+void QueryResponderBase::AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                                         const ResponseConfiguration & configuration)
 {
     // reply to dns-sd service list request
     for (size_t i = 0; i < mResponderInfoSize; i++)
@@ -152,7 +153,9 @@ void QueryResponderBase::AddAllResponses(const chip::Inet::IPPacketInfo * source
             continue;
         }
 
-        delegate->AddResponse(PtrResourceRecord(GetQName(), mResponderInfos[i].responder->GetQName()));
+        PtrResourceRecord record(GetQName(), mResponderInfos[i].responder->GetQName());
+        configuration.Adjust(record);
+        delegate->AddResponse(record);
     }
 }
 

--- a/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/QueryResponder.h
@@ -252,7 +252,8 @@ public:
     /// Implementation of the responder delegate.
     ///
     /// Adds responses for all known _dns-sd services.
-    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override;
+    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                         const ResponseConfiguration & configuration) override;
 
     QueryResponderIterator begin(QueryResponderRecordFilter * filter)
     {

--- a/src/lib/dnssd/minimal_mdns/responders/Responder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Responder.h
@@ -50,11 +50,8 @@ public:
         return *this;
     }
 
-    ResponseConfiguration & SetTtlSecondsOverride(uint32_t value)
-    {
-        return SetTtlSecondsOverride(chip::Optional<uint32_t>::Value(value));
-    }
-    ResponseConfiguration & ClearTtlSecondsOverride() { return SetTtlSecondsOverride(chip::Optional<uint32_t>::Missing()); }
+    ResponseConfiguration & SetTtlSecondsOverride(uint32_t value) { return SetTtlSecondsOverride(chip::MakeOptional(value)); }
+    ResponseConfiguration & ClearTtlSecondsOverride() { return SetTtlSecondsOverride(chip::NullOptional); }
 
     /// Applies any adjustments to resource records before they are being serialized
     /// to some form of reply.

--- a/src/lib/dnssd/minimal_mdns/responders/Responder.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Responder.h
@@ -21,6 +21,7 @@
 #include <lib/dnssd/minimal_mdns/records/ResourceRecord.h>
 
 #include <inet/IPPacketInfo.h>
+#include <lib/core/Optional.h>
 
 namespace mdns {
 namespace Minimal {
@@ -32,6 +33,41 @@ public:
 
     /// Add the specified resource record to the response
     virtual void AddResponse(const ResourceRecord & record) = 0;
+};
+
+/// Controls specific options for responding to mDNS queries
+///
+class ResponseConfiguration
+{
+public:
+    ResponseConfiguration() {}
+    ~ResponseConfiguration() = default;
+
+    chip::Optional<uint32_t> GetTtlSecondsOverride() const { return mTtlSecondsOverride; }
+    ResponseConfiguration & SetTtlSecondsOverride(chip::Optional<uint32_t> override)
+    {
+        mTtlSecondsOverride = override;
+        return *this;
+    }
+
+    ResponseConfiguration & SetTtlSecondsOverride(uint32_t value)
+    {
+        return SetTtlSecondsOverride(chip::Optional<uint32_t>::Value(value));
+    }
+    ResponseConfiguration & ClearTtlSecondsOverride() { return SetTtlSecondsOverride(chip::Optional<uint32_t>::Missing()); }
+
+    /// Applies any adjustments to resource records before they are being serialized
+    /// to some form of reply.
+    void Adjust(ResourceRecord & record) const
+    {
+        if (mTtlSecondsOverride.HasValue())
+        {
+            record.SetTtl(mTtlSecondsOverride.Value());
+        }
+    }
+
+private:
+    chip::Optional<uint32_t> mTtlSecondsOverride;
 };
 
 /// Adds ability to respond with specific types of data
@@ -51,7 +87,8 @@ public:
     /// Report all reponses maintained by this responder
     ///
     /// Responses are associated with the objects type/class/qname.
-    virtual void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) = 0;
+    virtual void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                                 const ResponseConfiguration & configuration) = 0;
 
 private:
     const QType mQType;

--- a/src/lib/dnssd/minimal_mdns/responders/Srv.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Srv.h
@@ -28,9 +28,12 @@ class SrvResponder : public RecordResponder
 public:
     SrvResponder(const SrvResourceRecord & record) : RecordResponder(QType::SRV, record.GetName()), mRecord(record) {}
 
-    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override
+    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                         const ResponseConfiguration & configuration) override
     {
-        delegate->AddResponse(mRecord);
+        SrvResourceRecord record = mRecord;
+        configuration.Adjust(record);
+        delegate->AddResponse(record);
     }
 
 private:

--- a/src/lib/dnssd/minimal_mdns/responders/Txt.h
+++ b/src/lib/dnssd/minimal_mdns/responders/Txt.h
@@ -28,9 +28,12 @@ class TxtResponder : public RecordResponder
 public:
     TxtResponder(const TxtResourceRecord & record) : RecordResponder(QType::TXT, record.GetName()), mRecord(record) {}
 
-    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate) override
+    void AddAllResponses(const chip::Inet::IPPacketInfo * source, ResponderDelegate * delegate,
+                         const ResponseConfiguration & configuration) override
     {
-        delegate->AddResponse(mRecord);
+        TxtResourceRecord record = mRecord;
+        configuration.Adjust(record);
+        delegate->AddResponse(record);
     }
 
 private:

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestIPResponder.cpp
@@ -81,7 +81,7 @@ void TestIPv4(nlTestSuite * inSuite, void * inContext)
     packetInfo.DestPort    = kMdnsPort;
     packetInfo.Interface   = FindValidInterfaceId();
 
-    responder.AddAllResponses(&packetInfo, &acc);
+    responder.AddAllResponses(&packetInfo, &acc, ResponseConfiguration());
 }
 #endif // INET_CONFIG_ENABLE_IPV4
 
@@ -105,7 +105,7 @@ void TestIPv6(nlTestSuite * inSuite, void * inContext)
     packetInfo.DestPort    = kMdnsPort;
     packetInfo.Interface   = FindValidInterfaceId();
 
-    responder.AddAllResponses(&packetInfo, &acc);
+    responder.AddAllResponses(&packetInfo, &acc, ResponseConfiguration());
 }
 
 const nlTest sTests[] = {

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
@@ -39,7 +39,7 @@ const QNamePart kTargetNames[] = { "point", "to", "this" };
 class PtrResponseAccumulator : public ResponderDelegate
 {
 public:
-    PtrResponseAccumulator(nlTestSuite * suite) : mSuite(suite) {}
+    PtrResponseAccumulator(nlTestSuite * suite, const uint32_t expectedTtl) : mSuite(suite), mExpectedTtl(expectedTtl) {}
     void AddResponse(const ResourceRecord & record) override
     {
 
@@ -72,6 +72,7 @@ public:
             NL_TEST_ASSERT(mSuite, start == (buffer + out.Needed()));
             NL_TEST_ASSERT(mSuite, data.GetName() == FullQName(kNames));
             NL_TEST_ASSERT(mSuite, data.GetType() == QType::PTR);
+            NL_TEST_ASSERT(mSuite, data.GetTtlSeconds() == mExpectedTtl);
 
             NL_TEST_ASSERT(mSuite, ParsePtrRecord(data.GetData(), validDataRange, &target));
             NL_TEST_ASSERT(mSuite, target == FullQName(kTargetNames));
@@ -80,6 +81,7 @@ public:
 
 private:
     nlTestSuite * mSuite;
+    const uint32_t mExpectedTtl;
 };
 
 void TestPtrResponse(nlTestSuite * inSuite, void * inContext)
@@ -93,7 +95,7 @@ void TestPtrResponse(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, responder.GetQType() == QType::PTR);
     NL_TEST_ASSERT(inSuite, responder.GetQName() == kNames);
 
-    PtrResponseAccumulator acc(inSuite);
+    PtrResponseAccumulator acc(inSuite, ResourceRecord::kDefaultTtl);
     chip::Inet::IPPacketInfo packetInfo;
 
     packetInfo.SrcAddress  = ipAddress;
@@ -105,9 +107,33 @@ void TestPtrResponse(nlTestSuite * inSuite, void * inContext)
     responder.AddAllResponses(&packetInfo, &acc, ResponseConfiguration());
 }
 
+void TestPtrResponseOverrideTtl(nlTestSuite * inSuite, void * inContext)
+{
+    IPAddress ipAddress;
+    NL_TEST_ASSERT(inSuite, IPAddress::FromString("2607:f8b0:4005:804::200e", ipAddress));
+
+    PtrResponder responder(kNames, kTargetNames);
+
+    NL_TEST_ASSERT(inSuite, responder.GetQClass() == QClass::IN);
+    NL_TEST_ASSERT(inSuite, responder.GetQType() == QType::PTR);
+    NL_TEST_ASSERT(inSuite, responder.GetQName() == kNames);
+
+    PtrResponseAccumulator acc(inSuite, 123);
+    chip::Inet::IPPacketInfo packetInfo;
+
+    packetInfo.SrcAddress  = ipAddress;
+    packetInfo.DestAddress = ipAddress;
+    packetInfo.SrcPort     = kMdnsPort;
+    packetInfo.DestPort    = kMdnsPort;
+    packetInfo.Interface   = InterfaceId::Null();
+
+    responder.AddAllResponses(&packetInfo, &acc, ResponseConfiguration().SetTtlSecondsOverride(123));
+}
+
 const nlTest sTests[] = {
-    NL_TEST_DEF("TestPtrResponse", TestPtrResponse), //
-    NL_TEST_SENTINEL()                               //
+    NL_TEST_DEF("TestPtrResponse", TestPtrResponse),                       //
+    NL_TEST_DEF("TestPtrResponseOverrideTtl", TestPtrResponseOverrideTtl), //
+    NL_TEST_SENTINEL()                                                     //
 };
 
 } // namespace

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestPtrResponder.cpp
@@ -102,7 +102,7 @@ void TestPtrResponse(nlTestSuite * inSuite, void * inContext)
     packetInfo.DestPort    = kMdnsPort;
     packetInfo.Interface   = InterfaceId::Null();
 
-    responder.AddAllResponses(&packetInfo, &acc);
+    responder.AddAllResponses(&packetInfo, &acc, ResponseConfiguration());
 }
 
 const nlTest sTests[] = {

--- a/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
+++ b/src/lib/dnssd/minimal_mdns/responders/tests/TestQueryResponder.cpp
@@ -38,7 +38,7 @@ class EmptyResponder : public RecordResponder
 {
 public:
     EmptyResponder(const FullQName & qName) : RecordResponder(QType::NULLVALUE, qName) {}
-    void AddAllResponses(const chip::Inet::IPPacketInfo *, ResponderDelegate *) override {}
+    void AddAllResponses(const chip::Inet::IPPacketInfo *, ResponderDelegate *, const ResponseConfiguration &) override {}
 };
 
 class DnssdReplyAccumulator : public ResponderDelegate
@@ -111,7 +111,7 @@ void RespondsToDnsSdQueries(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, responder.GetQName() == kDnsSdname);
 
     DnssdReplyAccumulator accumulator(inSuite);
-    responder.AddAllResponses(nullptr, &accumulator);
+    responder.AddAllResponses(nullptr, &accumulator, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, accumulator.Captures().size() == 2);
     if (accumulator.Captures().size() == 2)
@@ -160,7 +160,7 @@ void NonDiscoverableService(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, responder.AddResponder(&empty2).SetReportInServiceListing(true).IsValid());
 
     DnssdReplyAccumulator accumulator(inSuite);
-    responder.AddAllResponses(nullptr, &accumulator);
+    responder.AddAllResponses(nullptr, &accumulator, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, accumulator.Captures().size() == 1);
     if (accumulator.Captures().size() == 1)

--- a/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
+++ b/src/lib/dnssd/minimal_mdns/tests/TestResponseSender.cpp
@@ -98,7 +98,7 @@ void SrvAnyResponseToInstance(nlTestSuite * inSuite, void * inContext)
     QueryData queryData = QueryData(QType::ANY, QClass::IN, false, common.requestNameStart, common.requestBytesRange);
 
     common.server.AddExpectedRecord(&common.srvRecord);
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common.server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, common.server.GetHeaderFound());
@@ -120,7 +120,7 @@ void SrvTxtAnyResponseToInstance(nlTestSuite * inSuite, void * inContext)
     // We requested ANY on the host name, expect both back.
     common.server.AddExpectedRecord(&common.srvRecord);
     common.server.AddExpectedRecord(&common.txtRecord);
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common.server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, common.server.GetHeaderFound());
@@ -145,7 +145,7 @@ void PtrSrvTxtAnyResponseToServiceName(nlTestSuite * inSuite, void * inContext)
     common.server.AddExpectedRecord(&common.srvRecord);
     common.server.AddExpectedRecord(&common.txtRecord);
 
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common.server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, common.server.GetHeaderFound());
@@ -169,7 +169,7 @@ void PtrSrvTxtAnyResponseToInstance(nlTestSuite * inSuite, void * inContext)
     common.server.AddExpectedRecord(&common.srvRecord);
     common.server.AddExpectedRecord(&common.txtRecord);
 
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common.server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, common.server.GetHeaderFound());
@@ -192,7 +192,7 @@ void PtrSrvTxtSrvResponseToInstance(nlTestSuite * inSuite, void * inContext)
     // We didn't set the txt as an additional on the srv name so expect only srv.
     common.server.AddExpectedRecord(&common.srvRecord);
 
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common.server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, common.server.GetHeaderFound());
@@ -216,7 +216,7 @@ void PtrSrvTxtAnyResponseToServiceListing(nlTestSuite * inSuite, void * inContex
     PtrResourceRecord serviceRecord = PtrResourceRecord(common.dnsSd, common.ptrRecord.GetName());
     common.server.AddExpectedRecord(&serviceRecord);
 
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common.server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, common.server.GetHeaderFound());
@@ -230,15 +230,15 @@ void NoQueryResponder(nlTestSuite * inSuite, void * inContext)
     QueryData queryData = QueryData(QType::ANY, QClass::IN, false, common.requestNameStart, common.requestBytesRange);
 
     common.recordWriter.WriteQName(common.dnsSd);
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
     NL_TEST_ASSERT(inSuite, !common.server.GetSendCalled());
 
     common.recordWriter.WriteQName(common.service);
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
     NL_TEST_ASSERT(inSuite, !common.server.GetSendCalled());
 
     common.recordWriter.WriteQName(common.instance);
-    responseSender.Respond(1, queryData, &common.packetInfo);
+    responseSender.Respond(1, queryData, &common.packetInfo, ResponseConfiguration());
     NL_TEST_ASSERT(inSuite, !common.server.GetSendCalled());
 }
 
@@ -304,7 +304,7 @@ void PtrSrvTxtMultipleRespondersToInstance(nlTestSuite * inSuite, void * inConte
     common1.server.AddExpectedRecord(&common2.srvRecord);
     common1.server.AddExpectedRecord(&common2.txtRecord);
 
-    responseSender.Respond(1, queryData, &common1.packetInfo);
+    responseSender.Respond(1, queryData, &common1.packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common1.server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, common1.server.GetHeaderFound());
@@ -338,7 +338,7 @@ void PtrSrvTxtMultipleRespondersToServiceListing(nlTestSuite * inSuite, void * i
     PtrResourceRecord serviceRecord2 = PtrResourceRecord(common2.dnsSd, common2.ptrRecord.GetName());
     common1.server.AddExpectedRecord(&serviceRecord2);
 
-    responseSender.Respond(1, queryData, &common1.packetInfo);
+    responseSender.Respond(1, queryData, &common1.packetInfo, ResponseConfiguration());
 
     NL_TEST_ASSERT(inSuite, common1.server.GetSendCalled());
     NL_TEST_ASSERT(inSuite, common1.server.GetHeaderFound());


### PR DESCRIPTION
#### Problem
MinMDNS hardcodes a TTL for all records of 2 minutes (since it actually does not really know about real validity).

This means for fast operations (e.g. advertise commissionable and then actually commission), the device will stay up for 2 minutes for servers that implement caching and honor ttl (e.g. bonjour, avahi, other non min-mdns systems)

#### Change overview
Support a "send all records with TTL=0" operation min minmdns. Use this in MinMdns advertiser.
Cleanup shutdown logic in minmdns demo server, however since that does not use the real advertiser, it will not send either of boot time or shut down advertisements. This one did not seem as important to fix (2 min timeout seems ok here).

#### Testing
a) started all-clusters-app on linux, noticed that avahi-browse stops showing the services immediately after ^C (before they persisted)
b) Adjusted one unit test to validate that "set TTL to 0" works
c) CI will validate that normal operations are still ok - specifically commission and operation tests on linux use minMDNS.