### PR TITLE
Add functionality to read attributes from content apps

### DIFF
--- a/examples/tv-app/android/App/common-api/src/main/java/com/matter/tv/app/api/MatterIntentConstants.java
+++ b/examples/tv-app/android/App/common-api/src/main/java/com/matter/tv/app/api/MatterIntentConstants.java
@@ -15,9 +15,14 @@ public class MatterIntentConstants {
 
   public static final String EXTRA_RESPONSE_PAYLOAD = "EXTRA_RESPONSE_PAYLOAD";
 
+  public static final String EXTRA_ATTRIBUTE_ACTION = "EXTRA_ATTRIBUTE_ACTION";
+
+  public static final String ATTRIBUTE_ACTION_READ = "ATTRIBUTE_ACTION_READ";
+
   public static final String EXTRA_DIRECTIVE_RESPONSE_PENDING_INTENT =
       "EXTRA_DIRECTIVE_RESPONSE_PENDING_INTENT";
 
   public static final String EXTRA_COMMAND_ID = "EXTRA_COMMAND_ID";
   public static final String EXTRA_CLUSTER_ID = "EXTRA_CLUSTER_ID";
+  public static final String EXTRA_ATTRIBUTE_ID = "EXTRA_ATTRIBUTE_ID";
 }

--- a/examples/tv-app/android/App/content-app/src/main/java/com/example/contentapp/receiver/MatterCommandReceiver.java
+++ b/examples/tv-app/android/App/content-app/src/main/java/com/example/contentapp/receiver/MatterCommandReceiver.java
@@ -9,6 +9,8 @@ import com.matter.tv.app.api.MatterIntentConstants;
 
 public class MatterCommandReceiver extends BroadcastReceiver {
   private static final String TAG = "MatterCommandReceiver";
+  private static final int ACCEPT_HEADER = 0;
+  private static final int SUPPORTED_STREAMING_PROTOCOLS = 1;
 
   @Override
   public void onReceive(Context context, Intent intent) {
@@ -21,37 +23,48 @@ public class MatterCommandReceiver extends BroadcastReceiver {
 
     switch (intentAction) {
       case MatterIntentConstants.ACTION_MATTER_COMMAND:
-        byte[] commandPayload =
-            intent.getByteArrayExtra(MatterIntentConstants.EXTRA_COMMAND_PAYLOAD);
         int commandId = intent.getIntExtra(MatterIntentConstants.EXTRA_COMMAND_ID, -1);
-        int clusterId = intent.getIntExtra(MatterIntentConstants.EXTRA_CLUSTER_ID, -1);
-        Log.d(
-            TAG,
-            new StringBuilder()
-                .append("Received matter command ")
-                .append(commandId)
-                .append(" on cluster ")
-                .append(clusterId)
-                .append(" with payload : ")
-                .append(new String(commandPayload))
-                .toString());
-
-        PendingIntent pendingIntent =
-            intent.getParcelableExtra(
-                MatterIntentConstants.EXTRA_DIRECTIVE_RESPONSE_PENDING_INTENT);
-        if (pendingIntent != null) {
-          final Intent responseIntent =
-              new Intent()
-                  .putExtra(
-                      MatterIntentConstants.EXTRA_RESPONSE_PAYLOAD,
-                      "{\"value\":{\"0\":1, \"1\":\"custom response from content app\"}}"
-                          .getBytes());
-          try {
-            pendingIntent.send(context, 0, responseIntent);
-          } catch (final PendingIntent.CanceledException ex) {
-            Log.e(TAG, "Error sending pending intent to the Matter agent", ex);
+        if (commandId != -1) {
+          int clusterId = intent.getIntExtra(MatterIntentConstants.EXTRA_CLUSTER_ID, -1);
+          byte[] commandPayload =
+              intent.getByteArrayExtra(MatterIntentConstants.EXTRA_COMMAND_PAYLOAD);
+          Log.d(
+              TAG,
+              new StringBuilder()
+                  .append("Received matter command ")
+                  .append(commandId)
+                  .append(" on cluster ")
+                  .append(clusterId)
+                  .append(" with payload : ")
+                  .append(new String(commandPayload))
+                  .toString());
+          String response = "{\"0\":1, \"1\":\"custom response from content app\"}";
+          sendResponseViaPendingIntent(context, intent, response);
+        } else {
+          int attributeId = intent.getIntExtra(MatterIntentConstants.EXTRA_ATTRIBUTE_ID, -1);
+          String attributeAction =
+              intent.getStringExtra(MatterIntentConstants.EXTRA_ATTRIBUTE_ACTION);
+          if (attributeAction.equals(MatterIntentConstants.ATTRIBUTE_ACTION_READ)) {
+            String response;
+            if (attributeId == ACCEPT_HEADER) {
+              response =
+                  "{\"0\": [\"video/mp4\", \"application/x-mpegURL\", \"application/dash+xml\"] }";
+            } else if (attributeId == SUPPORTED_STREAMING_PROTOCOLS) {
+              response = "{\"1\":3}";
+            } else {
+              response = "";
+            }
+            sendResponseViaPendingIntent(context, intent, response);
+          } else {
+            Log.e(
+                TAG,
+                new StringBuilder()
+                    .append("Received unknown Attribute Action: ")
+                    .append(intent.getAction())
+                    .toString());
           }
         }
+
         break;
       default:
         Log.e(
@@ -60,6 +73,20 @@ public class MatterCommandReceiver extends BroadcastReceiver {
                 .append("Received unknown Intent: ")
                 .append(intent.getAction())
                 .toString());
+    }
+  }
+
+  private void sendResponseViaPendingIntent(Context context, Intent intent, String response) {
+    PendingIntent pendingIntent =
+        intent.getParcelableExtra(MatterIntentConstants.EXTRA_DIRECTIVE_RESPONSE_PENDING_INTENT);
+    if (pendingIntent != null) {
+      final Intent responseIntent =
+          new Intent().putExtra(MatterIntentConstants.EXTRA_RESPONSE_PAYLOAD, response.getBytes());
+      try {
+        pendingIntent.send(context, 0, responseIntent);
+      } catch (final PendingIntent.CanceledException ex) {
+        Log.e(TAG, "Error sending pending intent to the Matter agent", ex);
+      }
     }
   }
 }

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/handlers/ContentAppEndpointManagerImpl.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/handlers/ContentAppEndpointManagerImpl.java
@@ -29,4 +29,24 @@ public class ContentAppEndpointManagerImpl implements ContentAppEndpointManager 
     }
     return "Success";
   }
+
+  public String readAttribute(int endpointId, int clusterId, int attributeId) {
+    Log.d(
+        TAG,
+        "Received a attribute read request for endpointId "
+            + endpointId
+            + "clusterId"
+            + clusterId
+            + " attributeId "
+            + attributeId);
+    for (ContentApp app :
+        ContentAppDiscoveryService.getReceiverInstance().getDiscoveredContentApps().values()) {
+      if (app.getEndpointId() == endpointId) {
+        Log.d(TAG, "Sending attribute read request for endpointId " + endpointId);
+        return ContentAppAgentService.sendAttributeReadRequest(
+            context, app.getAppName(), clusterId, attributeId);
+      }
+    }
+    return "";
+  }
 }

--- a/examples/tv-app/android/BUILD.gn
+++ b/examples/tv-app/android/BUILD.gn
@@ -44,6 +44,8 @@ shared_library("jni") {
     "java/ChannelManager.cpp",
     "java/ChannelManager.h",
     "java/ClusterChangeAttribute.cpp",
+    "java/ContentAppAttributeDelegate.cpp",
+    "java/ContentAppAttributeDelegate.h",
     "java/ContentAppCommandDelegate.cpp",
     "java/ContentAppCommandDelegate.h",
     "java/ContentLauncherManager.cpp",

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -27,7 +27,7 @@ using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::ContentLauncher;
 using ContentAppAttributeDelegate = chip::AppPlatform::ContentAppAttributeDelegate;
 
-AppContentLauncherManager::AppContentLauncherManager(ContentAppAttributeDelegate * attributeDelegate,
+AppContentLauncherManager::AppContentLauncherManager(ContentAppAttributeDelegate attributeDelegate,
                                                      list<std::string> acceptHeaderList, uint32_t supportedStreamingProtocols) :
     mAttributeDelegate(attributeDelegate)
 {
@@ -85,7 +85,7 @@ CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEn
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetAcceptHeaderList");
     chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::ContentLauncher::Id,
                                                chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id);
-    const char * resStr = mAttributeDelegate->Read(aPath);
+    const char * resStr = mAttributeDelegate.Read(aPath);
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response %s", resStr);
 
     if (resStr != nullptr && *resStr != 0)
@@ -93,9 +93,10 @@ CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEn
         Json::Reader reader;
         Json::Value value;
         reader.parse(resStr, value);
-        const char * attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id).c_str();
-        ChipLogProgress(
-            Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s", attrId);
+        std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id).c_str();
+        ChipLogProgress(Zcl,
+                        "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
+                        attrId.c_str());
         if (value[attrId].isArray())
         {
             mAcceptHeaderList.clear();
@@ -121,7 +122,7 @@ uint32_t AppContentLauncherManager::HandleGetSupportedStreamingProtocols()
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols");
     chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::ContentLauncher::Id,
                                                chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id);
-    const char * resStr = mAttributeDelegate->Read(aPath);
+    const char * resStr = mAttributeDelegate.Read(aPath);
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response %s", resStr);
 
     if (resStr == nullptr || *resStr == 0)
@@ -132,9 +133,9 @@ uint32_t AppContentLauncherManager::HandleGetSupportedStreamingProtocols()
     Json::Reader reader;
     Json::Value value;
     reader.parse(resStr, value);
-    const char * attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id).c_str();
+    std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id);
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
-                    attrId);
+                    attrId.c_str());
     if (!value[attrId].empty())
     {
         uint32_t supportedStreamingProtocols = static_cast<uint32_t>(value[attrId].asInt());

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -95,9 +95,9 @@ CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEn
         if (reader.parse(resStr, value))
         {
             std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id);
-            ChipLogProgress(Zcl,
-                            "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
-                            attrId.c_str());
+            ChipLogProgress(
+                Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
+                attrId.c_str());
             if (value[attrId].isArray())
             {
                 mAcceptHeaderList.clear();

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -17,18 +17,19 @@
  */
 
 #include "AppContentLauncherManager.h"
-#include "../../java/ContentAppCommandDelegate.h"
+#include "../../java/ContentAppAttributeDelegate.h"
+#include <json/json.h>
 
 using namespace std;
 using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::DataModel;
 using namespace chip::app::Clusters::ContentLauncher;
-using ContentAppCommandDelegate = chip::AppPlatform::ContentAppCommandDelegate;
+using ContentAppAttributeDelegate = chip::AppPlatform::ContentAppAttributeDelegate;
 
-AppContentLauncherManager::AppContentLauncherManager(ContentAppCommandDelegate commandDelegate, list<std::string> acceptHeaderList,
-                                                     uint32_t supportedStreamingProtocols) :
-    mCommandDelegate(commandDelegate)
+AppContentLauncherManager::AppContentLauncherManager(ContentAppAttributeDelegate * attributeDelegate,
+                                                     list<std::string> acceptHeaderList, uint32_t supportedStreamingProtocols) :
+    mAttributeDelegate(attributeDelegate)
 {
     mAcceptHeaderList            = acceptHeaderList;
     mSupportedStreamingProtocols = supportedStreamingProtocols;
@@ -73,11 +74,8 @@ void AppContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchResp
     string displayStringString(displayString.data(), displayString.size());
 
     // TODO: Insert code here
-
-    const char * resStr = mCommandDelegate.sendCommand(mEndpointId, contentUrlString);
-
     LaunchResponseType response;
-    response.data   = chip::MakeOptional(CharSpan::fromCharString(resStr));
+    response.data   = chip::MakeOptional(CharSpan::fromCharString("Success"));
     response.status = ContentLauncher::ContentLaunchStatusEnum::kSuccess;
     helper.Success(response);
 }
@@ -85,6 +83,29 @@ void AppContentLauncherManager::HandleLaunchUrl(CommandResponseHelper<LaunchResp
 CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEncoder & aEncoder)
 {
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetAcceptHeaderList");
+    chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::ContentLauncher::Id,
+                                               chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id);
+    const char * resStr = mAttributeDelegate->Read(aPath);
+    ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response %s", resStr);
+
+    if (resStr != nullptr && *resStr != 0)
+    {
+        Json::Reader reader;
+        Json::Value value;
+        reader.parse(resStr, value);
+        const char * attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id).c_str();
+        ChipLogProgress(
+            Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s", attrId);
+        if (value[attrId].isArray())
+        {
+            mAcceptHeaderList.clear();
+            for (Json::Value & entry : value[attrId])
+            {
+                mAcceptHeaderList.push_back(entry.asString());
+            }
+        }
+    }
+
     return aEncoder.EncodeList([this](const auto & encoder) -> CHIP_ERROR {
         for (std::string & entry : mAcceptHeaderList)
         {
@@ -98,6 +119,27 @@ CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEn
 uint32_t AppContentLauncherManager::HandleGetSupportedStreamingProtocols()
 {
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols");
+    chip::app::ConcreteReadAttributePath aPath(mEndpointId, chip::app::Clusters::ContentLauncher::Id,
+                                               chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id);
+    const char * resStr = mAttributeDelegate->Read(aPath);
+    ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response %s", resStr);
+
+    if (resStr == nullptr || *resStr == 0)
+    {
+        return mSupportedStreamingProtocols;
+    }
+
+    Json::Reader reader;
+    Json::Value value;
+    reader.parse(resStr, value);
+    const char * attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id).c_str();
+    ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
+                    attrId);
+    if (!value[attrId].empty())
+    {
+        uint32_t supportedStreamingProtocols = static_cast<uint32_t>(value[attrId].asInt());
+        mSupportedStreamingProtocols         = supportedStreamingProtocols;
+    }
     return mSupportedStreamingProtocols;
 }
 

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.cpp
@@ -92,17 +92,19 @@ CHIP_ERROR AppContentLauncherManager::HandleGetAcceptHeaderList(AttributeValueEn
     {
         Json::Reader reader;
         Json::Value value;
-        reader.parse(resStr, value);
-        std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id).c_str();
-        ChipLogProgress(Zcl,
-                        "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
-                        attrId.c_str());
-        if (value[attrId].isArray())
+        if (reader.parse(resStr, value))
         {
-            mAcceptHeaderList.clear();
-            for (Json::Value & entry : value[attrId])
+            std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::Id);
+            ChipLogProgress(Zcl,
+                            "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
+                            attrId.c_str());
+            if (value[attrId].isArray())
             {
-                mAcceptHeaderList.push_back(entry.asString());
+                mAcceptHeaderList.clear();
+                for (Json::Value & entry : value[attrId])
+                {
+                    mAcceptHeaderList.push_back(entry.asString());
+                }
             }
         }
     }
@@ -132,7 +134,10 @@ uint32_t AppContentLauncherManager::HandleGetSupportedStreamingProtocols()
 
     Json::Reader reader;
     Json::Value value;
-    reader.parse(resStr, value);
+    if (!reader.parse(resStr, value))
+    {
+        return mSupportedStreamingProtocols;
+    }
     std::string attrId = to_string(chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::Id);
     ChipLogProgress(Zcl, "AppContentLauncherManager::HandleGetSupportedStreamingProtocols response parsing done. reading attr %s",
                     attrId.c_str());

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.h
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.h
@@ -18,24 +18,24 @@
 
 #pragma once
 
-#include "../../java/ContentAppCommandDelegate.h"
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include "../../java/ContentAppAttributeDelegate.h"
 #include <app/clusters/content-launch-server/content-launch-server.h>
 
 using chip::CharSpan;
 using chip::EndpointId;
 using chip::app::AttributeValueEncoder;
 using chip::app::CommandResponseHelper;
-using ContentLauncherDelegate   = chip::app::Clusters::ContentLauncher::Delegate;
-using LaunchResponseType        = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type;
-using ParameterType             = chip::app::Clusters::ContentLauncher::Structs::Parameter::DecodableType;
-using BrandingInformationType   = chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type;
-using ContentAppCommandDelegate = chip::AppPlatform::ContentAppCommandDelegate;
+using ContentLauncherDelegate     = chip::app::Clusters::ContentLauncher::Delegate;
+using LaunchResponseType          = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type;
+using ParameterType               = chip::app::Clusters::ContentLauncher::Structs::Parameter::DecodableType;
+using BrandingInformationType     = chip::app::Clusters::ContentLauncher::Structs::BrandingInformation::Type;
+using ContentAppAttributeDelegate = chip::AppPlatform::ContentAppAttributeDelegate;
 
 class AppContentLauncherManager : public ContentLauncherDelegate
 {
 public:
-    AppContentLauncherManager(ContentAppCommandDelegate commandDelegate, std::list<std::string> acceptHeaderList,
+    AppContentLauncherManager(ContentAppAttributeDelegate * attributeDelegate, std::list<std::string> acceptHeaderList,
                               uint32_t supportedStreamingProtocols);
 
     void HandleLaunchContent(CommandResponseHelper<LaunchResponseType> & helper,
@@ -56,8 +56,9 @@ protected:
 
 private:
     EndpointId mEndpointId;
-    ContentAppCommandDelegate mCommandDelegate;
 
     // TODO: set this based upon meta data from app
     uint32_t mDynamicEndpointFeatureMap = 3;
+
+    ContentAppAttributeDelegate * mAttributeDelegate;
 };

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.h
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.h
@@ -35,7 +35,7 @@ using ContentAppAttributeDelegate = chip::AppPlatform::ContentAppAttributeDelega
 class AppContentLauncherManager : public ContentLauncherDelegate
 {
 public:
-    AppContentLauncherManager(ContentAppAttributeDelegate * attributeDelegate, std::list<std::string> acceptHeaderList,
+    AppContentLauncherManager(ContentAppAttributeDelegate attributeDelegate, std::list<std::string> acceptHeaderList,
                               uint32_t supportedStreamingProtocols);
 
     void HandleLaunchContent(CommandResponseHelper<LaunchResponseType> & helper,
@@ -60,5 +60,5 @@ private:
     // TODO: set this based upon meta data from app
     uint32_t mDynamicEndpointFeatureMap = 3;
 
-    ContentAppAttributeDelegate * mAttributeDelegate;
+    ContentAppAttributeDelegate mAttributeDelegate;
 };

--- a/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.h
+++ b/examples/tv-app/android/include/content-launcher/AppContentLauncherManager.h
@@ -18,8 +18,8 @@
 
 #pragma once
 
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include "../../java/ContentAppAttributeDelegate.h"
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/content-launch-server/content-launch-server.h>
 
 using chip::CharSpan;

--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -357,7 +357,7 @@ ContentApp * ContentAppFactoryImpl::LoadContentApp(const CatalogVendorApp & vend
     return nullptr;
 }
 
-EndpointId ContentAppFactoryImpl::AddContentApp(ContentAppImpl * app)
+EndpointId ContentAppFactoryImpl::AddContentApp(ContentAppImpl * app, jobject contentAppEndpointManager)
 {
     DataVersion dataVersionBuf[ArraySize(contentAppClusters)];
     EndpointId epId = ContentAppPlatform::GetInstance().AddContentApp(app, &contentAppEndpoint, Span<DataVersion>(dataVersionBuf),
@@ -471,7 +471,7 @@ EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const cha
     ContentAppImpl * app =
         new ContentAppImpl(szVendorName, vendorId, szApplicationName, productId, szApplicationVersion, "20202021", manager);
     ChipLogProgress(DeviceLayer, "AppImpl: AddContentApp vendorId=%d applicationName=%s ", vendorId, szApplicationName);
-    return gFactory.AddContentApp(app);
+    return gFactory.AddContentApp(app, manager);
 #endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     return 0;
 }

--- a/examples/tv-app/android/java/AppImpl.h
+++ b/examples/tv-app/android/java/AppImpl.h
@@ -39,7 +39,7 @@
 #include "../include/target-navigator/TargetNavigatorManager.h"
 #include "ChannelManager.h"
 #include "CommissionerMain.h"
-#include "ContentAppCommandDelegate.h"
+#include "ContentAppAttributeDelegate.h"
 #include "KeypadInputManager.h"
 #include "MediaPlaybackManager.h"
 #include "MyUserPrompter-JNI.h"
@@ -72,7 +72,7 @@ using KeypadInputDelegate         = app::Clusters::KeypadInput::Delegate;
 using MediaPlaybackDelegate       = app::Clusters::MediaPlayback::Delegate;
 using TargetNavigatorDelegate     = app::Clusters::TargetNavigator::Delegate;
 using SupportedStreamingProtocol  = app::Clusters::ContentLauncher::SupportedStreamingProtocol;
-using ContentAppCommandDelegate   = chip::AppPlatform::ContentAppCommandDelegate;
+using ContentAppAttributeDelegate = chip::AppPlatform::ContentAppAttributeDelegate;
 
 static const int kCatalogVendorId = CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID;
 
@@ -86,9 +86,10 @@ public:
                    const char * szApplicationVersion, const char * setupPIN, jobject manager) :
         mApplicationBasicDelegate(kCatalogVendorId, BuildAppId(vendorId), szVendorName, vendorId, szApplicationName, productId,
                                   szApplicationVersion),
-        mAccountLoginDelegate(setupPIN), mContentLauncherDelegate(ContentAppCommandDelegate(manager), { "image/*", "video/*" },
-                                                                  to_underlying(SupportedStreamingProtocol::kDash) |
-                                                                      to_underlying(SupportedStreamingProtocol::kHls)),
+        mAccountLoginDelegate(setupPIN),
+        mContentLauncherDelegate(
+            new ContentAppAttributeDelegate(manager, app::Clusters::ContentLauncher::Id), { "image/*", "video/*" },
+            to_underlying(SupportedStreamingProtocol::kDash) | to_underlying(SupportedStreamingProtocol::kHls)),
         mTargetNavigatorDelegate({ "home", "search", "info", "guide", "menu" }, 0){};
     virtual ~ContentAppImpl() {}
 
@@ -131,7 +132,7 @@ public:
     // Lookup ContentApp for this catalog id / app id and load it
     ContentApp * LoadContentApp(const CatalogVendorApp & vendorApp) override;
 
-    EndpointId AddContentApp(ContentAppImpl * app);
+    EndpointId AddContentApp(ContentAppImpl * app, jobject contentAppEndpointManager);
 
     void SendTestMessage(EndpointId epID, const char * message);
 

--- a/examples/tv-app/android/java/AppImpl.h
+++ b/examples/tv-app/android/java/AppImpl.h
@@ -87,9 +87,9 @@ public:
         mApplicationBasicDelegate(kCatalogVendorId, BuildAppId(vendorId), szVendorName, vendorId, szApplicationName, productId,
                                   szApplicationVersion),
         mAccountLoginDelegate(setupPIN),
-        mContentLauncherDelegate(
-            new ContentAppAttributeDelegate(manager, app::Clusters::ContentLauncher::Id), { "image/*", "video/*" },
-            to_underlying(SupportedStreamingProtocol::kDash) | to_underlying(SupportedStreamingProtocol::kHls)),
+        mContentLauncherDelegate(new ContentAppAttributeDelegate(manager), { "image/*", "video/*" },
+                                 to_underlying(SupportedStreamingProtocol::kDash) |
+                                     to_underlying(SupportedStreamingProtocol::kHls)),
         mTargetNavigatorDelegate({ "home", "search", "info", "guide", "menu" }, 0){};
     virtual ~ContentAppImpl() {}
 

--- a/examples/tv-app/android/java/AppImpl.h
+++ b/examples/tv-app/android/java/AppImpl.h
@@ -86,10 +86,9 @@ public:
                    const char * szApplicationVersion, const char * setupPIN, jobject manager) :
         mApplicationBasicDelegate(kCatalogVendorId, BuildAppId(vendorId), szVendorName, vendorId, szApplicationName, productId,
                                   szApplicationVersion),
-        mAccountLoginDelegate(setupPIN),
-        mContentLauncherDelegate(new ContentAppAttributeDelegate(manager), { "image/*", "video/*" },
-                                 to_underlying(SupportedStreamingProtocol::kDash) |
-                                     to_underlying(SupportedStreamingProtocol::kHls)),
+        mAccountLoginDelegate(setupPIN), mContentLauncherDelegate(ContentAppAttributeDelegate(manager), { "image/*", "video/*" },
+                                                                  to_underlying(SupportedStreamingProtocol::kDash) |
+                                                                      to_underlying(SupportedStreamingProtocol::kHls)),
         mTargetNavigatorDelegate({ "home", "search", "info", "guide", "menu" }, 0){};
     virtual ~ContentAppImpl() {}
 

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
@@ -21,7 +21,6 @@
  */
 
 #include "ContentAppAttributeDelegate.h"
-
 #include <app-common/zap-generated/cluster-objects.h>
 #include <app/AttributeAccessInterface.h>
 #include <jni.h>
@@ -33,8 +32,7 @@
 namespace chip {
 namespace AppPlatform {
 
-using AttributeAccessInterface = app::AttributeAccessInterface;
-using LaunchResponseType       = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type;
+using LaunchResponseType = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type;
 
 const char * ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttributePath & aPath)
 {
@@ -53,87 +51,14 @@ const char * ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttr
             ChipLogError(Zcl, "Java exception in ContentAppAttributeDelegate::Read");
             env->ExceptionDescribe();
             env->ExceptionClear();
-            //            FormatResponseData(handlerContext, "{\"value\":{}}");
             return "";
         }
         const char * respStr = env->GetStringUTFChars(resp, 0);
         ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read got response %s", respStr);
-        //        FormatResponseData(handlerContext, respStr);
         return respStr;
     }
     return "";
 }
-
-CHIP_ERROR ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttributePath & aPath,
-                                             chip::app::AttributeValueEncoder & aEncoder)
-{
-    if (aPath.mEndpointId >= FIXED_ENDPOINT_COUNT)
-    {
-        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-
-        ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read being called for endpoint %d cluster %d attribute %d",
-                        aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
-
-        jstring resp =
-            (jstring) env->CallObjectMethod(mContentAppEndpointManager, mReadAttributeMethod, static_cast<jint>(aPath.mEndpointId),
-                                            static_cast<jint>(aPath.mClusterId), static_cast<jint>(aPath.mAttributeId));
-        if (env->ExceptionCheck())
-        {
-            ChipLogError(Zcl, "Java exception in ContentAppAttributeDelegate::Read");
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            //            FormatResponseData(handlerContext, "{\"value\":{}}");
-            return CHIP_NO_ERROR;
-        }
-        const char * respStr = env->GetStringUTFChars(resp, 0);
-        ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read got response %s", respStr);
-        //        FormatResponseData(handlerContext, respStr);
-        return CHIP_NO_ERROR;
-    }
-    return CHIP_NO_ERROR;
-}
-
-/*
-void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::HandlerContext & handlerContext, const char * response)
-{
-    Json::Reader reader;
-    Json::Value value;
-    reader.parse(response, value);
-
-    switch (handlerContext.mRequestPath.mClusterId)
-    {
-    case app::Clusters::ContentLauncher::Id: {
-        LaunchResponseType launchResponse;
-        if (value["0"].empty())
-        {
-            launchResponse.status = chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum::kAuthFailed;
-        }
-        else
-        {
-            launchResponse.status = static_cast<chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum>(value["0"].asInt());
-            if (!value["1"].empty())
-            {
-                launchResponse.data = chip::MakeOptional(CharSpan::fromCharString(value["1"].asCString()));
-            }
-        }
-        handlerContext.mCommandHandler.AddResponseData(handlerContext.mRequestPath, launchResponse);
-        handlerContext.SetCommandHandled();
-        break;
-    }
-
-    // case app::Clusters::TargetNavigator::Id:
-    //     break;
-
-    // case app::Clusters::MediaPlayback::Id:
-    //     break;
-
-    // case app::Clusters::AccountLogin::Id:
-    //     break;
-    default:
-        handlerContext.SetCommandNotHandled();
-    }
-}
-*/
 
 } // namespace AppPlatform
 } // namespace chip

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
@@ -1,0 +1,139 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @brief Contains Implementation of the ContentAppAttributeDelegate
+ */
+
+#include "ContentAppAttributeDelegate.h"
+
+#include <app-common/zap-generated/cluster-objects.h>
+#include <app/AttributeAccessInterface.h>
+#include <jni.h>
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+#include <zap-generated/endpoint_config.h>
+
+namespace chip {
+namespace AppPlatform {
+
+using AttributeAccessInterface = app::AttributeAccessInterface;
+using LaunchResponseType       = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type;
+
+const char * ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttributePath & aPath)
+{
+    if (aPath.mEndpointId >= FIXED_ENDPOINT_COUNT)
+    {
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+
+        ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read being called for endpoint %d cluster %d attribute %d",
+                        aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
+
+        jstring resp =
+            (jstring) env->CallObjectMethod(mContentAppEndpointManager, mReadAttributeMethod, static_cast<jint>(aPath.mEndpointId),
+                                            static_cast<jint>(aPath.mClusterId), static_cast<jint>(aPath.mAttributeId));
+        if (env->ExceptionCheck())
+        {
+            ChipLogError(Zcl, "Java exception in ContentAppAttributeDelegate::Read");
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            //            FormatResponseData(handlerContext, "{\"value\":{}}");
+            return "";
+        }
+        const char * respStr = env->GetStringUTFChars(resp, 0);
+        ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read got response %s", respStr);
+        //        FormatResponseData(handlerContext, respStr);
+        return respStr;
+    }
+    return "";
+}
+
+CHIP_ERROR ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttributePath & aPath,
+                                             chip::app::AttributeValueEncoder & aEncoder)
+{
+    if (aPath.mEndpointId >= FIXED_ENDPOINT_COUNT)
+    {
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+
+        ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read being called for endpoint %d cluster %d attribute %d",
+                        aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
+
+        jstring resp =
+            (jstring) env->CallObjectMethod(mContentAppEndpointManager, mReadAttributeMethod, static_cast<jint>(aPath.mEndpointId),
+                                            static_cast<jint>(aPath.mClusterId), static_cast<jint>(aPath.mAttributeId));
+        if (env->ExceptionCheck())
+        {
+            ChipLogError(Zcl, "Java exception in ContentAppAttributeDelegate::Read");
+            env->ExceptionDescribe();
+            env->ExceptionClear();
+            //            FormatResponseData(handlerContext, "{\"value\":{}}");
+            return CHIP_NO_ERROR;
+        }
+        const char * respStr = env->GetStringUTFChars(resp, 0);
+        ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read got response %s", respStr);
+        //        FormatResponseData(handlerContext, respStr);
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_NO_ERROR;
+}
+
+/*
+void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::HandlerContext & handlerContext, const char * response)
+{
+    Json::Reader reader;
+    Json::Value value;
+    reader.parse(response, value);
+
+    switch (handlerContext.mRequestPath.mClusterId)
+    {
+    case app::Clusters::ContentLauncher::Id: {
+        LaunchResponseType launchResponse;
+        if (value["0"].empty())
+        {
+            launchResponse.status = chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum::kAuthFailed;
+        }
+        else
+        {
+            launchResponse.status = static_cast<chip::app::Clusters::ContentLauncher::ContentLaunchStatusEnum>(value["0"].asInt());
+            if (!value["1"].empty())
+            {
+                launchResponse.data = chip::MakeOptional(CharSpan::fromCharString(value["1"].asCString()));
+            }
+        }
+        handlerContext.mCommandHandler.AddResponseData(handlerContext.mRequestPath, launchResponse);
+        handlerContext.SetCommandHandled();
+        break;
+    }
+
+    // case app::Clusters::TargetNavigator::Id:
+    //     break;
+
+    // case app::Clusters::MediaPlayback::Id:
+    //     break;
+
+    // case app::Clusters::AccountLogin::Id:
+    //     break;
+    default:
+        handlerContext.SetCommandNotHandled();
+    }
+}
+*/
+
+} // namespace AppPlatform
+} // namespace chip

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.cpp
@@ -36,28 +36,28 @@ using LaunchResponseType = chip::app::Clusters::ContentLauncher::Commands::Launc
 
 const char * ContentAppAttributeDelegate::Read(const chip::app::ConcreteReadAttributePath & aPath)
 {
-    if (aPath.mEndpointId >= FIXED_ENDPOINT_COUNT)
+    if (aPath.mEndpointId < FIXED_ENDPOINT_COUNT)
     {
-        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-
-        ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read being called for endpoint %d cluster %d attribute %d",
-                        aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
-
-        jstring resp =
-            (jstring) env->CallObjectMethod(mContentAppEndpointManager, mReadAttributeMethod, static_cast<jint>(aPath.mEndpointId),
-                                            static_cast<jint>(aPath.mClusterId), static_cast<jint>(aPath.mAttributeId));
-        if (env->ExceptionCheck())
-        {
-            ChipLogError(Zcl, "Java exception in ContentAppAttributeDelegate::Read");
-            env->ExceptionDescribe();
-            env->ExceptionClear();
-            return "";
-        }
-        const char * respStr = env->GetStringUTFChars(resp, 0);
-        ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read got response %s", respStr);
-        return respStr;
+        return "";
     }
-    return "";
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+
+    ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read being called for endpoint %d cluster %d attribute %d",
+                    aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId);
+
+    jstring resp =
+        (jstring) env->CallObjectMethod(mContentAppEndpointManager, mReadAttributeMethod, static_cast<jint>(aPath.mEndpointId),
+                                        static_cast<jint>(aPath.mClusterId), static_cast<jint>(aPath.mAttributeId));
+    if (env->ExceptionCheck())
+    {
+        ChipLogError(Zcl, "Java exception in ContentAppAttributeDelegate::Read");
+        env->ExceptionDescribe();
+        env->ExceptionClear();
+        return "";
+    }
+    const char * respStr = env->GetStringUTFChars(resp, 0);
+    ChipLogProgress(Zcl, "ContentAppAttributeDelegate::Read got response %s", respStr);
+    return respStr;
 }
 
 } // namespace AppPlatform

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.h
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.h
@@ -31,13 +31,10 @@
 namespace chip {
 namespace AppPlatform {
 
-using AttributeAccessInterface = app::AttributeAccessInterface;
-
-class ContentAppAttributeDelegate : public AttributeAccessInterface
+class ContentAppAttributeDelegate
 {
 public:
-    ContentAppAttributeDelegate(jobject manager, ClusterId aClusterId) :
-        AttributeAccessInterface(Optional<EndpointId>::Missing(), aClusterId)
+    ContentAppAttributeDelegate(jobject manager)
     {
         if (manager == nullptr)
         {
@@ -47,7 +44,6 @@ public:
         InitializeJNIObjects(manager);
     }
 
-    CHIP_ERROR Read(const chip::app::ConcreteReadAttributePath & aPath, chip::app::AttributeValueEncoder & aEncoder) override;
     const char * Read(const chip::app::ConcreteReadAttributePath & aPath);
 
 private:

--- a/examples/tv-app/android/java/ContentAppAttributeDelegate.h
+++ b/examples/tv-app/android/java/ContentAppAttributeDelegate.h
@@ -1,0 +1,80 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @brief Facilitates communication with the application handlers in Java
+ */
+
+#pragma once
+
+#include <app-common/zap-generated/ids/Clusters.h>
+#include <app/AttributeAccessInterface.h>
+#include <jni.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/support/JniReferences.h>
+
+namespace chip {
+namespace AppPlatform {
+
+using AttributeAccessInterface = app::AttributeAccessInterface;
+
+class ContentAppAttributeDelegate : public AttributeAccessInterface
+{
+public:
+    ContentAppAttributeDelegate(jobject manager, ClusterId aClusterId) :
+        AttributeAccessInterface(Optional<EndpointId>::Missing(), aClusterId)
+    {
+        if (manager == nullptr)
+        {
+            // To support the existing hardcoded sample apps.
+            return;
+        }
+        InitializeJNIObjects(manager);
+    }
+
+    CHIP_ERROR Read(const chip::app::ConcreteReadAttributePath & aPath, chip::app::AttributeValueEncoder & aEncoder) override;
+    const char * Read(const chip::app::ConcreteReadAttributePath & aPath);
+
+private:
+    void InitializeJNIObjects(jobject manager)
+    {
+        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+        VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Failed to GetEnvForCurrentThread for ContentAppEndpointManager"));
+
+        mContentAppEndpointManager = env->NewGlobalRef(manager);
+        VerifyOrReturn(mContentAppEndpointManager != nullptr,
+                       ChipLogError(Zcl, "Failed to NewGlobalRef ContentAppEndpointManager"));
+
+        jclass ContentAppEndpointManagerClass = env->GetObjectClass(manager);
+        VerifyOrReturn(ContentAppEndpointManagerClass != nullptr,
+                       ChipLogError(Zcl, "Failed to get ContentAppEndpointManager Java class"));
+
+        mReadAttributeMethod = env->GetMethodID(ContentAppEndpointManagerClass, "readAttribute", "(III)Ljava/lang/String;");
+        if (mReadAttributeMethod == nullptr)
+        {
+            ChipLogError(Zcl, "Failed to access ContentAppEndpointManager 'readAttribute' method");
+            env->ExceptionClear();
+        }
+    }
+
+    jobject mContentAppEndpointManager = nullptr;
+    jmethodID mReadAttributeMethod     = nullptr;
+};
+
+} // namespace AppPlatform
+} // namespace chip

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -112,7 +112,11 @@ void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::Hand
 {
     Json::Reader reader;
     Json::Value value;
-    reader.parse(response, value);
+    if (!reader.parse(response, value))
+    {
+        handlerContext.SetCommandNotHandled();
+        return;
+    }
 
     switch (handlerContext.mRequestPath.mClusterId)
     {

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -79,8 +79,9 @@ void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerCo
             return;
         }
 
-        JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-        UtfString jsonString(env, JsonToString(json).c_str());
+        JNIEnv * env      = JniReferences::GetInstance().GetEnvForCurrentThread();
+        Json::Value value = json["value"];
+        UtfString jsonString(env, JsonToString(value).c_str());
 
         ChipLogProgress(Zcl, "ContentAppCommandDelegate::InvokeCommand send command being called with payload %s",
                         JsonToString(json).c_str());
@@ -110,9 +111,8 @@ void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerCo
 void ContentAppCommandDelegate::FormatResponseData(CommandHandlerInterface::HandlerContext & handlerContext, const char * response)
 {
     Json::Reader reader;
-    Json::Value resJson;
-    reader.parse(response, resJson);
-    Json::Value value = resJson["value"];
+    Json::Value value;
+    reader.parse(response, value);
 
     switch (handlerContext.mRequestPath.mClusterId)
     {

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/ContentAppEndpointManager.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/ContentAppEndpointManager.java
@@ -3,4 +3,6 @@ package com.matter.tv.server.tvapp;
 public interface ContentAppEndpointManager {
 
   public String sendCommand(int endpointId, int clusterId, int commandId, String commandPayload);
+
+  public String readAttribute(int endpointId, int clusterId, int attributeId);
 }


### PR DESCRIPTION
#### Problem
Functionality for reading attributes from content apps was missing in the tv-app example

#### Change overview
Added mechanism to send attribute read requests to content app and send the response back to the client. One cluster attributes were implemented as an example.

#### Testing
Manually using the tv-casting-app 