### PR TITLE
Add storage audit codepaths to Server

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -50,6 +50,11 @@
 #include <system/SystemPacketBuffer.h>
 #include <system/TLVPacketBufferBackingStore.h>
 #include <transport/SessionManager.h>
+
+#if defined(CHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT) || defined(CHIP_SUPPORT_ENABLE_STORAGE_LOAD_TEST_AUDIT)
+#include <lib/support/PersistentStorageAudit.h>
+#endif // defined(CHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT) || defined(CHIP_SUPPORT_ENABLE_STORAGE_LOAD_TEST_AUDIT)
+
 using namespace chip::DeviceLayer;
 
 using chip::kMinValidFabricIndex;
@@ -130,6 +135,14 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     mOpCertStore              = initParams.opCertStore;
 
     mCertificateValidityPolicy = initParams.certificateValidityPolicy;
+
+#if defined(CHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT)
+    VerifyOrDie(chip::audit::ExecutePersistentStorageApiAudit(*mDeviceStorage));
+#endif
+
+#if defined(CHIP_SUPPORT_ENABLE_STORAGE_LOAD_TEST_AUDIT)
+    VerifyOrDie(chip::audit::ExecutePersistentStorageLoadTestAudit(*mDeviceStorage));
+#endif
 
     // Set up attribute persistence before we try to bring up the data model
     // handler.

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -24,11 +24,11 @@ import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/lib/core/core.gni")
 
 declare_args() {
-    # Set to true to run the PersistentStorageDelegate API compliance audit
-    chip_support_enable_storage_api_audit = false
+  # Set to true to run the PersistentStorageDelegate API compliance audit
+  chip_support_enable_storage_api_audit = false
 
-    # Set to true to run the PersistentStorageDelegate load test audit
-    chip_support_enable_storage_load_test_audit = false
+  # Set to true to run the PersistentStorageDelegate load test audit
+  chip_support_enable_storage_load_test_audit = false
 }
 
 config("storage_audit_config") {

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -23,6 +23,26 @@ import("${chip_root}/build/chip/chip_version.gni")
 import("${chip_root}/build/chip/tests.gni")
 import("${chip_root}/src/lib/core/core.gni")
 
+declare_args() {
+    # Set to true to run the PersistentStorageDelegate API compliance audit
+    chip_support_enable_storage_api_audit = false
+
+    # Set to true to run the PersistentStorageDelegate load test audit
+    chip_support_enable_storage_load_test_audit = false
+}
+
+config("storage_audit_config") {
+  defines = []
+
+  if (chip_support_enable_storage_api_audit) {
+    defines += [ "CHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT" ]
+  }
+
+  if (chip_support_enable_storage_load_test_audit) {
+    defines += [ "CHIP_SUPPORT_ENABLE_STORAGE_LOAD_TEST_AUDIT" ]
+  }
+}
+
 if (chip_pw_tokenizer_logging) {
   import("//build_overrides/pigweed.gni")
 }
@@ -91,6 +111,8 @@ static_library("support") {
     "LifetimePersistedCounter.h",
     "ObjectLifeCycle.h",
     "PersistedCounter.h",
+    "PersistentStorageAudit.cpp",
+    "PersistentStorageAudit.h",
     "PersistentStorageMacros.h",
     "Pool.cpp",
     "Pool.h",
@@ -160,6 +182,7 @@ static_library("support") {
   public_configs = [
     "${chip_root}/src:includes",
     "${chip_root}/src/system:system_config",
+    ":storage_audit_config",
   ]
 
   if (chip_config_memory_management == "simple") {

--- a/src/lib/support/PersistentStorageAudit.cpp
+++ b/src/lib/support/PersistentStorageAudit.cpp
@@ -1,0 +1,42 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <lib/core/CHIPError.h>
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/support/logging/CHIPLogging.h>
+
+#include "PersistentStorageAudit.h"
+
+namespace chip {
+namespace audit {
+
+bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
+{
+    (void)storage;
+    ChipLogError(Automation, "==== PersistentStorageDelegate API audit: SUCCESS ====");
+    return true;
+}
+
+bool ExecutePersistentStorageLoadTestAudit(PersistentStorageDelegate & storage)
+{
+    (void)storage;
+    ChipLogError(Automation, "==== PersistentStorageDelegate load test audit: SUCCESS ====");
+    return true;
+}
+
+} // namespace audit
+} // namespace chip

--- a/src/lib/support/PersistentStorageAudit.cpp
+++ b/src/lib/support/PersistentStorageAudit.cpp
@@ -26,14 +26,14 @@ namespace audit {
 
 bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
 {
-    (void)storage;
+    (void) storage;
     ChipLogError(Automation, "==== PersistentStorageDelegate API audit: SUCCESS ====");
     return true;
 }
 
 bool ExecutePersistentStorageLoadTestAudit(PersistentStorageDelegate & storage)
 {
-    (void)storage;
+    (void) storage;
     ChipLogError(Automation, "==== PersistentStorageDelegate load test audit: SUCCESS ====");
     return true;
 }

--- a/src/lib/support/PersistentStorageAudit.h
+++ b/src/lib/support/PersistentStorageAudit.h
@@ -1,0 +1,78 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+
+namespace chip {
+namespace audit {
+
+/**
+ * @brief Execute a storage API compliance audit to validate PersistentStorageDelegate implemented in a
+ *        final integration.
+ *
+ * This audit runs a device-based test that validates the internals of whatever back-end is used to implement
+ * the PersistentStorageDelegate interface, which is used across the board. If it fails, the device may not
+ * function as expected and subtly fail important functionality of the Matter stack.
+ *
+ * The audit uses ChipLogError against the `Automation` module for assertions failure details..
+ *
+ * @param storage - Reference to the PersistentStorageDelegate that would be passed in chip::Server::InitParams
+ *                  or chip::Controller::FactoryInitParams.
+ *
+ * @return true on success, otherwise false on failure
+ */
+bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage);
+
+/**
+ * @brief Execute a storage API load test audit to validate bare-minimum storage requirements
+ *        for spec-mandated minimums.
+ *
+ * This audit runs a device-based test that validates the storage of a large number of
+ * persistent storage values, consistent with a "full loaded" configuration of just
+ * the minima required by spec.
+ *
+ * If it fails, the device may not function as expected and subtly fail important functionality of
+ * the Matter stack. Furthermore, if it fails, it MAY FAIL at runtime later. This audit DOES NOT
+ * GUARANTEE the fitness overall of the implementation. It is mostly used as a helpful "smoke test"
+ * for conditions that are quite complex to reproduce at runtime in integration tests.
+ *
+ * Overall the audit attempts to:
+ *   - Store the equivalent of 5 full fabric tables
+ *     - Each with full Access Control List with the required minimum-to-be-supported entries
+ *   - Store additional metadata known to be required by the SDK, depending on some
+ *     feature flags.
+ *
+ * The contents are not real, but the sizing of the keys and values is representative of
+ * worst case.
+ *
+ * Because this audit does not have access to internal constants of all the underlying modules,
+ * consider this starting version to be a "point in time" check. Refinements will be done
+ * via integration tests.
+ *
+ * The audit uses ChipLogError against the `Automation` module for assertions failure details.
+ *
+ * @param storage - Reference to the PersistentStorageDelegate that would be passed in chip::Server::InitParams
+ *                  or chip::Controller::FactoryInitParams.
+ *
+ * @return true on success, otherwise false on failure
+ */
+bool ExecutePersistentStorageLoadTestAudit(PersistentStorageDelegate & storage);
+
+} // namespace audit
+} // namespace chip


### PR DESCRIPTION
#### Change Overview
- Storage audit will soon be conducted to determine readiness of platforms
  in terms of compliance of the storage API implementations.
- This PR adds a no-op audit disabled by default


#### Testing
- `scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone chip_config_network_layer_ble=false chip_support_enable_storage_api_audit=true chip_support_enable_storage_load_test_audit=true`
  shows that the audits run and succeed, and without the arguments,
  they are not executed at all and don't appear in the final binary.
