### PR TITLE
[BL602] 1.add matter ota support, 2. use matter example DeviceInfoPro…

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl602/BUILD.gn
@@ -82,6 +82,7 @@ bl602_executable("lighting_app") {
     "${chip_root}/examples/lighting-app/lighting-common",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
+    "${chip_root}/examples/providers:device_info_provider",
   ]
 
   include_dirs = [ "include" ]

--- a/examples/lighting-app/bouffalolab/bl602/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl602/BUILD.gn
@@ -80,9 +80,9 @@ bl602_executable("lighting_app") {
     ":sdk",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lighting-app/lighting-common",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
-    "${chip_root}/examples/providers:device_info_provider",
   ]
 
   include_dirs = [ "include" ]

--- a/examples/lighting-app/bouffalolab/bl602/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/bouffalolab/bl602/include/CHIPProjectConfig.h
@@ -68,7 +68,38 @@
  * TODO: 3R
  */
 //#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0xF001
-#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8005
+#define CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID 0x8001
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION
+ *
+ * The hardware version number assigned to device or product by the device vendor.  This
+ * number is scoped to the device product id, and typically corresponds to a revision of the
+ * physical device, a change to its packaging, and/or a change to its marketing presentation.
+ * This value is generally *not* incremented for device software versions.
+ */
+#define CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION 1
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+ *
+ * A string identifying the software version running on the device.
+ * CHIP service currently expects the software version to be in the format
+ * {MAJOR_VERSION}.0d{MINOR_VERSION}
+ */
+#ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
+#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "0.1ALPHA"
+
+/**
+ * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION
+ *
+ * A uint32_t identifying the software version running on the device.
+ */
+/* The SoftwareVersion attribute of the Basic cluster. */
+#ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION
+#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION 0x0001
+#endif
+#endif
 
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_REVISION

--- a/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
@@ -25,6 +25,10 @@
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
+#include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestor.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorDriver.h>
+#include <app/clusters/ota-requestor/DefaultOTARequestorStorage.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
 #include <app/util/af-enums.h>
@@ -34,7 +38,9 @@
 #include <lib/support/CodeUtils.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/bouffalolab/BL602/NetworkCommissioningDriver.h>
+#include <platform/bouffalolab/BL602/OTAImageProcessorImpl.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
+#include <DeviceInfoProviderImpl.h>
 
 #include <bl_sys_ota.h>
 #include <lib/support/ErrorStr.h>
@@ -71,6 +77,12 @@ chip::app::Clusters::NetworkCommissioning::Instance
 } // namespace
 
 using namespace ::chip::System;
+
+DefaultOTARequestor gRequestorCore;
+DefaultOTARequestorStorage gRequestorStorage;
+DefaultOTARequestorDriver gRequestorUser;
+BDXDownloader gDownloader;
+OTAImageProcessorImpl gImageProcessor;
 
 AppTask AppTask::sAppTask;
 static DeviceCallbacks EchoCallbacks;
@@ -121,7 +133,13 @@ CHIP_ERROR AppTask::Init()
 
     LightMgr().SetCallbacks(ActionInitiated, ActionCompleted);
 
-    UpdateClusterState();
+    SetRequestorInstance(&gRequestorCore);
+    gRequestorStorage.Init(chip::Server::GetInstance().GetPersistentStorage());
+    gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
+    gImageProcessor.SetOTADownloader(&gDownloader);
+    gDownloader.SetImageProcessorDelegate(&gImageProcessor);
+    gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
+    SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());
 
     ConfigurationMgr().LogDeviceConfig();
 

--- a/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
@@ -21,6 +21,7 @@
 #include "CHIPDeviceManager.h"
 #include "DeviceCallbacks.h"
 #include "LEDWidget.h"
+#include <DeviceInfoProviderImpl.h>
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
@@ -40,7 +41,6 @@
 #include <platform/bouffalolab/BL602/NetworkCommissioningDriver.h>
 #include <platform/bouffalolab/BL602/OTAImageProcessorImpl.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <DeviceInfoProviderImpl.h>
 
 #include <bl_sys_ota.h>
 #include <lib/support/ErrorStr.h>

--- a/examples/lighting-app/bouffalolab/bl602/src/DeviceCallbacks.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/DeviceCallbacks.cpp
@@ -31,6 +31,7 @@
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/cluster-id.h>
 #include <app/CommandHandler.h>
+#include <app/clusters/identify-server/identify-server.h>
 #include <app/server/Dnssd.h>
 #include <app/util/basic-types.h>
 #include <app/util/util.h>
@@ -250,3 +251,38 @@ bool emberAfBasicClusterMfgSpecificPingCallback(chip::app::CommandHandler * comm
     emberAfSendDefaultResponse(emberAfCurrentCommand(), EMBER_ZCL_STATUS_SUCCESS);
     return true;
 }
+
+void OnIdentifyStart(Identify *)
+{
+    ChipLogProgress(Zcl, "OnIdentifyStart");
+}
+
+void OnIdentifyStop(Identify *)
+{
+    ChipLogProgress(Zcl, "OnIdentifyStop");
+}
+
+void OnTriggerEffect(Identify * identify)
+{
+    switch (identify->mCurrentEffectIdentifier)
+    {
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
+        ChipLogProgress(Zcl, "EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY");
+        break;
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
+        break;
+    default:
+        ChipLogProgress(Zcl, "No identifier effect");
+        return;
+    }
+}
+
+static Identify gIdentify1 = {
+    chip::EndpointId{ 1 }, OnIdentifyStart, OnIdentifyStop, EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED, OnTriggerEffect,
+};

--- a/src/platform/bouffalolab/BL602/BUILD.gn
+++ b/src/platform/bouffalolab/BL602/BUILD.gn
@@ -40,16 +40,19 @@ static_library("BL602") {
     "DeviceNetworkProvisioningDelegateImpl.h",
     "DiagnosticDataProviderImpl.cpp",
     "DiagnosticDataProviderImpl.h",
-    "DnssdImpl.cpp",
     "InetPlatformConfig.h",
     "Logging.cpp",
     "NetworkCommissioningDriver.cpp",
+    "OTAImageProcessorImpl.cpp",
     "PlatformManagerImpl.cpp",
     "PlatformManagerImpl.h",
     "SystemPlatformConfig.h",
   ]
 
-  deps = [ "${chip_root}/src/lib/dnssd:platform_header" ]
+  deps = [
+    "${chip_root}/src/lib/dnssd:platform_header",
+    "${chip_root}/src/setup_payload",
+  ]
 
   public_deps = [ "${chip_root}/src/platform:platform_base" ]
 

--- a/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.cpp
@@ -23,9 +23,8 @@
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <DiagnosticDataProviderImpl.h>
 #include <crypto/CHIPCryptoPAL.h>
-#include <platform/DiagnosticDataProvider.h>
-#include <platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.h>
 
 #include <lwip/tcpip.h>
 

--- a/src/platform/bouffalolab/BL602/DnssdImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DnssdImpl.cpp
@@ -42,6 +42,25 @@ namespace chip {
 namespace Dnssd {
 
 #define MDNS_MAX_PACKET_SIZE 64
+typedef struct
+{
+    const char * key;   /*!< item key name */
+    const char * value; /*!< item value string */
+    size_t value_len;
+} mdns_txt_item_t;
+
+typedef struct mdns
+{
+    struct netif * netif;
+    uint8_t slot[10];
+    uint8_t slot_idx;
+    int txt_cnt;
+} mdns_t;
+
+#define MDNS_TXT_MAX_LEN 128
+static mdns_t mdns      = { NULL, 0, 0, 0, 0 };
+mdns_txt_item_t * items = nullptr;
+uint8_t packet[MDNS_TXT_MAX_LEN];
 
 static const DnssdService * glservice;
 
@@ -50,6 +69,7 @@ CHIP_ERROR ChipDnssdInit(DnssdAsyncReturnCallback initCallback, DnssdAsyncReturn
     CHIP_ERROR error = CHIP_NO_ERROR;
 
     mdns_resp_init();
+    mdns.slot_idx = 0;
     initCallback(context, error);
 
     glservice = static_cast<DnssdService *>(chip::Platform::MemoryCalloc(1, sizeof(DnssdService)));
@@ -66,24 +86,6 @@ static const char * GetProtocolString(DnssdServiceProtocol protocol)
 {
     return protocol == DnssdServiceProtocol::kDnssdProtocolTcp ? "_tcp" : "_udp";
 }
-
-typedef struct
-{
-    const char * key;   /*!< item key name */
-    const char * value; /*!< item value string */
-    size_t value_len;
-} mdns_txt_item_t;
-
-typedef struct mdns
-{
-    struct netif * netif;
-    int slot;
-} mdns_t;
-
-#define MDNS_TXT_MAX_LEN 128
-static mdns_t mdns      = { NULL, -1 };
-mdns_txt_item_t * items = nullptr;
-uint8_t packet[MDNS_TXT_MAX_LEN];
 
 static inline uint8_t _mdns_append_u8(uint8_t * packet, uint16_t * index, uint8_t value)
 {
@@ -139,7 +141,7 @@ static void srv_txt(struct mdns_service * service, void * txt_userdata)
     int i, ret;
     int index = 0;
 
-    for (i = 0; i < 3; i++)
+    for (i = 0; i < mdns.txt_cnt; i++)
     {
         ret = mdns_resp_add_service_txtitem(service, &(packet[index + 1]), packet[index]);
         if (ret)
@@ -179,18 +181,21 @@ int mdns_responder_ops(struct netif * netif)
         return -1;
     }
 
-    mdns.netif = netif;
-
-    ret = mdns_resp_add_netif(netif, glservice->mHostName, 10);
-    if (ret != 0)
+    if (!(mdns.netif))
     {
-        mdns_resp_deinit();
-        log_info("add netif failed:%d\r\n", ret);
-        return -1;
+        mdns.netif = netif;
+
+        ret = mdns_resp_add_netif(netif, glservice->mHostName, 10);
+        if (ret != 0)
+        {
+            mdns_resp_deinit();
+            log_info("add netif failed:%d\r\n", ret);
+            return -1;
+        }
     }
 
-    items = static_cast<mdns_txt_item_t *>(chip::Platform::MemoryCalloc(glservice->mTextEntrySize, sizeof(mdns_txt_item_t)));
-
+    items        = static_cast<mdns_txt_item_t *>(chip::Platform::MemoryCalloc(glservice->mTextEntrySize, sizeof(mdns_txt_item_t)));
+    mdns.txt_cnt = glservice->mTextEntrySize;
     for (size_t i = 0; i < glservice->mTextEntrySize; i++)
     {
         items[i].key       = glservice->mTextEntries[i].mKey;
@@ -199,8 +204,6 @@ int mdns_responder_ops(struct netif * netif)
         packet_len         = packet_len + strlen(items[i].key) + items[i].value_len + 1;
     }
 
-    // todo:use malloc?
-    // packet = static_cast<uint8_t*>(chip::Platform::MemoryCalloc(packet_len, sizeof(uint8_t)));
     if (MDNS_TXT_MAX_LEN < packet_len)
     {
         return -1;
@@ -220,6 +223,11 @@ int mdns_responder_ops(struct netif * netif)
         return -1;
     }
 
+    mdns.slot[mdns.slot_idx] = slot;
+    mdns.slot_idx++;
+    mdns_resp_announce(netif);
+
+#if 0
     // for ota
     slot =
         mdns_resp_add_service(netif, "MATTER OTA", "_ota", static_cast<uint8_t>(glservice->mProtocol), 3333, 1000, ota_txt, NULL);
@@ -229,6 +237,7 @@ int mdns_responder_ops(struct netif * netif)
         mdns_resp_deinit();
         log_info("ota mdns fail.\r\n");
     }
+#endif
 
     return slot;
 }
@@ -262,6 +271,8 @@ CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCal
         return CHIP_ERROR_INTERNAL;
     }
 
+    // mdns_responder_ops(netif);
+
     slot = netifapi_netif_common(netif, NULL, mdns_responder_start_netifapi_errt_fn);
     if (slot < 0)
     {
@@ -274,7 +285,23 @@ CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCal
 
 CHIP_ERROR ChipDnssdRemoveServices()
 {
-    // netifapi_netif_common(mdns.netif, NULL, mdns_responder_stop_netifapi_errt_fn);
+    struct netif * netif;
+    int i = 0;
+
+    netif = wifi_mgmr_sta_netif_get();
+    if (netif == NULL)
+    {
+        log_info("find failed\r\n");
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    for (i = 0; i < mdns.slot_idx; i++)
+    {
+        mdns_resp_del_service(netif, mdns.slot[i]);
+    }
+
+    mdns.slot_idx = 0;
+
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/bouffalolab/BL602/InetPlatformConfig.h
+++ b/src/platform/bouffalolab/BL602/InetPlatformConfig.h
@@ -34,11 +34,7 @@
 #define INET_CONFIG_ERROR_MIN 1000000
 #define INET_CONFIG_ERROR_MAX 1000999
 
-#if LWIP_CONFIG_ENABLE_IPV4
 #define INET_CONFIG_ENABLE_IPV4 1
-#else
-#define INET_CONFIG_ENABLE_IPV4 0
-#endif
 
 // ========== Platform-specific Configuration Overrides =========
 

--- a/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.h
@@ -114,6 +114,11 @@ public:
     CHIP_ERROR ReConnectWiFiNetwork(void);
     void OnConnectWiFiNetwork();
     void OnScanWiFiNetworkDone();
+    void OnNetworkStatusChange();
+
+    CHIP_ERROR SetLastDisconnectReason(const ChipDeviceEvent * event);
+    int32_t GetLastDisconnectReason();
+
     static BLWiFiDriver & GetInstance()
     {
         static BLWiFiDriver instance;
@@ -130,6 +135,7 @@ private:
     ScanCallback * mpScanCallback;
     ConnectCallback * mpConnectCallback;
     NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;
+    int32_t mLastDisconnectedReason;
 };
 // #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 

--- a/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.cpp
+++ b/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.cpp
@@ -1,0 +1,268 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/clusters/ota-requestor/OTADownloader.h>
+#include <app/clusters/ota-requestor/OTARequestorInterface.h>
+
+#include "OTAImageProcessorImpl.h"
+#include "lib/core/CHIPError.h"
+#include <hal_sys.h>
+#include <hosal_ota.h>
+
+#define TAG "OTAImageProcessor"
+using namespace chip::System;
+using namespace ::chip::DeviceLayer::Internal;
+
+namespace chip {
+namespace {
+
+void HandleRestart(Layer * systemLayer, void * appState)
+{
+    hal_reboot();
+
+    return;
+}
+} // namespace
+
+bool OTAImageProcessorImpl::IsFirstImageRun()
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor == nullptr)
+    {
+        return false;
+    }
+
+    return requestor->GetCurrentUpdateState() == OTARequestorInterface::OTAUpdateStateEnum::kApplying;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ConfirmCurrentImage()
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor == nullptr)
+    {
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    uint32_t currentVersion;
+    ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(currentVersion));
+    if (currentVersion != requestor->GetTargetVersion())
+    {
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
+{
+    DeviceLayer::PlatformMgr().ScheduleWork(HandlePrepareDownload, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::Finalize()
+{
+    DeviceLayer::PlatformMgr().ScheduleWork(HandleFinalize, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::Apply()
+{
+    DeviceLayer::PlatformMgr().ScheduleWork(HandleApply, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::Abort()
+{
+    DeviceLayer::PlatformMgr().ScheduleWork(HandleAbort, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
+{
+    CHIP_ERROR err = SetBlock(block);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(SoftwareUpdate, "Cannot set block data: %" CHIP_ERROR_FORMAT, err.Format());
+        return err;
+    }
+    DeviceLayer::PlatformMgr().ScheduleWork(HandleProcessBlock, reinterpret_cast<intptr_t>(this));
+    return CHIP_NO_ERROR;
+}
+
+void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
+{
+    int err = 0;
+
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    if (imageProcessor == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
+        return;
+    }
+    else if (imageProcessor->mDownloader == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "mDownloader is null");
+        return;
+    }
+
+    err = hosal_ota_start();
+    if (err != 0)
+    {
+        return;
+    }
+
+    imageProcessor->offset = 0;
+    imageProcessor->mHeaderParser.Init();
+    imageProcessor->mDownloader->OnPreparedForDownload(CHIP_NO_ERROR);
+}
+
+void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
+{
+    int err               = 0;
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    if (imageProcessor == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
+        return;
+    }
+
+    err = hosal_ota_finish(0, 0);
+    if (err != 0)
+    {
+        log_info("HandleApply: %d!", err);
+        return;
+    }
+
+    imageProcessor->ReleaseBlock();
+}
+
+void OTAImageProcessorImpl::HandleAbort(intptr_t context)
+{
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    if (imageProcessor == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
+        return;
+    }
+    imageProcessor->ReleaseBlock();
+}
+
+void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
+{
+    int err = 0;
+
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+    if (imageProcessor == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
+        return;
+    }
+    else if (imageProcessor->mDownloader == nullptr)
+    {
+        ChipLogError(SoftwareUpdate, "mDownloader is null");
+        return;
+    }
+
+    ByteSpan block = ByteSpan(imageProcessor->mBlock.data(), imageProcessor->mBlock.size());
+
+    CHIP_ERROR error = imageProcessor->ProcessHeader(block);
+    if (error != CHIP_NO_ERROR)
+    {
+        log_info("Failed to process OTA image header");
+        imageProcessor->mDownloader->EndDownload(error);
+        return;
+    }
+
+    err = hosal_ota_update(imageProcessor->offset, block.data(), block.size());
+    if (err != 0)
+    {
+        log_info("Update ota failed.\r\n");
+        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
+        return;
+    }
+
+    imageProcessor->offset += block.size();
+
+    imageProcessor->mParams.downloadedBytes += block.size();
+    imageProcessor->mDownloader->FetchNextData();
+}
+
+void OTAImageProcessorImpl::HandleApply(intptr_t context)
+{
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+
+    hal_reboot();
+}
+
+CHIP_ERROR OTAImageProcessorImpl::SetBlock(ByteSpan & block)
+{
+    if (!IsSpanUsable(block))
+    {
+        ReleaseBlock();
+        return CHIP_NO_ERROR;
+    }
+    if (mBlock.size() < block.size())
+    {
+        if (!mBlock.empty())
+        {
+            ReleaseBlock();
+        }
+        uint8_t * mBlock_ptr = static_cast<uint8_t *>(chip::Platform::MemoryAlloc(block.size()));
+        if (mBlock_ptr == nullptr)
+        {
+            return CHIP_ERROR_NO_MEMORY;
+        }
+        mBlock = MutableByteSpan(mBlock_ptr, block.size());
+    }
+    CHIP_ERROR err = CopySpanToMutableSpan(block, mBlock);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(SoftwareUpdate, "Cannot copy block data: %" CHIP_ERROR_FORMAT, err.Format());
+        return err;
+    }
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ReleaseBlock()
+{
+    if (mBlock.data() != nullptr)
+    {
+        chip::Platform::MemoryFree(mBlock.data());
+    }
+    mBlock = MutableByteSpan();
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)
+{
+    if (mHeaderParser.IsInitialized())
+    {
+        OTAImageHeader header;
+        CHIP_ERROR error = mHeaderParser.AccumulateAndDecode(block, header);
+
+        // Need more data to decode the header
+        ReturnErrorCodeIf(error == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_NO_ERROR);
+        ReturnErrorOnFailure(error);
+
+        mParams.totalFileBytes = header.mPayloadSize;
+        mHeaderParser.Clear();
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+} // namespace chip

--- a/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.h
+++ b/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.h
@@ -1,0 +1,57 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <lib/core/OTAImageHeader.h>
+#include <platform/CHIPDeviceLayer.h>
+#include <platform/OTAImageProcessor.h>
+
+namespace chip {
+
+class OTAImageProcessorImpl : public OTAImageProcessorInterface
+{
+public:
+    //////////// OTAImageProcessorInterface Implementation ///////////////
+    CHIP_ERROR PrepareDownload() override;
+    CHIP_ERROR Finalize() override;
+    CHIP_ERROR Apply() override;
+    CHIP_ERROR Abort() override;
+    CHIP_ERROR ProcessBlock(ByteSpan & block) override;
+    void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; };
+    bool IsFirstImageRun() override;
+    CHIP_ERROR ConfirmCurrentImage() override;
+
+private:
+    static void HandlePrepareDownload(intptr_t context);
+    static void HandleFinalize(intptr_t context);
+    static void HandleAbort(intptr_t context);
+    static void HandleProcessBlock(intptr_t context);
+    static void HandleApply(intptr_t context);
+
+    CHIP_ERROR SetBlock(ByteSpan & block);
+    CHIP_ERROR ReleaseBlock();
+    CHIP_ERROR ProcessHeader(ByteSpan & block);
+
+    OTADownloader * mDownloader = nullptr;
+    MutableByteSpan mBlock;
+    uint32_t offset = 0;
+    OTAImageHeaderParser mHeaderParser;
+};
+
+} // namespace chip

--- a/src/platform/bouffalolab/BL602/PlatformManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL602/PlatformManagerImpl.cpp
@@ -84,6 +84,10 @@ void event_cb_wifi_event(input_event_t * event, void * private_data)
         NetworkCommissioning::BLWiFiDriver::GetInstance().OnScanWiFiNetworkDone();
     }
     break;
+    case CODE_WIFI_ON_DISCONNECT: {
+        printf("[APP] [EVT] disconnect %lld, Reason: %s\r\n", aos_now_ms(), wifi_mgmr_status_code_str(event->value));
+    }
+    break;
     case CODE_WIFI_ON_CONNECTING: {
         log_info("[APP] [EVT] Connecting %lld\r\n", aos_now_ms());
         ConnectivityManagerImpl::mWiFiStationState = ConnectivityManager::kWiFiStationState_Connecting;

--- a/src/platform/bouffalolab/BL602/args.gni
+++ b/src/platform/bouffalolab/BL602/args.gni
@@ -23,7 +23,6 @@ riscv_platform_config = "${bl602_sdk_build_root}/bl602_riscv.gni"
 mbedtls_target = "${bl602_sdk_build_root}:bl602_sdk"
 
 chip_device_platform = "bl602"
-chip_mdns = "platform"
 
 lwip_platform = "bl602"
 

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -80,7 +80,8 @@ declare_args() {
   # Select DNS-SD implementation
   if (chip_device_platform == "linux" || chip_device_platform == "esp32" ||
       chip_device_platform == "mbed" || chip_device_platform == "p6" ||
-      chip_device_platform == "ameba" || chip_device_platform == "webos") {
+      chip_device_platform == "ameba" || chip_device_platform == "webos" ||
+      chip_device_platform == "bl602") {
     chip_mdns = "minimal"
   } else if (chip_device_platform == "darwin" ||
              chip_device_platform == "cc13x2_26x2" || current_os == "android" ||

--- a/third_party/bouffalolab/bl602_sdk/bl602_sdk.gni
+++ b/third_party/bouffalolab/bl602_sdk/bl602_sdk.gni
@@ -267,6 +267,7 @@ template("bl602_sdk") {
 
     cflags_cc = [ "-fpermissive" ]
     cflags_cc += [ "-std=c++17" ]
+    cflags_cc += [ "-D _GNU_SOURCE" ]
 
     foreach(include_dir, _include_dirs) {
       cflags += [ "-isystem" + rebase_path(include_dir, root_build_dir) ]


### PR DESCRIPTION
…viderImpl.cpp for adaption, 3.usd matter default dnssd, 4. add compile compile parameters, 5.change product id.

#### Problem
* add matter ota support.
* use matter default DeviceInfoProviderImpl.cpp for adaption
* use matter default dnssd
* add compile compile parameters
* change product id

#### Change overview
add matter ota, add DeviceInfoProviderImpl.cpp for adaption, use matter default dnssd , add compile parameters and change product id.
#### Testing
How was this tested? (at least one bullet point required)
* add matter ota support.
use test event TC-SU to test this case.
* add DeviceInfoProviderImpl.cpp for adaption.
use test event TC-TFL to test this case.
* use matter default dnssd.
use chip tool commission with bl602.
