### PR TITLE
[Ameba] Handle WiFi-Diagnostic events and add SupportsWatermarks

### DIFF
--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -35,6 +35,7 @@
 #include <platform/Ameba/AmebaUtils.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
 #include <platform/internal/BLEManager.h>
+#include <platform/DiagnosticDataProvider.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -584,6 +585,12 @@ void ConnectivityManagerImpl::OnStationConnected()
     event.Type                          = DeviceEventType::kWiFiConnectivityChange;
     event.WiFiConnectivityChange.Result = kConnectivity_Established;
     PlatformMgr().PostEventOrDie(&event);
+    WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
+
+    if (delegate)
+    {
+        delegate->OnConnectionStatusChanged(chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kConnected));
+    }
 
     UpdateInternetConnectivityState();
 }
@@ -595,6 +602,42 @@ void ConnectivityManagerImpl::OnStationDisconnected()
     event.Type                          = DeviceEventType::kWiFiConnectivityChange;
     event.WiFiConnectivityChange.Result = kConnectivity_Lost;
     PlatformMgr().PostEventOrDie(&event);
+    WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
+    uint16_t reason = NetworkCommissioning::AmebaWiFiDriver::GetInstance().GetLastDisconnectReason();
+    uint8_t associationFailureCause = chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kUnknown);
+
+    if (delegate)
+    {
+        switch (reason)
+        {
+            case RTW_NO_ERROR:
+            case RTW_NONE_NETWORK:
+                associationFailureCause = chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kSsidNotFound);
+                delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+                break;
+            case RTW_CONNECT_FAIL:
+                associationFailureCause = chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAssociationFailed);
+                delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+                break;
+            case RTW_WRONG_PASSWORD:
+                associationFailureCause = chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAuthenticationFailed);
+                delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+                break;
+#if defined(CONFIG_PLATFORM_8710C)
+            case RTW_4WAY_HANDSHAKE_TIMEOUT:
+#endif
+            case RTW_DHCP_FAIL:
+            case RTW_UNKNOWN:
+                break;
+
+            default:
+                delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+                break;
+        }
+        delegate->OnDisconnectionDetected(reason);
+        delegate->OnConnectionStatusChanged(chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kNotConnected));
+    }
+
 
     UpdateInternetConnectivityState();
 }

--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -34,8 +34,8 @@
 
 #include <platform/Ameba/AmebaUtils.h>
 #include <platform/Ameba/NetworkCommissioningDriver.h>
-#include <platform/internal/BLEManager.h>
 #include <platform/DiagnosticDataProvider.h>
+#include <platform/internal/BLEManager.h>
 #include <support/CodeUtils.h>
 #include <support/logging/CHIPLogging.h>
 
@@ -589,7 +589,8 @@ void ConnectivityManagerImpl::OnStationConnected()
 
     if (delegate)
     {
-        delegate->OnConnectionStatusChanged(chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kConnected));
+        delegate->OnConnectionStatusChanged(
+            chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kConnected));
     }
 
     UpdateInternetConnectivityState();
@@ -603,41 +604,45 @@ void ConnectivityManagerImpl::OnStationDisconnected()
     event.WiFiConnectivityChange.Result = kConnectivity_Lost;
     PlatformMgr().PostEventOrDie(&event);
     WiFiDiagnosticsDelegate * delegate = GetDiagnosticDataProvider().GetWiFiDiagnosticsDelegate();
-    uint16_t reason = NetworkCommissioning::AmebaWiFiDriver::GetInstance().GetLastDisconnectReason();
-    uint8_t associationFailureCause = chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kUnknown);
+    uint16_t reason                    = NetworkCommissioning::AmebaWiFiDriver::GetInstance().GetLastDisconnectReason();
+    uint8_t associationFailureCause =
+        chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kUnknown);
 
     if (delegate)
     {
         switch (reason)
         {
-            case RTW_NO_ERROR:
-            case RTW_NONE_NETWORK:
-                associationFailureCause = chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kSsidNotFound);
-                delegate->OnAssociationFailureDetected(associationFailureCause, reason);
-                break;
-            case RTW_CONNECT_FAIL:
-                associationFailureCause = chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAssociationFailed);
-                delegate->OnAssociationFailureDetected(associationFailureCause, reason);
-                break;
-            case RTW_WRONG_PASSWORD:
-                associationFailureCause = chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAuthenticationFailed);
-                delegate->OnAssociationFailureDetected(associationFailureCause, reason);
-                break;
+        case RTW_NO_ERROR:
+        case RTW_NONE_NETWORK:
+            associationFailureCause =
+                chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kSsidNotFound);
+            delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+            break;
+        case RTW_CONNECT_FAIL:
+            associationFailureCause =
+                chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAssociationFailed);
+            delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+            break;
+        case RTW_WRONG_PASSWORD:
+            associationFailureCause =
+                chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::AssociationFailureCause::kAuthenticationFailed);
+            delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+            break;
 #if defined(CONFIG_PLATFORM_8710C)
-            case RTW_4WAY_HANDSHAKE_TIMEOUT:
+        case RTW_4WAY_HANDSHAKE_TIMEOUT:
 #endif
-            case RTW_DHCP_FAIL:
-            case RTW_UNKNOWN:
-                break;
+        case RTW_DHCP_FAIL:
+        case RTW_UNKNOWN:
+            break;
 
-            default:
-                delegate->OnAssociationFailureDetected(associationFailureCause, reason);
-                break;
+        default:
+            delegate->OnAssociationFailureDetected(associationFailureCause, reason);
+            break;
         }
         delegate->OnDisconnectionDetected(reason);
-        delegate->OnConnectionStatusChanged(chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kNotConnected));
+        delegate->OnConnectionStatusChanged(
+            chip::to_underlying(chip::app::Clusters::WiFiNetworkDiagnostics::WiFiConnectionStatus::kNotConnected));
     }
-
 
     UpdateInternetConnectivityState();
 }

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.h
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.h
@@ -37,6 +37,7 @@ public:
 
     // ===== Methods that implement the PlatformManager abstract interface.
 
+    bool SupportsWatermarks() override { return true; }
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;


### PR DESCRIPTION
#### Problem
- Need to handle WiFi-Diagnostics events
- ResetWatermark is supported but feature-map is 0

#### Change overview
- Handle WiFi events
- Add SupportsWatermarks method which will return true

#### Testing
- WiFi event tested using `./chip-tool wifinetworkdiagnostics read-event connection-status 1 0`
- Read feature map `./chip-tool softwarediagnostics read feature-map 1  0` returns 1
