### PR TITLE
[IM] Support 3 subs / fabric (as per spec)

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -797,11 +797,9 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  *
  * The default value comes from 3sub per fabric * max number of fabrics.
  *
- * TODO: (#17085) Should be changed to (CHIP_CONFIG_MAX_FABRICS * 3) after we can hold more read handlers on more concise
- * devices.
  */
 #ifndef CHIP_IM_MAX_NUM_SUBSCRIPTIONS
-#define CHIP_IM_MAX_NUM_SUBSCRIPTIONS (CHIP_CONFIG_MAX_FABRICS * 2)
+#define CHIP_IM_MAX_NUM_SUBSCRIPTIONS (CHIP_CONFIG_MAX_FABRICS * 3)
 #endif
 
 /**


### PR DESCRIPTION
#### Problem

The default value for `CHIP_IM_MAX_NUM_SUBSCRIPTIONS` still indicates support for just 2 subs / fabric, which is not compliant with the spec.

This was originally done due to the `ReadHandler` being too big to fit on memory constrained devices. Since #18072 went in, let's try to see if we can bump it up to the spec mandated value.

#### Solution

Attempt to set it to 3, and see if builds pass.