### PR TITLE
[IM] Update GetMinSubscriptionsPerFabric

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -87,8 +87,8 @@ public:
      * Spec 8.5.1 A publisher SHALL always ensure that every fabric the node is commissioned into can create at least three
      * subscriptions to the publisher and that each subscription SHALL support at least 3 attribute/event paths.
      */
-    static constexpr size_t kMinSupportedSubscriptionsPerFabric = 2;
-    static constexpr size_t kMinSupportedPathsPerSubscription   = 2;
+    static constexpr size_t kMinSupportedSubscriptionsPerFabric = 3;
+    static constexpr size_t kMinSupportedPathsPerSubscription   = 3;
     static constexpr size_t kMinSupportedPathsPerReadRequest    = 9;
     static constexpr size_t kMinSupportedReadRequestsPerFabric  = 1;
     static constexpr size_t kReadHandlerPoolSize                = CHIP_IM_MAX_NUM_SUBSCRIPTIONS + CHIP_IM_MAX_NUM_READS;
@@ -260,7 +260,13 @@ public:
      */
     bool TrimFabricForRead(FabricIndex aFabricIndex);
 
-    uint16_t GetMinSubscriptionsPerFabric() const;
+    /**
+     * Returns the minimal value of guaranteed subscriptions per fabic. UINT16_MAX will be returned if current app is configured to
+     * use heap for the object pools used by interaction model engine.
+     *
+     * @retval the minimal value of guaranteed subscriptions per fabic.
+     */
+    uint16_t GetMinGuaranteedSubscriptionsPerFabric() const;
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     //

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -275,7 +275,7 @@ CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attrib
         constexpr uint16_t kMinCaseSessionsPerFabricMandatedBySpec = 3;
 
         capabilityMinima.caseSessionsPerFabric  = kMinCaseSessionsPerFabricMandatedBySpec;
-        capabilityMinima.subscriptionsPerFabric = InteractionModelEngine::GetInstance()->GetMinSubscriptionsPerFabric();
+        capabilityMinima.subscriptionsPerFabric = InteractionModelEngine::GetInstance()->GetMinGuaranteedSubscriptionsPerFabric();
 
         status = aEncoder.Encode(capabilityMinima);
         break;


### PR DESCRIPTION
#### Problem

Fixes #19535 

#### Change overview

- Renamed `GetMinSubscriptionsPerFabric` to `GetMinGuaranteedSubscriptionsPerFabric`
- The updated code is a solution that will never be wrong. (Return a constant value)
- Updated     static constexpr size_t kMinSupportedSubscriptionsPerFabric = 3; static constexpr size_t kMinSupportedPathsPerSubscription   = 3; Which should be updated in previous PRs, but I think it is also suitable to include the change in this PR

#### Testing

- Build with `#define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 1` it returns 65535
- Build with `#define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 0` it returns 3
- Build without heap, and with `#define CHIP_IM_MAX_NUM_SUBSCRIPTIONS (CHIP_CONFIG_MAX_FABRICS * 5)` it returns 5
