### PR TITLE
Ensure that Controller convenience APIs don't notify more than once.

### DIFF
--- a/src/controller/TypedCommandCallback.h
+++ b/src/controller/TypedCommandCallback.h
@@ -61,13 +61,24 @@ private:
     void OnResponse(app::CommandSender * apCommandSender, const app::ConcreteCommandPath & aCommandPath,
                     const app::StatusIB & aStatus, TLV::TLVReader * aReader) override;
 
-    void OnError(const app::CommandSender * apCommandSender, CHIP_ERROR aError) override { mOnError(aError); }
+    void OnError(const app::CommandSender * apCommandSender, CHIP_ERROR aError) override
+    {
+        if (mCalledCallback)
+        {
+            return;
+        }
+        mCalledCallback = true;
+
+        mOnError(aError);
+    }
 
     void OnDone(app::CommandSender * apCommandSender) override { mOnDone(apCommandSender); }
 
     OnSuccessCallbackType mOnSuccess;
     OnErrorCallbackType mOnError;
     OnDoneCallbackType mOnDone;
+
+    bool mCalledCallback = false;
 };
 
 /*
@@ -80,6 +91,12 @@ void TypedCommandCallback<CommandResponseObjectT>::OnResponse(app::CommandSender
                                                               const app::ConcreteCommandPath & aCommandPath,
                                                               const app::StatusIB & aStatus, TLV::TLVReader * aReader)
 {
+    if (mCalledCallback)
+    {
+        return;
+    }
+    mCalledCallback = true;
+
     CommandResponseObjectT response;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -120,6 +137,12 @@ inline void TypedCommandCallback<app::DataModel::NullObjectType>::OnResponse(app
                                                                              const app::StatusIB & aStatus,
                                                                              TLV::TLVReader * aReader)
 {
+    if (mCalledCallback)
+    {
+        return;
+    }
+    mCalledCallback = true;
+
     //
     // If we got a valid reader, it means we received response data that we were not expecting to receive.
     //

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -73,6 +73,12 @@ private:
     void OnAttributeData(const app::ConcreteDataAttributePath & aPath, TLV::TLVReader * apData,
                          const app::StatusIB & aStatus) override
     {
+        if (mCalledCallback && mReadClient->IsReadType())
+        {
+            return;
+        }
+        mCalledCallback = true;
+
         CHIP_ERROR err = CHIP_NO_ERROR;
         DecodableAttributeType value;
 
@@ -97,7 +103,16 @@ private:
         }
     }
 
-    void OnError(CHIP_ERROR aError) override { mOnError(nullptr, aError); }
+    void OnError(CHIP_ERROR aError) override
+    {
+        if (mCalledCallback && mReadClient->IsReadType())
+        {
+            return;
+        }
+        mCalledCallback = true;
+
+        mOnError(nullptr, aError);
+    }
 
     void OnDone(app::ReadClient *) override { mOnDone(this); }
 
@@ -138,6 +153,8 @@ private:
     OnResubscriptionAttemptCallbackType mOnResubscriptionAttempt;
     app::BufferedReadCallback mBufferedReadAdapter;
     Platform::UniquePtr<app::ReadClient> mReadClient;
+    // For reads, we ensure that we make only one data/error callback to our consumer.
+    bool mCalledCallback = false;
 };
 
 template <typename DecodableEventType>
@@ -164,6 +181,12 @@ public:
 private:
     void OnEventData(const app::EventHeader & aEventHeader, TLV::TLVReader * apData, const app::StatusIB * apStatus) override
     {
+        if (mCalledCallback && mReadClient->IsReadType())
+        {
+            return;
+        }
+        mCalledCallback = true;
+
         CHIP_ERROR err = CHIP_NO_ERROR;
         DecodableEventType value;
 
@@ -187,7 +210,16 @@ private:
         }
     }
 
-    void OnError(CHIP_ERROR aError) override { mOnError(nullptr, aError); }
+    void OnError(CHIP_ERROR aError) override
+    {
+        if (mCalledCallback && mReadClient->IsReadType())
+        {
+            return;
+        }
+        mCalledCallback = true;
+
+        mOnError(nullptr, aError);
+    }
 
     void OnDone(app::ReadClient * apReadClient) override
     {
@@ -228,6 +260,8 @@ private:
     OnSubscriptionEstablishedCallbackType mOnSubscriptionEstablished;
     OnResubscriptionAttemptCallbackType mOnResubscriptionAttempt;
     Platform::UniquePtr<app::ReadClient> mReadClient;
+    // For reads, we ensure that we make only one data/error callback to our consumer.
+    bool mCalledCallback = false;
 };
 
 } // namespace Controller

--- a/src/controller/WriteInteraction.h
+++ b/src/controller/WriteInteraction.h
@@ -59,6 +59,12 @@ public:
     void OnResponse(const app::WriteClient * apWriteClient, const app::ConcreteDataAttributePath & aPath,
                     app::StatusIB status) override
     {
+        if (mCalledCallback)
+        {
+            return;
+        }
+        mCalledCallback = true;
+
         if (status.IsSuccess())
         {
             mOnSuccess(aPath);
@@ -69,7 +75,16 @@ public:
         }
     }
 
-    void OnError(const app::WriteClient * apWriteClient, CHIP_ERROR aError) override { mOnError(nullptr, aError); }
+    void OnError(const app::WriteClient * apWriteClient, CHIP_ERROR aError) override
+    {
+        if (mCalledCallback)
+        {
+            return;
+        }
+        mCalledCallback = true;
+
+        mOnError(nullptr, aError);
+    }
 
     void OnDone(app::WriteClient * apWriteClient) override
     {
@@ -87,6 +102,8 @@ private:
     OnSuccessCallbackType mOnSuccess = nullptr;
     OnErrorCallbackType mOnError     = nullptr;
     OnDoneCallbackType mOnDone       = nullptr;
+
+    bool mCalledCallback = false;
 
     app::ChunkedWriteCallback mCallback;
 };

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -56,7 +56,9 @@ enum ResponseDirective
 {
     kSendDataResponse,
     kSendSuccessStatusCode,
+    kSendMultipleSuccessStatusCodes,
     kSendError,
+    kSendMultipleErrors,
     kSendSuccessStatusCodeWithClusterStatus,
     kSendErrorWithClusterStatus,
     kAsync,
@@ -112,9 +114,29 @@ void DispatchSingleClusterCommand(const ConcreteCommandPath & aCommandPath, chip
         {
             apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Success);
         }
+        else if (responseDirective == kSendMultipleSuccessStatusCodes)
+        {
+            // TODO: Right now all but the first AddStatus call fail, so this
+            // test is not really testing what it should.
+            for (size_t i = 0; i < 4; ++i)
+            {
+                apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Success);
+            }
+            // And one failure on the end.
+            apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
+        }
         else if (responseDirective == kSendError)
         {
             apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
+        }
+        else if (responseDirective == kSendMultipleErrors)
+        {
+            // TODO: Right now all but the first AddStatus call fail, so this
+            // test is not really testing what it should.
+            for (size_t i = 0; i < 4; ++i)
+            {
+                apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::Failure);
+            }
         }
         else if (responseDirective == kSendSuccessStatusCodeWithClusterStatus)
         {
@@ -159,8 +181,10 @@ public:
     TestCommandInteraction() {}
     static void TestDataResponse(nlTestSuite * apSuite, void * apContext);
     static void TestSuccessNoDataResponse(nlTestSuite * apSuite, void * apContext);
+    static void TestMultipleSuccessNoDataResponses(nlTestSuite * apSuite, void * apContext);
     static void TestAsyncResponse(nlTestSuite * apSuite, void * apContext);
     static void TestFailure(nlTestSuite * apSuite, void * apContext);
+    static void TestMultipleFailures(nlTestSuite * apSuite, void * apContext);
     static void TestSuccessNoDataResponseWithClusterStatus(nlTestSuite * apSuite, void * apContext);
     static void TestFailureWithClusterStatus(nlTestSuite * apSuite, void * apContext);
 
@@ -263,6 +287,45 @@ void TestCommandInteraction::TestSuccessNoDataResponse(nlTestSuite * apSuite, vo
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
+void TestCommandInteraction::TestMultipleSuccessNoDataResponses(nlTestSuite * apSuite, void * apContext)
+{
+    struct FakeRequest : public TestCluster::Commands::TestSimpleArgumentRequest::Type
+    {
+        using ResponseType = DataModel::NullObjectType;
+    };
+
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    FakeRequest request;
+    auto sessionHandle = ctx.GetSessionBobToAlice();
+
+    size_t successCalls = 0;
+    size_t failureCalls = 0;
+    bool statusCheck    = false;
+    request.arg1        = true;
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onSuccessCb = [&successCalls, &statusCheck](const ConcreteCommandPath & commandPath, const StatusIB & aStatus,
+                                                     const auto & dataResponse) {
+        statusCheck = (aStatus.mStatus == InteractionModel::Status::Success);
+        ++successCalls;
+    };
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onFailureCb = [&failureCalls](CHIP_ERROR aError) { ++failureCalls; };
+
+    responseDirective = kSendMultipleSuccessStatusCodes;
+
+    Controller::InvokeCommandRequest(&ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb, onFailureCb);
+
+    ctx.DrainAndServiceIO();
+
+    NL_TEST_ASSERT(apSuite, successCalls == 1 && statusCheck);
+    NL_TEST_ASSERT(apSuite, failureCalls == 0);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
 void TestCommandInteraction::TestAsyncResponse(nlTestSuite * apSuite, void * apContext)
 {
     struct FakeRequest : public TestCluster::Commands::TestSimpleArgumentRequest::Type
@@ -353,6 +416,45 @@ void TestCommandInteraction::TestFailure(nlTestSuite * apSuite, void * apContext
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
+void TestCommandInteraction::TestMultipleFailures(nlTestSuite * apSuite, void * apContext)
+{
+    struct FakeRequest : public TestCluster::Commands::TestSimpleArgumentRequest::Type
+    {
+        using ResponseType = DataModel::NullObjectType;
+    };
+
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    FakeRequest request;
+    auto sessionHandle = ctx.GetSessionBobToAlice();
+
+    size_t successCalls = 0;
+    size_t failureCalls = 0;
+    bool statusCheck    = false;
+    request.arg1        = true;
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onSuccessCb = [&successCalls](const ConcreteCommandPath & commandPath, const StatusIB & aStatus,
+                                       const auto & dataResponse) { ++successCalls; };
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onFailureCb = [&failureCalls, &statusCheck](CHIP_ERROR aError) {
+        statusCheck = aError.IsIMStatus() && StatusIB(aError).mStatus == InteractionModel::Status::Failure;
+        ++failureCalls;
+    };
+
+    responseDirective = kSendMultipleErrors;
+
+    Controller::InvokeCommandRequest(&ctx.GetExchangeManager(), sessionHandle, kTestEndpointId, request, onSuccessCb, onFailureCb);
+
+    ctx.DrainAndServiceIO();
+
+    NL_TEST_ASSERT(apSuite, successCalls == 0);
+    NL_TEST_ASSERT(apSuite, failureCalls == 1 && statusCheck);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
 void TestCommandInteraction::TestSuccessNoDataResponseWithClusterStatus(nlTestSuite * apSuite, void * apContext)
 {
     struct FakeRequest : public TestCluster::Commands::TestSimpleArgumentRequest::Type
@@ -438,8 +540,10 @@ const nlTest sTests[] =
 {
     NL_TEST_DEF("TestDataResponse", TestCommandInteraction::TestDataResponse),
     NL_TEST_DEF("TestSuccessNoDataResponse", TestCommandInteraction::TestSuccessNoDataResponse),
+    NL_TEST_DEF("TestMultipleSuccessNoDataResponses", TestCommandInteraction::TestMultipleSuccessNoDataResponses),
     NL_TEST_DEF("TestAsyncResponse", TestCommandInteraction::TestAsyncResponse),
     NL_TEST_DEF("TestFailure", TestCommandInteraction::TestFailure),
+    NL_TEST_DEF("TestMultipleFailures", TestCommandInteraction::TestMultipleFailures),
     NL_TEST_DEF("TestSuccessNoDataResponseWithClusterStatus", TestCommandInteraction::TestSuccessNoDataResponseWithClusterStatus),
     NL_TEST_DEF("TestFailureWithClusterStatus", TestCommandInteraction::TestFailureWithClusterStatus),
     NL_TEST_SENTINEL()

--- a/src/controller/tests/data_model/TestWrite.cpp
+++ b/src/controller/tests/data_model/TestWrite.cpp
@@ -47,6 +47,8 @@ enum ResponseDirective
 {
     kSendAttributeSuccess,
     kSendAttributeError,
+    kSendMultipleSuccess,
+    kSendMultipleErrors,
 };
 
 ResponseDirective responseDirective;
@@ -150,6 +152,30 @@ CHIP_ERROR WriteSingleClusterData(const Access::SubjectDescriptor & aSubjectDesc
         return CHIP_NO_ERROR;
     }
 
+    if (aPath.mClusterId == TestCluster::Id && aPath.mAttributeId == Attributes::Boolean::TypeInfo::GetAttributeId())
+    {
+        InteractionModel::Status status;
+        if (responseDirective == kSendMultipleSuccess)
+        {
+            status = InteractionModel::Status::Success;
+        }
+        else if (responseDirective == kSendMultipleErrors)
+        {
+            status = InteractionModel::Status::Failure;
+        }
+        else
+        {
+            return CHIP_ERROR_INCORRECT_STATE;
+        }
+
+        for (size_t i = 0; i < 4; ++i)
+        {
+            aWriteHandler->AddStatus(aPath, status);
+        }
+
+        return CHIP_NO_ERROR;
+    }
+
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 } // namespace app
@@ -168,6 +194,8 @@ public:
     static void TestAttributeError(nlTestSuite * apSuite, void * apContext);
     static void TestFabricScopedAttributeWithoutFabricIndex(nlTestSuite * apSuite, void * apContext);
     static void TestWriteTimeout(nlTestSuite * apSuite, void * apContext);
+    static void TestMultipleSuccessResponses(nlTestSuite * apSuite, void * apContext);
+    static void TestMultipleFailureResponses(nlTestSuite * apSuite, void * apContext);
 };
 
 void TestWriteInteraction::TestDataResponse(nlTestSuite * apSuite, void * apContext)
@@ -368,6 +396,62 @@ void TestWriteInteraction::TestFabricScopedAttributeWithoutFabricIndex(nlTestSui
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
 }
 
+void TestWriteInteraction::TestMultipleSuccessResponses(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx   = *static_cast<TestContext *>(apContext);
+    auto sessionHandle  = ctx.GetSessionBobToAlice();
+    size_t successCalls = 0;
+    size_t failureCalls = 0;
+
+    responseDirective = kSendMultipleSuccess;
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onSuccessCb = [&successCalls](const ConcreteAttributePath & attributePath) { ++successCalls; };
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onFailureCb = [&failureCalls](const ConcreteAttributePath * attributePath, CHIP_ERROR aError) { ++failureCalls; };
+
+    chip::Controller::WriteAttribute<TestCluster::Attributes::Boolean::TypeInfo>(sessionHandle, kTestEndpointId, true, onSuccessCb,
+                                                                                 onFailureCb);
+
+    ctx.DrainAndServiceIO();
+
+    NL_TEST_ASSERT(apSuite, successCalls == 1);
+    NL_TEST_ASSERT(apSuite, failureCalls == 0);
+    NL_TEST_ASSERT(apSuite, chip::app::InteractionModelEngine::GetInstance()->GetNumActiveWriteHandlers() == 0);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
+void TestWriteInteraction::TestMultipleFailureResponses(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx   = *static_cast<TestContext *>(apContext);
+    auto sessionHandle  = ctx.GetSessionBobToAlice();
+    size_t successCalls = 0;
+    size_t failureCalls = 0;
+
+    responseDirective = kSendMultipleErrors;
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onSuccessCb = [&successCalls](const ConcreteAttributePath & attributePath) { ++successCalls; };
+
+    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
+    // not safe to do so.
+    auto onFailureCb = [&failureCalls](const ConcreteAttributePath * attributePath, CHIP_ERROR aError) { ++failureCalls; };
+
+    chip::Controller::WriteAttribute<TestCluster::Attributes::Boolean::TypeInfo>(sessionHandle, kTestEndpointId, true, onSuccessCb,
+                                                                                 onFailureCb);
+
+    ctx.DrainAndServiceIO();
+
+    NL_TEST_ASSERT(apSuite, successCalls == 0);
+    NL_TEST_ASSERT(apSuite, failureCalls == 1);
+    NL_TEST_ASSERT(apSuite, chip::app::InteractionModelEngine::GetInstance()->GetNumActiveWriteHandlers() == 0);
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
 // clang-format off
 const nlTest sTests[] =
 {
@@ -376,6 +460,8 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestDataResponseWithRejectedDataVersion", TestWriteInteraction::TestDataResponseWithRejectedDataVersion),
     NL_TEST_DEF("TestAttributeError", TestWriteInteraction::TestAttributeError),
     NL_TEST_DEF("TestWriteFabricScopedAttributeWithoutFabricIndex", TestWriteInteraction::TestFabricScopedAttributeWithoutFabricIndex),
+    NL_TEST_DEF("TestMultipleSuccessResponses", TestWriteInteraction::TestMultipleSuccessResponses),
+    NL_TEST_DEF("TestMultipleFailureResponses", TestWriteInteraction::TestMultipleFailureResponses),
     NL_TEST_SENTINEL()
 };
 // clang-format on


### PR DESCRIPTION
ReadInteraction (for reads, not subscribes), WriteInteraction, and
InvokeInteraction could end up making multiple callbacks when the
consumer just expected to get one.  Since the consumer expects only
one callback, it would free itself when that callback happened, and
then we would end up with use-after-free.

The fix is to ensure we don't deliver extra callbacks to the consumer
after the one callback we're supposed to do.

Fixes https://github.com/project-chip/connectedhomeip/issues/12627

#### Problem
See #12627

#### Change overview
See above.

#### Testing
Unit tests added.  Except the Invoke ones don't actually work, because CommandHandler never sends more than one IB.  For Invoke I have not figured out a good way to test this yet.