### PR TITLE
Remove detail logging to make efr32 rpc builds link

### DIFF
--- a/examples/lock-app/efr32/with_pw_rpc.gni
+++ b/examples/lock-app/efr32/with_pw_rpc.gni
@@ -26,3 +26,6 @@ chip_enable_openthread = true
 chip_openthread_ftd = true
 
 cpp_standard = "gnu++17"
+
+# To fit in flash
+chip_detail_logging = false


### PR DESCRIPTION
#### Problem
```
Step #3 - "EFR32": 2022-06-24 21:56:42 INFO    FAILED: chip-efr32-lock-example.out chip-efr32-lock-example.out.map 
Step #3 - "EFR32": 2022-06-24 21:56:42 INFO    arm-none-eabi-g++ -T../../examples/lock-app/efr32/third_party/connectedhomeip/examples/platform/efr32/ldscripts/efr32mg12.ld -march=armv7e-m -mcpu=cortex-m4 -mabi=aapcs -mfpu=fpv4-sp-d16 -mfloat-abi=softfp -mthumb -Og --specs=nosys.specs --specs=nano.specs -Werror -Wl,--fatal-warnings -fdiagnostics-color -Wl,--gc-sections -Wl,--wrap=malloc -Wl,--wrap=free -Wl,--wrap=realloc -Wl,--wrap=calloc -Wl,--wrap=MemoryAlloc -Wl,--wrap=_malloc_r -Wl,--wrap=_realloc_r -Wl,--wrap=_free_r -Wl,--wrap=_calloc_r -Wl,-Map,./chip-efr32-lock-example.out.map @./chip-efr32-lock-example.out.rsp -o ./chip-efr32-lock-example.out
Step #3 - "EFR32": 2022-06-24 21:56:42 INFO    /pwenv/cipd/packages/arm/bin/../lib/gcc/arm-none-eabi/10.2.1/../../../../arm-none-eabi/bin/ld: FLASH memory overlapped with NVM section.
Step #3 - "EFR32": 2022-06-24 21:56:42 INFO    collect2: error: ld returned 1 exit status
```

#### Change overview
Disable detail-logging to free some flash for rpc efr32 builds (non-rpc are fine)

#### Testing
Locally compiled and it linked