### PR TITLE
[Tizen] Build chip-tool using build_examples.py

### DIFF
--- a/.github/workflows/examples-tizen.yaml
+++ b/.github/workflows/examples-tizen.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-tizen:0.5.79
+            image: connectedhomeip/chip-build-tizen:0.5.81
             options: --user root
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -557,6 +557,7 @@ def TizenTargets():
 
     target = Target('tizen-arm', TizenBuilder, board=TizenBoard.ARM)
 
+    builder.targets.append(target.Extend('chip-tool', app=TizenApp.CHIP_TOOL))
     builder.targets.append(target.Extend('light', app=TizenApp.LIGHT))
 
     for target in builder.AllVariants():

--- a/scripts/build/builders/tizen.py
+++ b/scripts/build/builders/tizen.py
@@ -21,11 +21,15 @@ from .gn import GnBuilder
 
 
 class TizenApp(Enum):
+
+    CHIP_TOOL = auto()
     LIGHT = auto()
 
-    def ExampleName(self):
-        if self == TizenApp.LIGHT:
-            return 'lighting-app'
+    def ExamplePath(self):
+        if self == TizenApp.CHIP_TOOL:
+            return 'chip-tool'
+        elif self == TizenApp.LIGHT:
+            return 'lighting-app/tizen'
         else:
             raise Exception('Unknown app type: %r' % self)
 
@@ -68,7 +72,7 @@ class TizenBuilder(GnBuilder):
                  use_tsan: bool = False,
                  ):
         super(TizenBuilder, self).__init__(
-            root=os.path.join(root, 'examples', app.ExampleName(), 'tizen'),
+            root=os.path.join(root, 'examples', app.ExamplePath()),
             runner=runner)
 
         self.app = app

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -231,6 +231,14 @@ qpg-persistent-storage
 qpg-shell
 telink-tlsr9518adk80d-light
 telink-tlsr9518adk80d-light-switch
+tizen-arm-chip-tool
+tizen-arm-chip-tool-asan (NOGLOB: Reduce default build variants)
+tizen-arm-chip-tool-no-ble (NOGLOB: Reduce default build variants)
+tizen-arm-chip-tool-no-ble-asan (NOGLOB: Reduce default build variants)
+tizen-arm-chip-tool-no-ble-no-wifi (NOGLOB: Reduce default build variants)
+tizen-arm-chip-tool-no-ble-no-wifi-asan (NOGLOB: Reduce default build variants)
+tizen-arm-chip-tool-no-wifi (NOGLOB: Reduce default build variants)
+tizen-arm-chip-tool-no-wifi-asan (NOGLOB: Reduce default build variants)
 tizen-arm-light
 tizen-arm-light-asan (NOGLOB: Reduce default build variants)
 tizen-arm-light-no-ble (NOGLOB: Reduce default build variants)

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -1114,6 +1114,30 @@ export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-light-switch -b tlsr9518adk80d {root}/examples/light-switch-app/telink'
 
+# Generating tizen-arm-chip-tool
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-chip-tool
+
+# Generating tizen-arm-chip-tool-asan
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-chip-tool-asan
+
+# Generating tizen-arm-chip-tool-no-ble
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_config_network_layer_ble=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-chip-tool-no-ble
+
+# Generating tizen-arm-chip-tool-no-ble-asan
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_config_network_layer_ble=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-chip-tool-no-ble-asan
+
+# Generating tizen-arm-chip-tool-no-ble-no-wifi
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_config_network_layer_ble=false chip_enable_wifi=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-chip-tool-no-ble-no-wifi
+
+# Generating tizen-arm-chip-tool-no-ble-no-wifi-asan
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_config_network_layer_ble=false chip_enable_wifi=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-chip-tool-no-ble-no-wifi-asan
+
+# Generating tizen-arm-chip-tool-no-wifi
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_enable_wifi=false target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-chip-tool-no-wifi
+
+# Generating tizen-arm-chip-tool-no-wifi-asan
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_enable_wifi=false is_asan=true target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-chip-tool-no-wifi-asan
+
 # Generating tizen-arm-light
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/tizen '--args=target_os="tizen" target_cpu="arm" tizen_sdk_root="TEST_TIZEN_SDK_ROOT" tizen_sdk_sysroot="TEST_TIZEN_SDK_SYSROOT"' {out}/tizen-arm-light
 
@@ -2207,6 +2231,30 @@ ninja -C {out}/telink-tlsr9518adk80d-light
 
 # Building telink-tlsr9518adk80d-light-switch
 ninja -C {out}/telink-tlsr9518adk80d-light-switch
+
+# Building tizen-arm-chip-tool
+ninja -C {out}/tizen-arm-chip-tool
+
+# Building tizen-arm-chip-tool-asan
+ninja -C {out}/tizen-arm-chip-tool-asan
+
+# Building tizen-arm-chip-tool-no-ble
+ninja -C {out}/tizen-arm-chip-tool-no-ble
+
+# Building tizen-arm-chip-tool-no-ble-asan
+ninja -C {out}/tizen-arm-chip-tool-no-ble-asan
+
+# Building tizen-arm-chip-tool-no-ble-no-wifi
+ninja -C {out}/tizen-arm-chip-tool-no-ble-no-wifi
+
+# Building tizen-arm-chip-tool-no-ble-no-wifi-asan
+ninja -C {out}/tizen-arm-chip-tool-no-ble-no-wifi-asan
+
+# Building tizen-arm-chip-tool-no-wifi
+ninja -C {out}/tizen-arm-chip-tool-no-wifi
+
+# Building tizen-arm-chip-tool-no-wifi-asan
+ninja -C {out}/tizen-arm-chip-tool-no-wifi-asan
 
 # Building tizen-arm-light
 ninja -C {out}/tizen-arm-light

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -110,4 +110,5 @@ qpg-persistent-storage
 qpg-shell
 telink-tlsr9518adk80d-light
 telink-tlsr9518adk80d-light-switch
+tizen-arm-chip-tool
 tizen-arm-light


### PR DESCRIPTION
#### Problem

Easy way to build chip-tool for Tizen platform.

#### Change overview

- added chip-tool for Tizen to build_examples.py script

#### Testing

```
./scripts/build/build_examples.py --target tizen-arm-chip-tool build
```