### PR TITLE
Fix MinInterval handling in ReadClient.

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -865,13 +865,14 @@ CHIP_ERROR ReadClient::SendSubscribeRequest(const ReadPrepareParams & aReadPrepa
 {
     VerifyOrReturnError(aReadPrepareParams.mMinIntervalFloorSeconds <= aReadPrepareParams.mMaxIntervalCeilingSeconds,
                         CHIP_ERROR_INVALID_ARGUMENT);
-    mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;
     return SendSubscribeRequestImpl(aReadPrepareParams);
 }
 
 CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadPrepareParams)
 {
     VerifyOrReturnError(ClientState::Idle == mState, CHIP_ERROR_INCORRECT_STATE);
+
+    mMinIntervalFloorSeconds = aReadPrepareParams.mMinIntervalFloorSeconds;
 
     // Todo: Remove the below, Update span in ReadPrepareParams
     Span<AttributePathParams> attributePaths(aReadPrepareParams.mpAttributePathParamsList,


### PR DESCRIPTION
We had codepaths on which we did not store MinInterval for an outgoing
subscribe request, and would later report the wrong MinInterval.

#### Problem
chip-tool subscribe ended up showing minInterval as 0, because we never stored the incoming value on the codepath chip-tool ends up using.

#### Change overview
Store the value on the codepath all subscribes go through.

#### Testing
Ran `chip-tool onoff  subscribe on-off 90 900 17 1` and observed that the log says:
```
Subscription established with SubscriptionID = 0x42c18ac6 MinInterval = 90s MaxInterval = 900s Peer = 01:0000000000000011
```
where before it would say:
```
Subscription established with SubscriptionID = 0xe3d42426 MinInterval = 0s MaxInterval = 900s Peer = 01:0000000000000011
```