### PR TITLE
Log error on bad packets instead of silent return

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -433,7 +433,7 @@ void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::
     CHIP_ERROR err = packetHeader.DecodeAndConsume(msg);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Inet, "Malformed message received: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(Inet, "Failed to deode packet header: %" CHIP_ERROR_FORMAT, err.Format());
         return;
     }
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -430,7 +430,12 @@ void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::
     CHIP_TRACE_PREPARED_MESSAGE_RECEIVED(&peerAddress, &msg);
     PacketHeader packetHeader;
 
-    ReturnOnFailure(packetHeader.DecodeAndConsume(msg));
+    CHIP_ERROR err = packetHeader.DecodeAndConsume(msg);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Inet, "Malformed message received: %" CHIP_ERROR_FORMAT, err.Format());
+        return;
+    }
 
     if (packetHeader.IsEncrypted())
     {

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -433,7 +433,7 @@ void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::
     CHIP_ERROR err = packetHeader.DecodeAndConsume(msg);
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Inet, "Failed to deode packet header: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(Inet, "Failed to decode packet header: %" CHIP_ERROR_FORMAT, err.Format());
         return;
     }
 


### PR DESCRIPTION
#### Problem
Silent return on CHIP_ERROR makes it hard to debug any unexpected errors.

#### Change overview
Also log error instead of just silently returning from the message processing loop.

#### Testing
Sent an invalid BTP message, saw the event log on an EFR32 device.