### PR TITLE
Fix chef CI no op and prevent in future

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -355,7 +355,10 @@ def main(argv: Sequence[str]) -> None:
     #
 
     if options.ci:
-        for device_name in [d for d in _DEVICE_LIST if d in cicd_config["ci_allow_list"]]:
+        for device_name in cicd_config["ci_allow_list"]:
+            if device_name not in _DEVICE_LIST:
+                flush_print(f"{device_name} in CICD config but not {_DEVICE_FOLDER}!")
+                exit(1)
             if options.build_target == "nrfconnect":
                 shell.run_cmd("export GNUARMEMB_TOOLCHAIN_PATH=\"$PW_ARM_CIPD_INSTALL_DIR\"")
             shell.run_cmd(f"cd {_CHEF_SCRIPT_PATH}")

--- a/examples/chef/cicd_config.json
+++ b/examples/chef/cicd_config.json
@@ -1,5 +1,5 @@
 {
-    "ci_allow_list": ["rootnode_dimmablelight_gY80DaqEUL"],
+    "ci_allow_list": ["rootnode_dimmablelight_bCwGYSDpoe"],
     "cd_platforms": {
         "linux": "linux_x86",
         "esp32": "m5stack",


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* The example device used in CI had its name changed, but the CI allow list in CICD config was not updated, meaning CI is currently doing no ops.

#### Change overview
* Updated CI allowlist in CICD config
* Fail CI if any example in CI allow list is not in the device folder

#### Testing
How was this tested? (at least one bullet point required)
* CI job [ran in fork](https://github.com/aBozowski/connectedhomeip/runs/7137135604?check_suite_focus=true)
