### PR TITLE
Bump timeout for building Darwin test apps in Tests job.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -176,7 +176,7 @@ jobs:
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
             - name: Build Apps
-              timeout-minutes: 30
+              timeout-minutes: 40
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \


### PR DESCRIPTION
We're hitting the 30-minute timout a fair amount.

#### Problem
Intermittent timeouts.

#### Change overview
Increase timeout.

#### Testing
CI.