### PR TITLE
[OpenThread] Changed ErrorRates in NeighborTableList from value to percentage

### DIFF
--- a/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
+++ b/src/platform/OpenThread/GenericThreadStackManagerImpl_OpenThread.cpp
@@ -1112,6 +1112,9 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
 
     case ThreadNetworkDiagnostics::Attributes::NeighborTableList::Id: {
         err = encoder.EncodeList([this](const auto & aEncoder) -> CHIP_ERROR {
+            constexpr uint16_t kFrameErrorRate100Percent   = 0xffff;
+            constexpr uint16_t kMessageErrorRate100Percent = 0xffff;
+
             otNeighborInfo neighInfo;
             otNeighborInfoIterator iterator = OT_NEIGHBOR_INFO_ITERATOR_INIT;
 
@@ -1132,8 +1135,10 @@ CHIP_ERROR GenericThreadStackManagerImpl_OpenThread<ImplClass>::_WriteThreadNetw
                 neighborTable.linkFrameCounter = neighInfo.mLinkFrameCounter;
                 neighborTable.mleFrameCounter  = neighInfo.mMleFrameCounter;
                 neighborTable.lqi              = neighInfo.mLinkQualityIn;
-                neighborTable.frameErrorRate   = neighInfo.mFrameErrorRate;
-                neighborTable.messageErrorRate = neighInfo.mMessageErrorRate;
+                neighborTable.frameErrorRate =
+                    static_cast<uint8_t>((static_cast<uint32_t>(neighInfo.mFrameErrorRate) * 100) / kFrameErrorRate100Percent);
+                neighborTable.messageErrorRate =
+                    static_cast<uint8_t>((static_cast<uint32_t>(neighInfo.mMessageErrorRate) * 100) / kMessageErrorRate100Percent);
                 neighborTable.rxOnWhenIdle     = neighInfo.mRxOnWhenIdle;
                 neighborTable.fullThreadDevice = neighInfo.mFullThreadDevice;
                 neighborTable.fullNetworkData  = neighInfo.mFullNetworkData;


### PR DESCRIPTION
#### Problem
Currently the frameErrorRate(uint8) and the messageErrorRate(uint8) NeighborTable parameters were set as a direct value of otNeighbotInfo fields (uint16). 
That causes inconsistency of types because, in Matter, we expect frame/message Error Rate as a percentage of received frames from the neighbor that contained errors (value from 0 to 100) instead of raw uint16 value.

Fixes https://github.com/project-chip/connectedhomeip/issues/19844 
The second part of issue is a spec issue: https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/5415

#### Change overview
To fix it, I added a conversion from raw uint16 value to percentage, where 0xffff equals 100%.

#### Testing
Tested on nRF52DK
