### PR TITLE
Enabling group cluster for endpoint 0 (Lock App )

### DIFF
--- a/examples/lock-app/lock-common/lock-app.zap
+++ b/examples/lock-app/lock-common/lock-app.zap
@@ -353,7 +353,7 @@
           "mfgCode": null,
           "define": "GROUPS_CLUSTER",
           "side": "server",
-          "enabled": 0,
+          "enabled": 1,
           "commands": [
             {
               "name": "AddGroupResponse",


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We are enabling group clusters for Endpoint 0 it was disabled earlier.

#### Change overview
We are enabling group clusters for Endpoint 0

#### Testing
How was this tested? (at least one bullet point required)
* Checked by running group cluster commands with endpoint 0
