### PR TITLE
iOS TvCasting app: Displaying onboarding payload and aesthetic improvements

### DIFF
--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/CastingServerBridge.h
@@ -16,6 +16,7 @@
  */
 
 #import "DiscoveredNodeData.h"
+#import "OnboardingPayload.h"
 #import <Foundation/Foundation.h>
 
 #ifndef CastingServerBridge_h
@@ -26,6 +27,8 @@
 @property void (^_Nullable commissioningCompleteCallback)(bool);
 
 @property void (^_Nullable launchUrlResponseCallback)(bool);
+
+@property OnboardingPayload * _Nonnull onboardingPayload;
 
 + (CastingServerBridge * _Nullable)getSharedInstance;
 
@@ -70,6 +73,13 @@
                            platformInterface:(unsigned int)platformInterface
                                  clientQueue:(dispatch_queue_t _Nonnull)clientQueue
                        udcRequestSentHandler:(nullable void (^)(bool))udcRequestSentHandler;
+
+/*!
+ @brief Return the onboarding payload for this app (setup passcode, discriminator)
+
+ @return Onboarding payload
+ */
+- (OnboardingPayload * _Nonnull)getOnboardingPaylod;
 
 /*!
  @brief Request opening of a basic commissioning window

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/OnboardingPayload.h
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/OnboardingPayload.h
@@ -1,0 +1,31 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef OnboardingPayload_h
+#define OnboardingPayload_h
+
+@interface OnboardingPayload : NSObject
+
+@property uint32_t setupPasscode;
+
+@property uint16_t setupDiscriminator;
+
+- (instancetype)initWithSetupPasscode:(uint32_t)setupPasscode setupDiscriminator:(uint16_t)setupDiscriminator;
+
+@end
+
+#endif /* OnboardingPayload_h */

--- a/examples/tv-casting-app/darwin/TvCasting/MatterBridge/OnboardingPayload.m
+++ b/examples/tv-casting-app/darwin/TvCasting/MatterBridge/OnboardingPayload.m
@@ -1,0 +1,33 @@
+/**
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import "OnboardingPayload.h"
+
+@implementation OnboardingPayload
+
+- (instancetype)initWithSetupPasscode:(uint32_t)setupPasscode setupDiscriminator:(uint16_t)setupDiscriminator
+{
+    if (self = [super init]) {
+        _setupPasscode = setupPasscode;
+        _setupDiscriminator = setupDiscriminator;
+    }
+    return self;
+}
+
+@end

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting.xcodeproj/project.pbxproj
@@ -15,6 +15,7 @@
 		3C7507B92853EFF000D7DB3A /* CommissioningViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507B82853EFF000D7DB3A /* CommissioningViewModel.swift */; };
 		3C7507BC2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm in Sources */ = {isa = PBXBuildFile; fileRef = 3C7507BB2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm */; };
 		3C9ACC05284ABF4000718B2D /* libTvCastingCommon.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */; };
+		3C9EE55E2864D88700BA9115 /* OnboardingPayload.m in Sources */ = {isa = PBXBuildFile; fileRef = 3C9EE55D2864D88700BA9115 /* OnboardingPayload.m */; };
 		3CA19435285BA780004768D5 /* ContentLauncherView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA19434285BA780004768D5 /* ContentLauncherView.swift */; };
 		3CA19437285BA877004768D5 /* ContentLauncherViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CA19436285BA877004768D5 /* ContentLauncherViewModel.swift */; };
 		3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CC0E8F92841DD3400EC6A18 /* TvCastingApp.swift */; };
@@ -36,6 +37,8 @@
 		3C7507BB2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = DiscoveredNodeDataConverter.mm; sourceTree = "<group>"; };
 		3C7507BD2857A72A00D7DB3A /* DiscoveredNodeDataConverter.hpp */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.h; path = DiscoveredNodeDataConverter.hpp; sourceTree = "<group>"; };
 		3C9ACC04284ABF2F00718B2D /* libTvCastingCommon.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libTvCastingCommon.a; path = lib/libTvCastingCommon.a; sourceTree = BUILT_PRODUCTS_DIR; };
+		3C9EE55C2864D7EB00BA9115 /* OnboardingPayload.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = OnboardingPayload.h; sourceTree = "<group>"; };
+		3C9EE55D2864D88700BA9115 /* OnboardingPayload.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = OnboardingPayload.m; sourceTree = "<group>"; };
 		3CA19434285BA780004768D5 /* ContentLauncherView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLauncherView.swift; sourceTree = "<group>"; };
 		3CA19436285BA877004768D5 /* ContentLauncherViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentLauncherViewModel.swift; sourceTree = "<group>"; };
 		3CC0E8F62841DD3400EC6A18 /* TvCasting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TvCasting.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -126,6 +129,8 @@
 				3C7507A62851188500D7DB3A /* DiscoveredNodeData.mm */,
 				3C7507BB2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm */,
 				3C7507BD2857A72A00D7DB3A /* DiscoveredNodeDataConverter.hpp */,
+				3C9EE55C2864D7EB00BA9115 /* OnboardingPayload.h */,
+				3C9EE55D2864D88700BA9115 /* OnboardingPayload.m */,
 			);
 			path = MatterBridge;
 			sourceTree = "<group>";
@@ -241,6 +246,7 @@
 				3C7507AD285299DF00D7DB3A /* CommissionerDiscoveryView.swift in Sources */,
 				3CC0E8FA2841DD3400EC6A18 /* TvCastingApp.swift in Sources */,
 				3C7507B92853EFF000D7DB3A /* CommissioningViewModel.swift in Sources */,
+				3C9EE55E2864D88700BA9115 /* OnboardingPayload.m in Sources */,
 				3C7507BC2857A6EE00D7DB3A /* DiscoveredNodeDataConverter.mm in Sources */,
 				3C7507A72851188500D7DB3A /* DiscoveredNodeData.mm in Sources */,
 				3CA19437285BA877004768D5 /* ContentLauncherViewModel.swift in Sources */,

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningView.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningView.swift
@@ -30,47 +30,57 @@ struct CommissioningView: View {
     var body: some View {
         VStack(alignment: .leading) {
             if(viewModel.commisisoningWindowOpened == true) {
-                Text("Commissioning window opened.")
+                Text("Commissioning window opened.").padding()
                 
+                Text("Onboarding PIN: " + String((CastingServerBridge.getSharedInstance()?.getOnboardingPaylod().setupPasscode)!))
+                    .border(Color.blue, width: 1)
+                    .padding()
+                Text("Discriminator: " + String((CastingServerBridge.getSharedInstance()?.getOnboardingPaylod().setupDiscriminator)!))
+                    .border(Color.blue, width: 1)
+                    .padding()
+
                 if(self.selectedCommissioner != nil)
                 {
                     if(viewModel.udcRequestSent == true)
                     {
                         Text("Complete commissioning on " + (selectedCommissioner?.deviceName)!)
+                            .padding()
                     }
                     else if(viewModel.udcRequestSent == false) {
                         Text("Could not send user directed commissioning request to " + (selectedCommissioner?.deviceName)! + "! Complete commissioning manually!")
                             .foregroundColor(Color.red)
+                            .padding()
                     }
                 }
                 else{
-                    Text("Complete commissioning with a commissioner manually!")
+                    Text("Complete commissioning with a commissioner manually!").padding()
                 }
-                
-                // TBD: actual values
-                Text("Onboarding PIN: ")
-                    .padding()
-                    .border(Color.black, width: 1)
-                Text("Discriminator: ")
-                    .padding()
-                    .border(Color.black, width: 1)
             }
             else if(viewModel.commisisoningWindowOpened == false) {
                 Text("Failed to open Commissioning window!")
                     .foregroundColor(Color.red)
+                    .padding()
             }
             
             if(viewModel.commisisoningComplete == true)
             {
+                Text("Commissioning finished!").padding()
                 NavigationLink(
                     destination: ContentLauncherView(),
                     label: {
                         Text("Next")
-                            .frame(width: 75, height: 30, alignment: .center)
+                            .frame(width: 100, height: 30, alignment: .center)
                             .border(Color.black, width: 1)
                     }
                 ).background(Color.blue)
                     .foregroundColor(Color.white)
+                    .frame(maxHeight: .infinity, alignment: .bottom)
+                    .padding()
+            }
+            else if(viewModel.commisisoningComplete == false)
+            {
+                Text("Commissioning failure!")
+                    .foregroundColor(Color.red)
                     .padding()
             }
         }

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/CommissioningViewModel.swift
@@ -36,7 +36,9 @@ class CommissioningViewModel: ObservableObject {
                 { (result: Bool) -> () in
                     // commissioning complete handler code
                     self.Log.info("Commissioning status: \(result)")
-                    self.commisisoningComplete = result
+                    DispatchQueue.main.async {
+                        self.commisisoningComplete = result
+                    }
                 },
                 clientQueue: DispatchQueue.main,
                 commissioningWindowRequestedHandler: { (result: Bool) -> () in

--- a/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentLauncherViewModel.swift
+++ b/examples/tv-casting-app/darwin/TvCasting/TvCasting/ContentLauncherViewModel.swift
@@ -37,7 +37,9 @@ class ContentLauncherViewModel: ObservableObject {
                                               launchUrlResponseCallback:
                                                 { (result: Bool) -> () in
                         self.Log.info("ContentLauncherViewModel.launchUrl.launchUrlResponseCallback result \(result)")
-                        self.status = result ? "Launched URL successfully" : "Launch URL failure!"
+                        DispatchQueue.main.async {
+                            self.status = result ? "Launched URL successfully" : "Launch URL failure!"
+                        }
                     },
                                               clientQueue: DispatchQueue.main,
                                               launchUrlRequestSentHandler:


### PR DESCRIPTION
#### Problem
TvCasting app was not displaying any setup passcode or discriminator on the CommissioningView.

#### Change overview
1. Implemented a way to display the test setup passcode and discriminator on the CommissioningView.
2. Fixed some alignment and color issues on the CommissioningView.

#### Testing
Tested on a real iPhone and verified that the onboarding payload is displayed correctly.