### PR TITLE
[nrfconnect] Added versioning to the factory data

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -16,6 +16,8 @@
 
 rsource "../../zephyr/Kconfig"
 
+if CHIP
+
 config CHIP_NFC_COMMISSIONING
 	bool "Enable NFC commissioning support"
 	default n
@@ -98,10 +100,20 @@ config CHIP_FACTORY_DATA_BUILD
 	  configuration file pm_static.yml.
 	  As a result a new output file factory_data.hex will be created.
 
+config CHIP_FACTORY_DATA_VERSION
+	int
+	default 1
+	help
+	  The Factory data version contains a current version of a factory data 
+	  parameter set that the user cannot change. 
+	  After moving to the next version of the factory data set, change the default value. 
+	  This config is used to validate the version of a factory data set on a device-side 
+	  with the version of factory data saved in the Flash memory.
+
 if CHIP_FACTORY_DATA_BUILD
 
 # Factory data definitions
-config CHIP_MERGE_FACTORY_DATA_WITH_FIRMWARE
+config CHIP_FACTORY_DATA_MERGE_WITH_FIRMWARE
 	bool "Enable merging generated factory data with the build target .hex file"
 	default y
 	help
@@ -240,3 +252,5 @@ config CHIP_DEVICE_ROTATING_DEVICE_UID
 	help
 	  A device rotating id unique id which will be generated if
 	  this config is not set in prj.conf file.
+
+endif

--- a/config/nrfconnect/chip-module/generate_factory_data.cmake
+++ b/config/nrfconnect/chip-module/generate_factory_data.cmake
@@ -21,7 +21,7 @@
 # Created JSON file can be checked using JSON SCHEMA file if it is provided.
 #
 # This script can be manipulated using following kConfigs:
-# - To merge generated factory data with final zephyr.hex file set kConfig CONFIG_CHIP_MERGE_FACTORY_DATA_WITH_FIRMWARE=y
+# - To merge generated factory data with final zephyr.hex file set kConfig CONFIG_CHIP_FACTORY_DATA_MERGE_WITH_FIRMWARE=y
 # - To use default certification paths set CONFIG_CHIP_FACTORY_DATA_USE_DEFAULTS_CERTS_PATH=y 
 # 
 # During generation process a some file will be created in zephyr's build directory:
@@ -187,7 +187,7 @@ nrfconnect_create_factory_data_hex_file(factory_data
                                         ${OUTPUT_FILE_PATH} 
                                         factory_data_hex)
 
-if(CONFIG_CHIP_MERGE_FACTORY_DATA_WITH_FIRMWARE)                                   
+if(CONFIG_CHIP_FACTORY_DATA_MERGE_WITH_FIRMWARE)                                   
     # set custom target for merging factory_data hex file
     add_custom_target(factory_data_merge
         DEPENDS ${factory_data_hex}

--- a/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
+++ b/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
@@ -217,7 +217,7 @@ class FactoryDataGenerator:
         """ If rotating device unique ID has not been provided it should be generated """
         log.warning("Can not find rotating device UID in provided arguments list. A new one will be generated.")
         rdu = secrets.token_bytes(16)
-        log.info("\n\nThe new rotate device UID: {}\n".format(rdu).hex())
+        log.info("\n\nThe new rotate device UID: {}\n".format(rdu.hex()))
         return rdu
 
     def _validate_output_json(self, output_json: str):
@@ -325,9 +325,6 @@ def main():
     optional_arguments.add_argument("--user", type=str,
                                     help="[string] Provide additional user-specific keys in Json format: {'name_1': 'value_1', 'name_2': 'value_2', ... 'name_n', 'value_n'}.")
     args = parser.parse_args()
-
-    if(args.chip_cert_path):
-        print("Generating DAC and PAI certificates is not supported yet")
 
     if args.verbose:
         log.basicConfig(format='[%(asctime)s][%(levelname)s] %(message)s', level=log.DEBUG)

--- a/scripts/tools/nrfconnect/nrfconnect_factory_data.schema
+++ b/scripts/tools/nrfconnect/nrfconnect_factory_data.schema
@@ -4,6 +4,7 @@
     "description": "A representation of all factory data used in Matter's NrfConnect device",
     "type": "object",
     "required": [
+        "version",
         "sn",
         "vendor_id",
         "product_id",
@@ -21,6 +22,12 @@
         "discriminator"
     ],
     "properties": {
+        "version": {
+            "description": "Current version of the factory data set",
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+        },
         "sn": {
             "description": "Serial number of device",
             "type": "string",

--- a/src/platform/nrfconnect/FactoryDataParser.c
+++ b/src/platform/nrfconnect/FactoryDataParser.c
@@ -58,7 +58,11 @@ bool ParseFactoryData(uint8_t * buffer, uint16_t bufferSize, struct FactoryData 
             break;
         }
 
-        if (strncmp("hw_ver", (const char *) currentString.value, currentString.len) == 0)
+        if (strncmp("version", (const char *) currentString.value, currentString.len) == 0)
+        {
+            res = res && uint16_decode(states, &factoryData->version);
+        }
+        else if (strncmp("hw_ver", (const char *) currentString.value, currentString.len) == 0)
         {
             res                       = res && uint16_decode(states, &factoryData->hw_ver);
             factoryData->hwVerPresent = res;

--- a/src/platform/nrfconnect/FactoryDataParser.h
+++ b/src/platform/nrfconnect/FactoryDataParser.h
@@ -33,6 +33,7 @@ struct FactoryDataString
 
 struct FactoryData
 {
+    uint16_t version;
     struct FactoryDataString sn;
     uint16_t date_year;
     uint8_t date_month;

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "FactoryDataProvider.h"
+#include "CHIPDevicePlatformConfig.h"
 #include <crypto/CHIPCryptoPAL.h>
 
 #include <logging/log.h>
@@ -53,6 +54,13 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::Init()
     {
         ChipLogError(DeviceLayer, "Failed to parse factory data");
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    }
+
+    // Check if factory data version is correct
+    if (mFactoryData.version != CONFIG_CHIP_FACTORY_DATA_VERSION)
+    {
+        ChipLogError(DeviceLayer, "Factory data version mismatch. Flash version: %d vs code version: %d", mFactoryData.version, CONFIG_CHIP_FACTORY_DATA_VERSION);
+        return CHIP_ERROR_VERSION_MISMATCH;
     }
 
     return CHIP_NO_ERROR;

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -59,7 +59,8 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::Init()
     // Check if factory data version is correct
     if (mFactoryData.version != CONFIG_CHIP_FACTORY_DATA_VERSION)
     {
-        ChipLogError(DeviceLayer, "Factory data version mismatch. Flash version: %d vs code version: %d", mFactoryData.version, CONFIG_CHIP_FACTORY_DATA_VERSION);
+        ChipLogError(DeviceLayer, "Factory data version mismatch. Flash version: %d vs code version: %d", mFactoryData.version,
+                     CONFIG_CHIP_FACTORY_DATA_VERSION);
         return CHIP_ERROR_VERSION_MISMATCH;
     }
 


### PR DESCRIPTION
#### Problem
Currently, the nRF Connect Factory Data parameter set does not contain a `version` field that can be used to verify if a Factory Data Provider version is compatible with the Python scripts version.

#### Change overview
- Added versioning to the factory data to check the compatibility of a factory data set stored in the Flash memory with the current implementation of a factory data provider. 
- Added a version field to the Python script and the JSON Schema file.
- Added version checking in the `FactoryDataProvider.cpp` file.
- Provided some fixes to python scripts and Kconfig definitions. 

#### Testing
Tested manually on nRF52 DK and nRF53 DK
