### PR TITLE
[zephyr] fix crash when BLE initialization

### DIFF
--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -107,15 +107,10 @@ CHIP_ERROR InitRandomStaticAddress()
     int error = 0;
     bt_addr_le_t addr;
 
-#if CONFIG_BT_HOST_CRYPTO
-    // When CONFIG_BT_HOST_CRYPTO is enabled, bt_addr_le_create_static() depends on HCI transport
-    // which is not yet started at this point, so use a different method for generating the address
+    // generating the address
     addr.type = BT_ADDR_LE_RANDOM;
     error     = sys_csrand_get(addr.a.val, sizeof(addr.a.val));
     BT_ADDR_SET_STATIC(&addr.a);
-#else
-    error = bt_addr_le_create_static(&addr);
-#endif
 
     if (error)
     {


### PR DESCRIPTION
rng is initialized after bt_enable, in bt_enable() open rng device in
latest zephyr version, then could get random address, otherwise will be crashed
