### PR TITLE
Remove the polymorphic delete of SessionResumptionStorage

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -160,12 +160,6 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     stateParams.messageCounterManager     = chip::Platform::New<secure_channel::MessageCounterManager>();
     stateParams.groupDataProvider         = params.groupDataProvider;
 
-    // This is constructed with a base class deleter so we can std::move it into
-    // stateParams without a manual conversion below.
-    auto sessionResumptionStorage =
-        std::unique_ptr<SimpleSessionResumptionStorage, Platform::Deleter<chip::SessionResumptionStorage>>(
-            Platform::New<SimpleSessionResumptionStorage>());
-
     // if no fabricTable was provided, create one and track it in stateParams for cleanup
     FabricTable * tempFabricTable = nullptr;
     stateParams.fabricTable       = params.fabricTable;
@@ -174,6 +168,8 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
         stateParams.fabricTable = tempFabricTable = chip::Platform::New<FabricTable>();
         ReturnErrorOnFailure(stateParams.fabricTable->Init(params.fabricIndependentStorage, params.operationalKeystore));
     }
+
+    auto sessionResumptionStorage = chip::Platform::MakeUnique<SimpleSessionResumptionStorage>();
     ReturnErrorOnFailure(sessionResumptionStorage->Init(params.fabricIndependentStorage));
     stateParams.sessionResumptionStorage = std::move(sessionResumptionStorage);
 

--- a/src/controller/CHIPDeviceControllerSystemState.h
+++ b/src/controller/CHIPDeviceControllerSystemState.h
@@ -36,6 +36,7 @@
 #include <lib/core/CHIPConfig.h>
 #include <protocols/secure_channel/CASEServer.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
+#include <protocols/secure_channel/SimpleSessionResumptionStorage.h>
 #include <protocols/secure_channel/UnsolicitedStatusHandler.h>
 
 #include <transport/TransportMgr.h>
@@ -84,7 +85,7 @@ struct DeviceControllerSystemStateParams
     // Params that will be deallocated via Platform::Delete in
     // DeviceControllerSystemState::Shutdown.
     DeviceTransportMgr * transportMgr = nullptr;
-    Platform::UniquePtr<SessionResumptionStorage> sessionResumptionStorage;
+    Platform::UniquePtr<SimpleSessionResumptionStorage> sessionResumptionStorage;
     Credentials::CertificateValidityPolicy * certificateValidityPolicy            = nullptr;
     SessionManager * sessionMgr                                                   = nullptr;
     Protocols::SecureChannel::UnsolicitedStatusHandler * unsolicitedStatusHandler = nullptr;
@@ -203,7 +204,7 @@ private:
     CASEClientPool * mCASEClientPool                                               = nullptr;
     Credentials::GroupDataProvider * mGroupDataProvider                            = nullptr;
     FabricTable::Delegate * mFabricTableDelegate                                   = nullptr;
-    Platform::UniquePtr<SessionResumptionStorage> mSessionResumptionStorage;
+    Platform::UniquePtr<SimpleSessionResumptionStorage> mSessionResumptionStorage;
 
     // If mTempFabricTable is not null, it was created during
     // DeviceControllerFactory::InitSystemState and needs to be


### PR DESCRIPTION
#### Problem

Polymorphic destruction is problematic with our approach to wrapping of
malloc/free, as even with a virtual destructor we end up calling free()
with the address of a base class subobject. This subobject may not be
pointer-interconvertible with the dynamic (actual) type of the object.

#### Change overview

Remove the polymorphic destruction of SimpleSessionResumptionStorage in
DeviceControllerFactory. Note that this will block use of any other
implementation, rendering the interface itself rather pointless.

That should most likely be resolved by changing the ownership model of
the system state entirely (in favor of external ownership), although
removing PlatformMalloc/PlatformDelete in favor of standard new/delete
would also solve the problem as it's not clear that these wrappers
are serving a useful purpose.

#### Testing

Compile & CI
