### PR TITLE
[BL602] Enable async log output

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
@@ -41,6 +41,7 @@
 #include <platform/bouffalolab/BL602/OTAImageProcessorImpl.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <async_log.h>
 #include <bl_sys_ota.h>
 #include <lib/support/ErrorStr.h>
 
@@ -152,6 +153,7 @@ void AppTask::AppTaskMain(void * pvParameter)
     CHIP_ERROR err;
 
     log_info("App Task entered\r\n");
+    enable_async_log();
 
     err = sWiFiNetworkCommissioningInstance.Init();
     if (CHIP_NO_ERROR != err)

--- a/src/platform/bouffalolab/BL602/DnssdImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DnssdImpl.cpp
@@ -256,8 +256,6 @@ CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCal
     int slot;
     bool mdns_flag;
 
-    log_info("============================== ChipDnssdPublishService.\r\n");
-
     if (!(chip::DeviceLayer::ConnectivityMgrImpl()._IsWiFiStationConnected()))
     {
         return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/third_party/bouffalolab/bl602_sdk/bl602_sdk.gni
+++ b/third_party/bouffalolab/bl602_sdk/bl602_sdk.gni
@@ -133,6 +133,7 @@ template("bl602_sdk") {
       "${bl602_sdk_root}/components/utils/include/",
       "${bl602_sdk_root}/components/platform/soc/bl602/bl602_std/bl602_std/StdDriver/Inc/",
       "${bl602_sdk_root}/components/platform/hosal/bl602_hal/",
+      "${bl602_sdk_root}/components/utils/async_log/",
     ]
 
     #    if (bl602_board == "BL-HWC-G1") {
@@ -155,7 +156,6 @@ template("bl602_sdk") {
 
       "SYS_BLOG_ENABLE=1",
       "SYS_VFS_ENABLE=1",
-      "SYS_VFS_UART_ENABLE=1",
       "SYS_AOS_LOOP_ENABLE=1",
       "BL602=BL602",
       "SYS_LOOPRT_ENABLE=1",
@@ -539,6 +539,7 @@ template("bl602_sdk") {
       "${bl602_sdk_root}/components/sys/bloop/looprt/src/looprt.c",
       "${bl602_sdk_root}/components/sys/bloop/loopset/src/loopset_led.c",
       "${bl602_sdk_root}/components/sys/bltime/bl_sys_time.c",
+      "${bl602_sdk_root}/components/utils/async_log/async_log.c",
       "${bl602_sdk_root}/components/utils/src/utils_crc.c",
       "${bl602_sdk_root}/components/utils/src/utils_dns.c",
       "${bl602_sdk_root}/components/utils/src/utils_hmac_sha1_fast.c",


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Enable async log output

#### Change overview
cherry-pick from master:b886c2c2b72e23c55d67f454839f9c60b9e98eb5
#### Testing
How was this tested? (at least one bullet point required)
* use "picocom -b 115200 /dev/ttyACM0", and log can output normally.
