### PR TITLE
Implement TestEventTrigger delegate for OTA query

### DIFF
--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -30,6 +30,7 @@
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/clusters/identify-server/identify-server.h>
+#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/util/attribute-storage.h>
 
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -57,6 +58,9 @@ LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
 
 namespace {
+
+constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                     0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 
 LEDWidget sStatusLED;
 UnusedLedsWrapper<3> sUnusedLeds{ { DK_LED2, DK_LED3, DK_LED4 } };
@@ -182,9 +186,10 @@ CHIP_ERROR AppTask::Init()
     // Initialize CHIP server
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
-    static chip::CommonCaseDeviceServerInitParams initParams;
+    static CommonCaseDeviceServerInitParams initParams;
+    static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(kTestEventTriggerEnableKey) };
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
-
+    initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());

--- a/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/AppTask.cpp
@@ -59,6 +59,8 @@ K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(Ap
 
 namespace {
 
+// NOTE! This key is for test/certification only and should not be available in production devices.
+// Ideally, it should be a part of the factory data set.
 constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                                      0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -30,6 +30,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/clusters/identify-server/identify-server.h>
+#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/server/Dnssd.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -66,6 +67,8 @@ constexpr EndpointId kLightEndpointId          = 1;
 constexpr uint32_t kIdentifyBlinkRateMs        = 500;
 constexpr uint8_t kDefaultMinLevel             = 0;
 constexpr uint8_t kDefaultMaxLevel             = 254;
+constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                     0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), kAppEventQueueSize, alignof(AppEvent));
 k_timer sFunctionTimer;
@@ -167,8 +170,10 @@ CHIP_ERROR AppTask::Init()
     // Initialize CHIP server
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
-    static chip::CommonCaseDeviceServerInitParams initParams;
+    static CommonCaseDeviceServerInitParams initParams;
+    static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(kTestEventTriggerEnableKey) };
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -58,15 +58,15 @@ using namespace ::chip::DeviceLayer;
 
 namespace {
 
-constexpr int kFactoryResetTriggerTimeout      = 3000;
-constexpr int kFactoryResetCancelWindowTimeout = 3000;
-constexpr int kAppEventQueueSize               = 10;
-constexpr uint8_t kButtonPushEvent             = 1;
-constexpr uint8_t kButtonReleaseEvent          = 0;
-constexpr EndpointId kLightEndpointId          = 1;
-constexpr uint32_t kIdentifyBlinkRateMs        = 500;
-constexpr uint8_t kDefaultMinLevel             = 0;
-constexpr uint8_t kDefaultMaxLevel             = 254;
+constexpr int kFactoryResetTriggerTimeout        = 3000;
+constexpr int kFactoryResetCancelWindowTimeout   = 3000;
+constexpr int kAppEventQueueSize                 = 10;
+constexpr uint8_t kButtonPushEvent               = 1;
+constexpr uint8_t kButtonReleaseEvent            = 0;
+constexpr EndpointId kLightEndpointId            = 1;
+constexpr uint32_t kIdentifyBlinkRateMs          = 500;
+constexpr uint8_t kDefaultMinLevel               = 0;
+constexpr uint8_t kDefaultMaxLevel               = 254;
 constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                                      0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -516,7 +516,7 @@ void AppTask::OTAHandler(AppEvent * aEvent)
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
 void AppTask::StartOTAQuery(intptr_t arg)
 {
-    static_cast<DefaultOTARequestor *>(GetRequestorInstance())->TriggerImmediateQuery();
+    GetRequestorInstance()->TriggerImmediateQuery();
 }
 
 void AppTask::PostOTAResume()

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -28,6 +28,7 @@
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/clusters/door-lock-server/door-lock-server.h>
+#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -59,6 +60,8 @@ using namespace ::chip::DeviceLayer;
 
 namespace {
 constexpr EndpointId kLockEndpointId = 1;
+constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                     0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
@@ -151,9 +154,11 @@ CHIP_ERROR AppTask::Init()
 
     // Initialize CHIP server
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-    static chip::CommonCaseDeviceServerInitParams initParams;
-    (void) initParams.InitializeStaticResourcesBeforeServerInit();
 
+    static CommonCaseDeviceServerInitParams initParams;
+    static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(kTestEventTriggerEnableKey) };
+    (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -59,7 +59,7 @@ using namespace ::chip::DeviceLayer;
 #define BUTTON_RELEASE_EVENT 0
 
 namespace {
-constexpr EndpointId kLockEndpointId = 1;
+constexpr EndpointId kLockEndpointId             = 1;
 constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                                      0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 

--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -59,7 +59,10 @@ using namespace ::chip::DeviceLayer;
 #define BUTTON_RELEASE_EVENT 0
 
 namespace {
-constexpr EndpointId kLockEndpointId             = 1;
+constexpr EndpointId kLockEndpointId = 1;
+
+// NOTE! This key is for test/certification only and should not be available in production devices.
+// Ideally, it should be a part of the factory data set.
 constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                                      0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 

--- a/examples/ota-requestor-app/p6/src/AppTask.cpp
+++ b/examples/ota-requestor-app/p6/src/AppTask.cpp
@@ -441,8 +441,7 @@ void OnTriggerUpdateTimerHandler(Layer * systemLayer, void * appState)
 {
     P6_LOG("Triggering immediate OTA update query");
 
-    DefaultOTARequestor * req = static_cast<DefaultOTARequestor *>(GetRequestorInstance());
-    req->TriggerImmediateQuery();
+    GetRequestorInstance()->TriggerImmediateQuery();
 }
 
 void AppTask::InitOTARequestor()

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -20,7 +20,6 @@
 #include <platform/PlatformManager.h>
 
 #include <app/clusters/network-commissioning/network-commissioning.h>
-#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <crypto/CHIPCryptoPAL.h>
@@ -67,6 +66,10 @@
 #include "TraceDecoder.h"
 #include "TraceHandlers.h"
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
+
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
+#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
+#endif
 
 #include <signal.h>
 
@@ -306,9 +309,11 @@ void ChipLinuxAppMainLoop()
         initParams.operationalKeystore = &LinuxDeviceOptions::GetInstance().mCSRResponseOptions.badCsrOperationalKeyStoreForTest;
     }
 
+#if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(
         LinuxDeviceOptions::GetInstance().testEventTriggerEnableKey) };
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
+#endif
 
     // Init ZCL Data Model and CHIP App Server
     Server::GetInstance().Init(initParams);

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -20,6 +20,7 @@
 #include <platform/PlatformManager.h>
 
 #include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <crypto/CHIPCryptoPAL.h>
@@ -304,6 +305,10 @@ void ChipLinuxAppMainLoop()
             initParams.persistentStorageDelegate);
         initParams.operationalKeystore = &LinuxDeviceOptions::GetInstance().mCSRResponseOptions.badCsrOperationalKeyStoreForTest;
     }
+
+    static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(
+        LinuxDeviceOptions::GetInstance().testEventTriggerEnableKey) };
+    initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
 
     // Init ZCL Data Model and CHIP App Server
     Server::GetInstance().Init(initParams);

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -17,10 +17,15 @@ import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/app/common_flags.gni")
 import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/lib/lib.gni")
-import("${chip_root}/src/platform/device.gni")
 
 config("app-main-config") {
   include_dirs = [ "." ]
+}
+
+source_set("ota-test-event-trigger") {
+  sources = [
+    "${chip_root}/src/app/clusters/ota-requestor/OTATestEventTriggerDelegate.h",
+  ]
 }
 
 source_set("app-main") {
@@ -56,6 +61,7 @@ source_set("app-main") {
   }
 
   public_deps = [
+    ":ota-test-event-trigger",
     "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/app/server",
     "${chip_root}/src/credentials:default_attestation_verifier",
@@ -67,11 +73,6 @@ source_set("app-main") {
   if (chip_enable_transport_trace) {
     public_deps +=
         [ "${chip_root}/examples/common/tracing:trace_handlers_decoder" ]
-  }
-
-  if (chip_enable_ota_requestor) {
-    public_deps +=
-        [ "${chip_root}/examples/ota-requestor-app/ota-requestor-common" ]
   }
 
   public_configs = [ ":app-main-config" ]

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -70,7 +70,8 @@ source_set("app-main") {
   }
 
   if (chip_enable_ota_requestor) {
-    public_deps += [ "${chip_root}/examples/ota-requestor-app/ota-requestor-common" ]
+    public_deps +=
+        [ "${chip_root}/examples/ota-requestor-app/ota-requestor-common" ]
   }
 
   public_configs = [ ":app-main-config" ]

--- a/examples/platform/linux/BUILD.gn
+++ b/examples/platform/linux/BUILD.gn
@@ -17,6 +17,7 @@ import("${chip_root}/examples/common/pigweed/pigweed_rpcs.gni")
 import("${chip_root}/src/app/common_flags.gni")
 import("${chip_root}/src/lib/core/core.gni")
 import("${chip_root}/src/lib/lib.gni")
+import("${chip_root}/src/platform/device.gni")
 
 config("app-main-config") {
   include_dirs = [ "." ]
@@ -66,6 +67,10 @@ source_set("app-main") {
   if (chip_enable_transport_trace) {
     public_deps +=
         [ "${chip_root}/examples/common/tracing:trace_handlers_decoder" ]
+  }
+
+  if (chip_enable_ota_requestor) {
+    public_deps += [ "${chip_root}/examples/ota-requestor-app/ota-requestor-common" ]
   }
 
   public_configs = [ ":app-main-config" ]

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -59,6 +59,7 @@ struct LinuxDeviceOptions
     chip::Optional<std::string> traceStreamFilename;
     chip::Credentials::DeviceAttestationCredentialsProvider * dacProvider = nullptr;
     chip::CSRResponseOptions mCSRResponseOptions;
+    uint8_t testEventTriggerEnableKey[16] = { 0 };
 
     static LinuxDeviceOptions & GetInstance();
 };

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -27,6 +27,7 @@
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
@@ -60,6 +61,9 @@ using namespace ::chip::DeviceLayer;
 #define ONOFF_CLUSTER_ENDPOINT 1
 
 namespace {
+
+constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                     0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
@@ -149,9 +153,11 @@ CHIP_ERROR AppTask::Init()
 
     // Initialize CHIP server
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-    static chip::CommonCaseDeviceServerInitParams initParams;
-    (void) initParams.InitializeStaticResourcesBeforeServerInit();
 
+    static CommonCaseDeviceServerInitParams initParams;
+    static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(kTestEventTriggerEnableKey) };
+    (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());

--- a/examples/pump-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-app/nrfconnect/main/AppTask.cpp
@@ -62,6 +62,8 @@ using namespace ::chip::DeviceLayer;
 
 namespace {
 
+// NOTE! This key is for test/certification only and should not be available in production devices.
+// Ideally, it should be a part of the factory data set.
 constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                                      0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -59,6 +59,8 @@ using namespace ::chip::DeviceLayer;
 
 namespace {
 
+// NOTE! This key is for test/certification only and should not be available in production devices.
+// Ideally, it should be a part of the factory data set.
 constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                                      0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 

--- a/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
+++ b/examples/pump-controller-app/nrfconnect/main/AppTask.cpp
@@ -27,6 +27,7 @@
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
@@ -57,6 +58,9 @@ using namespace ::chip::DeviceLayer;
 #define BUTTON_RELEASE_EVENT 0
 
 namespace {
+
+constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                     0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 
 LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
@@ -146,9 +150,11 @@ CHIP_ERROR AppTask::Init()
 
     // Initialize CHIP server
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-    static chip::CommonCaseDeviceServerInitParams initParams;
-    (void) initParams.InitializeStaticResourcesBeforeServerInit();
 
+    static CommonCaseDeviceServerInitParams initParams;
+    static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(kTestEventTriggerEnableKey) };
+    (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -55,6 +55,8 @@ K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(Ap
 
 namespace {
 
+// NOTE! This key is for test/certification only and should not be available in production devices.
+// Ideally, it should be a part of the factory data set.
 constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
                                                      0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 

--- a/examples/window-app/nrfconnect/main/AppTask.cpp
+++ b/examples/window-app/nrfconnect/main/AppTask.cpp
@@ -29,6 +29,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/util/attribute-storage.h>
 
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -53,6 +54,9 @@ LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
 K_MSGQ_DEFINE(sAppEventQueue, sizeof(AppEvent), APP_EVENT_QUEUE_SIZE, alignof(AppEvent));
 
 namespace {
+
+constexpr uint8_t kTestEventTriggerEnableKey[16] = { 0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+                                                     0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff };
 
 LEDWidget sStatusLED;
 UnusedLedsWrapper<1> sUnusedLeds{ { DK_LED4 } };
@@ -150,8 +154,10 @@ CHIP_ERROR AppTask::Init()
     // Initialize CHIP server
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
-    static chip::CommonCaseDeviceServerInitParams initParams;
+    static CommonCaseDeviceServerInitParams initParams;
+    static OTATestEventTriggerDelegate testEventTriggerDelegate{ ByteSpan(kTestEventTriggerEnableKey) };
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
     ReturnErrorOnFailure(chip::Server::GetInstance().Init(initParams));
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -133,6 +133,8 @@ template("chip_data_model") {
           "${_app_root}/clusters/${cluster}/DefaultOTARequestorUserConsent.h",
           "${_app_root}/clusters/${cluster}/ExtendedOTARequestorDriver.cpp",
           "${_app_root}/clusters/${cluster}/OTARequestorStorage.h",
+          "${_app_root}/clusters/${cluster}/OTATestEventTriggerDelegate.cpp",
+          "${_app_root}/clusters/${cluster}/OTATestEventTriggerDelegate.h",
         ]
       } else if (cluster == "bindings") {
         sources += [

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -548,14 +548,17 @@ CHIP_ERROR DefaultOTARequestor::TriggerImmediateQuery(FabricIndex fabricIndex)
 
     if (!providerFound)
     {
-        ChipLogError(SoftwareUpdate, "No OTA Providers available");
-        return CHIP_ERROR_INCORRECT_STATE;
+        ChipLogError(SoftwareUpdate, "No OTA Providers available for immediate query");
+        return CHIP_ERROR_NOT_FOUND;
     }
 
     SetCurrentProviderLocation(providerLocation);
 
     // Go through the driver as it has additional logic to execute
     mOtaRequestorDriver->SendQueryImage();
+
+    ChipLogProgress(SoftwareUpdate, "Triggered immediate OTA query for fabric: 0x%x",
+                    static_cast<unsigned>(providerLocation.GetFabricIndex()));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -522,14 +522,34 @@ void DefaultOTARequestor::TriggerImmediateQueryInternal()
     ConnectToProvider(kQueryImage);
 }
 
-OTARequestorInterface::OTATriggerResult DefaultOTARequestor::TriggerImmediateQuery()
+CHIP_ERROR DefaultOTARequestor::TriggerImmediateQuery(FabricIndex fabricIndex)
 {
     ProviderLocationType providerLocation;
-    bool listExhausted = false;
-    if (mOtaRequestorDriver->GetNextProviderLocation(providerLocation, listExhausted) != true)
+    bool providerFound = false;
+
+    if (fabricIndex == kUndefinedFabricIndex)
+    {
+        bool listExhausted = false;
+        providerFound      = mOtaRequestorDriver->GetNextProviderLocation(providerLocation, listExhausted);
+    }
+    else
+    {
+        for (auto providerIter = mDefaultOtaProviderList.Begin(); providerIter.Next();)
+        {
+            providerLocation = providerIter.GetValue();
+
+            if (providerLocation.GetFabricIndex() == fabricIndex)
+            {
+                providerFound = true;
+                break;
+            }
+        }
+    }
+
+    if (!providerFound)
     {
         ChipLogError(SoftwareUpdate, "No OTA Providers available");
-        return kNoProviderKnown;
+        return CHIP_ERROR_INCORRECT_STATE;
     }
 
     SetCurrentProviderLocation(providerLocation);
@@ -537,7 +557,7 @@ OTARequestorInterface::OTATriggerResult DefaultOTARequestor::TriggerImmediateQue
     // Go through the driver as it has additional logic to execute
     mOtaRequestorDriver->SendQueryImage();
 
-    return kTriggerSuccessful;
+    return CHIP_NO_ERROR;
 }
 
 void DefaultOTARequestor::DownloadUpdate()

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -47,7 +47,7 @@ public:
         const app::Clusters::OtaSoftwareUpdateRequestor::Commands::AnnounceOtaProvider::DecodableType & commandData) override;
 
     // Application API to send the QueryImage command and start the image update process with the next available Provider
-    OTATriggerResult TriggerImmediateQuery() override;
+    CHIP_ERROR TriggerImmediateQuery(FabricIndex fabricIndex) override;
 
     // Internal API meant for use by OTARequestorDriver to send the QueryImage command and start the image update process
     // with the Provider currently set

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -145,14 +145,6 @@ public:
     using OTAUpdateStateEnum   = chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum;
     using ProviderLocationType = app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::Type;
 
-    // Return value for various trigger-type APIs
-    enum OTATriggerResult
-    {
-        kTriggerSuccessful = 0,
-        kNoProviderKnown   = 1,
-        kWrongState        = 2
-    };
-
     // Reset any relevant states
     virtual void Reset(void) = 0;
 
@@ -167,8 +159,9 @@ public:
     // Destructor
     virtual ~OTARequestorInterface() = default;
 
-    // Application API to send the QueryImage command and start the image update process with the next available Provider
-    virtual OTATriggerResult TriggerImmediateQuery() = 0;
+    // Application API to send the QueryImage command and start the image update process.
+    // The `fabricIndex` optional argument can be used to explicitly select the OTA provider.
+    virtual CHIP_ERROR TriggerImmediateQuery(FabricIndex fabricIndex = kUndefinedFabricIndex) = 0;
 
     // Internal API meant for use by OTARequestorDriver to send the QueryImage command and start the image update process
     // with the preset provider

--- a/src/app/clusters/ota-requestor/OTATestEventTriggerDelegate.cpp
+++ b/src/app/clusters/ota-requestor/OTATestEventTriggerDelegate.cpp
@@ -1,0 +1,46 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "OTATestEventTriggerDelegate.h"
+
+#include "OTARequestorInterface.h"
+
+#include <lib/support/CodeUtils.h>
+
+namespace chip {
+
+bool OTATestEventTriggerDelegate::DoesEnableKeyMatch(const ByteSpan & enableKey) const
+{
+    return !mEnableKey.empty() && mEnableKey.data_equal(enableKey);
+}
+
+CHIP_ERROR OTATestEventTriggerDelegate::HandleEventTrigger(uint64_t eventTrigger)
+{
+    if ((eventTrigger & ~kOtaQueryFabricIndexMask) == kOtaQueryTrigger)
+    {
+        OTARequestorInterface * requestor = GetRequestorInstance();
+        const FabricIndex fabricIndex     = eventTrigger & kOtaQueryFabricIndexMask;
+
+        VerifyOrReturnError(requestor != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        return requestor->TriggerImmediateQuery(fabricIndex);
+    }
+
+    return CHIP_ERROR_INVALID_ARGUMENT;
+}
+
+} // namespace chip

--- a/src/app/clusters/ota-requestor/OTATestEventTriggerDelegate.h
+++ b/src/app/clusters/ota-requestor/OTATestEventTriggerDelegate.h
@@ -1,0 +1,40 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/TestEventTriggerDelegate.h>
+
+namespace chip {
+
+class OTATestEventTriggerDelegate : public TestEventTriggerDelegate
+{
+public:
+    static constexpr uint64_t kOtaQueryTrigger         = 0x0100'0000'0000'0100;
+    static constexpr uint64_t kOtaQueryFabricIndexMask = 0xff;
+
+    explicit OTATestEventTriggerDelegate(const ByteSpan & enableKey) : mEnableKey(enableKey) {}
+
+    bool DoesEnableKeyMatch(const ByteSpan & enableKey) const override;
+    CHIP_ERROR HandleEventTrigger(uint64_t eventTrigger) override;
+
+private:
+    ByteSpan mEnableKey;
+};
+
+} // namespace chip


### PR DESCRIPTION
#### Problem
As described in #19623, we need some sort of manual trigger of the OTA query so that certification tests don't need to wait up to 24 hours for the next query.
@tcarmelveilleux proposed that we use `TestEventTrigger` command of `GeneralDiagnostics` cluster for this purpose.

#### Change overview
Implement TestEventTriggerDelegate that handles triggers with values: `0x0100'0000'0000'01<fi>`, where `<fi>` is fabric index of the OTA provider to query, or `00` if the OTA provider is supposed to be selected automatically.
Initialize the delegate in nRF Connect examples using a constant enable key.
Initialize the delegate in Linux examples using an enable key configured at runtime using `--enable-key` argument.
Fixes #19623

#### Testing
Did smoke tests of the functionality on both nRF Connect lighting-app and Linux OTA-requestor app.
