### PR TITLE
[xml] GenericSwitch: remove unrequired clusters: Binding, Groups, Scenes

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1256,42 +1256,6 @@ limitations under the License.
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="true" server="false" clientLocked="false" serverLocked="true">
-                <requireAttribute>BINDING</requireAttribute>
-            </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
-                <requireCommand>AddGroup</requireCommand>
-                <requireCommand>AddGroupResponse</requireCommand>
-                <requireCommand>ViewGroup</requireCommand>
-                <requireCommand>ViewGroupResponse</requireCommand>
-                <requireCommand>GetGroupMembership</requireCommand>
-                <requireCommand>GetGroupMembershipResponse</requireCommand>
-                <requireCommand>RemoveGroup</requireCommand>
-                <requireCommand>RemoveGroupResponse</requireCommand>
-                <requireCommand>RemoveAllGroups</requireCommand>
-                <requireCommand>AddGroupIfIdentifying</requireCommand>
-            </include>
-            <include cluster="Scenes" client="true" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>SCENE_COUNT</requireAttribute>
-                <requireAttribute>CURRENT_SCENE</requireAttribute>
-                <requireAttribute>CURRENT_GROUP</requireAttribute>
-                <requireAttribute>SCENE_VALID</requireAttribute>
-                <requireAttribute>SCENE_NAME_SUPPORT</requireAttribute>
-                <requireCommand>AddScene</requireCommand>
-                <requireCommand>AddSceneResponse</requireCommand>
-                <requireCommand>ViewScene</requireCommand>
-                <requireCommand>ViewSceneResponse</requireCommand>
-                <requireCommand>RemoveScene</requireCommand>
-                <requireCommand>RemoveSceneResponse</requireCommand>
-                <requireCommand>RemoveAllScenes</requireCommand>
-                <requireCommand>RemoveAllScenesResponse</requireCommand>
-                <requireCommand>StoreScene</requireCommand>
-                <requireCommand>StoreSceneResponse</requireCommand>
-                <requireCommand>RecallScene</requireCommand>
-                <requireCommand>GetSceneMembership</requireCommand>
-                <requireCommand>GetSceneMembershipResponse</requireCommand>
-            </include>
             <include cluster="Switch" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Fixed Label" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="User Label" client="false" server="false" clientLocked="true" serverLocked="false"></include>


### PR DESCRIPTION
#### Problem

GenericSwitch only requires
```
ClusterName Client/Server Quality Conformance
Identify Server M
Switch Server M
FixedLabel Server desc
```
according to spec.


As requested in https://github.com/project-chip/connectedhomeip/pull/19848#discussion_r904231782.

#### Change overview

XML change.

#### Testing

Eyeball-review. Testing by CI.