### PR TITLE
[Infineon] Remove lwIP from CYW30739 OpenThread implementation.

### DIFF
--- a/examples/lighting-app/cyw30739/src/main.cpp
+++ b/examples/lighting-app/cyw30739/src/main.cpp
@@ -29,6 +29,7 @@
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/server/Server.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <inet/EndPointStateOpenThread.h>
 #include <lib/shell/Engine.h>
 #include <lib/support/CHIPPlatformMemory.h>
 #include <mbedtls/platform.h>
@@ -152,6 +153,11 @@ void InitApp(intptr_t args)
     /* Start CHIP datamodel server */
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = [] { ThreadStackMgr().LockThreadStack(); };
+    nativeParams.unlockCb              = [] { ThreadStackMgr().UnlockThreadStack(); };
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
@@ -159,7 +165,7 @@ void InitApp(intptr_t args)
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     LightMgr().Init();
-    LightMgr().SetCallbacks(LightManagerCallback, NULL);
+    LightMgr().SetCallbacks(LightManagerCallback, nullptr);
     LightMgr().WriteClusterLevel(254);
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR

--- a/examples/lock-app/cyw30739/src/main.cpp
+++ b/examples/lock-app/cyw30739/src/main.cpp
@@ -31,6 +31,7 @@
 #include <app/clusters/door-lock-server/door-lock-server.h>
 #include <app/server/Server.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <inet/EndPointStateOpenThread.h>
 #include <lib/shell/Engine.h>
 #include <lib/support/CHIPPlatformMemory.h>
 #include <mbedtls/platform.h>
@@ -168,6 +169,11 @@ void InitApp(intptr_t args)
     /* Start CHIP datamodel server */
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = [] { ThreadStackMgr().LockThreadStack(); };
+    nativeParams.unlockCb              = [] { ThreadStackMgr().UnlockThreadStack(); };
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/ota-requestor-app/cyw30739/src/main.cpp
+++ b/examples/ota-requestor-app/cyw30739/src/main.cpp
@@ -22,6 +22,7 @@
 #include <OTAConfig.h>
 #include <app/server/Server.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
+#include <inet/EndPointStateOpenThread.h>
 #include <lib/shell/Engine.h>
 #include <lib/support/CHIPPlatformMemory.h>
 #include <mbedtls/platform.h>
@@ -116,6 +117,11 @@ void InitApp(intptr_t args)
     /* Start CHIP datamodel server */
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
+    nativeParams.lockCb                = [] { ThreadStackMgr().LockThreadStack(); };
+    nativeParams.unlockCb              = [] { ThreadStackMgr().UnlockThreadStack(); };
+    nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
+    initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/src/platform/CYW30739/PlatformManagerImpl.cpp
+++ b/src/platform/CYW30739/PlatformManagerImpl.cpp
@@ -48,9 +48,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
-    /* Initialize LwIP. */
-    lwip_init();
-
     /* Create the thread object. */
     mThread = wiced_rtos_create_thread();
     VerifyOrExit(mThread != nullptr, err = CHIP_ERROR_NO_MEMORY);

--- a/src/platform/CYW30739/SystemPlatformConfig.h
+++ b/src/platform/CYW30739/SystemPlatformConfig.h
@@ -27,5 +27,6 @@
 // ==================== Platform Adaptations ====================
 #define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME 1
 #define CHIP_SYSTEM_CONFIG_EVENT_OBJECT_TYPE const struct ::chip::DeviceLayer::ChipDeviceEvent *
+#define CHIP_SYSTEM_CONFIG_PACKETBUFFER_POOL_SIZE 0
 
 // ========== Platform-specific Configuration Overrides =========

--- a/src/platform/CYW30739/ThreadStackManagerImpl.cpp
+++ b/src/platform/CYW30739/ThreadStackManagerImpl.cpp
@@ -21,12 +21,12 @@
  *
  */
 /* this file behaves like a config.h, comes first */
+#include <platform/CHIPDeviceEvent.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
-#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.cpp>
+#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp>
 
 #include <lib/support/CHIPPlatformMemory.h>
-#include <lwip/ip.h>
 #include <openthread-system.h>
 #include <wiced_platform.h>
 
@@ -52,7 +52,7 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
     VerifyOrExit(result == WICED_SUCCESS, err = CHIP_ERROR_INTERNAL);
     otSysInit(0, NULL);
 
-    err = GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>::DoInit(NULL);
+    err = GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>::DoInit(NULL);
 
 exit:
     return err;
@@ -110,10 +110,4 @@ extern "C" void * otPlatCAlloc(size_t aNum, size_t aSize)
 extern "C" void otPlatFree(void * aPtr)
 {
     CHIPPlatformMemoryFree(aPtr);
-}
-
-/* A wrapper for the GenericThreadStackManagerImpl_OpenThread_LwIP implementation. */
-err_t tcpip_input(struct pbuf * p, struct netif * inp)
-{
-    return ip_input(p, inp);
 }

--- a/src/platform/CYW30739/ThreadStackManagerImpl.h
+++ b/src/platform/CYW30739/ThreadStackManagerImpl.h
@@ -24,7 +24,8 @@
 
 #pragma once
 
-#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread_LwIP.h>
+#include <platform/CHIPDeviceEvent.h>
+#include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
 #include <wiced_rtos.h>
 
 namespace chip {
@@ -34,7 +35,7 @@ namespace DeviceLayer {
  * Concrete implementation of the ThreadStackManager singleton object for the platform.
  */
 class ThreadStackManagerImpl final : public ThreadStackManager,
-                                     public Internal::GenericThreadStackManagerImpl_OpenThread_LwIP<ThreadStackManagerImpl>
+                                     public Internal::GenericThreadStackManagerImpl_OpenThread<ThreadStackManagerImpl>
 {
     // Allow the ThreadStackManager interface class to delegate method calls to
     // the implementation methods provided by this class.
@@ -100,5 +101,3 @@ inline ThreadStackManagerImpl & ThreadStackMgrImpl(void)
 
 } // namespace DeviceLayer
 } // namespace chip
-
-err_t tcpip_input(struct pbuf * p, struct netif * inp);

--- a/src/platform/CYW30739/args.gni
+++ b/src/platform/CYW30739/args.gni
@@ -34,12 +34,11 @@ chip_enable_openthread = true
 lwip_platform = "cyw30739"
 
 chip_inet_config_enable_ipv4 = false
-chip_inet_config_enable_dns_resolver = false
 chip_inet_config_enable_tcp_endpoint = false
-chip_inet_config_enable_raw_endpoint = false
+chip_system_config_use_open_thread_inet_endpoints = true
+chip_with_lwip = false
 
 chip_system_config_locking = "none"
-chip_system_config_use_lwip = true
 chip_system_config_use_sockets = false
 
 optimize_debug_level = "s"

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -148,6 +148,9 @@ source_set("system_config_header") {
       if (chip_device_platform == "k32w0") {
         public_deps += [ "${k32w0_sdk_build_root}:k32w0_sdk" ]
       }
+      if (chip_device_platform == "cyw30739") {
+        public_deps += [ "${cyw30739_sdk_build_root}:cyw30739_sdk" ]
+      }
 
       # Add platform here as needed.
     }


### PR DESCRIPTION
#### Problem
The thread-based platform CYW30739 no longer needs lwIP.

#### Change overview
Remove lwIP from CYW30739 OpenThread implementation.

#### Testing
* chip-tool pairing
* chip-tool ota test cases