### PR TITLE
Increase EFR32 timeout from 60 to 90 minutes

### DIFF
--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
   efr32:
     name: EFR32
-    timeout-minutes: 60
+    timeout-minutes: 90
 
     env:
       EFR32_BOARD: BRD4161A


### PR DESCRIPTION
#### Problem
EFR32 builds keep timing out

#### Change overview
Change timeout from 60 to 90 minutes

#### Testing
N/A