### PR TITLE
[logging] Use CHIP_ERROR_FORMAT in more places

### DIFF
--- a/src/app/DeviceProxy.cpp
+++ b/src/app/DeviceProxy.cpp
@@ -32,7 +32,6 @@
 #include <lib/core/CHIPEncoding.h>
 #include <lib/dnssd/Resolver.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/ErrorStr.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip::Callback;

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -27,7 +27,6 @@
 #include <lib/core/CHIPEventLoggingConfig.h>
 #include <lib/core/CHIPTLVUtilities.hpp>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/ErrorStr.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace chip::TLV;
@@ -468,7 +467,7 @@ CHIP_ERROR EventManagement::LogEventPrivate(EventLoggingDelegate * apDelegate, c
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(EventLogging, "Log event with error %s", ErrorStr(err));
+        ChipLogError(EventLogging, "Log event with error %" CHIP_ERROR_FORMAT, err.Format());
         writer = checkpoint;
     }
     else if (opts.mPriority >= CHIP_CONFIG_EVENT_GLOBAL_PRIORITY)

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -31,7 +31,6 @@
 
 #include <app/AppBuildConfig.h>
 #include <lib/core/CHIPCore.h>
-#include <lib/support/ErrorStr.h>
 
 using namespace chip;
 using namespace chip::TLV;

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -36,7 +36,6 @@
 #include <lib/core/CHIPEncoding.h>
 #include <lib/dnssd/Resolver.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/ErrorStr.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <system/SystemLayer.h>
 

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -394,7 +394,7 @@ CHIP_ERROR WriteClient::SendWriteRequest(const SessionHandle & session, System::
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DataManagement, "Write client failed to SendWriteRequest: %s", ErrorStr(err));
+        ChipLogError(DataManagement, "Write client failed to SendWriteRequest: %" CHIP_ERROR_FORMAT, err.Format());
     }
     else
     {

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -115,7 +115,7 @@ void CommissioningWindowManager::OnSessionEstablishmentError(CHIP_ERROR err)
 void CommissioningWindowManager::HandleFailedAttempt(CHIP_ERROR err)
 {
     mFailedCommissioningAttempts++;
-    ChipLogError(AppServer, "Commissioning failed (attempt %d): %s", mFailedCommissioningAttempts, ErrorStr(err));
+    ChipLogError(AppServer, "Commissioning failed (attempt %d): %" CHIP_ERROR_FORMAT, mFailedCommissioningAttempts, err.Format());
 #if CONFIG_NETWORK_LAYER_BLE
     mServer->GetBleLayerObject()->CloseAllBleConnections();
 #endif

--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -132,35 +132,35 @@ bool DnssdServer::OnExpiration(System::Clock::Timestamp expirationMs)
     CHIP_ERROR err = Dnssd::ServiceAdvertiser::Instance().Init(chip::DeviceLayer::UDPEndPointManager());
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to initialize advertiser: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to initialize advertiser: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // reset advertising
     err = Dnssd::ServiceAdvertiser::Instance().RemoveServices();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to remove advertised services: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to remove advertised services: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // restart operational (if needed)
     err = AdvertiseOperational();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to advertise operational node: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to advertise operational node: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
     err = AdvertiseCommissioner();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to advertise commissioner: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to advertise commissioner: %" CHIP_ERROR_FORMAT, err.Format());
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     err = Dnssd::ServiceAdvertiser::Instance().FinalizeServiceUpdate();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to finalize service update: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to finalize service update: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return true;
@@ -183,7 +183,7 @@ void DnssdServer::OnDiscoveryExpiration(System::Layer * aSystemLayer, void * aAp
         CHIP_ERROR err = AdvertiseCommissionableNode(chip::Dnssd::CommissioningMode::kDisabled);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Discovery, "Failed to advertise extended commissionable node: %s", chip::ErrorStr(err));
+            ChipLogError(Discovery, "Failed to advertise extended commissionable node: %" CHIP_ERROR_FORMAT, err.Format());
         }
         // set timeout
         ScheduleExtendedDiscoveryExpiration();
@@ -433,19 +433,19 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
     CHIP_ERROR err = Dnssd::ServiceAdvertiser::Instance().Init(chip::DeviceLayer::UDPEndPointManager());
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to initialize advertiser: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to initialize advertiser: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     err = Dnssd::ServiceAdvertiser::Instance().RemoveServices();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to remove advertised services: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to remove advertised services: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     err = AdvertiseOperational();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to advertise operational node: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to advertise operational node: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     if (mode != chip::Dnssd::CommissioningMode::kDisabled)
@@ -453,7 +453,7 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
         err = AdvertiseCommissionableNode(mode);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Discovery, "Failed to advertise commissionable node: %s", chip::ErrorStr(err));
+            ChipLogError(Discovery, "Failed to advertise commissionable node: %" CHIP_ERROR_FORMAT, err.Format());
         }
 
         // If any fabrics exist, the commissioning window must have been opened by the administrator
@@ -469,7 +469,7 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
         err = AdvertiseCommissionableNode(mode);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Discovery, "Failed to advertise extended commissionable node: %s", chip::ErrorStr(err));
+            ChipLogError(Discovery, "Failed to advertise extended commissionable node: %" CHIP_ERROR_FORMAT, err.Format());
         }
         // set timeout
         ScheduleExtendedDiscoveryExpiration();
@@ -480,14 +480,14 @@ void DnssdServer::StartServer(Dnssd::CommissioningMode mode)
     err = AdvertiseCommissioner();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to advertise commissioner: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to advertise commissioner: %" CHIP_ERROR_FORMAT, err.Format());
     }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
 
     err = Dnssd::ServiceAdvertiser::Instance().FinalizeServiceUpdate();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to finalize service update: %s", chip::ErrorStr(err));
+        ChipLogError(Discovery, "Failed to finalize service update: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -43,7 +43,7 @@ void PrintOnboardingCodes(chip::RendezvousInformationFlags aRendezvousFlags)
     CHIP_ERROR err = GetPayloadContents(payload, aRendezvousFlags);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetPayloadContents() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetPayloadContents() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     PrintOnboardingCodes(payload);
@@ -105,7 +105,7 @@ CHIP_ERROR GetPayloadContents(chip::PayloadContents & aPayload, chip::Rendezvous
     err = GetCommissionableDataProvider()->GetSetupPasscode(aPayload.setUpPINCode);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetCommissionableDataProvider()->GetSetupPasscode() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetCommissionableDataProvider()->GetSetupPasscode() failed: %" CHIP_ERROR_FORMAT, err.Format());
 #if defined(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE) && CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE
         ChipLogProgress(AppServer, "*** Using default EXAMPLE passcode %u ***",
                         static_cast<unsigned>(CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE));
@@ -118,21 +118,22 @@ CHIP_ERROR GetPayloadContents(chip::PayloadContents & aPayload, chip::Rendezvous
     err = GetCommissionableDataProvider()->GetSetupDiscriminator(aPayload.discriminator);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetCommissionableDataProvider()->GetSetupDiscriminator() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetCommissionableDataProvider()->GetSetupDiscriminator() failed: %" CHIP_ERROR_FORMAT,
+                     err.Format());
         return err;
     }
 
     err = chip::DeviceLayer::GetDeviceInstanceInfoProvider()->GetVendorId(aPayload.vendorID);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetDeviceInstanceInfoProvider()->GetVendorId() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetDeviceInstanceInfoProvider()->GetVendorId() failed: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
 
     err = chip::DeviceLayer::GetDeviceInstanceInfoProvider()->GetProductId(aPayload.productID);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetDeviceInstanceInfoProvider()->GetProductId() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetDeviceInstanceInfoProvider()->GetProductId() failed: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
 
@@ -146,7 +147,7 @@ CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, chip::RendezvousInformatio
     CHIP_ERROR err = GetPayloadContents(payload, aRendezvousFlags);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetPayloadContents() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetPayloadContents() failed: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
 
@@ -158,7 +159,7 @@ CHIP_ERROR GetQRCode(chip::MutableCharSpan & aQRCode, const chip::PayloadContent
     CHIP_ERROR err = chip::QRCodeBasicSetupPayloadGenerator(payload).payloadBase38Representation(aQRCode);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "Generating QR Code failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "Generating QR Code failed: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
 
@@ -186,7 +187,7 @@ CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, chip
     CHIP_ERROR err = GetPayloadContents(payload, aRendezvousFlags);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "GetPayloadContents() failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "GetPayloadContents() failed: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
     return GetManualPairingCode(aManualPairingCode, payload);
@@ -197,7 +198,7 @@ CHIP_ERROR GetManualPairingCode(chip::MutableCharSpan & aManualPairingCode, cons
     CHIP_ERROR err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(aManualPairingCode);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "Generating Manual Pairing Code failed: %s", chip::ErrorStr(err));
+        ChipLogError(AppServer, "Generating Manual Pairing Code failed: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -35,7 +35,6 @@
 #include <lib/dnssd/ServiceNaming.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DefaultStorageKeyAllocator.h>
-#include <lib/support/ErrorStr.h>
 #include <lib/support/PersistedCounter.h>
 #include <lib/support/TestGroupData.h>
 #include <lib/support/logging/CHIPLogging.h>
@@ -306,7 +305,7 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "ERROR setting up transport: %s", ErrorStr(err));
+        ChipLogError(AppServer, "ERROR setting up transport: %" CHIP_ERROR_FORMAT, err.Format());
     }
     else
     {
@@ -436,7 +435,7 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
     err = app::DnssdServer::Instance().GetCommissionableInstanceName(nameBuffer, sizeof(nameBuffer));
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(AppServer, "Failed to get mdns instance name error: %s", ErrorStr(err));
+        ChipLogError(AppServer, "Failed to get mdns instance name error: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
     ChipLogDetail(AppServer, "instanceName=%s", nameBuffer);
@@ -455,7 +454,7 @@ CHIP_ERROR Server::SendUserDirectedCommissioningRequest(chip::Transport::PeerAdd
     }
     else
     {
-        ChipLogError(AppServer, "Send UDC request failed, err: %s\n", chip::ErrorStr(err));
+        ChipLogError(AppServer, "Send UDC request failed, err: %" CHIP_ERROR_FORMAT, err.Format());
     }
     return err;
 }

--- a/src/app/server/java/AndroidAppServerWrapper.cpp
+++ b/src/app/server/java/AndroidAppServerWrapper.cpp
@@ -64,7 +64,7 @@ CHIP_ERROR ChipAndroidAppInit(void)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogProgress(NotSpecified, "Failed to run ChipAndroidAppInit: %s ", ErrorStr(err));
+        ChipLogProgress(NotSpecified, "Failed to run ChipAndroidAppInit: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
     return err;

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -1026,7 +1026,7 @@ CHIP_ERROR WriteSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, 
     uint16_t dataLen            = 0;
     if ((preparationError = prepareWriteData(attributeMetadata, aReader, dataLen)) != CHIP_NO_ERROR)
     {
-        ChipLogDetail(Zcl, "Failed to prepare data to write: %s", ErrorStr(preparationError));
+        ChipLogDetail(Zcl, "Failed to prepare data to write: %" CHIP_ERROR_FORMAT, preparationError.Format());
         return apWriteHandler->AddStatus(aPath, Protocols::InteractionModel::Status::InvalidValue);
     }
 

--- a/src/ble/BleError.cpp
+++ b/src/ble/BleError.cpp
@@ -30,8 +30,6 @@
 #include <ble/BleError.h>
 #include <ble/BleLayer.h>
 
-#include <lib/support/ErrorStr.h>
-
 namespace chip {
 namespace Ble {
 

--- a/src/include/platform/internal/GenericPlatformManagerImpl.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl.ipp
@@ -61,7 +61,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     err = InitEntropy();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Entropy initialization failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Entropy initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
@@ -69,7 +69,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     err = SystemLayer().Init();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "SystemLayer initialization failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "SystemLayer initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
@@ -77,7 +77,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     err = ConfigurationMgr().Init();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Configuration Manager initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
@@ -85,7 +85,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     err = UDPEndPointManager()->Init(SystemLayer());
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "UDP initialization failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "UDP initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
@@ -96,7 +96,7 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     err = BLEMgr().Init();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "BLEManager initialization failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "BLEManager initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 #endif
@@ -105,14 +105,15 @@ CHIP_ERROR GenericPlatformManagerImpl<ImplClass>::_InitChipStack()
     err = ConnectivityMgr().Init();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Connectivity Manager initialization failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Connectivity Manager initialization failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
     SuccessOrExit(err);
 
     // Initialize the NFC Manager.
 #if CHIP_DEVICE_CONFIG_ENABLE_NFC
     err = NFCMgr().Init();
-    VerifyOrExit(err == CHIP_NO_ERROR, ChipLogError(DeviceLayer, "NFC Manager initialization failed: %s", ErrorStr(err)));
+    VerifyOrExit(err == CHIP_NO_ERROR,
+                 ChipLogError(DeviceLayer, "NFC Manager initialization failed: %" CHIP_ERROR_FORMAT, err.Format()));
 #endif
 
     // TODO Initialize CHIP Event Logging.

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -175,7 +175,7 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
                 err = static_cast<System::LayerImplFreeRTOS &>(DeviceLayer::SystemLayer()).HandlePlatformTimer();
                 if (err != CHIP_NO_ERROR)
                 {
-                    ChipLogError(DeviceLayer, "Error handling CHIP timers: %s", ErrorStr(err));
+                    ChipLogError(DeviceLayer, "Error handling CHIP timers: %" CHIP_ERROR_FORMAT, err.Format());
                 }
 
                 // When processing the event queue below, do not wait if the queue is empty.  Instead

--- a/src/inet/InetError.cpp
+++ b/src/inet/InetError.cpp
@@ -26,8 +26,6 @@
 #include <inet/Inet.h>
 #include <inet/InetError.h>
 
-#include <lib/support/ErrorStr.h>
-
 extern void FormatError(char * buf, uint16_t bufSize, const char * subsys, int32_t err, const char * desc);
 
 namespace chip {

--- a/src/lib/asn1/ASN1Error.cpp
+++ b/src/lib/asn1/ASN1Error.cpp
@@ -25,7 +25,6 @@
 #include <stdlib.h>
 
 #include <lib/asn1/ASN1.h>
-#include <lib/support/ErrorStr.h>
 
 namespace chip {
 namespace ASN1 {

--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -323,7 +323,7 @@ void AdvertiserMinMdns::OnQuery(const QueryData & data)
     CHIP_ERROR err = mResponseSender.Respond(mMessageId, data, mCurrentSource, defaultResponseConfiguration);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Discovery, "Failed to reply to query: %s", ErrorStr(err));
+        ChipLogError(Discovery, "Failed to reply to query: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
@@ -936,7 +936,7 @@ void AdvertiserMinMdns::AdvertiseRecords(BroadcastAdvertiseType type)
         CHIP_ERROR err = mResponseSender.Respond(0, queryData, &packetInfo, responseConfiguration);
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(Discovery, "Failed to advertise records: %s", ErrorStr(err));
+            ChipLogError(Discovery, "Failed to advertise records: %" CHIP_ERROR_FORMAT, err.Format());
         }
     }
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -27,7 +27,6 @@
 #include <lib/dnssd/platform/Dnssd.h>
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/ErrorStr.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceConfig.h>
 #include <platform/CHIPDeviceLayer.h>
@@ -375,13 +374,13 @@ void DiscoveryImplPlatform::HandleDnssdInit(void * context, CHIP_ERROR initError
         CHIP_ERROR error = chip::DeviceLayer::PlatformMgr().PostEvent(&event);
         if (error != CHIP_NO_ERROR)
         {
-            ChipLogError(Discovery, "Posting DNS-SD platform initialized event failed with %s", chip::ErrorStr(error));
+            ChipLogError(Discovery, "Posting DNS-SD platform initialized event failed with %" CHIP_ERROR_FORMAT, error.Format());
         }
 #endif
     }
     else
     {
-        ChipLogError(Discovery, "DNS-SD initialization failed with %s", chip::ErrorStr(initError));
+        ChipLogError(Discovery, "DNS-SD initialization failed with %" CHIP_ERROR_FORMAT, initError.Format());
         publisher->mDnssdInitialized = false;
     }
 }
@@ -410,7 +409,7 @@ void DiscoveryImplPlatform::HandleDnssdError(void * context, CHIP_ERROR error)
     }
     else
     {
-        ChipLogError(Discovery, "DNS-SD error: %s", chip::ErrorStr(error));
+        ChipLogError(Discovery, "DNS-SD error: %" CHIP_ERROR_FORMAT, error.Format());
     }
 }
 
@@ -441,7 +440,7 @@ void DiscoveryImplPlatform::HandleDnssdPublish(void * context, const char * type
     }
     else
     {
-        ChipLogError(Discovery, "mDNS service published error: %s", chip::ErrorStr(error));
+        ChipLogError(Discovery, "mDNS service published error: %" CHIP_ERROR_FORMAT, error.Format());
     }
 }
 

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -240,8 +240,8 @@ CHIP_ERROR ServerBase::Listen(chip::Inet::EndPointManager<chip::Inet::UDPEndPoin
             interfaceId.GetInterfaceName(interfaceName, sizeof(interfaceName));
 
             // Log only as non-fatal error. Failure to join will mean we reply to unicast queries only.
-            ChipLogError(DeviceLayer, "MDNS failed to join multicast group on %s for address type %s: %s", interfaceName,
-                         AddressTypeStr(addressType), chip::ErrorStr(err));
+            ChipLogError(DeviceLayer, "MDNS failed to join multicast group on %s for address type %s: %" CHIP_ERROR_FORMAT,
+                         interfaceName, AddressTypeStr(addressType), err.Format());
 
             endPointHolder.reset();
         }

--- a/src/messaging/ExchangeMgr.cpp
+++ b/src/messaging/ExchangeMgr.cpp
@@ -273,7 +273,8 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
     else if (!payloadHeader.NeedsAck())
     {
         // Using same error message for all errors to reduce code size.
-        ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(CHIP_ERROR_UNSOLICITED_MSG_NO_ORIGINATOR));
+        ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %" CHIP_ERROR_FORMAT,
+                     CHIP_ERROR_UNSOLICITED_MSG_NO_ORIGINATOR.Format());
         return;
     }
 
@@ -287,7 +288,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         if (err != CHIP_NO_ERROR)
         {
             // Using same error message for all errors to reduce code size.
-            ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(err));
+            ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %" CHIP_ERROR_FORMAT, err.Format());
             SendStandaloneAckIfNeeded(packetHeader, payloadHeader, session, msgFlags, std::move(msgBuf));
             return;
         }
@@ -302,7 +303,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
             }
 
             // Using same error message for all errors to reduce code size.
-            ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(CHIP_ERROR_NO_MEMORY));
+            ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %" CHIP_ERROR_FORMAT, CHIP_ERROR_NO_MEMORY.Format());
             // No resource for creating new exchange, SendStandaloneAckIfNeeded probably also fails, so do not try it here
             return;
         }
@@ -312,7 +313,8 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
 
         if (ec->IsEncryptionRequired() != packetHeader.IsEncrypted())
         {
-            ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(CHIP_ERROR_INVALID_MESSAGE_TYPE));
+            ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %" CHIP_ERROR_FORMAT,
+                         CHIP_ERROR_INVALID_MESSAGE_TYPE.Format());
             ec->Close();
             SendStandaloneAckIfNeeded(packetHeader, payloadHeader, session, msgFlags, std::move(msgBuf));
             return;
@@ -322,7 +324,7 @@ void ExchangeManager::OnMessageReceived(const PacketHeader & packetHeader, const
         if (err != CHIP_NO_ERROR)
         {
             // Using same error message for all errors to reduce code size.
-            ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(err));
+            ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %" CHIP_ERROR_FORMAT, err.Format());
         }
         return;
     }
@@ -348,7 +350,7 @@ void ExchangeManager::SendStandaloneAckIfNeeded(const PacketHeader & packetHeade
     if (ec == nullptr)
     {
         // Using same error message for all errors to reduce code size.
-        ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(CHIP_ERROR_NO_MEMORY));
+        ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %" CHIP_ERROR_FORMAT, CHIP_ERROR_NO_MEMORY.Format());
         return;
     }
 
@@ -360,7 +362,7 @@ void ExchangeManager::SendStandaloneAckIfNeeded(const PacketHeader & packetHeade
     if (err != CHIP_NO_ERROR)
     {
         // Using same error message for all errors to reduce code size.
-        ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %s", ErrorStr(err));
+        ChipLogError(ExchangeManager, "OnMessageReceived failed, err = %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // The exchange should be closed inside HandleMessage function. So don't bother close it here.

--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -236,7 +236,7 @@ void BLEManagerImpl::DriveBLEState()
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
     }
 }
@@ -670,7 +670,7 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Disabling CHIPoBLE service due to error: %" CHIP_ERROR_FORMAT, err.Format());
         mServiceMode = ConnectivityManager::kCHIPoBLEServiceMode_Disabled;
         PlatformMgr().ScheduleWork(DriveBLEState, 0);
     }
@@ -729,7 +729,7 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(DeviceLayer, "BLEManagerImpl::SendIndication() failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "BLEManagerImpl::SendIndication() failed: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err == CHIP_NO_ERROR;

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -188,7 +188,7 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     const CHIP_ERROR err = PersistedStorage::KeyValueStoreMgrImpl().DoFactoryReset();
 
     if (err != CHIP_NO_ERROR)
-        ChipLogError(DeviceLayer, "Factory reset failed: %s", ErrorStr(err));
+        ChipLogError(DeviceLayer, "Factory reset failed: %" CHIP_ERROR_FORMAT, err.Format());
 
 #if CHIP_DEVICE_CONFIG_ENABLE_THREAD
     ThreadStackMgr().ErasePersistentInfo();

--- a/src/platform/Zephyr/NFCManagerImpl.cpp
+++ b/src/platform/Zephyr/NFCManagerImpl.cpp
@@ -81,7 +81,7 @@ CHIP_ERROR NFCManagerImpl::_StartTagEmulation(const char * payload, size_t paylo
 
 exit:
     if (error != CHIP_NO_ERROR)
-        ChipLogError(DeviceLayer, "Starting NFC Tag emulation failed: %s", chip::ErrorStr(error));
+        ChipLogError(DeviceLayer, "Starting NFC Tag emulation failed: %" CHIP_ERROR_FORMAT, error.Format());
     return error;
 }
 

--- a/src/protocols/bdx/BdxTransferSession.cpp
+++ b/src/protocols/bdx/BdxTransferSession.cpp
@@ -881,7 +881,7 @@ void TransferSession::PrepareStatusReport(StatusCode code)
     mPendingMsgHandle = bbuf.Finalize();
     if (mPendingMsgHandle.IsNull())
     {
-        ChipLogError(BDX, "%s: error preparing message: %s", __FUNCTION__, ErrorStr(CHIP_ERROR_NO_MEMORY));
+        ChipLogError(BDX, "%s: error preparing message: %" CHIP_ERROR_FORMAT, __FUNCTION__, CHIP_ERROR_NO_MEMORY.Format());
         mPendingOutput = OutputEventType::kInternalError;
     }
     else

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -46,7 +46,7 @@ CHIP_ERROR TransferFacilitator::OnMessageReceived(chip::Messaging::ExchangeConte
         mTransfer.HandleMessageReceived(payloadHeader, std::move(payload), System::SystemClock().GetMonotonicTimestamp());
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(BDX, "failed to handle message: %s", ErrorStr(err));
+        ChipLogError(BDX, "failed to handle message: %" CHIP_ERROR_FORMAT, err.Format());
     }
 
     // Almost every BDX message will follow up with a response on the exchange. Even messages that might signify the end of a

--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -155,7 +155,7 @@ void CASEServer::PrepareForSessionEstablishment(const ScopedNodeId & previouslyE
 
 void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
 {
-    ChipLogError(Inet, "CASE Session establishment failed: %s", ErrorStr(err));
+    ChipLogError(Inet, "CASE Session establishment failed: %" CHIP_ERROR_FORMAT, err.Format());
 
     //
     // We're not allowed to call methods that will eventually result in calling SessionManager::AllocateSecureSession

--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -1604,7 +1604,8 @@ CHIP_ERROR CASESession::OnFailureStatusReport(Protocols::SecureChannel::GeneralS
         break;
     };
     mState = State::kInitialized;
-    ChipLogError(SecureChannel, "Received error (protocol code %d) during pairing process. %s", protocolCode, ErrorStr(err));
+    ChipLogError(SecureChannel, "Received error (protocol code %d) during pairing process: %" CHIP_ERROR_FORMAT, protocolCode,
+                 err.Format());
     return err;
 }
 

--- a/src/protocols/secure_channel/MessageCounterManager.cpp
+++ b/src/protocols/secure_channel/MessageCounterManager.cpp
@@ -219,7 +219,8 @@ exit:
             exchangeContext->Close();
         }
         state->GetSessionMessageCounter().GetPeerMessageCounter().SyncFailed();
-        ChipLogError(SecureChannel, "Failed to send message counter synchronization request with error:%s", ErrorStr(err));
+        ChipLogError(SecureChannel, "Failed to send message counter synchronization request with error:%" CHIP_ERROR_FORMAT,
+                     err.Format());
     }
 
     return err;
@@ -263,7 +264,7 @@ CHIP_ERROR MessageCounterManager::HandleMsgCounterSyncReq(Messaging::ExchangeCon
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(SecureChannel, "Failed to handle MsgCounterSyncReq message with error:%s", ErrorStr(err));
+        ChipLogError(SecureChannel, "Failed to handle MsgCounterSyncReq message with error:%" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;
@@ -303,7 +304,7 @@ CHIP_ERROR MessageCounterManager::HandleMsgCounterSyncResp(Messaging::ExchangeCo
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(SecureChannel, "Failed to handle MsgCounterSyncResp message with error:%s", ErrorStr(err));
+        ChipLogError(SecureChannel, "Failed to handle MsgCounterSyncResp message with error:%" CHIP_ERROR_FORMAT, err.Format());
     }
 
     return err;

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -37,7 +37,6 @@
 #include <lib/support/BufferWriter.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
-#include <lib/support/ErrorStr.h>
 #include <lib/support/SafeInt.h>
 #include <lib/support/TypeTraits.h>
 #include <protocols/Protocols.h>
@@ -758,7 +757,8 @@ CHIP_ERROR PASESession::OnFailureStatusReport(Protocols::SecureChannel::GeneralS
         err = CHIP_ERROR_INTERNAL;
         break;
     };
-    ChipLogError(SecureChannel, "Received error (protocol code %d) during PASE process. %s", protocolCode, ErrorStr(err));
+    ChipLogError(SecureChannel, "Received error (protocol code %d) during PASE process: %" CHIP_ERROR_FORMAT, protocolCode,
+                 err.Format());
     return err;
 }
 
@@ -852,7 +852,7 @@ exit:
         // exchange will handle that.
         DiscardExchange();
         Clear();
-        ChipLogError(SecureChannel, "Failed during PASE session setup. %s", ErrorStr(err));
+        ChipLogError(SecureChannel, "Failed during PASE session setup: %" CHIP_ERROR_FORMAT, err.Format());
         // Do this last in case the delegate frees us.
         mDelegate->OnSessionEstablishmentError(err);
     }

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -151,7 +151,7 @@ protected:
         CHIP_ERROR err = exchangeCtxt->SendMessage(Protocols::SecureChannel::MsgType::StatusReport, std::move(msg));
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(SecureChannel, "Failed to send status report message. %s", ErrorStr(err));
+            ChipLogError(SecureChannel, "Failed to send status report message: %" CHIP_ERROR_FORMAT, err.Format());
         }
     }
 

--- a/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
+++ b/src/protocols/user_directed_commissioning/UserDirectedCommissioningClient.cpp
@@ -47,12 +47,12 @@ CHIP_ERROR UserDirectedCommissioningClient::SendUDCMessage(TransportMgrBase * tr
         err = transportMgr->SendMessage(peerAddress, payload.CloneData());
         if (err != CHIP_NO_ERROR)
         {
-            ChipLogError(AppServer, "UDC SendMessage failed, err: %s\n", chip::ErrorStr(err));
+            ChipLogError(AppServer, "UDC SendMessage failed: %" CHIP_ERROR_FORMAT, err.Format());
             return err;
         }
         sleep(1);
     }
-    ChipLogProgress(Inet, "UDC msg send status %s", ErrorStr(err));
+    ChipLogProgress(Inet, "UDC msg send status %" CHIP_ERROR_FORMAT, err.Format());
     return err;
 }
 

--- a/src/system/SystemLayer.cpp
+++ b/src/system/SystemLayer.cpp
@@ -26,7 +26,7 @@ CHIP_ERROR Layer::ScheduleLambdaBridge(LambdaBridge && bridge)
     CHIP_ERROR lReturn = PlatformEventing::ScheduleLambdaBridge(*this, std::move(bridge));
     if (lReturn != CHIP_NO_ERROR)
     {
-        ChipLogError(chipSystemLayer, "Failed to queue CHIP System Layer lambda event: %s", ErrorStr(lReturn));
+        ChipLogError(chipSystemLayer, "Failed to queue CHIP System Layer lambda event: %" CHIP_ERROR_FORMAT, lReturn.Format());
     }
     return lReturn;
 }

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -380,7 +380,7 @@ void LayerImplSelect::HandleEvents()
 
     if (!IsSelectResultValid())
     {
-        ChipLogError(DeviceLayer, "select failed: %s\n", ErrorStr(CHIP_ERROR_POSIX(errno)));
+        ChipLogError(DeviceLayer, "Select failed: %" CHIP_ERROR_FORMAT, CHIP_ERROR_POSIX(errno).Format());
         return;
     }
 

--- a/src/system/WakeEvent.cpp
+++ b/src/system/WakeEvent.cpp
@@ -101,7 +101,8 @@ void WakeEvent::Confirm() const
         res = ::read(mReadFD, buffer, sizeof(buffer));
         if (res < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
         {
-            ChipLogError(chipSystemLayer, "System wake event confirm failed: %s", ErrorStr(CHIP_ERROR_POSIX(errno)));
+            ChipLogError(chipSystemLayer, "System wake event confirm failed: %" CHIP_ERROR_FORMAT,
+                         CHIP_ERROR_POSIX(errno).Format());
             return;
         }
     } while (res == sizeof(buffer));
@@ -149,7 +150,7 @@ void WakeEvent::Confirm() const
 
     if (::read(mReadFD, &value, sizeof(value)) < 0 && errno != EAGAIN && errno != EWOULDBLOCK)
     {
-        ChipLogError(chipSystemLayer, "System wake event confirm failed: %s", ErrorStr(CHIP_ERROR_POSIX(errno)));
+        ChipLogError(chipSystemLayer, "System wake event confirm failed: %" CHIP_ERROR_FORMAT, CHIP_ERROR_POSIX(errno).Format());
     }
 }
 

--- a/src/test_driver/nrfconnect/main/runner.cpp
+++ b/src/test_driver/nrfconnect/main/runner.cpp
@@ -16,7 +16,6 @@
  */
 
 #include <lib/support/CodeUtils.h>
-#include <lib/support/ErrorStr.h>
 #include <lib/support/UnitTestRegistration.h>
 #include <platform/CHIPDeviceLayer.h>
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -65,7 +65,7 @@ uint32_t EncryptedPacketBufferHandle::GetMessageCounter() const
         return header.GetMessageCounter();
     }
 
-    ChipLogError(Inet, "Failed to decode EncryptedPacketBufferHandle header with error: %s", ErrorStr(err));
+    ChipLogError(Inet, "Failed to decode EncryptedPacketBufferHandle header with error: %" CHIP_ERROR_FORMAT, err.Format());
 
     return 0;
 }

--- a/src/transport/raw/BLE.cpp
+++ b/src/transport/raw/BLE.cpp
@@ -150,14 +150,14 @@ exit:
             mBleEndPoint->Close();
             mBleEndPoint = nullptr;
         }
-        ChipLogError(Inet, "Failed to setup BLE endPoint: %s", ErrorStr(err));
+        ChipLogError(Inet, "Failed to setup BLE endPoint: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
 void BLEBase::OnBleConnectionError(CHIP_ERROR err)
 {
     ClearPendingPackets();
-    ChipLogDetail(Inet, "BleConnection Error: %s", ErrorStr(err));
+    ChipLogDetail(Inet, "BleConnection Error: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 void BLEBase::OnEndPointMessageReceived(BLEEndPoint * endPoint, PacketBufferHandle && buffer)
@@ -171,7 +171,7 @@ void BLEBase::OnEndPointConnectComplete(BLEEndPoint * endPoint, CHIP_ERROR err)
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Inet, "Failed to establish BLE connection: %s", ErrorStr(err));
+        ChipLogError(Inet, "Failed to establish BLE connection: %" CHIP_ERROR_FORMAT, err.Format());
         OnEndPointConnectionClosed(endPoint, err);
         return;
     }
@@ -183,7 +183,7 @@ void BLEBase::OnEndPointConnectComplete(BLEEndPoint * endPoint, CHIP_ERROR err)
             err = endPoint->Send(std::move(mPendingPackets[i]));
             if (err != CHIP_NO_ERROR)
             {
-                ChipLogError(Inet, "Deferred sending failed: %s", ErrorStr(err));
+                ChipLogError(Inet, "Deferred sending failed: %" CHIP_ERROR_FORMAT, err.Format());
             }
         }
     }

--- a/src/transport/raw/UDP.cpp
+++ b/src/transport/raw/UDP.cpp
@@ -68,7 +68,7 @@ CHIP_ERROR UDP::Init(UdpListenParameters & params)
 exit:
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogProgress(Inet, "Failed to initialize Udp transport: %s", ErrorStr(err));
+        ChipLogProgress(Inet, "Failed to initialize Udp transport: %" CHIP_ERROR_FORMAT, err.Format());
         if (mUDPEndPoint)
         {
             mUDPEndPoint->Free();
@@ -123,13 +123,13 @@ void UDP::OnUdpReceive(Inet::UDPEndPoint * endPoint, System::PacketBufferHandle 
 
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Inet, "Failed to receive UDP message: %s", ErrorStr(err));
+        ChipLogError(Inet, "Failed to receive UDP message: %" CHIP_ERROR_FORMAT, err.Format());
     }
 }
 
 void UDP::OnUdpError(Inet::UDPEndPoint * endPoint, CHIP_ERROR err, const Inet::IPPacketInfo * pktInfo)
 {
-    ChipLogError(Inet, "Failed to receive UDP message: %s", ErrorStr(err));
+    ChipLogError(Inet, "Failed to receive UDP message: %" CHIP_ERROR_FORMAT, err.Format());
 }
 
 CHIP_ERROR UDP::MulticastGroupJoinLeave(const Transport::PeerAddress & address, bool join)


### PR DESCRIPTION
#### Problem
We have two alternative ways of logging an error code:
- using CHIP_ERROR_FORMAT which resolves either to %s or %u
- using %s + ErrorStr()

Both methods are supposed to have the same effect, but the former generates slightly smaller code, so it's worth using it everywhere.

#### Change overview
Replace: `"%s", ErrorStr(err)` with `"%" CHIP_ERROR_FORMAT, err.Format()` in most places.
Do minor cleanup of logs. For example, remove unnecessary new line characters.

#### Testing
Did smoke tests on nRF52840
