### PR TITLE
[EFR32] Added functionality for scan-network, network interfaces and increased the heap size for multiadmin

### DIFF
--- a/examples/platform/efr32/FreeRTOSConfig.h
+++ b/examples/platform/efr32/FreeRTOSConfig.h
@@ -198,7 +198,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 
 #ifndef configTOTAL_HEAP_SIZE
 #ifdef SL_WIFI
-#define configTOTAL_HEAP_SIZE ((size_t)(28 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(30 * 1024))
 #else
 #define configTOTAL_HEAP_SIZE ((size_t)(20 * 1024))
 #endif

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -253,6 +253,9 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->offPremiseServicesReachableIPv4.SetNull();
     ifp->offPremiseServicesReachableIPv6.SetNull();
     ifp->type = InterfaceType::EMBER_ZCL_INTERFACE_TYPE_THREAD;
+    uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
+    ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);
+    ifp->hardwareAddress = ByteSpan(macBuffer, ConfigurationManager::kPrimaryMACAddressLength);
 #else
     NetworkInterface * head = NULL;
     for (Inet::InterfaceIterator interfaceIterator; interfaceIterator.HasCurrent(); interfaceIterator.Next())
@@ -323,9 +326,6 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     }
     *netifpp = head;
 #endif
-    uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
-    ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);
-    ifp->hardwareAddress = ByteSpan(macBuffer, ConfigurationManager::kPrimaryMACAddressLength);
 
     *netifpp = ifp;
     return CHIP_NO_ERROR;

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -254,7 +254,74 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
     ifp->offPremiseServicesReachableIPv6.SetNull();
     ifp->type = InterfaceType::EMBER_ZCL_INTERFACE_TYPE_THREAD;
 #else
-    /* TODO */
+    NetworkInterface * head = NULL;
+    for (Inet::InterfaceIterator interfaceIterator; interfaceIterator.HasCurrent(); interfaceIterator.Next())
+    {
+        interfaceIterator.GetInterfaceName(ifp->Name, Inet::InterfaceId::kMaxIfNameLength);
+        ifp->name          = CharSpan::fromCharString(ifp->Name);
+        ifp->isOperational = true;
+        Inet::InterfaceType interfaceType;
+        if (interfaceIterator.GetInterfaceType(interfaceType) == CHIP_NO_ERROR)
+        {
+            switch (interfaceType)
+            {
+            case Inet::InterfaceType::Unknown:
+                ifp->type = EMBER_ZCL_INTERFACE_TYPE_UNSPECIFIED;
+                break;
+            case Inet::InterfaceType::WiFi:
+                ifp->type = EMBER_ZCL_INTERFACE_TYPE_WI_FI;
+                break;
+            case Inet::InterfaceType::Ethernet:
+                ifp->type = EMBER_ZCL_INTERFACE_TYPE_ETHERNET;
+                break;
+            case Inet::InterfaceType::Thread:
+                ifp->type = EMBER_ZCL_INTERFACE_TYPE_THREAD;
+                break;
+            case Inet::InterfaceType::Cellular:
+                ifp->type = EMBER_ZCL_INTERFACE_TYPE_CELLULAR;
+                break;
+            }
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "Failed to get interface type");
+        }
+
+        ifp->offPremiseServicesReachableIPv4.SetNull();
+        ifp->offPremiseServicesReachableIPv6.SetNull();
+
+        uint8_t addressSize;
+        if (interfaceIterator.GetHardwareAddress(ifp->MacAddress, addressSize, sizeof(ifp->MacAddress)) != CHIP_NO_ERROR)
+        {
+            ChipLogError(DeviceLayer, "Failed to get network hardware address");
+        }
+        else
+        {
+            ifp->hardwareAddress = ByteSpan(ifp->MacAddress, addressSize);
+        }
+
+        // Assuming IPv6-only support
+        Inet::InterfaceAddressIterator interfaceAddressIterator;
+        uint8_t ipv6AddressesCount = 0;
+        while (interfaceAddressIterator.HasCurrent() && ipv6AddressesCount < kMaxIPv6AddrCount)
+        {
+            if (interfaceAddressIterator.GetInterfaceId() == interfaceIterator.GetInterfaceId())
+            {
+                chip::Inet::IPAddress ipv6Address;
+                if (interfaceAddressIterator.GetAddress(ipv6Address) == CHIP_NO_ERROR)
+                {
+                    memcpy(ifp->Ipv6AddressesBuffer[ipv6AddressesCount], ipv6Address.Addr, kMaxIPv6AddrSize);
+                    ifp->Ipv6AddressSpans[ipv6AddressesCount] = ByteSpan(ifp->Ipv6AddressesBuffer[ipv6AddressesCount]);
+                    ipv6AddressesCount++;
+                }
+            }
+            interfaceAddressIterator.Next();
+        }
+
+        ifp->IPv6Addresses = chip::app::DataModel::List<chip::ByteSpan>(ifp->Ipv6AddressSpans, ipv6AddressesCount);
+        head               = ifp;
+    }
+    *netifpp = head;    
 #endif
     uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
     ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -321,7 +321,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         ifp->IPv6Addresses = chip::app::DataModel::List<chip::ByteSpan>(ifp->Ipv6AddressSpans, ipv6AddressesCount);
         head               = ifp;
     }
-    *netifpp = head;    
+    *netifpp = head;
 #endif
     uint8_t macBuffer[ConfigurationManager::kPrimaryMACAddressLength];
     ConfigurationMgr().GetPrimary802154MACAddress(macBuffer);


### PR DESCRIPTION
#### Problem
scan-network implementation used the wrong api to scan the nearby networks. 
added implementation to show network interfaces for wifi devices(RS9116 and WF200)
increased the heap size for multiadmin for wifi

#### Change overview
Added bgscan api since scan was not working after connecting to an AP
Network-interfaces used to return null when ran with wifi devices and implementation for that
Increased the heap-size which was leading for heap overflow when connecting multiple devices

#### Testing
Tested on EFR32+RS9116 and EFR32+WF200
