### PR TITLE
Enable "are we on the right thread?" asserts on Darwin.

### DIFF
--- a/src/darwin/Framework/CHIP/CHIPDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/CHIPDeviceController_Internal.h
@@ -80,6 +80,14 @@ NS_ASSUME_NONNULL_BEGIN
                     fabricIndex:(chip::FabricIndex)fabricIndex
                       isRunning:(BOOL *)isRunning;
 
+/**
+ * Shut down the underlying C++ controller.  Must be called on the Matter work
+ * queue or after the Matter work queue has been shut down.
+ *
+ * Only MTRControllerFactory should be calling this.
+ */
+- (void)shutDownCppController;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MatterControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MatterControllerFactory.mm
@@ -525,6 +525,13 @@ static NSString * const kErrorCertStoreInit = @"Init failure while initializing 
         // shuts down, because shutdown of the last controller will tear
         // down most of the world.
         DeviceLayer::PlatformMgrImpl().StopEventLoopTask();
+
+        [controller shutDownCppController];
+    } else {
+        // Do the controller shutdown on the Matter work queue.
+        dispatch_sync(_chipWorkQueue, ^{
+            [controller shutDownCppController];
+        });
     }
 }
 

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -73,7 +73,7 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
   if (chip_stack_lock_tracking == "auto") {
     if (chip_device_platform == "linux" || chip_device_platform == "tizen" ||
         chip_device_platform == "android" || current_os == "freertos" ||
-        chip_device_platform == "webos") {
+        chip_device_platform == "webos" || chip_device_platform == "darwin") {
       # TODO: should be fatal for development. Change once bugs are fixed
       chip_stack_lock_tracking = "fatal"
     } else {

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -49,6 +49,7 @@ public:
         {
             mWorkQueue = dispatch_queue_create(CHIP_CONTROLLER_QUEUE, DISPATCH_QUEUE_SERIAL);
             dispatch_suspend(mWorkQueue);
+            mIsWorkQueueSuspended = true;
         }
         return mWorkQueue;
     }
@@ -71,7 +72,7 @@ private:
     CHIP_ERROR _PostEvent(const ChipDeviceEvent * event);
 
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
-    bool _IsChipStackLockedByCurrentThread() const { return false; };
+    bool _IsChipStackLockedByCurrentThread() const;
 #endif
 
     // ===== Members for internal use by the following friends.
@@ -88,7 +89,11 @@ private:
     // Semaphore used to implement blocking behavior in _RunEventLoop.
     dispatch_semaphore_t mRunLoopSem;
 
-    bool mIsWorkQueueRunning = false;
+    bool mIsWorkQueueSuspended = false;
+    // TODO: mIsWorkQueueSuspensionPending might need to be an atomic and use
+    // atomic ops, if we're worried about calls to StopEventLoopTask() from
+    // multiple threads racing somehow...
+    bool mIsWorkQueueSuspensionPending = false;
 
     inline ImplClass * Impl() { return static_cast<PlatformManagerImpl *>(this); }
 };


### PR DESCRIPTION
A few changes here:

1) Enable chip_stack_lock_tracking on darwin.
2) Implement _IsChipStackLockedByCurrentThread on Darwin in a way that makes
   sense with the actual "no locks" setup there (by checking that we are on the
   right dispatch queue).
3) Fix controller shutdown on Darwin to not happen from outside the Matter event
   loop while the event loop is running.

Removing the dealloc method from the Darwin controller implementation is safe
because:

* The only place where controllers get allocated is MTRControllerFactory's
  createController.
* At that callsite, if initWithFactory returns nil it guarantees that it has
  called cleanup.
* After allocation + init, we add the controller to the factory's controller
  list.  After that the controller cannot be deallocated until we remove it from
  that list, which only happens in controllerShuttingDown, which is always
  followed by a call to cleanup.

#### Problem
Lack of threading asserts, which meant that real threading bugs were not getting caught.

#### Change overview
Enable the asserts.

#### Testing
Ran darwin-framework-tool through some tests and made sure the asserts were not getting hit.