### PR TITLE
submodule: bump third_party/openthread/repo from `130afd9` to `f4c2233`

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1492,8 +1492,13 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
             otOperationalDataset activeDataset;
             otError otErr = otDatasetGetActive(mOTInst, &activeDataset);
             VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
-            uint64_t activeTimestamp = activeDataset.mPendingTimestamp;
-            err                      = encoder.Encode(activeTimestamp);
+#if OPENTHREAD_API_VERSION >= 219
+            uint64_t activeTimestamp = (activeDataset.mActiveTimestamp.mSeconds << 16) |
+                (activeDataset.mActiveTimestamp.mTicks << 1) | activeDataset.mActiveTimestamp.mAuthoritative;
+#else
+            uint64_t activeTimestamp  = activeDataset.mActiveTimestamp;
+#endif
+            err = encoder.Encode(activeTimestamp);
         }
     }
     break;
@@ -1505,8 +1510,13 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
             otOperationalDataset activeDataset;
             otError otErr = otDatasetGetActive(mOTInst, &activeDataset);
             VerifyOrExit(otErr == OT_ERROR_NONE, err = MapOpenThreadError(otErr));
+#if OPENTHREAD_API_VERSION >= 219
+            uint64_t pendingTimestamp = (activeDataset.mPendingTimestamp.mSeconds << 16) |
+                (activeDataset.mPendingTimestamp.mTicks << 1) | activeDataset.mPendingTimestamp.mAuthoritative;
+#else
             uint64_t pendingTimestamp = activeDataset.mPendingTimestamp;
-            err                       = encoder.Encode(pendingTimestamp);
+#endif
+            err = encoder.Encode(pendingTimestamp);
         }
     }
     break;


### PR DESCRIPTION
#### Problem
* Fixes https://github.com/openthread/openthread/issues/7742

#### Change overview
* Update openthread hash to include recent fixes
* https://github.com/openthread/openthread/pull/7776
* Using `mPendingTimestamp` as the active timestamp is a bug that is also fixed by this PR.