### PR TITLE
[Ameba] Add descriptor service into RPC

### DIFF
--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -51,6 +51,17 @@ pw_proto_library(button_service
     pw_protobuf.common_proto
 )
 
+pw_proto_library(descriptor_service
+  SOURCES
+    ${chip_dir}/examples/common/pigweed/protos/descriptor_service.proto
+  PREFIX
+    descriptor_service
+  STRIP_PREFIX
+    ${chip_dir}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
 pw_proto_library(device_service
   SOURCES
     ${chip_dir}/examples/common/pigweed/protos/device_service.proto
@@ -202,6 +213,7 @@ if (matter_enable_rpc)
 target_link_libraries(${chip_main} PUBLIC
     attributes_service.nanopb_rpc
     button_service.nanopb_rpc
+    descriptor_service.nanopb_rpc
     device_service.nanopb_rpc
     lighting_service.nanopb_rpc
     locking_service.nanopb_rpc
@@ -240,6 +252,7 @@ list(
 
     -DPW_RPC_ATTRIBUTE_SERVICE=1
     -DPW_RPC_BUTTON_SERVICE=1
+    -DPW_RPC_DESCRIPTOR_SERVICE=1
     -DPW_RPC_DEVICE_SERVICE=1
     -DPW_RPC_LIGHTING_SERVICE=1
     -DPW_RPC_LOCKING_SERVICE=1

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -8,7 +8,122 @@ set(dir "${sdk_root}/component/common/api")
 set(chip_main chip_main)
 set(list_chip_main_sources chip_main_sources)
 
+if (matter_enable_rpc)
+set(pigweed_dir "${chip_dir}/third_party/pigweed/repo")
+
+include(${pigweed_dir}/pw_build/pigweed.cmake)
+include(${pigweed_dir}/pw_protobuf_compiler/proto.cmake)
+
+set(dir_pw_third_party_nanopb "${chip_dir}/third_party/nanopb/repo" CACHE STRING "" FORCE)
+
+pw_set_module_config(pw_rpc_CONFIG pw_rpc.disable_global_mutex_config)
+pw_set_backend(pw_log pw_log_basic)
+pw_set_backend(pw_assert.check pw_assert_log.check_backend)
+pw_set_backend(pw_assert.assert pw_assert.assert_compatibility_backend)
+pw_set_backend(pw_sys_io pw_sys_io.ameba)
+pw_set_backend(pw_trace pw_trace_tokenized)
+
+add_subdirectory(${chip_dir}/third_party/pigweed/repo ${chip_dir}/examples/lighting-app/ameba/out/pigweed)
+add_subdirectory(${chip_dir}/third_party/nanopb/repo ${chip_dir}/examples/lighting-app/ameba/out/nanopb)
+add_subdirectory(${chip_dir}/examples/platform/ameba/pw_sys_io ${chip_dir}/examples/lighting-app/ameba/out/pw_sys_io)
+
+pw_proto_library(attributes_service
+  SOURCES
+    ${chip_dir}/examples/common/pigweed/protos/attributes_service.proto
+  INPUTS
+    ${chip_dir}/examples/common/pigweed/protos/attributes_service.options
+  PREFIX
+    attributes_service
+  STRIP_PREFIX
+    ${chip_dir}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
+pw_proto_library(button_service
+  SOURCES
+    ${chip_dir}/examples/common/pigweed/protos/button_service.proto
+  PREFIX
+    button_service
+  STRIP_PREFIX
+    ${chip_dir}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
+pw_proto_library(descriptor_service
+  SOURCES
+    ${chip_dir}/examples/common/pigweed/protos/descriptor_service.proto
+  PREFIX
+    descriptor_service
+  STRIP_PREFIX
+    ${chip_dir}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
+pw_proto_library(device_service
+  SOURCES
+    ${chip_dir}/examples/common/pigweed/protos/device_service.proto
+  INPUTS
+    ${chip_dir}/examples/common/pigweed/protos/device_service.options
+  PREFIX
+    device_service
+  STRIP_PREFIX
+    ${chip_dir}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
+pw_proto_library(lighting_service
+  SOURCES
+    ${chip_dir}/examples/common/pigweed/protos/lighting_service.proto
+  PREFIX
+    lighting_service
+  STRIP_PREFIX
+    ${chip_dir}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
+pw_proto_library(locking_service
+  SOURCES
+    ${chip_dir}/examples/common/pigweed/protos/locking_service.proto
+  PREFIX
+    locking_service
+  STRIP_PREFIX
+    ${chip_dir}/examples/common/pigweed/protos
+  DEPS
+    pw_protobuf.common_proto
+)
+
+pw_proto_library(wifi_service
+  SOURCES
+    ${chip_dir}/examples/common/pigweed/protos/wifi_service.proto
+  INPUTS
+    ${chip_dir}/examples/common/pigweed/protos/wifi_service.options
+  PREFIX
+    wifi_service
+  DEPS
+    pw_protobuf.common_proto
+  STRIP_PREFIX
+    ${chip_dir}/examples/common/pigweed/protos
+)
+
+endif(matter_enable_rpc)
+
 include(${prj_root}/GCC-RELEASE/project_hp/asdk/includepath.cmake)
+
+if (matter_enable_rpc)
+list(
+    APPEND ${list_chip_main_sources}
+    #rpc
+    ${chip_dir}/examples/platform/ameba/PigweedLogger.cpp
+    ${chip_dir}/examples/platform/ameba/Rpc.cpp
+    ${chip_dir}/examples/common/pigweed/RpcService.cpp
+    ${chip_dir}/examples/common/pigweed/ameba/PigweedLoggerMutex.cpp
+)
+endif (matter_enable_rpc)
 
 if (matter_enable_ota_requestor)
 list(
@@ -52,6 +167,22 @@ chip_configure_data_model(chip_main
     ZAP_FILE ${matter_example_path}/../lighting-common/lighting-app.zap
 )
 
+if (matter_enable_rpc)
+target_include_directories(
+    ${chip_main}
+    PUBLIC
+    #rpc
+    ${chip_dir}/examples/platform/ameba
+    ${chip_dir}/examples/platform/ameba/pw_sys_io/public
+    ${chip_dir}/examples/common
+    ${chip_dir}/examples/common/pigweed
+    ${chip_dir}/examples/common/pigweed/ameba
+    ${chip_dir}/src
+    ${chip_dir}/src/lib/support
+    ${pigweed_dir}/pw_rpc/nanopb/public
+)
+endif (matter_enable_rpc)
+
 target_include_directories(
     ${chip_main}
     PUBLIC
@@ -77,6 +208,31 @@ target_include_directories(
     ${chip_dir}/third_party/nlunit-test/repo/src
 )
 
+if (matter_enable_rpc)
+target_link_libraries(${chip_main} PUBLIC
+    attributes_service.nanopb_rpc
+    button_service.nanopb_rpc
+    descriptor_service.nanopb_rpc
+    device_service.nanopb_rpc
+    lighting_service.nanopb_rpc
+    locking_service.nanopb_rpc
+    wifi_service.nanopb_rpc
+    pw_checksum
+    pw_hdlc
+    pw_log
+    pw_rpc.server
+    pw_trace_tokenized
+    pw_trace_tokenized.trace_buffer
+    pw_trace_tokenized.rpc_service
+    pw_trace_tokenized.protos.nanopb_rpc
+    PwRpc
+)
+
+link_directories(
+    ${chip_dir_output}/lib
+)
+endif (matter_enable_rpc)
+
 list(
     APPEND chip_main_flags
 
@@ -88,6 +244,20 @@ list(
     -DMBEDTLS_CONFIG_FILE=<mbedtls_config.h>
     -DMATTER_LIGHTING_APP=1
 )
+
+if (matter_enable_rpc)
+list(
+    APPEND chip_main_flags
+
+    -DPW_RPC_ATTRIBUTE_SERVICE=1
+    -DPW_RPC_BUTTON_SERVICE=1
+    -DPW_RPC_DESCRIPTOR_SERVICE=1
+    -DPW_RPC_DEVICE_SERVICE=1
+    -DPW_RPC_LIGHTING_SERVICE=1
+    -DPW_RPC_LOCKING_SERVICE=1
+    -DCONFIG_ENABLE_PW_RPC=1
+)
+endif (matter_enable_rpc)
 
 list(
     APPEND chip_main_cpp_flags

--- a/examples/lighting-app/ameba/main/chipinterface.cpp
+++ b/examples/lighting-app/ameba/main/chipinterface.cpp
@@ -43,6 +43,10 @@
 
 #include <lwip_netconf.h>
 
+#if CONFIG_ENABLE_PW_RPC
+#include "Rpc.h"
+#endif
+
 using namespace ::chip;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
@@ -137,6 +141,10 @@ extern "C" void ChipTest(void)
 {
     ChipLogProgress(DeviceLayer, "Lighting App Demo!");
     CHIP_ERROR err = CHIP_NO_ERROR;
+
+#if CONFIG_ENABLE_PW_RPC
+    chip::rpc::Init();
+#endif
 
     initPref();
 

--- a/examples/platform/ameba/Rpc.cpp
+++ b/examples/platform/ameba/Rpc.cpp
@@ -42,6 +42,10 @@
 #include "pigweed/rpc_services/Button.h"
 #endif // defined(PW_RPC_BUTTON_SERVICE) && PW_RPC_BUTTON_SERVICE
 
+#if defined(PW_RPC_DESCRIPTOR_SERVICE) && PW_RPC_DESCRIPTOR_SERVICE
+#include "pigweed/rpc_services/Descriptor.h"
+#endif // defined(PW_RPC_DESCRIPTOR_SERVICE) && PW_RPC_DESCRIPTOR_SERVICE
+
 #if defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE
 #include "pigweed/rpc_services/Device.h"
 #endif // defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE
@@ -104,6 +108,10 @@ Attributes attributes_service;
 AmebaButton button_service;
 #endif // defined(PW_RPC_BUTTON_SERVICE) && PW_RPC_BUTTON_SERVICE
 
+#if defined(PW_RPC_DESCRIPTOR_SERVICE) && PW_RPC_DESCRIPTOR_SERVICE
+Descriptor descriptor_service;
+#endif // defined(PW_RPC_DESCRIPTOR_SERVICE) && PW_RPC_DESCRIPTOR_SERVICE
+
 #if defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE
 AmebaDevice device_service;
 #endif // defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE
@@ -125,6 +133,10 @@ void RegisterServices(pw::rpc::Server & server)
 #if defined(PW_RPC_BUTTON_SERVICE) && PW_RPC_BUTTON_SERVICE
     server.RegisterService(button_service);
 #endif // defined(PW_RPC_BUTTON_SERVICE) && PW_RPC_BUTTON_SERVICE
+
+#if defined(PW_RPC_DESCRIPTOR_SERVICE) && PW_RPC_DESCRIPTOR_SERVICE
+    server.RegisterService(descriptor_service);
+#endif // defined(PW_RPC_DESCRIPTOR_SERVICE) && PW_RPC_DESCRIPTOR_SERVICE
 
 #if defined(PW_RPC_DEVICE_SERVICE) && PW_RPC_DEVICE_SERVICE
     server.RegisterService(device_service);


### PR DESCRIPTION
#### Problem
- Missing descriptor service in RPC
- Lighting-app missing RPC

#### Change overview
- Add descriptor service into RPC
- Add RPC into ameba lighting-app

#### Testing
Tested with rpc_console
