### PR TITLE
Re-disable rosetta for bootstrap on M1 Mac

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -58,11 +58,6 @@ EOF
     PW_ROOT="$_CHIP_ROOT/third_party/pigweed/repo"
     export PW_ROOT
 
-    # Do not force use Rosetta in Pigweed because Matter is using host toolchain
-    if [ -z "$PW_BOOTSTRAP_USE_ROSETTA" ]; then
-        export PW_BOOTSTRAP_USE_ROSETTA=false
-    fi
-
     . "$_CHIP_ROOT/third_party/pigweed/repo/pw_env_setup/util.sh"
 
     _chip_bootstrap_banner() {

--- a/scripts/environment.json
+++ b/scripts/environment.json
@@ -9,5 +9,6 @@
         "gn_targets": [":python_packages.install"]
     },
     "required_submodules": ["third_party/pigweed/repo"],
+    "rosetta": "never",
     "gni_file": "build_overrides/pigweed_environment.gni"
 }


### PR DESCRIPTION
#### Problem

Bootstraps on M1 Macs are running in Rosetta.

#### Change overview

Disable Rosetta.

This will produce native arm64 binaries by default instead of x64, which
will not be able to link with an arm64 openssl installed by brew.

Fixes #19134 

#### Testing

chip-tool built on M1