### PR TITLE
[Ameba] Use BLE random address and add uxTaskGetFreeStackSize & uxTaskGetStackSize

### DIFF
--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -3,7 +3,7 @@ FROM connectedhomeip/chip-build:${VERSION}
 
 # Setup Ameba
 ARG AMEBA_DIR=/opt/ameba
-ARG TAG_NAME=ameba_update_2022_06_06
+ARG TAG_NAME=ameba_update_2022_06_20
 RUN set -x \
     && apt-get update \
     && mkdir ${AMEBA_DIR} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.80 Version bump reason: [Tizen] Add vscode debug support
+0.5.81 Version bump reason: [Ameba] Update Ameba SDK to use BLE random address and add uxTaskGetFreeStackSize and uxTaskGetStackSize


### PR DESCRIPTION
#### Problem
- Config BLE using random address
- Add uxTaskGetFreeStackSize & uxTaskGetStackSize
- Need to exclude SSID with length 0 during scan-network

#### Change overview
* Update chip-build-ameba/Dockerfile
* Update version
* Fixes #19727

#### Testing
Tested docker build
