### PR TITLE
Use 5% tolerance when checking CurrentLevel attribute in TC-LVL-6.1

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_LVL_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_6_1.yaml
@@ -102,8 +102,9 @@ tests:
       command: "readAttribute"
       attribute: "current level"
       response:
-          value: 25
           constraints:
+              minValue: 23
+              maxValue: 27
               notValue: CurrentLevelValue
 
     - label: "Sends a move up command to DUT"
@@ -147,13 +148,12 @@ tests:
                     transitioning."
 
     - label: "Reads CurrentLevel attribute from DUT"
-      disabled: true # https://github.com/project-chip/connectedhomeip/issues/19869
-      PICS: PICS_SKIP_SAMPLE_APP
       command: "readAttribute"
       attribute: "current level"
       response:
-          value: 50
           constraints:
+              minValue: 48
+              maxValue: 52
               notValue: CurrentLevelValue
 
     - label: "Reset level to 254"

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -15232,7 +15232,7 @@ private:
 class Test_TC_LVL_6_1Suite : public TestCommand
 {
 public:
-    Test_TC_LVL_6_1Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_6_1", 15, credsIssuerConfig)
+    Test_TC_LVL_6_1Suite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("Test_TC_LVL_6_1", 16, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -15313,7 +15313,8 @@ private:
             {
                 uint8_t value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("currentLevel", value, 25U));
+                VerifyOrReturn(CheckConstraintMinValue("value", value, 23U));
+                VerifyOrReturn(CheckConstraintMaxValue("value", value, 27U));
                 VerifyOrReturn(CheckConstraintNotValue("value", value, CurrentLevelValue));
             }
             break;
@@ -15333,8 +15334,18 @@ private:
             break;
         case 13:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                uint8_t value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckConstraintMinValue("value", value, 48U));
+                VerifyOrReturn(CheckConstraintMaxValue("value", value, 52U));
+                VerifyOrReturn(CheckConstraintNotValue("value", value, CurrentLevelValue));
+            }
             break;
         case 14:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 15:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             shouldContinue = true;
             break;
@@ -15465,7 +15476,12 @@ private:
             return UserPrompt(kIdentityAlpha, value);
         }
         case 13: {
-            LogStep(13, "Reset level to 254");
+            LogStep(13, "Reads CurrentLevel attribute from DUT");
+            return ReadAttribute(kIdentityAlpha, GetEndpoint(1), LevelControl::Id, LevelControl::Attributes::CurrentLevel::Id, true,
+                                 chip::NullOptional);
+        }
+        case 14: {
+            LogStep(14, "Reset level to 254");
             ListFreer listFreer;
             chip::app::Clusters::LevelControl::Commands::MoveToLevel::Type value;
             value.level          = 254U;
@@ -15477,8 +15493,8 @@ private:
 
             );
         }
-        case 14: {
-            LogStep(14, "Wait 100ms");
+        case 15: {
+            LogStep(15, "Wait 100ms");
             ListFreer listFreer;
             chip::app::Clusters::DelayCommands::Commands::WaitForMs::Type value;
             value.ms = 100UL;


### PR DESCRIPTION
Modified script TC-LVl-6.1
We are observing inconsistent values for the CurrentLevel attribute after the wait time, instead of checking for specific value we have updated the script to check for a range with 5% tolerance
Added auto generated files

Attached execution logs for reference:
[Execution_log.txt](https://github.com/project-chip/connectedhomeip/files/9000870/Execution_log.txt)

Fixes #19869