### PR TITLE
Assert that controllers are inited and shut down with the Matter lock held.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -64,6 +64,7 @@
 #include <lib/support/TimeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ExchangeContext.h>
+#include <platform/LockTracker.h>
 #include <protocols/secure_channel/MessageCounterManager.h>
 #include <setup_payload/QRCodeSetupPayloadParser.h>
 #include <trace/trace.h>
@@ -105,6 +106,8 @@ DeviceController::DeviceController()
 
 CHIP_ERROR DeviceController::Init(ControllerInitParams params)
 {
+    assertChipStackLockedByCurrentThread();
+
     VerifyOrReturnError(mState == State::NotInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError(params.systemState != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -282,6 +285,8 @@ CHIP_ERROR DeviceController::InitControllerNOCChain(const ControllerInitParams &
 
 void DeviceController::Shutdown()
 {
+    assertChipStackLockedByCurrentThread();
+
     VerifyOrReturn(mState != State::NotInitialized);
 
     ChipLogDetail(Controller, "Shutting down the controller");

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -215,14 +215,6 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
             eventReceived = xQueueReceive(mChipEventQueue, &event, 0);
         }
     }
-
-#if defined(INCLUDE_vTaskDelete) && INCLUDE_vTaskDelete
-    if (mEventLoopTask)
-    {
-        vTaskDelete(mEventLoopTask);
-        mEventLoopTask = nullptr;
-    }
-#endif // INCLUDE_vTaskDelete
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_FreeRTOS.ipp
@@ -215,6 +215,14 @@ void GenericPlatformManagerImpl_FreeRTOS<ImplClass>::_RunEventLoop(void)
             eventReceived = xQueueReceive(mChipEventQueue, &event, 0);
         }
     }
+
+#if defined(INCLUDE_vTaskDelete) && INCLUDE_vTaskDelete
+    if (mEventLoopTask)
+    {
+        vTaskDelete(mEventLoopTask);
+        mEventLoopTask = nullptr;
+    }
+#endif // INCLUDE_vTaskDelete
 }
 
 template <class ImplClass>

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -77,7 +77,6 @@ protected:
     struct sched_param mChipTaskSchedParam;
 
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
-    bool mMainLoopStarted   = false;
     bool mChipStackIsLocked = false;
     pthread_t mChipStackLockOwnerThread;
 #endif

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -117,7 +117,7 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_UnlockChipStack()
 template <class ImplClass>
 bool GenericPlatformManagerImpl_POSIX<ImplClass>::_IsChipStackLockedByCurrentThread() const
 {
-    return !mMainLoopStarted || (mChipStackIsLocked && (pthread_equal(pthread_self(), mChipStackLockOwnerThread)));
+    return !mHasValidChipTask || (mChipStackIsLocked && (pthread_equal(pthread_self(), mChipStackLockOwnerThread)));
 }
 #endif
 
@@ -201,7 +201,6 @@ template <class ImplClass>
 void * GenericPlatformManagerImpl_POSIX<ImplClass>::EventLoopTaskMain(void * arg)
 {
     ChipLogDetail(DeviceLayer, "CHIP task running");
-    static_cast<GenericPlatformManagerImpl_POSIX<ImplClass> *>(arg)->Impl()->mMainLoopStarted = true;
     static_cast<GenericPlatformManagerImpl_POSIX<ImplClass> *>(arg)->Impl()->RunEventLoop();
     return nullptr;
 }


### PR DESCRIPTION
We were not asserting this, and some consumers were not doing this,
leading to data races.

#### Problem
See above.

#### Change overview
Add asserts.

#### Testing
CI will tell.