### PR TITLE
Update SoftwareFault event definition to match spec

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -1193,7 +1193,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -67,17 +67,17 @@ void HandleSoftwareFaultEvent(intptr_t arg)
     if (!IsClusterPresentOnAnyEndpoint(Clusters::SoftwareDiagnostics::Id))
         return;
 
-    Clusters::SoftwareDiagnostics::Structs::SoftwareFaultStruct::Type softwareFault;
+    Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type softwareFault;
     char threadName[kMaxThreadNameLength + 1];
 
     softwareFault.id = static_cast<uint64_t>(getpid());
     Platform::CopyString(threadName, std::to_string(softwareFault.id).c_str());
 
-    softwareFault.name = CharSpan::fromCharString(threadName);
+    softwareFault.name.SetValue(CharSpan::fromCharString(threadName));
 
-    std::time_t result           = std::time(nullptr);
-    char * asctime               = std::asctime(std::localtime(&result));
-    softwareFault.faultRecording = ByteSpan(Uint8::from_const_char(asctime), strlen(asctime));
+    std::time_t result = std::time(nullptr);
+    char * asctime     = std::asctime(std::localtime(&result));
+    softwareFault.faultRecording.SetValue(ByteSpan(Uint8::from_const_char(asctime), strlen(asctime)));
 
     Clusters::SoftwareDiagnosticsServer::Instance().OnSoftwareFaultDetect(softwareFault);
 }

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -1108,7 +1108,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute bitmap32 featureMap = 65532;

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -882,7 +882,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -938,7 +938,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -884,7 +884,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -860,7 +860,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -998,7 +998,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -998,7 +998,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -506,7 +506,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute int64u currentHeapHighWatermark = 3;

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -834,7 +834,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -937,7 +937,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -1089,7 +1089,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -931,7 +931,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.cpp
@@ -200,7 +200,7 @@ SoftwareDiagnosticsServer & SoftwareDiagnosticsServer::Instance()
 }
 
 // Gets called when a software fault that has taken place on the Node.
-void SoftwareDiagnosticsServer::OnSoftwareFaultDetect(const SoftwareDiagnostics::Structs::SoftwareFaultStruct::Type & softwareFault)
+void SoftwareDiagnosticsServer::OnSoftwareFaultDetect(const SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault)
 {
     ChipLogDetail(Zcl, "SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected");
 
@@ -208,9 +208,8 @@ void SoftwareDiagnosticsServer::OnSoftwareFaultDetect(const SoftwareDiagnostics:
     {
         // If Software Diagnostics cluster is implemented on this endpoint
         EventNumber eventNumber;
-        Events::SoftwareFault::Type event{ softwareFault };
 
-        if (CHIP_NO_ERROR != LogEvent(event, endpoint, eventNumber))
+        if (CHIP_NO_ERROR != LogEvent(softwareFault, endpoint, eventNumber))
         {
             ChipLogError(Zcl, "SoftwareDiagnosticsDelegate: Failed to record SoftwareFault event");
         }

--- a/src/app/clusters/software-diagnostics-server/software-diagnostics-server.h
+++ b/src/app/clusters/software-diagnostics-server/software-diagnostics-server.h
@@ -39,7 +39,7 @@ public:
      * @brief
      *   Called when a software fault that has taken place on the Node.
      */
-    void OnSoftwareFaultDetect(const chip::app::Clusters::SoftwareDiagnostics::Structs::SoftwareFaultStruct::Type & softwareFault);
+    void OnSoftwareFaultDetect(const chip::app::Clusters::SoftwareDiagnostics::Events::SoftwareFault::Type & softwareFault);
 
 private:
     static SoftwareDiagnosticsServer instance;

--- a/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/software-diagnostics-cluster.xml
@@ -24,12 +24,6 @@ limitations under the License.
     <item name="StackFreeMinimum" type="INT32U" optional="true"/>
     <item name="StackSize" type="INT32U" optional="true"/>
   </struct>
-  <struct name="SoftwareFaultStruct">
-    <cluster code="0x0034"/>
-    <item name="Id" type="INT64U"/>
-    <item name="Name" type="CHAR_STRING" length="8"/>
-    <item name="FaultRecording" type="OCTET_STRING" length="1024"/>
-  </struct>  
   <cluster>
     <domain>General</domain>
     <name>Software Diagnostics</name>
@@ -45,7 +39,9 @@ limitations under the License.
     </command>
     <event side="server" code="0x00" name="SoftwareFault" priority="info" optional="true">
       <description>Indicate the last software fault that has taken place on the Node.</description>
-      <field id="0" name="SoftwareFault" type="SoftwareFaultStruct"/>
+      <field id="0" name="Id" type="INT64U"/>
+      <field id="1" name="Name" type="CHAR_STRING" length="8" optional="true"/>
+      <field id="2" name="FaultRecording" type="OCTET_STRING" length="1024" optional="true"/>
     </event>    
   </cluster>
   <bitmap name="SoftwareDiagnosticsFeature" type="BITMAP32">

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -1369,7 +1369,9 @@ client cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipStructs.java
@@ -678,36 +678,6 @@ public class ChipStructs {
     }
   }
 
-  public static class SoftwareDiagnosticsClusterSoftwareFaultStruct {
-    public Long id;
-    public String name;
-    public byte[] faultRecording;
-
-    public SoftwareDiagnosticsClusterSoftwareFaultStruct(
-        Long id, String name, byte[] faultRecording) {
-      this.id = id;
-      this.name = name;
-      this.faultRecording = faultRecording;
-    }
-
-    @Override
-    public String toString() {
-      StringBuilder output = new StringBuilder();
-      output.append("SoftwareDiagnosticsClusterSoftwareFaultStruct {\n");
-      output.append("\tid: ");
-      output.append(id);
-      output.append("\n");
-      output.append("\tname: ");
-      output.append(name);
-      output.append("\n");
-      output.append("\tfaultRecording: ");
-      output.append(Arrays.toString(faultRecording));
-      output.append("\n");
-      output.append("}\n");
-      return output.toString();
-    }
-  }
-
   public static class SoftwareDiagnosticsClusterThreadMetrics {
     public Long id;
     public Optional<String> name;

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -10719,21 +10719,6 @@ class SoftwareDiagnostics(Cluster):
 
     class Structs:
         @dataclass
-        class SoftwareFaultStruct(ClusterObject):
-            @ChipUtility.classproperty
-            def descriptor(cls) -> ClusterObjectDescriptor:
-                return ClusterObjectDescriptor(
-                    Fields = [
-                            ClusterObjectFieldDescriptor(Label="id", Tag=0, Type=uint),
-                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=str),
-                            ClusterObjectFieldDescriptor(Label="faultRecording", Tag=2, Type=bytes),
-                    ])
-
-            id: 'uint' = 0
-            name: 'str' = ""
-            faultRecording: 'bytes' = b""
-
-        @dataclass
         class ThreadMetrics(ClusterObject):
             @ChipUtility.classproperty
             def descriptor(cls) -> ClusterObjectDescriptor:
@@ -10930,10 +10915,14 @@ class SoftwareDiagnostics(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="softwareFault", Tag=0, Type=SoftwareDiagnostics.Structs.SoftwareFaultStruct),
+                            ClusterObjectFieldDescriptor(Label="id", Tag=0, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="name", Tag=1, Type=typing.Optional[str]),
+                            ClusterObjectFieldDescriptor(Label="faultRecording", Tag=2, Type=typing.Optional[bytes]),
                     ])
 
-            softwareFault: 'SoftwareDiagnostics.Structs.SoftwareFaultStruct' = field(default_factory=lambda: SoftwareDiagnostics.Structs.SoftwareFaultStruct())
+            id: 'uint' = 0
+            name: 'typing.Optional[str]' = None
+            faultRecording: 'typing.Optional[bytes]' = None
 
 
 @dataclass

--- a/src/darwin/Framework/CHIP/templates/CHIPStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/CHIPStructsObjc-src.zapt
@@ -41,7 +41,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSString *)description
 {
-  NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_event_fields}}{{asStructPropertyName name}}:%@; {{/zcl_event_fields}}>", NSStringFromClass([self class]){{#zcl_event_fields}},{{#if isArray}}_{{asStructPropertyName name}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName name}}{{/if}}{{/zcl_event_fields}}];
+  NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_event_fields}}{{asStructPropertyName name}}:%@; {{/zcl_event_fields}}>", NSStringFromClass([self class]){{#zcl_event_fields}},{{#if isArray}}_{{asStructPropertyName name}}{{else if (isOctetString type)}}[_{{asStructPropertyName name}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName name}}{{/if}}{{/zcl_event_fields}}];
   return descriptionString;
 }
 

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPEventTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPEventTLVValueDecoder.mm
@@ -850,15 +850,30 @@ id CHIPDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRea
             CHIPSoftwareDiagnosticsClusterSoftwareFaultEvent * value = [CHIPSoftwareDiagnosticsClusterSoftwareFaultEvent new];
 
             do {
-                CHIPSoftwareDiagnosticsClusterSoftwareFaultStruct * _Nonnull memberValue;
-                memberValue = [CHIPSoftwareDiagnosticsClusterSoftwareFaultStruct new];
-                memberValue.id = [NSNumber numberWithUnsignedLongLong:cppValue.softwareFault.id];
-                memberValue.name = [[NSString alloc] initWithBytes:cppValue.softwareFault.name.data()
-                                                            length:cppValue.softwareFault.name.size()
-                                                          encoding:NSUTF8StringEncoding];
-                memberValue.faultRecording = [NSData dataWithBytes:cppValue.softwareFault.faultRecording.data()
-                                                            length:cppValue.softwareFault.faultRecording.size()];
-                value.softwareFault = memberValue;
+                NSNumber * _Nonnull memberValue;
+                memberValue = [NSNumber numberWithUnsignedLongLong:cppValue.id];
+                value.id = memberValue;
+            } while (0);
+            do {
+                NSString * _Nullable memberValue;
+                if (cppValue.name.HasValue()) {
+                    memberValue = [[NSString alloc] initWithBytes:cppValue.name.Value().data()
+                                                           length:cppValue.name.Value().size()
+                                                         encoding:NSUTF8StringEncoding];
+                } else {
+                    memberValue = nil;
+                }
+                value.name = memberValue;
+            } while (0);
+            do {
+                NSData * _Nullable memberValue;
+                if (cppValue.faultRecording.HasValue()) {
+                    memberValue = [NSData dataWithBytes:cppValue.faultRecording.Value().data()
+                                                 length:cppValue.faultRecording.Value().size()];
+                } else {
+                    memberValue = nil;
+                }
+                value.faultRecording = memberValue;
             } while (0);
 
             return value;

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.h
@@ -273,13 +273,6 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) NSNumber * _Nonnull bootReason;
 @end
 
-@interface CHIPSoftwareDiagnosticsClusterSoftwareFaultStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull id;
-@property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSData * _Nonnull faultRecording;
-- (instancetype)init;
-@end
-
 @interface CHIPSoftwareDiagnosticsClusterThreadMetrics : NSObject
 @property (strong, nonatomic) NSNumber * _Nonnull id;
 @property (strong, nonatomic) NSString * _Nullable name;
@@ -290,7 +283,9 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface CHIPSoftwareDiagnosticsClusterSoftwareFaultEvent : NSObject
-@property (strong, nonatomic) CHIPSoftwareDiagnosticsClusterSoftwareFaultStruct * _Nonnull softwareFault;
+@property (strong, nonatomic) NSNumber * _Nonnull id;
+@property (strong, nonatomic) NSString * _Nullable name;
+@property (strong, nonatomic) NSData * _Nullable faultRecording;
 @end
 
 @interface CHIPThreadNetworkDiagnosticsClusterNeighborTable : NSObject

--- a/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/CHIPStructsObjc.mm
@@ -900,30 +900,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation CHIPSoftwareDiagnosticsClusterSoftwareFaultStruct
-- (instancetype)init
-{
-    if (self = [super init]) {
-
-        _id = @(0);
-
-        _name = @"";
-
-        _faultRecording = [NSData data];
-    }
-    return self;
-}
-
-- (NSString *)description
-{
-    NSString * descriptionString =
-        [NSString stringWithFormat:@"<%@: id:%@; name:%@; faultRecording:%@; >", NSStringFromClass([self class]), _id, _name,
-                  [_faultRecording base64EncodedStringWithOptions:0]];
-    return descriptionString;
-}
-
-@end
-
 @implementation CHIPSoftwareDiagnosticsClusterThreadMetrics
 - (instancetype)init
 {
@@ -957,7 +933,11 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
-        _softwareFault = [CHIPSoftwareDiagnosticsClusterSoftwareFaultStruct new];
+        _id = @(0);
+
+        _name = nil;
+
+        _faultRecording = nil;
     }
     return self;
 }
@@ -965,7 +945,8 @@ NS_ASSUME_NONNULL_BEGIN
 - (NSString *)description
 {
     NSString * descriptionString =
-        [NSString stringWithFormat:@"<%@: softwareFault:%@; >", NSStringFromClass([self class]), _softwareFault];
+        [NSString stringWithFormat:@"<%@: id:%@; name:%@; faultRecording:%@; >", NSStringFromClass([self class]), _id, _name,
+                  [_faultRecording base64EncodedStringWithOptions:0]];
     return descriptionString;
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -509,14 +509,6 @@ typedef struct _SecurityPolicy
     uint16_t Flags;
 } SecurityPolicy;
 
-// Struct for SoftwareFaultStruct
-typedef struct _SoftwareFaultStruct
-{
-    uint64_t Id;
-    chip::CharSpan Name;
-    chip::ByteSpan FaultRecording;
-} SoftwareFaultStruct;
-
 // Struct for TargetInfo
 typedef struct _TargetInfo
 {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -8971,54 +8971,6 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
 } // namespace GeneralDiagnostics
 namespace SoftwareDiagnostics {
 namespace Structs {
-namespace SoftwareFaultStruct {
-CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
-{
-    TLV::TLVType outer;
-    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kId)), id));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kName)), name));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFaultRecording)), faultRecording));
-    ReturnErrorOnFailure(writer.EndContainer(outer));
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
-{
-    CHIP_ERROR err = CHIP_NO_ERROR;
-    TLV::TLVType outer;
-    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
-    err = reader.EnterContainer(outer);
-    ReturnErrorOnFailure(err);
-    while ((err = reader.Next()) == CHIP_NO_ERROR)
-    {
-        if (!TLV::IsContextTag(reader.GetTag()))
-        {
-            continue;
-        }
-        switch (TLV::TagNumFromTag(reader.GetTag()))
-        {
-        case to_underlying(Fields::kId):
-            ReturnErrorOnFailure(DataModel::Decode(reader, id));
-            break;
-        case to_underlying(Fields::kName):
-            ReturnErrorOnFailure(DataModel::Decode(reader, name));
-            break;
-        case to_underlying(Fields::kFaultRecording):
-            ReturnErrorOnFailure(DataModel::Decode(reader, faultRecording));
-            break;
-        default:
-            break;
-        }
-    }
-
-    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
-    ReturnErrorOnFailure(reader.ExitContainer(outer));
-
-    return CHIP_NO_ERROR;
-}
-
-} // namespace SoftwareFaultStruct
 namespace ThreadMetrics {
 CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
@@ -9159,7 +9111,9 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kSoftwareFault)), softwareFault));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kId)), id));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kName)), name));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFaultRecording)), faultRecording));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -9178,8 +9132,14 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
-        case to_underlying(Fields::kSoftwareFault):
-            ReturnErrorOnFailure(DataModel::Decode(reader, softwareFault));
+        case to_underlying(Fields::kId):
+            ReturnErrorOnFailure(DataModel::Decode(reader, id));
+            break;
+        case to_underlying(Fields::kName):
+            ReturnErrorOnFailure(DataModel::Decode(reader, name));
+            break;
+        case to_underlying(Fields::kFaultRecording):
+            ReturnErrorOnFailure(DataModel::Decode(reader, faultRecording));
             break;
         default:
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -11179,31 +11179,6 @@ public:
 } // namespace GeneralDiagnostics
 namespace SoftwareDiagnostics {
 namespace Structs {
-namespace SoftwareFaultStruct {
-enum class Fields
-{
-    kId             = 0,
-    kName           = 1,
-    kFaultRecording = 2,
-};
-
-struct Type
-{
-public:
-    uint64_t id = static_cast<uint64_t>(0);
-    chip::CharSpan name;
-    chip::ByteSpan faultRecording;
-
-    CHIP_ERROR Decode(TLV::TLVReader & reader);
-
-    static constexpr bool kIsFabricScoped = false;
-
-    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
-};
-
-using DecodableType = Type;
-
-} // namespace SoftwareFaultStruct
 namespace ThreadMetrics {
 enum class Fields
 {
@@ -11385,7 +11360,9 @@ static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
 
 enum class Fields
 {
-    kSoftwareFault = 0,
+    kId             = 0,
+    kName           = 1,
+    kFaultRecording = 2,
 };
 
 struct Type
@@ -11396,7 +11373,9 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
     static constexpr bool kIsFabricScoped = false;
 
-    Structs::SoftwareFaultStruct::Type softwareFault;
+    uint64_t id = static_cast<uint64_t>(0);
+    Optional<chip::CharSpan> name;
+    Optional<chip::ByteSpan> faultRecording;
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -11408,7 +11387,9 @@ public:
     static constexpr EventId GetEventId() { return Events::SoftwareFault::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::SoftwareDiagnostics::Id; }
 
-    Structs::SoftwareFaultStruct::DecodableType softwareFault;
+    uint64_t id = static_cast<uint64_t>(0);
+    Optional<chip::CharSpan> name;
+    Optional<chip::ByteSpan> faultRecording;
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };

--- a/zzz_generated/chef-rootnode_contactsensor_DreXRHtsq9/zap-generated/rootnode_contactsensor_DreXRHtsq9.matter
+++ b/zzz_generated/chef-rootnode_contactsensor_DreXRHtsq9/zap-generated/rootnode_contactsensor_DreXRHtsq9.matter
@@ -744,7 +744,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_dimmablelight_gY80DaqEUL/zap-generated/rootnode_dimmablelight_gY80DaqEUL.matter
+++ b/zzz_generated/chef-rootnode_dimmablelight_gY80DaqEUL/zap-generated/rootnode_dimmablelight_gY80DaqEUL.matter
@@ -988,7 +988,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_flowsensor_nRfPWc0i3j/zap-generated/rootnode_flowsensor_nRfPWc0i3j.matter
+++ b/zzz_generated/chef-rootnode_flowsensor_nRfPWc0i3j/zap-generated/rootnode_flowsensor_nRfPWc0i3j.matter
@@ -753,7 +753,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_heatingcoolingunit_Yt3sl2ssuP/zap-generated/rootnode_heatingcoolingunit_Yt3sl2ssuP.matter
+++ b/zzz_generated/chef-rootnode_heatingcoolingunit_Yt3sl2ssuP/zap-generated/rootnode_heatingcoolingunit_Yt3sl2ssuP.matter
@@ -981,7 +981,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_humiditysensor_bCXcaZPQ1O/zap-generated/rootnode_humiditysensor_bCXcaZPQ1O.matter
+++ b/zzz_generated/chef-rootnode_humiditysensor_bCXcaZPQ1O/zap-generated/rootnode_humiditysensor_bCXcaZPQ1O.matter
@@ -753,7 +753,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_occupancysensor_52g0FarxiO/zap-generated/rootnode_occupancysensor_52g0FarxiO.matter
+++ b/zzz_generated/chef-rootnode_occupancysensor_52g0FarxiO/zap-generated/rootnode_occupancysensor_52g0FarxiO.matter
@@ -753,7 +753,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_onofflightswitch_zbddTYGOPV/zap-generated/rootnode_onofflightswitch_zbddTYGOPV.matter
+++ b/zzz_generated/chef-rootnode_onofflightswitch_zbddTYGOPV/zap-generated/rootnode_onofflightswitch_zbddTYGOPV.matter
@@ -1058,7 +1058,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_onoffpluginunit_Jgnh29qK1p/zap-generated/rootnode_onoffpluginunit_Jgnh29qK1p.matter
+++ b/zzz_generated/chef-rootnode_onoffpluginunit_Jgnh29qK1p/zap-generated/rootnode_onoffpluginunit_Jgnh29qK1p.matter
@@ -905,7 +905,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_pressuresensor_fBO7Lvhj9j/zap-generated/rootnode_pressuresensor_fBO7Lvhj9j.matter
+++ b/zzz_generated/chef-rootnode_pressuresensor_fBO7Lvhj9j/zap-generated/rootnode_pressuresensor_fBO7Lvhj9j.matter
@@ -753,7 +753,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_speaker_TlTVZFjAlM/zap-generated/rootnode_speaker_TlTVZFjAlM.matter
+++ b/zzz_generated/chef-rootnode_speaker_TlTVZFjAlM/zap-generated/rootnode_speaker_TlTVZFjAlM.matter
@@ -868,7 +868,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_temperaturesensor_19A4msmCzW/zap-generated/rootnode_temperaturesensor_19A4msmCzW.matter
+++ b/zzz_generated/chef-rootnode_temperaturesensor_19A4msmCzW/zap-generated/rootnode_temperaturesensor_19A4msmCzW.matter
@@ -753,7 +753,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_thermostat_dtbxxgX9aj/zap-generated/rootnode_thermostat_dtbxxgX9aj.matter
+++ b/zzz_generated/chef-rootnode_thermostat_dtbxxgX9aj/zap-generated/rootnode_thermostat_dtbxxgX9aj.matter
@@ -863,7 +863,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chef-rootnode_windowcovering_hv8WSnPgSV/zap-generated/rootnode_windowcovering_hv8WSnPgSV.matter
+++ b/zzz_generated/chef-rootnode_windowcovering_hv8WSnPgSV/zap-generated/rootnode_windowcovering_hv8WSnPgSV.matter
@@ -855,7 +855,9 @@ server cluster SoftwareDiagnostics = 52 {
   }
 
   info event SoftwareFault = 0 {
-    SoftwareFaultStruct softwareFault = 0;
+    INT64U id = 0;
+    optional CHAR_STRING name = 1;
+    optional OCTET_STRING faultRecording = 2;
   }
 
   readonly attribute ThreadMetrics threadMetrics[] = 0;

--- a/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp
@@ -1802,36 +1802,6 @@ void ComplexArgumentParser::Finalize(chip::app::Clusters::TestCluster::Structs::
     ComplexArgumentParser::Finalize(request.h);
 }
 CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
-                                        chip::app::Clusters::SoftwareDiagnostics::Structs::SoftwareFaultStruct::Type & request,
-                                        Json::Value & value)
-{
-    VerifyOrReturnError(value.isObject(), CHIP_ERROR_INVALID_ARGUMENT);
-
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("SoftwareFaultStruct.id", "id", value.isMember("id")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("SoftwareFaultStruct.name", "name", value.isMember("name")));
-    ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("SoftwareFaultStruct.faultRecording", "faultRecording",
-                                                                  value.isMember("faultRecording")));
-
-    char labelWithMember[kMaxLabelLength];
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "id");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.id, value["id"]));
-
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "name");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.name, value["name"]));
-
-    snprintf(labelWithMember, sizeof(labelWithMember), "%s.%s", label, "faultRecording");
-    ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.faultRecording, value["faultRecording"]));
-
-    return CHIP_NO_ERROR;
-}
-
-void ComplexArgumentParser::Finalize(chip::app::Clusters::SoftwareDiagnostics::Structs::SoftwareFaultStruct::Type & request)
-{
-    ComplexArgumentParser::Finalize(request.id);
-    ComplexArgumentParser::Finalize(request.name);
-    ComplexArgumentParser::Finalize(request.faultRecording);
-}
-CHIP_ERROR ComplexArgumentParser::Setup(const char * label,
                                         chip::app::Clusters::ContentLauncher::Structs::StyleInformation::Type & request,
                                         Json::Value & value)
 {

--- a/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.h
@@ -207,10 +207,6 @@ static CHIP_ERROR Setup(const char * label, chip::app::Clusters::TestCluster::St
                         Json::Value & value);
 
 static void Finalize(chip::app::Clusters::TestCluster::Structs::SimpleStruct::Type & request);
-static CHIP_ERROR Setup(const char * label, chip::app::Clusters::SoftwareDiagnostics::Structs::SoftwareFaultStruct::Type & request,
-                        Json::Value & value);
-
-static void Finalize(chip::app::Clusters::SoftwareDiagnostics::Structs::SoftwareFaultStruct::Type & request);
 static CHIP_ERROR Setup(const char * label, chip::app::Clusters::ContentLauncher::Structs::StyleInformation::Type & request,
                         Json::Value & value);
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -1940,39 +1940,6 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 
     return CHIP_NO_ERROR;
 }
-CHIP_ERROR
-DataModelLogger::LogValue(const char * label, size_t indent,
-                          const chip::app::Clusters::SoftwareDiagnostics::Structs::SoftwareFaultStruct::DecodableType & value)
-{
-    DataModelLogger::LogString(label, indent, "{");
-    {
-        CHIP_ERROR err = LogValue("Id", indent + 1, value.id);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'Id'");
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = LogValue("Name", indent + 1, value.name);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'Name'");
-            return err;
-        }
-    }
-    {
-        CHIP_ERROR err = LogValue("FaultRecording", indent + 1, value.faultRecording);
-        if (err != CHIP_NO_ERROR)
-        {
-            DataModelLogger::LogString(indent + 1, "Struct truncated due to invalid value for 'FaultRecording'");
-            return err;
-        }
-    }
-    DataModelLogger::LogString(indent, "}");
-
-    return CHIP_NO_ERROR;
-}
 CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
                                      const chip::app::Clusters::ContentLauncher::Structs::StyleInformation::DecodableType & value)
 {
@@ -2908,10 +2875,26 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 {
     DataModelLogger::LogString(label, indent, "{");
     {
-        CHIP_ERROR err = DataModelLogger::LogValue("SoftwareFault", indent + 1, value.softwareFault);
+        CHIP_ERROR err = DataModelLogger::LogValue("Id", indent + 1, value.id);
         if (err != CHIP_NO_ERROR)
         {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'SoftwareFault'");
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'Id'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("Name", indent + 1, value.name);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'Name'");
+            return err;
+        }
+    }
+    {
+        CHIP_ERROR err = DataModelLogger::LogValue("FaultRecording", indent + 1, value.faultRecording);
+        if (err != CHIP_NO_ERROR)
+        {
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'FaultRecording'");
             return err;
         }
     }

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.h
@@ -114,8 +114,6 @@ static CHIP_ERROR LogValue(const char * label, size_t indent,
 static CHIP_ERROR LogValue(const char * label, size_t indent,
                            const chip::app::Clusters::TestCluster::Structs::SimpleStruct::DecodableType & value);
 static CHIP_ERROR LogValue(const char * label, size_t indent,
-                           const chip::app::Clusters::SoftwareDiagnostics::Structs::SoftwareFaultStruct::DecodableType & value);
-static CHIP_ERROR LogValue(const char * label, size_t indent,
                            const chip::app::Clusters::ContentLauncher::Structs::StyleInformation::DecodableType & value);
 static CHIP_ERROR LogValue(const char * label, size_t indent,
                            const chip::app::Clusters::AccessControl::Structs::Target::DecodableType & value);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Per spec, this event should have three fields. In our implementation, it has one field, which is a struct with three fields. And even those fields do not match the spec event definition (e.g. they're all required, while some of the spec fields are optional).

* Fixes #19207

#### Change overview
Update SoftwareFault event definition to match spec

#### Testing
How was this tested? (at least one bullet point required)
* Trigger the event from new shell
```
yufengwang@yufengwang:~$ ps -A | grep chip
 122962 pts/4    00:00:00 chip-all-cluste
yufengwang@yufengwang:~$ kill -SIGUSR1 122962

```
* Confirm the software event is recorded
```
[1655922592.493622][122962:122962] CHIP:DL: Caught signal 10
[1655922592.493699][122962:122962] CHIP:DL: select failed: ../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/system/SystemLayerImplSelect.cpp:383: OS Error 0x02000004: Interrupted system call

[1655922592.493786][122962:122962] CHIP:ZCL: SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected
[1655922592.493836][122962:122962] CHIP:EVL: LogEvent event number: 0x0000000000000002 priority: 1, endpoint id:  0x0 cluster id: 0x0000_0034 event id: 0x0 Sys timestamp: 0x0000000006A309A0
```

