### PR TITLE
Stop using Credentials::GetDefaultDACVerifier on Darwin.

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -327,7 +327,13 @@ void DeviceControllerFactory::Shutdown()
 
 CHIP_ERROR DeviceControllerSystemState::Shutdown()
 {
-    VerifyOrReturnError(mRefCount == 1, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mRefCount <= 1, CHIP_ERROR_INCORRECT_STATE);
+    if (mHaveShutDown)
+    {
+        // Nothing else to do here.
+        return CHIP_NO_ERROR;
+    }
+    mHaveShutDown = true;
 
     ChipLogDetail(Controller, "Shutting down the System State, this will teardown the CHIP Stack");
 

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -106,7 +106,13 @@ class DeviceControllerSystemState
     using CASEClientPool        = DeviceControllerSystemStateParams::CASEClientPool;
 
 public:
-    ~DeviceControllerSystemState(){};
+    ~DeviceControllerSystemState()
+    {
+        // We could get here if a DeviceControllerFactory is shut down
+        // without ever creating any controllers, so our refcount never goes
+        // above 1.  In that case we need to make sure we call Shutdown().
+        Shutdown();
+    };
     DeviceControllerSystemState(DeviceControllerSystemStateParams params) :
         mSystemLayer(params.systemLayer), mTCPEndPointManager(params.tcpEndPointManager),
         mUDPEndPointManager(params.udpEndPointManager), mTransportMgr(params.transportMgr), mSessionMgr(params.sessionMgr),
@@ -194,6 +200,8 @@ private:
     FabricTable * mTempFabricTable = nullptr;
 
     std::atomic<uint32_t> mRefCount{ 1 };
+
+    bool mHaveShutDown = false;
 
     CHIP_ERROR Shutdown();
 };

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
@@ -145,31 +145,7 @@ CHIP_ERROR GetCertificationDeclarationCertificate(const ByteSpan & skid, Mutable
     return CopySpanToMutableSpan(ByteSpan{ sCertChainLookupTable[certChainLookupTableIdx].mCertificate }, outCertificate);
 }
 
-class DefaultDACVerifier : public DeviceAttestationVerifier
-{
-public:
-    DefaultDACVerifier(const AttestationTrustStore * paaRootStore) : mAttestationTrustStore(paaRootStore) {}
-
-    void VerifyAttestationInformation(const DeviceAttestationVerifier::AttestationInfo & info,
-                                      Callback::Callback<OnAttestationInformationVerification> * onCompletion) override;
-
-    AttestationVerificationResult ValidateCertificationDeclarationSignature(const ByteSpan & cmsEnvelopeBuffer,
-                                                                            ByteSpan & certDeclBuffer) override;
-
-    AttestationVerificationResult ValidateCertificateDeclarationPayload(const ByteSpan & certDeclBuffer,
-                                                                        const ByteSpan & firmwareInfo,
-                                                                        const DeviceInfoForAttestation & deviceInfo) override;
-
-    CHIP_ERROR VerifyNodeOperationalCSRInformation(const ByteSpan & nocsrElementsBuffer,
-                                                   const ByteSpan & attestationChallengeBuffer,
-                                                   const ByteSpan & attestationSignatureBuffer, const P256PublicKey & dacPublicKey,
-                                                   const ByteSpan & csrNonce) override;
-
-protected:
-    DefaultDACVerifier() {}
-
-    const AttestationTrustStore * mAttestationTrustStore;
-};
+} // namespace
 
 void DefaultDACVerifier::VerifyAttestationInformation(const DeviceAttestationVerifier::AttestationInfo & info,
                                                       Callback::Callback<OnAttestationInformationVerification> * onCompletion)
@@ -442,8 +418,6 @@ CHIP_ERROR DefaultDACVerifier::VerifyNodeOperationalCSRInformation(const ByteSpa
 
     return CHIP_NO_ERROR;
 }
-
-} // namespace
 
 const AttestationTrustStore * GetTestAttestationTrustStore()
 {

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -44,6 +44,7 @@
 #include <controller/CommissioningWindowOpener.h>
 #include <credentials/FabricTable.h>
 #include <credentials/GroupDataProvider.h>
+#include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
 #include <platform/PlatformManager.h>
 #include <setup_payload/ManualSetupPayloadGenerator.h>
@@ -277,6 +278,7 @@ static NSString * const kErrorCommitPendingFabricData = @"Committing fabric data
             commissionerParams.controllerNOC = noc;
         }
         commissionerParams.controllerVendorId = static_cast<chip::VendorId>([startupParams.vendorId unsignedShortValue]);
+        commissionerParams.deviceAttestationVerifier = _factory.deviceAttestationVerifier;
 
         auto & factory = chip::Controller::DeviceControllerFactory::GetInstance();
 

--- a/src/darwin/Framework/CHIP/MatterControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MatterControllerFactory_Internal.h
@@ -31,6 +31,7 @@ class CHIPPersistentStorageDelegateBridge;
 namespace chip {
 namespace Credentials {
     class GroupDataProvider;
+    class DeviceAttestationVerifier;
 } // namespace Credentials
 } // namespace chip
 
@@ -44,7 +45,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @property (readonly) CHIPPersistentStorageDelegateBridge * storageDelegateBridge;
 @property (readonly) chip::Credentials::GroupDataProvider * groupData;
-
+@property (readonly) chip::Credentials::DeviceAttestationVerifier * deviceAttestationVerifier;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
+++ b/src/darwin/Framework/CHIPTests/CHIPClustersTests.m
@@ -103,8 +103,17 @@ static CHIPDeviceController * sController = nil;
     __auto_type * storage = [[CHIPTestStorage alloc] init];
     __auto_type * factoryParams = [[MatterControllerFactoryParams alloc] initWithStorage:storage];
     factoryParams.port = @(kLocalPort);
+    // For our first startup, use a dummy paaCerts array.
+    factoryParams.paaCerts = [[NSArray alloc] init];
 
     BOOL ok = [factory startup:factoryParams];
+    XCTAssertTrue(ok);
+
+    // Test that things still work right if we then shut down and
+    // restart the factory.
+    [factory shutdown];
+    factoryParams.paaCerts = nil;
+    ok = [factory startup:factoryParams];
     XCTAssertTrue(ok);
 
     __auto_type * testKeys = [[CHIPTestKeys alloc] init];


### PR DESCRIPTION
Credentials::GetDefaultDACVerifier returns a singleton object,
initialized the very first time the function is called.  The Darwin
framework wants to be able to shut down and restart with a new PAA
trust store, which means not relying on this initialized-once
singleton.

The fixes to DeviceControllerSystemState shutdown were needed to make
the tests (which start up a factory, then shut it down without
bringing up any controllers, which is a valid thing to do) pass.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Modified CI tests to exercise these bits.