### PR TITLE
RPC: Add lock while reading fabric info

### DIFF
--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -265,6 +265,7 @@ public:
         DeviceLayer::GetDiagnosticDataProvider().GetUpTime(time_since_boot_sec);
         response.time_since_boot_millis = time_since_boot_sec * 1000;
         size_t count                    = 0;
+        DeviceLayer::StackLock lock;
         for (const FabricInfo & fabricInfo : Server::GetInstance().GetFabricTable())
         {
             if (count < ArraySize(response.fabric_info))


### PR DESCRIPTION

#### Problem
RPC has flake when reading FabricInfo, especially reproducible while commissioning.

#### Change overview
Lock chip stack while reading the fabric info.

#### Testing
Ran a script which repeatedly gets the fabric info:
```
    for i in range(10000):
        s,r = device_service.GetDeviceState(pw_rpc_timeout_s=5)
```
Running this script while commissioning reproduces the flake consistently, adding this lock fixed the problem. 
