### PR TITLE
[BL602] 1.Enable async log output, 2.Adjuct DeviceInfoProvider init b…

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
@@ -41,9 +41,9 @@
 #include <platform/bouffalolab/BL602/OTAImageProcessorImpl.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <async_log.h>
 #include <bl_sys_ota.h>
 #include <lib/support/ErrorStr.h>
-#include <async_log.h>
 
 #define FACTORY_RESET_TRIGGER_TIMEOUT 3000
 #define FACTORY_RESET_CANCEL_WINDOW_TIMEOUT 3000

--- a/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
@@ -21,7 +21,6 @@
 #include "CHIPDeviceManager.h"
 #include "DeviceCallbacks.h"
 #include "LEDWidget.h"
-#include <DeviceInfoProviderImpl.h>
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
@@ -44,6 +43,7 @@
 
 #include <bl_sys_ota.h>
 #include <lib/support/ErrorStr.h>
+#include <async_log.h>
 
 #define FACTORY_RESET_TRIGGER_TIMEOUT 3000
 #define FACTORY_RESET_CANCEL_WINDOW_TIMEOUT 3000
@@ -139,7 +139,6 @@ CHIP_ERROR AppTask::Init()
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
-    SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());
 
     ConfigurationMgr().LogDeviceConfig();
 
@@ -154,6 +153,7 @@ void AppTask::AppTaskMain(void * pvParameter)
     CHIP_ERROR err;
 
     log_info("App Task entered\r\n");
+    enable_async_log();
 
     err = sWiFiNetworkCommissioningInstance.Init();
     if (CHIP_NO_ERROR != err)

--- a/examples/lighting-app/bouffalolab/bl602/src/main.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/main.cpp
@@ -89,7 +89,7 @@ extern "C" int main()
 
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
     SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());
-    CHIP_ERROR error              = deviceMgr.Init(&EchoCallbacks);
+    CHIP_ERROR error = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {
         log_info("device init failed: %s", ErrorStr(error));

--- a/examples/lighting-app/bouffalolab/bl602/src/main.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/main.cpp
@@ -18,6 +18,7 @@
 #include "AppTask.h"
 #include "CHIPDeviceManager.h"
 #include "DeviceCallbacks.h"
+#include <DeviceInfoProviderImpl.h>
 #include <FreeRTOS.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <app/server/OnboardingCodesUtil.h>
@@ -87,6 +88,7 @@ extern "C" int main()
     log_info("------------------------Starting App Task---------------------------\r\n");
 
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
+    SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());
     CHIP_ERROR error              = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {

--- a/third_party/bouffalolab/bl602_sdk/bl602_sdk.gni
+++ b/third_party/bouffalolab/bl602_sdk/bl602_sdk.gni
@@ -133,6 +133,7 @@ template("bl602_sdk") {
       "${bl602_sdk_root}/components/utils/include/",
       "${bl602_sdk_root}/components/platform/soc/bl602/bl602_std/bl602_std/StdDriver/Inc/",
       "${bl602_sdk_root}/components/platform/hosal/bl602_hal/",
+      "${bl602_sdk_root}/components/utils/async_log/"
     ]
 
     #    if (bl602_board == "BL-HWC-G1") {
@@ -155,7 +156,6 @@ template("bl602_sdk") {
 
       "SYS_BLOG_ENABLE=1",
       "SYS_VFS_ENABLE=1",
-      "SYS_VFS_UART_ENABLE=1",
       "SYS_AOS_LOOP_ENABLE=1",
       "BL602=BL602",
       "SYS_LOOPRT_ENABLE=1",
@@ -549,6 +549,7 @@ template("bl602_sdk") {
       "${bl602_sdk_root}/components/utils/src/utils_psk_fast.c",
       "${bl602_sdk_root}/components/utils/src/utils_rbtree.c",
       "${bl602_sdk_root}/components/utils/src/utils_tlv_bl.c",
+      "${bl602_sdk_root}/components/utils/async_log/async_log.c",
     ]
 
     #    } else if (bl_family == "bl706") {

--- a/third_party/bouffalolab/bl602_sdk/bl602_sdk.gni
+++ b/third_party/bouffalolab/bl602_sdk/bl602_sdk.gni
@@ -133,7 +133,7 @@ template("bl602_sdk") {
       "${bl602_sdk_root}/components/utils/include/",
       "${bl602_sdk_root}/components/platform/soc/bl602/bl602_std/bl602_std/StdDriver/Inc/",
       "${bl602_sdk_root}/components/platform/hosal/bl602_hal/",
-      "${bl602_sdk_root}/components/utils/async_log/"
+      "${bl602_sdk_root}/components/utils/async_log/",
     ]
 
     #    if (bl602_board == "BL-HWC-G1") {
@@ -540,6 +540,7 @@ template("bl602_sdk") {
       "${bl602_sdk_root}/components/sys/bloop/looprt/src/looprt.c",
       "${bl602_sdk_root}/components/sys/bloop/loopset/src/loopset_led.c",
       "${bl602_sdk_root}/components/sys/bltime/bl_sys_time.c",
+      "${bl602_sdk_root}/components/utils/async_log/async_log.c",
       "${bl602_sdk_root}/components/utils/src/utils_crc.c",
       "${bl602_sdk_root}/components/utils/src/utils_dns.c",
       "${bl602_sdk_root}/components/utils/src/utils_hmac_sha1_fast.c",
@@ -549,7 +550,6 @@ template("bl602_sdk") {
       "${bl602_sdk_root}/components/utils/src/utils_psk_fast.c",
       "${bl602_sdk_root}/components/utils/src/utils_rbtree.c",
       "${bl602_sdk_root}/components/utils/src/utils_tlv_bl.c",
-      "${bl602_sdk_root}/components/utils/async_log/async_log.c",
     ]
 
     #    } else if (bl_family == "bl706") {


### PR DESCRIPTION
…efore device manager init

#### Problem
What is being fixed?  Examples:
* Enable async log output
* Adjuct DeviceInfoProvider init before device manager init.

#### Change overview
1.Enable async log output, 2.Adjuct DeviceInfoProvider init before device manager init.

#### Testing
How was this tested? (at least one bullet point required)
* Enable async log output.
use "picocom -b 115200 /dev/ttyACM0", and log can output normally.
* Adjuct DeviceInfoProvider init before device manager init.
You can successfully commission with chip-tool and bl602.
