### PR TITLE
linux:SystemTimeSupport: make compatible with time64 (64-bit time_t)

### DIFF
--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -92,7 +92,7 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
         const time_t timep = tv.tv_sec;
         struct tm calendar;
         localtime_r(&timep, &calendar);
-        ChipLogProgress(DeviceLayer, "Real time clock set to %ld (%04d/%02d/%02d %02d:%02d:%02d UTC)", tv.tv_sec, calendar.tm_year,
+        ChipLogProgress(DeviceLayer, "Real time clock set to %lld (%04d/%02d/%02d %02d:%02d:%02d UTC)", static_cast<long long>(tv.tv_sec), calendar.tm_year,
                         calendar.tm_mon, calendar.tm_mday, calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
     }
 #endif // CHIP_PROGRESS_LOGGING

--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -92,8 +92,9 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
         const time_t timep = tv.tv_sec;
         struct tm calendar;
         localtime_r(&timep, &calendar);
-        ChipLogProgress(DeviceLayer, "Real time clock set to %lld (%04d/%02d/%02d %02d:%02d:%02d UTC)", static_cast<long long>(tv.tv_sec), calendar.tm_year,
-                        calendar.tm_mon, calendar.tm_mday, calendar.tm_hour, calendar.tm_min, calendar.tm_sec);
+        ChipLogProgress(DeviceLayer, "Real time clock set to %lld (%04d/%02d/%02d %02d:%02d:%02d UTC)",
+                        static_cast<long long>(tv.tv_sec), calendar.tm_year, calendar.tm_mon, calendar.tm_mday, calendar.tm_hour,
+                        calendar.tm_min, calendar.tm_sec);
     }
 #endif // CHIP_PROGRESS_LOGGING
     return CHIP_NO_ERROR;


### PR DESCRIPTION
Some environments (e.g. musl >=1.2.0, as used in OpenWrt) have switched to time64 - using a 64bit type for time_t to prevent year 2037 problems due to 32bit epoch time overflow.

This PR fixes a formatstring error that appears when time_t is 64bit. It does so in a way that keeps compatibility with 32bit time_t while now also compiling and working correctly for 64bit.

Testing:
- verified correctly building and running in a musl 1.2 based experimental build of mine (time64)
- verified still correctly working in a standard Linux build (time32)