### PR TITLE
[python] Fix Python device library build

### DIFF
--- a/scripts/build_python_device.sh
+++ b/scripts/build_python_device.sh
@@ -41,7 +41,6 @@ ENVIRONMENT_ROOT="$CHIP_ROOT/out/python_env"
 declare chip_detail_logging=false
 declare enable_pybindings=false
 declare chip_mdns
-declare clusters=true
 
 help() {
 
@@ -54,8 +53,6 @@ Input Options:
                                                             By default it is false.
   -m, --chip_mdns           ChipMDNSValue                   Specify ChipMDNSValue as platform or minimal.
                                                             By default it is minimal.
-  -c, --clusters_for_ip_commissioning  true/false           Specify whether to use clusters for IP commissioning.
-                                                            By default it is true.
   -p, --enable_pybindings   EnableValue                     Specify whether to enable pybindings as python controller.
 "
 }
@@ -74,10 +71,6 @@ while (($#)); do
             ;;
         --chip_mdns | -m)
             chip_mdns=$2
-            shift
-            ;;
-        --clusters_for_ip_commissioning | -c)
-            clusters=$2
             shift
             ;;
         --enable_pybindings | -p)
@@ -104,7 +97,7 @@ source "$CHIP_ROOT/scripts/activate.sh"
 
 chip_data_model_arg="chip_data_model=\"///examples/lighting-app/lighting-common\""
 
-gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings chip_use_clusters_for_ip_commissioning=$clusters $chip_mdns_arg chip_controller=false $chip_data_model_arg"
+gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_detail_logging enable_pylib=$enable_pybindings enable_rtti=$enable_pybindings $chip_mdns_arg chip_controller=false $chip_data_model_arg"
 
 # Compiles python files
 # Check pybindings was requested

--- a/src/controller/python/chip/server/ServerInit.cpp
+++ b/src/controller/python/chip/server/ServerInit.cpp
@@ -168,9 +168,6 @@ void pychip_server_native_init()
 
     // parts from ChipLinuxAppMainLoop
 
-    uint16_t securePort   = CHIP_PORT;
-    uint16_t unsecurePort = CHIP_UDC_PORT;
-
     // Init ZCL Data Model and CHIP App Server
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();


### PR DESCRIPTION
#### Problem
Trying to compile Python device library fails with:

```
$ scripts/build_python_device.sh
...
../../src/controller/python/chip/server/ServerInit.cpp: In function ‘void pychip_server_native_init()’:
../../src/controller/python/chip/server/ServerInit.cpp:171:14: error: unused variable ‘securePort’ [-Werror=unused-variable]
  171 |     uint16_t securePort   = CHIP_PORT;                       
      |              ^~~~~~~~~~                                                                                                                                
../../src/controller/python/chip/server/ServerInit.cpp:172:14: error: unused variable ‘unsecurePort’ [-Werror=unused-variable]
  172 |     uint16_t unsecurePort = CHIP_UDC_PORT;                                                                                                             
      |
```

Also, there is a gn warning:

```
WARNING at the command-line "--args":1:103: Build argument has no effect.                                                                                                                                                                                                                                                     
chip_detail_logging=false enable_pylib=false enable_rtti=false chip_use_clusters_for_ip_commissioning=true  chip_controller=false chip_data_model="///examples/lighting-app/lighting-common"
```


#### Change overview
Remove unused variables and drop non-existing build argument `chip_use_clusters_for_ip_commissioning`.

#### Testing
Compiled locally.