### PR TITLE
Fix conditions in workflows.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -67,7 +67,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -106,7 +106,7 @@ jobs:
               run: scripts/run_in_build_env.sh "ninja -C ./out"
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-core-linux-gcc-debug
                   path: /tmp/cores/
@@ -114,7 +114,7 @@ jobs:
                   retention-days: 5
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-objdir-linux-gcc-debug
                   path: out/
@@ -168,7 +168,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -239,7 +239,7 @@ jobs:
                     "./scripts/build/build_examples.py --no-log-timestamps --target linux-fake-tests build"
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-core-linux
                   path: /tmp/cores/
@@ -247,7 +247,7 @@ jobs:
                   retention-days: 5
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-objdir-linux
                   path: out/
@@ -359,7 +359,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -407,7 +407,7 @@ jobs:
                     "
             - name: Uploading diagnostic logs
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-log-darwin
                   path: ~/Library/Logs/DiagnosticReports/

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -127,7 +127,7 @@ jobs:
                      -- scripts/tests/cirque_tests.sh run_all_tests
             - name: Uploading Binaries
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: cirque_log-${{steps.outsuffix.outputs.value}}-logs
                   path: /tmp/cirque_test_output/

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -73,7 +73,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: |
@@ -134,7 +134,7 @@ jobs:
             #       "
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-core-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: /cores/
@@ -142,13 +142,13 @@ jobs:
                   retention-days: 5
             - name: Uploading diagnostic logs
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-log-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: ~/Library/Logs/DiagnosticReports/
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-objdir-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: objdir-clone/

--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -57,7 +57,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -127,7 +127,7 @@ jobs:
               working-directory: src/darwin/Framework
             - name: Uploading log files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: darwin-framework-test-logs
                   path: /tmp/darwin/framework-tests

--- a/.github/workflows/examples-cc13x2x7_26x2x7.yaml
+++ b/.github/workflows/examples-cc13x2x7_26x2x7.yaml
@@ -58,7 +58,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-cyw30739.yaml
+++ b/.github/workflows/examples-cyw30739.yaml
@@ -57,7 +57,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-efr32.yaml
+++ b/.github/workflows/examples-efr32.yaml
@@ -61,7 +61,7 @@ jobs:
         run: scripts/build/gn_bootstrap.sh
       - name: Uploading bootstrap logs
         uses: actions/upload-artifact@v2
-        if: ${{ always() }} && ${{ !env.ACT }}
+        if: ${{ always() && !env.ACT }}
         with:
           name: bootstrap-logs
           path: |

--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -59,7 +59,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -140,7 +140,7 @@ jobs:
 
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-infineon.yaml
+++ b/.github/workflows/examples-infineon.yaml
@@ -57,7 +57,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -60,7 +60,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -58,7 +58,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -61,7 +61,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-mbed.yaml
+++ b/.github/workflows/examples-mbed.yaml
@@ -75,7 +75,7 @@ jobs:
 
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/examples-nrfconnect.yaml
+++ b/.github/workflows/examples-nrfconnect.yaml
@@ -74,7 +74,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -196,7 +196,7 @@ jobs:
                   scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target nrf-native-posix-64-tests build"
             - name: Uploading Failed Test Logs
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: test-log
                   path: |

--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -60,7 +60,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -53,7 +53,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/fuzzing-build.yaml
+++ b/.github/workflows/fuzzing-build.yaml
@@ -55,7 +55,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -113,7 +113,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/qemu.yaml
+++ b/.github/workflows/qemu.yaml
@@ -54,7 +54,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/release_artifacts.yaml
+++ b/.github/workflows/release_artifacts.yaml
@@ -47,7 +47,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |
@@ -92,7 +92,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -54,7 +54,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -69,7 +69,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs-linux-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: |
@@ -106,7 +106,7 @@ jobs:
                   "
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-core-linux-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: /tmp/cores/
@@ -114,7 +114,7 @@ jobs:
                   retention-days: 5
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-objdir-linux-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: objdir-clone/
@@ -170,7 +170,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: |
@@ -208,7 +208,7 @@ jobs:
                   "
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-core-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: /cores/
@@ -216,13 +216,13 @@ jobs:
                   retention-days: 5
             - name: Uploading diagnostic logs
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-log-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: ~/Library/Logs/DiagnosticReports/
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-objdir-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: objdir-clone/
@@ -259,7 +259,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs-linux-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: |
@@ -282,7 +282,7 @@ jobs:
                   scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --app out/linux-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factoryreset --script-args "--log-level INFO -t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-core-linux-python-repl
                   path: /tmp/cores/
@@ -290,7 +290,7 @@ jobs:
                   retention-days: 5
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-objdir-linux-python-repl
                   path: objdir-clone/
@@ -339,7 +339,7 @@ jobs:
               run: scripts/build/gn_bootstrap.sh
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs-darwin-${{ matrix.build_variant }}${{ matrix.chip_tool }}
                   path: |
@@ -361,7 +361,7 @@ jobs:
                   scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --app out/darwin-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factoryreset --app-args "--discriminator 3840 --interface-id -1" --script-args "-t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
             - name: Uploading core files
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-core-darwin-python-repl
                   path: /cores/
@@ -369,13 +369,13 @@ jobs:
                   retention-days: 5
             - name: Uploading diagnostic logs
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-log-darwin-python-repl
                   path: ~/Library/Logs/DiagnosticReports/
             - name: Uploading objdir for debugging
               uses: actions/upload-artifact@v2
-              if: ${{ failure() }} && ${{ !env.ACT }}
+              if: ${{ failure() && !env.ACT }}
               with:
                   name: crash-objdir-darwin-python-repl
                   path: objdir-clone/

--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -60,7 +60,7 @@ jobs:
                   scripts/build/gn_bootstrap.sh ;
             - name: Uploading bootstrap logs
               uses: actions/upload-artifact@v2
-              if: ${{ always() }} && ${{ !env.ACT }}
+              if: ${{ always() && !env.ACT }}
               with:
                   name: bootstrap-logs
                   path: |


### PR DESCRIPTION
The "if:" can be an expression, but trying to do boolean and of two
expressions just ends up looking like an expression trying to evaluate
something like "failure() }} && ${{ !env.ACT" to GitHub, which
confuses it.  As a result we were uploading various artifacts that
should only be uploaded on failure even if the relevant jobs had not
failed.

This PR was generated by installing git-extras and running:

    git sed '}} && ${{' '\&\&'

#### Problem
Uploading artifacts when we should not.

#### Change overview
See above.

#### Testing
Tried both syntaxes at https://github.com/bzbarsky-apple/connectedhomeip/runs/7160611688?check_suite_focus=true and verified that what we have right now ends up doing an upload while the post-change syntax does not.