### PR TITLE
[nrfconnect] Added some code size optimization for all-clusters-app

### DIFF
--- a/examples/all-clusters-app/nrfconnect/prj_dfu.conf
+++ b/examples/all-clusters-app/nrfconnect/prj_dfu.conf
@@ -43,3 +43,9 @@ CONFIG_CHIP_PROJECT_CONFIG="main/include/CHIPProjectConfig.h"
 
 # CHIP PID: 32769 == 0x8001 (all-clusters-app)
 CONFIG_CHIP_DEVICE_PRODUCT_ID=32769
+
+# reduce application size by disabling including assertions in the output file.
+CONFIG_ASSERT_VERBOSE=n
+CONFIG_ASSERT_NO_FILE_INFO=y
+CONFIG_ASSERT_NO_COND_INFO=y
+CONFIG_ASSERT_NO_MSG_INFO=y


### PR DESCRIPTION
#### Problem
All-clusters-app's size became too big and started not to fit the size of the application partition. 

#### Change overview
We performed some optimization and disabled adding asserts to the output code.

#### Testing
Tested locally on nRF52 DK and nRF53 DK.
