### PR TITLE
Fix incorrect return codes in door lock cluster

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -21,32 +21,34 @@ from .test_definition import ApplicationPaths, TestDefinition, TestTarget
 
 
 def target_for_name(name: str):
-    if name.startswith('TV_') or name.startswith('Test_TC_MC_'):
+    if name.startswith("TV_") or name.startswith("Test_TC_MC_"):
         return TestTarget.TV
-    if name.startswith('DL_') or name.startswith('Test_TC_DL_'):
+    if name.startswith("DL_") or name.startswith("Test_TC_DLRK_"):
         return TestTarget.LOCK
-    if name.startswith('OTA_'):
+    if name.startswith("OTA_"):
         return TestTarget.OTA
     return TestTarget.ALL_CLUSTERS
 
 
 def tests_with_command(chip_tool: str, is_manual: bool):
     """Executes `chip_tool` binary to see what tests are available, using cmd
-       to get the list.
+    to get the list.
     """
-    cmd = 'list'
+    cmd = "list"
     if is_manual:
-        cmd += '-manual'
+        cmd += "-manual"
 
-    result = subprocess.run([chip_tool, 'tests', cmd], capture_output=True)
+    result = subprocess.run([chip_tool, "tests", cmd], capture_output=True)
 
-    for name in result.stdout.decode('utf8').split('\n'):
+    for name in result.stdout.decode("utf8").split("\n"):
         if not name:
             continue
 
         target = target_for_name(name)
 
-        yield TestDefinition(run_name=name, name=name, target=target, is_manual=is_manual)
+        yield TestDefinition(
+            run_name=name, name=name, target=target, is_manual=is_manual
+        )
 
 
 def AllTests(chip_tool: str):
@@ -58,6 +60,10 @@ def AllTests(chip_tool: str):
 
 
 __all__ = [
-    'TestTarget', 'TestDefinition', 'AllTests', 'ApplicationPaths',
-    'linux', 'runner',
+    "TestTarget",
+    "TestDefinition",
+    "AllTests",
+    "ApplicationPaths",
+    "linux",
+    "runner",
 ]

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -819,7 +819,7 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - user does not exist "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d]",
                                       endpointId, weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
 
@@ -912,7 +912,7 @@ void DoorLockServer::GetWeekDayScheduleCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[GetWeekDaySchedule] User does not exist [endpointId=%d,weekDayIndex=%d,userIndex=%d]",
                                       endpointId, weekDayIndex, userIndex);
-        sendGetWeekDayScheduleResponse(commandObj, commandPath, weekDayIndex, userIndex, DlStatus::kNotFound);
+        sendGetWeekDayScheduleResponse(commandObj, commandPath, weekDayIndex, userIndex, DlStatus::kFailure);
         return;
     }
 
@@ -974,7 +974,7 @@ void DoorLockServer::ClearWeekDayScheduleCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[ClearWeekDaySchedule] User does not exist [endpointId=%d,weekDayIndex=%d,userIndex=%d]",
                                       endpointId, weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
 
@@ -1057,7 +1057,7 @@ void DoorLockServer::SetYearDayScheduleCommandHandler(
         emberAfDoorLockClusterPrintln("[SetYearDaySchedule] Unable to add schedule - user does not exist "
                                       "[endpointId=%d,yearDayIndex=%d,userIndex=%d]",
                                       endpointId, yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
 
@@ -1122,7 +1122,7 @@ void DoorLockServer::GetYearDayScheduleCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[GetYearDaySchedule] User does not exist [endpointId=%d,yearDayIndex=%d,userIndex=%d]",
                                       endpointId, yearDayIndex, userIndex);
-        sendGetYearDayScheduleResponse(commandObj, commandPath, yearDayIndex, userIndex, DlStatus::kNotFound);
+        sendGetYearDayScheduleResponse(commandObj, commandPath, yearDayIndex, userIndex, DlStatus::kFailure);
         return;
     }
 
@@ -1183,7 +1183,7 @@ void DoorLockServer::ClearYearDayScheduleCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[ClearYearDaySchedule] User does not exist [endpointId=%d,yearDayIndex=%d,userIndex=%d]",
                                       endpointId, yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
 

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -117,45 +117,6 @@ public:
     bool GetNumberOfCredentialsSupportedPerUser(chip::EndpointId endpointId, uint8_t & numberOfCredentialsSupportedPerUser);
     bool GetNumberOfHolidaySchedulesSupported(chip::EndpointId endpointId, uint8_t & numberOfHolidaySchedules);
 
-    void SetUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                               const chip::app::Clusters::DoorLock::Commands::SetUser::DecodableType & commandData);
-
-    void GetUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                               const chip::app::Clusters::DoorLock::Commands::GetUser::DecodableType & commandData);
-
-    void ClearUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                 const chip::app::Clusters::DoorLock::Commands::ClearUser::DecodableType & commandData);
-
-    void SetCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                     const chip::app::Clusters::DoorLock::Commands::SetCredential::DecodableType & commandData);
-
-    void GetCredentialStatusCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::DecodableType & commandData);
-
-    void ClearCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                       const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData);
-
-    void SetWeekDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::DecodableType & commandData);
-    void GetWeekDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::DecodableType & commandData);
-    void ClearWeekDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::DecodableType & commandData);
-
-    void SetYearDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::DecodableType & commandData);
-    void GetYearDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::DecodableType & commandData);
-    void ClearYearDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::DecodableType & commandData);
-
     bool HasFeature(chip::EndpointId endpointId, DoorLockFeature feature);
 
     inline bool SupportsPIN(chip::EndpointId endpointId) { return HasFeature(endpointId, DoorLockFeature::kPINCredentials); }
@@ -263,10 +224,12 @@ private:
     bool clearFabricFromCredentials(chip::EndpointId endpointId, DlCredentialType credentialType, chip::FabricIndex fabricToRemove);
     bool clearFabricFromCredentials(chip::EndpointId endpointId, chip::FabricIndex fabricToRemove);
 
-    CHIP_ERROR sendSetCredentialResponse(chip::app::CommandHandler * commandObj, DlStatus status, uint16_t userIndex,
-                                         uint16_t nextCredentialIndex);
+    void sendSetCredentialResponse(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                   DlStatus status, uint16_t userIndex, uint16_t nextCredentialIndex);
 
     // TODO: Maybe use CHIP_APPLICATION_ERROR instead of boolean in class methods?
+    // OPTIMIZE: there are a lot of methods such as this that could be made static which could help reduce the stack footprint
+    // in case of multiple lock endpoints
     bool credentialTypeSupported(chip::EndpointId endpointId, DlCredentialType type);
 
     bool weekDayIndexValid(chip::EndpointId endpointId, uint8_t weekDayIndex);
@@ -304,14 +267,57 @@ private:
 
     DlLockDataType credentialTypeToLockDataType(DlCredentialType credentialType);
 
-    void setHolidaySchedule(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                            uint8_t holidayIndex, uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode);
+    void setUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                               const chip::app::Clusters::DoorLock::Commands::SetUser::DecodableType & commandData);
 
-    void getHolidaySchedule(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                            uint8_t holidayIndex);
+    void getUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                               uint16_t userIndex);
 
-    void clearHolidaySchedule(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                              uint8_t holidayIndex);
+    void clearUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                 uint16_t userIndex);
+
+    void setCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                     const chip::app::Clusters::DoorLock::Commands::SetCredential::DecodableType & commandData);
+
+    void getCredentialStatusCommandHandler(chip::app::CommandHandler * commandObj,
+                                           const chip::app::ConcreteCommandPath & commandPath, DlCredentialType credentialType,
+                                           uint16_t credentialIndex);
+
+    void clearCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                       const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData);
+
+    void setWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                          uint16_t userIndex, const chip::BitMask<DlDaysMaskMap> & daysMask, uint8_t startHour,
+                                          uint8_t startMinute, uint8_t endHour, uint8_t endMinute);
+
+    void getWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                          uint16_t userIndex);
+
+    void clearWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                            const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                            uint16_t userIndex);
+
+    void setYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                          uint16_t userIndex, uint32_t localStartTime, uint32_t localEndTime);
+    void getYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                          uint16_t userIndex);
+    void clearYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                            const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                            uint16_t userIndex);
+
+    void setHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex,
+                                          uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode);
+
+    void getHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex);
+
+    void clearHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                            const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex);
 
     bool RemoteOperationEnabled(chip::EndpointId endpointId) const;
 
@@ -323,8 +329,8 @@ private:
      * @param opType        remote operation type (lock, unlock)
      * @param opHandler     plugin handler for specified command
      * @param pinCode       pin code passed by client
-     * @return true         if locking/unlocking was successfull
-     * @return false        if error happenned during lock/unlock
+     * @return true         if locking/unlocking was successful
+     * @return false        if error happened during lock/unlock
      */
     bool HandleRemoteLockOperation(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                    DlLockOperationType opType, RemoteLockOpHandler opHandler,
@@ -342,7 +348,7 @@ private:
      * @param nodeId        node id
      * @param credList      list of credentials used in lock operation (can be NULL if no credentials were used)
      * @param credListSize  size of credentials list (if 0, then no credentials were used)
-     * @param opSuccess     flags if operation was successfull or not
+     * @param opSuccess     flags if operation was successful or not
      */
     void SendLockOperationEvent(chip::EndpointId endpointId, DlLockOperationType opType, DlOperationSource opSource,
                                 DlOperationError opErr, const Nullable<uint16_t> & userId,
@@ -423,6 +429,57 @@ private:
     friend bool emberAfDoorLockClusterClearHolidayScheduleCallback(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
         const chip::app::Clusters::DoorLock::Commands::ClearHolidaySchedule::DecodableType & commandData);
+
+    friend bool
+    emberAfDoorLockClusterSetUserCallback(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath,
+                                          const chip::app::Clusters::DoorLock::Commands::SetUser::DecodableType & commandData);
+
+    friend bool
+    emberAfDoorLockClusterGetUserCallback(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath,
+                                          const chip::app::Clusters::DoorLock::Commands::GetUser::DecodableType & commandData);
+
+    friend bool
+    emberAfDoorLockClusterClearUserCallback(chip::app::CommandHandler * commandObj,
+                                            const chip::app::ConcreteCommandPath & commandPath,
+                                            const chip::app::Clusters::DoorLock::Commands::ClearUser::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterSetCredentialCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::SetCredential::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterGetCredentialStatusCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterClearCredentialCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterSetWeekDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterGetWeekDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterClearWeekDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterSetYearDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterGetYearDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterClearYearDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::DecodableType & commandData);
 
     EmberEventControl AutolockEvent; /**< for automatic relock scheduling */
 

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -154,7 +154,7 @@ private:
     bool credentialIndexValid(chip::EndpointId endpointId, DlCredentialType type, uint16_t credentialIndex);
     bool credentialIndexValid(chip::EndpointId endpointId, DlCredentialType type, uint16_t credentialIndex,
                               uint16_t & maxNumberOfCredentials);
-    bool getCredentialRange(chip::EndpointId endpointId, DlCredentialType type, size_t & minSize, size_t & maxSize);
+    DlStatus credentialLengthWithinRange(chip::EndpointId endpointId, DlCredentialType type, const chip::ByteSpan & credentialData);
     bool getMaxNumberOfCredentials(chip::EndpointId endpointId, DlCredentialType credentialType, uint16_t & maxNumberOfCredentials);
 
     bool findOccupiedUserSlot(chip::EndpointId endpointId, uint16_t startIndex, uint16_t & userIndex);

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -38,7 +38,7 @@ tests:
       response:
           value: 2
 
-    - label: "Try to unlock the door without a PIN"
+    - label: "Try to lock the door without a PIN"
       command: "LockDoor"
       timedInteractionTimeoutMs: 10000
 

--- a/src/app/tests/suites/DL_Schedules.yaml
+++ b/src/app/tests/suites/DL_Schedules.yaml
@@ -192,7 +192,7 @@ tests:
               - name: "endMinute"
                 value: 00
       response:
-          error: NOT_FOUND
+          error: FAILURE
 
     - label: "Create Week Day schedule with 0 days mask"
       command: "SetWeekDaySchedule"
@@ -488,7 +488,7 @@ tests:
               - name: "userIndex"
                 value: 2
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     #
     # Excercise SetYearDay schedules with invalid parameters
@@ -566,7 +566,7 @@ tests:
               - name: "localEndTime"
                 value: 12345689
       response:
-          error: NOT_FOUND
+          error: FAILURE
 
     - label: "Create Year Day schedule with start hour later that end hour"
       command: "SetYearDaySchedule"
@@ -581,7 +581,7 @@ tests:
               - name: "localEndTime"
                 value: 12345688
       response:
-          error: INVALID_FIELD
+          error: INVALID_COMMAND
 
     - label: "Make sure that previous operations did not create a schedule"
       command: "GetYearDaySchedule"
@@ -686,7 +686,7 @@ tests:
               - name: "userIndex"
                 value: 2
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     #
     # Excercise Set Holiday schedules with invalid parameters
@@ -962,7 +962,7 @@ tests:
               - name: "userIndex"
                 value: 2
       response:
-          error: NOT_FOUND
+          error: FAILURE
 
     - label: "Make sure that week day schedule was not deleted"
       command: "GetWeekDaySchedule"
@@ -1087,7 +1087,7 @@ tests:
               - name: "userIndex"
                 value: 2
       response:
-          error: NOT_FOUND
+          error: FAILURE
 
     - label: "Make sure that week day schedule was not deleted"
       command: "GetWeekDaySchedule"
@@ -1799,7 +1799,7 @@ tests:
               - name: "userIndex"
                 value: 1
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     - label: "Make sure clearing first user also cleared year day schedules"
       command: "GetYearDaySchedule"
@@ -1816,7 +1816,7 @@ tests:
               - name: "userIndex"
                 value: 1
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     - label: "Make sure clearing second user also cleared week day schedules"
       command: "GetWeekDaySchedule"
@@ -1833,7 +1833,7 @@ tests:
               - name: "userIndex"
                 value: 2
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     - label: "Make sure clearing second user also cleared year day schedules"
       command: "GetYearDaySchedule"
@@ -1850,7 +1850,7 @@ tests:
               - name: "userIndex"
                 value: 2
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     # Make sure that all the manipulations did not affect the holiday schedules
     - label: "Make sure that first holiday schedule was not deleted"

--- a/src/app/tests/suites/certification/Test_TC_DLRK_2_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DLRK_2_7.yaml
@@ -181,8 +181,7 @@ tests:
                     hasValue: false
 
     - label:
-          "send Get Year Day Schedule Command to DUT and verify FAILURE
-          response"
+          "send Get Year Day Schedule Command to DUT and verify FAILURE response"
       command: "GetYearDaySchedule"
       arguments:
           values:

--- a/src/app/tests/suites/certification/Test_TC_DLRK_2_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DLRK_2_7.yaml
@@ -181,7 +181,7 @@ tests:
                     hasValue: false
 
     - label:
-          "send Get Year Day Schedule Command to DUT and verify NOT_FOUND
+          "send Get Year Day Schedule Command to DUT and verify FAILURE
           response"
       command: "GetYearDaySchedule"
       arguments:
@@ -197,7 +197,7 @@ tests:
               - name: "userIndex"
                 value: 5
               - name: "status"
-                value: 0x8B
+                value: 0x01
               - name: "LocalStartTime"
                 constraints:
                     hasValue: false

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -57169,7 +57169,7 @@ private:
                                  chip::NullOptional);
         }
         case 3: {
-            LogStep(3, "Try to unlock the door without a PIN");
+            LogStep(3, "Try to lock the door without a PIN");
             ListFreer listFreer;
             chip::app::Clusters::DoorLock::Commands::LockDoor::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), DoorLock::Id, DoorLock::Commands::LockDoor::Id, value,
@@ -57420,7 +57420,7 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
             break;
         case 10:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
@@ -57519,7 +57519,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 2U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 26:
@@ -57535,10 +57535,10 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
             break;
         case 30:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 31:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_COMMAND));
             break;
         case 32:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -57610,7 +57610,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 2U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 38:
@@ -57742,7 +57742,7 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
             break;
         case 55:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 56:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -57821,7 +57821,7 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
             break;
         case 63:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 64:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -58314,7 +58314,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 1U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 104:
@@ -58326,7 +58326,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 1U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 105:
@@ -58338,7 +58338,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 2U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 106:
@@ -58350,7 +58350,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 2U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 107:
@@ -61211,7 +61211,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 5U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
 
                 VerifyOrReturn(CheckConstraintHasValue("value.localStartTime", value.localStartTime, false));
 
@@ -61372,7 +61372,7 @@ private:
             );
         }
         case 9: {
-            LogStep(9, "send Get Year Day Schedule Command to DUT and verify NOT_FOUND response");
+            LogStep(9, "send Get Year Day Schedule Command to DUT and verify FAILURE response");
             ListFreer listFreer;
             chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type value;
             value.yearDayIndex = 10U;


### PR DESCRIPTION
#### Problem
* Fixes #19622
* Fixes #19563

#### Change overview
* Now door lock cluster returns generic failure instead of NOT_FOUND when working with Week Day/Year Day credentials.
* Door lock now checks the enum ranges for Set Credential, Set User and Set Holiday Schedule commands.
* Refactor the door lock cluster a little bit

#### Testing
* Run DL_LockUnlock, DL_Schedules and DL_UsersAndCredentials tests
* Run commands from linked issues to make sure they return appropriate error codes
