### PR TITLE
Update some constraints.txt requirements for python 3.10 support

### DIFF
--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -144,7 +144,7 @@ mbed-tools==7.49.1 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via -r requirements.mbed.txt
 mobly==1.10.1
     # via -r requirements.txt
-numpy==1.20.3
+numpy>=1.22
     # via pandas
 packaging==20.9
     # via
@@ -152,7 +152,7 @@ packaging==20.9
     #   ghapi
     #   pytest
     #   west
-pandas==1.2.4 ; platform_machine != "aarch64" and platform_machine != "arm64"
+pandas==1.4.3 ; platform_machine != "aarch64" and platform_machine != "arm64"
     # via -r requirements.txt
 parso==0.8.2
     # via jedi
@@ -297,6 +297,7 @@ west==0.12.0
     # via -r requirements.txt
 wheel==0.36.2
     # via -r requirements.txt
+tornado==6.1
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -58,3 +58,6 @@ cryptography
 
 # python unit tests
 colorama
+
+# update tornado for pw_watch
+tornado


### PR DESCRIPTION
Note that pip compile fails because mbed and esp32 disagree on click
version, so I manually edited the constraints file

I managed to use it to bootstrap on 3.10 (after some more changes to the
PW repo to pw_doctor) and also bootstrapped on 3.9 in a vscode docker
image.