### PR TITLE
Linux KVS Get impl should return buffer too small if the buffer is too small

### DIFF
--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -65,14 +65,15 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     VerifyOrReturnError(buf.Alloc(read_size), CHIP_ERROR_NO_MEMORY);
     ReturnErrorOnFailure(mStorage.ReadValueBin(key, buf.Get(), read_size, read_size));
 
-    size_t copy_size = std::min(value_size, read_size - offset_bytes);
+    size_t total_size_to_read = read_size - offset_bytes;
+    size_t copy_size = std::min(value_size, total_size_to_read);
     if (read_bytes_size != nullptr)
     {
         *read_bytes_size = copy_size;
     }
     ::memcpy(value, buf.Get() + offset_bytes, copy_size);
 
-    return (value_size < read_size - offset_bytes) ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR;
+    return (value_size < total_size_to_read) ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR;
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)

--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -72,7 +72,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     }
     ::memcpy(value, buf.Get() + offset_bytes, copy_size);
 
-    return CHIP_NO_ERROR;
+    return (value_size < read_size - offset_bytes) ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR;
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)

--- a/src/platform/Linux/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Linux/KeyValueStoreManagerImpl.cpp
@@ -66,7 +66,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     ReturnErrorOnFailure(mStorage.ReadValueBin(key, buf.Get(), read_size, read_size));
 
     size_t total_size_to_read = read_size - offset_bytes;
-    size_t copy_size = std::min(value_size, total_size_to_read);
+    size_t copy_size          = std::min(value_size, total_size_to_read);
     if (read_bytes_size != nullptr)
     {
         *read_bytes_size = copy_size;


### PR DESCRIPTION
#### Problem
* `KeyValueStoreManager::Get` is expected to return CHIP_ERROR_BUFFER_TOO_SMALL if the buffer could not fit the entire value, but as many bytes as possible were written to it. Linux impl was not doing this.

#### Change overview
* Return appropriate return code for `KeyValueStoreManagerImpl::_Get`

#### Testing
* In PR that expecting `KeyValueStoreManager::Get` to return `CHIP_ERROR_BUFFER_TOO_SMALL` when giving a buffer of size 0, confirmed we are now getting `CHIP_ERROR_BUFFER_TOO_SMALL` instead of `CHIP_NO_ERROR`.