### PR TITLE
[Infineon] SoftwareDiagnostic update

### DIFF
--- a/src/platform/CYW30739/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/CYW30739/DiagnosticDataProviderImpl.cpp
@@ -124,6 +124,16 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
         Platform::Delete(del);
     }
 }
+
+CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
+{
+    // If implemented, the server SHALL set the value of the CurrentHeapHighWatermark attribute to the
+    // value of the CurrentHeapUsed.
+    // On CYW30739, overide with non-op to pass CI.
+
+    return CHIP_NO_ERROR;
+}
+
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_THREAD */
 
 } // namespace DeviceLayer

--- a/src/platform/CYW30739/DiagnosticDataProviderImpl.h
+++ b/src/platform/CYW30739/DiagnosticDataProviderImpl.h
@@ -39,11 +39,13 @@ public:
 
     // ===== Methods that implement the PlatformManager abstract interface.
 
+    bool SupportsWatermarks() override { return true; }
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
+    CHIP_ERROR ResetWatermarks() override;
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
     void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;


### PR DESCRIPTION
Problem
Infineon CYW30739 doesn't support DGSW.S.F00(Watermarks)

Change overview
Add DGSW.S.F00(Watermarks) support

Testing
./chip-tool softwarediagnostics reset-watermarks 1234 0
