### PR TITLE
Make all public FabricInfo getters const

### DIFF
--- a/examples/all-clusters-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-app/esp32/main/include/ShellCommands.h
@@ -125,7 +125,7 @@ public:
     // Register the CASESession commands
     void Register();
 
-    void SetFabricInfo(FabricInfo * fabricInfo) { mFabricInfo = fabricInfo; }
+    void SetFabricInfo(const FabricInfo * fabricInfo) { mFabricInfo = fabricInfo; }
     void SetNodeId(NodeId nodeId) { mNodeId = nodeId; }
     void SetOnConnecting(bool onConnecting) { mOnConnecting = onConnecting; }
     const FabricInfo * GetFabricInfo(void) { return mFabricInfo; }

--- a/examples/all-clusters-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-app/esp32/main/include/ShellCommands.h
@@ -128,7 +128,7 @@ public:
     void SetFabricInfo(FabricInfo * fabricInfo) { mFabricInfo = fabricInfo; }
     void SetNodeId(NodeId nodeId) { mNodeId = nodeId; }
     void SetOnConnecting(bool onConnecting) { mOnConnecting = onConnecting; }
-    FabricInfo * GetFabricInfo(void) { return mFabricInfo; }
+    const FabricInfo * GetFabricInfo(void) { return mFabricInfo; }
     NodeId GetNodeId(void) { return mNodeId; }
     bool GetOnConnecting(void) { return mOnConnecting; }
 
@@ -167,7 +167,7 @@ private:
             return CHIP_ERROR_INCORRECT_STATE;
         }
         const FabricIndex fabricIndex = static_cast<FabricIndex>(strtoul(argv[0], nullptr, 10));
-        FabricInfo * fabricInfo       = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
+        const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
 
         if (fabricInfo == nullptr)
         {
@@ -201,9 +201,9 @@ private:
     static Callback::Callback<OnDeviceConnected> sOnConnectedCallback;
     static Callback::Callback<OnDeviceConnectionFailure> sOnConnectionFailureCallback;
     static Shell::Engine sSubShell;
-    FabricInfo * mFabricInfo = nullptr;
-    NodeId mNodeId           = 0;
-    bool mOnConnecting       = false;
+    const FabricInfo * mFabricInfo = nullptr;
+    NodeId mNodeId                 = 0;
+    bool mOnConnecting             = false;
 };
 
 } // namespace Shell

--- a/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
@@ -125,7 +125,7 @@ public:
     // Register the CASESession commands
     void Register();
 
-    void SetFabricInfo(FabricInfo * fabricInfo) { mFabricInfo = fabricInfo; }
+    void SetFabricInfo(const FabricInfo * fabricInfo) { mFabricInfo = fabricInfo; }
     void SetNodeId(NodeId nodeId) { mNodeId = nodeId; }
     void SetOnConnecting(bool onConnecting) { mOnConnecting = onConnecting; }
     const FabricInfo * GetFabricInfo(void) { return mFabricInfo; }

--- a/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
@@ -128,7 +128,7 @@ public:
     void SetFabricInfo(FabricInfo * fabricInfo) { mFabricInfo = fabricInfo; }
     void SetNodeId(NodeId nodeId) { mNodeId = nodeId; }
     void SetOnConnecting(bool onConnecting) { mOnConnecting = onConnecting; }
-    FabricInfo * GetFabricInfo(void) { return mFabricInfo; }
+    const FabricInfo * GetFabricInfo(void) { return mFabricInfo; }
     NodeId GetNodeId(void) { return mNodeId; }
     bool GetOnConnecting(void) { return mOnConnecting; }
 
@@ -167,7 +167,7 @@ private:
             return CHIP_ERROR_INCORRECT_STATE;
         }
         const FabricIndex fabricIndex = static_cast<FabricIndex>(strtoul(argv[0], nullptr, 10));
-        FabricInfo * fabricInfo       = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
+        const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
 
         if (fabricInfo == nullptr)
         {
@@ -201,9 +201,9 @@ private:
     static Callback::Callback<OnDeviceConnected> sOnConnectedCallback;
     static Callback::Callback<OnDeviceConnectionFailure> sOnConnectionFailureCallback;
     static Shell::Engine sSubShell;
-    FabricInfo * mFabricInfo = nullptr;
-    NodeId mNodeId           = 0;
-    bool mOnConnecting       = false;
+    const FabricInfo * mFabricInfo = nullptr;
+    NodeId mNodeId                 = 0;
+    bool mOnConnecting             = false;
 };
 
 } // namespace Shell

--- a/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
+++ b/examples/ota-provider-app/ota-provider-common/OTAProviderExample.cpp
@@ -247,9 +247,9 @@ void OTAProviderExample::SendQueryImageResponse(app::CommandHandler * commandObj
 
         // TODO: This uses the current node as the provider to supply the OTA image. This can be configurable such that the
         // provider supplying the response is not the provider supplying the OTA image.
-        FabricIndex fabricIndex = commandObj->GetAccessingFabricIndex();
-        FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
-        NodeId nodeId           = fabricInfo->GetPeerId().GetNodeId();
+        FabricIndex fabricIndex       = commandObj->GetAccessingFabricIndex();
+        const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
+        NodeId nodeId                 = fabricInfo->GetPeerId().GetNodeId();
 
         // Generate the ImageURI if one is not already preset
         if (strlen(mImageUri) == 0)

--- a/examples/tv-casting-app/tv-casting-common/commands/clusters/ModelCommand.cpp
+++ b/examples/tv-casting-app/tv-casting-common/commands/clusters/ModelCommand.cpp
@@ -48,7 +48,7 @@ CHIP_ERROR ModelCommand::RunCommand()
     }
 
     Server * server           = &(chip::Server::GetInstance());
-    chip::FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(fabricIndex);
+    const FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(fabricIndex);
     if (fabric == nullptr)
     {
         ChipLogError(AppServer, "Did not find fabric for index %d", fabricIndex);

--- a/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
@@ -33,7 +33,7 @@ CHIP_ERROR TargetVideoPlayerInfo::Initialize(NodeId nodeId, FabricIndex fabricIn
     }
 
     Server * server           = &(chip::Server::GetInstance());
-    chip::FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(fabricIndex);
+    const FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(fabricIndex);
     if (fabric == nullptr)
     {
         ChipLogError(AppServer, "Did not find fabric for index %d", fabricIndex);

--- a/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
+++ b/src/app/clusters/administrator-commissioning-server/administrator-commissioning-server.cpp
@@ -105,10 +105,10 @@ bool emberAfAdministratorCommissioningClusterOpenCommissioningWindowCallback(
 
     ChipLogProgress(Zcl, "Received command to open commissioning window");
 
-    FabricIndex fabricIndex = commandObj->GetAccessingFabricIndex();
-    FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
-    auto & failSafeContext  = Server::GetInstance().GetFailSafeContext();
-    auto & commissionMgr    = Server::GetInstance().GetCommissioningWindowManager();
+    FabricIndex fabricIndex       = commandObj->GetAccessingFabricIndex();
+    const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
+    auto & failSafeContext        = Server::GetInstance().GetFailSafeContext();
+    auto & commissionMgr          = Server::GetInstance().GetCommissioningWindowManager();
 
     VerifyOrExit(fabricInfo != nullptr, status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
     VerifyOrExit(!failSafeContext.IsFailSafeArmed(), status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_BUSY));
@@ -167,10 +167,10 @@ bool emberAfAdministratorCommissioningClusterOpenBasicCommissioningWindowCallbac
     InteractionModel::Status globalStatus = InteractionModel::Status::Success;
     ChipLogProgress(Zcl, "Received command to open basic commissioning window");
 
-    FabricIndex fabricIndex = commandObj->GetAccessingFabricIndex();
-    FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
-    auto & failSafeContext  = Server::GetInstance().GetFailSafeContext();
-    auto & commissionMgr    = Server::GetInstance().GetCommissioningWindowManager();
+    FabricIndex fabricIndex       = commandObj->GetAccessingFabricIndex();
+    const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
+    auto & failSafeContext        = Server::GetInstance().GetFailSafeContext();
+    auto & commissionMgr          = Server::GetInstance().GetCommissioningWindowManager();
 
     VerifyOrExit(fabricInfo != nullptr, status.Emplace(StatusCode::EMBER_ZCL_STATUS_CODE_PAKE_PARAMETER_ERROR));
 

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -52,7 +52,7 @@ namespace {
 
 chip::PeerId PeerIdForNode(chip::FabricTable * fabricTable, chip::FabricIndex fabric, chip::NodeId node)
 {
-    chip::FabricInfo * fabricInfo = fabricTable->FindFabricWithIndex(fabric);
+    const chip::FabricInfo * fabricInfo = fabricTable->FindFabricWithIndex(fabric);
     if (fabricInfo == nullptr)
     {
         return chip::PeerId();
@@ -202,7 +202,7 @@ CHIP_ERROR BindingManager::NotifyBoundClusterChanged(EndpointId endpoint, Cluste
         {
             if (iter->type == EMBER_UNICAST_BINDING)
             {
-                FabricInfo * fabricInfo = mInitParams.mFabricTable->FindFabricWithIndex(iter->fabricIndex);
+                const FabricInfo * fabricInfo = mInitParams.mFabricTable->FindFabricWithIndex(iter->fabricIndex);
                 VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_NOT_FOUND);
                 PeerId peer                         = fabricInfo->GetPeerIdForNode(iter->nodeId);
                 OperationalDeviceProxy * peerDevice = mInitParams.mCASESessionManager->FindExistingSession(peer);

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -274,7 +274,7 @@ CHIP_ERROR ComputeAttestationSignature(app::CommandHandler * commandObj,
     return CHIP_NO_ERROR;
 }
 
-FabricInfo * RetrieveCurrentFabric(CommandHandler * aCommandHandler)
+const FabricInfo * RetrieveCurrentFabric(CommandHandler * aCommandHandler)
 {
     FabricIndex index = aCommandHandler->GetAccessingFabricIndex();
     ChipLogDetail(Zcl, "OpCreds: Finding fabric with fabricIndex 0x%x", static_cast<unsigned>(index));
@@ -312,7 +312,7 @@ void FailSafeCleanup(const chip::DeviceLayer::ChipDeviceEvent * event)
         CASESessionManager * caseSessionManager = Server::GetInstance().GetCASESessionManager();
         if (caseSessionManager)
         {
-            FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
+            const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
             VerifyOrReturn(fabricInfo != nullptr);
 
             caseSessionManager->ReleaseSessionsForFabric(fabricInfo->GetFabricIndex());
@@ -519,7 +519,7 @@ bool emberAfOperationalCredentialsClusterUpdateFabricLabelCallback(app::CommandH
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
 
     // Fetch current fabric
-    FabricInfo * fabric = RetrieveCurrentFabric(commandObj);
+    const FabricInfo * fabric = RetrieveCurrentFabric(commandObj);
     if (fabric == nullptr)
     {
         SendNOCResponse(commandObj, commandPath, OperationalCertStatus::kInsufficientPrivilege, ourFabricIndex,
@@ -637,8 +637,8 @@ bool emberAfOperationalCredentialsClusterAddNOCCallback(app::CommandHandler * co
     CHIP_ERROR err             = CHIP_NO_ERROR;
     FabricIndex newFabricIndex = kUndefinedFabricIndex;
     Credentials::GroupDataProvider::KeySet keyset;
-    FabricInfo * newFabricInfo = nullptr;
-    auto & fabricTable         = Server::GetInstance().GetFabricTable();
+    const FabricInfo * newFabricInfo = nullptr;
+    auto & fabricTable               = Server::GetInstance().GetFabricTable();
 
     auto * secureSession   = commandObj->GetExchangeContext()->GetSessionHandle()->AsSecureSession();
     auto & failSafeContext = Server::GetInstance().GetFailSafeContext();
@@ -811,9 +811,9 @@ bool emberAfOperationalCredentialsClusterUpdateNOCCallback(app::CommandHandler *
 
     ChipLogProgress(Zcl, "OpCreds: Received an UpdateNOC command");
 
-    auto & fabricTable      = Server::GetInstance().GetFabricTable();
-    auto & failSafeContext  = Server::GetInstance().GetFailSafeContext();
-    FabricInfo * fabricInfo = RetrieveCurrentFabric(commandObj);
+    auto & fabricTable            = Server::GetInstance().GetFabricTable();
+    auto & failSafeContext        = Server::GetInstance().GetFailSafeContext();
+    const FabricInfo * fabricInfo = RetrieveCurrentFabric(commandObj);
 
     bool csrWasForUpdateNoc = false; //< Output param of HasPendingOperationalKey
     bool hasPendingKey      = fabricTable.HasPendingOperationalKey(csrWasForUpdateNoc);
@@ -1022,7 +1022,7 @@ bool emberAfOperationalCredentialsClusterCSRRequestCallback(app::CommandHandler 
     bool isForUpdateNoc = commandData.isForUpdateNOC.ValueOr(false);
 
     failSafeContext.SetCsrRequestForUpdateNoc(isForUpdateNoc);
-    FabricInfo * fabricInfo = RetrieveCurrentFabric(commandObj);
+    const FabricInfo * fabricInfo = RetrieveCurrentFabric(commandObj);
 
     VerifyOrExit(CSRNonce.size() == Credentials::kExpectedAttestationNonceSize, finalStatus = Status::InvalidCommand);
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -363,7 +363,7 @@ void DefaultOTARequestor::ConnectToProvider(OnConnectedAction onConnectedAction)
         return;
     }
 
-    FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderLocation.Value().fabricIndex);
+    const FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderLocation.Value().fabricIndex);
 
     if (fabricInfo == nullptr)
     {
@@ -393,7 +393,7 @@ void DefaultOTARequestor::DisconnectFromProvider()
         return;
     }
 
-    FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderLocation.Value().fabricIndex);
+    const FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderLocation.Value().fabricIndex);
     if (fabricInfo == nullptr)
     {
         ChipLogError(SoftwareUpdate, "Cannot find fabric");
@@ -726,7 +726,7 @@ CHIP_ERROR DefaultOTARequestor::GenerateUpdateToken()
         VerifyOrReturnError(mServer != nullptr, CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnError(mProviderLocation.HasValue(), CHIP_ERROR_INCORRECT_STATE);
 
-        FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderLocation.Value().fabricIndex);
+        const FabricInfo * fabricInfo = mServer->GetFabricTable().FindFabricWithIndex(mProviderLocation.Value().fabricIndex);
         VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
         static_assert(sizeof(NodeId) == sizeof(uint64_t), "Unexpected NodeId size");

--- a/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/ExtendedOTARequestorDriver.cpp
@@ -77,7 +77,7 @@ CHIP_ERROR ExtendedOTARequestorDriver::GetUserConsentSubject(chip::ota::UserCons
         return CHIP_ERROR_INTERNAL;
     }
 
-    FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(subject.fabricIndex);
+    const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(subject.fabricIndex);
     if (fabricInfo == nullptr)
     {
         ChipLogError(SoftwareUpdate, "Cannot find fabric");

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -370,7 +370,7 @@ private:
 
         void OnGroupAdded(chip::FabricIndex fabric_index, const Credentials::GroupDataProvider::GroupInfo & new_group) override
         {
-            FabricInfo * fabric = mServer->GetFabricTable().FindFabricWithIndex(fabric_index);
+            const FabricInfo * fabric = mServer->GetFabricTable().FindFabricWithIndex(fabric_index);
             if (fabric == nullptr)
             {
                 ChipLogError(AppServer, "Group added to nonexistent fabric?");
@@ -386,7 +386,7 @@ private:
 
         void OnGroupRemoved(chip::FabricIndex fabric_index, const Credentials::GroupDataProvider::GroupInfo & old_group) override
         {
-            FabricInfo * fabric = mServer->GetFabricTable().FindFabricWithIndex(fabric_index);
+            const FabricInfo * fabric = mServer->GetFabricTable().FindFabricWithIndex(fabric_index);
             if (fabric == nullptr)
             {
                 ChipLogError(AppServer, "Group added to nonexistent fabric?");

--- a/src/app/tests/TestOperationalDeviceProxy.cpp
+++ b/src/app/tests/TestOperationalDeviceProxy.cpp
@@ -51,8 +51,8 @@ void TestOperationalDeviceProxy_EstablishSessionDirectly(nlTestSuite * inSuite, 
     System::LayerImpl systemLayer;
     // Heap-allocate the fairly large FabricTable so we don't end up with a huge
     // stack.
-    FabricTable * fabrics = Platform::New<FabricTable>();
-    FabricInfo * fabric   = fabrics->FindFabricWithIndex(1);
+    FabricTable * fabrics     = Platform::New<FabricTable>();
+    const FabricInfo * fabric = fabrics->FindFabricWithIndex(1);
     VerifyOrDie(fabric != nullptr);
     secure_channel::MessageCounterManager messageCounterManager;
     chip::TestPersistentStorageDelegate deviceStorage;

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -467,7 +467,7 @@ const FabricInfo * FabricTable::FindFabric(const Crypto::P256PublicKey & rootPub
     return nullptr;
 }
 
-FabricInfo * FabricTable::FindFabricWithIndex(FabricIndex fabricIndex)
+FabricInfo * FabricTable::GetMutableFabricByIndex(FabricIndex fabricIndex)
 {
     // Try to match pending fabric first if available
     if (HasPendingFabricUpdate() && (mPendingFabric.GetFabricIndex() == fabricIndex))
@@ -870,13 +870,13 @@ CHIP_ERROR FabricTable::Delete(FabricIndex fabricIndex)
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(IsValidFabricIndex(fabricIndex), CHIP_ERROR_INVALID_ARGUMENT);
 
-    FabricInfo * fabricInfo = FindFabricWithIndex(fabricIndex);
+    FabricInfo * fabricInfo = GetMutableFabricByIndex(fabricIndex);
     if (fabricInfo == &mPendingFabric)
     {
         // Asked to Delete while pending an update: reset the pending state and
         // get back to the underlying fabric data for existing fabric.
         RevertPendingFabricData();
-        fabricInfo = FindFabricWithIndex(fabricIndex);
+        fabricInfo = GetMutableFabricByIndex(fabricIndex);
     }
 
     bool fabricIsInitialized = fabricInfo != nullptr && fabricInfo->IsInitialized();
@@ -1053,7 +1053,7 @@ void FabricTable::Forget(FabricIndex fabricIndex)
 {
     ChipLogProgress(FabricProvisioning, "Forgetting fabric 0x%x", static_cast<unsigned>(fabricIndex));
 
-    auto * fabricInfo = FindFabricWithIndex(fabricIndex);
+    auto * fabricInfo = GetMutableFabricByIndex(fabricIndex);
     VerifyOrReturn(fabricInfo != nullptr);
 
     RevertPendingFabricData();
@@ -1719,7 +1719,7 @@ CHIP_ERROR FabricTable::CommitPendingFabricData()
     }
 
     // Make sure we actually have a pending fabric
-    FabricInfo * pendingFabricEntry = FindFabricWithIndex(fabricIndexBeingCommitted);
+    FabricInfo * pendingFabricEntry = GetMutableFabricByIndex(fabricIndexBeingCommitted);
 
     if (isUpdating && hasPending && !hasInvalidInternalState)
     {
@@ -1806,7 +1806,7 @@ CHIP_ERROR FabricTable::CommitPendingFabricData()
         if (isUpdating)
         {
             // This will get the non-pending fabric
-            FabricInfo * existingFabricToUpdate = FindFabricWithIndex(fabricIndexBeingCommitted);
+            FabricInfo * existingFabricToUpdate = GetMutableFabricByIndex(fabricIndexBeingCommitted);
 
             // Multiple interlocks validated the below, so it's fatal if we are somehow incoherent here
             VerifyOrDie((existingFabricToUpdate != nullptr) && (existingFabricToUpdate != &mPendingFabric));
@@ -1817,7 +1817,7 @@ CHIP_ERROR FabricTable::CommitPendingFabricData()
         }
 
         // Store pending metadata first
-        FabricInfo * liveFabricEntry = FindFabricWithIndex(fabricIndexBeingCommitted);
+        FabricInfo * liveFabricEntry = GetMutableFabricByIndex(fabricIndexBeingCommitted);
         VerifyOrDie(liveFabricEntry != nullptr);
 
         CHIP_ERROR metadataErr = StoreFabricMetadata(liveFabricEntry);
@@ -1978,7 +1978,7 @@ CHIP_ERROR FabricTable::SetFabricLabel(FabricIndex fabricIndex, const CharSpan &
 
     ReturnErrorCodeIf(fabricLabel.size() > kFabricLabelMaxLengthInBytes, CHIP_ERROR_INVALID_ARGUMENT);
 
-    FabricInfo * fabricInfo  = FindFabricWithIndex(fabricIndex);
+    FabricInfo * fabricInfo  = GetMutableFabricByIndex(fabricIndex);
     bool fabricIsInitialized = (fabricInfo != nullptr) && fabricInfo->IsInitialized();
     VerifyOrReturnError(fabricIsInitialized, CHIP_ERROR_INCORRECT_STATE);
 

--- a/src/credentials/FabricTable.h
+++ b/src/credentials/FabricTable.h
@@ -400,22 +400,6 @@ public:
 #endif // CONFIG_BUILD_FOR_HOST_UNIT_TEST
 
     const FabricInfo * FindFabric(const Crypto::P256PublicKey & rootPubKey, FabricId fabricId) const;
-
-    /**
-     * @brief Get a mutable FabricInfo entry from the table by FabricIndex.
-     *
-     * NOTE: This is private for use within the FabricTable itself. All mutations have to go through the
-     *       FabricTable public methods that take a FabricIndex so that there are no mutations about which
-     *       the FabricTable is unaware, since this would break expectations regarding shadow/pending
-     *       entries used during fail-safe.
-     *
-     * TODO(#19929): Need to make this const and private, but can't just yet.
-     *
-     * @param fabricIndex - fabric index for which to get the FabricInfo entry/
-     * @return the FabricInfo entry for the fabricIndex if found, or nullptr if not found
-     */
-    FabricInfo * FindFabricWithIndex(FabricIndex fabricIndex);
-
     const FabricInfo * FindFabricWithIndex(FabricIndex fabricIndex) const;
     const FabricInfo * FindFabricWithCompressedId(CompressedFabricId compressedFabricId) const;
 
@@ -504,6 +488,19 @@ public:
     }
     ConstFabricIterator begin() const { return cbegin(); }
     ConstFabricIterator end() const { return cend(); }
+
+    /**
+     * @brief Get a mutable FabricInfo entry from the table by FabricIndex.
+     *
+     * NOTE: This is private for use within the FabricTable itself. All mutations have to go through the
+     *       FabricTable public methods that take a FabricIndex so that there are no mutations about which
+     *       the FabricTable is unaware, since this would break expectations regarding shadow/pending
+     *       entries used during fail-safe.
+     *
+     * @param fabricIndex - fabric index for which to get a mutable FabricInfo entry
+     * @return the FabricInfo entry for the fabricIndex if found, or nullptr if not found
+     */
+    FabricInfo * GetMutableFabricByIndex(FabricIndex fabricIndex);
 
     /**
      * @brief Get the RCAC (operational root certificate) associated with a fabric.

--- a/src/darwin/Framework/CHIP/CHIPDeviceController.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController.mm
@@ -719,7 +719,7 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         return CHIP_NO_ERROR;
     }
 
-    chip::FabricInfo * otherFabric = fabricTable->FindFabricWithIndex(fabricIndex);
+    const chip::FabricInfo * otherFabric = fabricTable->FindFabricWithIndex(fabricIndex);
     if (!otherFabric) {
         // Should not happen...
         return CHIP_ERROR_INCORRECT_STATE;

--- a/src/darwin/Framework/CHIP/CHIPDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/CHIPDeviceControllerStartupParams.mm
@@ -204,7 +204,7 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
         return nil;
     }
 
-    FabricInfo * fabric = fabricTable->FindFabricWithIndex(fabricIndex);
+    const FabricInfo * fabric = fabricTable->FindFabricWithIndex(fabricIndex);
 
     if (self.vendorId == nil) {
         self.vendorId = @(fabric->GetVendorId());

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -213,7 +213,7 @@ CHIP_ERROR InitCredentialSets()
             gCommissionerFabrics.AddNewFabricForTest(rcacSpan, icacSpan, nocSpan, opKeySpan, &gCommissionerFabricIndex));
     }
 
-    FabricInfo * newFabric = gCommissionerFabrics.FindFabricWithIndex(gCommissionerFabricIndex);
+    const FabricInfo * newFabric = gCommissionerFabrics.FindFabricWithIndex(gCommissionerFabricIndex);
     VerifyOrReturnError(newFabric != nullptr, CHIP_ERROR_INTERNAL);
     ReturnErrorOnFailure(InitTestIpk(gCommissionerGroupDataProvider, *newFabric, /* numIpks= */ 1));
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -152,7 +152,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         auto * groups     = Credentials::GetGroupDataProvider();
         VerifyOrReturnError(nullptr != groups, CHIP_ERROR_INTERNAL);
 
-        FabricInfo * fabric = mFabricTable->FindFabricWithIndex(groupSession->GetFabricIndex());
+        const FabricInfo * fabric = mFabricTable->FindFabricWithIndex(groupSession->GetFabricIndex());
         VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
         packetHeader.SetDestinationGroupId(groupSession->GetGroupId());
@@ -277,7 +277,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
     case Transport::Session::SessionType::kGroupOutgoing: {
         auto groupSession = sessionHandle->AsOutgoingGroupSession();
 
-        FabricInfo * fabric = mFabricTable->FindFabricWithIndex(groupSession->GetFabricIndex());
+        const FabricInfo * fabric = mFabricTable->FindFabricWithIndex(groupSession->GetFabricIndex());
         VerifyOrReturnError(fabric != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
         multicastAddress = Transport::PeerAddress::Multicast(fabric->GetFabricId(), groupSession->GetGroupId());


### PR DESCRIPTION
#### Problem
- Only FabricTable APIs are allowed to mutate FabricInfo entries
  due to the requirements of fail-safe shadow data handling
- Previous PRs made sure none of the mutators were used outside
  of FabricTable, but `FindFabricByIndex` remained a non-const
  getter due to how much code was using it.

Fixes #19929

#### Change overview
- Renames the mutable `FabricInfo *` getter as `GetMutableFabricByIndex()`
  and makes it private to FabricTable.
- Adds `const` qualifier to every other usage of FindFabricByIndex in the SDK.

#### Testing
- All unit tests pass
- Cert tests still pass
- Still compiles
