### PR TITLE
RPC: Add linux light rpc to build script

### DIFF
--- a/examples/common/pigweed/rpc_services/Descriptor.h
+++ b/examples/common/pigweed/rpc_services/Descriptor.h
@@ -83,7 +83,7 @@ public:
                     EndpointId endpoint_id = emberAfEndpointFromIndex(index);
                     if (endpoint_id == 0)
                         continue;
-                    chip_rpc_Endpoint out{ endpoint : endpoint_id };
+                    chip_rpc_Endpoint out{ .endpoint = endpoint_id };
                     writer.Write(out);
                 }
             }
@@ -99,7 +99,7 @@ private:
         for (uint8_t cluster_index = 0; cluster_index < cluster_count; cluster_index++)
         {
             const EmberAfCluster * cluster = emberAfGetNthCluster(endpoint, cluster_index, server);
-            chip_rpc_Cluster out{ cluster_id : cluster->clusterId };
+            chip_rpc_Cluster out{ .cluster_id = cluster->clusterId };
             writer.Write(out);
         }
         writer.Finish();

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -247,6 +247,7 @@ def HostTargets():
         app_targets.append(target.Extend('thermostat', app=HostApp.THERMOSTAT))
         app_targets.append(target.Extend('minmdns', app=HostApp.MIN_MDNS))
         app_targets.append(target.Extend('light', app=HostApp.LIGHT))
+        app_targets.append(target.Extend('light-rpc', app=HostApp.LIGHT, enable_rpcs=True))
         app_targets.append(target.Extend('lock', app=HostApp.LOCK))
         app_targets.append(target.Extend('shell', app=HostApp.SHELL))
         app_targets.append(target.Extend(

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -198,7 +198,7 @@ class HostBuilder(GnBuilder):
     def __init__(self, root, runner, app: HostApp, board=HostBoard.NATIVE, enable_ipv4=True,
                  enable_ble=True, enable_wifi=True, use_tsan=False,  use_asan=False, separate_event_loop=True,
                  use_libfuzzer=False, use_clang=False, interactive_mode=True, extra_tests=False,
-                 use_platform_mdns=False):
+                 use_platform_mdns=False, enable_rpcs=False):
         super(HostBuilder, self).__init__(
             root=os.path.join(root, 'examples', app.ExamplePath()),
             runner=runner)
@@ -206,6 +206,9 @@ class HostBuilder(GnBuilder):
         self.app = app
         self.board = board
         self.extra_gn_options = []
+
+        if enable_rpcs:
+            self.extra_gn_options.append('import("//with_pw_rpc.gni")')
 
         if not enable_ipv4:
             self.extra_gn_options.append('chip_inet_config_enable_ipv4=false')

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -46,6 +46,16 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-light-ipv6only'
 
+# Generating linux-arm64-light-rpc
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=import("//with_pw_rpc.gni") target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-light-rpc'
+
+# Generating linux-arm64-light-rpc-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=import("//with_pw_rpc.gni") chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-light-rpc-ipv6only'
+
 # Generating linux-arm64-lock
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
@@ -173,6 +183,12 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-light-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-light-ipv6only
 
+# Generating linux-x64-light-rpc
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '--args=import("//with_pw_rpc.gni")' {out}/linux-x64-light-rpc
+
+# Generating linux-x64-light-rpc-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '--args=import("//with_pw_rpc.gni") chip_inet_config_enable_ipv4=false' {out}/linux-x64-light-rpc-ipv6only
+
 # Generating linux-x64-lock
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/linux {out}/linux-x64-lock
 
@@ -259,6 +275,12 @@ ninja -C {out}/linux-arm64-light
 
 # Building linux-arm64-light-ipv6only
 ninja -C {out}/linux-arm64-light-ipv6only
+
+# Building linux-arm64-light-rpc
+ninja -C {out}/linux-arm64-light-rpc
+
+# Building linux-arm64-light-rpc-ipv6only
+ninja -C {out}/linux-arm64-light-rpc-ipv6only
 
 # Building linux-arm64-lock
 ninja -C {out}/linux-arm64-lock
@@ -352,6 +374,12 @@ ninja -C {out}/linux-x64-light
 
 # Building linux-x64-light-ipv6only
 ninja -C {out}/linux-x64-light-ipv6only
+
+# Building linux-x64-light-rpc
+ninja -C {out}/linux-x64-light-rpc
+
+# Building linux-x64-light-rpc-ipv6only
+ninja -C {out}/linux-x64-light-rpc-ipv6only
 
 # Building linux-x64-lock
 ninja -C {out}/linux-x64-lock


### PR DESCRIPTION
#### Problem
Need RPi linux RPC enabled builds for testing. 

#### Change overview
Add a target to build the linux lighting app with RPCs enabled.

#### Testing
Built both arm64 and x64 linux lighting apps, and verified RPC worked:
```./scripts/build/build_examples.py --target-glob 'linux*rpc' build```