### PR TITLE
docs: lighting-app/efr32: fix Markdown

### DIFF
--- a/examples/lighting-app/efr32/README.md
+++ b/examples/lighting-app/efr32/README.md
@@ -1,4 +1,4 @@
-#CHIP EFR32 Lighting Example
+# CHIP EFR32 Lighting Example
 
 An example showing the use of CHIP on the Silicon Labs EFR32 MG12.
 
@@ -52,11 +52,11 @@ Silicon Labs platform.
 -   Download and install a suitable ARM gcc tool chain:
     [GNU Arm Embedded Toolchain 9-2019-q4-major](https://developer.arm.com/tools-and-software/open-source-software/developer-tools/gnu-toolchain/gnu-rm/downloads)
 
--   Install some additional tools(likely already present for CHIP developers):
+-   Install some additional tools (likely already present for CHIP developers):
 
-#Linux `sudo apt-get install git libwebkitgtk-1.0-0 ninja-build`
+    -   Linux: `sudo apt-get install git libwebkitgtk-1.0-0 ninja-build`
 
-#Mac OS X `brew install ninja`
+    -   Mac OS X: `brew install ninja`
 
 -   Supported hardware:
 
@@ -80,73 +80,55 @@ Silicon Labs platform.
 
 *   Build the example application:
 
-          ```
           cd ~/connectedhomeip
           ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32/ ./out/lighting-app BRD4161A
-          ```
 
 -   To delete generated executable, libraries and object files use:
 
-          ```
           $ cd ~/connectedhomeip
           $ rm -rf ./out/
-          ```
 
     OR use GN/Ninja directly
 
-          ```
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export EFR32_BOARD=BRD4161A
           $ gn gen out/debug
           $ ninja -C out/debug
-          ```
 
 -   To delete generated executable, libraries and object files use:
 
-          ```
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ rm -rf out/
-          ```
 
 *   Build the example as Sleepy End Device (SED)
 
-          ```
           $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32/ ./out/lighting-app_SED BRD4161A --sed
-          ```
 
     or use gn as previously mentioned but adding the following arguments:
 
-          ```
           $ gn gen out/debug '--args=efr32_board="BRD4161A" enable_sleepy_device=true chip_openthread_ftd=false'
-          ```
 
 *   Build the example with pigweed RPC
 
-          ```
           $ ./scripts/examples/gn_efr32_example.sh examples/lighting-app/efr32/ out/lighting_app_rpc BRD4161A 'import("//with_pw_rpc.gni")'
-          ```
 
     or use GN/Ninja Directly
 
-          ```
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ git submodule update --init
           $ source third_party/connectedhomeip/scripts/activate.sh
           $ export EFR32_BOARD=BRD4161A
           $ gn gen out/debug --args='import("//with_pw_rpc.gni")'
           $ ninja -C out/debug
-          ```
 
     [Running Pigweed RPC console](#running-pigweed-rpc-console)
 
 For more build options, help is provided when running the build script without
 arguments
 
-         ```
          ./scripts/examples/gn_efr32_example.sh
-         ```
 
 <a name="flashing"></a>
 
@@ -154,10 +136,8 @@ arguments
 
 -   On the command line:
 
-          ```
           $ cd ~/connectedhomeip/examples/lighting-app/efr32
           $ python3 out/debug/chip-efr32-lighting-example.flash.py
-          ```
 
 -   Or with the Ozone debugger, just load the .out file.
 
@@ -185,18 +165,14 @@ after flashing the .out file.
 
 *   Install the J-Link software
 
-          ```
           $ cd ~/Downloads
           $ sudo dpkg -i JLink_Linux_V*_x86_64.deb
-          ```
 
 *   In Linux, grant the logged in user the ability to talk to the development
     hardware via the linux tty device (/dev/ttyACMx) by adding them to the
     dialout group.
 
-          ```
           $ sudo usermod -a -G dialout ${USER}
-          ```
 
 Once the above is complete, log output can be viewed using the JLinkExe tool in
 combination with JLinkRTTClient as follows:
@@ -205,21 +181,15 @@ combination with JLinkRTTClient as follows:
 
     For MG12 use:
 
-          ```
           $ JLinkExe -device EFR32MG12PXXXF1024 -if JTAG -speed 4000 -autoconnect 1
-          ```
 
     For MG21 use:
 
-          ```
           $ JLinkExe -device EFR32MG21AXXXF1024 -if SWD -speed 4000 -autoconnect 1
-          ```
 
 -   In a second terminal, run the JLinkRTTClient to view logs:
 
-          ```
           $ JLinkRTTClient
-          ```
 
 <a name="running-complete-example"></a>
 
@@ -290,11 +260,9 @@ combination with JLinkRTTClient as follows:
 
     Here is an example with the CHIPTool:
 
-    ```
     chip-tool pairing ble-thread 1 hex:<operationalDataset> 20202021 3840
 
     chip-tool onoff on 1 1
-    ```
 
 ### Notes
 
@@ -303,12 +271,12 @@ combination with JLinkRTTClient as follows:
     need to add a static ipv6 addresses on both device and then an ipv6 route to
     the border router on your PC
 
-#On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
+    -   On Border Router: `sudo ip addr add dev <Network interface> 2002::2/64`
 
-#On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
+    -   On PC(Linux): `sudo ip addr add dev <Network interface> 2002::1/64`
 
-#Add Ipv6 route on PC(Linux)
-`sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
+    -   Add Ipv6 route on PC(Linux)
+        `sudo ip route add <Thread global ipv6 prefix>/64 via 2002::2`
 
 <a name="running-pigweed-rpc-console"></a>
 
@@ -340,10 +308,8 @@ tracing, build with RPC enabled. See Build the example with pigweed RPC.
 
 Obtain tracing json file.
 
-```
     $ ./{PIGWEED_REPO}/pw_trace_tokenized/py/pw_trace_tokenized/get_trace.py -d {PORT} -o {OUTPUT_FILE} \
     -t {ELF_FILE} {PIGWEED_REPO}/pw_trace_tokenized/pw_trace_protos/trace_rpc.proto
-```
 
 ## Memory settings
 
@@ -386,33 +352,25 @@ passed to the build scripts.
 
 `chip_progress_logging, chip_detail_logging, chip_automation_logging`
 
-    ```
     $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32 ./out/lighting-app BRD4164A "chip_detail_logging=false chip_automation_logging=false chip_progress_logging=false"
-    ```
 
 ### Debug build / release build
 
 `is_debug`
 
-    ```
     $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32 ./out/lighting-app BRD4164A "is_debug=false"
-    ```
 
 ### Disabling LCD
 
 `show_qr_code`
 
-    ```
     $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32 ./out/lighting-app BRD4164A "show_qr_code=false"
-    ```
 
 ### KVS maximum entry count
 
 `kvs_max_entries`
 
-    ```
     Set the maximum Kvs entries that can be stored in NVM (Default 75)
     Thresholds: 30 <= kvs_max_entries <= 255
 
     $ ./scripts/examples/gn_efr32_example.sh ./examples/lighting-app/efr32 ./out/lighting-app BRD4164A kvs_max_entries=50
-    ```


### PR DESCRIPTION
Some Markdown in the README did not have a space after the headline
symbol (hash mark), causing the rendering to fail. Additionally, removed
redundant triple backticks for code formatting since starting a line
with spaces automatically formats that line as a quote.

#### Problem
Malformed markdown causing incorrect HTML rendering.

#### Change overview
Minor corrections to markdown and other spacing issues.

#### Testing
Tested by pushing to a fork and visually verifying rendered text on github.