### PR TITLE
Small refactor to TestCASESession bringing it inline with other unit tests

### DIFF
--- a/src/protocols/secure_channel/CASESession.h
+++ b/src/protocols/secure_channel/CASESession.h
@@ -188,7 +188,7 @@ public:
     void Clear();
 
 private:
-    friend class CASESessionForTest;
+    friend class TestCASESession;
     enum class State : uint8_t
     {
         kInitialized       = 0,

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -47,7 +47,6 @@ using namespace chip;
 using namespace Credentials;
 using namespace TestCerts;
 
-using namespace chip;
 using namespace chip::Inet;
 using namespace chip::Transport;
 using namespace chip::Messaging;
@@ -55,7 +54,9 @@ using namespace chip::Protocols;
 
 using TestContext = Test::LoopbackMessagingContext;
 
+namespace chip {
 namespace {
+
 CHIP_ERROR InitFabricTable(chip::FabricTable & fabricTable, chip::TestPersistentStorageDelegate * testStorage,
                            chip::Crypto::OperationalKeystore * opKeyStore,
                            chip::Credentials::PersistentStorageOpCertStore * opCertStore)
@@ -254,39 +255,56 @@ CHIP_ERROR InitCredentialSets()
     return CHIP_NO_ERROR;
 }
 
-} // namespace
+} // anonymous namespace
 
-void CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
+class TestCASESession
+{
+public:
+    static void CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext);
+    static void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext);
+    static void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext);
+    static void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext);
+    static void CASE_Sigma1ParsingTest(nlTestSuite * inSuite, void * inContext);
+    static void CASE_DestinationIdTest(nlTestSuite * inSuite, void * inContext);
+    static void CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContext);
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    static void CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuite * inSuite, void * inContext);
+#endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
+};
+
+
+void TestCASESession::CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
 {
     SessionManager sessionManager;
 
     // Test all combinations of invalid parameters
     TestCASESecurePairingDelegate delegate;
     FabricTable fabrics;
-    // In normal operation scope of FabricTable outlives CASESession. Without this scoping we hit
-    // ASAN test issue since FabricTable is not normally on the stack.
-    {
-        CASESession caseSession;
+    CASESession caseSession;
 
-        NL_TEST_ASSERT(inSuite, caseSession.GetSecureSessionType() == SecureSession::Type::kCASE);
+    NL_TEST_ASSERT(inSuite, caseSession.GetSecureSessionType() == SecureSession::Type::kCASE);
 
-        caseSession.SetGroupDataProvider(&gDeviceGroupDataProvider);
-        NL_TEST_ASSERT(inSuite,
-                       caseSession.PrepareForSessionEstablishment(
-                           sessionManager, nullptr, nullptr, nullptr, nullptr, ScopedNodeId(),
-                           Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_ERROR_INVALID_ARGUMENT);
-        NL_TEST_ASSERT(inSuite,
-                       caseSession.PrepareForSessionEstablishment(
-                           sessionManager, nullptr, nullptr, nullptr, &delegate, ScopedNodeId(),
-                           Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_ERROR_INVALID_ARGUMENT);
-        NL_TEST_ASSERT(
-            inSuite,
-            caseSession.PrepareForSessionEstablishment(sessionManager, &fabrics, nullptr, nullptr, &delegate, ScopedNodeId(),
-                                                       Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
-    }
+    caseSession.SetGroupDataProvider(&gDeviceGroupDataProvider);
+    NL_TEST_ASSERT(inSuite,
+                   caseSession.PrepareForSessionEstablishment(
+                       sessionManager, nullptr, nullptr, nullptr, nullptr, ScopedNodeId(),
+                       Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   caseSession.PrepareForSessionEstablishment(
+                       sessionManager, nullptr, nullptr, nullptr, &delegate, ScopedNodeId(),
+                       Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(
+        inSuite,
+        caseSession.PrepareForSessionEstablishment(sessionManager, &fabrics, nullptr, nullptr, &delegate, ScopedNodeId(),
+                                                   Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
+
+    // Calling Clear() here since ASAN will have an issue if FabricTable destructor is called before CASESession's
+    // destructor. We could reorder FabricTable and CaseSession, but this makes it a little more clear what we are
+    // doing here.
+    caseSession.Clear();
 }
 
-void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
     SessionManager sessionManager;
@@ -400,7 +418,7 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 }
 
-void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
 {
     SessionManager sessionManager;
     TestCASESecurePairingDelegate delegateCommissioner;
@@ -411,7 +429,7 @@ void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
 
 CASEServerForTest gPairingServer;
 
-void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext)
 {
     // TODO: Add cases for mismatching IPK config between initiator/responder
 
@@ -489,7 +507,7 @@ struct Sigma1Params
     static constexpr bool expectSuccess = true;
 };
 
-void CASE_DestinationIdTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::CASE_DestinationIdTest(nlTestSuite * inSuite, void * inContext)
 {
     // Validate example test vector from CASE section of spec
 
@@ -705,7 +723,7 @@ struct Sigma1SessionIdTooBig : public BadSigma1ParamsBase
     static constexpr uint32_t initiatorSessionId = UINT16_MAX + 1;
 };
 
-static void CASE_Sigma1ParsingTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::CASE_Sigma1ParsingTest(nlTestSuite * inSuite, void * inContext)
 {
     // 1280 bytes must be enough by definition.
     constexpr size_t bufferSize = 1280;
@@ -778,7 +796,7 @@ struct SessionResumptionTestStorage : SessionResumptionStorage
     Crypto::P256ECDHDerivedSecret * mSharedSecret = nullptr;
 };
 
-static void CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContext)
 {
     // Test the SessionResumptionStorage external interface.
     //
@@ -876,18 +894,8 @@ static void CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContex
     }
 }
 
-// TODO, move all tests above into this class
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-namespace chip {
-// TODO rename CASESessionForTest to TestCASESession. Not doing that immediately since that requires
-// removing a lot of the `using namesapce` above which is a larger cleanup.
-class CASESessionForTest
-{
-public:
-    static void CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuite * inSuite, void * inContext);
-};
-
-void CASESessionForTest::CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuite * inSuite, void * inContext)
 {
     SessionManager sessionManager;
     TestCASESecurePairingDelegate delegateCommissioner;
@@ -954,8 +962,9 @@ void CASESessionForTest::CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nl
     NL_TEST_ASSERT(inSuite, delegateAccessory.mNumPairingComplete == 0);
     NL_TEST_ASSERT(inSuite, delegateCommissioner.mNumPairingComplete == 0);
 }
-} // namespace chip
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
+
+} // namespace chip
 
 // Test Suite
 
@@ -965,17 +974,17 @@ void CASESessionForTest::CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nl
 // clang-format off
 static const nlTest sTests[] =
 {
-    NL_TEST_DEF("WaitInit",    CASE_SecurePairingWaitTest),
-    NL_TEST_DEF("Start",       CASE_SecurePairingStartTest),
-    NL_TEST_DEF("Handshake",   CASE_SecurePairingHandshakeTest),
-    NL_TEST_DEF("ServerHandshake", CASE_SecurePairingHandshakeServerTest),
-    NL_TEST_DEF("Sigma1Parsing", CASE_Sigma1ParsingTest),
-    NL_TEST_DEF("DestinationId", CASE_DestinationIdTest),
-    NL_TEST_DEF("SessionResumptionStorage", CASE_SessionResumptionStorage),
+    NL_TEST_DEF("WaitInit",    chip::TestCASESession::CASE_SecurePairingWaitTest),
+    NL_TEST_DEF("Start",       chip::TestCASESession::CASE_SecurePairingStartTest),
+    NL_TEST_DEF("Handshake",   chip::TestCASESession::CASE_SecurePairingHandshakeTest),
+    NL_TEST_DEF("ServerHandshake", chip::TestCASESession::CASE_SecurePairingHandshakeServerTest),
+    NL_TEST_DEF("Sigma1Parsing", chip::TestCASESession::CASE_Sigma1ParsingTest),
+    NL_TEST_DEF("DestinationId", chip::TestCASESession::CASE_DestinationIdTest),
+    NL_TEST_DEF("SessionResumptionStorage", chip::TestCASESession::CASE_SessionResumptionStorage),
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     // This is compiled for host tests which is enough test coverage to ensure updating NOC invalidates
     // CASESession that are in the process of establishing.
-    NL_TEST_DEF("InvalidatePendingSessionEstablishment", chip::CASESessionForTest::CASE_SimulateUpdateNOCInvalidatePendingEstablishment),
+    NL_TEST_DEF("InvalidatePendingSessionEstablishment", chip::TestCASESession::CASE_SimulateUpdateNOCInvalidatePendingEstablishment),
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
     NL_TEST_SENTINEL()
@@ -1046,9 +1055,9 @@ int CASE_TestSecurePairing_Teardown(void * inContext)
 /**
  *  Main
  */
-int TestCASESession()
+int TestCASESessionTest()
 {
     return chip::ExecuteTestsWithContext<TestContext>(&sSuite);
 }
 
-CHIP_REGISTER_TEST_SUITE(TestCASESession)
+CHIP_REGISTER_TEST_SUITE(TestCASESessionTest)

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -361,7 +361,7 @@ void TestCASESession::SecurePairingStartTest(nlTestSuite * inSuite, void * inCon
 }
 
 void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, SessionManager & sessionManager,
-                                           CASESession & pairingCommissioner, TestCASESecurePairingDelegate & delegateCommissioner)
+                                      CASESession & pairingCommissioner, TestCASESecurePairingDelegate & delegateCommissioner)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -257,22 +257,25 @@ CHIP_ERROR InitCredentialSets()
 
 } // anonymous namespace
 
+// Specifically for SimulateUpdateNOCInvalidatePendingEstablishment, we need it to be static so that the class below can
+// be a friend to CASESession so that test can get access to CASESession::State and test method that are not public. To
+// keep the rest of this file consistent we brought all other tests into this class.
 class TestCASESession
 {
 public:
-    static void CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext);
-    static void CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext);
-    static void CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext);
-    static void CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext);
-    static void CASE_Sigma1ParsingTest(nlTestSuite * inSuite, void * inContext);
-    static void CASE_DestinationIdTest(nlTestSuite * inSuite, void * inContext);
-    static void CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContext);
+    static void SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext);
+    static void SecurePairingStartTest(nlTestSuite * inSuite, void * inContext);
+    static void SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext);
+    static void SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext);
+    static void Sigma1ParsingTest(nlTestSuite * inSuite, void * inContext);
+    static void DestinationIdTest(nlTestSuite * inSuite, void * inContext);
+    static void SessionResumptionStorage(nlTestSuite * inSuite, void * inContext);
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    static void CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuite * inSuite, void * inContext);
+    static void SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuite * inSuite, void * inContext);
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 };
 
-void TestCASESession::CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
 {
     SessionManager sessionManager;
 
@@ -302,7 +305,7 @@ void TestCASESession::CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * i
     caseSession.Clear();
 }
 
-void TestCASESession::CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::SecurePairingStartTest(nlTestSuite * inSuite, void * inContext)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
     SessionManager sessionManager;
@@ -357,7 +360,7 @@ void TestCASESession::CASE_SecurePairingStartTest(nlTestSuite * inSuite, void * 
     loopback.mMessageSendError = CHIP_NO_ERROR;
 }
 
-void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, SessionManager & sessionManager,
+void SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inContext, SessionManager & sessionManager,
                                            CASESession & pairingCommissioner, TestCASESecurePairingDelegate & delegateCommissioner)
 {
     TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
@@ -416,18 +419,18 @@ void CASE_SecurePairingHandshakeTestCommon(nlTestSuite * inSuite, void * inConte
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 }
 
-void TestCASESession::CASE_SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::SecurePairingHandshakeTest(nlTestSuite * inSuite, void * inContext)
 {
     SessionManager sessionManager;
     TestCASESecurePairingDelegate delegateCommissioner;
     CASESession pairingCommissioner;
     pairingCommissioner.SetGroupDataProvider(&gCommissionerGroupDataProvider);
-    CASE_SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner, delegateCommissioner);
+    SecurePairingHandshakeTestCommon(inSuite, inContext, sessionManager, pairingCommissioner, delegateCommissioner);
 }
 
 CASEServerForTest gPairingServer;
 
-void TestCASESession::CASE_SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::SecurePairingHandshakeServerTest(nlTestSuite * inSuite, void * inContext)
 {
     // TODO: Add cases for mismatching IPK config between initiator/responder
 
@@ -505,7 +508,7 @@ struct Sigma1Params
     static constexpr bool expectSuccess = true;
 };
 
-void TestCASESession::CASE_DestinationIdTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::DestinationIdTest(nlTestSuite * inSuite, void * inContext)
 {
     // Validate example test vector from CASE section of spec
 
@@ -721,7 +724,7 @@ struct Sigma1SessionIdTooBig : public BadSigma1ParamsBase
     static constexpr uint32_t initiatorSessionId = UINT16_MAX + 1;
 };
 
-void TestCASESession::CASE_Sigma1ParsingTest(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::Sigma1ParsingTest(nlTestSuite * inSuite, void * inContext)
 {
     // 1280 bytes must be enough by definition.
     constexpr size_t bufferSize = 1280;
@@ -794,7 +797,7 @@ struct SessionResumptionTestStorage : SessionResumptionStorage
     Crypto::P256ECDHDerivedSecret * mSharedSecret = nullptr;
 };
 
-void TestCASESession::CASE_SessionResumptionStorage(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::SessionResumptionStorage(nlTestSuite * inSuite, void * inContext)
 {
     // Test the SessionResumptionStorage external interface.
     //
@@ -893,7 +896,7 @@ void TestCASESession::CASE_SessionResumptionStorage(nlTestSuite * inSuite, void 
 }
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-void TestCASESession::CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuite * inSuite, void * inContext)
+void TestCASESession::SimulateUpdateNOCInvalidatePendingEstablishment(nlTestSuite * inSuite, void * inContext)
 {
     SessionManager sessionManager;
     TestCASESecurePairingDelegate delegateCommissioner;
@@ -972,17 +975,17 @@ void TestCASESession::CASE_SimulateUpdateNOCInvalidatePendingEstablishment(nlTes
 // clang-format off
 static const nlTest sTests[] =
 {
-    NL_TEST_DEF("WaitInit",    chip::TestCASESession::CASE_SecurePairingWaitTest),
-    NL_TEST_DEF("Start",       chip::TestCASESession::CASE_SecurePairingStartTest),
-    NL_TEST_DEF("Handshake",   chip::TestCASESession::CASE_SecurePairingHandshakeTest),
-    NL_TEST_DEF("ServerHandshake", chip::TestCASESession::CASE_SecurePairingHandshakeServerTest),
-    NL_TEST_DEF("Sigma1Parsing", chip::TestCASESession::CASE_Sigma1ParsingTest),
-    NL_TEST_DEF("DestinationId", chip::TestCASESession::CASE_DestinationIdTest),
-    NL_TEST_DEF("SessionResumptionStorage", chip::TestCASESession::CASE_SessionResumptionStorage),
+    NL_TEST_DEF("WaitInit",    chip::TestCASESession::SecurePairingWaitTest),
+    NL_TEST_DEF("Start",       chip::TestCASESession::SecurePairingStartTest),
+    NL_TEST_DEF("Handshake",   chip::TestCASESession::SecurePairingHandshakeTest),
+    NL_TEST_DEF("ServerHandshake", chip::TestCASESession::SecurePairingHandshakeServerTest),
+    NL_TEST_DEF("Sigma1Parsing", chip::TestCASESession::Sigma1ParsingTest),
+    NL_TEST_DEF("DestinationId", chip::TestCASESession::DestinationIdTest),
+    NL_TEST_DEF("SessionResumptionStorage", chip::TestCASESession::SessionResumptionStorage),
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     // This is compiled for host tests which is enough test coverage to ensure updating NOC invalidates
     // CASESession that are in the process of establishing.
-    NL_TEST_DEF("InvalidatePendingSessionEstablishment", chip::TestCASESession::CASE_SimulateUpdateNOCInvalidatePendingEstablishment),
+    NL_TEST_DEF("InvalidatePendingSessionEstablishment", chip::TestCASESession::SimulateUpdateNOCInvalidatePendingEstablishment),
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
     NL_TEST_SENTINEL()

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -272,7 +272,6 @@ public:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 };
 
-
 void TestCASESession::CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * inContext)
 {
     SessionManager sessionManager;
@@ -286,17 +285,16 @@ void TestCASESession::CASE_SecurePairingWaitTest(nlTestSuite * inSuite, void * i
 
     caseSession.SetGroupDataProvider(&gDeviceGroupDataProvider);
     NL_TEST_ASSERT(inSuite,
-                   caseSession.PrepareForSessionEstablishment(
-                       sessionManager, nullptr, nullptr, nullptr, nullptr, ScopedNodeId(),
-                       Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_ERROR_INVALID_ARGUMENT);
+                   caseSession.PrepareForSessionEstablishment(sessionManager, nullptr, nullptr, nullptr, nullptr, ScopedNodeId(),
+                                                              Optional<ReliableMessageProtocolConfig>::Missing()) ==
+                       CHIP_ERROR_INVALID_ARGUMENT);
     NL_TEST_ASSERT(inSuite,
-                   caseSession.PrepareForSessionEstablishment(
-                       sessionManager, nullptr, nullptr, nullptr, &delegate, ScopedNodeId(),
-                       Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(
-        inSuite,
-        caseSession.PrepareForSessionEstablishment(sessionManager, &fabrics, nullptr, nullptr, &delegate, ScopedNodeId(),
-                                                   Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
+                   caseSession.PrepareForSessionEstablishment(sessionManager, nullptr, nullptr, nullptr, &delegate, ScopedNodeId(),
+                                                              Optional<ReliableMessageProtocolConfig>::Missing()) ==
+                       CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite,
+                   caseSession.PrepareForSessionEstablishment(sessionManager, &fabrics, nullptr, nullptr, &delegate, ScopedNodeId(),
+                                                              Optional<ReliableMessageProtocolConfig>::Missing()) == CHIP_NO_ERROR);
 
     // Calling Clear() here since ASAN will have an issue if FabricTable destructor is called before CASESession's
     // destructor. We could reorder FabricTable and CaseSession, but this makes it a little more clear what we are


### PR DESCRIPTION
#### Problem
* TestCASESession unit tests had a slightly different structure then other unit tests. This change brings consistency to all tests in this file and allows test to easily access non-public parts of `CASESession` going forward.

#### Change overview
* Small refactor to bring it inline with the other unit tests.
* Address comment given after another PR was merged

#### Testing
* Ran unit tests