### PR TITLE
Restore return statement that went missing.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -335,6 +335,7 @@ CHIP_ERROR DeviceController::DisconnectDevice(NodeId nodeId)
     if (proxy->IsConnected())
     {
         proxy->Disconnect();
+        return CHIP_NO_ERROR;
     }
 
     if (proxy->IsConnecting())


### PR DESCRIPTION
The changes in https://github.com/project-chip/connectedhomeip/pull/19870
incorrectly removed a return here.  Now we'll fall through to the cases that
assume the proxy is not in a connected state to start with, which is not
desirable.

#### Problem
Logic was changed in a way it should not have been.

#### Change overview
Restore old logic flow.

#### Testing
Examined the code before/after the changes involved.