### PR TITLE
Remove event-loop variant to Darwin/Linux tests

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
         strategy:
             matrix:
                 build_variant: [no-ble-tsan-clang]
-                chip_tool: ["", -same-event-loop]
+                chip_tool: [""]
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
@@ -126,7 +126,7 @@ jobs:
         strategy:
             matrix:
                 build_variant: [no-ble-tsan-clang, no-ble-asan-clang]
-                chip_tool: ["", -same-event-loop]
+                chip_tool: [""]
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}


### PR DESCRIPTION
#### Problem

Darwin and Linux tests both run tests on two variants of chip-tool - one that has everything running on the same event-loop and one that has it running on separate event/threading contexts.

Doing both is overkill, and for the purposes of TSAN, just having the one with separate threading contexts is sufficient.

#### Solution

Remove the `-same-event-loop` matrix variant.