### PR TITLE
iOS TvCasting app: Send Content Launch By URL request and Open commissioning window 

### DIFF
--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
@@ -29,28 +29,80 @@
 
 + (CastingServerBridge * _Nullable)getSharedInstance;
 
+/*!
+ @brief Browse for on-network commissioner TVs
+
+ @param clientQueue Queue to dispatch the call to the discoveryRequestSentHandler on
+
+ @param discoveryRequestSentHandler Handler to call after the Commissioner discovery request has been sent
+ */
 - (void)discoverCommissioners:(dispatch_queue_t _Nonnull)clientQueue
     discoveryRequestSentHandler:(nullable void (^)(bool))discoveryRequestSentHandler;
 
+/*!
+ @brief Retrieve a discovered commissioner TV
+
+ @param index Index in the list of discovered commissioners
+
+ @param clientQueue Queue to dispatch the call to the discoveredCommissionerHandler on
+
+ @param discoveredCommissionerHandler Handler to call after a discovered commissioner has been retrieved
+ */
 - (void)getDiscoveredCommissioner:(int)index
                       clientQueue:(dispatch_queue_t _Nonnull)clientQueue
     discoveredCommissionerHandler:(nullable void (^)(DiscoveredNodeData * _Nullable))discoveredCommissionerHandler;
 
+/*!
+ @brief Send a User Directed Commissioning request to a commissioner TV
+
+ @param commissionerIpAddress IP address of the commissioner
+
+ @param commissionerPort Port number at which the commissioner is listening for User Directed Commissioning requests
+
+ @param platformInterface Platform representation of the commissioner's IP address's interface
+
+ @param clientQueue Queue to dispatch the call to the udcRequestSentHandler on
+
+ @param udcRequestSentHandler Handler to call on sending the User Directed Commissioning request
+ */
 - (void)sendUserDirectedCommissioningRequest:(NSString * _Nonnull)commissionerIpAddress
                             commissionerPort:(uint16_t)commissionerPort
                            platformInterface:(unsigned int)platformInterface
                                  clientQueue:(dispatch_queue_t _Nonnull)clientQueue
                        udcRequestSentHandler:(nullable void (^)(bool))udcRequestSentHandler;
 
-- (void)openBasicCommissioningWindow:(nullable void (^)(bool))commissioningCompleteCallback
-                         clientQueue:(dispatch_queue_t _Nonnull)clientQueue
-    commisisoningWindowOpenedHandler:(nullable void (^)(bool))commisisoningWindowOpenedHandler;
+/*!
+ @brief Request opening of a basic commissioning window
 
+ @param commissioningCompleteCallback Callback for when commissioning of this app has been completed  via a call to the general
+ commissioning cluster (by usually an on-network TV/Media device acting as a Matter commissioner)
+
+ @param clientQueue Queue to dispatch the call to the commissioningWindowRequestedHandler on
+
+ @param commissioningWindowRequestedHandler Handler to call on requesting the opening of a commissioning window
+ */
+- (void)openBasicCommissioningWindow:(nullable void (^)(bool))commissioningCompleteCallback
+                            clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+    commissioningWindowRequestedHandler:(nullable void (^)(bool))commissioningWindowRequestedHandler;
+
+/*!
+ @brief Send a Content Launcher:LaunchURL request to a TV
+
+ @param contentUrl URL of the content to launch on the TV
+
+ @param contentDisplayStr Display string value corresponding to the content
+
+ @param launchUrlResponseCallback Callback for when the Launch URL response has been received
+
+ @param clientQueue Queue to dispatch the call to the launchUrlRequestSentHandler on
+
+ @param launchUrlRequestSentHandler Handler to call on sending the Launch URL request
+ */
 - (void)contentLauncherLaunchUrl:(NSString * _Nonnull)contentUrl
                contentDisplayStr:(NSString * _Nonnull)contentDisplayStr
        launchUrlResponseCallback:(nullable void (^)(bool))launchUrlResponseCallback
                      clientQueue:(dispatch_queue_t _Nonnull)clientQueue
-      launcUrlRequestSentHandler:(nullable void (^)(bool))launcUrlRequestSentHandler;
+     launchUrlRequestSentHandler:(nullable void (^)(bool))launchUrlRequestSentHandler;
 @end
 
 #endif /* CastingServerBridge_h */

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
@@ -23,6 +23,10 @@
 
 @interface CastingServerBridge : NSObject
 
+@property void (^_Nullable commissioningCompleteCallback)(bool);
+
+@property void (^_Nullable launchUrlResponseCallback)(bool);
+
 + (CastingServerBridge * _Nullable)getSharedInstance;
 
 - (void)discoverCommissioners:(dispatch_queue_t _Nonnull)clientQueue
@@ -38,6 +42,15 @@
                                  clientQueue:(dispatch_queue_t _Nonnull)clientQueue
                        udcRequestSentHandler:(nullable void (^)(bool))udcRequestSentHandler;
 
+- (void)openBasicCommissioningWindow:(nullable void (^)(bool))commissioningCompleteCallback
+                         clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+    commisisoningWindowOpenedHandler:(nullable void (^)(bool))commisisoningWindowOpenedHandler;
+
+- (void)contentLauncherLaunchUrl:(NSString * _Nonnull)contentUrl
+               contentDisplayStr:(NSString * _Nonnull)contentDisplayStr
+       launchUrlResponseCallback:(nullable void (^)(bool))launchUrlResponseCallback
+                     clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+      launcUrlRequestSentHandler:(nullable void (^)(bool))launcUrlRequestSentHandler;
 @end
 
 #endif /* CastingServerBridge_h */

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.mm
@@ -123,10 +123,11 @@
                                  clientQueue:(dispatch_queue_t _Nonnull)clientQueue
                        udcRequestSentHandler:(nullable void (^)(bool))udcRequestSentHandler
 {
-    ChipLogProgress(
-        AppServer, "CastingServerBridge().sendUserDirectedCommissioningRequest() called with port %d", commissionerPort);
+    ChipLogProgress(AppServer,
+        "CastingServerBridge().sendUserDirectedCommissioningRequest() called with IP %s port %d platformInterface %d",
+        [commissionerIpAddress UTF8String], commissionerPort, platformInterface);
 
-    dispatch_async(chip::DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
+    dispatch_async(_chipWorkQueue, ^{
         bool udcRequestStatus;
         chip::Inet::IPAddress commissionerAddrInet;
         if (chip::Inet::IPAddress::FromString([commissionerIpAddress UTF8String], commissionerAddrInet) == false) {
@@ -153,4 +154,39 @@
         });
     });
 }
+
+- (void)openBasicCommissioningWindow:(nullable void (^)(bool))commissioningCompleteCallback
+                         clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+    commisisoningWindowOpenedHandler:(nullable void (^)(bool))commisisoningWindowOpenedHandler
+{
+    ChipLogProgress(AppServer, "CastingServerBridge().openBasicCommissioningWindow() called");
+
+    dispatch_async(_chipWorkQueue, ^{
+        CHIP_ERROR err = CastingServer::GetInstance()->OpenBasicCommissioningWindow(
+            [&commissioningCompleteCallback](CHIP_ERROR err) { commissioningCompleteCallback(CHIP_NO_ERROR == err); });
+
+        dispatch_async(clientQueue, ^{
+            commisisoningWindowOpenedHandler(CHIP_NO_ERROR == err);
+        });
+    });
+}
+
+- (void)contentLauncherLaunchUrl:(NSString * _Nonnull)contentUrl
+               contentDisplayStr:(NSString * _Nonnull)contentDisplayStr
+       launchUrlResponseCallback:(nullable void (^)(bool))launchUrlResponseCallback
+                     clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+      launcUrlRequestSentHandler:(nullable void (^)(bool))launcUrlRequestSentHandler
+{
+    ChipLogProgress(AppServer, "CastingServerBridge().contentLauncherLaunchUrl() called");
+
+    dispatch_async(_chipWorkQueue, ^{
+        CHIP_ERROR err
+            = CastingServer::GetInstance()->ContentLauncherLaunchURL([contentUrl UTF8String], [contentDisplayStr UTF8String],
+                [&launchUrlResponseCallback](CHIP_ERROR err) { launchUrlResponseCallback(CHIP_NO_ERROR == err); });
+        dispatch_async(clientQueue, ^{
+            launcUrlRequestSentHandler(CHIP_NO_ERROR == err);
+        });
+    });
+}
+
 @end

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.mm
@@ -156,8 +156,8 @@
 }
 
 - (void)openBasicCommissioningWindow:(nullable void (^)(bool))commissioningCompleteCallback
-                         clientQueue:(dispatch_queue_t _Nonnull)clientQueue
-    commisisoningWindowOpenedHandler:(nullable void (^)(bool))commisisoningWindowOpenedHandler
+                            clientQueue:(dispatch_queue_t _Nonnull)clientQueue
+    commissioningWindowRequestedHandler:(nullable void (^)(bool))commissioningWindowRequestedHandler
 {
     ChipLogProgress(AppServer, "CastingServerBridge().openBasicCommissioningWindow() called");
 
@@ -166,7 +166,7 @@
             [&commissioningCompleteCallback](CHIP_ERROR err) { commissioningCompleteCallback(CHIP_NO_ERROR == err); });
 
         dispatch_async(clientQueue, ^{
-            commisisoningWindowOpenedHandler(CHIP_NO_ERROR == err);
+            commissioningWindowRequestedHandler(CHIP_NO_ERROR == err);
         });
     });
 }
@@ -175,7 +175,7 @@
                contentDisplayStr:(NSString * _Nonnull)contentDisplayStr
        launchUrlResponseCallback:(nullable void (^)(bool))launchUrlResponseCallback
                      clientQueue:(dispatch_queue_t _Nonnull)clientQueue
-      launcUrlRequestSentHandler:(nullable void (^)(bool))launcUrlRequestSentHandler
+     launchUrlRequestSentHandler:(nullable void (^)(bool))launchUrlRequestSentHandler
 {
     ChipLogProgress(AppServer, "CastingServerBridge().contentLauncherLaunchUrl() called");
 
@@ -184,7 +184,7 @@
             = CastingServer::GetInstance()->ContentLauncherLaunchURL([contentUrl UTF8String], [contentDisplayStr UTF8String],
                 [&launchUrlResponseCallback](CHIP_ERROR err) { launchUrlResponseCallback(CHIP_NO_ERROR == err); });
         dispatch_async(clientQueue, ^{
-            launcUrlRequestSentHandler(CHIP_NO_ERROR == err);
+            launchUrlRequestSentHandler(CHIP_NO_ERROR == err);
         });
     });
 }

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		3C7507B92853EFF000D7DB3A /* CommissioningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */; };
 		3C7507BC2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507BB2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm */; };
 		3C9ACC05284ABF4000718B2D /* libTvCastingCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */; };
+		3CA19435285BA780004768D5 /* ContentLauncherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA19434285BA780004768D5 /* ContentLauncherView.swift */; };
+		3CA19437285BA877004768D5 /* ContentLauncherViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA19436285BA877004768D5 /* ContentLauncherViewModel.swift */; };
 		3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */; };
 		3CC0E8FC2841DD3400EC6A18 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */; };
 		3CC0E8FE2841DD3500EC6A18 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 3CC0E8FD2841DD3500EC6A18 /* Assets.xcassets */; };
@@ -34,6 +36,8 @@
 		3C7507BB2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DiscoveredNodeDataConverter.mm; sourceTree = "<group>"; };
 		3C7507BD2857A72A00D7DB3A /* DiscoveredNodeDataConverter.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DiscoveredNodeDataConverter.hpp; sourceTree = "<group>"; };
 		3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libTvCastingCommon.a; path = lib/libTvCastingCommon.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3CA19434285BA780004768D5 /* ContentLauncherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLauncherView.swift; sourceTree = "<group>"; };
+		3CA19436285BA877004768D5 /* ContentLauncherViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLauncherViewModel.swift; sourceTree = "<group>"; };
 		3CC0E8F62841DD3400EC6A18 /* TvCasting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TvCasting.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TvCastingApp.swift; sourceTree = "<group>"; };
 		3CC0E8FB2841DD3400EC6A18 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -98,6 +102,8 @@
 				3C7507B62853A3AD00D7DB3A /* CommissionerDiscoveryViewModel.swift */,
 				3C7507AE28529A5F00D7DB3A /* CommissioningView.swift */,
 				3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */,
+				3CA19434285BA780004768D5 /* ContentLauncherView.swift */,
+				3CA19436285BA877004768D5 /* ContentLauncherViewModel.swift */,
 			);
 			path = TvCasting;
 			sourceTree = "<group>";
@@ -237,6 +243,8 @@
 				3C7507B92853EFF000D7DB3A /* CommissioningViewModel.swift in Sources */,
 				3C7507BC2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm in Sources */,
 				3C7507A72851188500D7DB3A /* DiscoveredNodeData.mm in Sources */,
+				3CA19437285BA877004768D5 /* ContentLauncherViewModel.swift in Sources */,
+				3CA19435285BA780004768D5 /* ContentLauncherView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -280,6 +288,7 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
+				"EXCLUDED_ARCHS[sdk=iphonesimulator*]" = arm64;
 				GCC_C_LANGUAGE_STANDARD = gnu11;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -296,7 +305,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -352,7 +361,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 15.2;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningView.swift
@@ -59,6 +59,20 @@ struct CommissioningView: View {
                 Text("Failed to open Commissioning window!")
                     .foregroundColor(Color.red)
             }
+            
+            if(viewModel.commisisoningComplete == true)
+            {
+                NavigationLink(
+                    destination: ContentLauncherView(),
+                    label: {
+                        Text("Next")
+                            .frame(width: 75, height: 30, alignment: .center)
+                            .border(Color.black, width: 1)
+                    }
+                ).background(Color.blue)
+                    .foregroundColor(Color.white)
+                    .padding()
+            }
         }
         .navigationTitle("Commissioning...")
         .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
@@ -39,7 +39,7 @@ class CommissioningViewModel: ObservableObject {
                     self.commisisoningComplete = result
                 },
                 clientQueue: DispatchQueue.main,
-                commisisoningWindowOpenedHandler: { (result: Bool) -> () in
+                commissioningWindowRequestedHandler: { (result: Bool) -> () in
                     self.commisisoningWindowOpened = result
                 })
         }

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
@@ -17,14 +17,34 @@
 
 
 import Foundation
+import os.log
 
 class CommissioningViewModel: ObservableObject {
+    let Log = Logger(subsystem: "com.matter.casting",
+                     category: "CommissioningViewModel")
+    
     @Published var udcRequestSent: Bool?;
     
     @Published var commisisoningWindowOpened: Bool?;
-    
+
+    @Published var commisisoningComplete: Bool?;
+
     func prepareForCommissioning(selectedCommissioner: DiscoveredNodeData?) {
-        // TBD: Call openBasicCommissioningWindow() and get Onboarding payload
+        if let castingServerBridge = CastingServerBridge.getSharedInstance()
+        {
+            castingServerBridge.openBasicCommissioningWindow(
+                { (result: Bool) -> () in
+                    // commissioning complete handler code
+                    self.Log.info("Commissioning status: \(result)")
+                    self.commisisoningComplete = result
+                },
+                clientQueue: DispatchQueue.main,
+                commisisoningWindowOpenedHandler: { (result: Bool) -> () in
+                    self.commisisoningWindowOpened = result
+                })
+        }
+        
+        // TBD: Get Onboarding payload
         
         // Send User directed commissioning request if a commissioner with a known IP addr was selected
         if(selectedCommissioner != nil && selectedCommissioner!.numIPs > 0)

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentLauncherView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentLauncherView.swift
@@ -1,0 +1,72 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+import SwiftUI
+
+struct ContentLauncherView: View {
+    @StateObject var viewModel = ContentLauncherViewModel()
+
+    @State private var contentUrl: String = ""
+    @State private var contentDisplayStr: String = ""
+    
+    var body: some View {
+        VStack(alignment: .leading) {
+            HStack() {
+                Text("Content URL")
+                
+                TextField(
+                    "https://www.test.com/videoid",
+                    text: $contentUrl
+                )
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .border(.secondary)
+            }
+            
+            HStack() {
+                Text("Display string")
+                
+                TextField(
+                    "Test video",
+                    text: $contentDisplayStr
+                )
+                .textInputAutocapitalization(.never)
+                .disableAutocorrection(true)
+                .border(.secondary)
+            }
+            
+            Button("Launch URL!") {
+                viewModel.launchUrl(contentUrl: contentUrl, contentDisplayStr: contentDisplayStr)
+            }
+            .background(Color.blue)
+            .foregroundColor(Color.white)
+            .cornerRadius(4)
+            .border(Color.black, width: 1)
+            .padding()
+            
+            Text(viewModel.status ?? "")
+        }
+        .navigationTitle("Content Launcher")
+        .frame(minWidth: 0, maxWidth: .infinity, minHeight: 0, maxHeight: .infinity, alignment: .top)
+    }
+}
+
+struct ContentLauncherView_Previews: PreviewProvider {
+    static var previews: some View {
+        ContentLauncherView()
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentLauncherViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentLauncherViewModel.swift
@@ -1,0 +1,56 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+
+import Foundation
+import os.log
+
+class ContentLauncherViewModel: ObservableObject {
+    let Log = Logger(subsystem: "com.matter.casting",
+                     category: "ContentLauncherViewModel")
+    
+    @Published var status: String?;
+    
+    func launchUrl(contentUrl: String?, contentDisplayStr: String?)
+    {
+        if ((contentUrl != nil && !contentUrl!.isEmpty) && (contentDisplayStr != nil && !contentDisplayStr!.isEmpty))
+        {
+            if let castingServerBridge = CastingServerBridge.getSharedInstance()
+            {
+                castingServerBridge
+                    .contentLauncherLaunchUrl(contentUrl!,
+                                              contentDisplayStr: contentDisplayStr!,
+                                              launchUrlResponseCallback:
+                                                { (result: Bool) -> () in
+                        self.Log.info("ContentLauncherViewModel.launchUrl.launchUrlResponseCallback result \(result)")
+                        self.status = result ? "Launched URL successfully" : "Launch URL failure!"
+                    },
+                                              clientQueue: DispatchQueue.main,
+                                              launcUrlRequestSentHandler:
+                                                { (result: Bool) -> () in
+                        self.Log.info("ContentLauncherViewModel.launchUrl.launcUrlRequestSentHandler result \(result)")
+                        self.status = result ? "Sent Launch URL request" : "Failed to send Launch URL request!"
+                    })
+            }
+        }
+        else
+        {
+            Log.debug("ContentLauncherViewModel.launchUrl input(s) missing!")
+            self.status = "Missing input parameter(s)!"
+        }
+    }
+}

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentLauncherViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentLauncherViewModel.swift
@@ -40,7 +40,7 @@ class ContentLauncherViewModel: ObservableObject {
                         self.status = result ? "Launched URL successfully" : "Launch URL failure!"
                     },
                                               clientQueue: DispatchQueue.main,
-                                              launcUrlRequestSentHandler:
+                                              launchUrlRequestSentHandler:
                                                 { (result: Bool) -> () in
                         self.Log.info("ContentLauncherViewModel.launchUrl.launcUrlRequestSentHandler result \(result)")
                         self.status = result ? "Sent Launch URL request" : "Failed to send Launch URL request!"

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentView.swift
@@ -20,7 +20,7 @@ import SwiftUI
 struct ContentView: View {
     var body: some View {
         NavigationView {
-                CommissionerDiscoveryView()
+            CommissionerDiscoveryView()
         }
     }
 }

--- a/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h
@@ -48,3 +48,6 @@
 #define CHIP_DEVICE_CONFIG_DEVICE_NAME "Test TV casting app"
 
 #define CHIP_DEVICE_CONFIG_ENABLE_PAIRING_AUTOSTART 0
+
+// Enable some test-only interaction model APIs.
+#define CONFIG_BUILD_FOR_HOST_UNIT_TEST 1


### PR DESCRIPTION
#### Problem
iOS TvCasting app does not have implementation for opening commissioning window or sending a content launch request.

#### Change overview
1. Added ContentLauncherView and ViewModel.
2. Added CastingServerBridge implementations to openBasicCommissioningWindow and send ContentLaunch by URL requests
3. Other fixes: Updated examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h with a flag to fix a compilation issue (no member named "AddRequestDataNoTimedCheck," "SendSubscribeRequestWithoutValidation.") Also, update to pbxproj file to allow debug build on a arm64 M1 mac.

#### Testing
Built and run on iOS simulator that displays the following view for Content Launcher (End-to-end test for this is pending)

<img src="https://user-images.githubusercontent.com/31142146/174671278-5d06194b-e066-41a3-8645-1ead883d95a1.png" width="278" height="600">
