### PR TITLE
[ESP32] fix BLE unable communicate with android app

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -111,7 +111,7 @@ const struct ble_gatt_svc_def BLEManagerImpl::CHIPoBLEGATTAttrs[] = {
               {
                   .uuid       = (ble_uuid_t *) (&UUID_CHIPoBLEChar_TX),
                   .access_cb  = gatt_svr_chr_access,
-                  .flags      = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY,
+                  .flags      = BLE_GATT_CHR_F_READ | BLE_GATT_CHR_F_NOTIFY | BLE_GATT_CHR_F_INDICATE,
                   .val_handle = &sInstance.mTXCharCCCDAttrHandle,
               },
 #if CHIP_ENABLE_ADDITIONAL_DATA_ADVERTISING


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:

19f54690b78e61ad477443e4645a0c422f24bd2b changes the method of 
"GATT C2 Characteristic" from `NOTIFICATION` to `INDICATION`.

Currently, the `C2 Characteristic(Client RX Buffer)` on ESP32 does not support `INDICATION`, so communicate will fail.


#### Change overview
This patch fix this issue by enable `INDICATION` for ESP32.

#### Testing
How was this tested? (at least one bullet point required)
This patch is manually tested on ESP32 platform with android CHIPTool.

