### PR TITLE
[Ameba] Populate other threadmetrics fields

### DIFF
--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -93,9 +93,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
             thread->id = taskStatusArray[x].xTaskNumber;
 
             thread->stackFreeMinimum.Emplace(taskStatusArray[x].usStackHighWaterMark);
-            /* Unsupported metrics */
-            // thread->stackSize;
-            // thread->stackFreeCurrent;
+            thread->stackSize.Emplace(uxTaskGetStackSize(taskStatusArray[x].xHandle));
+            thread->stackFreeCurrent.Emplace(uxTaskGetFreeStackSize(taskStatusArray[x].xHandle));
 
             thread->Next = head;
             head         = thread;


### PR DESCRIPTION
#### Problem
When reading threadmetrics, stackSize and stackFreeCurrent shows garbage values.

#### Change overview
Get stackSize and stackFreeCurrent using implemented API

#### Testing
Read threadmetrics and checked that these 2 fields shows the correct values.
