### PR TITLE
RemoveEndpoint(fabric, endpoint) now removes the group

### DIFF
--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -257,6 +257,12 @@ tests:
       endpoint: 1
       command: "RemoveAllGroups"
 
+    - label: "Read GroupTable 3"
+      command: "readAttribute"
+      attribute: "GroupTable"
+      response:
+          value: []
+
     - label: "KeySet Remove 2"
       command: "KeySetRemove"
       arguments:

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -66621,7 +66621,7 @@ class TestGroupKeyManagementClusterSuite : public TestCommand
 {
 public:
     TestGroupKeyManagementClusterSuite(CredentialIssuerCommands * credsIssuerConfig) :
-        TestCommand("TestGroupKeyManagementCluster", 20, credsIssuerConfig)
+        TestCommand("TestGroupKeyManagementCluster", 21, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -66834,8 +66834,21 @@ private:
             break;
         case 18:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::DataModel::DecodableList<
+                    chip::app::Clusters::GroupKeyManagement::Structs::GroupInfoMapStruct::DecodableType>
+                    value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                {
+                    auto iter_0 = value.begin();
+                    VerifyOrReturn(CheckNoMoreListItems<decltype(value)>("groupTable", iter_0, 0));
+                }
+            }
             break;
         case 19:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 20:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
             break;
         default:
@@ -67077,7 +67090,12 @@ private:
             );
         }
         case 18: {
-            LogStep(18, "KeySet Remove 2");
+            LogStep(18, "Read GroupTable 3");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(0), GroupKeyManagement::Id,
+                                 GroupKeyManagement::Attributes::GroupTable::Id, true, chip::NullOptional);
+        }
+        case 19: {
+            LogStep(19, "KeySet Remove 2");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetRemove::Type value;
             value.groupKeySetID = 418U;
@@ -67086,8 +67104,8 @@ private:
 
             );
         }
-        case 19: {
-            LogStep(19, "KeySet Read (also removed)");
+        case 20: {
+            LogStep(20, "KeySet Read (also removed)");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetRead::Type value;
             value.groupKeySetID = 418U;


### PR DESCRIPTION
GroupDataProviderImpl::RemoveEndpoint does not remove group entries without endpoints.

#### Problem
* Fixes [#19610](https://github.com/project-chip/connectedhomeip/issues/19610)

#### Change overview
* Now RemoveEndpoint(fabric, endpoint) also removes the group if it has no more endpoints.
* YAML tests updated.

#### Testing
Groups and GroupKeyManagement YAML tests run successfully.