### PR TITLE
[EFR32] support softwarediagnostics thread Metrics

### DIFF
--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -28,10 +28,10 @@
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.h>
 #endif
-
 #include "AppConfig.h"
 #include "FreeRTOS.h"
 #include "heap_4_silabs.h"
+#include <lib/support/CHIPMemString.h>
 
 using namespace ::chip::app::Clusters::GeneralDiagnostics;
 

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -92,6 +92,60 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadMetricsOut)
+{
+    /* Obtain all available task information */
+    TaskStatus_t * taskStatusArray;
+    ThreadMetrics * head = nullptr;
+    uint32_t arraySize, x, dummy;
+
+    arraySize = uxTaskGetNumberOfTasks();
+
+    taskStatusArray = static_cast<TaskStatus_t *>(chip::Platform::MemoryCalloc(arraySize, sizeof(TaskStatus_t)));
+
+    if (taskStatusArray != NULL)
+    {
+        /* Generate raw status information about each task. */
+        arraySize = uxTaskGetSystemState(taskStatusArray, arraySize, &dummy);
+        /* For each populated position in the taskStatusArray array,
+           format the raw data as human readable ASCII data. */
+
+        for (x = 0; x < arraySize; x++)
+        {
+            ThreadMetrics * thread = new ThreadMetrics();
+
+            strncpy(thread->NameBuf, taskStatusArray[x].pcTaskName, kMaxThreadNameLength - 1);
+            thread->NameBuf[kMaxThreadNameLength] = '\0';
+            thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+            thread->id = taskStatusArray[x].xTaskNumber;
+            thread->stackFreeMinimum.Emplace(taskStatusArray[x].usStackHighWaterMark);
+
+            /* Unsupported metrics */
+            // thread->stackSize
+            // thread->stackFreeCurrent
+
+            thread->Next = head;
+            head         = thread;
+        }
+
+        *threadMetricsOut = head;
+        /* The array is no longer needed, free the memory it consumes. */
+        chip::Platform::MemoryFree(taskStatusArray);
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+void DiagnosticDataProviderImpl::ReleaseThreadMetrics(ThreadMetrics * threadMetrics)
+{
+    while (threadMetrics)
+    {
+        ThreadMetrics * del = threadMetrics;
+        threadMetrics       = threadMetrics->Next;
+        delete del;
+    }
+}
+
 // General Diagnostics Getters
 
 CHIP_ERROR DiagnosticDataProviderImpl::GetRebootCount(uint16_t & rebootCount)

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -113,19 +113,20 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
         for (x = 0; x < arraySize; x++)
         {
             ThreadMetrics * thread = new ThreadMetrics();
+            if (thread)
+            {
+                Platform::CopyString(thread->NameBuf, taskStatusArray[x].pcTaskName);
+                thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
+                thread->id = taskStatusArray[x].xTaskNumber;
+                thread->stackFreeMinimum.Emplace(taskStatusArray[x].usStackHighWaterMark);
 
-            strncpy(thread->NameBuf, taskStatusArray[x].pcTaskName, kMaxThreadNameLength - 1);
-            thread->NameBuf[kMaxThreadNameLength] = '\0';
-            thread->name.Emplace(CharSpan::fromCharString(thread->NameBuf));
-            thread->id = taskStatusArray[x].xTaskNumber;
-            thread->stackFreeMinimum.Emplace(taskStatusArray[x].usStackHighWaterMark);
+                /* Unsupported metrics */
+                // thread->stackSize
+                // thread->stackFreeCurrent
 
-            /* Unsupported metrics */
-            // thread->stackSize
-            // thread->stackFreeCurrent
-
-            thread->Next = head;
-            head         = thread;
+                thread->Next = head;
+                head         = thread;
+            }
         }
 
         *threadMetricsOut = head;

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.h
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.h
@@ -44,6 +44,8 @@ public:
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
     CHIP_ERROR ResetWatermarks() override;
+    CHIP_ERROR GetThreadMetrics(ThreadMetrics ** threadMetricsOut) override;
+    void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
     CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
     CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;


### PR DESCRIPTION
#### Problem
EFR32 platform doesn't support the attribute threadMetrics

#### Change overview
Add the implementation to encode the attribute base of the available OS tasks stats

#### Testing
Manual test 
./chip-tool softwarediagnostics read thread-metrics 537 0
