### PR TITLE
Add Error Callback for subscriptions

### DIFF
--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -468,6 +468,7 @@ class SubscriptionTransaction:
     def __init__(self, transaction: 'AsyncReadTransaction', subscriptionId, devCtrl):
         self._onAttributeChangeCb = DefaultAttributeChangeCallback
         self._onEventChangeCb = DefaultEventChangeCallback
+        self._onErrorCb = DefaultErrorCallback
         self._readTransaction = transaction
         self._subscriptionId = subscriptionId
         self._devCtrl = devCtrl
@@ -502,6 +503,13 @@ class SubscriptionTransaction:
         if callback is not None:
             self._onEventChangeCb = callback
 
+    def SetErrorCallback(self, callback: Callable[[int, SubscriptionTransaction], None]):
+        '''
+        Sets the callback function in case a subscription error occured, accepts a Callable accepts an error code and the cached data.
+        '''
+        if callback is not None:
+            self._onErrorCb = callback
+
     @property
     def OnAttributeChangeCb(self) -> Callable[[TypedAttributePath, SubscriptionTransaction], None]:
         return self._onAttributeChangeCb
@@ -509,6 +517,10 @@ class SubscriptionTransaction:
     @property
     def OnEventChangeCb(self) -> Callable[[EventReadResult, SubscriptionTransaction], None]:
         return self._onEventChangeCb
+
+    @property
+    def OnErrorCb(self) -> Callable[[int, SubscriptionTransaction], None]:
+        return self._onErrorCb
 
     def Shutdown(self):
         if (self._isDone):
@@ -542,6 +554,10 @@ def DefaultAttributeChangeCallback(path: TypedAttributePath, transaction: Subscr
 def DefaultEventChangeCallback(data: EventReadResult, transaction: SubscriptionTransaction):
     print("Received Event:")
     pprint(data, expand_all=True)
+
+
+def DefaultErrorCallback(chipError: int, transaction: SubscriptionTransaction):
+    print("Error during Subscription: Chip Stack Error %d".format(chipError))
 
 
 def _BuildEventIndex():
@@ -658,8 +674,10 @@ class AsyncReadTransaction:
         self._handleEventData(header, path, data, status)
 
     def _handleError(self, chipError: int):
-        self._future.set_exception(
-            chip.exceptions.ChipStackError(chipError))
+        if not self._future.done():
+            self._future.set_exception(
+                chip.exceptions.ChipStackError(chipError))
+        self._subscription_handler.OnErrorCb(chipError, self._subscription_handler)
 
     def handleError(self, chipError: int):
         self._event_loop.call_soon_threadsafe(


### PR DESCRIPTION
#### Problem
If auto-renew is disabled, the following exception is thrown:

```
ERROR Exception in callback AsyncReadTransaction._handleError(50)
handle: <Handle AsyncReadTransaction._handleError(50)>
Traceback (most recent call last):
  File "/usr/lib/python3.9/asyncio/events.py", line 80, in _run
    self._context.run(self._callback, *self._args)
  File "/home/sag/projects/project-chip/connectedhomeip/out/python_env/lib/python3.9/site-packages/chip/clusters/Attribute.py", line 661, in _handleError
    self._future.set_exception(
asyncio.exceptions.InvalidStateError: invalid state
```

#### Change overview
Add Error Callback for subscriptions.

#### Testing
Local test using Python Controller.
