### PR TITLE
Remove workaround for mDNS bug with multi-fabric in the Python tests

### DIFF
--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -410,14 +410,7 @@ class BaseTestHelper:
             return False
 
         #
-        # Shutting down controllers results in races where the resolver still delivers
-        # resolution results to a now destroyed controller. Add a sleep for now to work around
-        # it while #14555 is being resolved.
-        time.sleep(1)
-
-        #
-        # Shut-down all the controllers (which will free them up as well as de-initialize the
-        # stack as well.
+        # Shut-down all the controllers (which will free them up)
         #
         self.logger.info(
             "Shutting down controllers & fabrics and re-initing stack...")


### PR DESCRIPTION
#### Problem

In the Python multi-fabric test, I had added a 1s delay between commissioning a device onto 2 fabrics and the subsequent shutdown of both controller instances because of race conditions in terms of mDNS result delivery to both controllers that were identified in #14555. Since then, @andreilitvin has fixed some of the major issues in the mDNS callback mechanisms, so removing the work-around in the test to stress that bit of the mDNS logic again!

🤞

#### Change overview

Remove work-around.

#### Testing

Ran the REPL tests 4x locally, saw no failures.