### PR TITLE
Add a lint for 0x used with non-hex format strings.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -93,3 +93,19 @@ jobs:
               if: always()
               run: |
                   scripts/tools/check_test_pics.py src/app/tests/suites/certification/ci-pics-values src/app/tests/suites/certification/PICS.yaml
+
+            # git grep exits with 0 if it finds a match, but we want
+            # to fail (exit nonzero) on match.  And we wasnt to exclude this file,
+            # to avoid our grep regexp matching itself.
+            - name: Check for use of 0x%u and the like, which lead to misleading output.
+              if: always()
+              run: |
+                  git grep -n '0x%[0-9l.-]*[^0-9lxX".-]' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0
+
+            # git grep exits with 0 if it finds a match, but we want
+            # to fail (exit nonzero) on match.  And we wasnt to exclude this file,
+            # to avoid our grep regexp matching itself.
+            - name: Check for use of '"0x" PRIu*' and the like, which lead to misleading output.
+              if: always()
+              run: |
+                  git grep -n '0x%[0-9-]*" *PRI[^xX]' -- './*' ':(exclude).github/workflows/lint.yml' && exit 1 || exit 0

--- a/examples/shell/shell_common/cmd_server.cpp
+++ b/examples/shell/shell_common/cmd_server.cpp
@@ -128,7 +128,7 @@ static bool PrintServerSession(void * context, SessionHandle & session)
 
     case Session::SessionType::kUnauthenticated: {
         UnauthenticatedSession * unsecuredSession = session->AsUnauthenticatedSession();
-        streamer_printf(streamer_get(), "session type=UNSECURED id=0x0000 peerNodeId=0x%016\r\n",
+        streamer_printf(streamer_get(), "session type=UNSECURED id=0x0000 peerNodeId=0x%016" PRIx64 "\r\n",
                         unsecuredSession->GetPeerNodeId());
         break;
     }

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -834,7 +834,7 @@ exit:
     else
     {
         commandObj->AddStatus(commandPath, nonDefaultStatus);
-        ChipLogError(Zcl, "OpCreds: Failed AddNOC request with IM error 0x%02u", to_underlying(nonDefaultStatus));
+        ChipLogError(Zcl, "OpCreds: Failed AddNOC request with IM error 0x%02x", to_underlying(nonDefaultStatus));
     }
 
     return true;
@@ -955,7 +955,7 @@ exit:
     else
     {
         commandObj->AddStatus(commandPath, nonDefaultStatus);
-        ChipLogError(Zcl, "OpCreds: Failed AddNOC request with IM error 0x%02u", to_underlying(nonDefaultStatus));
+        ChipLogError(Zcl, "OpCreds: Failed AddNOC request with IM error 0x%02x", to_underlying(nonDefaultStatus));
     }
 
     return true;
@@ -1081,7 +1081,7 @@ exit:
     if (finalStatus != Status::Success)
     {
         commandObj->AddStatus(commandPath, finalStatus);
-        ChipLogError(Zcl, "OpCreds: Failed AttestationRequest request with IM error 0x%02u (err = %" CHIP_ERROR_FORMAT ")",
+        ChipLogError(Zcl, "OpCreds: Failed AttestationRequest request with IM error 0x%02x (err = %" CHIP_ERROR_FORMAT ")",
                      to_underlying(finalStatus), err.Format());
     }
 
@@ -1201,7 +1201,7 @@ exit:
     if (finalStatus != Status::Success)
     {
         commandObj->AddStatus(commandPath, finalStatus);
-        ChipLogError(Zcl, "OpCreds: Failed CSRRequest request with IM error 0x%02u (err = %" CHIP_ERROR_FORMAT ")",
+        ChipLogError(Zcl, "OpCreds: Failed CSRRequest request with IM error 0x%02x (err = %" CHIP_ERROR_FORMAT ")",
                      to_underlying(finalStatus), err.Format());
     }
 
@@ -1259,7 +1259,7 @@ bool emberAfOperationalCredentialsClusterAddTrustedRootCertificateCallback(
 exit:
     if (finalStatus != Status::Success)
     {
-        ChipLogError(Zcl, "OpCreds: Failed AddTrustedRootCertificate request with IM error 0x%02u (err = %" CHIP_ERROR_FORMAT ")",
+        ChipLogError(Zcl, "OpCreds: Failed AddTrustedRootCertificate request with IM error 0x%02x (err = %" CHIP_ERROR_FORMAT ")",
                      to_underlying(finalStatus), err.Format());
     }
 

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1330,7 +1330,7 @@ void FabricTable::RevertPendingFabricData()
 {
     if (mIsPendingFabricDataPresent)
     {
-        ChipLogError(FabricProvisioning, "Reverting pending fabric data for fabric 0x%u",
+        ChipLogError(FabricProvisioning, "Reverting pending fabric data for fabric 0x%x",
                      static_cast<unsigned>(mFabricIndexWithPendingState));
     }
 


### PR DESCRIPTION
#### Problem
We have some `0x%u` logging, which leads to confusing output.

#### Change overview
Lint for that.

#### Testing
CI should pass.