### PR TITLE
[Python] Fix stack race between Python & Matter thread

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -99,7 +99,7 @@ class ChipDeviceController():
 
         res = self._ChipStack.Call(
             lambda: self._dmLib.pychip_OpCreds_AllocateController(ctypes.c_void_p(
-                opCredsContext), pointer(devCtrl), fabricIndex, fabricId, nodeId, ctypes.c_char_p(None if len(paaTrustStorePath) is 0 else str.encode(paaTrustStorePath)), useTestCommissioner)
+                opCredsContext), pointer(devCtrl), fabricIndex, fabricId, nodeId, ctypes.c_char_p(None if len(paaTrustStorePath) == 0 else str.encode(paaTrustStorePath)), useTestCommissioner)
         )
 
         if res != 0:
@@ -546,14 +546,12 @@ class ChipDeviceController():
         future = eventLoop.create_future()
 
         device = self.GetConnectedDeviceSync(nodeid)
-        res = self._ChipStack.Call(
-            lambda: ClusterCommand.SendCommand(
-                future, eventLoop, responseType, device, ClusterCommand.CommandPath(
-                    EndpointId=endpoint,
-                    ClusterId=payload.cluster_id,
-                    CommandId=payload.command_id,
-                ), payload, timedRequestTimeoutMs=timedRequestTimeoutMs)
-        )
+        res = ClusterCommand.SendCommand(
+            future, eventLoop, responseType, device, ClusterCommand.CommandPath(
+                EndpointId=endpoint,
+                ClusterId=payload.cluster_id,
+                CommandId=payload.command_id,
+            ), payload, timedRequestTimeoutMs=timedRequestTimeoutMs)
         if res != 0:
             future.set_exception(self._ChipStack.ErrorToException(res))
         return await future
@@ -585,10 +583,8 @@ class ChipDeviceController():
                 attrs.append(ClusterAttribute.AttributeWriteRequest(
                     v[0], v[1], v[2], 1, v[1].value))
 
-        res = self._ChipStack.Call(
-            lambda: ClusterAttribute.WriteAttributes(
-                future, eventLoop, device, attrs, timedRequestTimeoutMs=timedRequestTimeoutMs)
-        )
+        res = ClusterAttribute.WriteAttributes(
+            future, eventLoop, device, attrs, timedRequestTimeoutMs=timedRequestTimeoutMs)
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
         return await future
@@ -769,8 +765,8 @@ class ChipDeviceController():
         eventPaths = [self._parseEventPathTuple(
             v) for v in events] if events else None
 
-        res = self._ChipStack.Call(
-            lambda: ClusterAttribute.Read(future=future, eventLoop=eventLoop, device=device, devCtrl=self, attributes=attributePaths, dataVersionFilters=clusterDataVersionFilters, events=eventPaths, returnClusterObject=returnClusterObject, subscriptionParameters=ClusterAttribute.SubscriptionParameters(reportInterval[0], reportInterval[1]) if reportInterval else None, fabricFiltered=fabricFiltered, keepSubscriptions=keepSubscriptions))
+        res = ClusterAttribute.Read(future=future, eventLoop=eventLoop, device=device, devCtrl=self, attributes=attributePaths, dataVersionFilters=clusterDataVersionFilters, events=eventPaths, returnClusterObject=returnClusterObject,
+                                    subscriptionParameters=ClusterAttribute.SubscriptionParameters(reportInterval[0], reportInterval[1]) if reportInterval else None, fabricFiltered=fabricFiltered, keepSubscriptions=keepSubscriptions)
         if res != 0:
             raise self._ChipStack.ErrorToException(res)
         return await future

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -516,8 +516,9 @@ class SubscriptionTransaction:
             return
 
         handle = chip.native.GetLibraryHandle()
-        handle.pychip_ReadClient_Abort(
-            self._readTransaction._pReadClient, self._readTransaction._pReadCallback)
+        builtins.chipStack.Call(
+            lambda: handle.pychip_ReadClient_Abort(
+                self._readTransaction._pReadClient, self._readTransaction._pReadCallback))
         self._isDone = True
 
     def __del__(self):
@@ -853,8 +854,9 @@ def WriteAttributes(future: Future, eventLoop, device, attributes: List[Attribut
 
     transaction = AsyncWriteTransaction(future, eventLoop)
     ctypes.pythonapi.Py_IncRef(ctypes.py_object(transaction))
-    res = handle.pychip_WriteClient_WriteAttributes(
-        ctypes.py_object(transaction), device, ctypes.c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs), ctypes.c_size_t(len(attributes)), *writeargs)
+    res = builtins.chipStack.Call(
+        lambda: handle.pychip_WriteClient_WriteAttributes(
+            ctypes.py_object(transaction), device, ctypes.c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs), ctypes.c_size_t(len(attributes)), *writeargs))
     if res != 0:
         ctypes.pythonapi.Py_DecRef(ctypes.py_object(transaction))
     return res
@@ -954,17 +956,18 @@ def Read(future: Future, eventLoop, device, devCtrl, attributes: List[AttributeP
     params.IsFabricFiltered = fabricFiltered
     params = _ReadParams.build(params)
 
-    res = handle.pychip_ReadClient_Read(
-        ctypes.py_object(transaction),
-        ctypes.byref(readClientObj),
-        ctypes.byref(readCallbackObj),
-        device,
-        ctypes.c_char_p(params),
-        ctypes.c_size_t(0 if attributes is None else len(attributes)),
-        ctypes.c_size_t(
-            0 if dataVersionFilters is None else len(dataVersionFilters)),
-        ctypes.c_size_t(0 if events is None else len(events)),
-        *readargs)
+    res = builtins.chipStack.Call(
+        lambda: handle.pychip_ReadClient_Read(
+            ctypes.py_object(transaction),
+            ctypes.byref(readClientObj),
+            ctypes.byref(readCallbackObj),
+            device,
+            ctypes.c_char_p(params),
+            ctypes.c_size_t(0 if attributes is None else len(attributes)),
+            ctypes.c_size_t(
+                0 if dataVersionFilters is None else len(dataVersionFilters)),
+            ctypes.c_size_t(0 if events is None else len(events)),
+            *readargs))
 
     transaction.SetClientObjPointers(readClientObj, readCallbackObj)
 

--- a/src/controller/python/chip/clusters/Command.py
+++ b/src/controller/python/chip/clusters/Command.py
@@ -29,6 +29,7 @@ import chip.interaction_model
 
 import inspect
 import sys
+import builtins
 
 
 @dataclass
@@ -157,8 +158,9 @@ def SendCommand(future: Future, eventLoop, responseType: Type, device, commandPa
 
     payloadTLV = payload.ToTLV()
     ctypes.pythonapi.Py_IncRef(ctypes.py_object(transaction))
-    return handle.pychip_CommandSender_SendCommand(ctypes.py_object(
-        transaction), device, c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs), commandPath.EndpointId, commandPath.ClusterId, commandPath.CommandId, payloadTLV, len(payloadTLV))
+    return builtins.chipStack.Call(
+        lambda: handle.pychip_CommandSender_SendCommand(ctypes.py_object(
+            transaction), device, c_uint16(0 if timedRequestTimeoutMs is None else timedRequestTimeoutMs), commandPath.EndpointId, commandPath.ClusterId, commandPath.CommandId, payloadTLV, len(payloadTLV)))
 
 
 def Init():

--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -459,8 +459,11 @@ chip::ChipError::StorageType pychip_ReadClient_Read(void * appContext, ReadClien
             params.mMaxIntervalCeilingSeconds = pyParams.maxInterval;
             params.mKeepSubscriptions         = pyParams.keepSubscriptions;
             params.mResubscribePolicy         = PythonResubscribePolicy;
+
+            dataVersionFilters.release();
             attributePaths.release();
             eventPaths.release();
+
             err = readClient->SendAutoResubscribeRequest(std::move(params));
             SuccessOrExit(err);
         }

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -812,6 +812,13 @@ class BaseTestHelper:
 
             # thread changes 5 times, and sleeps for 3 seconds in between. Add an additional 3 seconds of slack. Timeout is in seconds.
             changeThread.join(18.0)
+
+            #
+            # Clean-up by shutting down the sub. Otherwise, we're going to get callbacks through OnValueChange on what will soon become an invalid
+            # execution context above.
+            #
+            subscription.Shutdown()
+
             if changeThread.is_alive():
                 # Thread join timed out
                 self.logger.error(f"Failed to join change thread")


### PR DESCRIPTION
#### Problem

When attempting to clean-up some of the subscription tests to call `Shutdown()` on the `SubscriptionTransaction` object before moving onto another test (otherwise, it causes occasional Cirque failure issues with attribute changes being posted to an event loop context that is now closed), ran into an issue where we were aborting the underlying `ReadClient` from a different threading context than Matter immediately upon receiving an attribute value.

This resulted in the underlying ReadClient being destroyed **before** the stack could finish completing the processing of the report, resulting in errors sending out a StatusResponse due to not having an exchange :S 

#### Fix

When calling C++ methods, ensure to dispatch those on the Matter execution context.

I've also cleaned up `ChipDeviceCtrl` to not dispatch Python function calls on the Matter threading context - instead, only do so right at the edge where we call into the C++ layer. This avoids issues with test code that assume (correctly), that most of our IM Python API surface is meant to be callable from any execution context. This is the general assumption in pretty much all of the Python API surface (unless explicitly called out).

Also fixes a use-after-free bug where we were inadvertently freeing up the heap-allocated dataVersionList prematurely.