### PR TITLE
Don't expire failsafe when commissioning window closes

### DIFF
--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -54,7 +54,7 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
         ChipLogProgress(AppServer, "Commissioning completed successfully");
         DeviceLayer::SystemLayer().CancelTimer(HandleCommissioningWindowTimeout, this);
         mCommissioningTimeoutTimerArmed = false;
-        Cleanup(/* expireFailSafeTimer */ true);
+        Cleanup();
         mServer->GetSecureSessionManager().ExpireAllPASEPairings();
         // That should have cleared out mPASESession.
 #if CONFIG_NETWORK_LAYER_BLE
@@ -100,14 +100,9 @@ void CommissioningWindowManager::ResetState()
     mCommissioningTimeoutTimerArmed = false;
 }
 
-void CommissioningWindowManager::Cleanup(bool expireFailSafeTimer)
+void CommissioningWindowManager::Cleanup()
 {
     StopAdvertisement(/* aShuttingDown = */ false);
-    if (expireFailSafeTimer)
-    {
-        ExpireFailSafeIfArmed();
-    }
-
     ResetState();
 }
 
@@ -135,7 +130,7 @@ void CommissioningWindowManager::HandleFailedAttempt(CHIP_ERROR err)
     {
         // The commissioning attempts limit was exceeded, or listening for
         // commmissioning connections failed.
-        Cleanup(/* expireFailSafeTimer */ true);
+        Cleanup();
 
         if (mAppDelegate != nullptr)
         {
@@ -277,7 +272,7 @@ CHIP_ERROR CommissioningWindowManager::OpenBasicCommissioningWindow(Seconds16 co
     CHIP_ERROR err = OpenCommissioningWindow(commissioningTimeout);
     if (err != CHIP_NO_ERROR)
     {
-        Cleanup(/* expireFailSafeTimer */ true);
+        Cleanup();
     }
 
     return err;
@@ -308,7 +303,7 @@ CHIP_ERROR CommissioningWindowManager::OpenEnhancedCommissioningWindow(Seconds16
     CHIP_ERROR err = OpenCommissioningWindow(commissioningTimeout);
     if (err != CHIP_NO_ERROR)
     {
-        Cleanup(/* expireFailSafeTimer */ true);
+        Cleanup();
     }
     return err;
 }
@@ -327,7 +322,7 @@ void CommissioningWindowManager::CloseCommissioningWindow()
         }
 #endif
         ChipLogProgress(AppServer, "Closing pairing window");
-        Cleanup(/* expireFailSafeTimer */ false);
+        Cleanup();
     }
 }
 

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -90,7 +90,6 @@ public:
     void OnSessionEstablished(const SessionHandle & session) override;
 
     void Shutdown();
-    void Cleanup(bool expireFailSafeTimer);
 
     void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event);
 
@@ -129,6 +128,8 @@ private:
     // advertisements, because Shutdown and Cleanup want to handle those
     // differently.
     void ResetState();
+
+    void Cleanup();
 
     /**
      * Function that gets called when our commissioning window timeout timer

--- a/src/app/server/CommissioningWindowManager.h
+++ b/src/app/server/CommissioningWindowManager.h
@@ -90,7 +90,7 @@ public:
     void OnSessionEstablished(const SessionHandle & session) override;
 
     void Shutdown();
-    void Cleanup();
+    void Cleanup(bool expireFailSafeTimer);
 
     void OnPlatformEvent(const DeviceLayer::ChipDeviceEvent * event);
 


### PR DESCRIPTION
#### Problem
*Fixes https://github.com/project-chip/connectedhomeip/issues/19678

#### Change overview
No longer expire the failsafe timer when the commission window closes either due to open window timeout or RevokeCommissioning command

#### Testing
* Github CI
* Did the following process:
  * Terminal 1:
    * `chip-tool pairing onnetwork 1 20202021`
    * `chip-tool pairing open-commissioning-window 1 0 200 1000 3840`
  * Terminal 2:
    * `chip-tool interactive start`
      * `pairing code-paseonly 17 749701123365521327694`
  * Terminal 1:
    * `chip-tool administratorcommissioning revoke-commissioning 1 0 --timedInteractionTimeoutMs 1000`
  * Terminal 2 (in interactive shell):
      * `generalcommissioning arm-fail-safe 60 0 17 0`
      * Confirmed command goes through, previously on the `revoke-commissioning` fail-safe would trigger and this command would never send
