### PR TITLE
Hook up basic OTA provider infrastructure in darwin-framework-tool.

### DIFF
--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -69,7 +69,6 @@ static_library("chip-tool-utils") {
     "commands/pairing/CloseSessionCommand.h",
     "commands/pairing/OpenCommissioningWindowCommand.cpp",
     "commands/pairing/OpenCommissioningWindowCommand.h",
-    "commands/pairing/PairingCommand.cpp",
     "commands/payload/AdditionalDataParseCommand.cpp",
     "commands/payload/SetupPayloadGenerateCommand.cpp",
     "commands/payload/SetupPayloadParseCommand.cpp",
@@ -95,7 +94,6 @@ static_library("chip-tool-utils") {
     "${chip_root}/src/app/tests/suites/commands/log",
     "${chip_root}/src/app/tests/suites/commands/system",
     "${chip_root}/src/app/tests/suites/pics",
-    "${chip_root}/src/controller/data_model",
     "${chip_root}/src/credentials:file_attestation_trust_store",
     "${chip_root}/src/lib",
     "${chip_root}/src/platform",
@@ -114,9 +112,15 @@ static_library("chip-tool-utils") {
 }
 
 executable("chip-tool") {
-  sources = [ "main.cpp" ]
+  sources = [
+    "commands/pairing/PairingCommand.cpp",
+    "main.cpp",
+  ]
 
-  deps = [ ":chip-tool-utils" ]
+  deps = [
+    ":chip-tool-utils",
+    "${chip_root}/src/controller/data_model",
+  ]
 
   output_dir = root_out_dir
 }

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -24,6 +24,7 @@ config("config") {
   include_dirs = [
     ".",
     "${chip_root}/zzz_generated/darwin-framework-tool",
+    "${chip_root}/zzz_generated/controller-clusters",
     "${chip_root}/examples/chip-tool/commands/clusters/ComplexArgument.h",
   ]
 
@@ -44,6 +45,11 @@ config("config") {
 
 executable("darwin-framework-tool") {
   sources = [
+    # We have to include privilege-storage.cpp here, not in the "Darwin
+    # framework" library, because otherwise the weak symbols from
+    # RequiredPrivilege.cpp mean we never actually pull in the function from
+    # privilege-storage.cpp.
+    "${chip_root}/src/app/util/privilege-storage.cpp",
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp",
     "commands/clusters/ClusterCommandBridge.h",
     "commands/clusters/ModelCommandBridge.mm",

--- a/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/CHIP.xcodeproj/project.pbxproj
@@ -58,6 +58,7 @@
 		51E51FBF282AD37A00FC978D /* CHIPDeviceControllerStartupParams.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E51FBC282AD37A00FC978D /* CHIPDeviceControllerStartupParams.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51E51FC0282AD37A00FC978D /* CHIPDeviceControllerStartupParams_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 51E51FBD282AD37A00FC978D /* CHIPDeviceControllerStartupParams_Internal.h */; };
 		51E51FC1282AD37A00FC978D /* CHIPDeviceControllerStartupParams.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51E51FBE282AD37A00FC978D /* CHIPDeviceControllerStartupParams.mm */; };
+		51F07EAD285C343C002FEBD8 /* privilege-storage.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51F07EAC285C343C002FEBD8 /* privilege-storage.cpp */; };
 		5A60370827EA1FF60020DB79 /* CHIPAttributeCacheContainer+XPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A60370727EA1FF60020DB79 /* CHIPAttributeCacheContainer+XPC.h */; };
 		5A6FEC9027B563D900F25F42 /* CHIPDeviceControllerOverXPC.m in Sources */ = {isa = PBXBuildFile; fileRef = 5A6FEC8F27B563D900F25F42 /* CHIPDeviceControllerOverXPC.m */; };
 		5A6FEC9227B5669C00F25F42 /* CHIPDeviceControllerOverXPC.h in Headers */ = {isa = PBXBuildFile; fileRef = 5A6FEC8D27B5624E00F25F42 /* CHIPDeviceControllerOverXPC.h */; };
@@ -171,6 +172,7 @@
 		51E51FBC282AD37A00FC978D /* CHIPDeviceControllerStartupParams.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceControllerStartupParams.h; sourceTree = "<group>"; };
 		51E51FBD282AD37A00FC978D /* CHIPDeviceControllerStartupParams_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceControllerStartupParams_Internal.h; sourceTree = "<group>"; };
 		51E51FBE282AD37A00FC978D /* CHIPDeviceControllerStartupParams.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDeviceControllerStartupParams.mm; sourceTree = "<group>"; };
+		51F07EAC285C343C002FEBD8 /* privilege-storage.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "privilege-storage.cpp"; path = "../../../app/util/privilege-storage.cpp"; sourceTree = "<group>"; };
 		5A60370727EA1FF60020DB79 /* CHIPAttributeCacheContainer+XPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "CHIPAttributeCacheContainer+XPC.h"; sourceTree = "<group>"; };
 		5A6FEC8B27B5609C00F25F42 /* CHIPDeviceOverXPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceOverXPC.h; sourceTree = "<group>"; };
 		5A6FEC8D27B5624E00F25F42 /* CHIPDeviceControllerOverXPC.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceControllerOverXPC.h; sourceTree = "<group>"; };
@@ -189,7 +191,7 @@
 		5AE6D4E327A99041001F2493 /* CHIPDeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = CHIPDeviceTests.m; sourceTree = "<group>"; };
 		754F3DF327FBB94B00E60580 /* CHIPEventTLVValueDecoder_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPEventTLVValueDecoder_Internal.h; sourceTree = "<group>"; };
 		7560FD1B27FBBD3F005E85B3 /* CHIPEventTLVValueDecoder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = CHIPEventTLVValueDecoder.mm; path = "zap-generated/CHIPEventTLVValueDecoder.mm"; sourceTree = "<group>"; };
-		75C645A32825AAC3007E2C29 /* MatterClusterConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MatterClusterConstants.h; path = "MatterClusterConstants.h"; sourceTree = "<group>"; };
+		75C645A32825AAC3007E2C29 /* MatterClusterConstants.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MatterClusterConstants.h; sourceTree = "<group>"; };
 		88EBF8CB27FABDD500686BC1 /* CHIPDeviceAttestationDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceAttestationDelegate.h; sourceTree = "<group>"; };
 		88EBF8CC27FABDD500686BC1 /* CHIPDeviceAttestationDelegateBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = CHIPDeviceAttestationDelegateBridge.mm; sourceTree = "<group>"; };
 		88EBF8CD27FABDD500686BC1 /* CHIPDeviceAttestationDelegateBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = CHIPDeviceAttestationDelegateBridge.h; sourceTree = "<group>"; };
@@ -251,6 +253,7 @@
 			isa = PBXGroup;
 			children = (
 				2FD775542695557E00FF4B12 /* error-mapping.cpp */,
+				51F07EAC285C343C002FEBD8 /* privilege-storage.cpp */,
 				51431AFA27D29CA4008A7943 /* ota-provider.cpp */,
 			);
 			name = CHIPApp;
@@ -620,6 +623,7 @@
 				88EBF8CF27FABDD500686BC1 /* CHIPDeviceAttestationDelegateBridge.mm in Sources */,
 				5A6FEC9827B5C6AF00F25F42 /* CHIPDeviceOverXPC.m in Sources */,
 				51431AF927D2973E008A7943 /* CHIPIMDispatch.mm in Sources */,
+				51F07EAD285C343C002FEBD8 /* privilege-storage.cpp in Sources */,
 				51431AFB27D29CA4008A7943 /* ota-provider.cpp in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/src/darwin/Framework/CHIP/BUILD.gn
+++ b/src/darwin/Framework/CHIP/BUILD.gn
@@ -28,6 +28,7 @@ config("darwin_config") {
 
 static_library("framework") {
   sources = [
+    "${chip_root}/src/app/clusters/ota-provider/ota-provider.cpp",
     "CHIP.h",
     "CHIPAttestationTrustStoreBridge.mm",
     "CHIPCluster.mm",
@@ -87,12 +88,13 @@ static_library("framework") {
 
   public_deps = [
     "${chip_root}/src/controller",
-    "${chip_root}/src/controller/data_model",
     "${chip_root}/src/credentials:default_attestation_verifier",
     "${chip_root}/src/lib/address_resolve",
     "${chip_root}/src/lib/core",
     "${chip_root}/src/lib/support",
   ]
+
+  include_dirs = [ "${chip_root}/zzz_generated/controller-clusters" ]
 
   frameworks = [ "Security.framework" ]
 


### PR DESCRIPTION
A few changes here:

1. The Darwin framework XCode build needs to compile in privilege-storage.cpp,
   because otherwise the ACL subsystem thinks that QueryImage needs Administer
   privilege.
2. darwin-framework-tool also needs to compile in privilege-storage.cpp.
3. The "Darwin framework" ninja library needs to include ota-provider.cpp, like
   the XCode build does.
4. Since darwin-framework-tool is not actually linking to the framework, but
   compiling its sources via ninja, we need to make sure that the ninja build
   does not pull in the "data model" bits, including
   ember-compatibility-functions.cpp, since the Darwin framework has a different
   implementation of the relevant functions that we want to use.  This means
   never having "src/controller/data_model" as deps, and that requires a few
   changes:
   a) In the "Darwin framework" library, need to add
      zzz_generated/controller-clusters to include_dirs, so we can pick up
      various generated CHIPCluster bits and whatnot.
   b) In the "chip-tool-utils" library, used by chip-tool and
      darwin-framework-tool, need to not include PairingCommand.cpp, which
      depends on the data model bits.  Luckily, darwin-framework-tool was not
      using that anyway, so we can just move it, and the data model bits, into
      the chip-tool executable build.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Used the steps from #19699 and instead of getting `No command 0x0000_0000 in Cluster 0x0000_0029 on Endpoint 0x0` got as far as `[1655439413204] [8012:13397990] CHIP: [ZCL] No OTAProviderDelegate set for ep:0`.

Also tested that I can get there with CHIPTool on iOS (to exercise the Xcode build).