### PR TITLE
[python] Split Python wheel in two separate wheels

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -316,7 +316,9 @@ jobs:
             - name: Run Python library specific unit tests
               timeout-minutes: 5
               run: |
-                  scripts/run_in_build_env.sh 'pip3 install ./out/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl'
+                  scripts/run_in_build_env.sh 'pip3 install ./out/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl'
+                  scripts/run_in_build_env.sh 'pip3 install ./out/controller/python/chip_clusters-0.0-py3-none-any.whl'
+                  scripts/run_in_build_env.sh 'pip3 install ./out/controller/python/chip_repl-0.0-py3-none-any.whl'
                   scripts/run_in_build_env.sh '(cd src/controller/python/test/unit_tests/ && python3 -m unittest -v)'
 
     build_darwin:

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -140,7 +140,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         if (enable_pylib) {
           deps += [ "${chip_root}/src/pybindings/pycontroller" ]
         }
-        deps += [ "${chip_root}/src/controller/python" ]
+        deps += [ "${chip_root}/src/controller/python:chip-repl" ]
       }
     }
 
@@ -166,7 +166,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         if (enable_pylib) {
           data_deps += [ "${chip_root}/src/pybindings/pycontroller" ]
         }
-        data_deps += [ "${chip_root}/src/controller/python" ]
+        data_deps += [ "${chip_root}/src/controller/python:chip-repl" ]
       }
 
       write_runtime_deps = "${root_out_dir}/certification.runtime_deps"

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -273,7 +273,7 @@ class HostBuilder(GnBuilder):
         elif app == HostApp.PYTHON_BINDINGS:
             self.extra_gn_options.append('enable_rtti=false')
             self.extra_gn_options.append('chip_project_config_include_dirs=["//config/python"]')
-            self.build_command = 'python'
+            self.build_command = 'chip-repl'
 
     def GnBuildArgs(self):
         if self.board == HostBoard.NATIVE:

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -359,7 +359,7 @@ ninja -C {out}/linux-arm64-ota-requestor
 ninja -C {out}/linux-arm64-ota-requestor-ipv6only
 
 # Building linux-arm64-python-bindings
-ninja -C {out}/linux-arm64-python-bindings python
+ninja -C {out}/linux-arm64-python-bindings chip-repl
 
 # Building linux-arm64-shell
 ninja -C {out}/linux-arm64-shell
@@ -470,7 +470,7 @@ ninja -C {out}/linux-x64-ota-requestor
 ninja -C {out}/linux-x64-ota-requestor-ipv6only
 
 # Building linux-x64-python-bindings
-ninja -C {out}/linux-x64-python-bindings python
+ninja -C {out}/linux-x64-python-bindings chip-repl
 
 # Building linux-x64-rpc-console
 ninja -C {out}/linux-x64-rpc-console

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -120,13 +120,13 @@ gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_deta
 if [ "$enable_pybindings" == true ]; then
     ninja -C "$OUTPUT_ROOT" pycontroller
 else
-    ninja -C "$OUTPUT_ROOT" python
+    ninja -C "$OUTPUT_ROOT" chip-repl chip-library
 fi
 
 if [ "$enable_pybindings" == true ]; then
-    WHEEL=$(ls "$OUTPUT_ROOT"/pybindings/pycontroller/pychip-*.whl | head -n 1)
+    WHEEL=("$OUTPUT_ROOT"/pybindings/pycontroller/pychip-*.whl)
 else
-    WHEEL=$(ls "$OUTPUT_ROOT"/controller/python/chip-*.whl | head -n 1)
+    WHEEL=("$OUTPUT_ROOT"/controller/python/chip*.whl)
 fi
 
 if [ "$install_wheel" = "no" ]; then
@@ -137,7 +137,7 @@ elif [ "$install_wheel" = "separate" ]; then
 
     source "$ENVIRONMENT_ROOT"/bin/activate
     "$ENVIRONMENT_ROOT"/bin/python -m pip install --upgrade pip
-    "$ENVIRONMENT_ROOT"/bin/pip install --upgrade --force-reinstall --no-cache-dir "$WHEEL"
+    "$ENVIRONMENT_ROOT"/bin/pip install --upgrade --force-reinstall --no-cache-dir "${WHEEL[@]}"
 
     echo ""
     echo_green "Compilation completed and WHL package installed in: "
@@ -146,7 +146,7 @@ elif [ "$install_wheel" = "separate" ]; then
     echo_green "To use please run:"
     echo_bold_white "  source $ENVIRONMENT_ROOT/bin/activate"
 elif [ "$install_wheel" = "build-env" ]; then
-    pip install --force-reinstall "$WHEEL"
+    pip install --force-reinstall "${WHEEL[@]}"
 
     echo ""
     echo_green "Compilation completed and WHL package installed in virtualenv for building sdk"

--- a/scripts/build_python.sh
+++ b/scripts/build_python.sh
@@ -120,7 +120,7 @@ gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_deta
 if [ "$enable_pybindings" == true ]; then
     ninja -C "$OUTPUT_ROOT" pycontroller
 else
-    ninja -C "$OUTPUT_ROOT" chip-repl chip-library
+    ninja -C "$OUTPUT_ROOT" chip-repl
 fi
 
 if [ "$enable_pybindings" == true ]; then

--- a/scripts/build_python_device.sh
+++ b/scripts/build_python_device.sh
@@ -104,7 +104,7 @@ gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_deta
 if [ "$enable_pybindings" == true ]; then
     ninja -v -C "$OUTPUT_ROOT" pycontroller
 else
-    ninja -v -C "$OUTPUT_ROOT" python
+    ninja -v -C "$OUTPUT_ROOT" chip-library
 fi
 
 # Create a virtual environment that has access to the built python tools
@@ -113,14 +113,14 @@ virtualenv --clear "$ENVIRONMENT_ROOT"
 # Activate the new environment to register the python WHL
 
 if [ "$enable_pybindings" == true ]; then
-    WHEEL=$(ls "$OUTPUT_ROOT"/pybindings/pycontroller/pychip-*.whl | head -n 1)
+    WHEEL=("$OUTPUT_ROOT"/pybindings/pycontroller/pychip-*.whl)
 else
-    WHEEL=$(ls "$OUTPUT_ROOT"/controller/python/chip-*.whl | head -n 1)
+    WHEEL=("$OUTPUT_ROOT"/controller/python/chip_library*.whl)
 fi
 
 source "$ENVIRONMENT_ROOT"/bin/activate
 "$ENVIRONMENT_ROOT"/bin/python -m pip install --upgrade pip
-"$ENVIRONMENT_ROOT"/bin/pip install --upgrade --force-reinstall --no-cache-dir "$WHEEL"
+"$ENVIRONMENT_ROOT"/bin/pip install --upgrade --force-reinstall --no-cache-dir "${WHEEL[@]}"
 
 echo ""
 echo_green "Compilation completed and WHL package installed in: "

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -206,8 +206,34 @@ pw_python_action("python") {
     ]
   }
 
+  _py_packages = [
+    "chip",
+    "chip.ble",
+    "chip.ble.commissioning",
+    "chip.configuration",
+    "chip.clusters",
+    "chip.utils",
+    "chip.discovery",
+    "chip.exceptions",
+    "chip.internal",
+    "chip.interaction_model",
+    "chip.logging",
+    "chip.native",
+    "chip.clusters",
+    "chip.tlv",
+    "chip.setup_payload",
+    "chip.storage",
+  ]
+
+  if (!chip_controller) {
+    _py_packages += [
+      "chip.server",
+    ]
+  }
+
   _py_manifest = {
     files = _py_manifest_files_rebased
+    packages = _py_packages
   }
 
   write_file(_py_manifest_file, _py_manifest, "json")

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -176,7 +176,7 @@ template("chip_python_wheel_action") {
   }
 }
 
-chip_python_wheel_action("chip-library") {
+chip_python_wheel_action("chip-core") {
 
   py_manifest_files = [
     {
@@ -188,7 +188,6 @@ chip_python_wheel_action("chip-library") {
         "chip/ChipCommissionableNodeCtrl.py",
         "chip/ChipCoreBluetoothMgr.py",
         "chip/ChipStack.py",
-        "chip/ChipUtility.py",
         "chip/FabricAdmin.py",
         "chip/__init__.py",
         "chip/ble/__init__.py",
@@ -198,12 +197,7 @@ chip_python_wheel_action("chip-library") {
         "chip/ble/scan_devices.py",
         "chip/ble/types.py",
         "chip/clusters/Attribute.py",
-        "chip/clusters/CHIPClusters.py",
-        "chip/clusters/ClusterObjects.py",
         "chip/clusters/Command.py",
-        "chip/clusters/Objects.py",
-        "chip/clusters/TestObjects.py",
-        "chip/clusters/Types.py",
         "chip/clusters/__init__.py",
         "chip/configuration/__init__.py",
         "chip/discovery/__init__.py",
@@ -223,7 +217,6 @@ chip_python_wheel_action("chip-library") {
         "chip/setup_payload/__init__.py",
         "chip/setup_payload/setup_payload.py",
         "chip/storage/__init__.py",
-        "chip/tlv/__init__.py",
         "chip/utils/CommissioningBuildingBlocks.py",
         "chip/utils/__init__.py",
       ]
@@ -271,7 +264,6 @@ chip_python_wheel_action("chip-library") {
     "chip.logging",
     "chip.native",
     "chip.clusters",
-    "chip.tlv",
     "chip.setup_payload",
     "chip.storage",
   ]
@@ -324,11 +316,49 @@ chip_python_wheel_action("chip-library") {
     lib_name = "_ChipServer.so"
   }
 
-  py_package_name = "chip-library"
+  py_package_name = "chip-core"
 
   public_deps = [ ":ChipDeviceCtrl" ]
 
-  output_name = "chip_library-${chip_python_version}-${tags}.whl"
+  output_name = "chip_core-${chip_python_version}-${tags}.whl"
+}
+
+chip_python_wheel_action("chip-clusters") {
+  py_manifest_files = [
+    {
+      src_dir = "."
+      sources = [
+        "chip/ChipUtility.py",
+        "chip/clusters/CHIPClusters.py",
+        "chip/clusters/ClusterObjects.py",
+        "chip/clusters/Objects.py",
+        "chip/clusters/TestObjects.py",
+        "chip/clusters/Types.py",
+        "chip/tlv/__init__.py",
+      ]
+    },
+    {
+      src_dir = "//"
+      sources = [ "//LICENSE" ]
+    },
+  ]
+
+  inputs = []
+
+  py_packages = [
+    "chip",
+    "chip.clusters",
+    "chip.tlv",
+  ]
+
+  py_package_reqs = [
+    "dacite",
+  ]
+
+  py_package_name = "chip-clusters"
+  py_platform_tag = "any"
+
+  output_name = "chip_clusters-${chip_python_version}-py3-any.whl"
 }
 
 chip_python_wheel_action("chip-repl") {
@@ -373,7 +403,7 @@ chip_python_wheel_action("chip-repl") {
   py_package_name = "chip-repl"
   py_platform_tag = "any"
 
-  data_deps = [ ":chip-library" ]
+  data_deps = [ ":chip-core", ":chip-clusters" ]
 
   output_name = "chip_repl-${chip_python_version}-py3-any.whl"
 }

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -271,6 +271,12 @@ pw_python_action("python") {
 
   tags = "cp37-abi3-" + platform_tag
 
+  if (chip_controller) {
+    lib_name = "_ChipDeviceCtrl.so"
+  } else {
+    lib_name = "_ChipServer.so"
+  }
+
   args = [
     "--package_name",
     "chip",
@@ -284,15 +290,9 @@ pw_python_action("python") {
     rebase_path(_py_manifest_file, root_build_dir),
     "--plat-name",
     platform_tag,
+    "--lib-name",
+    lib_name,
   ]
-
-  if (chip_controller) {
-  } else {
-    args += [
-      "--server",
-      "True",
-    ]
-  }
 
   public_deps = [ ":ChipDeviceCtrl" ]
 

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -373,5 +373,7 @@ chip_python_wheel_action("chip-repl") {
   py_package_name = "chip-repl"
   py_platform_tag = "any"
 
+  data_deps = [ ":chip-library" ]
+
   output_name = "chip_repl-${chip_python_version}-py3-any.whl"
 }

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -30,6 +30,8 @@ config("controller_wno_deprecate") {
   cflags = [ "-Wno-deprecated-declarations" ]
 }
 
+chip_python_version = "0.0"
+
 shared_library("ChipDeviceCtrl") {
   if (chip_controller) {
     output_name = "_ChipDeviceCtrl"
@@ -112,10 +114,71 @@ shared_library("ChipDeviceCtrl") {
   configs += [ ":controller_wno_deprecate" ]
 }
 
-pw_python_action("chip-library") {
-  script = "build-chip-wheel.py"
+template("chip_python_wheel_action") {
+  _dist_dir = "${root_out_dir}/controller/python"
 
-  _py_manifest_files = [
+  _py_manifest_file = "${target_gen_dir}/${target_name}.py_manifest.json"
+
+  pw_python_action(target_name) {
+    script = "build-chip-wheel.py"
+    forward_variables_from(invoker, "*")
+
+    _py_manifest_files_rebased = []
+    foreach(_manifest_entry, py_manifest_files) {
+      inputs += _manifest_entry.sources
+      _py_manifest_files_rebased += [
+        {
+          src_dir = rebase_path(_manifest_entry.src_dir,
+                                get_path_info(_py_manifest_file, "dir"))
+          sources = rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
+        },
+      ]
+    }
+
+    if (defined(invoker.py_scripts)) {
+      _py_scripts = invoker.py_scripts
+    } else {
+      _py_scripts = [ ]
+    }
+
+    _py_manifest = {
+      files = _py_manifest_files_rebased
+      packages = py_packages
+      scripts = _py_scripts
+      package_reqs = py_package_reqs
+    }
+
+    write_file(_py_manifest_file, _py_manifest, "json")
+
+    args = [
+      "--package_name",
+      py_package_name,
+      "--build_number",
+      chip_python_version,
+      "--build_dir",
+      rebase_path("${target_gen_dir}/${target_name}.py_build", root_build_dir),
+      "--dist_dir",
+      rebase_path(_dist_dir, root_build_dir),
+      "--manifest",
+      rebase_path(_py_manifest_file, root_build_dir),
+      "--plat-name",
+      py_platform_tag,
+    ]
+
+    if (defined(invoker.lib_name)) {
+      args += [
+        "--lib-name",
+        lib_name,
+      ]
+    }
+
+    outputs = [ "${_dist_dir}/$output_name" ]
+  }
+}
+
+chip_python_wheel_action("chip-library") {
+
+  py_manifest_files = [
     {
       src_dir = "."
       sources = [
@@ -192,22 +255,9 @@ pw_python_action("chip-library") {
     },
   ]
 
-  _py_manifest_file = "${target_gen_dir}/${target_name}.py_manifest.json"
-
   inputs = []
-  _py_manifest_files_rebased = []
-  foreach(_manifest_entry, _py_manifest_files) {
-    inputs += _manifest_entry.sources
-    _py_manifest_files_rebased += [
-      {
-        src_dir = rebase_path(_manifest_entry.src_dir,
-                              get_path_info(_py_manifest_file, "dir"))
-        sources = rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
-      },
-    ]
-  }
 
-  _py_packages = [
+  py_packages = [
     "chip",
     "chip.ble",
     "chip.ble.commissioning",
@@ -227,12 +277,12 @@ pw_python_action("chip-library") {
   ]
 
   if (!chip_controller) {
-    _py_packages += [
+    py_packages += [
       "chip.server",
     ]
   }
 
-  _py_package_reqs = [
+  py_package_reqs = [
     "coloredlogs",
     "construct",
     "dacite",
@@ -243,21 +293,10 @@ pw_python_action("chip-library") {
   ]
 
   if (current_os == "mac") {
-    _py_package_reqs += [ "pyobjc-framework-corebluetooth" ]
+    py_package_reqs += [ "pyobjc-framework-corebluetooth" ]
   } else if (current_os == "linux") {
-    _py_package_reqs += [ "dbus-python", "pygobject" ]
+    py_package_reqs += [ "dbus-python", "pygobject" ]
   }
-
-  _py_manifest = {
-    files = _py_manifest_files_rebased
-    packages = _py_packages
-    scripts = [ ]
-    package_reqs = _py_package_reqs
-  }
-
-  write_file(_py_manifest_file, _py_manifest, "json")
-
-  _dist_dir = "${root_out_dir}/controller/python"
 
   if (current_cpu == "x64") {
     cpu_tag = "x86_64"
@@ -270,14 +309,14 @@ pw_python_action("chip-library") {
   }
 
   if (current_os == "mac") {
-    platform_tag = "macosx_" + string_replace(mac_deployment_target, ".", "_")
+    py_platform_tag = "macosx_" + string_replace(mac_deployment_target, ".", "_")
   } else {
-    platform_tag = current_os
+    py_platform_tag = current_os
   }
 
-  platform_tag = platform_tag + "_" + cpu_tag
+  py_platform_tag = py_platform_tag + "_" + cpu_tag
 
-  tags = "cp37-abi3-" + platform_tag
+  tags = "cp37-abi3-" + py_platform_tag
 
   if (chip_controller) {
     lib_name = "_ChipDeviceCtrl.so"
@@ -285,44 +324,26 @@ pw_python_action("chip-library") {
     lib_name = "_ChipServer.so"
   }
 
-  args = [
-    "--package_name",
-    "chip-library",
-    "--build_number",
-    "0.0",
-    "--build_dir",
-    rebase_path("${target_gen_dir}/${target_name}.py_build", root_build_dir),
-    "--dist_dir",
-    rebase_path(_dist_dir, root_build_dir),
-    "--manifest",
-    rebase_path(_py_manifest_file, root_build_dir),
-    "--plat-name",
-    platform_tag,
-    "--lib-name",
-    lib_name,
-  ]
+  py_package_name = "chip-library"
 
   public_deps = [ ":ChipDeviceCtrl" ]
 
-  output_name = "chip-library-0.0-${tags}.whl"
-  outputs = [ "${_dist_dir}/$output_name" ]
+  output_name = "chip_library-${chip_python_version}-${tags}.whl"
 }
 
-pw_python_action("chip-repl") {
-  script = "build-chip-wheel.py"
-
-  _py_scripts = [
+chip_python_wheel_action("chip-repl") {
+  py_scripts = [
     "chip-device-ctrl.py",
     "chip-repl.py",
   ]
 
-  _py_manifest_files = [
+  py_manifest_files = [
     {
       src_dir = "."
       sources = [
         "chip/ChipReplStartup.py",
       ]
-      sources += _py_scripts
+      sources += py_scripts
     },
     {
       src_dir = "//"
@@ -330,22 +351,11 @@ pw_python_action("chip-repl") {
     },
   ]
 
-  _py_manifest_file = "${target_gen_dir}/${target_name}.py_manifest.json"
-
   inputs = []
-  _py_manifest_files_rebased = []
-  foreach(_manifest_entry, _py_manifest_files) {
-    inputs += _manifest_entry.sources
-    _py_manifest_files_rebased += [
-      {
-        src_dir = rebase_path(_manifest_entry.src_dir,
-                              get_path_info(_py_manifest_file, "dir"))
-        sources = rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
-      },
-    ]
-  }
 
-  _py_package_reqs = [
+  py_packages = [ "chip" ]
+
+  py_package_reqs = [
     "coloredlogs",
 
     #
@@ -360,32 +370,8 @@ pw_python_action("chip-repl") {
     "ipykernel",
   ]
 
-  _py_manifest = {
-    files = _py_manifest_files_rebased
-    packages = [ "chip" ]
-    scripts = _py_scripts
-    package_reqs = _py_package_reqs
-  }
+  py_package_name = "chip-repl"
+  py_platform_tag = "any"
 
-  write_file(_py_manifest_file, _py_manifest, "json")
-
-  _dist_dir = "${root_out_dir}/controller/python"
-
-  args = [
-    "--package_name",
-    "chip-repl",
-    "--build_number",
-    "0.0",
-    "--build_dir",
-    rebase_path("${target_gen_dir}/${target_name}.py_build", root_build_dir),
-    "--dist_dir",
-    rebase_path(_dist_dir, root_build_dir),
-    "--manifest",
-    rebase_path(_py_manifest_file, root_build_dir),
-    "--plat-name",
-    "any",
-  ]
-
-  output_name = "chip-repl-0.0-py3-any.whl"
-  outputs = [ "${_dist_dir}/$output_name" ]
+  output_name = "chip_repl-${chip_python_version}-py3-any.whl"
 }

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -112,7 +112,7 @@ shared_library("ChipDeviceCtrl") {
   configs += [ ":controller_wno_deprecate" ]
 }
 
-pw_python_action("python") {
+pw_python_action("chip-library") {
   script = "build-chip-wheel.py"
 
   _py_manifest_files = [
@@ -124,7 +124,6 @@ pw_python_action("python") {
         "chip/ChipBluezMgr.py",
         "chip/ChipCommissionableNodeCtrl.py",
         "chip/ChipCoreBluetoothMgr.py",
-        "chip/ChipReplStartup.py",
         "chip/ChipStack.py",
         "chip/ChipUtility.py",
         "chip/FabricAdmin.py",
@@ -233,32 +232,13 @@ pw_python_action("python") {
     ]
   }
 
-  _py_scripts = [ ]
-  if (chip_controller) {
-    _py_scripts += [
-      "chip-device-ctrl.py",
-      "chip-repl.py",
-    ]
-  }
-
   _py_package_reqs = [
     "coloredlogs",
     "construct",
-
-    #
-    # IPython 7.30.0 has a bug which results in the use of await ... failing on some platforms (see https://github.com/ipython/ipython/pull/13269)
-    # For now, let's just avoid that version.
-    #
-    # IPython 8.1.0 has a bug which causes issues: https://github.com/ipython/ipython/issues/13554
-    #
-    #
-    "ipython!=8.1.0",
     "dacite",
     "rich",
-    "stringcase",
     "pyyaml",
     "ipdb",
-    "ipykernel",
     "deprecation"
   ]
 
@@ -271,7 +251,7 @@ pw_python_action("python") {
   _py_manifest = {
     files = _py_manifest_files_rebased
     packages = _py_packages
-    scripts = _py_scripts
+    scripts = [ ]
     package_reqs = _py_package_reqs
   }
 
@@ -307,7 +287,7 @@ pw_python_action("python") {
 
   args = [
     "--package_name",
-    "chip",
+    "chip-library",
     "--build_number",
     "0.0",
     "--build_dir",
@@ -324,6 +304,88 @@ pw_python_action("python") {
 
   public_deps = [ ":ChipDeviceCtrl" ]
 
-  output_name = "chip-0.0-${tags}.whl"
+  output_name = "chip-library-0.0-${tags}.whl"
+  outputs = [ "${_dist_dir}/$output_name" ]
+}
+
+pw_python_action("chip-repl") {
+  script = "build-chip-wheel.py"
+
+  _py_scripts = [
+    "chip-device-ctrl.py",
+    "chip-repl.py",
+  ]
+
+  _py_manifest_files = [
+    {
+      src_dir = "."
+      sources = [
+        "chip/ChipReplStartup.py",
+      ]
+      sources += _py_scripts
+    },
+    {
+      src_dir = "//"
+      sources = [ "//LICENSE" ]
+    },
+  ]
+
+  _py_manifest_file = "${target_gen_dir}/${target_name}.py_manifest.json"
+
+  inputs = []
+  _py_manifest_files_rebased = []
+  foreach(_manifest_entry, _py_manifest_files) {
+    inputs += _manifest_entry.sources
+    _py_manifest_files_rebased += [
+      {
+        src_dir = rebase_path(_manifest_entry.src_dir,
+                              get_path_info(_py_manifest_file, "dir"))
+        sources = rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
+      },
+    ]
+  }
+
+  _py_package_reqs = [
+    "coloredlogs",
+
+    #
+    # IPython 7.30.0 has a bug which results in the use of await ... failing on some platforms (see https://github.com/ipython/ipython/pull/13269)
+    # For now, let's just avoid that version.
+    #
+    # IPython 8.1.0 has a bug which causes issues: https://github.com/ipython/ipython/issues/13554
+    #
+    #
+    "ipython!=8.1.0",
+    "rich",
+    "ipykernel",
+  ]
+
+  _py_manifest = {
+    files = _py_manifest_files_rebased
+    packages = [ "chip" ]
+    scripts = _py_scripts
+    package_reqs = _py_package_reqs
+  }
+
+  write_file(_py_manifest_file, _py_manifest, "json")
+
+  _dist_dir = "${root_out_dir}/controller/python"
+
+  args = [
+    "--package_name",
+    "chip-repl",
+    "--build_number",
+    "0.0",
+    "--build_dir",
+    rebase_path("${target_gen_dir}/${target_name}.py_build", root_build_dir),
+    "--dist_dir",
+    rebase_path(_dist_dir, root_build_dir),
+    "--manifest",
+    rebase_path(_py_manifest_file, root_build_dir),
+    "--plat-name",
+    "any",
+  ]
+
+  output_name = "chip-repl-0.0-py3-any.whl"
   outputs = [ "${_dist_dir}/$output_name" ]
 }

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -130,7 +130,8 @@ template("chip_python_wheel_action") {
         {
           src_dir = rebase_path(_manifest_entry.src_dir,
                                 get_path_info(_py_manifest_file, "dir"))
-          sources = rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
+          sources =
+              rebase_path(_manifest_entry.sources, _manifest_entry.src_dir)
         },
       ]
     }
@@ -138,7 +139,7 @@ template("chip_python_wheel_action") {
     if (defined(invoker.py_scripts)) {
       _py_scripts = invoker.py_scripts
     } else {
-      _py_scripts = [ ]
+      _py_scripts = []
     }
 
     _py_manifest = {
@@ -177,7 +178,6 @@ template("chip_python_wheel_action") {
 }
 
 chip_python_wheel_action("chip-core") {
-
   py_manifest_files = [
     {
       src_dir = "."
@@ -269,9 +269,7 @@ chip_python_wheel_action("chip-core") {
   ]
 
   if (!chip_controller) {
-    py_packages += [
-      "chip.server",
-    ]
+    py_packages += [ "chip.server" ]
   }
 
   py_package_reqs = [
@@ -281,13 +279,16 @@ chip_python_wheel_action("chip-core") {
     "rich",
     "pyyaml",
     "ipdb",
-    "deprecation"
+    "deprecation",
   ]
 
   if (current_os == "mac") {
     py_package_reqs += [ "pyobjc-framework-corebluetooth" ]
   } else if (current_os == "linux") {
-    py_package_reqs += [ "dbus-python", "pygobject" ]
+    py_package_reqs += [
+      "dbus-python",
+      "pygobject",
+    ]
   }
 
   if (current_cpu == "x64") {
@@ -301,7 +302,8 @@ chip_python_wheel_action("chip-core") {
   }
 
   if (current_os == "mac") {
-    py_platform_tag = "macosx_" + string_replace(mac_deployment_target, ".", "_")
+    py_platform_tag =
+        "macosx_" + string_replace(mac_deployment_target, ".", "_")
   } else {
     py_platform_tag = current_os
   }
@@ -351,9 +353,7 @@ chip_python_wheel_action("chip-clusters") {
     "chip.tlv",
   ]
 
-  py_package_reqs = [
-    "dacite",
-  ]
+  py_package_reqs = [ "dacite" ]
 
   py_package_name = "chip-clusters"
   py_platform_tag = "any"
@@ -370,9 +370,7 @@ chip_python_wheel_action("chip-repl") {
   py_manifest_files = [
     {
       src_dir = "."
-      sources = [
-        "chip/ChipReplStartup.py",
-      ]
+      sources = [ "chip/ChipReplStartup.py" ]
       sources += py_scripts
     },
     {
@@ -403,7 +401,10 @@ chip_python_wheel_action("chip-repl") {
   py_package_name = "chip-repl"
   py_platform_tag = "any"
 
-  data_deps = [ ":chip-core", ":chip-clusters" ]
+  data_deps = [
+    ":chip-clusters",
+    ":chip-core",
+  ]
 
   output_name = "chip_repl-${chip_python_version}-py3-any.whl"
 }

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -119,8 +119,6 @@ pw_python_action("python") {
     {
       src_dir = "."
       sources = [
-        "chip-device-ctrl.py",
-        "chip-repl.py",
         "chip/ChipBleBase.py",
         "chip/ChipBleUtility.py",
         "chip/ChipBluezMgr.py",
@@ -169,7 +167,11 @@ pw_python_action("python") {
       ]
 
       if (chip_controller) {
-        sources += [ "chip/ChipDeviceCtrl.py" ]
+        sources += [
+          "chip-device-ctrl.py",
+          "chip-repl.py",
+          "chip/ChipDeviceCtrl.py",
+        ]
       } else {
         sources += [
           "chip/server/__init__.py",
@@ -231,9 +233,18 @@ pw_python_action("python") {
     ]
   }
 
+  _py_scripts = [ ]
+  if (chip_controller) {
+    _py_scripts += [
+      "chip-device-ctrl.py",
+      "chip-repl.py",
+    ]
+  }
+
   _py_manifest = {
     files = _py_manifest_files_rebased
     packages = _py_packages
+    scripts = _py_scripts
   }
 
   write_file(_py_manifest_file, _py_manifest, "json")

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -241,10 +241,38 @@ pw_python_action("python") {
     ]
   }
 
+  _py_package_reqs = [
+    "coloredlogs",
+    "construct",
+
+    #
+    # IPython 7.30.0 has a bug which results in the use of await ... failing on some platforms (see https://github.com/ipython/ipython/pull/13269)
+    # For now, let's just avoid that version.
+    #
+    # IPython 8.1.0 has a bug which causes issues: https://github.com/ipython/ipython/issues/13554
+    #
+    #
+    "ipython!=8.1.0",
+    "dacite",
+    "rich",
+    "stringcase",
+    "pyyaml",
+    "ipdb",
+    "ipykernel",
+    "deprecation"
+  ]
+
+  if (current_os == "mac") {
+    _py_package_reqs += [ "pyobjc-framework-corebluetooth" ]
+  } else if (current_os == "linux") {
+    _py_package_reqs += [ "dbus-python", "pygobject" ]
+  }
+
   _py_manifest = {
     files = _py_manifest_files_rebased
     packages = _py_packages
     scripts = _py_scripts
+    package_reqs = _py_package_reqs
   }
 
   write_file(_py_manifest_file, _py_manifest, "json")

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -29,7 +29,6 @@ from wheel.bdist_wheel import bdist_wheel
 import argparse
 import json
 import os
-import platform
 import shutil
 
 
@@ -111,33 +110,7 @@ try:
             bdist_wheel.finalize_options(self)
             self.root_is_pure = False
 
-    requiredPackages = [
-        "coloredlogs",
-        'construct',
-
-        #
-        # IPython 7.30.0 has a bug which results in the use of await ... failing on some platforms (see https://github.com/ipython/ipython/pull/13269)
-        # For now, let's just avoid that version.
-        #
-        # IPython 8.1.0 has a bug which causes issues: https://github.com/ipython/ipython/issues/13554
-        #
-        #
-        'ipython!=8.1.0',
-        'dacite',
-        'rich',
-        'stringcase',
-        'pyyaml',
-        'ipdb',
-        'ipykernel',
-        'deprecation'
-    ]
-
-    if platform.system() == "Darwin":
-        requiredPackages.append("pyobjc-framework-corebluetooth")
-
-    if platform.system() == "Linux":
-        requiredPackages.append("dbus-python")
-        requiredPackages.append("pygobject")
+    requiredPackages = manifest['package_reqs']
 
     #
     # Build the chip package...

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -45,7 +45,7 @@ parser.add_argument('--manifest', help='list of files to package')
 parser.add_argument(
     '--plat-name', help='platform name to embed in generated filenames')
 parser.add_argument(
-    '--server', help='build the server variant', default=False, type=bool)
+    '--lib-name', help='the native library to include (if any)', default=None)
 
 args = parser.parse_args()
 
@@ -58,11 +58,8 @@ class InstalledScriptInfo:
         self.installName = os.path.splitext(name)[0]
 
 
-if args.server:
-    chipDLLName = "_ChipServer.so"
-else:
-    chipDLLName = "_ChipDeviceCtrl.so"
 packageName = args.package_name
+libName = args.lib_name
 chipPackageVer = args.build_number
 
 # Record the current directory at the start of execution.
@@ -148,7 +145,7 @@ try:
     packages = manifest['packages']
 
     print("packageName: {}".format(packageName))
-    print("chipDLLName: {}".format(chipDLLName))
+    print("libName: {}".format(libName))
 
     # Invoke the setuptools 'bdist_wheel' command to generate a wheel containing
     # the CHIP python packages, shared libraries and scripts.
@@ -173,8 +170,7 @@ try:
         },
         package_data={
             packageName: [
-                # Include the wrapper DLL as package data in the "chip" package.
-                chipDLLName
+                libName
             ]
         },
         scripts=[name for name in map(

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -65,14 +65,6 @@ else:
 packageName = args.package_name
 chipPackageVer = args.build_number
 
-if args.server:
-    installScripts = []
-else:
-    installScripts = [
-        InstalledScriptInfo("chip-device-ctrl.py"),
-        InstalledScriptInfo("chip-repl.py"),
-    ]
-
 # Record the current directory at the start of execution.
 curDir = os.curdir
 
@@ -110,6 +102,7 @@ try:
             os.makedirs(os.path.dirname(dstFile), exist_ok=True)
             shutil.copyfile(srcFile, dstFile)
 
+    installScripts = [ InstalledScriptInfo(script) for script in manifest['scripts'] ]
     for script in installScripts:
         os.rename(os.path.join(tmpDir, script.name),
                   os.path.join(tmpDir, script.installName))

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -98,7 +98,7 @@ try:
             os.makedirs(os.path.dirname(dstFile), exist_ok=True)
             shutil.copyfile(srcFile, dstFile)
 
-    installScripts = [ InstalledScriptInfo(script) for script in manifest['scripts'] ]
+    installScripts = [InstalledScriptInfo(script) for script in manifest['scripts']]
     for script in installScripts:
         os.rename(os.path.join(tmpDir, script.name),
                   os.path.join(tmpDir, script.installName))
@@ -145,7 +145,7 @@ try:
             packages[0]: [
                 libName
             ]
-        } if libName else { },
+        } if libName else {},
         scripts=[name for name in map(
             lambda script: os.path.join(tmpDir, script.installName),
             installScripts
@@ -166,7 +166,7 @@ try:
         },
         cmdclass={
             'bdist_wheel': bdist_wheel_override
-        } if libName else { },
+        } if libName else {},
         script_args=['clean', '--all', 'bdist_wheel']
     )
 

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -142,10 +142,10 @@ try:
             '': tmpDir,
         },
         package_data={
-            packageName: [
+            packages[0]: [
                 libName
             ]
-        },
+        } if libName else { },
         scripts=[name for name in map(
             lambda script: os.path.join(tmpDir, script.installName),
             installScripts
@@ -166,7 +166,7 @@ try:
         },
         cmdclass={
             'bdist_wheel': bdist_wheel_override
-        },
+        } if libName else { },
         script_args=['clean', '--all', 'bdist_wheel']
     )
 

--- a/src/controller/python/build-chip-wheel.py
+++ b/src/controller/python/build-chip-wheel.py
@@ -152,29 +152,7 @@ try:
     #
     # Build the chip package...
     #
-    packages = [
-        'chip',
-        'chip.ble',
-        'chip.ble.commissioning',
-        'chip.configuration',
-        'chip.clusters',
-        'chip.utils',
-        'chip.discovery',
-        'chip.exceptions',
-        'chip.internal',
-        'chip.interaction_model',
-        'chip.logging',
-        'chip.native',
-        'chip.clusters',
-        'chip.tlv',
-        'chip.setup_payload',
-        'chip.storage',
-    ]
-    #print ("Server: {}".format(args.server))
-    if args.server:
-        packages.append('chip.server')
-
-    #print("packages: {}".format(packages))
+    packages = manifest['packages']
 
     print("packageName: {}".format(packageName))
     print("chipDLLName: {}".format(chipDLLName))

--- a/src/controller/python/chip/clusters/CHIPClusters.py
+++ b/src/controller/python/chip/clusters/CHIPClusters.py
@@ -20,8 +20,6 @@
 '''
 
 import ctypes
-from chip.ChipStack import *
-from chip.exceptions import *
 
 __all__ = ["ChipClusters"]
 

--- a/src/controller/python/templates/python-CHIPClusters-py.zapt
+++ b/src/controller/python/templates/python-CHIPClusters-py.zapt
@@ -3,8 +3,6 @@
 '''
 
 import ctypes
-from chip.ChipStack import *
-from chip.exceptions import *
 
 __all__ = ["ChipClusters"]
 

--- a/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
@@ -91,7 +91,11 @@ class TestCommissioningFailure(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {} --fail-on-report".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureOnReportTest.py
@@ -91,11 +91,11 @@ class TestCommissioningFailure(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {} --fail-on-report".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/CommissioningFailureTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureTest.py
@@ -91,11 +91,11 @@ class TestCommissioningFailure(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/CommissioningFailureTest.py
+++ b/src/test_driver/linux-cirque/CommissioningFailureTest.py
@@ -91,7 +91,11 @@ class TestCommissioningFailure(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/CommissioningTest.py
+++ b/src/test_driver/linux-cirque/CommissioningTest.py
@@ -107,7 +107,11 @@ class TestCommissioner(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {} --discriminator {} --nodeid {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/CommissioningTest.py
+++ b/src/test_driver/linux-cirque/CommissioningTest.py
@@ -107,11 +107,11 @@ class TestCommissioner(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {} --discriminator {} --nodeid {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/FailsafeTest.py
+++ b/src/test_driver/linux-cirque/FailsafeTest.py
@@ -91,7 +91,11 @@ class TestFailsafe(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/FailsafeTest.py
+++ b/src/test_driver/linux-cirque/FailsafeTest.py
@@ -91,11 +91,11 @@ class TestFailsafe(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 -a {} --paa-trust-store-path {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -91,7 +91,11 @@ class TestPythonController(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 240 -a {} --paa-trust-store-path {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -91,11 +91,11 @@ class TestPythonController(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 240 -a {} --paa-trust-store-path {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/SplitCommissioningTest.py
+++ b/src/test_driver/linux-cirque/SplitCommissioningTest.py
@@ -99,7 +99,11 @@ class TestSplitCommissioning(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
+        self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 --address1 {} --address2 {} --paa-trust-store-path {}".format(
             os.path.join(

--- a/src/test_driver/linux-cirque/SplitCommissioningTest.py
+++ b/src/test_driver/linux-cirque/SplitCommissioningTest.py
@@ -99,11 +99,11 @@ class TestSplitCommissioning(CHIPVirtualHome):
         req_device_id = req_ids[0]
 
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_clusters-0.0-py3-none-any.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_core-0.0-cp37-abi3-linux_x86_64.whl")))
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
-            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-cp37-abi3-linux_x86_64.whl")))
+            CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
         command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 150 --address1 {} --address2 {} --paa-trust-store-path {}".format(
             os.path.join(


### PR DESCRIPTION
#### Problem
Currently the Python Controller library is one large wheel, with the native library, the clusters, the interaction model and the REPL packed in a single wheel.

This PR is a first step in break out the library into smaller wheels.

#### Change overview
The first few commits aim to make the current wheel build logic more generic by moving most wheel specific information into `BUILD.gn`. Then this splits it in two wheels: The main wheel named `chip-library` (still fairly monolithic, with cluster library and interaction model in a single wheel), and a `chip-repl`, with the REPL and its dependency.

This lowers the dependency of `chip-library` already. I also plan to split the fairly independent cluster library into a separate wheel in a follow up PR.

#### Testing
Build and runtime tested locally (using `scripts/build_python.sh -m minimal  -i separate` and `chip-repl`).