### PR TITLE
[Android] Fix Android commissioning complete fail

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -193,6 +193,8 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     }
     MutableByteSpan rcacSpan(rcac.Get(), kMaxCHIPDERCertLength);
 
+    Crypto::P256Keypair ephemeralKey;
+
     if (rootCertificate != nullptr && intermediateCertificate != nullptr && nodeOperationalCertificate != nullptr &&
         keypairDelegate != nullptr)
     {
@@ -217,7 +219,6 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     }
     else
     {
-        Crypto::P256Keypair ephemeralKey;
         *errInfoOnFailure = ephemeralKey.Initialize();
         if (*errInfoOnFailure != CHIP_NO_ERROR)
         {

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -193,6 +193,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     }
     MutableByteSpan rcacSpan(rcac.Get(), kMaxCHIPDERCertLength);
 
+    // The lifetime of the ephemeralKey variable must be kept until SetupParams is saved.
     Crypto::P256Keypair ephemeralKey;
 
     if (rootCertificate != nullptr && intermediateCertificate != nullptr && nodeOperationalCertificate != nullptr &&


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fix Android commissioning complete fail. (invalid keypair).
* This issue only occurs when no certificate is set.
* this issue was caused by the fix in #19545.

#### Change overview
The location of the keypair variable declaration has been changed.

#### Testing
How was this tested? (at least one bullet point required)
* Check Commissioning using Android Device.
