### PR TITLE
[QPG] Update BLE State machine for multiple advertisement start

### DIFF
--- a/src/platform/qpg/BLEManagerImpl.h
+++ b/src/platform/qpg/BLEManagerImpl.h
@@ -99,6 +99,7 @@ private:
         kDeviceNameSet            = 0x0020, /**< The device name has been set. */
         kRestartAdvertising = 0x0040, /**< The advertising will be restarted when stop advertising confirmation is received and this
                                             flag is set*/
+        kEnablingAdvertising = 0x0080, /**< The BLE controller is setting up Advertisements. */
     };
 
     enum


### PR DESCRIPTION

#### Problem
A situation existed where Event callacks restarted advertising on a FailSafe timeout.
Protection added by adding additional state.

#### Change overview
BLE state machine for QPG updated to prevent multiple start advertising calls.
Platform impl only change

#### Testing
* Case:
** Setup commissioning, but with wrong Thread credentials
** Device goes through BLE PASE, but fails to connect to non-existing OTBR
** FailSafe times out, restarting advertising
** Failure - advertising engine signals double start
** Success - advertising starts as expected