### PR TITLE
Run the DL certification tests against lock-app in CI.

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -32,7 +32,7 @@ def AllTests(chip_tool: str):
 
         if name.startswith('TV_') or name.startswith('Test_TC_MC_'):
             target = TestTarget.TV
-        elif name.startswith('DL_'):
+        elif name.startswith('DL_') or name.startswith('Test_TC_DL_'):
             target = TestTarget.LOCK
         elif name.startswith('OTA_'):
             target = TestTarget.OTA


### PR DESCRIPTION
all-clusters-app does not implement enough door-lock builds to test
this well against it.

#### Problem
There are door-lock bits that all-clusters-app does not do

#### Change overview
Run door lock certification CI against lock-app.

#### Testing
CI should still pass.