### PR TITLE
Fix test memory leaks, lifetime assumptions in CASEServer

### DIFF
--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1769,9 +1769,9 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
     ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
     readPrepareParams.mEventPathParamsListSize = 0;
 
-    chip::app::AttributePathParams * attributePathParams = new chip::app::AttributePathParams[2];
+    std::unique_ptr<chip::app::AttributePathParams[]> attributePathParams(new chip::app::AttributePathParams[2]);
     // Subscribe to full wildcard paths, repeat twice to ensure chunking.
-    readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+    readPrepareParams.mpAttributePathParamsList    = attributePathParams.get();
     readPrepareParams.mAttributePathParamsListSize = 2;
 
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
@@ -1873,11 +1873,11 @@ void TestReadInteraction::TestSubscribePartialOverlap(nlTestSuite * apSuite, voi
     ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
     readPrepareParams.mEventPathParamsListSize = 0;
 
-    chip::app::AttributePathParams * attributePathParams = new chip::app::AttributePathParams[1];
-    attributePathParams[0].mClusterId                    = Test::MockClusterId(3);
-    attributePathParams[0].mAttributeId                  = Test::MockAttributeId(1);
-    readPrepareParams.mpAttributePathParamsList          = attributePathParams;
-    readPrepareParams.mAttributePathParamsListSize       = 1;
+    std::unique_ptr<chip::app::AttributePathParams[]> attributePathParams(new chip::app::AttributePathParams[2]);
+    attributePathParams[0].mClusterId              = Test::MockClusterId(3);
+    attributePathParams[0].mAttributeId            = Test::MockAttributeId(1);
+    readPrepareParams.mpAttributePathParamsList    = attributePathParams.get();
+    readPrepareParams.mAttributePathParamsListSize = 1;
 
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
     readPrepareParams.mMaxIntervalCeilingSeconds = 0;
@@ -1948,12 +1948,12 @@ void TestReadInteraction::TestSubscribeSetDirtyFullyOverlap(nlTestSuite * apSuit
     ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
     readPrepareParams.mEventPathParamsListSize = 0;
 
-    chip::app::AttributePathParams * attributePathParams = new chip::app::AttributePathParams[1];
-    attributePathParams[0].mClusterId                    = Test::kMockEndpoint2;
-    attributePathParams[0].mClusterId                    = Test::MockClusterId(3);
-    attributePathParams[0].mAttributeId                  = Test::MockAttributeId(1);
-    readPrepareParams.mpAttributePathParamsList          = attributePathParams;
-    readPrepareParams.mAttributePathParamsListSize       = 1;
+    std::unique_ptr<chip::app::AttributePathParams[]> attributePathParams(new chip::app::AttributePathParams[1]);
+    attributePathParams[0].mClusterId              = Test::kMockEndpoint2;
+    attributePathParams[0].mClusterId              = Test::MockClusterId(3);
+    attributePathParams[0].mAttributeId            = Test::MockAttributeId(1);
+    readPrepareParams.mpAttributePathParamsList    = attributePathParams.get();
+    readPrepareParams.mAttributePathParamsListSize = 1;
 
     readPrepareParams.mMinIntervalFloorSeconds   = 0;
     readPrepareParams.mMaxIntervalCeilingSeconds = 0;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1816,6 +1816,9 @@ CHIP_ERROR ExtractVIDPIDFromX509Cert(const ByteSpan & certificate, AttestationCe
     }
 
 exit:
+    ASN1_OBJECT_free(commonNameObj);
+    ASN1_OBJECT_free(matterVidObj);
+    ASN1_OBJECT_free(matterPidObj);
     X509_free(x509certificate);
 
     return err;

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -201,8 +201,10 @@ void ForEachElement(nlTestSuite * inSuite, TLVReader & reader, void * context,
 struct TestTLVContext
 {
     nlTestSuite * mSuite;
-    int mEvictionCount;
-    uint32_t mEvictedBytes;
+    int mEvictionCount     = 0;
+    uint32_t mEvictedBytes = 0;
+
+    TestTLVContext(nlTestSuite * suite) : mSuite(suite) {}
 };
 
 void TestNull(nlTestSuite * inSuite, TLVReader & reader, Tag tag)
@@ -237,13 +239,15 @@ void TestDupString(nlTestSuite * inSuite, TLVReader & reader, Tag tag, const cha
     size_t expectedLen = strlen(expectedVal);
     NL_TEST_ASSERT(inSuite, reader.GetLength() == expectedLen);
 
-    chip::Platform::ScopedMemoryBuffer<char> valBuffer;
-    char * val = valBuffer.Alloc(expectedLen + 1).Get();
-
+    char * val     = nullptr;
     CHIP_ERROR err = reader.DupString(val);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen + 1) == 0);
+    NL_TEST_ASSERT(inSuite, val != nullptr);
+    if (val != nullptr)
+    {
+        NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen + 1) == 0);
+    }
+    chip::Platform::MemoryFree(val);
 }
 
 void TestDupBytes(nlTestSuite * inSuite, TLVReader & reader, Tag tag, const uint8_t * expectedVal, uint32_t expectedLen)
@@ -253,12 +257,15 @@ void TestDupBytes(nlTestSuite * inSuite, TLVReader & reader, Tag tag, const uint
 
     NL_TEST_ASSERT(inSuite, reader.GetLength() == expectedLen);
 
-    chip::Platform::ScopedMemoryBuffer<uint8_t> valBuffer;
-    uint8_t * val  = valBuffer.Alloc(expectedLen).Get();
+    uint8_t * val  = nullptr;
     CHIP_ERROR err = reader.DupBytes(val, expectedLen);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
-
-    NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen) == 0);
+    NL_TEST_ASSERT(inSuite, val != nullptr);
+    if (val != nullptr)
+    {
+        NL_TEST_ASSERT(inSuite, memcmp(val, expectedVal, expectedLen) == 0);
+    }
+    chip::Platform::MemoryFree(val);
 }
 
 void TestBufferContents(nlTestSuite * inSuite, const System::PacketBufferHandle & buffer, const uint8_t * expectedVal,

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -200,7 +200,7 @@ void ForEachElement(nlTestSuite * inSuite, TLVReader & reader, void * context,
 
 struct TestTLVContext
 {
-    nlTestSuite * mSuite = nullptr;
+    nlTestSuite * mSuite   = nullptr;
     int mEvictionCount     = 0;
     uint32_t mEvictedBytes = 0;
 

--- a/src/lib/core/tests/TestCHIPTLV.cpp
+++ b/src/lib/core/tests/TestCHIPTLV.cpp
@@ -200,7 +200,7 @@ void ForEachElement(nlTestSuite * inSuite, TLVReader & reader, void * context,
 
 struct TestTLVContext
 {
-    nlTestSuite * mSuite;
+    nlTestSuite * mSuite = nullptr;
     int mEvictionCount     = 0;
     uint32_t mEvictedBytes = 0;
 
@@ -4455,9 +4455,7 @@ int TestCHIPTLV(void)
         TestCHIPTLV_Teardown
     };
     // clang-format on
-    TestTLVContext context;
-
-    context.mSuite = &theSuite;
+    TestTLVContext context(&theSuite);
 
     // Run test suit against one context
     nlTestRunner(&theSuite, &context);

--- a/src/protocols/secure_channel/CASEServer.h
+++ b/src/protocols/secure_channel/CASEServer.h
@@ -44,6 +44,7 @@ public:
         if (mExchangeManager != nullptr)
         {
             mExchangeManager->UnregisterUnsolicitedMessageHandlerForType(Protocols::SecureChannel::MsgType::CASE_Sigma1);
+            mExchangeManager = nullptr;
         }
 
         GetSession().Clear();

--- a/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
+++ b/src/protocols/user_directed_commissioning/tests/TestUdcMessages.cpp
@@ -142,7 +142,7 @@ void TestUDCServerInstanceNameResolver(nlTestSuite * inSuite, void * inContext)
     const char * instanceName1 = "servertest1";
 
     // setup for tests
-    DeviceTransportMgr * mUdcTransportMgr = chip::Platform::New<DeviceTransportMgr>();
+    auto mUdcTransportMgr = chip::Platform::MakeUnique<DeviceTransportMgr>();
     mUdcTransportMgr->SetSessionManager(&udcServer);
     udcServer.SetInstanceNameResolver(&testCallback);
 


### PR DESCRIPTION
#### Problem

While building  #19931, asan found memory leaks and race conditions.

- OpenSSL leaks memory on reading VID/PID from certificates
- TestReadInteraction was leaking arrays
- CASEServer Calls exchange manager unregister unsolicited message handler several times, even after shutdown was called, assumes exchange manager lifetime and destructor ordering.
- TestUdcMessages was leaking the DeviceTransportMgr

#### Change overview
Fixes the above:

#### Testing
CI Unit tests