### PR TITLE
Increase session pool size on Darwin so we don't run out of sessions.

### DIFF
--- a/config/ios/CHIPProjectConfig.h
+++ b/config/ios/CHIPProjectConfig.h
@@ -44,4 +44,9 @@
 #define CHIP_CONFIG_KVS_PATH "chip.store"
 #endif
 
+// The session pool size limits how many subscriptions we can have live at
+// once.  Home supports up to 1000 accessories, and we subscribe to all of them,
+// so we need to make sure the pool is big enough for that.
+#define CHIP_CONFIG_SECURE_SESSION_POOL_SIZE 1000
+
 #endif /* CHIPPROJECTCONFIG_H */


### PR DESCRIPTION
We want to have enough sessions for all the subscriptions we will want
to have.

#### Problem
Default pool size is too small for the number of devices we might want simultaneous subscriptions to.

#### Change overview
Bump the size.

