### PR TITLE
[BL602] Enable command line to flash chip

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/README.md
+++ b/examples/lighting-app/bouffalolab/bl602/README.md
@@ -1,124 +1,95 @@
 # BL602
 
 This example functions as a wifi light bulb device type, with on/off
-capabilities. The steps were verified on BL602-IoT-DVK-3S board.
+capabilities. The steps were verified on BL602 development board.
 
-BL602-IoT-DVK-3S
+BL602 development board:
 <img src="../../../platform/bouffalolab/bl602/doc/images/bl602_iot_3S_v2.jpg" style="zoom:25%;" />
 
 ## Initial setup
 
--   Setting up the environment on ubuntu 20.04 or 18.04
+The steps in this document were validated on Ubuntu 18.04 and 20.04.
 
-```
-$ sudo apt-get update
-$ sudo apt-get upgrade
-$ sudo apt-get install git gcc g++ python pkg-config libssl-dev libdbus-1-dev libglib2.0-dev libavahi-client-dev ninja-build python3-venv python3-dev python3-pip unzip libgirepository1.0-dev libcairo2-dev bluez avahi-daemon
-$ sudo apt-get install pi-bluetooth (if not raspberry pi, sudo apt-get install bluetooth)
-$ reboot
+-   Install dependencies as specified in the connectedhomeip repository: [Building Matter](https://github.com/project-chip/connectedhomeip/blob/interop_testing_te9/docs/guides/BUILDING.md).
+-   Install other dependencies:
 
-```
+    ```
+    sudo apt-get update
+    sudo apt-get upgrade
+    sudo apt-get install bluez avahi-daemon bluetooth
+    reboot
+    ```
 
 -   Clone and initialize the connectedhomeip repo
 
-```
-git clone https://github.com/project-chip/connectedhomeip.git
-cd connectedhomeip
-git submodule update --init --recursive
-```
-
--   Install packets
-
-```
-$ cd {path-to-connectedhomeip}
-connectedhomeip$ source ./scripts/bootstrap.sh
-connectedhomeip$ source ./scripts/activate.sh
-
-```
+    ```
+    git clone https://github.com/project-chip/connectedhomeip.git
+    cd connectedhomeip
+    git submodule update --init --recursive
+    source ./scripts/activate.sh
+    ```
 
 ## Build the image
 
 -   Build the example application:
 
-    `connectedhomeip$ ./scripts/build/build_examples.py --target bl602-light build`
+    ```
+    connectedhomeip$ ./scripts/build/build_examples.py --target bl602-light build
+    ```
 
     Generated files
 
-    `connectedhomeip/out/bl602-light/chip-bl602-lighting-example.bin`
+    ```
+    connectedhomeip/out/bl602-light/chip-bl602-lighting-example.bin
+    ```
 
-    -   To delete generated executable, libraries and object files use:
+    To delete generated executable, libraries and object files use:
 
     ```
-    $ cd ~/connectedhomeip/
-    $ rm -rf out/
+    cd ~/connectedhomeip/
+    rm -rf out/
     ```
 
 ## Flash the board
 
--   Download [Bouffalo Lab Dev Cube](https://dev.bouffalolab.com/download/).
+-   Build the [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/bouffalolab/bl602)
 
-    Log in to the site as a guest.
+    ```
+    ./scripts/build/build_examples.py --target bl602-light build
+    ```
 
-    <img src="../../../platform/bouffalolab/bl602/doc/images/image-web-login.png" style="zoom:30%;" align=left />
+- Connect the board to your flashing station (MacOS, Ubuntu, Windows).
 
-    <img src="../../../platform/bouffalolab/bl602/doc/images/dev-cube.png" style="zoom:30%;" align=left />
+- Set the board to the download mode:
 
-run the software :
+  -   Press and hold the BOOT button.
+  -   Press the RESET button and release it.
+  -   Release the BOOT button.
 
-  <img src="../../../platform/bouffalolab/bl602/doc/images/dev-cube-home.png" style="zoom:70%;" align=left />
+- The device should present itself as a USB serial device on your computer. You may look it up in /dev/ttyACM0
+  
+    ```
+    ls -la /dev/tty*
+    ```
+    If the device is at /dev/ttyACM0, flash the board using the following commands:
 
-  <img src="../../../platform/bouffalolab/bl602/doc/images/dev-cube-iot.png" style="zoom:70%;" />
-
-The following picture shows the burning interface. To download the firmware, you
-need to enter the download mode: press and hold the Boot (IO8) pin of the
-development board, press the **RST** button, and then release the Boot button to
-enter the burning and downloading mode.
-
-<img src="../../../platform/bouffalolab/bl602/doc/images/image-dev-cube.png" style="zoom:70%;" align=left />
-
-Notice: Latest version Bouffalolab dev cube is recommended.
-
-Factory Params:
-`BouffaloLabDevCube-1.7.2-linux-x86/chips/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts`
-
-Partition Table:
-`BouffaloLabDevCube-1.7.2-linux-x86/chips/bl602/partition/partition_cfg_2M.toml`
-
-Boot2 Bin:
-`BouffaloLabDevCube-1.7.2-linux-x86/chips/bl602/builtin_imgs/boot2_iap_v5.5/boot2_iap_release.bin`
-
-Firmware Bin: `connectedhomeip/out/bl602-light/chip-bl602-lighting-example.bin`
-
-Partition Table：
-
-1. FW: The size of FW size0 must be larger than the bin size, we can do it by
-   reducing the size of FW size1 and media partition size0.
-
-COM Port:
-
-```
-   ls -la /dev/ttyUSB*
-```
-
-select the big one.
+    ```
+    cd third_party/bouffalolab/bl602_sdk/repo/tools/flash_tool
+    
+    ./bflb_iot_tool-ubuntu18 --chipname=BL602 --baudrate=115200  --port=/dev/ttyACM0 --pt=chips/bl602/partition/partition_cfg_4M.toml --dts=chips/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts --firmware=../../../../../../out/bl602-light/chip-bl602-lighting-example.bin
+    ```
+    If you want to erase previous network information in flash, you can add --erase parameters to the bflb_iot_tool-ubuntu18 command.
+    For Windows and MacOS, replace bflb_iot_tool-ubuntu18 with bflb_iot_tool.exe and bflb_iot_tool-macos, respectively.
 
 ## Validate the example
 
-1.The device should present itself as a USB serial device on your computer. You
-may look it up in `/dev/`:
+1.You can open the serial console. For example, if the device is at `/dev/ttyACM0`:
 
 ```
-ls -la /dev/tty*
+picocom -b 2000000 /dev/ttyACM0
 ```
 
-You can open the serial console. For example, if the device is at `/dev/USB1`:
-
-```
-picocom -b 2000000 /dev/ttyUSB1
-```
-
-To reset the board, press the **RST** button. And you will see the log from the
-demo board.
+2.To reset the board, press the RESET button, and you will see the log in the picocom terminal.
 
 ## Commission a device using chip-tool
 
@@ -150,8 +121,12 @@ $ sudo ./chip-tool pairing ble-wifi 1 ${SSID} ${PASSWORD} 20202021 3840
     the OnOff attribute. This allows you to toggle a parameter implemented by
     the device to be On or Off.
 
-    `$ sudo ./chip-tool onoff on 1 1`
+    ```
+    $ sudo ./chip-tool onoff on 1 1
+    ```
 
 -   Use ColorControl cluster command to control the color attributes:
 
-    `$ sudo ./chip-tool colorcontrol move-to-hue-and-saturation 240 100 0 0 0 1 1`
+    ```
+    $ sudo ./chip-tool colorcontrol move-to-hue-and-saturation 240 100 0 0 0 1 1
+    ```

--- a/examples/lighting-app/bouffalolab/bl602/README.md
+++ b/examples/lighting-app/bouffalolab/bl602/README.md
@@ -84,10 +84,9 @@ The steps in this document were validated on Ubuntu 18.04 and 20.04.
     ./bflb_iot_tool-ubuntu18 --chipname=BL602 --baudrate=115200  --port=/dev/ttyACM0 --pt=chips/bl602/partition/partition_cfg_4M.toml --dts=chips/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts --firmware=../../../../../../out/bl602-light/chip-bl602-lighting-example.bin
     ```
 
-    If you want to erase previous network information in flash, you can add
-    --erase parameters to the bflb_iot_tool-ubuntu18 command. For Windows and
-    MacOS, replace bflb_iot_tool-ubuntu18 with bflb_iot_tool.exe and
-    bflb_iot_tool-macos, respectively.
+    ```
+    If you want to erase previous network information in flash, you can add --erase parameters to the bflb_iot_tool-ubuntu18 command. For Windows and MacOS, replace bflb_iot_tool-ubuntu18 with bflb_iot_tool.exe and bflb_iot_tool-macos, respectively.
+    ```
 
 ## Validate the example
 
@@ -99,7 +98,7 @@ picocom -b 2000000 /dev/ttyACM0
 ```
 
 2.To reset the board, press the RESET button, and you will see the log in the
-picocom terminal.
+`picocom terminal`.
 
 ## Commission a device using chip-tool
 

--- a/examples/lighting-app/bouffalolab/bl602/README.md
+++ b/examples/lighting-app/bouffalolab/bl602/README.md
@@ -10,7 +10,8 @@ BL602 development board:
 
 The steps in this document were validated on Ubuntu 18.04 and 20.04.
 
--   Install dependencies as specified in the connectedhomeip repository: [Building Matter](https://github.com/project-chip/connectedhomeip/blob/interop_testing_te9/docs/guides/BUILDING.md).
+-   Install dependencies as specified in the connectedhomeip repository:
+    [Building Matter](https://github.com/project-chip/connectedhomeip/blob/interop_testing_te9/docs/guides/BUILDING.md).
 -   Install other dependencies:
 
     ```
@@ -52,44 +53,53 @@ The steps in this document were validated on Ubuntu 18.04 and 20.04.
 
 ## Flash the board
 
--   Build the [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/bouffalolab/bl602)
+-   Build the
+    [lighting-app](https://github.com/project-chip/connectedhomeip/tree/master/examples/lighting-app/bouffalolab/bl602)
 
     ```
     ./scripts/build/build_examples.py --target bl602-light build
     ```
 
-- Connect the board to your flashing station (MacOS, Ubuntu, Windows).
+-   Connect the board to your flashing station (MacOS, Ubuntu, Windows).
 
-- Set the board to the download mode:
+-   Set the board to the download mode:
 
-  -   Press and hold the BOOT button.
-  -   Press the RESET button and release it.
-  -   Release the BOOT button.
+    -   Press and hold the BOOT button.
+    -   Press the RESET button and release it.
+    -   Release the BOOT button.
 
-- The device should present itself as a USB serial device on your computer. You may look it up in /dev/ttyACM0
-  
+-   The device should present itself as a USB serial device on your computer.
+    You may look it up in /dev/ttyACM0
+
     ```
     ls -la /dev/tty*
     ```
-    If the device is at /dev/ttyACM0, flash the board using the following commands:
+
+    If the device is at /dev/ttyACM0, flash the board using the following
+    commands:
 
     ```
     cd third_party/bouffalolab/bl602_sdk/repo/tools/flash_tool
-    
+
     ./bflb_iot_tool-ubuntu18 --chipname=BL602 --baudrate=115200  --port=/dev/ttyACM0 --pt=chips/bl602/partition/partition_cfg_4M.toml --dts=chips/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts --firmware=../../../../../../out/bl602-light/chip-bl602-lighting-example.bin
     ```
-    If you want to erase previous network information in flash, you can add --erase parameters to the bflb_iot_tool-ubuntu18 command.
-    For Windows and MacOS, replace bflb_iot_tool-ubuntu18 with bflb_iot_tool.exe and bflb_iot_tool-macos, respectively.
+
+    If you want to erase previous network information in flash, you can add
+    --erase parameters to the bflb_iot_tool-ubuntu18 command. For Windows and
+    MacOS, replace bflb_iot_tool-ubuntu18 with bflb_iot_tool.exe and
+    bflb_iot_tool-macos, respectively.
 
 ## Validate the example
 
-1.You can open the serial console. For example, if the device is at `/dev/ttyACM0`:
+1.You can open the serial console. For example, if the device is at
+`/dev/ttyACM0`:
 
 ```
 picocom -b 2000000 /dev/ttyACM0
 ```
 
-2.To reset the board, press the RESET button, and you will see the log in the picocom terminal.
+2.To reset the board, press the RESET button, and you will see the log in the
+picocom terminal.
 
 ## Commission a device using chip-tool
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Enable command line to flash chip

#### Change overview
Enable command line to flash chip, and update README.md.

#### Testing
How was this tested? (at least one bullet point required)
* command line:
cd third_party/bouffalolab/bl602_sdk/repo/tools/flash_tool

ubuntu:
./bflb_iot_tool-ubuntu18 --chipname=BL602 --baudrate=115200  --port=/dev/ttyACM0 --pt=chips/bl602/partition/partition_cfg_4M.toml --dts=chips/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts --firmware=../../../../../../out/bl602-light/chip-bl602-lighting-example.bin

macos:
./bflb_iot_tool-macos --chipname=BL602 --baudrate=115200  --port=/dev/ttyACM0 --pt=chips/bl602/partition/partition_cfg_4M.toml --dts=chips/bl602/device_tree/bl_factory_params_IoTKitA_40M.dts --firmware=../../../../../../out/bl602-light/chip-bl602-lighting-example.bin
