### PR TITLE
Fix EC Delegate use-after-free in IM

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -407,12 +407,14 @@ CHIP_ERROR ReadClient::OnMessageReceived(Messaging::ExchangeContext * apExchange
     {
         VerifyOrExit(apExchangeContext == mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
         err = ProcessSubscribeResponse(std::move(aPayload));
-
-        // Forget the context as SUBSCRIBE RESPONSE is the last message in SUBSCRIBE transaction and
-        // ExchangeContext::HandleMessage automatically closes a context if no other messages need to
-        // be sent or received.
-        mpExchangeCtx = nullptr;
         SuccessOrExit(err);
+
+        //
+        // Null out the delegate and context as SubscribeResponse is the last message the Subscribe transaction and
+        // the exchange layer will automatically close the exchange.
+        //
+        mpExchangeCtx->SetDelegate(nullptr);
+        mpExchangeCtx = nullptr;
     }
     else if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::StatusResponse))
     {


### PR DESCRIPTION
#### Problem

Our test team accidentally encountered a crash with a slightly older version of chip-tool when using it with a newer all-clusters-app. Crash occurred because chip-tool failed parsing the SubscribeResponse message due to a missing `MinInterval` field that since been deleted in the newer all-clusters-app.

#### Cause

If an error was encountered parsing the SubscribeResponse message, `ReadClient::OnMessageReceived` would just null-out the EC pointer but not the delegate pointer within the EC. This meant that when we got back to the exchange management layer after unwinding the stack, it attempted to call `OnExchangeClosing` on the delegate that had by then, been free'ed as part of cleaning up the `ReadClient` object.

#### Fix

If we encountered an error, let `SuccessOrExit()` naturally take us to executing `Close` which will automatically clean-up the delegate + EC pointers.

If it was successful, manually clear it up.

#### Testing

Reproduced the crash by injecting the failure manually, then validated the fix worked.
