### PR TITLE
[nrfconnect] Clear OTA image download offset

### DIFF
--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -46,6 +46,7 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
 CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
 {
     mHeaderParser.Init();
+    mParams = {};
     ReturnErrorOnFailure(System::MapErrorZephyr(dfu_target_mcuboot_set_buf(mBuffer, sizeof(mBuffer))));
     ReturnErrorOnFailure(System::MapErrorZephyr(dfu_multi_image_init(mBuffer, sizeof(mBuffer))));
 


### PR DESCRIPTION
#### Problem
The number of already downloaded bytes of an OTA image was not cleared at the beginning of the OTA update.
As a result, if an OTA image transfer was interrupted, the next attempt to download the image would fail.

#### Change overview
Clear `downloadedBytes` and `totalFileBytes` in `PrepareDownload()`.

#### Testing
Tested using nRF Connect samples:
1. Triggered OTA download
2. Killed OTA provider
3. Waited for BDX transfer timeout
4. Started OTA provider
5. Triggered OTA download again.
