### PR TITLE
Truncate the branch info of the software version string while the total length greater equal to 64 bytes.

### DIFF
--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -65,6 +65,9 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
 
     # Indication that the CHIP data model is included
     chip_enable_data_model = false
+
+    # The string of device software version was built.
+    chip_device_config_device_software_version_string = ""
   }
 
   if (chip_stack_lock_tracking == "auto") {
@@ -253,6 +256,10 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
         "CHIP_DEVICE_LAYER_TARGET_ZEPHYR=1",
         "CHIP_DEVICE_LAYER_TARGET=Zephyr",
       ]
+    }
+
+    if (chip_device_config_device_software_version_string != "") {
+      defines += [ "CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING=\"${chip_device_config_device_software_version_string}\"" ]
     }
   }
 } else if (chip_device_platform == "none") {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* When the software version string provided by chef >= 64 bytes, then it's too large to put in the software_version_string field.  

#### Change overview
Therefore, let's put the truncated branch info so that it could fit in the 64 bytes limitation(and keep commit_id be a completed 40 bytes sha1 value).
And we also create a new option for this filling version behavior to make his build nondeterminism stamp not by default.

#### Testing
Testing on linux sample app of chef build, the build command is as below.

$ cd examples/chef.py
$ ./chef.py --bootstrap_zap
$ ./chef.py -zbra -t linux -d rootnode_dimmablelight_gY80DaqEUL

And use rpc console to getDeviceInfo to check the value of software version string.
