### PR TITLE
Allow conversion from Deleter<Derived> to Deleter<Base>

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -160,12 +160,6 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     stateParams.messageCounterManager     = chip::Platform::New<secure_channel::MessageCounterManager>();
     stateParams.groupDataProvider         = params.groupDataProvider;
 
-    // This is constructed with a base class deleter so we can std::move it into
-    // stateParams without a manual conversion below.
-    auto sessionResumptionStorage =
-        std::unique_ptr<SimpleSessionResumptionStorage, Platform::Deleter<chip::SessionResumptionStorage>>(
-            Platform::New<SimpleSessionResumptionStorage>());
-
     // if no fabricTable was provided, create one and track it in stateParams for cleanup
     FabricTable * tempFabricTable = nullptr;
     stateParams.fabricTable       = params.fabricTable;
@@ -174,6 +168,8 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         stateParams.fabricTable = tempFabricTable = chip::Platform::New<FabricTable>();
         ReturnErrorOnFailure(stateParams.fabricTable->Init(params.fabricIndependentStorage, params.operationalKeystore));
     }
+
+    auto sessionResumptionStorage = chip::Platform::MakeUnique<SimpleSessionResumptionStorage>();
     ReturnErrorOnFailure(sessionResumptionStorage->Init(params.fabricIndependentStorage));
     stateParams.sessionResumptionStorage = std::move(sessionResumptionStorage);
 

--- a/src/lib/support/CHIPMem.h
+++ b/src/lib/support/CHIPMem.h
@@ -167,6 +167,12 @@ inline void Delete(T * p)
 template <typename T>
 struct Deleter
 {
+    constexpr Deleter() = default;
+
+    template <typename U>
+    Deleter(const Deleter<U> &, typename std::enable_if<std::is_convertible<U *, T *>::value>::type * = 0)
+    {}
+
     void operator()(T * p) { Delete(p); }
 };
 


### PR DESCRIPTION
#### Problem

Our `UniquePtr<>` breaks developer expectations that pointers to derived classes
can be assigned to pointers to their base classes.

#### Change overview

Add the implicit conversion from `Deleter<Derived>` to `Deleter<Base>`.

This is in line with `std::default_delete`. it relies on having virtual destructors,
but we have -Wnon-virtual-dtor enabled so not having one will generate
a diagnostic at compile time.

#### Testing

Compile.