### PR TITLE
Remove chip-test build from cloudbuild

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -18,7 +18,7 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob '*' --skip-target-glob '{tizen-*,*-tests}' build
+              --target-glob '*' --skip-target-glob '{tizen-*,*-tests,*-chip-test}' build
               --create-archives /workspace/artifacts/
       id: CompileAll
       waitFor:

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -18,8 +18,9 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob '*' --skip-target-glob '{tizen-*,*-tests,*-chip-test}' build
-              --create-archives /workspace/artifacts/
+              --target-glob '*' --skip-target-glob
+              '{tizen-*,*-tests,*-chip-test}' build --create-archives
+              /workspace/artifacts/
       id: CompileAll
       waitFor:
           - Bootstrap


### PR DESCRIPTION
#### Problem
Tests are generally not supposed to be built by cloudbuild. Arm chip-test does not build:

```
...
Step #1 - "CompileAll": 2022-06-24 02:53:32 WARNING   /workspace/out/android-arm64-chip-test/../../src/crypto/CHIPCryptoPAL.cpp:970: undefined reference to `chip::ASN1::ASN1Writer::GetLengthWritten() const'
...
```

#### Change overview
This also removes android test builds from cloudbuild. Other tests were already removed before.

#### Testing
N/A - third party integration change