### PR TITLE
Disable verbose mDNS logging by default

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -369,8 +369,10 @@ void Resolver::ReArmTimer()
 
     if (nextTimeout == kInvalidTimeout)
     {
+#if CHIP_MINMDNS_HIGH_VERBOSITY
         // Generally this is only expected when no active lookups exist
         ChipLogProgress(Discovery, "Discovery does not require any more timeouts");
+#endif
         return;
     }
 

--- a/src/lib/dnssd/ActiveResolveAttempts.cpp
+++ b/src/lib/dnssd/ActiveResolveAttempts.cpp
@@ -48,9 +48,11 @@ void ActiveResolveAttempts::Complete(const PeerId & peerId)
         }
     }
 
+#if CHIP_MINMDNS_HIGH_VERBOSITY
     // This may happen during boot time adverisements: nodes come online
     // and advertise their IP without any explicit queries for them
     ChipLogProgress(Discovery, "Discovered node without a pending query");
+#endif
 }
 
 void ActiveResolveAttempts::Complete(const chip::Dnssd::DiscoveredNodeData & data)

--- a/src/lib/dnssd/minimal_mdns/BUILD.gn
+++ b/src/lib/dnssd/minimal_mdns/BUILD.gn
@@ -29,10 +29,9 @@ declare_args() {
       current_os == "mac" || current_os == "linux" || current_os == "android" ||
       current_os == "webos"
 
-  # Be very verbose regarding packet communication. Will spend extra RAM and
-  # Time to report mdns traffic in terms of sent and seen data.
-  chip_minmdns_high_verbosity =
-      current_os == "mac" || current_os == "linux" || current_os == "android"
+  # This enables verbose logging of sent/received mDNS messages. However, will incur extra RAM and
+  # time.
+  chip_minmdns_high_verbosity = false
 }
 
 config("config") {


### PR DESCRIPTION
By default, mDNS logging is enabled on Linux/Darwin platforms. This creates a lot of logging noise to the point that it hinders debugging of other issues.

This disables that by default and can be enabled selectively in situations that need those logs.