### PR TITLE
[nrfconnect] Support USR & PIN features in lock-app

### DIFF
--- a/examples/lock-app/nrfconnect/Kconfig
+++ b/examples/lock-app/nrfconnect/Kconfig
@@ -15,6 +15,18 @@
 #
 mainmenu "Matter nRF Connect Lock Example Application"
 
+config LOCK_NUM_USERS
+	int "Maximum number of users supported by lock"
+	default 10
+
+config LOCK_NUM_CREDENTIALS
+	int "Maximum number of credentials supported by lock"
+	default 20
+
+config LOCK_NUM_CREDENTIALS_PER_USER
+	int "Maximum number of credentials per user supported by lock"
+	default 3
+
 config STATE_LEDS
 	bool "Use LEDs to indicate the device state"
 	default y

--- a/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
+++ b/examples/lock-app/nrfconnect/main/BoltLockManager.cpp
@@ -23,6 +23,8 @@
 #include "AppEvent.h"
 #include "AppTask.h"
 
+using namespace chip;
+
 BoltLockManager BoltLockManager::sLock;
 
 void BoltLockManager::Init(StateChangeCallback callback)
@@ -31,6 +33,118 @@ void BoltLockManager::Init(StateChangeCallback callback)
 
     k_timer_init(&mActuatorTimer, &BoltLockManager::ActuatorTimerEventHandler, nullptr);
     k_timer_user_data_set(&mActuatorTimer, this);
+}
+
+bool BoltLockManager::GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user) const
+{
+    // userIndex is guaranteed by the caller to be between 1 and CONFIG_LOCK_NUM_USERS
+    user = mUsers[userIndex - 1];
+
+    ChipLogProgress(Zcl, "Getting lock user %u: %s", static_cast<unsigned>(userIndex),
+                    user.userStatus == DlUserStatus::kAvailable ? "available" : "occupied");
+
+    return true;
+}
+
+bool BoltLockManager::SetUser(uint16_t userIndex, FabricIndex creator, FabricIndex modifier, const CharSpan & userName,
+                              uint32_t uniqueId, DlUserStatus userStatus, DlUserType userType, DlCredentialRule credentialRule,
+                              const DlCredential * credentials, size_t totalCredentials)
+{
+    // userIndex is guaranteed by the caller to be between 1 and CONFIG_LOCK_NUM_USERS
+    UserData & userData = mUserData[userIndex - 1];
+    auto & user         = mUsers[userIndex - 1];
+
+    VerifyOrReturnError(userName.size() <= DOOR_LOCK_MAX_USER_NAME_SIZE, false);
+    VerifyOrReturnError(totalCredentials <= CONFIG_LOCK_NUM_CREDENTIALS_PER_USER, false);
+
+    Platform::CopyString(userData.mName, userName);
+    memcpy(userData.mCredentials, credentials, totalCredentials * sizeof(DlCredential));
+
+    user.userName           = CharSpan(userData.mName, userName.size());
+    user.credentials        = Span<const DlCredential>(userData.mCredentials, totalCredentials);
+    user.userUniqueId       = uniqueId;
+    user.userStatus         = userStatus;
+    user.userType           = userType;
+    user.credentialRule     = credentialRule;
+    user.creationSource     = DlAssetSource::kMatterIM;
+    user.createdBy          = creator;
+    user.modificationSource = DlAssetSource::kMatterIM;
+    user.lastModifiedBy     = modifier;
+
+    ChipLogProgress(Zcl, "Setting lock user %u: %s", static_cast<unsigned>(userIndex),
+                    userStatus == DlUserStatus::kAvailable ? "available" : "occupied");
+
+    return true;
+}
+
+bool BoltLockManager::GetCredential(uint16_t credentialIndex, DlCredentialType credentialType,
+                                    EmberAfPluginDoorLockCredentialInfo & credential) const
+{
+    VerifyOrReturnError(credentialIndex > 0 && credentialIndex <= CONFIG_LOCK_NUM_CREDENTIALS, false);
+
+    credential = mCredentials[credentialIndex - 1];
+
+    ChipLogProgress(Zcl, "Getting lock credential %u: %s", static_cast<unsigned>(credentialIndex),
+                    credential.status == DlCredentialStatus::kAvailable ? "available" : "occupied");
+
+    return true;
+}
+
+bool BoltLockManager::SetCredential(uint16_t credentialIndex, FabricIndex creator, FabricIndex modifier,
+                                    DlCredentialStatus credentialStatus, DlCredentialType credentialType, const ByteSpan & secret)
+{
+    VerifyOrReturnError(credentialIndex > 0 && credentialIndex <= CONFIG_LOCK_NUM_CREDENTIALS, false);
+    VerifyOrReturnError(secret.size() <= kMaxCredentialLength, false);
+
+    CredentialData & credentialData = mCredentialData[credentialIndex - 1];
+    auto & credential               = mCredentials[credentialIndex - 1];
+
+    if (!secret.empty())
+    {
+        memcpy(credentialData.mSecret.Alloc(secret.size()).Get(), secret.data(), secret.size());
+    }
+
+    credential.status             = credentialStatus;
+    credential.credentialType     = credentialType;
+    credential.credentialData     = ByteSpan(credentialData.mSecret.Get(), secret.size());
+    credential.creationSource     = DlAssetSource::kMatterIM;
+    credential.createdBy          = creator;
+    credential.modificationSource = DlAssetSource::kMatterIM;
+    credential.lastModifiedBy     = modifier;
+
+    ChipLogProgress(Zcl, "Setting lock credential %u: %s", static_cast<unsigned>(credentialIndex),
+                    credential.status == DlCredentialStatus::kAvailable ? "available" : "occupied");
+
+    return true;
+}
+
+bool BoltLockManager::ValidatePIN(const Optional<ByteSpan> & pinCode, DlOperationError & err) const
+{
+    // Optionality of the PIN code is validated by the caller, so assume it is OK not to provide the PIN code.
+    if (!pinCode.HasValue())
+    {
+        return true;
+    }
+
+    // Check the PIN code
+    for (const auto & credential : mCredentials)
+    {
+        if (credential.status == DlCredentialStatus::kAvailable || credential.credentialType != DlCredentialType::kPin)
+        {
+            continue;
+        }
+
+        if (credential.credentialData.data_equal(pinCode.Value()))
+        {
+            ChipLogDetail(Zcl, "Valid lock PIN code provided");
+            return true;
+        }
+    }
+
+    ChipLogDetail(Zcl, "Invalid lock PIN code provided");
+    err = DlOperationError::kInvalidCredential;
+
+    return false;
 }
 
 void BoltLockManager::Lock(OperationSource source)

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -49,34 +49,63 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     }
 }
 
-bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
+bool emberAfPluginDoorLockGetUser(EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user)
 {
-    return true;
+    return BoltLockMgr().GetUser(userIndex, user);
 }
 
-bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode,
-                                              DlOperationError & err)
+bool emberAfPluginDoorLockSetUser(EndpointId endpointId, uint16_t userIndex, FabricIndex creator, FabricIndex modifier,
+                                  const CharSpan & userName, uint32_t uniqueId, DlUserStatus userStatus, DlUserType userType,
+                                  DlCredentialRule credentialRule, const DlCredential * credentials, size_t totalCredentials)
 {
-    return true;
+    return BoltLockMgr().SetUser(userIndex, creator, modifier, userName, uniqueId, userStatus, userType, credentialRule,
+                                 credentials, totalCredentials);
+}
+
+bool emberAfPluginDoorLockGetCredential(EndpointId endpointId, uint16_t credentialIndex, DlCredentialType credentialType,
+                                        EmberAfPluginDoorLockCredentialInfo & credential)
+{
+    return BoltLockMgr().GetCredential(credentialIndex, credentialType, credential);
+}
+
+bool emberAfPluginDoorLockSetCredential(EndpointId endpointId, uint16_t credentialIndex, FabricIndex creator, FabricIndex modifier,
+                                        DlCredentialStatus credentialStatus, DlCredentialType credentialType,
+                                        const ByteSpan & secret)
+{
+    return BoltLockMgr().SetCredential(credentialIndex, creator, modifier, credentialStatus, credentialType, secret);
+}
+
+bool emberAfPluginDoorLockOnDoorLockCommand(EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
+{
+    return BoltLockMgr().ValidatePIN(pinCode, err);
+}
+
+bool emberAfPluginDoorLockOnDoorUnlockCommand(EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
+{
+    return BoltLockMgr().ValidatePIN(pinCode, err);
 }
 
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 {
     DoorLockServer::Instance().InitServer(endpoint);
 
-    EmberAfStatus status = DoorLock::Attributes::LockType::Set(endpoint, DlLockType::kDeadBolt);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        LOG_ERR("Updating type %x", status);
-    }
+    const auto logOnFailure = [](EmberAfStatus status, const char * attributeName) {
+        if (status != EMBER_ZCL_STATUS_SUCCESS)
+        {
+            ChipLogError(Zcl, "Failed to set DoorLock %s: %x", attributeName, status);
+        }
+    };
 
-    // Set FeatureMap to 0, default is:
+    logOnFailure(DoorLock::Attributes::LockType::Set(endpoint, DlLockType::kDeadBolt), "type");
+    logOnFailure(DoorLock::Attributes::NumberOfTotalUsersSupported::Set(endpoint, CONFIG_LOCK_NUM_USERS), "number of users");
+    logOnFailure(DoorLock::Attributes::NumberOfPINUsersSupported::Set(endpoint, CONFIG_LOCK_NUM_USERS), "number of PIN users");
+    logOnFailure(DoorLock::Attributes::NumberOfRFIDUsersSupported::Set(endpoint, 0), "number of RFID users");
+    logOnFailure(DoorLock::Attributes::NumberOfCredentialsSupportedPerUser::Set(endpoint, CONFIG_LOCK_NUM_CREDENTIALS_PER_USER),
+                 "number of credentials per user");
+
+    // Set FeatureMap to (kUsersManagement|kPINCredentials), default is:
     // (kUsersManagement|kAccessSchedules|kRFIDCredentials|kPINCredentials) 0x113
-    status = DoorLock::Attributes::FeatureMap::Set(endpoint, 0);
-    if (status != EMBER_ZCL_STATUS_SUCCESS)
-    {
-        LOG_ERR("Updating feature map %x", status);
-    }
+    logOnFailure(DoorLock::Attributes::FeatureMap::Set(endpoint, 0x101), "feature map");
 
     GetAppTask().UpdateClusterState(BoltLockMgr().GetState(), BoltLockManager::OperationSource::kUnspecified);
 }

--- a/examples/lock-app/nrfconnect/main/include/BoltLockManager.h
+++ b/examples/lock-app/nrfconnect/main/include/BoltLockManager.h
@@ -19,7 +19,9 @@
 
 #pragma once
 
+#include <app/clusters/door-lock-server/door-lock-server.h>
 #include <lib/core/ClusterEnums.h>
+#include <lib/support/ScopedBuffer.h>
 
 #include <zephyr/zephyr.h>
 
@@ -30,12 +32,25 @@ class AppEvent;
 class BoltLockManager
 {
 public:
+    static constexpr size_t kMaxCredentialLength = 128;
+
     enum class State : uint8_t
     {
         kLockingInitiated = 0,
         kLockingCompleted,
         kUnlockingInitiated,
         kUnlockingCompleted,
+    };
+
+    struct UserData
+    {
+        char mName[DOOR_LOCK_USER_NAME_BUFFER_SIZE];
+        DlCredential mCredentials[CONFIG_LOCK_NUM_CREDENTIALS_PER_USER];
+    };
+
+    struct CredentialData
+    {
+        chip::Platform::ScopedMemoryBuffer<uint8_t> mSecret;
     };
 
     using OperationSource     = chip::app::Clusters::DoorLock::DlOperationSource;
@@ -47,6 +62,18 @@ public:
 
     State GetState() const { return mState; }
     bool IsLocked() const { return mState == State::kLockingCompleted; }
+
+    bool GetUser(uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user) const;
+    bool SetUser(uint16_t userIndex, chip::FabricIndex creator, chip::FabricIndex modifier, const chip::CharSpan & userName,
+                 uint32_t uniqueId, DlUserStatus userStatus, DlUserType userType, DlCredentialRule credentialRule,
+                 const DlCredential * credentials, size_t totalCredentials);
+
+    bool GetCredential(uint16_t credentialIndex, DlCredentialType credentialType,
+                       EmberAfPluginDoorLockCredentialInfo & credential) const;
+    bool SetCredential(uint16_t credentialIndex, chip::FabricIndex creator, chip::FabricIndex modifier,
+                       DlCredentialStatus credentialStatus, DlCredentialType credentialType, const chip::ByteSpan & secret);
+
+    bool ValidatePIN(const Optional<chip::ByteSpan> & pinCode, DlOperationError & err) const;
 
     void Lock(OperationSource source);
     void Unlock(OperationSource source);
@@ -62,6 +89,12 @@ private:
     StateChangeCallback mStateChangeCallback = nullptr;
     OperationSource mActuatorOperationSource = OperationSource::kButton;
     k_timer mActuatorTimer                   = {};
+
+    UserData mUserData[CONFIG_LOCK_NUM_USERS];
+    EmberAfPluginDoorLockUserInfo mUsers[CONFIG_LOCK_NUM_USERS] = {};
+
+    CredentialData mCredentialData[CONFIG_LOCK_NUM_CREDENTIALS];
+    EmberAfPluginDoorLockCredentialInfo mCredentials[CONFIG_LOCK_NUM_CREDENTIALS] = {};
 
     static BoltLockManager sLock;
 };

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -1654,7 +1654,7 @@ EmberAfStatus DoorLockServer::createUser(chip::EndpointId endpointId, chip::Fabr
         return EMBER_ZCL_STATUS_FAILURE;
     }
 
-    const auto & newUserName            = !userName.IsNull() ? userName.Value() : chip::CharSpan("");
+    const auto & newUserName            = !userName.IsNull() ? userName.Value() : chip::CharSpan::fromCharString("");
     auto newUserUniqueId                = userUniqueId.IsNull() ? 0xFFFFFFFF : userUniqueId.Value();
     auto newUserStatus                  = userStatus.IsNull() ? DlUserStatus::kOccupiedEnabled : userStatus.Value();
     auto newUserType                    = userType.IsNull() ? DlUserType::kUnrestrictedUser : userType.Value();

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -120,7 +120,7 @@ tests:
       response:
           value: 2
 
-    - label: "Try to unlock the door with valid PIN"
+    - label: "Try to lock the door with valid PIN"
       command: "LockDoor"
       timedInteractionTimeoutMs: 10000
       arguments:

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -57545,7 +57545,7 @@ private:
                                  chip::NullOptional);
         }
         case 12: {
-            LogStep(12, "Try to unlock the door with valid PIN");
+            LogStep(12, "Try to lock the door with valid PIN");
             ListFreer listFreer;
             chip::app::Clusters::DoorLock::Commands::LockDoor::Type value;
             value.pinCode.Emplace();


### PR DESCRIPTION
#### Problem
nRF Connect Lock example does not support USR & PIN features and does not allow to configure a user PIN.

#### Change overview
Add functionality to store and validate user PIN codes in the Lock example.
Configure DoorLock attributes accordingly.
Fix a bug in door-lock-server when a user name is not provided.

#### Testing
Ran DL_LockUnlock and DL_UsersAndCredentials tests (the latter failed on steps that assume the number of RFID users, but passed PIN-related steps).
