### PR TITLE
Eliminated references to emAfCurrentCommand from color-control-server

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1975,7 +1975,7 @@ ColorControlServer::Color16uTransitionState * ColorControlServer::getTempTransit
  */
 EmberAfStatus ColorControlServer::moveToColorTemp(EndpointId aEndpoint, uint16_t colorTemperature, uint16_t transitionTime)
 {
-    EndpointId endpoint = emberAfCurrentEndpoint();
+    EndpointId endpoint = aEndpoint;
 
     Color16uTransitionState * colorTempTransitionState = getTempTransitionState(endpoint);
     VerifyOrReturnError(colorTempTransitionState != nullptr, EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT);
@@ -2450,12 +2450,6 @@ void ColorControlServer::levelControlColorTempChangeCommand(EndpointId endpoint)
 /**********************************************************
  * Callbacks Implementation
  *********************************************************/
-
-void emberAfPluginColorControlServerStopTransition(void)
-{
-    EndpointId endpoint = emberAfCurrentEndpoint();
-    ColorControlServer::Instance().stopAllColorTransitions(endpoint);
-}
 
 #ifdef EMBER_AF_PLUGIN_COLOR_CONTROL_SERVER_HSV
 


### PR DESCRIPTION
#### Problem
On a device that supports extended color server, when a `onoff` cluster is toggled, it triggers a call to `moveToColorTemp`. Then an exception is raised on the `moveToColorTemp` command, when tries accessing`emberAfCurrentEndpoint`.

#### Analysis
`DispatchSingleClusterCommand` sets value of `emAfCurrentCommand` through a call to `SetupEmberAfCommandHandler`, but soon after  cluster dispatch, it calls `ResetEmberAfObjects` that resets `emAfCurrentCommand` to `nullptr`. After the initial callback is serviced, any cluster that uses a transitions/delays cannot make additional calls to `emberAfCurrentEndpoint`.

#### Change overview
Eliminated references to `emberAfCurrentEndpoint` from `color-control-server.cpp`. 
- `emberAfPluginColorControlServerStopTransition` removed as there is no reference to it in the project.
- `moveToColorTemp` already has the endpoint information as an argument, and doesn't need to call `emberAfCurrentEndpoint`.

#### Testing
* Built a chef sample with `./chef.py -d <device that container matter extended color light on ep1> -t esp32 -zbefi -p 0x8000`
* Commissioned with `chip-tool`
* toggled onoff cluster on ep1 on via `out/debug/chip-tool onoff toggle 1 1`. This would cause the crash prior to this change