### PR TITLE
Assert that holders are added to sessions only with the Matter lock held.

### DIFF
--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.h
@@ -77,7 +77,6 @@ protected:
     struct sched_param mChipTaskSchedParam;
 
 #if CHIP_STACK_LOCK_TRACKING_ENABLED
-    bool mMainLoopStarted   = false;
     bool mChipStackIsLocked = false;
     pthread_t mChipStackLockOwnerThread;
 #endif

--- a/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_POSIX.ipp
@@ -117,7 +117,7 @@ void GenericPlatformManagerImpl_POSIX<ImplClass>::_UnlockChipStack()
 template <class ImplClass>
 bool GenericPlatformManagerImpl_POSIX<ImplClass>::_IsChipStackLockedByCurrentThread() const
 {
-    return !mMainLoopStarted || (mChipStackIsLocked && (pthread_equal(pthread_self(), mChipStackLockOwnerThread)));
+    return !mHasValidChipTask || (mChipStackIsLocked && (pthread_equal(pthread_self(), mChipStackLockOwnerThread)));
 }
 #endif
 
@@ -201,7 +201,6 @@ template <class ImplClass>
 void * GenericPlatformManagerImpl_POSIX<ImplClass>::EventLoopTaskMain(void * arg)
 {
     ChipLogDetail(DeviceLayer, "CHIP task running");
-    static_cast<GenericPlatformManagerImpl_POSIX<ImplClass> *>(arg)->Impl()->mMainLoopStarted = true;
     static_cast<GenericPlatformManagerImpl_POSIX<ImplClass> *>(arg)->Impl()->RunEventLoop();
     return nullptr;
 }

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -21,6 +21,7 @@
 #include <lib/core/PeerId.h>
 #include <lib/core/ScopedNodeId.h>
 #include <messaging/ReliableMessageProtocolConfig.h>
+#include <platform/LockTracker.h>
 #include <transport/SessionHolder.h>
 #include <transport/raw/PeerAddress.h>
 
@@ -55,12 +56,14 @@ public:
 
     void AddHolder(SessionHolder & holder)
     {
+        assertChipStackLockedByCurrentThread();
         VerifyOrDie(!holder.IsInList());
         mHolders.PushBack(&holder);
     }
 
     void RemoveHolder(SessionHolder & holder)
     {
+        assertChipStackLockedByCurrentThread();
         VerifyOrDie(mHolders.Contains(&holder));
         mHolders.Remove(&holder);
     }


### PR DESCRIPTION
Adding/removing holders manipulates circular lists, and if we end up with data
races on these manipulations we can end up in bad states.  Since sessions are
somewhat singleton resources, and the "hold on to a session" operation is pretty
hidden in many cases, it's easy to end up with a situation where a session is
being pointed to by objects being manipulated on multiple threads and hard to
catch this via manual code inspection.

#### Problem
See above.

#### Change overview
Add asserts.

#### Testing
CI should tell.