### PR TITLE
[nrfconnect] Added possibility to use Lock commands in all-clusters-app

### DIFF
--- a/examples/all-clusters-app/nrfconnect/CMakeLists.txt
+++ b/examples/all-clusters-app/nrfconnect/CMakeLists.txt
@@ -55,6 +55,7 @@ target_include_directories(app PRIVATE
 target_sources(app PRIVATE
                main/AppTask.cpp
                main/main.cpp
+               main/ZclDoorLockCallbacks.cpp
                ${ALL_CLUSTERS_COMMON_DIR}/src/static-supported-modes-manager.cpp
                ${ALL_CLUSTERS_COMMON_DIR}/src/bridged-actions-stub.cpp
                ${ALL_CLUSTERS_COMMON_DIR}/src/binding-handler.cpp

--- a/examples/all-clusters-app/nrfconnect/main/ZclDoorLockCallbacks.cpp
+++ b/examples/all-clusters-app/nrfconnect/main/ZclDoorLockCallbacks.cpp
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app-common/zap-generated/attributes/Accessors.h>
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/ConcreteAttributePath.h>
+#include <app/clusters/door-lock-server/door-lock-server.h>
+#include <lib/support/CodeUtils.h>
+
+using namespace ::chip;
+using namespace ::chip::app::Clusters;
+using namespace ::chip::app::Clusters::DoorLock;
+
+LOG_MODULE_DECLARE(app, CONFIG_MATTER_LOG_LEVEL);
+
+// Provided some empty callbacks and replaced feature map
+// to simulate DoorLock endpoint for All-Clusters-App example
+// without using kUsersManagement|kAccessSchedules|kRFIDCredentials|kPINCredentials
+
+bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
+{
+    return true;
+}
+
+bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode,
+                                              DlOperationError & err)
+{
+    return true;
+}
+
+void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
+{
+    DoorLockServer::Instance().InitServer(endpoint);
+
+    // Set FeatureMap to 0, default is:
+    // (kUsersManagement|kAccessSchedules|kRFIDCredentials|kPINCredentials) 0x113
+    EmberAfStatus status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
+    if (status != EMBER_ZCL_STATUS_SUCCESS)
+    {
+        LOG_ERR("Updating feature map %x", status);
+    }
+}


### PR DESCRIPTION
 #### Problem
The All-clusters-app nRF Connect example did not support Lock commands invoked by the chip-tool.

#### Change overview
The feature map of the Door Lock Cluster has been set to 0,
and now all-clusters-app can process Lock/Unlock commands sent via chip-tool.

#### Testing
Tested manually on nRF52DK.
