### PR TITLE
Allow using no CIPD pigweed configuration when activating

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -26,9 +26,8 @@ _bootstrap_or_activate() {
 
     local _CONFIG_FILE="scripts/environment.json"
 
-    if [ "$_BOOTSTRAP_NAME" = "no_cipd_bootstrap.sh" ]; then
-        _CONFIG_FILE="scripts/environment_no_cipd.json"
-        _BOOTSTRAP_NAME="bootstrap.sh"
+    if [ ! -z "$2" ]; then
+        _CONFIG_FILE="$2"
     fi
 
     if [ "$_BOOTSTRAP_NAME" = "bootstrap.sh" ] ||
@@ -88,7 +87,7 @@ EOF
     fi
 }
 
-_bootstrap_or_activate "$0"
+_bootstrap_or_activate "$0" "$1"
 unset -f _bootstrap_or_activate
 
 pw_cleanup

--- a/scripts/environment_no_cipd.json
+++ b/scripts/environment_no_cipd.json
@@ -4,5 +4,6 @@
         "gn_targets": [":python_packages.install"]
     },
     "required_submodules": ["third_party/pigweed/repo"],
+    "rosetta": "never",
     "gni_file": "build_overrides/pigweed_environment.gni"
 }

--- a/scripts/no_cipd_bootstrap.sh
+++ b/scripts/no_cipd_bootstrap.sh
@@ -1,1 +1,0 @@
-bootstrap.sh


### PR DESCRIPTION
#### Problem
Currently there is a no CIPD bootstrap script symlinked at `scripts/no_cipd_bootstrap.sh`. However, there is no `scripts/activate.sh` equivalent (which is useful in CI e.g. when cloning manually using `scripts/checkout_submodules.py` beforehand).

#### Change overview
Instead of using a separate script just allow to pass the Pigweed bootstrap configuration file as an argument.

#### Testing
Locally by building with:

```
scripts/checkout_submodules.py --shallow --platform linux
source scripts/activate.sh scripts/environment_no_cipd.json
```
