### PR TITLE
Fix some threading issues on Darwin.

### DIFF
--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -117,11 +117,11 @@ public:
 
         SetIdentity(identity);
 
-        // Disconnect our existing device; otherwise getConnectedDevice will
-        // just hand it right back to us without establishing a new CASE
+        // Invalidate our existing CASE session; otherwise getConnectedDevice
+        // will just hand it right back to us without establishing a new CASE
         // session.
         if (GetDevice(identity) != nil) {
-            [GetDevice(identity) disconnect];
+            [GetDevice(identity) invalidateCASESession];
             mConnectedDevices[identity] = nil;
         }
 

--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -121,10 +121,7 @@ public:
         // just hand it right back to us without establishing a new CASE
         // session.
         if (GetDevice(identity) != nil) {
-            auto device = [GetDevice(identity) internalDevice];
-            if (device != nullptr) {
-                device->Disconnect();
-            }
+            [GetDevice(identity) disconnect];
             mConnectedDevices[identity] = nil;
         }
 

--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -99,6 +99,12 @@ extern NSString * const kCHIPArrayValueType;
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
+ * Disconnect the device, so an attempt to getConnectedDevice for this device id
+ * will have to create a new secure session.
+ */
+- (void)disconnect;
+
+/**
  * Subscribe to receive attribute reports for everything (all endpoints, all
  * clusters, all attributes, all events) on the device.
  *

--- a/src/darwin/Framework/CHIP/CHIPDevice.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice.h
@@ -99,12 +99,6 @@ extern NSString * const kCHIPArrayValueType;
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * Disconnect the device, so an attempt to getConnectedDevice for this device id
- * will have to create a new secure session.
- */
-- (void)disconnect;
-
-/**
  * Subscribe to receive attribute reports for everything (all endpoints, all
  * clusters, all attributes, all events) on the device.
  *

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -244,6 +244,16 @@ static void CauseReadClientFailure(uint64_t deviceId, dispatch_queue_t queue, vo
     return _cppDevice;
 }
 
+- (void)disconnect
+{
+    dispatch_sync(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
+        DeviceProxy * device = [self internalDevice];
+        if (device != nullptr) {
+            device->Disconnect();
+        }
+    });
+}
+
 typedef void (^ReportCallback)(NSArray * _Nullable value, NSError * _Nullable error);
 typedef void (^DataReportCallback)(NSArray * value);
 typedef void (^ErrorCallback)(NSError * error);
@@ -371,76 +381,78 @@ private:
                errorHandler:(void (^)(NSError * error))errorHandler
     subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler
 {
-    DeviceProxy * device = [self internalDevice];
-    if (!device) {
-        dispatch_async(queue, ^{
-            errorHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
-        });
-        return;
-    }
-
-    // Wildcard endpoint, cluster, attribute, event.
-    auto attributePath = std::make_unique<AttributePathParams>();
-    auto eventPath = std::make_unique<EventPathParams>();
-    ReadPrepareParams readParams(device->GetSecureSession().Value());
-    readParams.mMinIntervalFloorSeconds = minInterval;
-    readParams.mMaxIntervalCeilingSeconds = maxInterval;
-    readParams.mpAttributePathParamsList = attributePath.get();
-    readParams.mAttributePathParamsListSize = 1;
-    readParams.mpEventPathParamsList = eventPath.get();
-    readParams.mEventPathParamsListSize = 1;
-    readParams.mKeepSubscriptions
-        = (params != nil) && (params.keepPreviousSubscriptions != nil) && [params.keepPreviousSubscriptions boolValue];
-
-    std::unique_ptr<SubscriptionCallback> callback;
-    std::unique_ptr<ReadClient> readClient;
-    std::unique_ptr<ClusterStateCache> attributeCache;
-    if (attributeCacheContainer) {
-        __weak CHIPAttributeCacheContainer * weakPtr = attributeCacheContainer;
-        callback = std::make_unique<SubscriptionCallback>(
-            queue, attributeReportHandler, eventReportHandler, errorHandler, subscriptionEstablishedHandler, ^{
-                CHIPAttributeCacheContainer * container = weakPtr;
-                if (container) {
-                    container.cppAttributeCache = nullptr;
-                }
+    dispatch_async(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
+        DeviceProxy * device = [self internalDevice];
+        if (!device) {
+            dispatch_async(queue, ^{
+                errorHandler([CHIPError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
             });
-        attributeCache = std::make_unique<ClusterStateCache>(*callback.get());
-        readClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-            attributeCache->GetBufferedCallback(), ReadClient::InteractionType::Subscribe);
-    } else {
-        callback = std::make_unique<SubscriptionCallback>(
-            queue, attributeReportHandler, eventReportHandler, errorHandler, subscriptionEstablishedHandler);
-        readClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-            callback->GetBufferedCallback(), ReadClient::InteractionType::Subscribe);
-    }
+            return;
+        }
 
-    CHIP_ERROR err;
-    if (params != nil && params.autoResubscribe != nil && ![params.autoResubscribe boolValue]) {
-        err = readClient->SendRequest(readParams);
-    } else {
-        // SendAutoResubscribeRequest cleans up the params, even on failure.
-        attributePath.release();
-        eventPath.release();
-        err = readClient->SendAutoResubscribeRequest(std::move(readParams));
-    }
+        // Wildcard endpoint, cluster, attribute, event.
+        auto attributePath = std::make_unique<AttributePathParams>();
+        auto eventPath = std::make_unique<EventPathParams>();
+        ReadPrepareParams readParams(device->GetSecureSession().Value());
+        readParams.mMinIntervalFloorSeconds = minInterval;
+        readParams.mMaxIntervalCeilingSeconds = maxInterval;
+        readParams.mpAttributePathParamsList = attributePath.get();
+        readParams.mAttributePathParamsListSize = 1;
+        readParams.mpEventPathParamsList = eventPath.get();
+        readParams.mEventPathParamsListSize = 1;
+        readParams.mKeepSubscriptions
+            = (params != nil) && (params.keepPreviousSubscriptions != nil) && [params.keepPreviousSubscriptions boolValue];
 
-    if (err != CHIP_NO_ERROR) {
-        dispatch_async(queue, ^{
-            errorHandler([CHIPError errorForCHIPErrorCode:err]);
-        });
+        std::unique_ptr<SubscriptionCallback> callback;
+        std::unique_ptr<ReadClient> readClient;
+        std::unique_ptr<ClusterStateCache> attributeCache;
+        if (attributeCacheContainer) {
+            __weak CHIPAttributeCacheContainer * weakPtr = attributeCacheContainer;
+            callback = std::make_unique<SubscriptionCallback>(
+                queue, attributeReportHandler, eventReportHandler, errorHandler, subscriptionEstablishedHandler, ^{
+                    CHIPAttributeCacheContainer * container = weakPtr;
+                    if (container) {
+                        container.cppAttributeCache = nullptr;
+                    }
+                });
+            attributeCache = std::make_unique<ClusterStateCache>(*callback.get());
+            readClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+                attributeCache->GetBufferedCallback(), ReadClient::InteractionType::Subscribe);
+        } else {
+            callback = std::make_unique<SubscriptionCallback>(
+                queue, attributeReportHandler, eventReportHandler, errorHandler, subscriptionEstablishedHandler);
+            readClient = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+                callback->GetBufferedCallback(), ReadClient::InteractionType::Subscribe);
+        }
 
-        return;
-    }
+        CHIP_ERROR err;
+        if (params != nil && params.autoResubscribe != nil && ![params.autoResubscribe boolValue]) {
+            err = readClient->SendRequest(readParams);
+        } else {
+            // SendAutoResubscribeRequest cleans up the params, even on failure.
+            attributePath.release();
+            eventPath.release();
+            err = readClient->SendAutoResubscribeRequest(std::move(readParams));
+        }
 
-    if (attributeCacheContainer) {
-        attributeCacheContainer.cppAttributeCache = attributeCache.get();
-        // ClusterStateCache will be deleted when OnDone is called or an error is encountered as well.
-        callback->AdoptAttributeCache(std::move(attributeCache));
-    }
-    // Callback and ReadClient will be deleted when OnDone is called or an error is
-    // encountered.
-    callback->AdoptReadClient(std::move(readClient));
-    callback.release();
+        if (err != CHIP_NO_ERROR) {
+            dispatch_async(queue, ^{
+                errorHandler([CHIPError errorForCHIPErrorCode:err]);
+            });
+
+            return;
+        }
+
+        if (attributeCacheContainer) {
+            attributeCacheContainer.cppAttributeCache = attributeCache.get();
+            // ClusterStateCache will be deleted when OnDone is called or an error is encountered as well.
+            callback->AdoptAttributeCache(std::move(attributeCache));
+        }
+        // Callback and ReadClient will be deleted when OnDone is called or an error is
+        // encountered.
+        callback->AdoptReadClient(std::move(readClient));
+        callback.release();
+    });
 }
 
 // Convert TLV data into NSObject

--- a/src/darwin/Framework/CHIP/CHIPDevice.mm
+++ b/src/darwin/Framework/CHIP/CHIPDevice.mm
@@ -244,7 +244,7 @@ static void CauseReadClientFailure(uint64_t deviceId, dispatch_queue_t queue, vo
     return _cppDevice;
 }
 
-- (void)disconnect
+- (void)invalidateCASESession
 {
     dispatch_sync(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
         DeviceProxy * device = [self internalDevice];

--- a/src/darwin/Framework/CHIP/CHIPDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/CHIPDevice_Internal.h
@@ -32,6 +32,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithDevice:(chip::DeviceProxy *)device;
 - (chip::DeviceProxy *)internalDevice;
 
+/**
+ * Invalidate the CASE session, so an attempt to getConnectedDevice for this
+ * device id will have to create a new CASE session.  Ideally this API will go
+ * away.
+ */
+- (void)invalidateCASESession;
+
 @end
 
 @interface CHIPAttributePath ()


### PR DESCRIPTION
There were two places where we were touching SDK data structures from
the wrong event queue.

#### Problem
Doing bad things with threads.

#### Change overview
Make sure to queue the relevant bits to the Matter queue.

#### Testing
Without this, #20180 will fail CI.