### PR TITLE
[nrfconnect] Enabled factory data protection against writing in internal memory

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -78,6 +78,7 @@ config CHIP_DEBUG_SYMBOLS
 config CHIP_FACTORY_DATA
 	bool "Enable Factory Data support"
 	select ZCBOR
+	select FPROTECT
 	help
 	  Enables support for reading factory data from flash memory partition.
 	  It requires factory_data partition to exist in the partition manager 

--- a/docs/guides/nrfconnect_factory_data_configuration.md
+++ b/docs/guides/nrfconnect_factory_data_configuration.md
@@ -22,6 +22,12 @@ For the nRF Connect platform, the factory data is stored by default in a
 separate partition of the internal flash memory. This helps to keep the factory
 data secure by applying hardware write protection.
 
+> Note: Due to hardware limitations, in the nRF Connect platform, protection
+> against writing can be applied only to the internal memory partition. The
+> [Fprotect](https://developer.nordicsemi.com/nRF_Connect_SDK/doc/latest/nrf/libraries/others/fprotect.html)
+> is the hardware flash protection driver, and we used it to ensure write
+> protection of the factory data partition in internal flash memory.
+
 <p align="center">
   <img src="../../examples/platform/nrfconnect/doc/images/Logo_RGB_H-small.png" alt="Nordic Semiconductor logo"/>
   <img src="../../examples/platform/nrfconnect/doc/images/nRF52840-DK-small.png" alt="nRF52840 DK">

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -44,9 +44,15 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::Init()
 
     CHIP_ERROR error = mFlashFactoryData.ProtectFactoryDataPartitionAgainstWrite();
 
-    if (error != CHIP_NO_ERROR)
+    // Protection against write for external storage is not supported.
+    if (error == CHIP_ERROR_NOT_IMPLEMENTED)
     {
-        ChipLogError(DeviceLayer, "Failed to protect the factory data partition");
+        ChipLogProgress(DeviceLayer, "The device does not support hardware protection against write.");
+        error = CHIP_NO_ERROR;
+    }
+    else if (error != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to protect the factory data partition.");
         return error;
     }
 

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -42,7 +42,15 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::Init()
     uint8_t * factoryData = nullptr;
     size_t factoryDataSize;
 
-    CHIP_ERROR error = mFlashFactoryData.GetFactoryDataPartition(factoryData, factoryDataSize);
+    CHIP_ERROR error = mFlashFactoryData.ProtectFactoryDataPartitionAgainstWrite();
+
+    if (error != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "Failed to protect the factory data partition");
+        return error;
+    }
+
+    error = mFlashFactoryData.GetFactoryDataPartition(factoryData, factoryDataSize);
 
     if (error != CHIP_NO_ERROR)
     {

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -22,6 +22,7 @@
 #include <platform/DeviceInstanceInfoProvider.h>
 
 #include <drivers/flash.h>
+#include <fprotect.h>
 #include <pm_config.h>
 
 #include "FactoryDataParser.h"
@@ -36,6 +37,12 @@ struct InternalFlashFactoryData
         data     = reinterpret_cast<uint8_t *>(PM_FACTORY_DATA_ADDRESS);
         dataSize = PM_FACTORY_DATA_SIZE;
         return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite()
+    {
+        int ret = fprotect_area(PM_FACTORY_DATA_ADDRESS, PM_FACTORY_DATA_SIZE);
+        return System::MapErrorZephyr(ret);
     }
 };
 
@@ -55,6 +62,8 @@ struct ExternalFlashFactoryData
 
         return CHIP_NO_ERROR;
     }
+
+    CHIP_ERROR ProtectFactoryDataPartitionAgainstWrite() { return CHIP_ERROR_NOT_IMPLEMENTED; }
 
     const struct device * mFlashDevice = DEVICE_DT_GET(DT_CHOSEN(zephyr_flash_controller));
     uint8_t mFactoryDataBuffer[PM_FACTORY_DATA_SIZE];

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -24,6 +24,7 @@
 #include <drivers/flash.h>
 #include <fprotect.h>
 #include <pm_config.h>
+#include <system/SystemError.h>
 
 #include "FactoryDataParser.h"
 


### PR DESCRIPTION
#### Problem
Factory data flash partition should be protected from write by firmware and OTA DFU.
This partition can be replaced only via a programmer.

#### Change overview
Added Fprotect hardware flash protection driver to protect factory data partition against write.

#### Testing
Tested on nRF52DK
