### PR TITLE
[chip-cert] Add support for 'chip-hex' encoding to certificate tool. 

### DIFF
--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -178,5 +178,17 @@ size_t UppercaseHexToUint32(const char * src_hex, const size_t src_size, uint32_
 /** Same as UppercaseHexToUint64() but for uint16_t. */
 size_t UppercaseHexToUint16(const char * src_hex, const size_t src_size, uint16_t & dest);
 
+/**
+ * Computes the hex encoded length for a given input length.
+ * Left shift to generate optimized equivalent of LEN*2.
+ */
+#define HEX_ENCODED_LENGTH(LEN) ((LEN) << 1)
+
+/**
+ * Computes the maximum possible decoded length for a given hex string input length.
+ * Right shift to generate optimized equivalent of LEN/2.
+ */
+#define HEX_MAX_DECODED_LENGTH(LEN) ((LEN) >> 1)
+
 } // namespace Encoding
 } // namespace chip

--- a/src/tools/chip-cert/Cmd_ConvertCert.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertCert.cpp
@@ -41,8 +41,9 @@ bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
 OptionDef gCmdOptionDefs[] =
 {
     { "x509-pem",   kNoArgument, 'p' },
-    { "x509-der",   kNoArgument, 'x' },
+    { "x509-der",   kNoArgument, 'd' },
     { "chip",       kNoArgument, 'c' },
+    { "chip-hex",   kNoArgument, 'x' },
     { "chip-b64",   kNoArgument, 'b' },
     { }
 };
@@ -52,13 +53,17 @@ const char * const gCmdOptionHelp =
     "\n"
     "       Output certificate in X.509 PEM format.\n"
     "\n"
-    "  -x, --x509-der\n"
+    "  -d, --x509-der\n"
     "\n"
     "       Output certificate in X.509 DER format.\n"
     "\n"
     "  -c, --chip\n"
     "\n"
     "       Output certificate in raw CHIP TLV format.\n"
+    "\n"
+    "  -x, --chip-hex\n"
+    "\n"
+    "       Output certificate in CHIP TLV hexidecimal format.\n"
     "\n"
     "  -b --chip-b64\n"
     "\n"
@@ -114,8 +119,11 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
     case 'p':
         gOutCertFormat = kCertFormat_X509_PEM;
         break;
-    case 'x':
+    case 'd':
         gOutCertFormat = kCertFormat_X509_DER;
+        break;
+    case 'x':
+        gOutCertFormat = kCertFormat_Chip_Hex;
         break;
     case 'b':
         gOutCertFormat = kCertFormat_Chip_Base64;

--- a/src/tools/chip-cert/Cmd_ConvertCert.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertCert.cpp
@@ -63,7 +63,7 @@ const char * const gCmdOptionHelp =
     "\n"
     "  -x, --chip-hex\n"
     "\n"
-    "       Output certificate in CHIP TLV hexidecimal format.\n"
+    "       Output certificate in CHIP TLV hexadecimal format.\n"
     "\n"
     "  -b --chip-b64\n"
     "\n"

--- a/src/tools/chip-cert/Cmd_ConvertKey.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertKey.cpp
@@ -41,8 +41,9 @@ bool HandleNonOptionArgs(const char * progName, int argc, char * const argv[]);
 OptionDef gCmdOptionDefs[] =
 {
     { "x509-pem",       kNoArgument, 'p' },
-    { "x509-der",       kNoArgument, 'x' },
+    { "x509-der",       kNoArgument, 'd' },
     { "chip",           kNoArgument, 'c' },
+    { "chip-hex",       kNoArgument, 'x' },
     { "chip-b64",       kNoArgument, 'b' },
     { }
 };
@@ -52,13 +53,16 @@ const char * const gCmdOptionHelp =
     "\n"
     "       Output the private key in SEC1/RFC-5915 PEM format.\n"
     "\n"
-    "   -x, --x509-der\n"
+    "   -d, --x509-der\n"
     "\n"
     "       Output the private key in SEC1/RFC-5915 DER format. \n"
     "\n"
     "   -c, --chip\n"
     "\n"
     "       Output the private key in raw CHIP serialized format.\n"
+    "   -x, --chip-hex\n"
+    "\n"
+    "       Output the private key in hex encoded CHIP serialized format.\n"
     "\n"
     "   -b, --chip-b64\n"
     "\n"
@@ -115,11 +119,14 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
     case 'p':
         gOutFormat = kKeyFormat_X509_PEM;
         break;
-    case 'x':
+    case 'd':
         gOutFormat = kKeyFormat_X509_DER;
         break;
     case 'b':
         gOutFormat = kKeyFormat_Chip_Base64;
+        break;
+    case 'x':
+        gOutFormat = kKeyFormat_Chip_Hex;
         break;
     case 'c':
         gOutFormat = kKeyFormat_Chip_Raw;

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -140,6 +140,7 @@ const char * const gCmdOptionHelp =
     "           x509-pem  - X.509 PEM format\n"
     "           x509-der  - X.509 DER format\n"
     "           chip      - raw CHIP TLV format\n"
+    "           chip-hex  - hex encoded CHIP TLV format\n"
     "           chip-b64  - base-64 encoded CHIP TLV format (default)\n"
     "\n"
     "   -V, --valid-from <YYYY>-<MM>-<DD> [ <HH>:<MM>:<SS> ]\n"
@@ -458,6 +459,11 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         {
             gOutCertFormat = kCertFormat_Chip_Base64;
             gOutKeyFormat  = kKeyFormat_Chip_Base64;
+        }
+        else if (strcmp(arg, "chip-hex") == 0)
+        {
+            gOutCertFormat = kCertFormat_Chip_Hex;
+            gOutKeyFormat  = kKeyFormat_Chip_Hex;
         }
         else
         {

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -2,26 +2,26 @@
 
 ## Table of Contents
 
-- [CHIP Certificate Tool](#chip-certificate-tool)
-  - [Table of Contents](#table-of-contents)
-  - [Introduction](#introduction)
-  - [Directory Structure](#directory-structure)
-    - [<code>/src/tools/chip-cert</code>](#srctoolschip-cert)
-  - [Usage Examples](#usage-examples)
-  - [Operational Certificates Usage Examples](#operational-certificates-usage-examples)
-    - [Attestation Certificates Usage Examples](#attestation-certificates-usage-examples)
-  - [Command Reference](#command-reference)
-    - [help](#help)
-    - [gen-cert](#gen-cert)
-    - [convert-cert](#convert-cert)
-    - [convert-key](#convert-key)
-    - [resign-cert](#resign-cert)
-    - [validate-cert](#validate-cert)
-    - [print-cert](#print-cert)
-    - [gen-att-cert](#gen-att-cert)
-    - [validate-att-cert](#validate-att-cert)
-    - [gen-cd](#gen-cd)
-    - [version](#version)
+-   [CHIP Certificate Tool](#chip-certificate-tool)
+    -   [Table of Contents](#table-of-contents)
+    -   [Introduction](#introduction)
+    -   [Directory Structure](#directory-structure)
+        -   [<code>/src/tools/chip-cert</code>](#srctoolschip-cert)
+    -   [Usage Examples](#usage-examples)
+    -   [Operational Certificates Usage Examples](#operational-certificates-usage-examples)
+        -   [Attestation Certificates Usage Examples](#attestation-certificates-usage-examples)
+    -   [Command Reference](#command-reference)
+        -   [help](#help)
+        -   [gen-cert](#gen-cert)
+        -   [convert-cert](#convert-cert)
+        -   [convert-key](#convert-key)
+        -   [resign-cert](#resign-cert)
+        -   [validate-cert](#validate-cert)
+        -   [print-cert](#print-cert)
+        -   [gen-att-cert](#gen-att-cert)
+        -   [validate-att-cert](#validate-att-cert)
+        -   [gen-cd](#gen-cd)
+        -   [version](#version)
 
 ## Introduction
 
@@ -317,7 +317,7 @@ COMMAND OPTIONS
 
   -x, --chip-hex
 
-       Output certificate in CHIP TLV hexidecimal format.
+       Output certificate in CHIP TLV hexadecimal format.
 
   -b --chip-b64
 

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -2,26 +2,26 @@
 
 ## Table of Contents
 
--   [CHIP Certificate Tool](#chip-certificate-tool)
-    -   [Table of Contents](#table-of-contents)
-    -   [Introduction](#introduction)
-    -   [Directory Structure](#directory-structure)
-        -   [<code>/src/tools/chip-cert</code>](#srctoolschip-cert)
-    -   [Usage Examples](#usage-examples)
-    -   [Operational Certificates Usage Examples](#operational-certificates-usage-examples)
-        -   [Attestation Certificates Usage Examples](#attestation-certificates-usage-examples)
-    -   [Command Reference](#command-reference)
-        -   [help](#help)
-        -   [gen-cert](#gen-cert)
-        -   [convert-cert](#convert-cert)
-        -   [convert-key](#convert-key)
-        -   [resign-cert](#resign-cert)
-        -   [validate-cert](#validate-cert)
-        -   [print-cert](#print-cert)
-        -   [gen-att-cert](#gen-att-cert)
-        -   [validate-att-cert](#validate-att-cert)
-        -   [gen-cd](#gen-cd)
-        -   [version](#version)
+- [CHIP Certificate Tool](#chip-certificate-tool)
+  - [Table of Contents](#table-of-contents)
+  - [Introduction](#introduction)
+  - [Directory Structure](#directory-structure)
+    - [<code>/src/tools/chip-cert</code>](#srctoolschip-cert)
+  - [Usage Examples](#usage-examples)
+  - [Operational Certificates Usage Examples](#operational-certificates-usage-examples)
+    - [Attestation Certificates Usage Examples](#attestation-certificates-usage-examples)
+  - [Command Reference](#command-reference)
+    - [help](#help)
+    - [gen-cert](#gen-cert)
+    - [convert-cert](#convert-cert)
+    - [convert-key](#convert-key)
+    - [resign-cert](#resign-cert)
+    - [validate-cert](#validate-cert)
+    - [print-cert](#print-cert)
+    - [gen-att-cert](#gen-att-cert)
+    - [validate-att-cert](#validate-att-cert)
+    - [gen-cd](#gen-cd)
+    - [version](#version)
 
 ## Introduction
 
@@ -258,6 +258,7 @@ COMMAND OPTIONS
            x509-pem  - X.509 PEM format
            x509-der  - X.509 DER format
            chip      - raw CHIP TLV format
+           chip-hex  - hex encoded CHIP TLV format
            chip-b64  - base-64 encoded CHIP TLV format (default)
 
    -V, --valid-from <YYYY>-<MM>-<DD> [ <HH>:<MM>:<SS> ]
@@ -306,13 +307,17 @@ COMMAND OPTIONS
 
        Output certificate in X.509 PEM format.
 
-  -x, --x509-der
+  -d, --x509-der
 
        Output certificate in X.509 DER format.
 
   -c, --chip
 
        Output certificate in raw CHIP TLV format.
+
+  -x, --chip-hex
+
+       Output certificate in CHIP TLV hexidecimal format.
 
   -b --chip-b64
 
@@ -353,13 +358,16 @@ COMMAND OPTIONS
 
        Output the private key in SEC1/RFC-5915 PEM format.
 
-   -x, --x509-der
+   -d, --x509-der
 
        Output the private key in SEC1/RFC-5915 DER format.
 
    -c, --chip
 
        Output the private key in raw CHIP serialized format.
+   -x, --chip-hex
+
+       Output the private key in hex encoded CHIP serialized format.
 
    -b, --chip-b64
 

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -105,7 +105,8 @@ enum KeyFormat
     kKeyFormat_X509_PEM,
     kKeyFormat_X509_PUBKEY_PEM,
     kKeyFormat_Chip_Raw,
-    kKeyFormat_Chip_Base64
+    kKeyFormat_Chip_Base64,
+    kKeyFormat_Chip_Hex
 };
 
 enum AttCertType

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -94,7 +94,8 @@ enum CertFormat
     kCertFormat_X509_DER,
     kCertFormat_X509_PEM,
     kCertFormat_Chip_Raw,
-    kCertFormat_Chip_Base64
+    kCertFormat_Chip_Base64,
+    kCertFormat_Chip_Hex,
 };
 
 enum KeyFormat


### PR DESCRIPTION
#### Problem
The chip TLV certificate encoding provides some nice compression, but is still a fairly new format.
Certificates in this format, such as the NOC, may be written to logs in hexadecimal format.
The chip-cert tool should make it easy to digest `chip-hex` encoded certificates and convert them into other forms.

#### Change overview
Add support for `chip-hex` format to the `chip-cert` tool, including both input and output of the `convert-cert`, `convert-key`, and `generate-cert` commands.

#### Testing
Manual.  A unit test framework to the `chip-cert` tool would be good to add.
Also ran `./src/tools/chip-cert/gen_com_dut_test_vectors.py` from the top-level and saw equivalent output discounting json whitespace.