### PR TITLE
Clean up optional arguments properly in chip-tool.

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -66,7 +66,8 @@ void ModelCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CH
 
 void ModelCommand::Shutdown()
 {
-    ResetArguments();
     mOnDeviceConnectedCallback.Cancel();
     mOnDeviceConnectionFailureCallback.Cancel();
+
+    CHIPCommand::Shutdown();
 }

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -101,7 +101,7 @@ protected:
 
     // Shut down the command.  After a Shutdown call the command object is ready
     // to be used for another command invocation.
-    virtual void Shutdown() {}
+    virtual void Shutdown() { ResetArguments(); }
 
     // Clean up any resources allocated by the command.  Some commands may hold
     // on to resources after Shutdown(), but Cleanup() will guarantee those are

--- a/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
+++ b/examples/chip-tool/commands/discover/DiscoverCommissionersCommand.cpp
@@ -42,4 +42,6 @@ void DiscoverCommissionersCommand::Shutdown()
 
     ChipLogProgress(chipTool, "Total of %d commissioner(s) discovered in %u sec", commissionerCount,
                     std::chrono::duration_cast<System::Clock::Seconds16>(GetWaitDuration()).count());
+
+    CHIPCommand::Shutdown();
 }


### PR DESCRIPTION
Otherwise in interactive mode we can end up with noise left over from
a previous command invocation.

Fixes https://github.com/project-chip/connectedhomeip/issues/20151

#### Problem
See issue above, but also we can get perfectly valid values getting carried over in interactive mode from a command that set an optional arg to one that is trying not to.

#### Change overview
Make sure to reset optional args during command shutdown.

#### Testing
Used test in #20151.