### PR TITLE
Chef - Fix broken esp32 RPC build caused by #18621

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -539,9 +539,9 @@ def main(argv: Sequence[str]) -> None:
 
         else:
             flush_print("RPC PW disabled")
-        if (options.build_target == "esp32"):
-            shell.run_cmd(
-                f"export SDKCONFIG_DEFAULTS={_CHEF_SCRIPT_PATH}/esp32/sdkconfig.defaults")
+            if (options.build_target == "esp32"):
+                shell.run_cmd(
+                    f"export SDKCONFIG_DEFAULTS={_CHEF_SCRIPT_PATH}/esp32/sdkconfig.defaults")
 
         flush_print(
             f"Product ID 0x{options.pid:02X} / Vendor ID 0x{options.vid:02X}")

--- a/examples/chef/esp32/CMakeLists.txt
+++ b/examples/chef/esp32/CMakeLists.txt
@@ -60,6 +60,9 @@ flashing_script()
 if (CONFIG_ENABLE_PW_RPC)
 get_filename_component(CHIP_ROOT ./third_party/connectedhomeip REALPATH)
 include(third_party/connectedhomeip/third_party/pigweed/repo/pw_build/pigweed.cmake)
+
+pw_set_module_config(pw_rpc_CONFIG pw_rpc.disable_global_mutex_config)
+
 pw_set_backend(pw_log pw_log_basic)
 pw_set_backend(pw_assert.check pw_assert_log.check_backend)
 pw_set_backend(pw_assert.assert pw_assert.assert_compatibility_backend)

--- a/examples/chef/esp32/main/CMakeLists.txt
+++ b/examples/chef/esp32/main/CMakeLists.txt
@@ -154,7 +154,7 @@ pw_proto_library(descriptor_service
   STRIP_PREFIX
     ${CHIP_ROOT}/examples/common/pigweed/protos
   DEPS
-    pw_protobuf.common_protos
+    pw_protobuf.common_proto
 )
 
 pw_proto_library(device_service
@@ -178,7 +178,7 @@ pw_proto_library(wifi_service
   PREFIX
     wifi_service
   DEPS
-    pw_protobuf.common_protos
+    pw_protobuf.common_proto
   STRIP_PREFIX
     ${CHIP_ROOT}/examples/common/pigweed/protos
 )


### PR DESCRIPTION
#### Problem
* esp32 RPC build is broken in Chef. It wasn't correctly building the RPC version of the app.

#### Change overview
* Fix esp32 RPC build so it does build the RPC version of the app.
* Fix esp32 RPC build issue caused by pigweed update.

#### Testing
* Tested RPC calls manually