### PR TITLE
[Ameba] Pass in RSSI to NetworkCommissioningDriver

### DIFF
--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -47,7 +47,7 @@ public:
         item.ssidLen  = mpScanResults[mIternum].SSID.len;
         item.channel  = mpScanResults[mIternum].channel;
         item.wiFiBand = chip::DeviceLayer::NetworkCommissioning::WiFiBand::k2g4;
-        // item.rssi     = mpScanResults[mIternum].rssi;
+        item.rssi     = mpScanResults[mIternum].signal_strength;
         memcpy(item.ssid, mpScanResults[mIternum].SSID.val, item.ssidLen);
         memcpy(item.bssid, mpScanResults[mIternum].BSSID.octet, 6);
 


### PR DESCRIPTION
#### Problem
During scan-network command, RSSI is not passed to matter application.

#### Change overview
Pass RSSI to matter application.

#### Testing
Tested using scan-network command, checked for correct RSSI
