### PR TITLE
[EFR32] Lock-app working schedules with nvm storage, nvm credentials fix, add comments

### DIFF
--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -50,11 +50,11 @@ namespace LockInitParams {
 struct LockParam
 {
     // Read from zap attributes
-    uint16_t numberOfUsers = 0;
-    uint8_t numberOfCredentialsPerUser = 0;
+    uint16_t numberOfUsers                  = 0;
+    uint8_t numberOfCredentialsPerUser      = 0;
     uint8_t numberOfWeekdaySchedulesPerUser = 0;
     uint8_t numberOfYeardaySchedulesPerUser = 0;
-    uint8_t numberOfHolidaySchedules = 0;
+    uint8_t numberOfHolidaySchedules        = 0;
 };
 
 class ParamBuilder

--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -29,28 +29,73 @@
 
 #include <lib/core/CHIPError.h>
 
+namespace EFR32DoorLock {
+namespace ResourceRanges {
+// Used to size arrays
+static constexpr uint16_t kMaxUsers                  = 10;
+static constexpr uint8_t kMaxCredentialsPerUser      = 10;
+static constexpr uint8_t kMaxWeekdaySchedulesPerUser = 10;
+static constexpr uint8_t kMaxYeardaySchedulesPerUser = 10;
+static constexpr uint8_t kMaxHolidaySchedules        = 10;
+static constexpr uint8_t kMaxCredentialSize          = 8;
+
+// Indices received for user/credential/schedules are 1-indexed
+static constexpr uint8_t kStartIndexValue = 1;
+
+static constexpr uint8_t kMaxCredentials = kMaxUsers * kMaxCredentialsPerUser;
+} // namespace ResourceRanges
+
+namespace LockInitParams {
+
+struct LockParam
+{
+    // Read from zap attributes
+    uint16_t numberOfUsers;
+    uint8_t numberOfCredentialsPerUser;
+    uint8_t numberOfWeekdaySchedulesPerUser;
+    uint8_t numberOfYeardaySchedulesPerUser;
+    uint8_t numberOfHolidaySchedules;
+};
+
+class ParamBuilder
+{
+public:
+    ParamBuilder & SetNumberOfUsers(uint16_t numberOfUsers)
+    {
+        lockParam_.numberOfUsers = numberOfUsers;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfCredentialsPerUser(uint8_t numberOfCredentialsPerUser)
+    {
+        lockParam_.numberOfCredentialsPerUser = numberOfCredentialsPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfWeekdaySchedulesPerUser(uint8_t numberOfWeekdaySchedulesPerUser)
+    {
+        lockParam_.numberOfWeekdaySchedulesPerUser = numberOfWeekdaySchedulesPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfYeardaySchedulesPerUser(uint8_t numberOfYeardaySchedulesPerUser)
+    {
+        lockParam_.numberOfYeardaySchedulesPerUser = numberOfYeardaySchedulesPerUser;
+        return *this;
+    }
+    ParamBuilder & SetNumberOfHolidaySchedules(uint8_t numberOfHolidaySchedules)
+    {
+        lockParam_.numberOfHolidaySchedules = numberOfHolidaySchedules;
+        return *this;
+    }
+    LockParam GetLockParam() { return lockParam_; }
+
+private:
+    LockParam lockParam_;
+};
+
+} // namespace LockInitParams
+} // namespace EFR32DoorLock
+
 using namespace ::chip;
-
-// up to 10 users are supported on the EFR32 platform
-#define DOOR_LOCK_MAX_USERS 10
-// max credential size supported is 8
-#define DOOR_LOCK_MAX_CREDENTIAL_SIZE 8
-// up to 10 schedules of each type supported
-#define DOOR_LOCK_MAX_SCHEDULES 10
-
-// up to 10 credentials are supported per user
-#define MAX_CREDENTIAL_PER_USER 10
-
-// up to 10 schedules are supported per user
-#define MAX_SCHEDULE_PER_USER 10
-
-// user, credential and schedule indices are 1-indexed
-#define MIN_USER_INDEX 1
-#define MIN_CREDENTIAL_INDEX 1
-#define MIN_SCHEDULE_INDEX 1
-
-// 10 users with 10 credentials each max
-#define MAX_CREDENTIALS 100
+using namespace EFR32DoorLock::ResourceRanges;
 
 class LockManager
 {
@@ -72,9 +117,7 @@ public:
     } State;
 
     CHIP_ERROR Init(chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state,
-                    uint8_t maxNumberOfCredentialsPerUser, uint16_t numberOfSupportedUsers,
-                    uint8_t numberOfWeekdaySchedulesPerUserSupported, uint8_t numberOfYeardaySchedulesPerUserSupported,
-                    uint8_t numberOfHolidaySchedulesPerUserSupported);
+                    EFR32DoorLock::LockInitParams::LockParam lockParam);
     bool NextState();
     bool IsActionInProgress();
     bool InitiateAction(int32_t aActor, Action_t aAction);
@@ -86,13 +129,13 @@ public:
     bool Lock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin, DlOperationError & err);
     bool Unlock(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pin, DlOperationError & err);
 
-    bool GetUser(chip::EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user) const;
+    bool GetUser(chip::EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user);
     bool SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip::FabricIndex creator, chip::FabricIndex modifier,
                  const chip::CharSpan & userName, uint32_t uniqueId, DlUserStatus userStatus, DlUserType usertype,
                  DlCredentialRule credentialRule, const DlCredential * credentials, size_t totalCredentials);
 
     bool GetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, DlCredentialType credentialType,
-                       EmberAfPluginDoorLockCredentialInfo & credential) const;
+                       EmberAfPluginDoorLockCredentialInfo & credential);
 
     bool SetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, chip::FabricIndex creator, chip::FabricIndex modifier,
                        DlCredentialStatus credentialStatus, DlCredentialType credentialType, const chip::ByteSpan & credentialData);
@@ -113,6 +156,12 @@ public:
 
     DlStatus SetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex, DlScheduleStatus status, uint32_t localStartTime,
                                 uint32_t localEndTime, DlOperatingMode operatingMode);
+
+    bool IsValidUserIndex(uint16_t userIndex);
+    bool IsValidCredentialIndex(uint16_t credentialIndex, DlCredentialType type);
+    bool IsValidWeekdayScheduleIndex(uint8_t scheduleIndex);
+    bool IsValidYeardayScheduleIndex(uint8_t scheduleIndex);
+    bool IsValidHolidayScheduleIndex(uint8_t scheduleIndex);
 
     bool setLockState(chip::EndpointId endpointId, DlLockState lockState, const Optional<chip::ByteSpan> & pin,
                       DlOperationError & err);
@@ -135,23 +184,18 @@ private:
     static void AutoLockTimerEventHandler(AppEvent * aEvent);
     static void ActuatorMovementTimerEventHandler(AppEvent * aEvent);
 
-    EmberAfPluginDoorLockUserInfo mLockUsers[DOOR_LOCK_MAX_USERS];
-    EmberAfPluginDoorLockCredentialInfo mLockCredentials[MAX_CREDENTIALS];
-    EmberAfPluginDoorLockWeekDaySchedule mWeekdaySchedule[DOOR_LOCK_MAX_USERS][DOOR_LOCK_MAX_SCHEDULES];
-    EmberAfPluginDoorLockYearDaySchedule mYeardaySchedule[DOOR_LOCK_MAX_USERS][DOOR_LOCK_MAX_SCHEDULES];
-    EmberAfPluginDoorLockHolidaySchedule mHolidaySchedule[DOOR_LOCK_MAX_SCHEDULES];
-
-    uint8_t mMaxCredentialsPerUser;
-    uint16_t mMaxUsers;
-    uint8_t mNumberOfWeekdaySchedulesPerUserSupported;
-    uint8_t mNumberOfYeardaySchedulesPerUserSupported;
-    uint8_t mNumberOfHolidaySchedulesSupported;
+    EmberAfPluginDoorLockUserInfo mLockUsers[kMaxUsers];
+    EmberAfPluginDoorLockCredentialInfo mLockCredentials[kMaxCredentials];
+    EmberAfPluginDoorLockWeekDaySchedule mWeekdaySchedule[kMaxUsers][kMaxWeekdaySchedulesPerUser];
+    EmberAfPluginDoorLockYearDaySchedule mYeardaySchedule[kMaxUsers][kMaxYeardaySchedulesPerUser];
+    EmberAfPluginDoorLockHolidaySchedule mHolidaySchedule[kMaxHolidaySchedules];
 
     char mUserNames[ArraySize(mLockUsers)][DOOR_LOCK_MAX_USER_NAME_SIZE];
-    uint8_t mCredentialData[MAX_CREDENTIALS][DOOR_LOCK_MAX_CREDENTIAL_SIZE];
-    DlCredential mCredentials[DOOR_LOCK_MAX_USERS][MAX_CREDENTIAL_PER_USER];
+    uint8_t mCredentialData[kMaxCredentials][kMaxCredentialSize];
+    DlCredential mCredentials[kMaxUsers][kMaxCredentialsPerUser];
 
     static LockManager sLock;
+    EFR32DoorLock::LockInitParams::LockParam LockParams;
 };
 
 inline LockManager & LockMgr()

--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -72,8 +72,9 @@ public:
     } State;
 
     CHIP_ERROR Init(chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state,
-                    uint8_t maxNumberOfCredentialsPerUser, uint16_t numberOfSupportedUsers, uint8_t numberOfWeekdaySchedulesPerUserSupported,
-                    uint8_t numberOfYeardaySchedulesPerUserSupported, uint8_t numberOfHolidaySchedulesPerUserSupported);
+                    uint8_t maxNumberOfCredentialsPerUser, uint16_t numberOfSupportedUsers,
+                    uint8_t numberOfWeekdaySchedulesPerUserSupported, uint8_t numberOfYeardaySchedulesPerUserSupported,
+                    uint8_t numberOfHolidaySchedulesPerUserSupported);
     bool NextState();
     bool IsActionInProgress();
     bool InitiateAction(int32_t aActor, Action_t aAction);
@@ -97,20 +98,21 @@ public:
                        DlCredentialStatus credentialStatus, DlCredentialType credentialType, const chip::ByteSpan & credentialData);
 
     DlStatus GetWeekdaySchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
-                                          EmberAfPluginDoorLockWeekDaySchedule & schedule);
+                                EmberAfPluginDoorLockWeekDaySchedule & schedule);
 
-    DlStatus SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
-                                          DlScheduleStatus status, DlDaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute,
-                                          uint8_t endHour, uint8_t endMinute);
+    DlStatus SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex, DlScheduleStatus status,
+                                DlDaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute, uint8_t endHour, uint8_t endMinute);
 
     DlStatus GetYeardaySchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
-                                          EmberAfPluginDoorLockYearDaySchedule & schedule);
+                                EmberAfPluginDoorLockYearDaySchedule & schedule);
 
-    DlStatus SetYeardaySchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex, DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime);
+    DlStatus SetYeardaySchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex, DlScheduleStatus status,
+                                uint32_t localStartTime, uint32_t localEndTime);
 
     DlStatus GetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex, EmberAfPluginDoorLockHolidaySchedule & schedule);
 
-    DlStatus SetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex, DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode);
+    DlStatus SetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex, DlScheduleStatus status, uint32_t localStartTime,
+                                uint32_t localEndTime, DlOperatingMode operatingMode);
 
     bool setLockState(chip::EndpointId endpointId, DlLockState lockState, const Optional<chip::ByteSpan> & pin,
                       DlOperationError & err);

--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -50,11 +50,11 @@ namespace LockInitParams {
 struct LockParam
 {
     // Read from zap attributes
-    uint16_t numberOfUsers;
-    uint8_t numberOfCredentialsPerUser;
-    uint8_t numberOfWeekdaySchedulesPerUser;
-    uint8_t numberOfYeardaySchedulesPerUser;
-    uint8_t numberOfHolidaySchedules;
+    uint16_t numberOfUsers = 0;
+    uint8_t numberOfCredentialsPerUser = 0;
+    uint8_t numberOfWeekdaySchedulesPerUser = 0;
+    uint8_t numberOfYeardaySchedulesPerUser = 0;
+    uint8_t numberOfHolidaySchedules = 0;
 };
 
 class ParamBuilder

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -254,9 +254,38 @@ CHIP_ERROR AppTask::Init()
                      endpointId);
         numberOfSupportedUsers = 10;
     }
+
+    uint8_t numberOfWeekdaySchedulesPerUserSupported = 0;
+    if (!DoorLockServer::Instance().GetNumberOfWeekDaySchedulesPerUserSupported(endpointId, numberOfWeekdaySchedulesPerUserSupported))
+    {
+        ChipLogError(Zcl,
+                     "Unable to get number of supported weekday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
+                     endpointId);
+        numberOfWeekdaySchedulesPerUserSupported = 10;
+    }
+
+    uint8_t numberOfYeardaySchedulesPerUserSupported = 0;
+    if (!DoorLockServer::Instance().GetNumberOfYearDaySchedulesPerUserSupported(endpointId, numberOfYeardaySchedulesPerUserSupported))
+    {
+        ChipLogError(Zcl,
+                     "Unable to get number of supported yearday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
+                     endpointId);
+        numberOfYeardaySchedulesPerUserSupported = 10;
+    }
+
+    uint8_t numberOfHolidaySchedulesSupported = 0;
+    if (!DoorLockServer::Instance().GetNumberOfHolidaySchedulesSupported(endpointId, numberOfHolidaySchedulesSupported))
+    {
+        ChipLogError(Zcl,
+                     "Unable to get number of supported holiday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
+                     endpointId);
+        numberOfHolidaySchedulesSupported = 10;
+    }
+
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    err = LockMgr().Init(state, maxCredentialsPerUser, numberOfSupportedUsers);
+    err = LockMgr().Init(state, maxCredentialsPerUser, numberOfSupportedUsers, numberOfWeekdaySchedulesPerUserSupported, 
+                         numberOfYeardaySchedulesPerUserSupported, numberOfHolidaySchedulesSupported);
     if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("LockMgr().Init() failed");

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -256,35 +256,40 @@ CHIP_ERROR AppTask::Init()
     }
 
     uint8_t numberOfWeekdaySchedulesPerUserSupported = 0;
-    if (!DoorLockServer::Instance().GetNumberOfWeekDaySchedulesPerUserSupported(endpointId, numberOfWeekdaySchedulesPerUserSupported))
+    if (!DoorLockServer::Instance().GetNumberOfWeekDaySchedulesPerUserSupported(endpointId,
+                                                                                numberOfWeekdaySchedulesPerUserSupported))
     {
-        ChipLogError(Zcl,
-                     "Unable to get number of supported weekday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
-                     endpointId);
+        ChipLogError(
+            Zcl,
+            "Unable to get number of supported weekday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
+            endpointId);
         numberOfWeekdaySchedulesPerUserSupported = 10;
     }
 
     uint8_t numberOfYeardaySchedulesPerUserSupported = 0;
-    if (!DoorLockServer::Instance().GetNumberOfYearDaySchedulesPerUserSupported(endpointId, numberOfYeardaySchedulesPerUserSupported))
+    if (!DoorLockServer::Instance().GetNumberOfYearDaySchedulesPerUserSupported(endpointId,
+                                                                                numberOfYeardaySchedulesPerUserSupported))
     {
-        ChipLogError(Zcl,
-                     "Unable to get number of supported yearday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
-                     endpointId);
+        ChipLogError(
+            Zcl,
+            "Unable to get number of supported yearday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
+            endpointId);
         numberOfYeardaySchedulesPerUserSupported = 10;
     }
 
     uint8_t numberOfHolidaySchedulesSupported = 0;
     if (!DoorLockServer::Instance().GetNumberOfHolidaySchedulesSupported(endpointId, numberOfHolidaySchedulesSupported))
     {
-        ChipLogError(Zcl,
-                     "Unable to get number of supported holiday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
-                     endpointId);
+        ChipLogError(
+            Zcl,
+            "Unable to get number of supported holiday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
+            endpointId);
         numberOfHolidaySchedulesSupported = 10;
     }
 
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    err = LockMgr().Init(state, maxCredentialsPerUser, numberOfSupportedUsers, numberOfWeekdaySchedulesPerUserSupported, 
+    err = LockMgr().Init(state, maxCredentialsPerUser, numberOfSupportedUsers, numberOfWeekdaySchedulesPerUserSupported,
                          numberOfYeardaySchedulesPerUserSupported, numberOfHolidaySchedulesSupported);
     if (err != CHIP_NO_ERROR)
     {

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -83,6 +83,7 @@ using chip::app::Clusters::DoorLock::DlOperationSource;
 using namespace chip;
 using namespace ::chip::DeviceLayer;
 using namespace ::chip::DeviceLayer::Internal;
+using namespace EFR32DoorLock::LockInitParams;
 
 namespace {
 TimerHandle_t sFunctionTimer; // FreeRTOS app sw timer.
@@ -236,61 +237,66 @@ CHIP_ERROR AppTask::Init()
     chip::DeviceLayer::PlatformMgr().LockChipStack();
     chip::app::Clusters::DoorLock::Attributes::LockState::Get(endpointId, state);
 
-    uint8_t maxCredentialsPerUser = 0;
-    if (!DoorLockServer::Instance().GetNumberOfCredentialsSupportedPerUser(endpointId, maxCredentialsPerUser))
+    uint8_t numberOfCredentialsPerUser = 0;
+    if (!DoorLockServer::Instance().GetNumberOfCredentialsSupportedPerUser(endpointId, numberOfCredentialsPerUser))
     {
         ChipLogError(Zcl,
                      "Unable to get number of credentials supported per user when initializing lock endpoint, defaulting to 5 "
                      "[endpointId=%d]",
                      endpointId);
-        maxCredentialsPerUser = 5;
+        numberOfCredentialsPerUser = 5;
     }
 
-    uint16_t numberOfSupportedUsers = 0;
-    if (!DoorLockServer::Instance().GetNumberOfUserSupported(endpointId, numberOfSupportedUsers))
+    uint16_t numberOfUsers = 0;
+    if (!DoorLockServer::Instance().GetNumberOfUserSupported(endpointId, numberOfUsers))
     {
         ChipLogError(Zcl,
                      "Unable to get number of supported users when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
                      endpointId);
-        numberOfSupportedUsers = 10;
+        numberOfUsers = 10;
     }
 
-    uint8_t numberOfWeekdaySchedulesPerUserSupported = 0;
-    if (!DoorLockServer::Instance().GetNumberOfWeekDaySchedulesPerUserSupported(endpointId,
-                                                                                numberOfWeekdaySchedulesPerUserSupported))
+    uint8_t numberOfWeekdaySchedulesPerUser = 0;
+    if (!DoorLockServer::Instance().GetNumberOfWeekDaySchedulesPerUserSupported(endpointId, numberOfWeekdaySchedulesPerUser))
     {
         ChipLogError(
             Zcl,
             "Unable to get number of supported weekday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
             endpointId);
-        numberOfWeekdaySchedulesPerUserSupported = 10;
+        numberOfWeekdaySchedulesPerUser = 10;
     }
 
-    uint8_t numberOfYeardaySchedulesPerUserSupported = 0;
-    if (!DoorLockServer::Instance().GetNumberOfYearDaySchedulesPerUserSupported(endpointId,
-                                                                                numberOfYeardaySchedulesPerUserSupported))
+    uint8_t numberOfYeardaySchedulesPerUser = 0;
+    if (!DoorLockServer::Instance().GetNumberOfYearDaySchedulesPerUserSupported(endpointId, numberOfYeardaySchedulesPerUser))
     {
         ChipLogError(
             Zcl,
             "Unable to get number of supported yearday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
             endpointId);
-        numberOfYeardaySchedulesPerUserSupported = 10;
+        numberOfYeardaySchedulesPerUser = 10;
     }
 
-    uint8_t numberOfHolidaySchedulesSupported = 0;
-    if (!DoorLockServer::Instance().GetNumberOfHolidaySchedulesSupported(endpointId, numberOfHolidaySchedulesSupported))
+    uint8_t numberOfHolidaySchedules = 0;
+    if (!DoorLockServer::Instance().GetNumberOfHolidaySchedulesSupported(endpointId, numberOfHolidaySchedules))
     {
         ChipLogError(
             Zcl,
             "Unable to get number of supported holiday schedules when initializing lock endpoint, defaulting to 10 [endpointId=%d]",
             endpointId);
-        numberOfHolidaySchedulesSupported = 10;
+        numberOfHolidaySchedules = 10;
     }
 
     chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
-    err = LockMgr().Init(state, maxCredentialsPerUser, numberOfSupportedUsers, numberOfWeekdaySchedulesPerUserSupported,
-                         numberOfYeardaySchedulesPerUserSupported, numberOfHolidaySchedulesSupported);
+    err = LockMgr().Init(state,
+                         ParamBuilder()
+                             .SetNumberOfUsers(numberOfUsers)
+                             .SetNumberOfCredentialsPerUser(numberOfCredentialsPerUser)
+                             .SetNumberOfWeekdaySchedulesPerUser(numberOfWeekdaySchedulesPerUser)
+                             .SetNumberOfYeardaySchedulesPerUser(numberOfYeardaySchedulesPerUser)
+                             .SetNumberOfHolidaySchedules(numberOfHolidaySchedules)
+                             .GetLockParam());
+
     if (err != CHIP_NO_ERROR)
     {
         EFR32_LOG("LockMgr().Init() failed");

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -101,12 +101,7 @@ CHIP_ERROR LockManager::Init(chip::app::DataModel::Nullable<chip::app::Clusters:
 
 bool LockManager::IsValidUserIndex(uint16_t userIndex)
 {
-    if (userIndex > kMaxUsers)
-    {
-        return false;
-    }
-
-    return true;
+    return (userIndex < kMaxUsers);
 }
 
 bool LockManager::IsValidCredentialIndex(uint16_t credentialIndex, DlCredentialType type)
@@ -117,44 +112,22 @@ bool LockManager::IsValidCredentialIndex(uint16_t credentialIndex, DlCredentialT
         return (0 == credentialIndex);
     }
 
-    if (credentialIndex > kMaxCredentialsPerUser)
-    {
-        return false;
-    }
-
-    // Check programming pin
-
-    return true;
+    return (credentialIndex < kMaxCredentialsPerUser);
 }
 
 bool LockManager::IsValidWeekdayScheduleIndex(uint8_t scheduleIndex)
 {
-    if (scheduleIndex > kMaxWeekdaySchedulesPerUser)
-    {
-        return false;
-    }
-
-    return true;
+    return (scheduleIndex < kMaxWeekdaySchedulesPerUser);
 }
 
 bool LockManager::IsValidYeardayScheduleIndex(uint8_t scheduleIndex)
 {
-    if (scheduleIndex > kMaxYeardaySchedulesPerUser)
-    {
-        return false;
-    }
-
-    return true;
+    return (scheduleIndex < kMaxYeardaySchedulesPerUser);
 }
 
 bool LockManager::IsValidHolidayScheduleIndex(uint8_t scheduleIndex)
 {
-    if (scheduleIndex > kMaxHolidaySchedules)
-    {
-        return false;
-    }
-
-    return true;
+    return (scheduleIndex < kMaxHolidaySchedules);
 }
 
 bool LockManager::ReadConfigValues()

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -33,8 +33,9 @@ TimerHandle_t sLockTimer;
 using namespace ::chip::DeviceLayer::Internal;
 
 CHIP_ERROR LockManager::Init(chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state,
-                             uint8_t maxNumberOfCredentialsPerUser, uint16_t numberOfSupportedUsers, uint8_t numberOfWeekdaySchedulesPerUserSupported,
-                             uint8_t numberOfYeardaySchedulesPerUserSupported, uint8_t numberOfHolidaySchedulesSupported)
+                             uint8_t maxNumberOfCredentialsPerUser, uint16_t numberOfSupportedUsers,
+                             uint8_t numberOfWeekdaySchedulesPerUserSupported, uint8_t numberOfYeardaySchedulesPerUserSupported,
+                             uint8_t numberOfHolidaySchedulesSupported)
 {
 
     mMaxCredentialsPerUser = maxNumberOfCredentialsPerUser;
@@ -50,24 +51,27 @@ CHIP_ERROR LockManager::Init(chip::app::DataModel::Nullable<chip::app::Clusters:
     mNumberOfWeekdaySchedulesPerUserSupported = numberOfWeekdaySchedulesPerUserSupported;
     if (mNumberOfWeekdaySchedulesPerUserSupported > MAX_SCHEDULE_PER_USER)
     {
-        EFR32_LOG("Max number of schedules is greater than %d, the maximum amount of schedules currently supported on this platform",
-                  MAX_SCHEDULE_PER_USER);
+        EFR32_LOG(
+            "Max number of schedules is greater than %d, the maximum amount of schedules currently supported on this platform",
+            MAX_SCHEDULE_PER_USER);
         return APP_ERROR_ALLOCATION_FAILED;
     }
 
     mNumberOfYeardaySchedulesPerUserSupported = numberOfYeardaySchedulesPerUserSupported;
     if (mNumberOfYeardaySchedulesPerUserSupported > MAX_SCHEDULE_PER_USER)
     {
-        EFR32_LOG("Max number of schedules is greater than %d, the maximum amount of schedules currently supported on this platform",
-                  MAX_SCHEDULE_PER_USER);
+        EFR32_LOG(
+            "Max number of schedules is greater than %d, the maximum amount of schedules currently supported on this platform",
+            MAX_SCHEDULE_PER_USER);
         return APP_ERROR_ALLOCATION_FAILED;
     }
 
     mNumberOfHolidaySchedulesSupported = numberOfHolidaySchedulesSupported;
     if (mNumberOfHolidaySchedulesSupported > MAX_SCHEDULE_PER_USER)
     {
-        EFR32_LOG("Max number of schedules is greater than %d, the maximum amount of schedules currently supported on this platform",
-                  MAX_SCHEDULE_PER_USER);
+        EFR32_LOG(
+            "Max number of schedules is greater than %d, the maximum amount of schedules currently supported on this platform",
+            MAX_SCHEDULE_PER_USER);
         return APP_ERROR_ALLOCATION_FAILED;
     }
 
@@ -109,16 +113,18 @@ bool LockManager::ReadConfigValues()
                                     sizeof(mCredentialData), outLen);
 
     EFR32Config::ReadConfigValueBin(EFR32Config::kConfigKey_UserCredentials, reinterpret_cast<uint8_t *>(mCredentials),
-                                     sizeof(DlCredential) * mMaxUsers * mMaxCredentialsPerUser, outLen);
+                                    sizeof(DlCredential) * mMaxUsers * mMaxCredentialsPerUser, outLen);
 
-    EFR32Config::ReadConfigValueBin(EFR32Config::kConfigKey_WeekDaySchedules, reinterpret_cast<uint8_t *> (mWeekdaySchedule), 
-                                    sizeof(EmberAfPluginDoorLockWeekDaySchedule) * mNumberOfWeekdaySchedulesPerUserSupported * mMaxUsers, outLen);
+    EFR32Config::ReadConfigValueBin(
+        EFR32Config::kConfigKey_WeekDaySchedules, reinterpret_cast<uint8_t *>(mWeekdaySchedule),
+        sizeof(EmberAfPluginDoorLockWeekDaySchedule) * mNumberOfWeekdaySchedulesPerUserSupported * mMaxUsers, outLen);
 
-    EFR32Config::ReadConfigValueBin(EFR32Config::kConfigKey_YearDaySchedules, reinterpret_cast<uint8_t *> (mYeardaySchedule), 
-                                        sizeof(EmberAfPluginDoorLockYearDaySchedule) * mNumberOfYeardaySchedulesPerUserSupported * mMaxUsers, outLen);
+    EFR32Config::ReadConfigValueBin(
+        EFR32Config::kConfigKey_YearDaySchedules, reinterpret_cast<uint8_t *>(mYeardaySchedule),
+        sizeof(EmberAfPluginDoorLockYearDaySchedule) * mNumberOfYeardaySchedulesPerUserSupported * mMaxUsers, outLen);
 
-    EFR32Config::ReadConfigValueBin(EFR32Config::kConfigKey_HolidaySchedules, reinterpret_cast<uint8_t *> (&(mHolidaySchedule)), 
-                                     sizeof(EmberAfPluginDoorLockHolidaySchedule) * mNumberOfHolidaySchedulesSupported, outLen);
+    EFR32Config::ReadConfigValueBin(EFR32Config::kConfigKey_HolidaySchedules, reinterpret_cast<uint8_t *>(&(mHolidaySchedule)),
+                                    sizeof(EmberAfPluginDoorLockHolidaySchedule) * mNumberOfHolidaySchedulesSupported, outLen);
 
     return true;
 }
@@ -343,10 +349,8 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
     EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_LockUser, reinterpret_cast<const uint8_t *>(&mLockUsers),
                                      sizeof(EmberAfPluginDoorLockUserInfo) * mMaxUsers);
 
-    EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_UserCredentials,
-                                      reinterpret_cast<const uint8_t *>(mCredentials),
-                                      sizeof(DlCredential) * mMaxUsers * mMaxCredentialsPerUser);
-
+    EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_UserCredentials, reinterpret_cast<const uint8_t *>(mCredentials),
+                                     sizeof(DlCredential) * mMaxUsers * mMaxCredentialsPerUser);
 
     EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_LockUserName, reinterpret_cast<const uint8_t *>(mUserNames),
                                      sizeof(mUserNames));
@@ -359,10 +363,10 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
 bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, DlCredentialType credentialType,
                                 EmberAfPluginDoorLockCredentialInfo & credential) const
 {
-    if((credentialIndex < MIN_CREDENTIAL_INDEX) || (credentialIndex > MAX_CREDENTIAL_PER_USER))
+    if ((credentialIndex < MIN_CREDENTIAL_INDEX) || (credentialIndex > MAX_CREDENTIAL_PER_USER))
     {
-        ChipLogError(Zcl, "Cannot get credential - credential index is out of range [endpoint=%d,index=%d]",
-                     endpointId, credentialIndex);
+        ChipLogError(Zcl, "Cannot get credential - credential index is out of range [endpoint=%d,index=%d]", endpointId,
+                     credentialIndex);
         return false;
     }
 
@@ -402,10 +406,10 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
                                 const chip::ByteSpan & credentialData)
 {
 
-    if((credentialIndex < MIN_CREDENTIAL_INDEX) || (credentialIndex > MAX_CREDENTIAL_PER_USER))
+    if ((credentialIndex < MIN_CREDENTIAL_INDEX) || (credentialIndex > MAX_CREDENTIAL_PER_USER))
     {
-        ChipLogError(Zcl, "Cannot set credential - credential index is out of range [endpoint=%d,index=%d]",
-                     endpointId, credentialIndex);
+        ChipLogError(Zcl, "Cannot set credential - credential index is out of range [endpoint=%d,index=%d]", endpointId,
+                     credentialIndex);
         return false;
     }
 
@@ -436,139 +440,130 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
 
     ChipLogProgress(Zcl, "Successfully set the credential [credentialType=%u]", to_underlying(credentialType));
 
-
     return true;
 }
 
 DlStatus LockManager::GetWeekdaySchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
-                                          EmberAfPluginDoorLockWeekDaySchedule & schedule)
+                                         EmberAfPluginDoorLockWeekDaySchedule & schedule)
 {
-    if((weekdayIndex < MIN_SCHEDULE_INDEX) || (weekdayIndex > MAX_SCHEDULE_PER_USER))
+    if ((weekdayIndex < MIN_SCHEDULE_INDEX) || (weekdayIndex > MAX_SCHEDULE_PER_USER))
     {
-        ChipLogError(Zcl, "Cannot get schedule - schedule index is out of range [endpoint=%d,index=%d]",
-                     endpointId, weekdayIndex);
+        ChipLogError(Zcl, "Cannot get schedule - schedule index is out of range [endpoint=%d,index=%d]", endpointId, weekdayIndex);
         return DlStatus::kFailure;
     }
-    if((userIndex < MIN_USER_INDEX) || (userIndex > DOOR_LOCK_MAX_USERS))
+    if ((userIndex < MIN_USER_INDEX) || (userIndex > DOOR_LOCK_MAX_USERS))
     {
-        ChipLogError(Zcl, "Cannot get schedule - user index is out of range [endpoint=%d,index=%d]",
-                     endpointId, userIndex);
+        ChipLogError(Zcl, "Cannot get schedule - user index is out of range [endpoint=%d,index=%d]", endpointId, userIndex);
         return DlStatus::kFailure;
     }
-    
+
     // doorlock server checks for valid indices
     uint8_t adjustedWeekDayIndex = weekdayIndex - 1;
-    uint16_t adjustedUserIndex = userIndex - 1;
+    uint16_t adjustedUserIndex   = userIndex - 1;
 
     auto & scheduleInStorage = mWeekdaySchedule[adjustedUserIndex][adjustedWeekDayIndex];
 
     schedule = scheduleInStorage;
 
     return DlStatus::kSuccess;
-
 }
 
 DlStatus LockManager::SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
-                                          DlScheduleStatus status, DlDaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute,
-                                          uint8_t endHour, uint8_t endMinute)
+                                         DlScheduleStatus status, DlDaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute,
+                                         uint8_t endHour, uint8_t endMinute)
 {
-    if((weekdayIndex < MIN_SCHEDULE_INDEX) || (weekdayIndex > MAX_SCHEDULE_PER_USER))
+    if ((weekdayIndex < MIN_SCHEDULE_INDEX) || (weekdayIndex > MAX_SCHEDULE_PER_USER))
     {
-        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]",
-                     endpointId, weekdayIndex);
+        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]", endpointId, weekdayIndex);
         return DlStatus::kFailure;
     }
-    if((userIndex < MIN_USER_INDEX) || (userIndex > DOOR_LOCK_MAX_USERS))
+    if ((userIndex < MIN_USER_INDEX) || (userIndex > DOOR_LOCK_MAX_USERS))
     {
-        ChipLogError(Zcl, "Cannot get schedule - user index is out of range [endpoint=%d,index=%d]",
-                     endpointId, userIndex);
+        ChipLogError(Zcl, "Cannot get schedule - user index is out of range [endpoint=%d,index=%d]", endpointId, userIndex);
         return DlStatus::kFailure;
     }
 
     // doorlock server checks for valid indices
     uint8_t adjustedWeekDayIndex = weekdayIndex - 1;
-    uint16_t adjustedUserIndex = userIndex - 1;
+    uint16_t adjustedUserIndex   = userIndex - 1;
 
     auto & scheduleInStorage = mWeekdaySchedule[adjustedUserIndex][adjustedWeekDayIndex];
 
-    scheduleInStorage.daysMask = daysMask;
-    scheduleInStorage.startHour = startHour;
+    scheduleInStorage.daysMask    = daysMask;
+    scheduleInStorage.startHour   = startHour;
     scheduleInStorage.startMinute = startMinute;
-    scheduleInStorage.endHour = endHour;
-    scheduleInStorage.endMinute = endMinute;
+    scheduleInStorage.endHour     = endHour;
+    scheduleInStorage.endMinute   = endMinute;
 
-    EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_WeekDaySchedules, reinterpret_cast<const uint8_t *> (mWeekdaySchedule), 
-                                     sizeof(EmberAfPluginDoorLockWeekDaySchedule) * mNumberOfWeekdaySchedulesPerUserSupported * mMaxUsers);
+    EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_WeekDaySchedules, reinterpret_cast<const uint8_t *>(mWeekdaySchedule),
+                                     sizeof(EmberAfPluginDoorLockWeekDaySchedule) * mNumberOfWeekdaySchedulesPerUserSupported *
+                                         mMaxUsers);
 
     return DlStatus::kSuccess;
-
 }
 
 DlStatus LockManager::GetYeardaySchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
-                                          EmberAfPluginDoorLockYearDaySchedule & schedule)
+                                         EmberAfPluginDoorLockYearDaySchedule & schedule)
 {
-    if((yearDayIndex < MIN_SCHEDULE_INDEX) || (yearDayIndex > MAX_SCHEDULE_PER_USER))
+    if ((yearDayIndex < MIN_SCHEDULE_INDEX) || (yearDayIndex > MAX_SCHEDULE_PER_USER))
     {
-        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]",
-                     endpointId, yearDayIndex);
+        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]", endpointId, yearDayIndex);
         return DlStatus::kFailure;
     }
-    if((userIndex < MIN_USER_INDEX) || (userIndex > DOOR_LOCK_MAX_USERS))
+    if ((userIndex < MIN_USER_INDEX) || (userIndex > DOOR_LOCK_MAX_USERS))
     {
-        ChipLogError(Zcl, "Cannot get schedule - user index is out of range [endpoint=%d,index=%d]",
-                     endpointId, userIndex);
+        ChipLogError(Zcl, "Cannot get schedule - user index is out of range [endpoint=%d,index=%d]", endpointId, userIndex);
         return DlStatus::kFailure;
     }
 
     // doorlock server checks for valid indices
     uint8_t adjustedYearDayIndex = yearDayIndex - 1;
-    uint16_t adjustedUserIndex = userIndex - 1;
+    uint16_t adjustedUserIndex   = userIndex - 1;
 
     auto & scheduleInStorage = mYeardaySchedule[adjustedUserIndex][adjustedYearDayIndex];
 
     schedule = scheduleInStorage;
 
-    return DlStatus::kSuccess;    
+    return DlStatus::kSuccess;
 }
 
 DlStatus LockManager::SetYeardaySchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
-                                          DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime)
+                                         DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime)
 {
-    if((yearDayIndex < MIN_SCHEDULE_INDEX) || (yearDayIndex > MAX_SCHEDULE_PER_USER))
+    if ((yearDayIndex < MIN_SCHEDULE_INDEX) || (yearDayIndex > MAX_SCHEDULE_PER_USER))
     {
-        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]",
-                     endpointId, yearDayIndex);
+        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]", endpointId, yearDayIndex);
         return DlStatus::kFailure;
     }
-    if((userIndex < MIN_USER_INDEX) || (userIndex > DOOR_LOCK_MAX_USERS))
+    if ((userIndex < MIN_USER_INDEX) || (userIndex > DOOR_LOCK_MAX_USERS))
     {
-        ChipLogError(Zcl, "Cannot get schedule - user index is out of range [endpoint=%d,index=%d]",
-                     endpointId, userIndex);
+        ChipLogError(Zcl, "Cannot get schedule - user index is out of range [endpoint=%d,index=%d]", endpointId, userIndex);
         return DlStatus::kFailure;
     }
 
     // doorlock server checks for valid indices
     uint8_t adjustedYearDayIndex = yearDayIndex - 1;
-    uint16_t adjustedUserIndex = userIndex - 1;
+    uint16_t adjustedUserIndex   = userIndex - 1;
 
     auto & scheduleInStorage = mYeardaySchedule[adjustedUserIndex][adjustedYearDayIndex];
 
-    //scheduleInStorage.status = status;
+    // scheduleInStorage.status = status;
     scheduleInStorage.localStartTime = localStartTime;
-    scheduleInStorage.localEndTime = localEndTime;
+    scheduleInStorage.localEndTime   = localEndTime;
 
-    EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_YearDaySchedules, reinterpret_cast<const uint8_t *> (mYeardaySchedule), 
-                                     sizeof(EmberAfPluginDoorLockYearDaySchedule) * mNumberOfYeardaySchedulesPerUserSupported * mMaxUsers);
+    EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_YearDaySchedules, reinterpret_cast<const uint8_t *>(mYeardaySchedule),
+                                     sizeof(EmberAfPluginDoorLockYearDaySchedule) * mNumberOfYeardaySchedulesPerUserSupported *
+                                         mMaxUsers);
 
     return DlStatus::kSuccess;
 }
 
-DlStatus LockManager::GetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex, EmberAfPluginDoorLockHolidaySchedule & schedule)
+DlStatus LockManager::GetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex,
+                                         EmberAfPluginDoorLockHolidaySchedule & schedule)
 {
-    if((holidayIndex < MIN_SCHEDULE_INDEX) || (holidayIndex > MAX_SCHEDULE_PER_USER))
+    if ((holidayIndex < MIN_SCHEDULE_INDEX) || (holidayIndex > MAX_SCHEDULE_PER_USER))
     {
-        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]",
-                     endpointId, holidayIndex);
+        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]", endpointId, holidayIndex);
         return DlStatus::kFailure;
     }
 
@@ -583,12 +578,11 @@ DlStatus LockManager::GetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
 }
 
 DlStatus LockManager::SetHolidaySchedule(chip::EndpointId endpointId, uint8_t holidayIndex, DlScheduleStatus status,
-                                 uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode)
+                                         uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode)
 {
-    if((holidayIndex < MIN_SCHEDULE_INDEX) || (holidayIndex > MAX_SCHEDULE_PER_USER))
+    if ((holidayIndex < MIN_SCHEDULE_INDEX) || (holidayIndex > MAX_SCHEDULE_PER_USER))
     {
-        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]",
-                     endpointId, holidayIndex);
+        ChipLogError(Zcl, "Cannot set schedule - schedule index is out of range [endpoint=%d,index=%d]", endpointId, holidayIndex);
         return DlStatus::kFailure;
     }
 
@@ -598,10 +592,11 @@ DlStatus LockManager::SetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
     auto & scheduleInStorage = mHolidaySchedule[adjustedHolidayIndex];
 
     scheduleInStorage.localStartTime = localStartTime;
-    scheduleInStorage.localEndTime = localEndTime;
-    scheduleInStorage.operatingMode = operatingMode;
+    scheduleInStorage.localEndTime   = localEndTime;
+    scheduleInStorage.operatingMode  = operatingMode;
 
-    EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_HolidaySchedules, reinterpret_cast<const uint8_t *> (&(mHolidaySchedule)), 
+    EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_HolidaySchedules,
+                                     reinterpret_cast<const uint8_t *>(&(mHolidaySchedule)),
                                      sizeof(EmberAfPluginDoorLockHolidaySchedule) * mNumberOfHolidaySchedulesSupported);
 
     return DlStatus::kSuccess;

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -363,18 +363,20 @@ bool LockManager::SetUser(chip::EndpointId endpointId, uint16_t userIndex, chip:
 bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credentialIndex, DlCredentialType credentialType,
                                 EmberAfPluginDoorLockCredentialInfo & credential) const
 {
-    if ((credentialIndex < MIN_CREDENTIAL_INDEX) || (credentialIndex > MAX_CREDENTIAL_PER_USER))
-    {
-        ChipLogError(Zcl, "Cannot get credential - credential index is out of range [endpoint=%d,index=%d]", endpointId,
-                     credentialIndex);
-        return false;
-    }
 
     // door-lock-server checks for valid credential index
     uint16_t adjustedCredentialIndex = credentialIndex - 1;
 
     ChipLogProgress(Zcl, "Lock App: LockManager::GetCredential [credentialType=%u], credentialIndex=%d",
                     to_underlying(credentialType), adjustedCredentialIndex);
+
+    if (credentialType == DlCredentialType::kProgrammingPIN)
+    {
+        ChipLogError(Zcl, "Programming user not supported [credentialType=%u], credentialIndex=%d", to_underlying(credentialType),
+                     adjustedCredentialIndex);
+
+        return true;
+    }
 
     const auto & credentialInStorage = mLockCredentials[adjustedCredentialIndex];
 

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -54,10 +54,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
  * @param endpoint   Ver.: always
  *
  */
-void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
-{
-
-}
+void emberAfDoorLockClusterInitCallback(EndpointId endpoint) {}
 
 bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
@@ -124,7 +121,8 @@ DlStatus emberAfPluginDoorLockGetSchedule(chip::EndpointId endpointId, uint8_t y
     return LockMgr().GetYeardaySchedule(endpointId, yearDayIndex, userIndex, schedule);
 }
 
-DlStatus emberAfPluginDoorLockGetSchedule(chip::EndpointId endpointId, uint8_t holidayIndex, EmberAfPluginDoorLockHolidaySchedule & holidaySchedule)
+DlStatus emberAfPluginDoorLockGetSchedule(chip::EndpointId endpointId, uint8_t holidayIndex,
+                                          EmberAfPluginDoorLockHolidaySchedule & holidaySchedule)
 {
     return LockMgr().GetHolidaySchedule(endpointId, holidayIndex, holidaySchedule);
 }
@@ -133,14 +131,14 @@ DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t w
                                           DlScheduleStatus status, DlDaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute,
                                           uint8_t endHour, uint8_t endMinute)
 {
-    return LockMgr().SetWeekdaySchedule(endpointId, weekdayIndex, userIndex, status, daysMask, startHour, startMinute, endHour, endMinute);
+    return LockMgr().SetWeekdaySchedule(endpointId, weekdayIndex, userIndex, status, daysMask, startHour, startMinute, endHour,
+                                        endMinute);
 }
 
 DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
                                           DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime)
 {
-    return LockMgr().SetYeardaySchedule(endpointId, yearDayIndex, userIndex,
-                                           status, localStartTime, localEndTime);
+    return LockMgr().SetYeardaySchedule(endpointId, yearDayIndex, userIndex, status, localStartTime, localEndTime);
 }
 
 DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t holidayIndex, DlScheduleStatus status,

--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -29,7 +29,6 @@
 #include <app/ConcreteAttributePath.h>
 #include <lib/support/logging/CHIPLogging.h>
 
-using namespace ::chip;
 using namespace ::chip::app::Clusters;
 using namespace ::chip::DeviceLayer::Internal;
 
@@ -57,7 +56,7 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
  */
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 {
-    // TODO: implement any additional Cluster Server init actions
+
 }
 
 bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
@@ -113,28 +112,39 @@ bool emberAfPluginDoorLockSetUser(chip::EndpointId endpointId, uint16_t userInde
                              credentials, totalCredentials);
 }
 
-// TODO: These functions will be supported by door-lock-server in the future. These are set to return failure until implemented.
 DlStatus emberAfPluginDoorLockGetSchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
                                           EmberAfPluginDoorLockWeekDaySchedule & schedule)
 {
-    return DlStatus::kFailure;
+    return LockMgr().GetWeekdaySchedule(endpointId, weekdayIndex, userIndex, schedule);
 }
 
 DlStatus emberAfPluginDoorLockGetSchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
                                           EmberAfPluginDoorLockYearDaySchedule & schedule)
 {
-    return DlStatus::kFailure;
+    return LockMgr().GetYeardaySchedule(endpointId, yearDayIndex, userIndex, schedule);
+}
+
+DlStatus emberAfPluginDoorLockGetSchedule(chip::EndpointId endpointId, uint8_t holidayIndex, EmberAfPluginDoorLockHolidaySchedule & holidaySchedule)
+{
+    return LockMgr().GetHolidaySchedule(endpointId, holidayIndex, holidaySchedule);
 }
 
 DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t weekdayIndex, uint16_t userIndex,
                                           DlScheduleStatus status, DlDaysMaskMap daysMask, uint8_t startHour, uint8_t startMinute,
                                           uint8_t endHour, uint8_t endMinute)
 {
-    return DlStatus::kFailure;
+    return LockMgr().SetWeekdaySchedule(endpointId, weekdayIndex, userIndex, status, daysMask, startHour, startMinute, endHour, endMinute);
 }
 
 DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t yearDayIndex, uint16_t userIndex,
                                           DlScheduleStatus status, uint32_t localStartTime, uint32_t localEndTime)
 {
-    return DlStatus::kFailure;
+    return LockMgr().SetYeardaySchedule(endpointId, yearDayIndex, userIndex,
+                                           status, localStartTime, localEndTime);
+}
+
+DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t holidayIndex, DlScheduleStatus status,
+                                          uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode)
+{
+    return LockMgr().SetHolidaySchedule(endpointId, holidayIndex, status, localStartTime, localEndTime, operatingMode);
 }

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -122,6 +122,10 @@ public:
     static constexpr Key kConfigKey_LockUserName       = EFR32ConfigKey(kMatterConfig_KeyBase, 0x12);
     static constexpr Key kConfigKey_CredentialData     = EFR32ConfigKey(kMatterConfig_KeyBase, 0x13);
     static constexpr Key kConfigKey_UserCredentials    = EFR32ConfigKey(kMatterConfig_KeyBase, 0x14);
+    static constexpr Key kConfigKey_WeekDaySchedules   = EFR32ConfigKey(kMatterConfig_KeyBase, 0x15);
+    static constexpr Key kConfigKey_YearDaySchedules   = EFR32ConfigKey(kMatterConfig_KeyBase, 0x16);
+    static constexpr Key kConfigKey_HolidaySchedules   = EFR32ConfigKey(kMatterConfig_KeyBase, 0x17);
+
 
     static constexpr Key kConfigKey_GroupKeyMax =
         EFR32ConfigKey(kMatterConfig_KeyBase, 0x1E); // Allows 16 Group Keys to be created.

--- a/src/platform/EFR32/EFR32Config.h
+++ b/src/platform/EFR32/EFR32Config.h
@@ -126,7 +126,6 @@ public:
     static constexpr Key kConfigKey_YearDaySchedules   = EFR32ConfigKey(kMatterConfig_KeyBase, 0x16);
     static constexpr Key kConfigKey_HolidaySchedules   = EFR32ConfigKey(kMatterConfig_KeyBase, 0x17);
 
-
     static constexpr Key kConfigKey_GroupKeyMax =
         EFR32ConfigKey(kMatterConfig_KeyBase, 0x1E); // Allows 16 Group Keys to be created.
     static constexpr Key kConfigKey_UniqueId = EFR32ConfigKey(kMatterFactory_KeyBase, 0x1F);


### PR DESCRIPTION
#### Problem
No schedules implementation
mCredentials not stored in nvm properly.

#### Change overview

EFR32 weekDay, yearDay and holiday schedules implemented with nvm storage
get maxSchedule attributes in app code
nvm storage fix for mCredentials
changed structure of mCredentials so it can be used with one nvm key
add/move comments

#### Testing
This was tested on EFR32.
setSchedule, getSchedule and clearSchedule were test for weekDay, yearDay and holiday schedules
