### PR TITLE
Added flag to remove the example attestation credentials.

### DIFF
--- a/src/credentials/BUILD.gn
+++ b/src/credentials/BUILD.gn
@@ -47,15 +47,20 @@ static_library("credentials") {
     "attestation_verifier/DeviceAttestationDelegate.h",
     "attestation_verifier/DeviceAttestationVerifier.cpp",
     "attestation_verifier/DeviceAttestationVerifier.h",
-    "examples/DeviceAttestationCredsExample.cpp",
-    "examples/DeviceAttestationCredsExample.h",
-    "examples/ExampleDACs.cpp",
-    "examples/ExampleDACs.h",
-    "examples/ExamplePAI.cpp",
-    "examples/ExamplePAI.h",
     "examples/LastKnownGoodTimeCertificateValidityPolicyExample.h",
     "examples/StrictCertificateValidityPolicyExample.h",
   ]
+
+  if (!chip_device_attestation_credentials) {
+    sources += [
+      "examples/DeviceAttestationCredsExample.cpp",
+      "examples/DeviceAttestationCredsExample.h",
+      "examples/ExampleDACs.cpp",
+      "examples/ExampleDACs.h",
+      "examples/ExamplePAI.cpp",
+      "examples/ExamplePAI.h",
+    ]
+  }
 
   # TODO: These tests files should be removed after the DeviceAttestationCredsExample implementation
   # is changed to generate it's own credentials instead of using Test credentials.

--- a/src/platform/device.gni
+++ b/src/platform/device.gni
@@ -23,6 +23,9 @@ declare_args() {
 
   # Substitute fake platform when building with chip_device_platform=auto.
   chip_fake_platform = false
+
+  # Use actual device attestation credentials
+  chip_device_attestation_credentials = false
 }
 
 if (chip_device_platform == "auto") {


### PR DESCRIPTION
#### Problem
Devices attestation certificates are currently hard-coded, and always included in all examples.

#### Change overview
This change allows to remove the example credentials, so they can be replaced with actual credentials. Since the new flag is false by default, this change should have no immediate effect.

#### Testing
Project built successfully. Automatic, and manual tests executed normally.