### PR TITLE
[android] Fixed getting product id and product name

### DIFF
--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -43,15 +43,31 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetHardwareVersionString(char * buf, 
 
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductId(uint16_t & productId)
 {
-    productId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
+    CHIP_ERROR err;
+    uint32_t u32ProductId = 0;
+    err                   = Internal::AndroidConfig::ReadConfigValue(Internal::AndroidConfig::kConfigKey_ProductId, u32ProductId);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        productId = static_cast<uint16_t>(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_ID);
+    }
+    else
+    {
+        productId = static_cast<uint16_t>(u32ProductId);
+    }
     return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductName(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
-    strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME);
-
+    CHIP_ERROR err;
+    size_t productNameSize = 0; // without counting null-terminator
+    err =
+        Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_ProductName, buf, bufSize, productNameSize);
+    if (err == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND)
+    {
+        ReturnErrorCodeIf(bufSize < sizeof(CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME), CHIP_ERROR_BUFFER_TOO_SMALL);
+        strcpy(buf, CHIP_DEVICE_CONFIG_DEVICE_PRODUCT_NAME);
+    }
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Problem
In the #19514 there was a mistake done, as Android methods were meant to only be moved to other module not change
their implementation.

#### Change overview
Restored the previous implementation/

