### PR TITLE
Temporarily disable flaky TestFailSafeContext

### DIFF
--- a/src/app/tests/TestFailSafeContext.cpp
+++ b/src/app/tests/TestFailSafeContext.cpp
@@ -50,12 +50,15 @@ constexpr FabricIndex kTestAccessingFabricIndex2 = 2;
 
 static void TestPlatformMgr_Init(nlTestSuite * inSuite, void * inContext)
 {
+    // TODO(#20089): Bring-back after we figure-out what crashes
     CHIP_ERROR err = PlatformMgr().InitChipStack();
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
 static void TestFailSafeContext_ArmFailSafe(nlTestSuite * inSuite, void * inContext)
 {
+    // TODO(#20089): Bring-back after we figure-out what crashes
+#if 0
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     chip::app::FailSafeContext failSafeContext;
@@ -69,10 +72,13 @@ static void TestFailSafeContext_ArmFailSafe(nlTestSuite * inSuite, void * inCont
 
     failSafeContext.DisarmFailSafe();
     NL_TEST_ASSERT(inSuite, failSafeContext.IsFailSafeArmed() == false);
+#endif
 }
 
 static void TestFailSafeContext_NocCommandInvoked(nlTestSuite * inSuite, void * inContext)
 {
+    // TODO(#20089): Bring-back after we figure-out what crashes
+#if 0
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     chip::app::FailSafeContext failSafeContext;
@@ -91,6 +97,7 @@ static void TestFailSafeContext_NocCommandInvoked(nlTestSuite * inSuite, void * 
     NL_TEST_ASSERT(inSuite, failSafeContext.UpdateNocCommandHasBeenInvoked() == true);
 
     failSafeContext.DisarmFailSafe();
+#endif
 }
 
 /**


### PR DESCRIPTION
#### Problem
- TestFailSafeContext is now crashy, even though it was just
  only recently moved in #20010 and no functional changes were
  done.
- This may be related to other flakiness seen recently on
  random tests.

Issue #20089

#### Change overview
This PR disables tests that are mostly covered by other
test cases and for trivial logic that we won't touch tomorrow.

#### Testing
- Other unit tests still pass