### PR TITLE
Add m5stack build configs for ota-requestor app

### DIFF
--- a/examples/ota-requestor-app/esp32/sdkconfig_m5stack.defaults
+++ b/examples/ota-requestor-app/esp32/sdkconfig_m5stack.defaults
@@ -1,0 +1,65 @@
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      CI uses this to select the ESP32 M5Stack.
+#
+CONFIG_IDF_TARGET="esp32"
+CONFIG_IDF_TARGET_ESP32=y
+CONFIG_DEVICE_TYPE_M5STACK=y
+
+# Default to 921600 baud when flashing and monitoring device
+CONFIG_ESPTOOLPY_BAUD_921600B=y
+CONFIG_ESPTOOLPY_BAUD=921600
+CONFIG_ESPTOOLPY_COMPRESSED=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD_115200B=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD=115200
+
+# Enable BT
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+
+# Enable lwip ipv6 autoconfig
+CONFIG_LWIP_IPV6_AUTOCONFIG=y
+
+# Use a custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+# Vendor and product id
+CONFIG_DEVICE_VENDOR_ID=0xFFF1
+CONFIG_DEVICE_PRODUCT_ID=0x8001
+
+# Main task needs a bit more stack than the default
+# default is 3584, bump this up to 5k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=5120
+
+# Enable debug shell
+CONFIG_ENABLE_CHIP_SHELL=y
+
+# Serial Flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
+
+# Disable Bluetooth modem sleep
+# Enable it may cause GPIO ISR triggers continuously
+CONFIG_BTDM_CTRL_MODEM_SLEEP=n
+CONFIG_BTDM_CTRL_MODEM_SLEEP_MODE_ORIG=n
+CONFIG_BTDM_CTRL_LPCLK_SEL_MAIN_XTAL=n
+
+# Enable OTA Requestor
+CONFIG_ENABLE_OTA_REQUESTOR=y
+CONFIG_DEVICE_SOFTWARE_VERSION_NUMBER=2

--- a/examples/ota-requestor-app/esp32/sdkconfig_m5stack_rpc.defaults
+++ b/examples/ota-requestor-app/esp32/sdkconfig_m5stack_rpc.defaults
@@ -1,0 +1,72 @@
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+#    Description:
+#      CI uses this to select the ESP32 M5Stack.
+#
+CONFIG_IDF_TARGET="esp32"
+CONFIG_IDF_TARGET_ESP32=y
+CONFIG_DEVICE_TYPE_M5STACK=y
+
+# Default to 921600 baud when flashing and monitoring device
+CONFIG_ESPTOOLPY_BAUD_921600B=y
+CONFIG_ESPTOOLPY_BAUD=921600
+CONFIG_ESPTOOLPY_COMPRESSED=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD_115200B=y
+CONFIG_ESPTOOLPY_MONITOR_BAUD=115200
+
+# Enable BT
+CONFIG_BT_ENABLED=y
+CONFIG_BT_NIMBLE_ENABLED=y
+
+# Enable lwip ipv6 autoconfig
+CONFIG_LWIP_IPV6_AUTOCONFIG=y
+
+# Use a custom partition table
+CONFIG_PARTITION_TABLE_CUSTOM=y
+CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"
+
+# Vendor and product id
+CONFIG_DEVICE_VENDOR_ID=0xFFF1
+CONFIG_DEVICE_PRODUCT_ID=0x8001
+
+# Main task needs a bit more stack than the default
+# default is 3584, bump this up to 5k.
+CONFIG_ESP_MAIN_TASK_STACK_SIZE=5120
+
+# Disable shell
+CONFIG_ENABLE_CHIP_SHELL=n
+
+# Serial Flasher config
+CONFIG_ESPTOOLPY_FLASHSIZE_4MB=y
+CONFIG_ESPTOOLPY_FLASHSIZE="4MB"
+
+# Disable Bluetooth modem sleep
+# Enable it may cause GPIO ISR triggers continuously
+CONFIG_BTDM_CTRL_MODEM_SLEEP=n
+CONFIG_BTDM_CTRL_MODEM_SLEEP_MODE_ORIG=n
+CONFIG_BTDM_CTRL_LPCLK_SEL_MAIN_XTAL=n
+
+# Enable OTA Requestor
+CONFIG_ENABLE_OTA_REQUESTOR=y
+CONFIG_DEVICE_SOFTWARE_VERSION_NUMBER=2
+
+# PW RPC Debug channel
+CONFIG_EXAMPLE_UART_PORT_NUM=0
+CONFIG_EXAMPLE_UART_BAUD_RATE=115200
+CONFIG_EXAMPLE_UART_RXD=3
+CONFIG_EXAMPLE_UART_TXD=1
+CONFIG_ENABLE_PW_RPC=y

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -320,6 +320,10 @@ def Esp32Targets():
     yield esp32_target.Extend('m5stack-all-clusters-rpc-ipv6only', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS,
                               enable_rpcs=True, enable_ipv4=False)
 
+    yield esp32_target.Extend('m5stack-ota-requestor', board=Esp32Board.M5Stack, app=Esp32App.OTA_REQUESTOR)
+    yield esp32_target.Extend('m5stack-ota-requestor-rpc', board=Esp32Board.M5Stack, app=Esp32App.OTA_REQUESTOR,
+                              enable_rpcs=True)
+
     yield esp32_target.Extend('c3devkit-all-clusters', board=Esp32Board.C3DevKit, app=Esp32App.ALL_CLUSTERS)
 
     yield esp32_target.Extend('m5stack-all-clusters-minimal', board=Esp32Board.M5Stack, app=Esp32App.ALL_CLUSTERS_MINIMAL)

--- a/scripts/build/builders/esp32.py
+++ b/scripts/build/builders/esp32.py
@@ -95,7 +95,7 @@ class Esp32App(Enum):
         if board == Esp32Board.QEMU:
             return self == Esp32App.TESTS
         elif board == Esp32Board.M5Stack:
-            return self == Esp32App.ALL_CLUSTERS or self == Esp32App.ALL_CLUSTERS_MINIMAL
+            return self == Esp32App.ALL_CLUSTERS or self == Esp32App.ALL_CLUSTERS_MINIMAL or self == Esp32App.OTA_REQUESTOR
         elif board == Esp32Board.C3DevKit:
             return self == Esp32App.ALL_CLUSTERS or self == Esp32App.ALL_CLUSTERS_MINIMAL
         else:

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -163,6 +163,8 @@ esp32-m5stack-all-clusters-minimal-rpc
 esp32-m5stack-all-clusters-minimal-rpc-ipv6only
 esp32-m5stack-all-clusters-rpc
 esp32-m5stack-all-clusters-rpc-ipv6only
+esp32-m5stack-ota-requestor
+esp32-m5stack-ota-requestor-rpc
 esp32-qemu-tests
 imx-all-clusters-app
 imx-all-clusters-app-release

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -774,6 +774,28 @@ bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh;
 export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfig.defaults
 idf.py -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters-rpc-ipv6only reconfigure'
 
+# Generating esp32-m5stack-ota-requestor
+mkdir -p {out}/esp32-m5stack-ota-requestor
+
+cp examples/ota-requestor-app/esp32/sdkconfig_m5stack.defaults {out}/esp32-m5stack-ota-requestor/sdkconfig.defaults
+
+rm -f examples/ota-requestor-app/esp32/sdkconfig
+
+bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
+export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-ota-requestor/sdkconfig.defaults
+idf.py -C examples/ota-requestor-app/esp32 -B {out}/esp32-m5stack-ota-requestor reconfigure'
+
+# Generating esp32-m5stack-ota-requestor-rpc
+mkdir -p {out}/esp32-m5stack-ota-requestor-rpc
+
+cp examples/ota-requestor-app/esp32/sdkconfig_m5stack_rpc.defaults {out}/esp32-m5stack-ota-requestor-rpc/sdkconfig.defaults
+
+rm -f examples/ota-requestor-app/esp32/sdkconfig
+
+bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
+export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-ota-requestor-rpc/sdkconfig.defaults
+idf.py -C examples/ota-requestor-app/esp32 -B {out}/esp32-m5stack-ota-requestor-rpc reconfigure'
+
 # Generating esp32-qemu-tests
 mkdir -p {out}/esp32-qemu-tests
 
@@ -1912,6 +1934,20 @@ rm -f examples/all-clusters-app/esp32/sdkconfig
 bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
 export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-all-clusters-rpc-ipv6only/sdkconfig.defaults
 idf.py -C examples/all-clusters-app/esp32 -B {out}/esp32-m5stack-all-clusters-rpc-ipv6only build'
+
+rm -f examples/ota-requestor-app/esp32/sdkconfig
+
+# Building esp32-m5stack-ota-requestor
+bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
+export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-ota-requestor/sdkconfig.defaults
+idf.py -C examples/ota-requestor-app/esp32 -B {out}/esp32-m5stack-ota-requestor build'
+
+rm -f examples/ota-requestor-app/esp32/sdkconfig
+
+# Building esp32-m5stack-ota-requestor-rpc
+bash -c 'source $IDF_PATH/export.sh; source scripts/activate.sh; 
+export SDKCONFIG_DEFAULTS={out}/esp32-m5stack-ota-requestor-rpc/sdkconfig.defaults
+idf.py -C examples/ota-requestor-app/esp32 -B {out}/esp32-m5stack-ota-requestor-rpc build'
 
 rm -f src/test_driver/esp32/sdkconfig
 

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -57,6 +57,8 @@ esp32-m5stack-all-clusters-minimal-rpc
 esp32-m5stack-all-clusters-minimal-rpc-ipv6only
 esp32-m5stack-all-clusters-rpc
 esp32-m5stack-all-clusters-rpc-ipv6only
+esp32-m5stack-ota-requestor
+esp32-m5stack-ota-requestor-rpc
 esp32-qemu-tests
 imx-all-clusters-app
 imx-all-clusters-app-release


### PR DESCRIPTION
#### Change overview
Added `ota-requestor` and `ota-requestor-rpc` build flavors of M5stack boards, to be built by smoke_test cloudbuild task.

#### Testing
Ran locally with `./scripts/build/build_examples.py --enable-flashbundle --target-glob '*-m5stack-*' build --create-archives /workspace/artifacts/`
