### PR TITLE
Add fake platform argument to running fake tests, exclude TestFailsaf…

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -285,6 +285,7 @@ class HostBuilder(GnBuilder):
                     'custom_toolchain="//build/toolchain/fake:fake_x64_gcc"',
                     'chip_link_tests=true',
                     'chip_device_platform="fake"',
+                    'chip_fake_platform=true',
                 ]
             )
             return self.extra_gn_options

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -142,7 +142,7 @@ PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-tv-casting-app-ipv6only'
 
 # Generating linux-fake-tests
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_build_tests=true custom_toolchain="//build/toolchain/fake:fake_x64_gcc" chip_link_tests=true chip_device_platform="fake"' {out}/linux-fake-tests
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_build_tests=true custom_toolchain="//build/toolchain/fake:fake_x64_gcc" chip_link_tests=true chip_device_platform="fake" chip_fake_platform=true' {out}/linux-fake-tests
 
 # Generating linux-x64-address-resolve-tool
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} {out}/linux-x64-address-resolve-tool

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -83,7 +83,6 @@ chip_test_suite("tests") {
     "TestEventOverflow.cpp",
     "TestEventPathParams.cpp",
     "TestFabricScopedEventLogging.cpp",
-    "TestFailSafeContext.cpp",
     "TestInteractionModelEngine.cpp",
     "TestMessageDef.cpp",
     "TestNumericAttributeTraits.cpp",
@@ -95,6 +94,10 @@ chip_test_suite("tests") {
     "TestTimedHandler.cpp",
     "TestWriteInteraction.cpp",
   ]
+
+  if (!chip_fake_platform) {
+    test_sources += ["TestFailSafeContext.cpp"]
+  }
 
   #
   # On NRF platforms, the allocation of a large number of pbufs in this test

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -96,7 +96,7 @@ chip_test_suite("tests") {
   ]
 
   if (!chip_fake_platform) {
-    test_sources += ["TestFailSafeContext.cpp"]
+    test_sources += [ "TestFailSafeContext.cpp" ]
   }
 
   #


### PR DESCRIPTION
…eContext from fake platform (no timer impl)

#### Problem
TestFailsafeContext crashes.

#### Change overview

Fixes #20089

#### Testing
Ran tests locally