### PR TITLE
Add payload parser to darwin framework tool

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -57,6 +57,7 @@ executable("darwin-framework-tool") {
     "commands/pairing/OpenCommissioningWindowCommand.mm",
     "commands/pairing/PairingCommandBridge.mm",
     "commands/pairing/PairingDelegateBridge.mm",
+    "commands/payload/SetupPayloadParseCommand.mm",
     "commands/storage/Commands.h",
     "commands/storage/StorageManagementCommand.mm",
     "main.mm",

--- a/examples/darwin-framework-tool/commands/payload/Commands.h
+++ b/examples/darwin-framework-tool/commands/payload/Commands.h
@@ -1,0 +1,31 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#include "SetupPayloadParseCommand.h"
+
+void registerCommandsPayload(Commands & commands)
+{
+    const char * clusterName      = "Payload";
+    commands_list clusterCommands = {
+        make_unique<SetupPayloadParseCommand>(), //
+    };
+
+    commands.Register(clusterName, clusterCommands);
+}

--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.h
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.h
@@ -1,0 +1,41 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#pragma once
+
+#import <CHIP/CHIP.h>
+#include <commands/common/Command.h>
+
+class SetupPayloadParseCommand : public Command {
+public:
+    SetupPayloadParseCommand()
+        : Command("parse-setup-payload")
+    {
+        AddArgument("payload", &mCode);
+    }
+    CHIP_ERROR Run() override;
+    static bool IsQRCode(NSString * codeString);
+
+private:
+    char * mCode;
+    CHIP_ERROR Print(CHIPSetupPayload * payload);
+
+    // Will log the given string and given error (as progress if success, error
+    // if failure).
+    void LogNSError(const char * logString, NSError * error);
+};

--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -1,0 +1,142 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "SetupPayloadParseCommand.h"
+#import <CHIP/CHIP.h>
+#import <CHIP/CHIPError_Internal.h>
+
+using namespace ::chip;
+
+namespace {
+
+#if CHIP_PROGRESS_LOGGING
+
+NSString * CustomFlowString(CHIPCommissioningFlow flow)
+{
+    switch (flow) {
+    case kCommissioningFlowStandard:
+        return @"STANDARD";
+    case kCommissioningFlowUserActionRequired:
+        return @"USER ACTION REQUIRED";
+    case kCommissioningFlowCustom:
+        return @"CUSTOM";
+    case kCommissioningFlowInvalid:
+        return @"INVALID";
+    }
+
+    return @"???";
+}
+
+#endif // CHIP_PROGRESS_LOGGING
+
+} // namespace
+
+void SetupPayloadParseCommand::LogNSError(const char * logString, NSError * error)
+{
+    CHIP_ERROR err = [CHIPError errorToCHIPErrorCode:error];
+    if (err == CHIP_NO_ERROR) {
+        ChipLogProgress(chipTool, "%s: %s", logString, chip::ErrorStr(err));
+    } else {
+        ChipLogError(chipTool, "%s: %s", logString, chip::ErrorStr(err));
+    }
+}
+
+CHIP_ERROR SetupPayloadParseCommand::Run()
+{
+    NSString * codeString = [NSString stringWithCString:mCode encoding:NSASCIIStringEncoding];
+    NSError * error;
+    CHIPSetupPayload * payload;
+    CHIPOnboardingPayloadType codeType;
+    if (IsQRCode(codeString)) {
+        codeType = CHIPOnboardingPayloadTypeQRCode;
+    } else {
+        codeType = CHIPOnboardingPayloadTypeManualCode;
+    }
+    payload = [CHIPOnboardingPayloadParser setupPayloadForOnboardingPayload:codeString ofType:codeType error:&error];
+    if (error) {
+        LogNSError("Error: ", error);
+        return CHIP_ERROR_INTERNAL;
+    }
+    ReturnErrorOnFailure(Print(payload));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR SetupPayloadParseCommand::Print(CHIPSetupPayload * payload)
+{
+    NSLog(@"Version:       %@", payload.version);
+    NSLog(@"VendorID:      %@", payload.vendorID);
+    NSLog(@"ProductID:     %@", payload.productID);
+    NSLog(@"Custom flow:   %lu    (%@)", payload.commissioningFlow, CustomFlowString(payload.commissioningFlow));
+    {
+        NSMutableString * humanFlags = [[NSMutableString alloc] init];
+
+        if (payload.rendezvousInformation) {
+            if (payload.rendezvousInformation & kRendezvousInformationNone) {
+                [humanFlags appendString:@"NONE"];
+            } else {
+                if (payload.rendezvousInformation & kRendezvousInformationSoftAP) {
+                    [humanFlags appendString:@"SoftAP"];
+                }
+                if (payload.rendezvousInformation & kRendezvousInformationBLE) {
+                    if (!humanFlags) {
+                        [humanFlags appendString:@", "];
+                    }
+                    [humanFlags appendString:@"BLE"];
+                }
+                if (payload.rendezvousInformation & kRendezvousInformationOnNetwork) {
+                    if (!humanFlags) {
+                        [humanFlags appendString:@", "];
+                    }
+                    [humanFlags appendString:@"ON NETWORK"];
+                }
+            }
+        } else {
+            [humanFlags appendString:@"NONE"];
+        }
+
+        NSLog(@"Capabilities:  0x%02lX (%@)", payload.rendezvousInformation, humanFlags);
+    }
+    NSLog(@"Discriminator: %@", payload.discriminator);
+    NSLog(@"Passcode:      %@", payload.setUpPINCode);
+
+    if (payload.serialNumber) {
+        NSLog(@"SerialNumber: %@", payload.serialNumber);
+    }
+    NSError * error;
+    NSArray<CHIPOptionalQRCodeInfo *> * optionalVendorData = [payload getAllOptionalVendorData:&error];
+    if (error) {
+        LogNSError("Error: ", error);
+        return CHIP_ERROR_INTERNAL;
+    }
+    for (const CHIPOptionalQRCodeInfo * info : optionalVendorData) {
+        bool isTypeString = [info.infoType isEqual:@(kOptionalQRCodeInfoTypeString)];
+        bool isTypeInt32 = [info.infoType isEqual:@(kOptionalQRCodeInfoTypeInt32)];
+        VerifyOrReturnError(isTypeString || isTypeInt32, CHIP_ERROR_INVALID_ARGUMENT);
+
+        if (isTypeString) {
+            NSLog(@"OptionalQRCodeInfo: tag=%@,string value=%@", info.tag, info.stringValue);
+        } else {
+            NSLog(@"OptionalQRCodeInfo: tag=%@,int value=%@", info.tag, info.integerValue);
+        }
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+bool SetupPayloadParseCommand::IsQRCode(NSString * codeString) { return [codeString hasPrefix:@"MT:"]; }

--- a/examples/darwin-framework-tool/main.mm
+++ b/examples/darwin-framework-tool/main.mm
@@ -19,6 +19,7 @@
 #include "commands/common/Commands.h"
 #include "commands/interactive/Commands.h"
 #include "commands/pairing/Commands.h"
+#include "commands/payload/Commands.h"
 #include "commands/storage/Commands.h"
 
 #include <zap-generated/cluster/Commands.h>
@@ -29,6 +30,7 @@ int main(int argc, const char * argv[])
     Commands commands;
     registerCommandsPairing(commands);
     registerCommandsInteractive(commands);
+    registerCommandsPayload(commands);
     registerCommandsStorage(commands);
     registerCommandsTests(commands);
     registerClusters(commands);


### PR DESCRIPTION
#### Problem
Darwin-framework-tool does not have a payload parser to demonstrate that a commissioner implemented using CHIP.framework can indeed parse out the Vendor ID and check to see if it is valid. 
* Fixes #19676

#### Change overview
- Add a parser to Darwin-framework-tool

#### Testing
- Parsed SetupQRCode
- Parsed ManualCode
