### PR TITLE
remove duplicate str encode in py SetWiFiCredentials

### DIFF
--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -345,7 +345,7 @@ class ChipDeviceController():
 
         return self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetWiFiCredentials(
-                ssid.encode("utf-8"), credentials.encode("utf-8"))
+                ssid, credentials)
         )
 
     def SetThreadOperationalDataset(self, threadOperationalDataset):


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #16678 , str encode duplicate in https://github.com/project-chip/connectedhomeip/blob/master/src/controller/python/chip-device-ctrl.py#L951 and https://github.com/project-chip/connectedhomeip/blob/master/src/controller/python/chip/ChipDeviceCtrl.py#L348
#### Change overview
What's in this PR
remove duplicate str encode

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
As this is part of the wifi configuration, it needs to be tested manually in python chip device ctrl.
