### PR TITLE
Change persistent storage SyncGetKeyValue API to match constraints of KvsStorageManager

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -115,7 +115,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 
     uint16_t dataSize = static_cast<uint16_t>(iniValue.size());
     ReturnErrorCodeIf(size == 0 && dataSize == 0, CHIP_NO_ERROR);
-    ReturnErrorCodeIf(((value == nullptr) && (size == 0)), CHIP_ERROR_BUFFER_TOO_SMALL);
+    ReturnErrorCodeIf(value == nullptr, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     uint16_t sizeToCopy = std::min(size, dataSize);
 

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 {
     std::string iniValue;
 
-    ReturnErrorCodeIf((value == nullptr) && (size != 0)), CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorCodeIf(((value == nullptr) && (size != 0)), CHIP_ERROR_INVALID_ARGUMENT);
 
     auto section = mConfig.sections[kDefaultSectionName];
     auto it      = section.find(key);
@@ -113,10 +113,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 
     iniValue = Base64ToString(iniValue);
 
-    if ((value == nullptr) && (size == 0))
-    {
-        return CHIP_ERROR_BUFFER_TOO_SMALL;
-    }
+    ReturnErrorCodeIf(((value == nullptr) && (size == 0)), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     uint16_t dataSize   = static_cast<uint16_t>(iniValue.size());
     uint16_t sizeToCopy = std::min(size, dataSize);

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -113,9 +113,10 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 
     iniValue = Base64ToString(iniValue);
 
+    uint16_t dataSize = static_cast<uint16_t>(iniValue.size());
+    ReturnErrorCodeIf(size == 0 && dataSize == 0, CHIP_NO_ERROR);
     ReturnErrorCodeIf(((value == nullptr) && (size == 0)), CHIP_ERROR_BUFFER_TOO_SMALL);
 
-    uint16_t dataSize   = static_cast<uint16_t>(iniValue.size());
     uint16_t sizeToCopy = std::min(size, dataSize);
 
     memcpy(value, iniValue.data(), sizeToCopy);

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -103,10 +103,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 {
     std::string iniValue;
 
-    if ((value == nullptr) && (size != 0))
-    {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
+    ReturnErrorCodeIf((value == nullptr) && (size != 0)), CHIP_ERROR_INVALID_ARGUMENT);
 
     auto section = mConfig.sections[kDefaultSectionName];
     auto it      = section.find(key);

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -121,7 +121,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
-    uint16_t dataSize = static_cast<uint16_t>(iniValue.size());
+    uint16_t dataSize   = static_cast<uint16_t>(iniValue.size());
     uint16_t sizeToCopy = std::min(size, dataSize);
 
     memcpy(value, iniValue.data(), sizeToCopy);

--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -103,7 +103,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 {
     std::string iniValue;
 
-    if ((buffer == nullptr) && (size != 0))
+    if ((value == nullptr) && (size != 0))
     {
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
@@ -116,7 +116,7 @@ CHIP_ERROR PersistentStorage::SyncGetKeyValue(const char * key, void * value, ui
 
     iniValue = Base64ToString(iniValue);
 
-    if ((buffer == nullptr) && (size == 0))
+    if ((value == nullptr) && (size == 0))
     {
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, vo
 
     uint16_t neededSize = val->second.size();
     ReturnErrorCodeIf(size == 0 && neededSize == 0, CHIP_NO_ERROR);
-    ReturnErrorCodeIf(((value == nullptr) && (size == 0)), CHIP_ERROR_BUFFER_TOO_SMALL);
+    ReturnErrorCodeIf(value == nullptr, CHIP_ERROR_BUFFER_TOO_SMALL);
 
     if (size < neededSize)
     {

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -24,6 +24,7 @@
 #include <string>
 
 #include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 namespace chip {

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -31,10 +31,7 @@ namespace Controller {
 
 CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
 {
-    if ((value == nullptr) && (size != 0))
-    {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
+    ReturnErrorCodeIf(((value == nullptr) && (size != 0)), CHIP_ERROR_INVALID_ARGUMENT);
 
     auto val = mStorage.find(key);
     if (val == mStorage.end())
@@ -43,10 +40,8 @@ CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, vo
     }
 
     uint16_t neededSize = val->second.size();
-    if ((value == nullptr) && (size == 0))
-    {
-        return CHIP_ERROR_BUFFER_TOO_SMALL;
-    }
+    ReturnErrorCodeIf(size == 0 && neededSize == 0, CHIP_NO_ERROR);
+    ReturnErrorCodeIf(((value == nullptr) && (size == 0)), CHIP_ERROR_BUFFER_TOO_SMALL);
 
     if (size < neededSize)
     {

--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -31,28 +31,26 @@ namespace Controller {
 
 CHIP_ERROR PythonPersistentStorageDelegate::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
 {
+    if ((value == nullptr) && (size != 0))
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
     auto val = mStorage.find(key);
     if (val == mStorage.end())
     {
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
 
-    if (value == nullptr)
-    {
-        size = 0;
-    }
-
     uint16_t neededSize = val->second.size();
-    if (size == 0)
+    if ((value == nullptr) && (size == 0))
     {
-        size = neededSize;
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
     if (size < neededSize)
     {
         memcpy(value, val->second.data(), size);
-        size = neededSize;
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 
@@ -86,6 +84,10 @@ namespace Python {
 CHIP_ERROR StorageAdapter::SyncGetKeyValue(const char * key, void * value, uint16_t & size)
 {
     ChipLogDetail(Controller, "StorageAdapter::GetKeyValue: Key = %s, Value = %p (%u)", key, value, size);
+    if ((value == nullptr) && (size != 0))
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     uint16_t tmpSize = size;
 
@@ -99,7 +101,6 @@ CHIP_ERROR StorageAdapter::SyncGetKeyValue(const char * key, void * value, uint1
     if (size < tmpSize)
     {
         ChipLogDetail(Controller, "Buf not big enough\n");
-        size = tmpSize;
         return CHIP_ERROR_BUFFER_TOO_SMALL;
     }
 

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -46,23 +46,29 @@ def _OnSyncSetKeyValueCb(storageObj, key: str, value, size):
 
 @_SyncGetKeyValueCbFunct
 def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
+    ''' This does not adhear API requirement of
+    PersistentStorageDelegate::SyncGetKeyValue, but that is okay since
+    the caller to is capable of converting results from calling this
+    to the requirements of PersistentStorageDelegate::SyncGetKeyValue.
+    '''
     try:
         keyValue = storageObj.GetSdkKey(key.decode("utf-8"))
     except Exception as ex:
         keyValue = None
 
     if (keyValue):
-        if (size[0] < len(keyValue)):
-            size[0] = len(keyValue)
-            return
+        sizeOfValue = size[0]
+        sizeToCopy = min(sizeOfValue, len(keyValue))
 
         count = 0
 
         for idx, val in enumerate(keyValue):
+            if sizeToCopy == count:
+                break
             value[idx] = val
             count = count + 1
 
-        size[0] = count
+        size[0] = len(keyValue)
     else:
         size[0] = 0
 

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -46,9 +46,9 @@ def _OnSyncSetKeyValueCb(storageObj, key: str, value, size):
 
 @_SyncGetKeyValueCbFunct
 def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
-    ''' This does not adhear API requirement of
+    ''' This does not adhere API requirement of
     PersistentStorageDelegate::SyncGetKeyValue, but that is okay since
-    the caller to is capable of converting results from calling this
+    the callers are capable of adapting results from this method
     to the requirements of PersistentStorageDelegate::SyncGetKeyValue.
     '''
     try:
@@ -68,6 +68,10 @@ def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
             value[idx] = val
             count = count + 1
 
+        # As mentioned above, we are intentionally not returning
+        # sizeToCopy as one might expected because the caller
+        # will use the value in size[0] to determine if it should
+        # return CHIP_ERROR_BUFFER_TOO_SMALL.
         size[0] = len(keyValue)
     else:
         size[0] = 0

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -46,7 +46,7 @@ def _OnSyncSetKeyValueCb(storageObj, key: str, value, size):
 
 @_SyncGetKeyValueCbFunct
 def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
-    ''' This does not adhere API requirement of
+    ''' This does not adhere to the API requirements of
     PersistentStorageDelegate::SyncGetKeyValue, but that is okay since
     the C++ storage binding layer is capable of adapting results from
     this method to the requirements of
@@ -70,7 +70,7 @@ def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
             count = count + 1
 
         # As mentioned above, we are intentionally not returning
-        # sizeToCopy as one might expected because the caller
+        # sizeToCopy as one might expect because the caller
         # will use the value in size[0] to determine if it should
         # return CHIP_ERROR_BUFFER_TOO_SMALL.
         size[0] = len(keyValue)

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -48,8 +48,9 @@ def _OnSyncSetKeyValueCb(storageObj, key: str, value, size):
 def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
     ''' This does not adhere API requirement of
     PersistentStorageDelegate::SyncGetKeyValue, but that is okay since
-    the callers are capable of adapting results from this method
-    to the requirements of PersistentStorageDelegate::SyncGetKeyValue.
+    the C++ storage binding layer is capable of adapting results from
+    this method to the requirements of
+    PersistentStorageDelegate::SyncGetKeyValue.
     '''
     try:
         keyValue = storageObj.GetSdkKey(key.decode("utf-8"))

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -52,14 +52,10 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key
         uint16_t valueSize = static_cast<uint16_t>([value length]);
         if (valueSize > size) {
             error = CHIP_ERROR_BUFFER_TOO_SMALL;
-            if (size != 0) {
-                // buffer is known to be non-null here.
-                memcpy(buffer, [value bytes], size);
-            }
-            return error;
+        } else {
+            size = valueSize;
         }
 
-        size = valueSize;
         if (size != 0) {
             // buffer is known to be non-null here.
             memcpy(buffer, [value bytes], size);

--- a/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/CHIPPersistentStorageDelegateBridge.mm
@@ -45,16 +45,18 @@ CHIP_ERROR CHIPPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key
         }
 
         if ([value length] > UINT16_MAX) {
-            error = CHIP_ERROR_BUFFER_TOO_SMALL;
-            size = 0;
+            error = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
             return;
         }
 
         uint16_t valueSize = static_cast<uint16_t>([value length]);
         if (valueSize > size) {
             error = CHIP_ERROR_BUFFER_TOO_SMALL;
-            size = valueSize;
-            return;
+            if (size != 0) {
+                // buffer is known to be non-null here.
+                memcpy(buffer, [value bytes], size);
+            }
+            return error;
         }
 
         size = valueSize;

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -53,9 +53,9 @@ public:
      *   CHIP_ERROR_BUFFER_TOO_SMALL will be returned, but the `buffer` will still be filled with the
      *   first `size` bytes of the stored value.
      *
-     *   A way to determine if the key exists is to pass `size` of 0, which is always valid to do,
-     *   and check if CHIP_ERROR_BUFFER_TOO_SMALL is returned. Alternatively, the helper
-     *   method SyncDoesKeyExist(key) can be used to more easily achieve the same effect.
+     *   In the case where `size` of 0 is given, and the value stored is of size 0, CHIP_NO_ERROR is
+     *   returned. It is recommended to use helper method SyncDoesKeyExist(key) to determine if key
+     *   exists.
      *
      *   It is legal to use `nullptr` for `buffer` if `size` is 0.
      *

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -46,18 +46,12 @@ public:
      *   Caller is responsible to take care of any special formatting needs (e.g. byte
      *   order, null terminators, consistency checks or versioning).
      *
-     *   This API allows for determining the size of a stored value. Whenever
-     *   the passed `size` is smaller than needed and the key exists in storage, the error
-     *   CHIP_ERROR_BUFFER_TOO_SMALL will be given, and the `size` will be updated to the
-     *   size of the stored value. It is legal to use `nullptr` for `buffer` if `size` is 0.
-     *
      *   If a key is found and the `buffer`'s `size` is large enough, then the value will
      *   be copied to `buffer` and `size` will be updated to the actual size used.
      *
-     *   The easiest way to determine if a key exists (and the value's size if so) is to pass
-     *   `size` of 0, which is always valid to do, and will return CHIP_ERROR_BUFFER_TOO_SMALL
-     *   if the key exists and CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND if the
-     *   key is not found.
+     *   Whenever the passed `size` is smaller than needed and the key exists in storage,
+     *   the error CHIP_ERROR_BUFFER_TOO_SMALL will be given. The `buffer` will be filled
+     *   up to`size`. It is legal to use `nullptr` for `buffer` if `size` is 0.
      *
      * @param[in]      key Key to lookup
      * @param[out]     buffer Pointer to a buffer where the place the read value.
@@ -65,11 +59,7 @@ public:
      *
      * @return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND the key is not found in storage.
      * @return CHIP_ERROR_BUFFER_TOO_SMALL the provided buffer is not big enough.  In this case
-     *                                     "size" will indicate the needed buffer size. Some data
-     *                                     may or may not be placed in "buffer" in this case; consumers
-     *                                     should not rely on that behavior. CHIP_ERROR_BUFFER_TOO_SMALL
-     *                                     combined with setting "size" to 0 means the actual size was
-     *                                     too large to fit in uint16_t.
+     *                                     `buffer` will be filled up to `size`.
      */
     virtual CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) = 0;
 
@@ -97,6 +87,21 @@ public:
      *         or another CHIP_ERROR value from implementation on failure.
      */
     virtual CHIP_ERROR SyncDeleteKeyValue(const char * key) = 0;
+
+    /**
+     * @brief
+     *   Helper function that identifies if a key exists.
+     *
+     * @param[in] key Key to check if it exist
+     *
+     * @return true if key exists in storage, false if key does not exist in storage.
+     */
+    bool SyncDoesKeyExist(const char * key)
+    {
+        uint16_t size  = 0;
+        CHIP_ERROR err = SyncGetKeyValue(key, nullptr, size);
+        return err == CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
 };
 
 } // namespace chip

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -53,6 +53,10 @@ public:
      *   CHIP_ERROR_BUFFER_TOO_SMALL will be given, but the `buffer` will still be filled `size`
      *   bytes of the stored value.
      *
+     *   A way to determine if the key exists is to pass `size` of 0, which is always valid to do,
+     *   and check if CHIP_ERROR_BUFFER_TOO_SMALL is returned. Alternativelt you can use the helper
+     *   function SyncDoesKeyExist(key).
+     *
      *   It is legal to use `nullptr` for `buffer` if `size` is 0.
      *
      * @param[in]      key Key to lookup

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -49,9 +49,11 @@ public:
      *   If a key is found and the `buffer`'s `size` is large enough, then the value will
      *   be copied to `buffer` and `size` will be updated to the actual size used.
      *
-     *   Whenever the passed `size` is smaller than needed and the key exists in storage,
-     *   the error CHIP_ERROR_BUFFER_TOO_SMALL will be given. The `buffer` will be filled
-     *   up to`size`. It is legal to use `nullptr` for `buffer` if `size` is 0.
+     *   Whenever the passed `size` is smaller than the value for which the key exists in storage,
+     *   CHIP_ERROR_BUFFER_TOO_SMALL will be given, but the `buffer` will still be filled `size`
+     *   bytes of the stored value.
+     *
+     *   It is legal to use `nullptr` for `buffer` if `size` is 0.
      *
      * @param[in]      key Key to lookup
      * @param[out]     buffer Pointer to a buffer where the place the read value.
@@ -91,20 +93,18 @@ public:
     /**
      * @brief
      *   Helper function that identifies if a key exists.
+     * 
+     *   This may be overridden to provide an implementation that is simpler or more direct.
      *
      * @param[in] key Key to check if it exist
      *
-     * @return true if key exists in storage, false if key does not exist in storage.
+     * @return true if key exists in storage. It returns false if key does not exist in storage or an internal error arises.
      */
-    bool SyncDoesKeyExist(const char * key)
+    virtual bool SyncDoesKeyExist(const char * key)
     {
         uint16_t size  = 0;
         CHIP_ERROR err = SyncGetKeyValue(key, nullptr, size);
-        if (err == CHIP_ERROR_BUFFER_TOO_SMALL || err == CHIP_NO_ERROR)
-        {
-            return true;
-        }
-        return false;
+        return (err == CHIP_ERROR_BUFFER_TOO_SMALL) || (err == CHIP_NO_ERROR);
     }
 };
 

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -54,8 +54,8 @@ public:
      *   bytes of the stored value.
      *
      *   A way to determine if the key exists is to pass `size` of 0, which is always valid to do,
-     *   and check if CHIP_ERROR_BUFFER_TOO_SMALL is returned. Alternativelt you can use the helper
-     *   function SyncDoesKeyExist(key).
+     *   and check if CHIP_ERROR_BUFFER_TOO_SMALL is returned. Alternatively, the helper
+     *   method SyncDoesKeyExist(key) can be used to more easily achieve the same effect.
      *
      *   It is legal to use `nullptr` for `buffer` if `size` is 0.
      *

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -93,7 +93,7 @@ public:
     /**
      * @brief
      *   Helper function that identifies if a key exists.
-     * 
+     *
      *   This may be overridden to provide an implementation that is simpler or more direct.
      *
      * @param[in] key Key to check if it exist

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -49,9 +49,9 @@ public:
      *   If a key is found and the `buffer`'s `size` is large enough, then the value will
      *   be copied to `buffer` and `size` will be updated to the actual size used.
      *
-     *   Whenever the passed `size` is smaller than the value for which the key exists in storage,
-     *   CHIP_ERROR_BUFFER_TOO_SMALL will be given, but the `buffer` will still be filled `size`
-     *   bytes of the stored value.
+     *   Whenever the passed `size` is smaller than the size of the stored value for the given key,
+     *   CHIP_ERROR_BUFFER_TOO_SMALL will be returned, but the `buffer` will still be filled with the
+     *   first `size` bytes of the stored value.
      *
      *   A way to determine if the key exists is to pass `size` of 0, which is always valid to do,
      *   and check if CHIP_ERROR_BUFFER_TOO_SMALL is returned. Alternatively, the helper
@@ -61,11 +61,11 @@ public:
      *
      * @param[in]      key Key to lookup
      * @param[out]     buffer Pointer to a buffer where the place the read value.
-     * @param[in, out] size Input is maximum buffer size, output updated to length of value.
+     * @param[in, out] size Input is maximum buffer size, output updated to number of bytes written into `buffer`.
      *
      * @return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND the key is not found in storage.
      * @return CHIP_ERROR_BUFFER_TOO_SMALL the provided buffer is not big enough.  In this case
-     *                                     `buffer` will be filled up to `size`.
+     *                                     the first `size` bytes of the value will be placed in `buffer`.
      */
     virtual CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) = 0;
 

--- a/src/lib/core/CHIPPersistentStorageDelegate.h
+++ b/src/lib/core/CHIPPersistentStorageDelegate.h
@@ -100,7 +100,11 @@ public:
     {
         uint16_t size  = 0;
         CHIP_ERROR err = SyncGetKeyValue(key, nullptr, size);
-        return err == CHIP_ERROR_BUFFER_TOO_SMALL;
+        if (err == CHIP_ERROR_BUFFER_TOO_SMALL || err == CHIP_NO_ERROR)
+        {
+            return true;
+        }
+        return false;
     }
 };
 

--- a/src/lib/support/PersistentStorageAudit.cpp
+++ b/src/lib/support/PersistentStorageAudit.cpp
@@ -276,7 +276,11 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     // Cleaning up
-    err = storage.SyncDeleteKeyValue("key3");
+    (void) storage.SyncDeleteKeyValue("roboto");
+    (void) storage.SyncDeleteKeyValue("key2");
+    (void) storage.SyncDeleteKeyValue("key3");
+    (void) storage.SyncDeleteKeyValue("key4");
+    (void) storage.SyncDeleteKeyValue(kLongKeyString);
 
     // ========== End of code from TestTestPersistentStorageDelegate.cpp =========
     if (inSuite->flagError)

--- a/src/lib/support/PersistentStorageAudit.cpp
+++ b/src/lib/support/PersistentStorageAudit.cpp
@@ -15,18 +15,276 @@
  *    limitations under the License.
  */
 
+#include <cstring>
+
 #include <lib/core/CHIPError.h>
 #include <lib/core/CHIPPersistentStorageDelegate.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 #include "PersistentStorageAudit.h"
 
+#ifdef NL_TEST_ASSERT
+#undef NL_TEST_ASSERT
+#endif
+
+#define NL_TEST_ASSERT(inSuite, inCondition)                              \
+    do {                                                                  \
+        (inSuite)->performedAssertions += 1;                              \
+                                                                          \
+        if (!(inCondition))                                               \
+        {                                                                 \
+            ChipLogError(Automation, "%s:%u: assertion failed: \"%s\"\n", \
+                         __FILE__, __LINE__, #inCondition);               \
+            (inSuite)->failedAssertions += 1;                             \
+            (inSuite)->flagError = true;                                  \
+        }                                                                 \
+    } while (0)
+
 namespace chip {
 namespace audit {
 
+// The following test is a copy of `src/lib/support/tests/TestTestPersistentStorageDelegate.cpp` 's
+// `TestBasicApi()` test. It has to be copied since we currently are not setup to
+// run on-device unit tests at large on all embedded platforms part of the SDK.
 bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
 {
-    (void) storage;
+    struct fakeTestSuite
+    {
+        int performedAssertions = 0;
+        int failedAssertions = 0;
+        bool flagError = false;
+    } theSuite;
+    auto * inSuite = &theSuite;
+
+    const char * kLongKeyString = "aKeyThatIsExactlyMaxKeyLengthhhh";
+    // Start fresh.
+    (void)storage.SyncDeleteKeyValue("roboto");
+    (void)storage.SyncDeleteKeyValue("key2");
+    (void)storage.SyncDeleteKeyValue("key3");
+    (void)storage.SyncDeleteKeyValue("key4");
+    (void)storage.SyncDeleteKeyValue("keyDOES_NOT_EXIST");
+    (void)storage.SyncDeleteKeyValue(kLongKeyString);
+
+    // ========== Start of actual audit from TestTestPersistentStorageDelegate.cpp =========
+
+    uint8_t buf[16];
+    const uint16_t actualSizeOfBuf = static_cast<uint16_t>(sizeof(buf));
+    uint16_t size                  = actualSizeOfBuf;
+
+    // Key not there
+    CHIP_ERROR err;
+    memset(&buf[0], 0, sizeof(buf));
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("roboto", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
+
+    err = storage.SyncDeleteKeyValue("roboto");
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+
+    // Add basic key, read it back, erase it
+    const char * kStringValue1 = "abcd";
+    err                        = storage.SyncSetKeyValue("roboto", kStringValue1, static_cast<uint16_t>(strlen(kStringValue1)));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    memset(&buf[0], 0, sizeof(buf));
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("roboto", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == strlen(kStringValue1));
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kStringValue1, strlen(kStringValue1)));
+
+    err = storage.SyncDeleteKeyValue("roboto");
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    memset(&buf[0], 0, sizeof(buf));
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("roboto", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
+
+    // Validate adding 2 different keys
+    const char * kStringValue2 = "0123abcd";
+    const char * kStringValue3 = "cdef89";
+    err                        = storage.SyncSetKeyValue("key2", kStringValue2, static_cast<uint16_t>(strlen(kStringValue2)));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    err = storage.SyncSetKeyValue("key3", kStringValue3, static_cast<uint16_t>(strlen(kStringValue3)));
+    NL_TEST_ASSERT(inSuite, storage.SyncDoesKeyExist("key3"));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Read them back
+
+    uint8_t all_zeroes[sizeof(buf)];
+    memset(&all_zeroes[0], 0, sizeof(all_zeroes));
+
+    memset(&buf[0], 0, sizeof(buf));
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("key2", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == strlen(kStringValue2));
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kStringValue2, strlen(kStringValue2)));
+    // Make sure that there was no buffer overflow during SyncGetKeyValue
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));
+
+    memset(&buf[0], 0, sizeof(buf));
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("key3", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == strlen(kStringValue3));
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kStringValue3, strlen(kStringValue3)));
+    // Make sure that there was no buffer overflow during SyncGetKeyValue
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));
+
+    // Read providing too small a buffer. Data read up to `size` and nothing more.
+    memset(&buf[0], 0, sizeof(buf));
+    size                               = static_cast<uint16_t>(strlen(kStringValue2) - 1);
+    uint16_t sizeBeforeGetKeyValueCall = size;
+    err                                = storage.SyncGetKeyValue("key2", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+    NL_TEST_ASSERT(inSuite, size == sizeBeforeGetKeyValueCall);
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kStringValue2, size));
+    // Make sure that there was no buffer overflow during SyncGetKeyValue
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));
+
+    // Read in too small a buffer, which is nullptr and size == 0: check CHIP_ERROR_BUFFER_TOO_SMALL is given.
+    memset(&buf[0], 0, sizeof(buf));
+    size                      = 0;
+    sizeBeforeGetKeyValueCall = size;
+    err                       = storage.SyncGetKeyValue("key2", nullptr, size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
+    NL_TEST_ASSERT(inSuite, size != strlen(kStringValue2));
+    NL_TEST_ASSERT(inSuite, size == sizeBeforeGetKeyValueCall);
+    // Just making sure that implementation doesn't hold onto reference of previous destination buffer when
+    // nullptr is provided.
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], sizeof(buf)));
+
+    // Read in too small a buffer, which is nullptr and size != 0: error
+    size                      = static_cast<uint16_t>(strlen(kStringValue2) - 1);
+    sizeBeforeGetKeyValueCall = size;
+    err                       = storage.SyncGetKeyValue("key2", nullptr, size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, size == sizeBeforeGetKeyValueCall);
+    // Just making sure that implementation doesn't hold onto reference of previous destination buffer when
+    // nullptr is provided.
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], sizeof(buf)));
+
+    // When key not found, size is not touched.
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("keyDOES_NOT_EXIST", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    NL_TEST_ASSERT(inSuite, actualSizeOfBuf == size);
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], sizeof(buf)));
+
+    size = 0;
+    err  = storage.SyncGetKeyValue("keyDOES_NOT_EXIST", nullptr, size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    NL_TEST_ASSERT(inSuite, 0 == size);
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], sizeof(buf)));
+
+    // Even when key not found, cannot pass nullptr with size != 0.
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("keyDOES_NOT_EXIST", nullptr, size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, actualSizeOfBuf == size);
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], size));
+
+    // Attempt an empty key write with either nullptr or zero size works
+    err = storage.SyncSetKeyValue("key2", kStringValue2, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, storage.SyncDoesKeyExist("key2"));
+
+    size = 0;
+    err  = storage.SyncGetKeyValue("key2", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == 0);
+
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("key2", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == 0);
+
+    err = storage.SyncSetKeyValue("key2", nullptr, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, storage.SyncDoesKeyExist("key2"));
+
+    size = 0;
+    err  = storage.SyncGetKeyValue("key2", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == 0);
+
+    // Failure to set key if buffer is nullptr and size != 0
+    size = 10;
+    err  = storage.SyncSetKeyValue("key4", nullptr, size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
+    NL_TEST_ASSERT(inSuite, !storage.SyncDoesKeyExist("key4"));
+
+    // Can delete empty key
+    err = storage.SyncDeleteKeyValue("key2");
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    NL_TEST_ASSERT(inSuite, !storage.SyncDoesKeyExist("key2"));
+
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue("key2", &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], size));
+
+    // Try using key that is a size that equals PersistentStorageDelegate::kKeyLengthMax
+    char longKeyString[PersistentStorageDelegate::kKeyLengthMax + 1];
+    memset(&longKeyString, 'X', PersistentStorageDelegate::kKeyLengthMax);
+    longKeyString[sizeof(longKeyString) - 1] = '\0';
+    // strlen() is not compile time so we just have this runtime assert that should aways pass as a sanity check.
+    NL_TEST_ASSERT(inSuite, strlen(longKeyString) == PersistentStorageDelegate::kKeyLengthMax);
+
+    err = storage.SyncSetKeyValue(longKeyString, kStringValue2, static_cast<uint16_t>(strlen(kStringValue2)));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    memset(&buf[0], 0, sizeof(buf));
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue(longKeyString, &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == strlen(kStringValue2));
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kStringValue2, strlen(kStringValue2)));
+    // Make sure that there was no buffer overflow during SyncGetKeyValue
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));
+
+    NL_TEST_ASSERT(inSuite, storage.SyncDoesKeyExist(longKeyString));
+
+    err = storage.SyncDeleteKeyValue(longKeyString);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, !storage.SyncDoesKeyExist(longKeyString));
+
+    constexpr size_t kMaxCHIPCertLength = 400; // From credentials/CHIPCert.h and spec
+    uint8_t largeBuffer[kMaxCHIPCertLength];
+    memset(&largeBuffer, 'X', sizeof(largeBuffer));
+    uint8_t largeBufferForCheck[sizeof(largeBuffer)];
+    memcpy(largeBufferForCheck, largeBuffer, sizeof(largeBuffer));
+
+    err = storage.SyncSetKeyValue(longKeyString, largeBuffer, static_cast<uint16_t>(sizeof(largeBuffer)));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    memset(&largeBuffer, 0, sizeof(largeBuffer));
+    size = static_cast<uint16_t>(sizeof(largeBuffer));
+    err  = storage.SyncGetKeyValue(longKeyString, &largeBuffer[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == static_cast<uint16_t>(sizeof(largeBuffer)));
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&largeBuffer, largeBufferForCheck, sizeof(largeBuffer)));
+
+    err = storage.SyncDeleteKeyValue(longKeyString);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    // Cleaning up
+    err = storage.SyncDeleteKeyValue("key3");
+
+    // ========== End of code from TestTestPersistentStorageDelegate.cpp =========
+    if (inSuite->flagError)
+    {
+        ChipLogError(Automation, "==== PersistentStorageDelegate API audit: FAILED: %d/%d failed assertions ====", inSuite->failedAssertions, inSuite->performedAssertions);
+        return false;
+    }
+
     ChipLogError(Automation, "==== PersistentStorageDelegate API audit: SUCCESS ====");
     return true;
 }

--- a/src/lib/support/PersistentStorageAudit.cpp
+++ b/src/lib/support/PersistentStorageAudit.cpp
@@ -231,6 +231,25 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], size));
 
+    // Using key and value with base64 symbols
+    const char * kBase64SymbolsKey   = "key+/=";
+    const char * kBase64SymbolValues = "value+/=";
+    err = storage.SyncSetKeyValue(kBase64SymbolsKey, kBase64SymbolValues, static_cast<uint16_t>(strlen(kBase64SymbolValues)));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    memset(&buf[0], 0, sizeof(buf));
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue(kBase64SymbolsKey, &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == strlen(kBase64SymbolValues));
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kBase64SymbolValues, strlen(kBase64SymbolValues)));
+    // Make sure that there was no buffer overflow during SyncGetKeyValue
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));
+
+    err = storage.SyncDeleteKeyValue(kBase64SymbolsKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, !storage.SyncDoesKeyExist(kBase64SymbolsKey));
+
     // Try using key that is a size that equals PersistentStorageDelegate::kKeyLengthMax
     char longKeyString[PersistentStorageDelegate::kKeyLengthMax + 1];
     memset(&longKeyString, 'X', PersistentStorageDelegate::kKeyLengthMax);
@@ -280,6 +299,7 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     (void) storage.SyncDeleteKeyValue("key2");
     (void) storage.SyncDeleteKeyValue("key3");
     (void) storage.SyncDeleteKeyValue("key4");
+    (void) storage.SyncDeleteKeyValue(kBase64SymbolsKey);
     (void) storage.SyncDeleteKeyValue(kLongKeyString);
 
     // ========== End of code from TestTestPersistentStorageDelegate.cpp =========

--- a/src/lib/support/PersistentStorageAudit.cpp
+++ b/src/lib/support/PersistentStorageAudit.cpp
@@ -27,17 +27,17 @@
 #undef NL_TEST_ASSERT
 #endif
 
-#define NL_TEST_ASSERT(inSuite, inCondition)                              \
-    do {                                                                  \
-        (inSuite)->performedAssertions += 1;                              \
-                                                                          \
-        if (!(inCondition))                                               \
-        {                                                                 \
-            ChipLogError(Automation, "%s:%u: assertion failed: \"%s\"\n", \
-                         __FILE__, __LINE__, #inCondition);               \
-            (inSuite)->failedAssertions += 1;                             \
-            (inSuite)->flagError = true;                                  \
-        }                                                                 \
+#define NL_TEST_ASSERT(inSuite, inCondition)                                                                                       \
+    do                                                                                                                             \
+    {                                                                                                                              \
+        (inSuite)->performedAssertions += 1;                                                                                       \
+                                                                                                                                   \
+        if (!(inCondition))                                                                                                        \
+        {                                                                                                                          \
+            ChipLogError(Automation, "%s:%u: assertion failed: \"%s\"\n", __FILE__, __LINE__, #inCondition);                       \
+            (inSuite)->failedAssertions += 1;                                                                                      \
+            (inSuite)->flagError = true;                                                                                           \
+        }                                                                                                                          \
     } while (0)
 
 namespace chip {
@@ -51,19 +51,19 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     struct fakeTestSuite
     {
         int performedAssertions = 0;
-        int failedAssertions = 0;
-        bool flagError = false;
+        int failedAssertions    = 0;
+        bool flagError          = false;
     } theSuite;
     auto * inSuite = &theSuite;
 
     const char * kLongKeyString = "aKeyThatIsExactlyMaxKeyLengthhhh";
     // Start fresh.
-    (void)storage.SyncDeleteKeyValue("roboto");
-    (void)storage.SyncDeleteKeyValue("key2");
-    (void)storage.SyncDeleteKeyValue("key3");
-    (void)storage.SyncDeleteKeyValue("key4");
-    (void)storage.SyncDeleteKeyValue("keyDOES_NOT_EXIST");
-    (void)storage.SyncDeleteKeyValue(kLongKeyString);
+    (void) storage.SyncDeleteKeyValue("roboto");
+    (void) storage.SyncDeleteKeyValue("key2");
+    (void) storage.SyncDeleteKeyValue("key3");
+    (void) storage.SyncDeleteKeyValue("key4");
+    (void) storage.SyncDeleteKeyValue("keyDOES_NOT_EXIST");
+    (void) storage.SyncDeleteKeyValue(kLongKeyString);
 
     // ========== Start of actual audit from TestTestPersistentStorageDelegate.cpp =========
 
@@ -281,7 +281,9 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     // ========== End of code from TestTestPersistentStorageDelegate.cpp =========
     if (inSuite->flagError)
     {
-        ChipLogError(Automation, "==== PersistentStorageDelegate API audit: FAILED: %d/%d failed assertions ====", inSuite->failedAssertions, inSuite->performedAssertions);
+        ChipLogError(Automation,
+                     "==== PersistentStorageDelegate API audit: FAILED: %d/%d failed assertions ====", inSuite->failedAssertions,
+                     inSuite->performedAssertions);
         return false;
     }
 

--- a/src/lib/support/PersistentStorageAudit.cpp
+++ b/src/lib/support/PersistentStorageAudit.cpp
@@ -199,6 +199,11 @@ bool ExecutePersistentStorageApiAudit(PersistentStorageDelegate & storage)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == 0);
 
+    size = 0;
+    err  = storage.SyncGetKeyValue("key2", nullptr, size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == 0);
+
     size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("key2", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -213,15 +213,22 @@ protected:
 
         std::vector<uint8_t> & value = mStorage[key];
         size_t valueSize             = value.size();
-        if (size < valueSize)
+        if (!CanCastTo<uint16_t>(valueSize))
         {
-            size = CanCastTo<uint16_t>(valueSize) ? static_cast<uint16_t>(valueSize) : 0;
+            return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
+        }
+
+        if ((buffer == nullptr) && (size == 0))
+        {
             return CHIP_ERROR_BUFFER_TOO_SMALL;
         }
 
-        size = static_cast<uint16_t>(valueSize);
+        uint16_t valueSizeUint16 = static_cast<uint16_t>(valueSize);
+        uint16_t sizeToCopy      = std::min(size, valueSizeUint16);
+
+        size = static_cast<uint16_t>(sizeToCopy);
         memcpy(buffer, value.data(), size);
-        return CHIP_NO_ERROR;
+        return size < valueSizeUint16 ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR;
     }
 
     virtual CHIP_ERROR SyncSetKeyValueInternal(const char * key, const void * value, uint16_t size)

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -217,7 +217,7 @@ protected:
 
         uint16_t valueSizeUint16 = static_cast<uint16_t>(valueSize);
         ReturnErrorCodeIf(size == 0 && valueSizeUint16 == 0, CHIP_NO_ERROR);
-        ReturnErrorCodeIf(((buffer == nullptr) && (size == 0)), CHIP_ERROR_BUFFER_TOO_SMALL);
+        ReturnErrorCodeIf(buffer == nullptr, CHIP_ERROR_BUFFER_TOO_SMALL);
 
         uint16_t sizeToCopy      = std::min(size, valueSizeUint16);
 

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -197,10 +197,7 @@ public:
 protected:
     virtual CHIP_ERROR SyncGetKeyValueInternal(const char * key, void * buffer, uint16_t & size)
     {
-        if ((buffer == nullptr) && (size != 0))
-        {
-            return CHIP_ERROR_INVALID_ARGUMENT;
-        }
+        ReturnErrorCodeIf(((buffer == nullptr) && (size != 0)), CHIP_ERROR_INVALID_ARGUMENT);
 
         // Making sure poison keys are not accessed
         if (mPoisonKeys.find(std::string(key)) != mPoisonKeys.end())
@@ -218,12 +215,10 @@ protected:
             return CHIP_ERROR_PERSISTED_STORAGE_FAILED;
         }
 
-        if ((buffer == nullptr) && (size == 0))
-        {
-            return CHIP_ERROR_BUFFER_TOO_SMALL;
-        }
-
         uint16_t valueSizeUint16 = static_cast<uint16_t>(valueSize);
+        ReturnErrorCodeIf(size == 0 && valueSizeUint16 == 0, CHIP_NO_ERROR);
+        ReturnErrorCodeIf(((buffer == nullptr) && (size == 0)), CHIP_ERROR_BUFFER_TOO_SMALL);
+
         uint16_t sizeToCopy      = std::min(size, valueSizeUint16);
 
         size = sizeToCopy;

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -219,7 +219,7 @@ protected:
         ReturnErrorCodeIf(size == 0 && valueSizeUint16 == 0, CHIP_NO_ERROR);
         ReturnErrorCodeIf(buffer == nullptr, CHIP_ERROR_BUFFER_TOO_SMALL);
 
-        uint16_t sizeToCopy      = std::min(size, valueSizeUint16);
+        uint16_t sizeToCopy = std::min(size, valueSizeUint16);
 
         size = sizeToCopy;
         memcpy(buffer, value.data(), size);

--- a/src/lib/support/TestPersistentStorageDelegate.h
+++ b/src/lib/support/TestPersistentStorageDelegate.h
@@ -226,7 +226,7 @@ protected:
         uint16_t valueSizeUint16 = static_cast<uint16_t>(valueSize);
         uint16_t sizeToCopy      = std::min(size, valueSizeUint16);
 
-        size = static_cast<uint16_t>(sizeToCopy);
+        size = sizeToCopy;
         memcpy(buffer, value.data(), size);
         return size < valueSizeUint16 ? CHIP_ERROR_BUFFER_TOO_SMALL : CHIP_NO_ERROR;
     }

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -225,6 +225,25 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], size));
 
+    // Using key and value with base64 symbols
+    const char * kBase64SymbolsKey   = "key+/=";
+    const char * kBase64SymbolValues = "value+/=";
+    err = storage.SyncSetKeyValue(kBase64SymbolsKey, kBase64SymbolValues, static_cast<uint16_t>(strlen(kBase64SymbolValues)));
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    memset(&buf[0], 0, sizeof(buf));
+    size = actualSizeOfBuf;
+    err  = storage.SyncGetKeyValue(kBase64SymbolsKey, &buf[0], size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == strlen(kBase64SymbolValues));
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kBase64SymbolValues, strlen(kBase64SymbolValues)));
+    // Make sure that there was no buffer overflow during SyncGetKeyValue
+    NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));
+
+    err = storage.SyncDeleteKeyValue(kBase64SymbolsKey);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, !storage.SyncDoesKeyExist(kBase64SymbolsKey));
+
     // Try using key that is a size that equals PersistentStorageDelegate::kKeyLengthMax
     char longKeyString[PersistentStorageDelegate::kKeyLengthMax + 1];
     memset(&longKeyString, 'X', PersistentStorageDelegate::kKeyLengthMax);

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -193,6 +193,11 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == 0);
 
+    size = 0;
+    err  = storage.SyncGetKeyValue("key2", nullptr, size);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, size == 0);
+
     size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("key2", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -56,7 +56,7 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
 
     uint8_t buf[16];
     const uint16_t actualSizeOfBuf = static_cast<uint16_t>(sizeof(buf));
-    uint16_t size = actualSizeOfBuf;
+    uint16_t size                  = actualSizeOfBuf;
 
     // Key not there
     CHIP_ERROR err;

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -237,9 +237,6 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     const char * kLongKeyString = "aKeyThatIsExactlyMaxKeyLengthhhh";
     // strlen() is not compile time so we just have this runtime assert that should aways pass as a sanity check.
     NL_TEST_ASSERT(inSuite, strlen(kLongKeyString) == PersistentStorageDelegate::kKeyLengthMax);
-    // TODO is what we have above what we are looking for of when strlen including null terminated character is
-    // PersistentStorageDelegate::kKeyLengthMax static_assert(sizeof(kLongKeyString) == PersistentStorageDelegate::kKeyLengthMax,
-    // "testing for");
 
     err = storage.SyncSetKeyValue(kLongKeyString, kStringValue2, static_cast<uint16_t>(strlen(kStringValue2)));
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -134,9 +134,9 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
 
     // Read providing too small a buffer. Data read up to `size` and nothing more.
     memset(&buf[0], 0, sizeof(buf));
-    size = static_cast<uint16_t>(strlen(kStringValue2) - 1);
+    size                               = static_cast<uint16_t>(strlen(kStringValue2) - 1);
     uint16_t sizeBeforeGetKeyValueCall = size;
-    err  = storage.SyncGetKeyValue("key2", &buf[0], size);
+    err                                = storage.SyncGetKeyValue("key2", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
     NL_TEST_ASSERT(inSuite, size != strlen(kStringValue2));
     NL_TEST_ASSERT(inSuite, size == sizeBeforeGetKeyValueCall);
@@ -146,9 +146,9 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
 
     // Read in too small a buffer, which is nullptr and size == 0: check correct size given
     memset(&buf[0], 0, sizeof(buf));
-    size = 0;
+    size                      = 0;
     sizeBeforeGetKeyValueCall = size;
-    err  = storage.SyncGetKeyValue("key2", nullptr, size);
+    err                       = storage.SyncGetKeyValue("key2", nullptr, size);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_BUFFER_TOO_SMALL);
     NL_TEST_ASSERT(inSuite, size != strlen(kStringValue2));
     NL_TEST_ASSERT(inSuite, size == sizeBeforeGetKeyValueCall);
@@ -157,9 +157,9 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], sizeof(buf)));
 
     // Read in too small a buffer, which is nullptr and size != 0: error
-    size = static_cast<uint16_t>(strlen(kStringValue2) - 1);
+    size                      = static_cast<uint16_t>(strlen(kStringValue2) - 1);
     sizeBeforeGetKeyValueCall = size;
-    err  = storage.SyncGetKeyValue("key2", nullptr, size);
+    err                       = storage.SyncGetKeyValue("key2", nullptr, size);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
     NL_TEST_ASSERT(inSuite, size == sizeBeforeGetKeyValueCall);
     // Just making sure that implementation doesn't hold onto reference of previous destination buffer when

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -16,8 +16,6 @@
  *    limitations under the License.
  */
 
-#include <credentials/CHIPCert.h>
-
 #include <lib/core/CHIPError.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <lib/support/UnitTestRegistration.h>
@@ -252,8 +250,8 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, !storage.SyncDoesKeyExist(longKeyString));
 
-    // Test to see that we can buffer for largest size currentl known to be stored in PersistentStorageDelegate.
-    uint8_t largeBuffer[chip::Credentials::kMaxCHIPCertLength];
+    constexpr size_t kMaxCHIPCertLength = 400; // From credentials/CHIPCert.h and spec
+    uint8_t largeBuffer[kMaxCHIPCertLength];
     memset(&largeBuffer, 'X', sizeof(largeBuffer));
     uint8_t largeBufferForCheck[sizeof(largeBuffer)];
     memcpy(largeBufferForCheck, largeBuffer, sizeof(largeBuffer));

--- a/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
+++ b/src/lib/support/tests/TestTestPersistentStorageDelegate.cpp
@@ -55,15 +55,16 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     TestPersistentStorageDelegate storage;
 
     uint8_t buf[16];
-    uint16_t size = sizeof(buf);
+    const uint16_t actualSizeOfBuf = static_cast<uint16_t>(sizeof(buf));
+    uint16_t size = actualSizeOfBuf;
 
     // Key not there
     CHIP_ERROR err;
     memset(&buf[0], 0, sizeof(buf));
-    size = sizeof(buf);
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("roboto", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-    NL_TEST_ASSERT(inSuite, size == sizeof(buf));
+    NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
 
     NL_TEST_ASSERT(inSuite, storage.GetNumKeys() == 0);
 
@@ -76,7 +77,7 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     memset(&buf[0], 0, sizeof(buf));
-    size = sizeof(buf);
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("roboto", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == strlen(kStringValue1));
@@ -86,10 +87,10 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     memset(&buf[0], 0, sizeof(buf));
-    size = sizeof(buf);
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("roboto", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-    NL_TEST_ASSERT(inSuite, size == sizeof(buf));
+    NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
 
     // Validate adding 2 different keys
     const char * kStringValue2 = "0123abcd";
@@ -112,27 +113,24 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     memset(&all_zeroes[0], 0, sizeof(all_zeroes));
 
     memset(&buf[0], 0, sizeof(buf));
-    size = sizeof(buf);
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("key2", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == strlen(kStringValue2));
-    NL_TEST_ASSERT(inSuite, size < sizeof(buf));
+    NL_TEST_ASSERT(inSuite, size < actualSizeOfBuf);
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kStringValue2, strlen(kStringValue2)));
     // Make sure that there was no buffer overflow during SyncGetKeyValue
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));
 
     memset(&buf[0], 0, sizeof(buf));
-    size = sizeof(buf);
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("key3", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == strlen(kStringValue3));
-    NL_TEST_ASSERT(inSuite, size < sizeof(buf));
+    NL_TEST_ASSERT(inSuite, size < actualSizeOfBuf);
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kStringValue3, strlen(kStringValue3)));
     // Make sure that there was no buffer overflow during SyncGetKeyValue
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));
-
-    // Pre-clear buffer to make sure next operations don't change contents
-    memset(&buf[0], 0, sizeof(buf));
 
     // Read providing too small a buffer. Data read up to `size` and nothing more.
     memset(&buf[0], 0, sizeof(buf));
@@ -169,10 +167,10 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], sizeof(buf)));
 
     // When key not found, size is not touched.
-    size = sizeof(buf);
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("keyDOES_NOT_EXIST", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-    NL_TEST_ASSERT(inSuite, sizeof(buf) == size);
+    NL_TEST_ASSERT(inSuite, actualSizeOfBuf == size);
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], sizeof(buf)));
 
     size = 0;
@@ -182,10 +180,10 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], sizeof(buf)));
 
     // Even when key not found, cannot pass nullptr with size != 0.
-    size = static_cast<uint16_t>(sizeof(buf));
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("keyDOES_NOT_EXIST", nullptr, size);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_INVALID_ARGUMENT);
-    NL_TEST_ASSERT(inSuite, sizeof(buf) == size);
+    NL_TEST_ASSERT(inSuite, actualSizeOfBuf == size);
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], size));
 
     // Attempt an empty key write with either nullptr or zero size works
@@ -198,7 +196,7 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == 0);
 
-    size = static_cast<uint16_t>(sizeof(buf));
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("key2", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == 0);
@@ -212,7 +210,7 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == 0);
 
-    size = static_cast<uint16_t>(sizeof(buf));
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("key2", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == 0);
@@ -229,10 +227,10 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
 
     NL_TEST_ASSERT(inSuite, !storage.SyncDoesKeyExist("key2"));
 
-    size = static_cast<uint16_t>(sizeof(buf));
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue("key2", &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-    NL_TEST_ASSERT(inSuite, size == sizeof(buf));
+    NL_TEST_ASSERT(inSuite, size == actualSizeOfBuf);
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], &all_zeroes[0], size));
 
     // Try using key that is a size that equals PersistentStorageDelegate::kKeyLengthMax
@@ -247,11 +245,11 @@ void TestBasicApi(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 
     memset(&buf[0], 0, sizeof(buf));
-    size = sizeof(buf);
+    size = actualSizeOfBuf;
     err  = storage.SyncGetKeyValue(kLongKeyString, &buf[0], size);
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, size == strlen(kStringValue2));
-    NL_TEST_ASSERT(inSuite, size < sizeof(buf));
+    NL_TEST_ASSERT(inSuite, size < actualSizeOfBuf);
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[0], kStringValue2, strlen(kStringValue2)));
     // Make sure that there was no buffer overflow during SyncGetKeyValue
     NL_TEST_ASSERT(inSuite, 0 == memcmp(&buf[size], &all_zeroes[0], sizeof(buf) - size));


### PR DESCRIPTION
#### Problem

* Fixes #20163

#### Change overview
* API no longer claims that `size` input/output argument is set to the total size of the value when `CHIP_ERROR_BUFFER_TOO_SMALL` is returned.
  * Rationale 1: PersistentStorageDelegate is 90%+ implemented by KeyValueStoreManager, which is itself implemented per-platform. KeyValueStoreManager doesn’t have the ability to determine value size for a given key
  * Rationale 2: PersistentStorageDelegate usage in SDK common code never makes use of that feature
  * Overall: cost of change to make all platform meet an API expectation on which no code currently relies in SDK is too high.
* When `CHIP_ERROR_BUFFER_TOO_SMALL` is returned by `SyncGetKeyValue`, we expect that the `buffer` will be populated up to the `size` provided.
  * Rationale: A lot of persistent data storage in SDK employs larger-than-needed buffers to account for future growth, since data is often read by TLVReader and can be backwards compatible in case of only added fields. Without this behavior of `SyncGetKeyValue` (which matches 1:1 to KeyValueStoreManager), we cannot actually “read however much we support” and try to deal with it. It would always error-out, making it harder to actually implement and test “upgrade/downgrade-safe” code.

#### Testing
* Unit test passes locally
* CI passes
* Run following command confirmed audit logs indicate audit was a success
  * `scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone chip_config_network_layer_ble=false chip_support_enable_storage_api_audit=true`
  * `./out/debug/standalone/chip-all-clusters-app`
  
