### PR TITLE
ExchangeContext: Implement a safer verion Abort/Close

### DIFF
--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -165,12 +165,10 @@ public:
 
     uint16_t GetExchangeId() const { return mExchangeId; }
 
-    /*
-     * In order to use reference counting (see refCount below) we use a hold/free paradigm where users of the exchange
-     * can hold onto it while it's out of their direct control to make sure it isn't closed before everyone's ready.
-     * A customized version of reference counting is used since there are some extra stuff to do within Release.
-     */
+    /// @brief Gracefully close an exchange context. This function can be call at any time on a valid exchange.
     void Close();
+
+    /// @brief Abort the Exchange context immediately. This function can be call at any time on a valid exchange.
     void Abort();
 
     // Applies a suggested response timeout value based on the session type and the given upper layer processing time for
@@ -239,14 +237,14 @@ private:
      * response.  If aCloseIfNeeded is true, check whether the exchange needs to
      * be closed.
      */
-    void NotifyResponseTimeout(bool aCloseIfNeeded);
+    void NotifyResponseTimeout();
 
     CHIP_ERROR StartResponseTimer();
 
     void CancelResponseTimer();
     static void HandleResponseTimeout(System::Layer * aSystemLayer, void * aAppState);
 
-    void DoClose(bool clearRetransTable);
+    void DoClose(bool clearRetransTable, bool shouldCallResponseTimout);
 
     /**
      * We have handled an application-level message in some way and should

--- a/src/messaging/ExchangeDelegate.h
+++ b/src/messaging/ExchangeDelegate.h
@@ -90,17 +90,19 @@ public:
 
     /**
      * @brief
-     *   This function is the protocol callback to invoke when the associated
-     *   exchange context is being closed.
+     *   This function is the protocol callback to invoke when the associated exchange context is being closed.
      *
-     *   If the exchange was in a state where it was expecting a message to be
-     *   sent due to an earlier WillSendMessage call or because the exchange has
-     *   just been created as an initiator, the consumer is holding a reference
-     *   to the exchange and it's the consumer's responsibility to call
-     *   Release() on the exchange at some point.  The usual way this happens is
-     *   that the consumer tries to send its message, that fails, and the
-     *   consumer calls Close() on the exchange.  Calling Close() after an
-     *   OnExchangeClosing() notification is allowed in this situation.
+     *   The exchange is getting released soon after this callback. If there is no message pending in the retrans queue in MRP, the
+     *   exchange will be released immediately after this callback, otherwise the exchange is released after the retrans entry is
+     *   removed, by either receiving an acknowledgment or give up. There is no way to prevent the exchange from releasing at this
+     *   stage.
+     *
+     *   The user do not need to call Close or Abort to release the reference when this callback is triggered, the reference is
+     *   already released. The user can call Abort if it want to clear the retrans entry of the last message, and speed up releasing
+     *   the exchange.
+     *
+     *   The user MUST release all pointers to the exchange in the callback, because the exchange is getting release soon, or else
+     *   they become dangling pointer.
      *
      *  @param[in]    ec            A pointer to the ExchangeContext object.
      */

--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -161,7 +161,8 @@ protected:
         /// When set, signifies that this exchange is waiting for a call to SendMessage.
         kFlagWillSendMessage = (1u << 6),
 
-        /// When set, we have had Close() or Abort() called on us already.
+        /// When set, signifies that the exchange is closed. All applications have already lost their refs to the exchange, and the
+        ///           only possible ref is the retrans entry in MPR.
         kFlagClosed = (1u << 7),
 
         /// When set, signifies that the exchange is requesting Sleepy End Device active mode.


### PR DESCRIPTION
#### Problem
Fixes #19747 Use-after-free when aborting already-closed exchange

#### Change overview
* Introduce safer version Abort and Close for ExchangeContext
   * Abort or Close can be called at anytime on a valid exchange which is not releasing.
* Once Abort or Close is called, or OnExchangeClosing is triggered, the exchange is releasing
  * The application should lose its control to that exchange. It must null-out all pointers to that exchange
  * The exchange will be released sooner or later. 

This change is based on following concepts
* Exchange refcounts are managed by internal states rather than by applications.
* Instead of manually manipulate refcounts, Applications manage Exchange states.
  * Only have 2 states now, Closed or not, identified by `kFlagClosed`.
  * The initial refcount is bound to "not closed state" (kFlagClosed is not set)

Note: Currently, there are 3 types of ref counts to an exchange
* The initial value: controlled by `kFlagClosed`
* The scoped `ExchangeHandle` in member functions of ExchangeContex
* The `ExchangeHandle` in `RetransTableEntry`

#### Testing
Verified by unit-tests.