### PR TITLE
[ESP32] Map ESP_ERR_NVS_INVALID_LENGTH to CHIP_ERROR_BUFFER_TOO_SMALL

### DIFF
--- a/src/platform/ESP32/ESP32Utils.cpp
+++ b/src/platform/ESP32/ESP32Utils.cpp
@@ -331,6 +331,10 @@ CHIP_ERROR ESP32Utils::MapError(esp_err_t error)
     {
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
     }
+    if (error == ESP_ERR_NVS_INVALID_LENGTH)
+    {
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    }
     return CHIP_ERROR(ChipError::Range::kPlatform, error);
 }
 


### PR DESCRIPTION
#### Problem
#20210

#### Change overview
This PR fixes few of the errors reported by the storage audit.

#### Testing
Ran the all-clusters-app and following were the reported errors
```
E (1686) chip[ATM]: ../../../../../../config/esp32/third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:145: assertion failed: "size == sizeBeforeGetKeyValueCall"

E (1726) chip[ATM]: ==== PersistentStorageDelegate API audit: FAILED: 1/81 failed assertions ====
```