### PR TITLE
[android] Add Soft-AP scanning using Android Wi-Fi Manager APIs.

### DIFF
--- a/src/android/CHIPTool/app/src/main/AndroidManifest.xml
+++ b/src/android/CHIPTool/app/src/main/AndroidManifest.xml
@@ -9,6 +9,8 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
     <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+    <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
+    <uses-permission android:name="android.permission.CHANGE_WIFI_STATE" />
     <uses-permission android:name="android.permission.NFC" />
 
     <application

--- a/src/android/CHIPTool/app/src/main/res/layout/address_commissioning_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/address_commissioning_fragment.xml
@@ -85,6 +85,24 @@
       app:layout_constraintTop_toBottomOf="@id/address_commissioning_fragment_flow">
 
     <Button
+        android:id="@+id/wifiScanBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/wifi_scan_btn_text"/>
+
+    <Spinner
+        android:id="@+id/wifiScanListSpinner"
+        android:padding="8dp"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content" />
+
+    <Button
+        android:id="@+id/wifiConnectBtn"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/wifi_connect_btn_text"/>
+
+    <Button
         android:id="@+id/discoverBtn"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -39,6 +39,7 @@
     <string name="enter_pincode_label_text">Pincode</string>
     <string name="commission_btn_text">Commission</string>
     <string name="dns_discover_btn_text">Discover</string>
+    <string name="wifi_scan_btn_text">Wi-Fi Scan</string>
 
     <string name="send_command_on_btn_text">On</string>
     <string name="send_command_off_btn_text">Off</string>
@@ -163,4 +164,5 @@
     <string name="select_a_command">Select a command</string>
     <string name="select_a_cluster">Select a cluster</string>
     <string name="endpoint_name">Endpoint: </string>
+    <string name="wifi_connect_btn_text">Connect</string>
 </resources>


### PR DESCRIPTION
#### Problem

* Support Soft-AP Scan and Connect in CHIPTool

#### Change overview

* After Wi-Fi AP list has been populated in the spinner
  * The user can select one from the spinner and connect to it.
  * Support OPEN authentication, no key management, and no encryption.

* After connected to the selected Wi-Fi AP
  * The user can then 'DISCOVER' the services around.

* After an IP address and its discriminator has been received
  * The user can 'COMMISSION' the device.

#### Testing

This change was tested partially (scan, connect, discover) with platform under porting and haven't been in the public.
However, the Wi-Fi Manager related code should be independent of chipsets and can be used with other Soft-AP based solutions that I don't have on hand.
