### PR TITLE
[door-lock] Validate OperatingMode attribute

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -313,6 +313,8 @@ private:
     void clearHolidaySchedule(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                               uint8_t holidayIndex);
 
+    bool RemoteOperationEnabled(chip::EndpointId endpointId) const;
+
     /**
      * @brief Common handler for LockDoor, UnlockDoor, UnlockWithTimeout commands
      *
@@ -378,7 +380,7 @@ private:
      */
     template <typename T>
     bool GetAttribute(chip::EndpointId endpointId, chip::AttributeId attributeId,
-                      EmberAfStatus (*getFn)(chip::EndpointId endpointId, T * value), T & value);
+                      EmberAfStatus (*getFn)(chip::EndpointId endpointId, T * value), T & value) const;
 
     /**
      * @brief Set generic attribute value

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -134,7 +134,25 @@ tests:
       response:
           value: 1
 
+    - label: "Set OperatingMode to NoRemoteLockUnlock"
+      command: "writeAttribute"
+      attribute: "OperatingMode"
+      arguments:
+          value: 3
+
+    - label: "Try to unlock the door when OperatingMode is NoRemoteLockUnlock"
+      command: "LockDoor"
+      timedInteractionTimeoutMs: 10000
+      response:
+          error: FAILURE
+
     # Clean-up
+    - label: "Set OperatingMode to Normal"
+      command: "writeAttribute"
+      attribute: "OperatingMode"
+      arguments:
+          value: 0
+
     - label: "Clean the created credential"
       command: "ClearCredential"
       timedInteractionTimeoutMs: 10000

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -57302,7 +57302,7 @@ private:
 class DL_LockUnlockSuite : public TestCommand
 {
 public:
-    DL_LockUnlockSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("DL_LockUnlock", 15, credsIssuerConfig)
+    DL_LockUnlockSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("DL_LockUnlock", 18, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -57426,6 +57426,15 @@ private:
             }
             break;
         case 14:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 15:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            break;
+        case 16:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 17:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         default:
@@ -57561,7 +57570,32 @@ private:
                                  chip::NullOptional);
         }
         case 14: {
-            LogStep(14, "Clean the created credential");
+            LogStep(14, "Set OperatingMode to NoRemoteLockUnlock");
+            ListFreer listFreer;
+            chip::app::Clusters::DoorLock::DlOperatingMode value;
+            value = static_cast<chip::app::Clusters::DoorLock::DlOperatingMode>(3);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), DoorLock::Id, DoorLock::Attributes::OperatingMode::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 15: {
+            LogStep(15, "Try to unlock the door when OperatingMode is NoRemoteLockUnlock");
+            ListFreer listFreer;
+            chip::app::Clusters::DoorLock::Commands::LockDoor::Type value;
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), DoorLock::Id, DoorLock::Commands::LockDoor::Id, value,
+                               chip::Optional<uint16_t>(10000), chip::NullOptional
+
+            );
+        }
+        case 16: {
+            LogStep(16, "Set OperatingMode to Normal");
+            ListFreer listFreer;
+            chip::app::Clusters::DoorLock::DlOperatingMode value;
+            value = static_cast<chip::app::Clusters::DoorLock::DlOperatingMode>(0);
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(1), DoorLock::Id, DoorLock::Attributes::OperatingMode::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 17: {
+            LogStep(17, "Clean the created credential");
             ListFreer listFreer;
             chip::app::Clusters::DoorLock::Commands::ClearCredential::Type value;
             value.credential.SetNonNull();


### PR DESCRIPTION
#### Problem
DoorLock Lock and Unlock commands should fail if OperatingMode is set to Privacy or NoRemoteLockUnlock.

#### Change overview
Add an appropriate check.
Add validation steps to the DoorLock test.

#### Testing
Ran DL_LockUnlock YAML tests.
