### PR TITLE
CASE resumption: fix wrong error messages during deletion

### DIFF
--- a/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
+++ b/src/protocols/secure_channel/DefaultSessionResumptionStorage.cpp
@@ -189,6 +189,7 @@ CHIP_ERROR DefaultSessionResumptionStorage::DeleteAll(FabricIndex fabricIndex)
         err = DeleteState(index.mNodes[cur]);
         if (err != CHIP_NO_ERROR && err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
         {
+            stickyErr = stickyErr == CHIP_NO_ERROR ? err : stickyErr;
             ChipLogError(SecureChannel,
                          "Session resumption cache is in an inconsistent state!  "
                          "Unable to delete node state during attempted deletion of fabric index %u: %" CHIP_ERROR_FORMAT,


### PR DESCRIPTION
#### Problem
DefaultSessionResumptionStorage::DeleteAll was emitting lots of incorrect error messages when trying to delete items that were not there. In addition, LoadState and DeleteState were unbalanced when DeleteLink failed.

#### Change overview
Do not emit error messages when trying to delete items that do not exist. Ensure that a successful LoadState is always balanced by DeleteState.

#### Testing
* tested manually using chip-tool
* before this fix every chip-tool run looked like this:
`[1656607339130] [94722:844686] CHIP: [SC] Session resumption cache deletion partially failed for fabric index 1, unable to delete node link: ../../examples/chip-tool/config/PersistentStorage.cpp:140: CHIP Error 0x000000A0: Value not found in the persisted storage
[1656607339130] [94722:844686] CHIP: [SC] Session resumption cache deletion partially failed for fabric index 1, unable to delete node link: ../../examples/chip-tool/config/PersistentStorage.cpp:140: CHIP Error 0x000000A0: Value not found in the persisted storage
[1656607339130] [94722:844686] CHIP: [SC] Session resumption cache deletion partially failed for fabric index 1, unable to delete node link: ../../examples/chip-tool/config/PersistentStorage.cpp:140: CHIP Error 0x000000A0: Value not found in the persisted storage
[1656607339130] [94722:844686] CHIP: [SC] Session resumption cache deletion partially failed for fabric index 1, unable to delete node link: ../../examples/chip-tool/config/PersistentStorage.cpp:140: CHIP Error 0x000000A0: Value not found in the persisted storage
[1656607339130] [94722:844686] CHIP: [SC] Session resumption cache deletion partially failed for fabric index 1, unable to delete node link: ../../examples/chip-tool/config/PersistentStorage.cpp:140: CHIP Error 0x000000A0: Value not found in the persisted storage
[1656607339130] [94722:844686] CHIP: [CTL] Warning, failed to delete session resumption state for fabric index 0x1: ../../examples/chip-tool/config/PersistentStorage.cpp:140: CHIP Error 0x000000A0: Value not found in the persisted storage`
