### PR TITLE
In the BdxOtaSender::TransferFacilitator.cpp there is no way currentl…

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -180,6 +180,7 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         break;
     case TransferSession::OutputEventType::kAckEOFReceived:
         ChipLogDetail(BDX, "Transfer completed, got AckEOF");
+        mStopPolling = true;
         Reset();
         break;
     case TransferSession::OutputEventType::kStatusReceived:

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -78,7 +78,10 @@ void TransferFacilitator::PollForOutput()
     HandleTransferSessionOutput(outEvent);
 
     VerifyOrReturn(mSystemLayer != nullptr, ChipLogError(BDX, "%s mSystemLayer is null", __FUNCTION__));
-    mSystemLayer->StartTimer(mPollFreq, PollTimerHandler, this);
+    if (!mStopPolling)
+        mSystemLayer->StartTimer(mPollFreq, PollTimerHandler, this);
+    else
+        mSystemLayer->CancelTimer(PollTimerHandler, this);
 }
 
 void TransferFacilitator::ScheduleImmediatePoll()

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -79,9 +79,14 @@ void TransferFacilitator::PollForOutput()
 
     VerifyOrReturn(mSystemLayer != nullptr, ChipLogError(BDX, "%s mSystemLayer is null", __FUNCTION__));
     if (!mStopPolling)
+    {
         mSystemLayer->StartTimer(mPollFreq, PollTimerHandler, this);
+    }
     else
+    {
         mSystemLayer->CancelTimer(PollTimerHandler, this);
+        mStopPolling = false;
+    }
 }
 
 void TransferFacilitator::ScheduleImmediatePoll()

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -94,6 +94,7 @@ protected:
     System::Clock::Timeout mPollFreq;
     static constexpr System::Clock::Timeout kDefaultPollFreq    = System::Clock::Milliseconds32(500);
     static constexpr System::Clock::Timeout kImmediatePollDelay = System::Clock::Milliseconds32(1);
+    bool mStopPolling                                           = false;
 };
 
 /**


### PR DESCRIPTION
#### Problem
What is being fixed? 
* In the BdxOtaSender::TransferFacilitator.cpp there is no way currently to cancel the PollTimerHandler, as needed, when receiving an kAckEOFReceived . The problem is that calling chip::DeviceLayer::SystemLayer().CancelTimer(PollTimerHandler, this); upon receiving kAckEOFReceived, it does not cancel the PollTimerHandler, as TransferFacilitator::PollForOutput() re-registers it.
* Fixes #20187 Update Bdx TransferFacilitator to allow for cancelling the PollTimerHandler.

#### Change overview
While the BdxOtaSender was provided as en example, that terminates when upon completing the Bdx transfer, the TransferFacilitator.cpp needs to allow cancelling the PollTimerHandler.

To accomplish it, adding a mStopPolling flag in TransferFacilitator::PollForOutput() allowed for cancelling the PollTimerHandler.

#### Testing
* Used M5Stack running The OTA Requestor feature to complete a full OTA Bdx fw transfer, and confirmed that the PollTimerHandler has been cancelled within the Bdx Sender.
