### PR TITLE
[K32W0] Fix SDK patching

### DIFF
--- a/third_party/nxp/k32w0_sdk/sdk_fixes/patch_k32w_sdk.sh
+++ b/third_party/nxp/k32w0_sdk/sdk_fixes/patch_k32w_sdk.sh
@@ -64,5 +64,8 @@ cp patch_for_K32W061_SDK_2_6_4/controller_interface.h "$NXP_K32W061_SDK_ROOT"/mi
 cp patch_for_K32W061_SDK_2_6_4/lib_ble_controller.a "$NXP_K32W061_SDK_ROOT"/middleware/wireless/ble_controller/lib/
 cp patch_for_K32W061_SDK_2_6_4/libPDM_extFlash.a "$NXP_K32W061_SDK_ROOT"/middleware/wireless/framework/PDM/Library/
 
+rm -rf patch_for_K32W061_SDK_2_6_4.zip
+rm -rf patch_for_K32W061_SDK_2_6_4
+
 echo "K32W SDK MR3 QP1 was patched!"
 exit 0


### PR DESCRIPTION
#### Problem
K32 builds seem to dirty the tree.

#### Change overview
Remove temporary files used for NXP SDK patching.
ot-nxp is still left in a dirty state - this will be solved in a future PR where ot-nxp submodule will be updated (the submodule will encapsulate the changes from the current patch).

#### Testing
Manual testing
