### PR TITLE
Stop updating all submodules during Xcode builds.

### DIFF
--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -143,7 +143,7 @@ find_in_ancestors() {
     fi
 
     # there are environments where these bits are unwanted, unnecessary, or impossible
-    [[ -n $CHIP_NO_SUBMODULES ]] || git submodule update --init
+    [[ -n $CHIP_NO_SUBMODULES ]] || scripts/checkout_submodules.py --shallow --platform darwin
     if [[ -z $CHIP_NO_ACTIVATE ]]; then
         # first run bootstrap/activate in an external env to build everything
         env -i PW_ENVSETUP_NO_BANNER=1 PW_ENVSETUP_QUIET=1 bash -c '. scripts/activate.sh'


### PR DESCRIPTION
In CI we were first fetching only the submodules we need for Darwin during the
submodules step, then the Xcode build would fetch _all_ submodules.  This took a
very long time.

Change the Xcode script to use the "fetch just the submodules we need"
machinery.

#### Problem
See above.

#### Change overview
See above.

#### Testing
1. Ran `git submodule deinit third_party/bouffalolab/bl602_sdk third_party/mbedtls`
2. Ran `ls third_party/bouffalolab/bl602_sdk/repo third_party/mbedtls/repo` and verified both dirs are empty.
3. Did an Xcode build.
4. Ran `ls third_party/bouffalolab/bl602_sdk/repo third_party/mbedtls/repo` and verified that mbedtls (which Darwin uses right now) got re-inited, but the other one is still empty.