### PR TITLE
[ESP32] Disable secondary network commissioning endpoint on ota requestor app

### DIFF
--- a/examples/ota-requestor-app/esp32/main/main.cpp
+++ b/examples/ota-requestor-app/esp32/main/main.cpp
@@ -48,9 +48,14 @@ namespace {
 const char * TAG = "ota-requester-app";
 static AppDeviceCallbacks EchoCallbacks;
 
+constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
+
 static void InitServer(intptr_t context)
 {
     Esp32AppServer::Init(); // Init ZCL Data Model and CHIP App Server AND Initialize device attestation config
+
+    // We only have network commissioning on endpoint 0.
+    emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
 }
 
 } // namespace


### PR DESCRIPTION
#### Problem
* Fixes #19694

#### Change overview
* Disable the secondary network commissioning endpoint on ota requestor app

#### Testing
* Tested commissioning using chip-tool, and read few basic cluster attributes