### PR TITLE
Make cleanup functions return 'void'

### DIFF
--- a/examples/chip-tool/commands/clusters/SubscriptionsCommands.h
+++ b/examples/chip-tool/commands/clusters/SubscriptionsCommands.h
@@ -56,7 +56,10 @@ public:
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override
     {
-        CHIP_ERROR err = chip::app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricIndex, mNodeId);
+        CHIP_ERROR err = CHIP_NO_ERROR;
+
+        chip::app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricIndex, mNodeId);
+
         SetCommandExitStatus(err);
         return CHIP_NO_ERROR;
     }

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -153,11 +153,11 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CHIPCommand::MaybeTearDownStack()
+void CHIPCommand::MaybeTearDownStack()
 {
     if (IsInteractive())
     {
-        return CHIP_NO_ERROR;
+        return;
     }
 
     //
@@ -165,21 +165,19 @@ CHIP_ERROR CHIPCommand::MaybeTearDownStack()
     // since the CHIP thread and event queue have been stopped, preventing any thread
     // races.
     //
-    ReturnLogErrorOnFailure(ShutdownCommissioner(kIdentityNull));
-    ReturnLogErrorOnFailure(ShutdownCommissioner(kIdentityAlpha));
-    ReturnLogErrorOnFailure(ShutdownCommissioner(kIdentityBeta));
-    ReturnLogErrorOnFailure(ShutdownCommissioner(kIdentityGamma));
+    ShutdownCommissioner(kIdentityNull);
+    ShutdownCommissioner(kIdentityAlpha);
+    ShutdownCommissioner(kIdentityBeta);
+    ShutdownCommissioner(kIdentityGamma);
 
     std::string name        = GetIdentity();
     chip::FabricId fabricId = strtoull(name.c_str(), nullptr, 0);
     if (fabricId >= kIdentityOtherFabricId)
     {
-        ReturnLogErrorOnFailure(ShutdownCommissioner(name));
+        ShutdownCommissioner(name);
     }
 
     StopTracing();
-
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR CHIPCommand::Run()
@@ -201,7 +199,7 @@ CHIP_ERROR CHIPCommand::Run()
         Cleanup();
     }
 
-    ReturnErrorOnFailure(MaybeTearDownStack());
+    MaybeTearDownStack();
 
     return err;
 }
@@ -322,9 +320,9 @@ chip::Controller::DeviceCommissioner & CHIPCommand::GetCommissioner(const char *
     return *item->second;
 }
 
-CHIP_ERROR CHIPCommand::ShutdownCommissioner(std::string key)
+void CHIPCommand::ShutdownCommissioner(std::string key)
 {
-    return mCommissioners[key].get()->Shutdown();
+    mCommissioners[key].get()->Shutdown();
 }
 
 CHIP_ERROR CHIPCommand::InitializeCommissioner(std::string key, chip::FabricId fabricId,

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -139,11 +139,11 @@ protected:
 
 private:
     CHIP_ERROR MaybeSetUpStack();
-    CHIP_ERROR MaybeTearDownStack();
+    void MaybeTearDownStack();
 
     CHIP_ERROR InitializeCommissioner(std::string key, chip::FabricId fabricId,
                                       const chip::Credentials::AttestationTrustStore * trustStore);
-    CHIP_ERROR ShutdownCommissioner(std::string key);
+    void ShutdownCommissioner(std::string key);
     chip::FabricId CurrentCommissionerId();
     static std::map<std::string, std::unique_ptr<ChipDeviceCommissioner>> mCommissioners;
     static std::set<CHIPCommand *> sDeferredCleanups;

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -94,7 +94,7 @@ protected:
 private:
     CHIP_ERROR InitializeCommissioner(std::string key, chip::FabricId fabricId,
                                       const chip::Credentials::AttestationTrustStore * trustStore);
-    CHIP_ERROR ShutdownCommissioner();
+    void ShutdownCommissioner();
     uint16_t CurrentCommissionerIndex();
 
     CHIP_ERROR mCommandExitStatus = CHIP_ERROR_INTERNAL;
@@ -103,7 +103,7 @@ private:
     void StopWaiting();
 
     CHIP_ERROR MaybeSetUpStack();
-    CHIP_ERROR MaybeTearDownStack();
+    void MaybeTearDownStack();
 
     // Our three controllers: alpha, beta, gamma.
     static std::map<std::string, CHIPDeviceController *> mControllers;

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -47,7 +47,7 @@ CHIP_ERROR CHIPCommandBridge::Run()
     } else {
         Cleanup();
     }
-    ReturnErrorOnFailure(MaybeTearDownStack());
+    MaybeTearDownStack();
 
     return CHIP_NO_ERROR;
 }
@@ -105,14 +105,12 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR CHIPCommandBridge::MaybeTearDownStack()
+void CHIPCommandBridge::MaybeTearDownStack()
 {
-    CHIP_ERROR err;
     if (IsInteractive()) {
-        return CHIP_NO_ERROR;
+        return;
     }
-    err = ShutdownCommissioner();
-    return err;
+    ShutdownCommissioner();
 }
 
 void CHIPCommandBridge::SetIdentity(const char * identity)
@@ -130,7 +128,7 @@ CHIPDeviceController * CHIPCommandBridge::CurrentCommissioner() { return mCurren
 
 CHIPDeviceController * CHIPCommandBridge::GetCommissioner(const char * identity) { return mControllers[identity]; }
 
-CHIP_ERROR CHIPCommandBridge::ShutdownCommissioner()
+void CHIPCommandBridge::ShutdownCommissioner()
 {
     ChipLogProgress(chipTool, "Shutting down controller");
     for (auto & pair : mControllers) {
@@ -140,8 +138,6 @@ CHIP_ERROR CHIPCommandBridge::ShutdownCommissioner()
     mCurrentController = nil;
 
     [[MatterControllerFactory sharedInstance] shutdown];
-
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR CHIPCommandBridge::StartWaiting(chip::System::Clock::Timeout duration)

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -204,7 +204,7 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ShutdownCommissioner()
+void ShutdownCommissioner()
 {
     UserDirectedCommissioningServer * udcServer = gCommissioner.GetUserDirectedCommissioningServer();
     if (udcServer != nullptr)
@@ -213,7 +213,6 @@ CHIP_ERROR ShutdownCommissioner()
     }
 
     gCommissioner.Shutdown();
-    return CHIP_NO_ERROR;
 }
 
 class PairingCommand : public Controller::DevicePairingDelegate

--- a/examples/platform/linux/CommissionerMain.h
+++ b/examples/platform/linux/CommissionerMain.h
@@ -35,7 +35,7 @@ CHIP_ERROR CommissionerPairOnNetwork(uint32_t pincode, uint16_t disc, PeerAddres
 CHIP_ERROR CommissionerPairUDC(uint32_t pincode, size_t index);
 
 CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort);
-CHIP_ERROR ShutdownCommissioner();
+void ShutdownCommissioner();
 
 DeviceCommissioner * GetDeviceCommissioner();
 CommissionerDiscoveryController * GetCommissionerDiscoveryController();

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -184,13 +184,12 @@ CHIP_ERROR AccessControl::Init(AccessControl::Delegate * delegate, DeviceTypeRes
     return retval;
 }
 
-CHIP_ERROR AccessControl::Finish()
+void AccessControl::Finish()
 {
-    VerifyOrReturnError(IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturn(IsInitialized());
     ChipLogProgress(DataManagement, "AccessControl: finishing");
-    CHIP_ERROR retval = mDelegate->Finish();
-    mDelegate         = nullptr;
-    return retval;
+    mDelegate->Finish();
+    mDelegate = nullptr;
 }
 
 CHIP_ERROR AccessControl::CreateEntry(const SubjectDescriptor * subjectDescriptor, FabricIndex fabric, size_t * index,

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -342,7 +342,7 @@ public:
         virtual void Release() {}
 
         virtual CHIP_ERROR Init() { return CHIP_NO_ERROR; }
-        virtual CHIP_ERROR Finish() { return CHIP_NO_ERROR; }
+        virtual void Finish() {}
 
         // Capabilities
         virtual CHIP_ERROR GetMaxEntriesPerFabric(size_t & value) const
@@ -430,7 +430,7 @@ public:
     /**
      * Deinitialize the access control module. Must be called when finished.
      */
-    CHIP_ERROR Finish();
+    void Finish();
 
     // Capabilities
     CHIP_ERROR GetMaxEntriesPerFabric(size_t & value) const

--- a/src/access/examples/ExampleAccessControlDelegate.cpp
+++ b/src/access/examples/ExampleAccessControlDelegate.cpp
@@ -965,11 +965,7 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR Finish() override
-    {
-        ChipLogProgress(DataManagement, "Examples::AccessControlDelegate::Finish");
-        return CHIP_NO_ERROR;
-    }
+    void Finish() override { ChipLogProgress(DataManagement, "Examples::AccessControlDelegate::Finish"); }
 
     CHIP_ERROR GetMaxEntriesPerFabric(size_t & value) const override
     {

--- a/src/access/examples/PermissiveAccessControlDelegate.cpp
+++ b/src/access/examples/PermissiveAccessControlDelegate.cpp
@@ -31,7 +31,7 @@ class AccessControlDelegate : public AccessControl::Delegate
 {
 public:
     CHIP_ERROR Init() override { return CHIP_NO_ERROR; }
-    CHIP_ERROR Finish() override { return CHIP_NO_ERROR; }
+    void Finish() override {}
 
     // Capabilities
     CHIP_ERROR GetMaxEntryCount(size_t & value) const override

--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -43,11 +43,11 @@ public:
     /**
      *  Mark any open session with the device as expired.
      */
-    virtual CHIP_ERROR Disconnect() = 0;
+    virtual void Disconnect() = 0;
 
     virtual NodeId GetDeviceId() const = 0;
 
-    virtual CHIP_ERROR ShutdownSubscriptions() { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    virtual void ShutdownSubscriptions() = 0;
 
     virtual CHIP_ERROR SendCommands(app::CommandSender * commandObj, chip::Optional<System::Clock::Timeout> timeout = NullOptional);
 

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -231,7 +231,7 @@ CHIP_ERROR InteractionModelEngine::ShutdownSubscription(SubscriptionId aSubscrip
     return CHIP_ERROR_KEY_NOT_FOUND;
 }
 
-CHIP_ERROR InteractionModelEngine::ShutdownSubscriptions(FabricIndex aFabricIndex, NodeId aPeerNodeId)
+void InteractionModelEngine::ShutdownSubscriptions(FabricIndex aFabricIndex, NodeId aPeerNodeId)
 {
     for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
     {
@@ -241,8 +241,6 @@ CHIP_ERROR InteractionModelEngine::ShutdownSubscriptions(FabricIndex aFabricInde
             readClient->Close(CHIP_NO_ERROR);
         }
     }
-
-    return CHIP_NO_ERROR;
 }
 
 void InteractionModelEngine::OnDone(CommandHandler & apCommandObj)

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -124,11 +124,8 @@ public:
 
     /**
      * Tears down active subscriptions for a given peer node ID.
-     *
-     * @retval #CHIP_ERROR_KEY_NOT_FOUND If no active subscription is found.
-     * @retval #CHIP_NO_ERROR On success.
      */
-    CHIP_ERROR ShutdownSubscriptions(FabricIndex aFabricIndex, NodeId aPeerNodeId);
+    void ShutdownSubscriptions(FabricIndex aFabricIndex, NodeId aPeerNodeId);
 
     /**
      * Expire active transactions and release related objects for the given fabric index.
@@ -391,9 +388,6 @@ private:
     Protocols::InteractionModel::Status CommandExists(const ConcreteCommandPath & aCommandPath) override;
 
     bool HasActiveRead();
-
-    CHIP_ERROR ShutdownExistingSubscriptionsIfNeeded(Messaging::ExchangeContext * apExchangeContext,
-                                                     System::PacketBufferHandle && aPayload);
 
     inline size_t GetPathPoolCapacityForReads() const
     {

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -313,9 +313,9 @@ void OperationalDeviceProxy::OnSessionEstablished(const SessionHandle & session)
     // Do not touch this instance anymore; it might have been destroyed by a callback.
 }
 
-CHIP_ERROR OperationalDeviceProxy::Disconnect()
+void OperationalDeviceProxy::Disconnect()
 {
-    ReturnErrorCodeIf(mState != State::SecureConnected, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturn(mState == State::SecureConnected);
 
     if (mSecureSession)
     {
@@ -331,7 +331,6 @@ CHIP_ERROR OperationalDeviceProxy::Disconnect()
     mSecureSession.Release();
 
     MoveToState(State::HasAddress);
-    return CHIP_NO_ERROR;
 }
 
 void OperationalDeviceProxy::CleanupCASEClient()
@@ -358,9 +357,9 @@ void OperationalDeviceProxy::OnSessionHang()
     // TODO: establish a new session
 }
 
-CHIP_ERROR OperationalDeviceProxy::ShutdownSubscriptions()
+void OperationalDeviceProxy::ShutdownSubscriptions()
 {
-    return app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricIndex, GetDeviceId());
+    app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricIndex, GetDeviceId());
 }
 
 OperationalDeviceProxy::~OperationalDeviceProxy()

--- a/src/app/OperationalDeviceProxy.h
+++ b/src/app/OperationalDeviceProxy.h
@@ -167,13 +167,13 @@ public:
     /**
      *  Mark any open session with the device as expired.
      */
-    CHIP_ERROR Disconnect() override;
+    void Disconnect() override;
 
     NodeId GetDeviceId() const override { return mPeerId.GetNodeId(); }
 
     PeerId GetPeerId() const { return mPeerId; }
 
-    CHIP_ERROR ShutdownSubscriptions() override;
+    void ShutdownSubscriptions() override;
 
     Messaging::ExchangeManager * GetExchangeManager() const override { return mInitParams.exchangeMgr; }
 

--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -70,10 +70,9 @@ CHIP_ERROR Instance::Init()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR Instance::Shutdown()
+void Instance::Shutdown()
 {
-    ReturnErrorOnFailure(mpBaseDriver->Shutdown());
-    return CHIP_NO_ERROR;
+    mpBaseDriver->Shutdown();
 }
 
 void Instance::InvokeCommand(HandlerContext & ctxt)

--- a/src/app/clusters/network-commissioning/network-commissioning.h
+++ b/src/app/clusters/network-commissioning/network-commissioning.h
@@ -46,7 +46,7 @@ public:
      * Register will register the network commissioning instance to the attribute and command dispatching route.
      */
     CHIP_ERROR Init();
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
     // CommandHandlerInterface
     void InvokeCommand(HandlerContext & ctx) override;

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -407,11 +407,7 @@ void Server::Shutdown()
     chip::Dnssd::Resolver::Instance().Shutdown();
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
     mMessageCounterManager.Shutdown();
-    CHIP_ERROR err = mExchangeMgr.Shutdown();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(AppServer, "Exchange Mgr shutdown: %" CHIP_ERROR_FORMAT, err.Format());
-    }
+    mExchangeMgr.Shutdown();
     mSessions.Shutdown();
     mTransports.Close();
     mAccessControl.Finish();

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -49,14 +49,12 @@ CHIP_ERROR AppContext::Init()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AppContext::Shutdown()
+void AppContext::Shutdown()
 {
-    ReturnErrorOnFailure(Access::GetAccessControl().Finish());
+    Access::GetAccessControl().Finish();
 
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
-    ReturnErrorOnFailure(Super::Shutdown());
-
-    return CHIP_NO_ERROR;
+    Super::Shutdown();
 }
 
 } // namespace Test

--- a/src/app/tests/AppTestContext.h
+++ b/src/app/tests/AppTestContext.h
@@ -33,7 +33,7 @@ public:
     CHIP_ERROR Init() override;
 
     // Shutdown all layers, finalize operations
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 };
 
 } // namespace Test

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -298,13 +298,13 @@ CHIP_ERROR BleLayer::Init(BlePlatformDelegate * platformDelegate, BleApplication
     return Init(platformDelegate, nullptr, appDelegate, systemLayer);
 }
 
-CHIP_ERROR BleLayer::Shutdown()
+void BleLayer::Shutdown()
 {
     mState = kState_NotInitialized;
-    return CloseAllBleConnections();
+    CloseAllBleConnections();
 }
 
-CHIP_ERROR BleLayer::CloseAllBleConnections()
+void BleLayer::CloseAllBleConnections()
 {
     // Close and free all BLE end points.
     for (size_t i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
@@ -329,10 +329,9 @@ CHIP_ERROR BleLayer::CloseAllBleConnections()
             }
         }
     }
-    return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR BleLayer::CloseBleConnection(BLE_CONNECTION_OBJECT connObj)
+void BleLayer::CloseBleConnection(BLE_CONNECTION_OBJECT connObj)
 {
     // Close and free all BLE endpoints.
     for (size_t i = 0; i < BLE_LAYER_NUM_BLE_ENDPOINTS; i++)
@@ -357,7 +356,6 @@ CHIP_ERROR BleLayer::CloseBleConnection(BLE_CONNECTION_OBJECT connObj)
             }
         }
     }
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BleLayer::CancelBleIncompleteConnection()

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -242,7 +242,7 @@ public:
                     chip::System::Layer * systemLayer);
     CHIP_ERROR Init(BlePlatformDelegate * platformDelegate, BleConnectionDelegate * connDelegate,
                     BleApplicationDelegate * appDelegate, chip::System::Layer * systemLayer);
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
     CHIP_ERROR CancelBleIncompleteConnection();
     CHIP_ERROR NewBleConnectionByDiscriminator(uint16_t connDiscriminator, void * appState = nullptr,
@@ -251,8 +251,8 @@ public:
     CHIP_ERROR NewBleConnectionByObject(BLE_CONNECTION_OBJECT connObj);
     CHIP_ERROR NewBleEndPoint(BLEEndPoint ** retEndPoint, BLE_CONNECTION_OBJECT connObj, BleRole role, bool autoClose);
 
-    CHIP_ERROR CloseAllBleConnections();
-    CHIP_ERROR CloseBleConnection(BLE_CONNECTION_OBJECT connObj);
+    void CloseAllBleConnections();
+    void CloseBleConnection(BLE_CONNECTION_OBJECT connObj);
 
     /**< Platform interface functions:
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -280,9 +280,9 @@ CHIP_ERROR DeviceController::InitControllerNOCChain(const ControllerInitParams &
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceController::Shutdown()
+void DeviceController::Shutdown()
 {
-    VerifyOrReturnError((mState == State::Initialized) && (mSystemState != nullptr), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturn(mState != State::NotInitialized);
 
     ChipLogDetail(Controller, "Shutting down the controller");
 
@@ -312,8 +312,6 @@ CHIP_ERROR DeviceController::Shutdown()
 
     mDNSResolver.Shutdown();
     mDeviceDiscoveryDelegate = nullptr;
-
-    return CHIP_NO_ERROR;
 }
 
 void DeviceController::ReleaseOperationalDevice(NodeId remoteNodeId)
@@ -336,7 +334,7 @@ CHIP_ERROR DeviceController::DisconnectDevice(NodeId nodeId)
 
     if (proxy->IsConnected())
     {
-        return proxy->Disconnect();
+        proxy->Disconnect();
     }
 
     if (proxy->IsConnecting())
@@ -456,9 +454,9 @@ CHIP_ERROR DeviceCommissioner::Init(CommissionerInitParams params)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceCommissioner::Shutdown()
+void DeviceCommissioner::Shutdown()
 {
-    VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturn(mState != State::NotInitialized);
 
     ChipLogDetail(Controller, "Shutting down the commissioner");
 
@@ -489,7 +487,6 @@ CHIP_ERROR DeviceCommissioner::Shutdown()
     mCommissioneeDevicePool.ReleaseAll();
 
     DeviceController::Shutdown();
-    return CHIP_NO_ERROR;
 }
 
 CommissioneeDeviceProxy * DeviceCommissioner::FindCommissioneeDevice(NodeId id)
@@ -1379,12 +1376,12 @@ void DeviceCommissioner::ConnectBleTransportToSelf()
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
 
-CHIP_ERROR DeviceCommissioner::CloseBleConnection()
+void DeviceCommissioner::CloseBleConnection()
 {
     // It is fine since we can only commission one device at the same time.
     // We should be able to distinguish different BLE connections if we want
     // to commission multiple devices at the same time over BLE.
-    return mSystemState->BleLayer()->CloseAllBleConnections();
+    mSystemState->BleLayer()->CloseAllBleConnections();
 }
 #endif
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -153,7 +153,7 @@ public:
      *  This will also not stop the CHIP event queue / thread (if one exists).  Consumers are expected to
      *  ensure this happened before calling this method.
      */
-    virtual CHIP_ERROR Shutdown();
+    virtual void Shutdown();
 
     SessionManager * SessionMgr()
     {
@@ -408,7 +408,7 @@ public:
      *
      *  Please see implementation for more details.
      */
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // ----- Connection Management -----
     /**
@@ -582,9 +582,8 @@ public:
      *   Once we have finished all commissioning work, the Controller should close the BLE
      *   connection to the device and establish CASE session / another PASE session to the device
      *   if needed.
-     * @return CHIP_ERROR   The return status
      */
-    CHIP_ERROR CloseBleConnection();
+    void CloseBleConnection();
 #endif
     /**
      * @brief

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -422,8 +422,7 @@ void DeviceControllerSystemState::Shutdown()
     // Consumers are expected to call PlaformMgr().StopEventLoopTask() before calling
     // DeviceController::Shutdown() in the CONFIG_DEVICE_LAYER configuration
     //
-    CHIP_ERROR error = DeviceLayer::PlatformMgr().Shutdown();
-    VerifyOrDie(error == CHIP_NO_ERROR);
+    DeviceLayer::PlatformMgr().Shutdown();
 #endif
 
     if (mExchangeMgr != nullptr)

--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -56,9 +56,9 @@ void CommissioneeDeviceProxy::OnSessionReleased()
     mState = ConnectionState::NotConnected;
 }
 
-CHIP_ERROR CommissioneeDeviceProxy::CloseSession()
+void CommissioneeDeviceProxy::CloseSession()
 {
-    ReturnErrorCodeIf(mState != ConnectionState::SecureConnected, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturn(mState == ConnectionState::SecureConnected);
     if (mSecureSession)
     {
         mSecureSession->AsSecureSession()->MarkForEviction();
@@ -66,7 +66,6 @@ CHIP_ERROR CommissioneeDeviceProxy::CloseSession()
 
     mState = ConnectionState::NotConnected;
     mPairing.Clear();
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR CommissioneeDeviceProxy::UpdateDeviceData(const Transport::PeerAddress & addr,

--- a/src/controller/CommissioneeDeviceProxy.h
+++ b/src/controller/CommissioneeDeviceProxy.h
@@ -103,9 +103,9 @@ public:
     /**
      *  In case there exists an open session to the device, mark it as expired.
      */
-    CHIP_ERROR CloseSession();
+    void CloseSession();
 
-    CHIP_ERROR Disconnect() override { return CloseSession(); }
+    void Disconnect() override { CloseSession(); }
 
     /**
      * @brief
@@ -133,6 +133,7 @@ public:
     bool IsSessionSetupInProgress() const { return mState == ConnectionState::Connecting; }
 
     NodeId GetDeviceId() const override { return mPeerId.GetNodeId(); }
+    void ShutdownSubscriptions() override {}
     PeerId GetPeerId() const { return mPeerId; }
     CHIP_ERROR SetPeerId(ByteSpan rcac, ByteSpan noc) override;
     const Transport::PeerAddress & GetPeerAddress() const { return mDeviceAddress; }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -769,11 +769,8 @@ JNI_METHOD(void, shutdownCommissioning)
 (JNIEnv * env, jobject self, jlong handle)
 {
     chip::DeviceLayer::StackLock lock;
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err                                      = wrapper->Controller()->Shutdown();
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error invoking shutdownCommissioning: %s", ErrorStr(err)));
+    wrapper->Controller()->Shutdown();
 }
 
 JNI_METHOD(jbyteArray, getAttestationChallenge)

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -644,7 +644,8 @@ ChipError::StorageType pychip_GetDeviceBeingCommissioned(chip::Controller::Devic
 ChipError::StorageType pychip_DeviceCommissioner_CloseBleConnection(chip::Controller::DeviceCommissioner * devCtrl)
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    return devCtrl->CloseBleConnection().AsInteger();
+    devCtrl->CloseBleConnection();
+    return CHIP_NO_ERROR.AsInteger();
 #else
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE.AsInteger();
 #endif

--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -154,7 +154,7 @@ public:
     /**
      * @brief Shuts down the driver, this function will be called when shutting down the network commissioning cluster.
      */
-    virtual CHIP_ERROR Shutdown() { return CHIP_NO_ERROR; }
+    virtual void Shutdown() {}
 
     /**
      * @brief Returns maximum number of network configs can be added to the driver.

--- a/src/include/platform/PlatformManager.h
+++ b/src/include/platform/PlatformManager.h
@@ -186,7 +186,7 @@ public:
     void LockChipStack();
     bool TryLockChipStack();
     void UnlockChipStack();
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
     bool IsChipStackLockedByCurrentThread() const;
@@ -399,12 +399,10 @@ inline CHIP_ERROR PlatformManager::StopEventLoopTask()
  *   This DOES NOT stop the chip thread or event queue from running.
  *
  */
-inline CHIP_ERROR PlatformManager::Shutdown()
+inline void PlatformManager::Shutdown()
 {
-    CHIP_ERROR err = static_cast<ImplClass *>(this)->_Shutdown();
-    if (err == CHIP_NO_ERROR)
-        mInitialized = false;
-    return err;
+    static_cast<ImplClass *>(this)->_Shutdown();
+    mInitialized = false;
 }
 
 inline void PlatformManager::LockChipStack()

--- a/src/include/platform/internal/BLEManager.h
+++ b/src/include/platform/internal/BLEManager.h
@@ -54,7 +54,7 @@ public:
     using BLEAdvertisingMode  = ConnectivityManager::BLEAdvertisingMode;
 
     CHIP_ERROR Init();
-    CHIP_ERROR Shutdown();
+    void Shutdown();
     CHIPoBLEServiceMode GetCHIPoBLEServiceMode();
     CHIP_ERROR SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool IsAdvertisingEnabled();
@@ -117,12 +117,12 @@ inline CHIP_ERROR BLEManager::Init()
     return static_cast<ImplClass *>(this)->_Init();
 }
 
-inline CHIP_ERROR BLEManager::Shutdown()
+inline void BLEManager::Shutdown()
 {
 #if CONFIG_NETWORK_LAYER_BLE
-    ReturnErrorOnFailure(GetBleLayer()->Shutdown());
+    GetBleLayer()->Shutdown();
 #endif
-    return static_cast<ImplClass *>(this)->_Shutdown();
+    static_cast<ImplClass *>(this)->_Shutdown();
 }
 
 inline BLEManager::CHIPoBLEServiceMode BLEManager::GetCHIPoBLEServiceMode()

--- a/src/include/platform/internal/GenericPlatformManagerImpl.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.h
@@ -52,7 +52,7 @@ protected:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack();
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
     CHIP_ERROR _AddEventHandler(PlatformManager::EventHandlerFunct handler, intptr_t arg);
     void _RemoveEventHandler(PlatformManager::EventHandlerFunct handler, intptr_t arg);
     void _HandleServerStarted();

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -127,20 +127,18 @@ exit:
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_Shutdown()
+void GenericPlatformManagerImpl<ImplClass>::_Shutdown()
 {
     ChipLogError(DeviceLayer, "Inet Layer shutdown");
-    CHIP_ERROR err = UDPEndPointManager()->Shutdown();
+    UDPEndPointManager()->Shutdown();
 
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     ChipLogError(DeviceLayer, "BLE shutdown");
-    err = BLEMgr().Shutdown();
+    BLEMgr().Shutdown();
 #endif
 
     ChipLogError(DeviceLayer, "System Layer shutdown");
-    err = SystemLayer().Shutdown();
-
-    return err;
+    SystemLayer().Shutdown();
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.h
@@ -76,7 +76,7 @@ protected:
     CHIP_ERROR _StartEventLoopTask(void);
     CHIP_ERROR _StopEventLoopTask();
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout duration);
-    CHIP_ERROR _Shutdown(void);
+    void _Shutdown(void);
 
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
     bool _IsChipStackLockedByCurrentThread() const;

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -273,9 +273,8 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::PostEventFromISR(const Chip
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
+void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_Shutdown(void)
 {
-    return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -94,7 +94,7 @@ protected:
     CHIP_ERROR _StartEventLoopTask();
     CHIP_ERROR _StopEventLoopTask();
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout duration);
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
     bool _IsChipStackLockedByCurrentThread() const;

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -298,7 +298,7 @@ exit:
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown()
+void GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown()
 {
     pthread_mutex_destroy(&mStateLock);
     pthread_cond_destroy(&mEventQueueStoppedCond);
@@ -307,7 +307,7 @@ CHIP_ERROR GenericPlatformManagerImpl_POSIX<ImplClass>::_Shutdown()
     // Call up to the base class _Shutdown() to perform the actual stack de-initialization
     // and clean-up
     //
-    return GenericPlatformManagerImpl<ImplClass>::_Shutdown();
+    GenericPlatformManagerImpl<ImplClass>::_Shutdown();
 }
 
 // Fully instantiate the generic implementation class in whatever compilation unit includes this file.

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.h
@@ -79,7 +79,7 @@ protected:
     CHIP_ERROR _StartEventLoopTask(void);
     CHIP_ERROR _StopEventLoopTask();
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout duration);
-    CHIP_ERROR _Shutdown(void);
+    void _Shutdown(void);
 
     // ===== Methods available to the implementation subclass.
     explicit GenericPlatformManagerImpl_Zephyr(ThreadStack stack) : mChipThreadStack(stack) {}
@@ -92,6 +92,9 @@ private:
     void ProcessDeviceEvents();
 
     volatile bool mShouldRunEventLoop;
+
+    bool mInitialized = false;
+
     static void EventLoopTaskMain(void * thisPtr, void *, void *);
 };
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp
@@ -56,6 +56,9 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_InitChipStack(void)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+    if (mInitialized)
+      return err;
+
     k_mutex_init(&mChipStackLock);
 
     k_msgq_init(&mChipEventQueue, reinterpret_cast<char *>(&mChipEventRingBuffer), sizeof(ChipDeviceEvent),
@@ -66,6 +69,8 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_InitChipStack(void)
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();
     SuccessOrExit(err);
+
+    mInitialized = true;
 
 exit:
     return err;
@@ -104,13 +109,12 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_StopEventLoopTask(void
 }
 
 template <class ImplClass>
-CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_Shutdown(void)
+void GenericPlatformManagerImpl_Zephyr<ImplClass>::_Shutdown(void)
 {
 #if CONFIG_REBOOT
     sys_reboot(SYS_REBOOT_WARM);
-    return CHIP_NO_ERROR;
 #else
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    // NB: When this is implemented, |mInitialized| can be removed.
 #endif
 }
 

--- a/src/inet/InetLayer.h
+++ b/src/inet/InetLayer.h
@@ -68,13 +68,11 @@ public:
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR Shutdown()
+    void Shutdown()
     {
         // Return to uninitialized state to permit re-initialization.
-        VerifyOrReturnError(mLayerState.ResetFromInitialized(), CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(mSystemLayer->IsInitialized(), CHIP_ERROR_INCORRECT_STATE);
+        mLayerState.ResetFromInitialized();
         mSystemLayer = nullptr;
-        return CHIP_NO_ERROR;
     }
 
     System::Layer & SystemLayer() const { return *mSystemLayer; }

--- a/src/inet/TCPEndPoint.h
+++ b/src/inet/TCPEndPoint.h
@@ -307,24 +307,14 @@ public:
 
     /**
      * @brief   Initiate TCP half close, in other words, finished with sending.
-     *
-     * @retval  CHIP_NO_ERROR           success: address and port extracted.
-     * @retval  CHIP_ERROR_INCORRECT_STATE  TCP connection not established.
-     *
-     * @retval  other                   another system or platform error
      */
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
     /**
      * @brief   Initiate TCP full close, in other words, finished with both send and
      *  receive.
-     *
-     * @retval  CHIP_NO_ERROR           success: address and port extracted.
-     * @retval  CHIP_ERROR_INCORRECT_STATE  TCP connection not established.
-     *
-     * @retval  other                   another system or platform error
      */
-    CHIP_ERROR Close();
+    void Close();
 
     /**
      * @brief   Abortively close the endpoint, in other words, send RST packets.
@@ -609,7 +599,7 @@ protected:
     void DriveReceiving();
     void HandleConnectComplete(CHIP_ERROR err);
     void HandleAcceptError(CHIP_ERROR err);
-    CHIP_ERROR DoClose(CHIP_ERROR err, bool suppressCallback);
+    void DoClose(CHIP_ERROR err, bool suppressCallback);
     static bool IsConnected(State state);
 
     static void TCPConnectTimeoutHandler(chip::System::Layer * aSystemLayer, void * aAppState);

--- a/src/inet/tests/TestInetLayer.cpp
+++ b/src/inet/tests/TestInetLayer.cpp
@@ -869,8 +869,6 @@ static void StartTest()
 
 static void CleanupTest()
 {
-    CHIP_ERROR lStatus;
-
     gSendIntervalExpired = false;
     gSystemLayer.CancelTimer(Common::HandleSendTimerComplete, nullptr);
 
@@ -878,9 +876,7 @@ static void CleanupTest()
 
     if (sTCPIPEndPoint != nullptr)
     {
-        lStatus = sTCPIPEndPoint->Close();
-        INET_FAIL_ERROR(lStatus, "TCPEndPoint::Close failed");
-
+        sTCPIPEndPoint->Close();
         sTCPIPEndPoint->Free();
     }
 

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -142,12 +142,8 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
 
 /**
  * This function shuts down the mdns module
- *
- * @retval CHIP_NO_ERROR  The shutdown succeeds.
- * @retval Error code     The shutdown fails
- *
  */
-CHIP_ERROR ChipDnssdShutdown();
+void ChipDnssdShutdown();
 
 /**
  * Removes or marks all services being advertised for removal.

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -92,9 +92,9 @@ CHIP_ERROR ExchangeManager::Init(SessionManager * sessionManager)
     return err;
 }
 
-CHIP_ERROR ExchangeManager::Shutdown()
+void ExchangeManager::Shutdown()
 {
-    VerifyOrReturnError(mState == State::kState_Initialized, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturn(mState != State::kState_NotInitialized);
 
     mReliableMessageMgr.Shutdown();
 
@@ -105,8 +105,6 @@ CHIP_ERROR ExchangeManager::Shutdown()
     }
 
     mState = State::kState_NotInitialized;
-
-    return CHIP_NO_ERROR;
 }
 
 ExchangeContext * ExchangeManager::NewContext(const SessionHandle & session, ExchangeDelegate * delegate)

--- a/src/messaging/ExchangeMgr.h
+++ b/src/messaging/ExchangeMgr.h
@@ -81,10 +81,8 @@ public:
      *     there are no active ExchangeContext objects. Furthermore, it is the
      *     onus of the application to de-allocate the ExchangeManager
      *     object after calling ExchangeManager::Shutdown().
-     *
-     *  @return #CHIP_NO_ERROR unconditionally.
      */
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
     /**
      *  Creates a new ExchangeContext with a given peer CHIP node specified by the peer node identifier.

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -73,9 +73,9 @@ CHIP_ERROR MessagingContext::Init(TransportMgrBase * transport, IOContext * ioCo
 }
 
 // Shutdown all layers, finalize operations
-CHIP_ERROR MessagingContext::Shutdown()
+void MessagingContext::Shutdown()
 {
-    VerifyOrReturnError(mInitialized == true, CHIP_ERROR_INTERNAL);
+    VerifyOrDie(mInitialized);
     mInitialized = false;
 
     mExchangeManager.Shutdown();
@@ -83,7 +83,6 @@ CHIP_ERROR MessagingContext::Shutdown()
     mFabricTable.Shutdown();
     mOpCertStore.Finish();
     mOpKeyStore.Finish();
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR MessagingContext::InitFromExisting(const MessagingContext & existing)
@@ -91,13 +90,12 @@ CHIP_ERROR MessagingContext::InitFromExisting(const MessagingContext & existing)
     return Init(existing.mTransport, existing.mIOContext);
 }
 
-CHIP_ERROR MessagingContext::ShutdownAndRestoreExisting(MessagingContext & existing)
+void MessagingContext::ShutdownAndRestoreExisting(MessagingContext & existing)
 {
-    CHIP_ERROR err = Shutdown();
+    Shutdown();
     // Point the transport back to the original session manager, since we had
     // pointed it to ours.
     existing.mTransport->SetSessionManager(&existing.GetSecureSessionManager());
-    return err;
 }
 
 CHIP_ERROR MessagingContext::CreateSessionBobToAlice()

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -84,7 +84,7 @@ public:
     CHIP_ERROR Init(TransportMgrBase * transport, IOContext * io);
 
     // Shutdown all layers, finalize operations
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
     // Initialize from an existing messaging context.  Useful if we want to
     // share some state (like the transport).
@@ -92,7 +92,7 @@ public:
 
     // The shutdown method to use if using InitFromExisting.  Must pass in the
     // same existing context as was passed to InitFromExisting.
-    CHIP_ERROR ShutdownAndRestoreExisting(MessagingContext & existing);
+    void ShutdownAndRestoreExisting(MessagingContext & existing);
 
     static Inet::IPAddress GetAddress()
     {
@@ -188,12 +188,11 @@ public:
     }
 
     // Shutdown all layers, finalize operations
-    virtual CHIP_ERROR Shutdown()
+    virtual void Shutdown()
     {
-        ReturnErrorOnFailure(MessagingContext::Shutdown());
-        ReturnErrorOnFailure(LoopbackTransportManager::Shutdown());
+        MessagingContext::Shutdown();
+        LoopbackTransportManager::Shutdown();
         chip::Platform::MemoryShutdown();
-        return CHIP_NO_ERROR;
     }
 
     // Init/Shutdown Helpers that can be used directly as the nlTestSuite
@@ -207,7 +206,8 @@ public:
     static int Finalize(void * context)
     {
         auto * ctx = static_cast<LoopbackMessagingContext *>(context);
-        return ctx->Shutdown() == CHIP_NO_ERROR ? SUCCESS : FAILURE;
+        ctx->Shutdown();
+        return SUCCESS;
     }
 
     using LoopbackTransportManager::GetSystemLayer;

--- a/src/platform/Ameba/BLEManagerImpl.h
+++ b/src/platform/Ameba/BLEManagerImpl.h
@@ -46,7 +46,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -90,7 +90,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -56,10 +56,9 @@ CHIP_ERROR AmebaWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChan
     return err;
 }
 
-CHIP_ERROR AmebaWiFiDriver::Shutdown()
+void AmebaWiFiDriver::Shutdown()
 {
     mpStatusChangeCallback = nullptr;
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR AmebaWiFiDriver::CommitConfiguration()

--- a/src/platform/Ameba/PlatformManagerImpl.cpp
+++ b/src/platform/Ameba/PlatformManagerImpl.cpp
@@ -88,7 +88,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     uint64_t upTime = 0;
 
@@ -110,7 +110,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
-    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
+    Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Ameba/PlatformManagerImpl.h
+++ b/src/platform/Ameba/PlatformManagerImpl.h
@@ -53,7 +53,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/CYW30739/BLEManagerImpl.h
+++ b/src/platform/CYW30739/BLEManagerImpl.h
@@ -51,7 +51,7 @@ class BLEManagerImpl final : public BLEManager,
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/CYW30739/PlatformManagerImpl.cpp
+++ b/src/platform/CYW30739/PlatformManagerImpl.cpp
@@ -173,10 +173,7 @@ CHIP_ERROR PlatformManagerImpl::_StartChipTimer(System::Clock::Timeout durationM
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
-{
-    return CHIP_NO_ERROR;
-}
+void PlatformManagerImpl::_Shutdown() {}
 
 void PlatformManagerImpl::SetEventFlags(uint32_t flags)
 {

--- a/src/platform/CYW30739/PlatformManagerImpl.h
+++ b/src/platform/CYW30739/PlatformManagerImpl.h
@@ -55,7 +55,7 @@ private:
     void _UnlockChipStack(void);
     CHIP_ERROR _PostEvent(const ChipDeviceEvent * event);
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout durationMS);
-    CHIP_ERROR _Shutdown(void);
+    void _Shutdown(void);
 
     void SetEventFlags(uint32_t flags);
     void HandleTimerEvent(void);

--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -47,7 +47,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -355,10 +355,7 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback successCallback, DnssdAsyncRet
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDnssdShutdown()
-{
-    return CHIP_NO_ERROR;
-}
+void ChipDnssdShutdown() {}
 
 CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCallback callback, void * context)
 {

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -118,10 +118,10 @@ void PlatformManagerImpl::_RunEventLoop()
     dispatch_semaphore_wait(mRunLoopSem, DISPATCH_TIME_FOREVER);
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     // Call up to the base class _Shutdown() to perform the bulk of the shutdown.
-    return GenericPlatformManagerImpl<ImplClass>::_Shutdown();
+    GenericPlatformManagerImpl<ImplClass>::_Shutdown();
 }
 
 CHIP_ERROR PlatformManagerImpl::_PostEvent(const ChipDeviceEvent * event)

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -58,7 +58,7 @@ public:
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
     CHIP_ERROR _InitChipStack();
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout delay) { return CHIP_ERROR_NOT_IMPLEMENTED; };
     CHIP_ERROR _StartEventLoopTask();

--- a/src/platform/EFR32/BLEManagerImpl.h
+++ b/src/platform/EFR32/BLEManagerImpl.h
@@ -49,7 +49,7 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/EFR32/PlatformManagerImpl.cpp
+++ b/src/platform/EFR32/PlatformManagerImpl.cpp
@@ -69,7 +69,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     uint64_t upTime = 0;
 
@@ -91,7 +91,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
-    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
+    Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
 }
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI_STATION
 void PlatformManagerImpl::HandleWFXSystemEvent(wfx_event_base_t eventBase, sl_wfx_generic_message_t * eventData)

--- a/src/platform/EFR32/PlatformManagerImpl.h
+++ b/src/platform/EFR32/PlatformManagerImpl.h
@@ -59,7 +59,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
-    CHIP_ERROR _Shutdown(void);
+    void _Shutdown(void);
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/ESP32/BLEManagerImpl.h
+++ b/src/platform/ESP32/BLEManagerImpl.h
@@ -81,7 +81,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/ESP32/DnssdImpl.cpp
+++ b/src/platform/ESP32/DnssdImpl.cpp
@@ -131,10 +131,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR ChipDnssdShutdown()
-{
-    return CHIP_NO_ERROR;
-}
+void ChipDnssdShutdown() {}
 
 static const char * GetProtocolString(DnssdServiceProtocol protocol)
 {

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -66,10 +66,9 @@ CHIP_ERROR ESPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     return err;
 }
 
-CHIP_ERROR ESPWiFiDriver::Shutdown()
+void ESPWiFiDriver::Shutdown()
 {
     mpStatusChangeCallback = nullptr;
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ESPWiFiDriver::CommitConfiguration()

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -88,7 +88,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -131,7 +131,7 @@ exit:
     return chip::DeviceLayer::Internal::ESP32Utils::MapError(err);
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     uint64_t upTime = 0;
 
@@ -153,7 +153,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
-    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
+    Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
 }
 
 void PlatformManagerImpl::HandleESPSystemEvent(void * arg, esp_event_base_t eventBase, int32_t eventId, void * eventData)

--- a/src/platform/ESP32/PlatformManagerImpl.h
+++ b/src/platform/ESP32/PlatformManagerImpl.h
@@ -57,7 +57,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -93,12 +93,10 @@ exit:
     return err;
 }
 
-CHIP_ERROR BLEManagerImpl::_Shutdown()
+void BLEManagerImpl::_Shutdown()
 {
     // ensure scan resources are cleared (e.g. timeout timers)
     mDeviceScanner.reset();
-
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BLEManagerImpl::_SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val)

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -112,7 +112,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init();
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode();
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled();

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -328,10 +328,7 @@ CHIP_ERROR MdnsAvahi::Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncRetu
     CHIP_ERROR error = CHIP_NO_ERROR;
     int avahiError   = 0;
 
-    if (Shutdown() != CHIP_NO_ERROR)
-    {
-        ChipLogError(DeviceLayer, "Shutdown() failed, continue anyway...");
-    }
+    Shutdown();
 
     VerifyOrExit(initCallback != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(errorCallback != nullptr, error = CHIP_ERROR_INVALID_ARGUMENT);
@@ -347,7 +344,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR MdnsAvahi::Shutdown()
+void MdnsAvahi::Shutdown()
 {
     if (mGroup)
     {
@@ -359,7 +356,6 @@ CHIP_ERROR MdnsAvahi::Shutdown()
         avahi_client_free(mClient);
         mClient = nullptr;
     }
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR MdnsAvahi::SetHostname(const char * hostname)
@@ -826,9 +822,9 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
     return MdnsAvahi::GetInstance().Init(initCallback, errorCallback, context);
 }
 
-CHIP_ERROR ChipDnssdShutdown()
+void ChipDnssdShutdown()
 {
-    return MdnsAvahi::GetInstance().Shutdown();
+    MdnsAvahi::GetInstance().Shutdown();
 }
 
 CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCallback callback, void * context)

--- a/src/platform/Linux/DnssdImpl.h
+++ b/src/platform/Linux/DnssdImpl.h
@@ -105,7 +105,7 @@ public:
     MdnsAvahi & operator=(const MdnsAvahi &) = delete;
 
     CHIP_ERROR Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context);
-    CHIP_ERROR Shutdown();
+    void Shutdown();
     CHIP_ERROR SetHostname(const char * hostname);
     CHIP_ERROR PublishService(const DnssdService & service, DnssdPublishCallback callback, void * context);
     CHIP_ERROR StopPublish();

--- a/src/platform/Linux/NetworkCommissioningDriver.h
+++ b/src/platform/Linux/NetworkCommissioningDriver.h
@@ -80,7 +80,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }
@@ -130,7 +130,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new ThreadNetworkIterator(this); }
     CHIP_ERROR Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }

--- a/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningThreadDriver.cpp
@@ -53,10 +53,9 @@ CHIP_ERROR LinuxThreadDriver::Init(BaseDriver::NetworkStatusChangeCallback * net
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LinuxThreadDriver::Shutdown()
+void LinuxThreadDriver::Shutdown()
 {
     ThreadStackMgrImpl().SetNetworkStatusChangeCallback(nullptr);
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LinuxThreadDriver::CommitConfiguration()

--- a/src/platform/Linux/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningWiFiDriver.cpp
@@ -78,10 +78,9 @@ CHIP_ERROR LinuxWiFiDriver::Init(BaseDriver::NetworkStatusChangeCallback * netwo
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LinuxWiFiDriver::Shutdown()
+void LinuxWiFiDriver::Shutdown()
 {
     ConnectivityMgrImpl().SetNetworkStatusChangeCallback(nullptr);
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LinuxWiFiDriver::CommitConfiguration()

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -186,7 +186,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     uint64_t upTime = 0;
 
@@ -208,7 +208,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
-    return Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_Shutdown();
+    Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_Shutdown();
 }
 
 #if CHIP_WITH_GIO

--- a/src/platform/Linux/PlatformManagerImpl.h
+++ b/src/platform/Linux/PlatformManagerImpl.h
@@ -60,7 +60,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack();
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/OpenThread/DnssdImpl.cpp
+++ b/src/platform/OpenThread/DnssdImpl.cpp
@@ -39,10 +39,7 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
     return ThreadStackMgr().ClearSrpHost(hostname);
 }
 
-CHIP_ERROR ChipDnssdShutdown()
-{
-    return CHIP_NO_ERROR;
-}
+void ChipDnssdShutdown() {}
 
 const char * GetProtocolString(DnssdServiceProtocol protocol)
 {

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -57,10 +57,9 @@ CHIP_ERROR GenericThreadDriver::Init(Internal::BaseDriver::NetworkStatusChangeCa
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR GenericThreadDriver::Shutdown()
+void GenericThreadDriver::Shutdown()
 {
     ThreadStackMgrImpl().SetNetworkStatusChangeCallback(nullptr);
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR GenericThreadDriver::CommitConfiguration()

--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.h
@@ -85,7 +85,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new ThreadNetworkIterator(this); }
     CHIP_ERROR Init(Internal::BaseDriver::NetworkStatusChangeCallback * statusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }

--- a/src/platform/P6/BLEManagerImpl.h
+++ b/src/platform/P6/BLEManagerImpl.h
@@ -51,7 +51,7 @@ class BLEManagerImpl final : public BLEManager,
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/P6/NetworkCommissioningDriver.h
+++ b/src/platform/P6/NetworkCommissioningDriver.h
@@ -92,7 +92,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/P6/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/P6/NetworkCommissioningWiFiDriver.cpp
@@ -69,10 +69,9 @@ CHIP_ERROR P6WiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
     return err;
 }
 
-CHIP_ERROR P6WiFiDriver::Shutdown()
+void P6WiFiDriver::Shutdown()
 {
     mpStatusChangeCallback = nullptr;
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR P6WiFiDriver::CommitConfiguration()

--- a/src/platform/P6/PlatformManagerImpl.cpp
+++ b/src/platform/P6/PlatformManagerImpl.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR PlatformManagerImpl::InitLwIPCoreLock(void)
     return Internal::InitLwIPCoreLock();
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     uint64_t upTime = 0;
 
@@ -88,7 +88,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
-    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
+    Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/P6/PlatformManagerImpl.h
+++ b/src/platform/P6/PlatformManagerImpl.h
@@ -55,7 +55,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -87,7 +87,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -460,11 +460,11 @@ exit:
     return CHIP_ERROR_INTERNAL;
 }
 
-CHIP_ERROR DnssdTizen::Shutdown()
+void DnssdTizen::Shutdown()
 {
     int ret = dnssd_deinitialize();
-    VerifyOrReturnError(ret == DNSSD_ERROR_NONE, CHIP_ERROR_INTERNAL);
-    return CHIP_NO_ERROR;
+    if (ret != DNSSD_ERROR_NONE)
+        ChipLogError(DeviceLayer, "DNSsd %s: Error: %d", __func__, ret);
 }
 
 CHIP_ERROR DnssdTizen::RegisterService(const DnssdService & service, DnssdPublishCallback callback, void * context)
@@ -685,9 +685,9 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
     return DnssdTizen::GetInstance().Init(initCallback, errorCallback, context);
 }
 
-CHIP_ERROR ChipDnssdShutdown()
+void ChipDnssdShutdown()
 {
-    return DnssdTizen::GetInstance().Shutdown();
+    DnssdTizen::GetInstance().Shutdown();
 }
 
 CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCallback callback, void * context)

--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -112,7 +112,7 @@ public:
     DnssdTizen & operator=(const DnssdTizen &) = delete;
 
     CHIP_ERROR Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context);
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
     CHIP_ERROR RegisterService(const DnssdService & service, DnssdPublishCallback callback, void * context);
     CHIP_ERROR UnregisterAllServices();

--- a/src/platform/Tizen/NetworkCommissioningDriver.h
+++ b/src/platform/Tizen/NetworkCommissioningDriver.h
@@ -53,7 +53,6 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override { return CHIP_NO_ERROR; }
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }
@@ -102,7 +101,6 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new ThreadNetworkIterator(this); }
     CHIP_ERROR Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override { return CHIP_NO_ERROR; }
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }

--- a/src/platform/Zephyr/BLEManagerImpl.h
+++ b/src/platform/Zephyr/BLEManagerImpl.h
@@ -59,7 +59,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/android/BLEManagerImpl.h
+++ b/src/platform/android/BLEManagerImpl.h
@@ -56,7 +56,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init();
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode();
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled();

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -61,10 +61,7 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDnssdShutdown()
-{
-    return CHIP_NO_ERROR;
-}
+void ChipDnssdShutdown() {}
 
 CHIP_ERROR ChipDnssdRemoveServices()
 {

--- a/src/platform/bouffalolab/BL602/BLEManagerImpl.h
+++ b/src/platform/bouffalolab/BL602/BLEManagerImpl.h
@@ -50,7 +50,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/bouffalolab/BL602/DnssdImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DnssdImpl.cpp
@@ -77,10 +77,7 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
     return error;
 }
 
-CHIP_ERROR ChipDnssdShutdown()
-{
-    return CHIP_NO_ERROR;
-}
+void ChipDnssdShutdown() {}
 
 static const char * GetProtocolString(DnssdServiceProtocol protocol)
 {

--- a/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.cpp
+++ b/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.cpp
@@ -76,10 +76,9 @@ CHIP_ERROR BLWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChangeC
     return err;
 }
 
-CHIP_ERROR BLWiFiDriver::Shutdown()
+void BLWiFiDriver::Shutdown()
 {
     mpStatusChangeCallback = nullptr;
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BLWiFiDriver::CommitConfiguration()

--- a/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.h
@@ -90,7 +90,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/bouffalolab/BL602/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/bouffalolab/BL602/NetworkCommissioningWiFiDriver.cpp
@@ -71,10 +71,7 @@ CHIP_ERROR BLWiFiDriver::Init()
     return err;
 }
 
-CHIP_ERROR BLWiFiDriver::Shutdown()
-{
-    return CHIP_NO_ERROR;
-}
+void BLWiFiDriver::Shutdown() {}
 
 CHIP_ERROR BLWiFiDriver::CommitConfiguration()
 {

--- a/src/platform/cc13x2_26x2/BLEManagerImpl.h
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.h
@@ -207,7 +207,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/fake/DnssdImpl.cpp
+++ b/src/platform/fake/DnssdImpl.cpp
@@ -96,10 +96,7 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ChipDnssdShutdown()
-{
-    return CHIP_NO_ERROR;
-}
+void ChipDnssdShutdown() {}
 
 CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCallback callback, void * context)
 {

--- a/src/platform/fake/PlatformManagerImpl.h
+++ b/src/platform/fake/PlatformManagerImpl.h
@@ -45,7 +45,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack() { return CHIP_NO_ERROR; }
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
 
     CHIP_ERROR _AddEventHandler(EventHandlerFunct handler, intptr_t arg = 0) { return CHIP_ERROR_NOT_IMPLEMENTED; }
     void _RemoveEventHandler(EventHandlerFunct handler, intptr_t arg = 0) {}

--- a/src/platform/mbed/BLEManagerImpl.h
+++ b/src/platform/mbed/BLEManagerImpl.h
@@ -46,7 +46,7 @@ class BLEManagerImpl final : public BLEManager, private BleLayer, private BlePla
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/mbed/NetworkCommissioningDriver.h
+++ b/src/platform/mbed/NetworkCommissioningDriver.h
@@ -94,7 +94,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return kMaxWiFiNetworks; }

--- a/src/platform/mbed/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/mbed/NetworkCommissioningWiFiDriver.cpp
@@ -87,7 +87,7 @@ CHIP_ERROR WiFiDriverImpl::Init(NetworkStatusChangeCallback * networkStatusChang
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR WiFiDriverImpl::Shutdown()
+void WiFiDriverImpl::Shutdown()
 {
     Network network;
     auto networks = GetNetworks();
@@ -115,8 +115,6 @@ CHIP_ERROR WiFiDriverImpl::Shutdown()
     mStagingNetwork.credentialsLen = 0;
     mSavedNetwork.ssidLen          = 0;
     mSavedNetwork.credentialsLen   = 0;
-
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR WiFiDriverImpl::CommitConfiguration()

--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -270,19 +270,15 @@ CHIP_ERROR PlatformManagerImpl::_StartChipTimer(System::Clock::Timeout duration)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     //
     // Call up to the base class _Shutdown() to perform the actual stack de-initialization
     // and clean-up
     //
-    auto err = GenericPlatformManagerImpl<ImplClass>::_Shutdown();
-    if (err == CHIP_NO_ERROR)
-    {
-        mInitialized = false;
-        mQueue.background(nullptr);
-    }
-    return err;
+    GenericPlatformManagerImpl<ImplClass>::_Shutdown();
+    mInitialized = false;
+    mQueue.background(nullptr);
 }
 
 CHIP_ERROR PlatformManagerImpl::TranslateOsStatus(osStatus error)

--- a/src/platform/mbed/PlatformManagerImpl.h
+++ b/src/platform/mbed/PlatformManagerImpl.h
@@ -89,7 +89,7 @@ private:
     CHIP_ERROR _StartEventLoopTask();
     CHIP_ERROR _StopEventLoopTask();
     CHIP_ERROR _StartChipTimer(System::Clock::Timeout duration);
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
     void ProcessDeviceEvents();
 

--- a/src/platform/nxp/k32w/k32w0/BLEManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/BLEManagerImpl.h
@@ -64,7 +64,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
@@ -133,7 +133,7 @@ exit:
     return err;
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     uint64_t upTime = 0;
 
@@ -155,7 +155,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
-    return Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
+    Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.h
@@ -55,7 +55,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
     // ===== Members for internal use by the following friends.
 

--- a/src/platform/qpg/BLEManagerImpl.h
+++ b/src/platform/qpg/BLEManagerImpl.h
@@ -48,7 +48,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown() { return CHIP_NO_ERROR; }
+    void _Shutdown() {}
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/telink/BLEManagerImpl.cpp
+++ b/src/platform/telink/BLEManagerImpl.cpp
@@ -467,13 +467,6 @@ void BLEManagerImpl::_InitGatt(void)
     bls_att_setAttributeTable((u8 *) gattTable);
 }
 
-CHIP_ERROR _Shutdown(void)
-{
-    ChipLogProgress(DeviceLayer, "BLEManagerImpl::_Shutdown");
-
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR BLEManagerImpl::_SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val)
 {
     return CHIP_NO_ERROR;

--- a/src/platform/telink/BLEManagerImpl.h
+++ b/src/platform/telink/BLEManagerImpl.h
@@ -44,7 +44,7 @@ private:
     // Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode(void);
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled(void);

--- a/src/platform/tests/TestPlatformMgr.cpp
+++ b/src/platform/tests/TestPlatformMgr.cpp
@@ -50,8 +50,7 @@ static void TestPlatformMgr_InitShutdown(nlTestSuite * inSuite, void * inContext
     CHIP_ERROR err = PlatformMgr().InitChipStack();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = PlatformMgr().Shutdown();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    PlatformMgr().Shutdown();
 }
 
 static void TestPlatformMgr_BasicEventLoopTask(nlTestSuite * inSuite, void * inContext)
@@ -65,8 +64,7 @@ static void TestPlatformMgr_BasicEventLoopTask(nlTestSuite * inSuite, void * inC
     err = PlatformMgr().StopEventLoopTask();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
-    err = PlatformMgr().Shutdown();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    PlatformMgr().Shutdown();
 }
 
 static bool stopRan;
@@ -91,8 +89,7 @@ static void TestPlatformMgr_BasicRunEventLoop(nlTestSuite * inSuite, void * inCo
     PlatformMgr().RunEventLoop();
     NL_TEST_ASSERT(inSuite, stopRan);
 
-    err = PlatformMgr().Shutdown();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    PlatformMgr().Shutdown();
 }
 
 static bool sleepRan;
@@ -118,8 +115,7 @@ static void TestPlatformMgr_RunEventLoopTwoTasks(nlTestSuite * inSuite, void * i
     NL_TEST_ASSERT(inSuite, stopRan);
     NL_TEST_ASSERT(inSuite, sleepRan);
 
-    err = PlatformMgr().Shutdown();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    PlatformMgr().Shutdown();
 }
 
 void StopAndSleep(intptr_t arg)
@@ -143,8 +139,7 @@ static void TestPlatformMgr_RunEventLoopStopBeforeSleep(nlTestSuite * inSuite, v
     NL_TEST_ASSERT(inSuite, stopRan);
     NL_TEST_ASSERT(inSuite, sleepRan);
 
-    err = PlatformMgr().Shutdown();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    PlatformMgr().Shutdown();
 }
 
 static void TestPlatformMgr_TryLockChipStack(nlTestSuite * inSuite, void * inContext)
@@ -206,8 +201,7 @@ static void TestPlatformMgr_MockSystemLayer(nlTestSuite * inSuite, void * inCont
         inSuite, DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::kZero, nullptr, nullptr) == CHIP_APPLICATION_ERROR(1));
     NL_TEST_ASSERT(inSuite, DeviceLayer::SystemLayer().ScheduleWork(nullptr, nullptr) == CHIP_APPLICATION_ERROR(2));
 
-    err = PlatformMgr().Shutdown();
-    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    PlatformMgr().Shutdown();
 
     DeviceLayer::SetSystemLayerForTesting(nullptr);
 }

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -128,12 +128,10 @@ exit:
     return err;
 }
 
-CHIP_ERROR BLEManagerImpl::_Shutdown()
+void BLEManagerImpl::_Shutdown()
 {
     // ensure scan resources are cleared (e.g. timeout timers)
     mDeviceScanner.reset();
-
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR BLEManagerImpl::_SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val)

--- a/src/platform/webos/BLEManagerImpl.h
+++ b/src/platform/webos/BLEManagerImpl.h
@@ -95,7 +95,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init();
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
     CHIPoBLEServiceMode _GetCHIPoBLEServiceMode();
     CHIP_ERROR _SetCHIPoBLEServiceMode(CHIPoBLEServiceMode val);
     bool _IsAdvertisingEnabled();

--- a/src/platform/webos/DnssdImpl.cpp
+++ b/src/platform/webos/DnssdImpl.cpp
@@ -342,7 +342,7 @@ exit:
     return error;
 }
 
-CHIP_ERROR MdnsAvahi::Shutdown()
+void MdnsAvahi::Shutdown()
 {
     if (mGroup)
     {
@@ -354,7 +354,6 @@ CHIP_ERROR MdnsAvahi::Shutdown()
         avahi_client_free(mClient);
         mClient = nullptr;
     }
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR MdnsAvahi::SetHostname(const char * hostname)
@@ -820,9 +819,9 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
     return MdnsAvahi::GetInstance().Init(initCallback, errorCallback, context);
 }
 
-CHIP_ERROR ChipDnssdShutdown()
+void ChipDnssdShutdown()
 {
-    return MdnsAvahi::GetInstance().Shutdown();
+    MdnsAvahi::GetInstance().Shutdown();
 }
 
 CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCallback callback, void * context)

--- a/src/platform/webos/DnssdImpl.h
+++ b/src/platform/webos/DnssdImpl.h
@@ -105,7 +105,7 @@ public:
     MdnsAvahi & operator=(const MdnsAvahi &) = delete;
 
     CHIP_ERROR Init(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturnCallback errorCallback, void * context);
-    CHIP_ERROR Shutdown();
+    void Shutdown();
     CHIP_ERROR SetHostname(const char * hostname);
     CHIP_ERROR PublishService(const DnssdService & service, DnssdPublishCallback callback, void * context);
     CHIP_ERROR StopPublish();

--- a/src/platform/webos/NetworkCommissioningDriver.h
+++ b/src/platform/webos/NetworkCommissioningDriver.h
@@ -80,7 +80,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new WiFiNetworkIterator(this); }
     CHIP_ERROR Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }
@@ -130,7 +130,7 @@ public:
     // BaseDriver
     NetworkIterator * GetNetworks() override { return new ThreadNetworkIterator(this); }
     CHIP_ERROR Init(BaseDriver::NetworkStatusChangeCallback * networkStatusChangeCallback) override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
 
     // WirelessDriver
     uint8_t GetMaxNetworks() override { return 1; }

--- a/src/platform/webos/NetworkCommissioningThreadDriver.cpp
+++ b/src/platform/webos/NetworkCommissioningThreadDriver.cpp
@@ -53,10 +53,9 @@ CHIP_ERROR LinuxThreadDriver::Init(BaseDriver::NetworkStatusChangeCallback * net
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LinuxThreadDriver::Shutdown()
+void LinuxThreadDriver::Shutdown()
 {
     ThreadStackMgrImpl().SetNetworkStatusChangeCallback(nullptr);
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LinuxThreadDriver::CommitConfiguration()

--- a/src/platform/webos/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/webos/NetworkCommissioningWiFiDriver.cpp
@@ -78,10 +78,9 @@ CHIP_ERROR LinuxWiFiDriver::Init(BaseDriver::NetworkStatusChangeCallback * netwo
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LinuxWiFiDriver::Shutdown()
+void LinuxWiFiDriver::Shutdown()
 {
     ConnectivityMgrImpl().SetNetworkStatusChangeCallback(nullptr);
-    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR LinuxWiFiDriver::CommitConfiguration()

--- a/src/platform/webos/PlatformManagerImpl.cpp
+++ b/src/platform/webos/PlatformManagerImpl.cpp
@@ -177,7 +177,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR PlatformManagerImpl::_Shutdown()
+void PlatformManagerImpl::_Shutdown()
 {
     uint64_t upTime = 0;
 
@@ -199,7 +199,7 @@ CHIP_ERROR PlatformManagerImpl::_Shutdown()
         ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
     }
 
-    return Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_Shutdown();
+    Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_Shutdown();
 }
 
 #if CHIP_WITH_GIO

--- a/src/platform/webos/PlatformManagerImpl.h
+++ b/src/platform/webos/PlatformManagerImpl.h
@@ -60,7 +60,7 @@ private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack();
-    CHIP_ERROR _Shutdown();
+    void _Shutdown();
 
     // ===== Members for internal use by the following friends.
 

--- a/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
+++ b/src/protocols/secure_channel/tests/TestMessageCounterManager.cpp
@@ -158,8 +158,8 @@ int Initialize(void * aContext)
  */
 int Finalize(void * aContext)
 {
-    CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Shutdown();
-    return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
+    reinterpret_cast<TestContext *>(aContext)->Shutdown();
+    return SUCCESS;
 }
 
 } // namespace

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -86,7 +86,7 @@ public:
      * Some other layers hold pointers to System::Layer, so care must be taken
      * to ensure that they are not used after calling Shutdown().
      */
-    virtual CHIP_ERROR Shutdown() = 0;
+    virtual void Shutdown() = 0;
 
     /**
      * True if this Layer is initialized. No method on Layer or its abstract descendants, other than this and `Init()`,

--- a/src/system/SystemLayerImplFreeRTOS.cpp
+++ b/src/system/SystemLayerImplFreeRTOS.cpp
@@ -44,10 +44,9 @@ CHIP_ERROR LayerImplFreeRTOS::Init()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LayerImplFreeRTOS::Shutdown()
+void LayerImplFreeRTOS::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.ResetFromInitialized(), CHIP_ERROR_INCORRECT_STATE);
-    return CHIP_NO_ERROR;
+    mLayerState.ResetFromInitialized();
 }
 
 CHIP_ERROR LayerImplFreeRTOS::StartTimer(Clock::Timeout delay, TimerCompleteCallback onComplete, void * appState)

--- a/src/system/SystemLayerImplFreeRTOS.h
+++ b/src/system/SystemLayerImplFreeRTOS.h
@@ -37,7 +37,7 @@ public:
 
     // Layer overrides.
     CHIP_ERROR Init() override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
     bool IsInitialized() const override { return mLayerState.IsInitialized(); }
     CHIP_ERROR StartTimer(Clock::Timeout delay, TimerCompleteCallback onComplete, void * appState) override;
     void CancelTimer(TimerCompleteCallback onComplete, void * appState) override;

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -62,9 +62,9 @@ CHIP_ERROR LayerImplSelect::Init()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR LayerImplSelect::Shutdown()
+void LayerImplSelect::Shutdown()
 {
-    VerifyOrReturnError(mLayerState.SetShuttingDown(), CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturn(mLayerState.SetShuttingDown());
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     TimerList::Node * timer;
@@ -85,7 +85,6 @@ CHIP_ERROR LayerImplSelect::Shutdown()
     mWakeEvent.Close(*this);
 
     mLayerState.ResetFromShuttingDown(); // Return to uninitialized state to permit re-initialization.
-    return CHIP_NO_ERROR;
 }
 
 void LayerImplSelect::Signal()

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -45,7 +45,7 @@ public:
 
     // Layer overrides.
     CHIP_ERROR Init() override;
-    CHIP_ERROR Shutdown() override;
+    void Shutdown() override;
     bool IsInitialized() const override { return mLayerState.IsInitialized(); }
     CHIP_ERROR StartTimer(Clock::Timeout delay, TimerCompleteCallback onComplete, void * appState) override;
     void CancelTimer(TimerCompleteCallback onComplete, void * appState) override;

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -231,10 +231,7 @@ int PacketBufferTest::TestSetup(void * inContext)
 
 int PacketBufferTest::TestTeardown(void * inContext)
 {
-    CHIP_ERROR err = chip::DeviceLayer::PlatformMgr().Shutdown();
-    // RTOS shutdown is not implemented, ignore CHIP_ERROR_NOT_IMPLEMENTED
-    if (err != CHIP_NO_ERROR && err != CHIP_ERROR_NOT_IMPLEMENTED)
-        return FAILURE;
+    chip::DeviceLayer::PlatformMgr().Shutdown();
 
     chip::Platform::MemoryShutdown();
 

--- a/src/system/tests/TestSystemScheduleLambda.cpp
+++ b/src/system/tests/TestSystemScheduleLambda.cpp
@@ -79,11 +79,7 @@ static int TestSetup(void * aContext)
  */
 static int TestTeardown(void * aContext)
 {
-    CHIP_ERROR err = chip::DeviceLayer::PlatformMgr().Shutdown();
-    // RTOS shutdown is not implemented, ignore CHIP_ERROR_NOT_IMPLEMENTED
-    if (err != CHIP_NO_ERROR && err != CHIP_ERROR_NOT_IMPLEMENTED)
-        return FAILURE;
-
+    chip::DeviceLayer::PlatformMgr().Shutdown();
     return (SUCCESS);
 }
 

--- a/src/transport/raw/tests/NetworkTestHelpers.cpp
+++ b/src/transport/raw/tests/NetworkTestHelpers.cpp
@@ -44,15 +44,11 @@ CHIP_ERROR IOContext::Init()
 }
 
 // Shutdown all layers, finalize operations
-CHIP_ERROR IOContext::Shutdown()
+void IOContext::Shutdown()
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
     ShutdownNetwork();
     ShutdownSystemLayer();
     Platform::MemoryShutdown();
-
-    return err;
 }
 
 void IOContext::DriveIO()

--- a/src/transport/raw/tests/NetworkTestHelpers.h
+++ b/src/transport/raw/tests/NetworkTestHelpers.h
@@ -40,7 +40,7 @@ public:
     CHIP_ERROR Init();
 
     // Shutdown all layers, finalize operations
-    CHIP_ERROR Shutdown();
+    void Shutdown();
 
     /// Perform a single short IO Loop
     void DriveIO();

--- a/src/transport/raw/tests/TestTCP.cpp
+++ b/src/transport/raw/tests/TestTCP.cpp
@@ -497,8 +497,8 @@ static int Initialize(void * aContext)
  */
 static int Finalize(void * aContext)
 {
-    CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Shutdown();
-    return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
+    reinterpret_cast<TestContext *>(aContext)->Shutdown();
+    return SUCCESS;
 }
 
 int TestTCP()

--- a/src/transport/raw/tests/TestUDP.cpp
+++ b/src/transport/raw/tests/TestUDP.cpp
@@ -205,8 +205,8 @@ static int Initialize(void * aContext)
  */
 static int Finalize(void * aContext)
 {
-    CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Shutdown();
-    return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
+    reinterpret_cast<TestContext *>(aContext)->Shutdown();
+    return SUCCESS;
 }
 
 int TestUDP()

--- a/src/transport/tests/LoopbackTransportManager.h
+++ b/src/transport/tests/LoopbackTransportManager.h
@@ -36,11 +36,10 @@ public:
     }
 
     // Shutdown all layers, finalize operations
-    CHIP_ERROR Shutdown()
+    void Shutdown()
     {
         GetLoopback().ShutdownLoopbackTransport();
-        ReturnErrorOnFailure(mIOContext.Shutdown());
-        return CHIP_NO_ERROR;
+        mIOContext.Shutdown();
     }
 
     System::Layer & GetSystemLayer() { return mIOContext.GetSystemLayer(); }

--- a/src/transport/tests/TestSessionManager.cpp
+++ b/src/transport/tests/TestSessionManager.cpp
@@ -1004,8 +1004,8 @@ int Initialize(void * aContext)
  */
 int Finalize(void * aContext)
 {
-    CHIP_ERROR err = reinterpret_cast<TestContext *>(aContext)->Shutdown();
-    return (err == CHIP_NO_ERROR) ? SUCCESS : FAILURE;
+    reinterpret_cast<TestContext *>(aContext)->Shutdown();
+    return SUCCESS;
 }
 
 } // namespace


### PR DESCRIPTION
#### Problem

Destructors, Shutdown functions, and other cleanup code should be
declared with a 'void' return type as typically there is nothing that
can be done in the caller when an error is returned.

#### Change overview

This removes the error return from such functions throughought Matter.
This transformation is straightforward in every case, and semantic
preserving in almost every case (broken semantics such as leaking memory
or leaving objects in an inconsistent state are not necessarily
preserved); it's rare for shutdown functions to actually return errors,
and also rare for callers to check for them.

Removing the threat of errors from cleanup functions simplifies control
flow in shutdown paths. It also facilitates shutdown from destructors
which is the typical C++ resource management paradigm ("RAII"), as
destructors have no return type.

Some functions had error cases that only occured when there was nothing
to do (e.g. not fully initialized returning 'invalid state'); these are
removed. The postcondition already holds in these cases, and maintaining
a precondition regarding the state would impose duplicative bookkeeping
in client code to track it without any real upside.

This changes a fair number of APIs, but the changes are easy to
accomodate as it is simply a matter of removing dead code (much of
which was already dead; one class even included the note

```
  @return #CHIP_NO_ERROR unconditionally.
```

as documentation that an error was not actually possible).

#### Testing

CI
