### PR TITLE
[Pump-server] Add unsupported operation mode handling in pump server

### DIFF
--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -389,7 +389,7 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
         }
     }
     break;
-    
+
     case Attributes::OperationMode::Id:
         PumpOperationMode operationMode;
         NumericAttributeTraits<PumpOperationMode>::StorageType tmp;

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -354,9 +354,9 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
     {
     case Attributes::ControlMode::Id: {
         PumpControlMode controlMode;
-        NumericAttributeTraits<PumpControlMode>::StorageType storage;
-        memcpy(&storage, value, size);
-        controlMode = NumericAttributeTraits<PumpControlMode>::StorageToWorking(storage);
+        NumericAttributeTraits<PumpControlMode>::StorageType tmp;
+        memcpy(&tmp, value, size);
+        controlMode = NumericAttributeTraits<PumpControlMode>::StorageToWorking(tmp);
         switch (controlMode)
         {
         case PumpControlMode::kConstantFlow:
@@ -385,12 +385,41 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
             }
             break;
         default:
-            status = Protocols::InteractionModel::Status::Success;
+            status = Protocols::InteractionModel::Status::ConstraintError;
         }
     }
     break;
+    
     case Attributes::OperationMode::Id:
-        // TODO: Implement checks on the Operation Mode values
+        PumpOperationMode operationMode;
+        NumericAttributeTraits<PumpOperationMode>::StorageType tmp;
+        memcpy(&tmp, value, size);
+        operationMode = NumericAttributeTraits<PumpOperationMode>::StorageToWorking(tmp);
+
+        switch (operationMode)
+        {
+        case PumpOperationMode::kNormal:
+            // No constraint
+            break;
+        case PumpOperationMode::kMinimum:
+            if (!IsFeatureSupported(attributePath.mEndpointId, Attributes::MinConstSpeed::Get, Attributes::MaxConstSpeed::Get))
+            {
+                status = Protocols::InteractionModel::Status::ConstraintError;
+            }
+            break;
+        case PumpOperationMode::kMaximum:
+            if (!IsFeatureSupported(attributePath.mEndpointId, Attributes::MinConstSpeed::Get, Attributes::MaxConstSpeed::Get))
+            {
+                status = Protocols::InteractionModel::Status::ConstraintError;
+            }
+            break;
+        case PumpOperationMode::kLocal:
+            // No constraint
+            break;
+        default:
+            status = Protocols::InteractionModel::Status::ConstraintError;
+        }
+
         break;
     default:
         status = Protocols::InteractionModel::Status::Success;

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -385,7 +385,7 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
             }
             break;
         default:
-            status = Protocols::InteractionModel::Status::ConstraintError;
+            status = Protocols::InteractionModel::Status::Success;
         }
     }
     break;
@@ -398,9 +398,6 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
 
         switch (operationMode)
         {
-        case PumpOperationMode::kNormal:
-            // No constraint
-            break;
         case PumpOperationMode::kMinimum:
             if (!IsFeatureSupported(attributePath.mEndpointId, Attributes::MinConstSpeed::Get, Attributes::MaxConstSpeed::Get))
             {
@@ -413,11 +410,8 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
-        case PumpOperationMode::kLocal:
-            // No constraint
-            break;
         default:
-            status = Protocols::InteractionModel::Status::ConstraintError;
+            status = Protocols::InteractionModel::Status::Success;
         }
 
         break;


### PR DESCRIPTION
#### Problem
What is being fixed?
* Minimum and maximum operation modes are linked to the speed control mode, if this is not supported by a device it should not allow to set these operation modes.

#### Change overview
Added check to determine if speed "feature" is supported be the device and returns error if these modes are not supported. Similar to how the control mode attribute is handled.

#### Testing
How was this tested? (at least one bullet point required)
* Manually tested on cc2652r7 launchpad