### PR TITLE
[vscode] Add file watcher excludes to fix CPU fan spin by cpptools.

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -117,6 +117,13 @@
         "random": "cpp",
         "thread": "cpp"
     },
+    // Configure paths or glob patterns to exclude from file watching.
+    "files.watcherExclude": {
+        "**/.git/objects/**": true,
+        "**/.git/subtree-cache/**": true,
+        "out/": true,
+        "**/third_party/**": true
+    },
     "files.eol": "\n",
     "editor.formatOnSave": true,
     "better-comments.tags": [


### PR DESCRIPTION
On mac os especially, just opening the project-chip folder in vscode would hold one CPU spinning at 98% by a cpptools process owned by vscode. This patch to settings.json excludes the file watcher from endless recursion via `examples/**/third_party/connectedhomeip`...

#### Testing
Locally confirmed my CPU fans wind down when this is applied.