### PR TITLE
Fix failsafe error code in network commissioning cluster

### DIFF
--- a/src/app/clusters/network-commissioning/network-commissioning.cpp
+++ b/src/app/clusters/network-commissioning/network-commissioning.cpp
@@ -308,7 +308,7 @@ bool CheckFailSafeArmed(CommandHandlerInterface::HandlerContext & ctx)
         return true;
     }
 
-    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::UnsupportedAccess);
+    ctx.mCommandHandler.AddStatus(ctx.mRequestPath, Protocols::InteractionModel::Status::FailsafeRequired);
     return false;
 }
 


### PR DESCRIPTION
#### Problem
New error code was introduced in
https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/5328

#### Change overview
Changes UNSUPPORTED_ACCESS error to FAILSAFE_REQUIRED per the spec change

#### Testing
chip-tool - sent RemoveNetwork command with no failsafe and saw correct error.
