### PR TITLE
Upload core files when the Builds job fails on Linux.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,7 @@ jobs:
               run: |
                   mkdir /tmp/cores || true
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
-                  mkdir objdir-clone || true
+                  mkdir /tmp/executables || true
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -105,6 +105,9 @@ jobs:
             - name: Run Build Without Error Logging
               timeout-minutes: 20
               run: scripts/run_in_build_env.sh "ninja -C ./out"
+            - name: Copying executables
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              run: find out/ -type f -executable | xargs cp -t /tmp/executables
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
@@ -113,12 +116,12 @@ jobs:
                   path: /tmp/cores/
                   # Cores are big; don't hold on to them too long.
                   retention-days: 5
-            - name: Uploading objdir for debugging
+            - name: Uploading executables for debugging
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
               with:
-                  name: crash-objdir-linux-gcc-debug
-                  path: out/
+                  name: crash-executables-linux-gcc-debug
+                  path: /tmp/executables/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
     build_linux:
@@ -164,7 +167,7 @@ jobs:
               run: |
                   mkdir /tmp/cores || true
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
-                  mkdir objdir-clone || true
+                  mkdir /tmp/executables || true
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -239,6 +242,9 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --no-log-timestamps --target linux-fake-tests build"
+            - name: Copying executables
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              run: find out/ -type f -executable | xargs cp -t /tmp/executables
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
@@ -247,13 +253,13 @@ jobs:
                   path: /tmp/cores/
                   # Cores are big; don't hold on to them too long.
                   retention-days: 5
-            - name: Uploading objdir for debugging
+            - name: Uploading executables for debugging
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
               with:
-                  name: crash-objdir-linux
-                  path: out/
-                  # objdirs are big; don't hold on to them too long.
+                  name: crash-executables-linux
+                  path: /tmp/executables/
+                  # Executables are big; don't hold on to them too long.
                   retention-days: 5
 
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,7 +62,6 @@ jobs:
               run: |
                   mkdir /tmp/cores || true
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
-                  mkdir /tmp/executables || true
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -105,9 +104,6 @@ jobs:
             - name: Run Build Without Error Logging
               timeout-minutes: 20
               run: scripts/run_in_build_env.sh "ninja -C ./out"
-            - name: Copying executables
-              if: ${{ failure() }} && ${{ !env.ACT }}
-              run: find out/ -type f -executable | xargs cp -t /tmp/executables
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
@@ -116,12 +112,12 @@ jobs:
                   path: /tmp/cores/
                   # Cores are big; don't hold on to them too long.
                   retention-days: 5
-            - name: Uploading executables for debugging
+            - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
               with:
-                  name: crash-executables-linux-gcc-debug
-                  path: /tmp/executables/
+                  name: crash-objdir-linux-gcc-debug
+                  path: out/
                   # objdirs are big; don't hold on to them too long.
                   retention-days: 5
     build_linux:
@@ -167,7 +163,6 @@ jobs:
               run: |
                   mkdir /tmp/cores || true
                   sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
-                  mkdir /tmp/executables || true
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -242,9 +237,6 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --no-log-timestamps --target linux-fake-tests build"
-            - name: Copying executables
-              if: ${{ failure() }} && ${{ !env.ACT }}
-              run: find out/ -type f -executable | xargs cp -t /tmp/executables
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
@@ -253,13 +245,13 @@ jobs:
                   path: /tmp/cores/
                   # Cores are big; don't hold on to them too long.
                   retention-days: 5
-            - name: Uploading executables for debugging
+            - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
               if: ${{ failure() }} && ${{ !env.ACT }}
               with:
-                  name: crash-executables-linux
-                  path: /tmp/executables/
-                  # Executables are big; don't hold on to them too long.
+                  name: crash-objdir-linux
+                  path: out/
+                  # objdirs are big; don't hold on to them too long.
                   retention-days: 5
 
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,7 +35,7 @@ jobs:
             image: connectedhomeip/chip-build:0.5.79
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
-            options: --sysctl "net.ipv6.conf.all.disable_ipv6=0
+            options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 
         steps:
@@ -57,6 +57,12 @@ jobs:
                   attempt_delay: 2000
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --shallow --platform linux
+            - name: Try to ensure the directories for core dumping exist and we
+                  can write them.
+              run: |
+                  mkdir /tmp/cores || true
+                  sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
+                  mkdir objdir-clone || true
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -99,6 +105,22 @@ jobs:
             - name: Run Build Without Error Logging
               timeout-minutes: 20
               run: scripts/run_in_build_env.sh "ninja -C ./out"
+            - name: Uploading core files
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name: crash-core-linux-gcc-debug
+                  path: /tmp/cores/
+                  # Cores are big; don't hold on to them too long.
+                  retention-days: 5
+            - name: Uploading objdir for debugging
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name: crash-objdir-linux-gcc-debug
+                  path: out/
+                  # objdirs are big; don't hold on to them too long.
+                  retention-days: 5
     build_linux:
         name: Build on Linux (fake, gcc_release, clang, simulated)
         timeout-minutes: 120
@@ -110,7 +132,7 @@ jobs:
             image: connectedhomeip/chip-build:0.5.79
             volumes:
                 - "/tmp/log_output:/tmp/test_logs"
-            options: --sysctl "net.ipv6.conf.all.disable_ipv6=0
+            options: --privileged --sysctl "net.ipv6.conf.all.disable_ipv6=0
                 net.ipv4.conf.all.forwarding=1 net.ipv6.conf.all.forwarding=1"
 
         steps:
@@ -137,6 +159,12 @@ jobs:
             #      languages: "cpp"
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --shallow --platform linux
+            - name: Try to ensure the directories for core dumping exist and we
+                  can write them.
+              run: |
+                  mkdir /tmp/cores || true
+                  sysctl -w kernel.core_pattern=/tmp/cores/core.%u.%p.%t || true
+                  mkdir objdir-clone || true
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -211,6 +239,22 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                     "./scripts/build/build_examples.py --no-log-timestamps --target linux-fake-tests build"
+            - name: Uploading core files
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name: crash-core-linux
+                  path: /tmp/cores/
+                  # Cores are big; don't hold on to them too long.
+                  retention-days: 5
+            - name: Uploading objdir for debugging
+              uses: actions/upload-artifact@v2
+              if: ${{ failure() }} && ${{ !env.ACT }}
+              with:
+                  name: crash-objdir-linux
+                  path: out/
+                  # objdirs are big; don't hold on to them too long.
+                  retention-days: 5
 
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512


### PR DESCRIPTION
We've had some crashes recently in the job that would be good to debug.

#### Problem
Trying to debug crashes we are seeing in CI.

#### Change overview
Upload cores and objdirs as needed to allow debugging this.

#### Testing
Checked that if I introduce a crash in a unit test I get these uploaded.