### PR TITLE
[nrfconnect] Adapt Pigweed Logger to newer Zephyr versions

### DIFF
--- a/examples/platform/nrfconnect/util/PigweedLogger.cpp
+++ b/examples/platform/nrfconnect/util/PigweedLogger.cpp
@@ -98,25 +98,17 @@ void init(const log_backend *)
     pw_sys_io_Init();
 }
 
-void putMessageSync(const log_backend *, log_msg_ids srcLevel, uint32_t timestamp, const char * fmt, va_list args)
+void processMessage(const struct log_backend * const backend, union log_msg2_generic * msg)
 {
     int ret = k_sem_take(&sLoggerLock, K_FOREVER);
     assert(ret == 0);
 
     if (!sIsPanicMode)
-        log_backend_std_sync_string(&pigweedLogOutput, 0, srcLevel, timestamp, fmt, args);
+    {
+        log_format_func_t outputFunc = log_format_func_t_get(LOG_OUTPUT_TEXT);
 
-    k_sem_give(&sLoggerLock);
-}
-
-void putHexdumpSync(const log_backend *, log_msg_ids srcLevel, uint32_t timestamp, const char * metadata, const uint8_t * data,
-                    uint32_t length)
-{
-    int ret = k_sem_take(&sLoggerLock, K_FOREVER);
-    assert(ret == 0);
-
-    if (!sIsPanicMode)
-        log_backend_std_sync_hexdump(&pigweedLogOutput, 0, srcLevel, timestamp, metadata, data, length);
+        outputFunc(&pigweedLogOutput, &msg->log, log_backend_std_get_flags());
+    }
 
     k_sem_give(&sLoggerLock);
 }
@@ -134,11 +126,9 @@ void panic(const log_backend *)
 }
 
 const log_backend_api pigweedLogApi = {
-    .put              = nullptr,
-    .put_sync_string  = putMessageSync,
-    .put_sync_hexdump = putHexdumpSync,
-    .panic            = panic,
-    .init             = init,
+    .process = processMessage,
+    .panic   = panic,
+    .init    = init,
 };
 
 LOG_BACKEND_DEFINE(pigweedLogBackend, pigweedLogApi, /* autostart */ true);


### PR DESCRIPTION
#### Problem
nRF Connect lighting-app built with RPC crashes after bumping to the recent NCS version.

#### Change overview
Initialization of the Pigwed HDLC-based Zephyr logging backend would fail due to usage of deprecated backend API.
Switch to the new API.
Fixes #19679

#### Testing
Tested that the example boots correctly and prints logs to the console.