### PR TITLE
Fix stub _WriteThreadNetworkDiagnosticAttributeToTlv impls.

### DIFF
--- a/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
+++ b/src/include/platform/internal/GenericConnectivityManagerImpl_NoThread.h
@@ -149,16 +149,160 @@ inline CHIP_ERROR GenericConnectivityManagerImpl_NoThread<ImplClass>::_WriteThre
     {
     case app::Clusters::ThreadNetworkDiagnostics::Attributes::NeighborTableList::Id:
     case app::Clusters::ThreadNetworkDiagnostics::Attributes::RouteTableList::Id:
-    case app::Clusters::ThreadNetworkDiagnostics::Attributes::SecurityPolicy::Id:
-    case app::Clusters::ThreadNetworkDiagnostics::Attributes::OperationalDatasetComponents::Id:
-    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ActiveNetworkFaultsList::Id: {
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ActiveNetworkFaultsList::Id:
         err = encoder.EncodeEmptyList();
         break;
-    }
-    default: {
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::Channel::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RoutingRole::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::NetworkName::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::PanId::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ExtendedPanId::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::MeshLocalPrefix::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::PartitionId::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::Weighting::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::DataVersion::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::StableDataVersion::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::LeaderRouterId::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ActiveTimestamp::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::PendingTimestamp::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::Delay::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ChannelMask::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::SecurityPolicy::Id:
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::OperationalDatasetComponents::Id:
+        err = encoder.EncodeNull();
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::OverrunCount::Id:
+        err = encoder.Encode(static_cast<uint64_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::DetachedRoleCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ChildRoleCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RouterRoleCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::LeaderRoleCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::AttachAttemptCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::PartitionIdChangeCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::BetterPartitionAttachAttemptCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::ParentChangeCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxTotalCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxUnicastCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBroadcastCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxAckRequestedCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxAckedCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxNoAckRequestedCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDataCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDataPollCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBeaconCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxBeaconRequestCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxOtherCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxRetryCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxDirectMaxRetryExpiryCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxIndirectMaxRetryExpiryCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrCcaCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrAbortCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::TxErrBusyChannelCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxTotalCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxUnicastCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBroadcastCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDataCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDataPollCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBeaconCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxBeaconRequestCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxOtherCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxAddressFilteredCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDestAddrFilteredCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxDuplicatedCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrNoFrameCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrUnknownNeighborCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrInvalidSrcAddrCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrSecCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrFcsCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case app::Clusters::ThreadNetworkDiagnostics::Attributes::RxErrOtherCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    default:
         err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
         break;
-    }
     }
 
     return err;

--- a/src/platform/Linux/ThreadStackManagerImpl.cpp
+++ b/src/platform/Linux/ThreadStackManagerImpl.cpp
@@ -840,7 +840,7 @@ CHIP_ERROR ThreadStackManagerImpl::_WriteThreadNetworkDiagnosticAttributeToTlv(A
     }
 
     return err;
-} // namespace DeviceLayer
+}
 
 CHIP_ERROR
 ThreadStackManagerImpl::_AttachToThreadNetwork(const Thread::OperationalDataset & dataset,

--- a/src/platform/webos/ThreadStackManagerImpl.cpp
+++ b/src/platform/webos/ThreadStackManagerImpl.cpp
@@ -683,9 +683,153 @@ CHIP_ERROR ThreadStackManagerImpl::_WriteThreadNetworkDiagnosticAttributeToTlv(A
     case ThreadNetworkDiagnostics::Attributes::ActiveNetworkFaultsList::Id:
         err = encoder.EncodeEmptyList();
         break;
+    case ThreadNetworkDiagnostics::Attributes::Channel::Id:
+    case ThreadNetworkDiagnostics::Attributes::RoutingRole::Id:
+    case ThreadNetworkDiagnostics::Attributes::NetworkName::Id:
+    case ThreadNetworkDiagnostics::Attributes::PanId::Id:
+    case ThreadNetworkDiagnostics::Attributes::ExtendedPanId::Id:
+    case ThreadNetworkDiagnostics::Attributes::MeshLocalPrefix::Id:
+    case ThreadNetworkDiagnostics::Attributes::PartitionId::Id:
+    case ThreadNetworkDiagnostics::Attributes::Weighting::Id:
+    case ThreadNetworkDiagnostics::Attributes::DataVersion::Id:
+    case ThreadNetworkDiagnostics::Attributes::StableDataVersion::Id:
+    case ThreadNetworkDiagnostics::Attributes::LeaderRouterId::Id:
+    case ThreadNetworkDiagnostics::Attributes::ActiveTimestamp::Id:
+    case ThreadNetworkDiagnostics::Attributes::PendingTimestamp::Id:
+    case ThreadNetworkDiagnostics::Attributes::Delay::Id:
+    case ThreadNetworkDiagnostics::Attributes::ChannelMask::Id:
     case ThreadNetworkDiagnostics::Attributes::SecurityPolicy::Id:
     case ThreadNetworkDiagnostics::Attributes::OperationalDatasetComponents::Id:
         err = encoder.EncodeNull();
+        break;
+    case ThreadNetworkDiagnostics::Attributes::OverrunCount::Id:
+        err = encoder.Encode(static_cast<uint64_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::DetachedRoleCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::ChildRoleCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RouterRoleCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::LeaderRoleCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::AttachAttemptCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::PartitionIdChangeCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::BetterPartitionAttachAttemptCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::ParentChangeCount::Id:
+        err = encoder.Encode(static_cast<uint16_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxTotalCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxUnicastCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxBroadcastCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxAckRequestedCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxAckedCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxNoAckRequestedCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxDataCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxDataPollCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxBeaconCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxBeaconRequestCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxOtherCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxRetryCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxDirectMaxRetryExpiryCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxIndirectMaxRetryExpiryCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxErrCcaCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxErrAbortCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::TxErrBusyChannelCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxTotalCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxUnicastCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxBroadcastCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxDataCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxDataPollCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxBeaconCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxBeaconRequestCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxOtherCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxAddressFilteredCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxDestAddrFilteredCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxDuplicatedCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxErrNoFrameCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxErrUnknownNeighborCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxErrInvalidSrcAddrCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxErrSecCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxErrFcsCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
+        break;
+    case ThreadNetworkDiagnostics::Attributes::RxErrOtherCount::Id:
+        err = encoder.Encode(static_cast<uint32_t>(0));
         break;
     default:
         err = CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;


### PR DESCRIPTION
When the contract for this function was changed, the non-Linux
implementations were not updated.

#### Problem
See above.

#### Change overview
Copy/paste the Linux code into the other stubs.

#### Testing
Should compile.