### PR TITLE
Set detect_leaks=1 in all places where we do ASan builds in CI.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -377,6 +377,9 @@ jobs:
                   scripts/run_in_build_env.sh "ninja -C ./out/$BUILD_TYPE"
             - name: Setup Build, Run Build and Run Tests
               timeout-minutes: 120
+              # We can't enable leak checking here in LSAN_OPTIONS, because on
+              # Darwin that's only supported with a new endough clang, and we're
+              # not building with the pigweed clang here.
               run: |
                   for BUILD_TYPE in default python_lib; do
                       case $BUILD_TYPE in

--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -35,6 +35,7 @@ jobs:
                 build_variant: [no-ble-asan]
         env:
             BUILD_VARIANT: ${{matrix.build_variant}}
+            LSAN_OPTIONS: detect_leaks=1 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
         if: github.actor != 'restyled-io[bot]'
         runs-on: macos-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -38,6 +38,7 @@ jobs:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
             TSAN_OPTIONS: "halt_on_error=1 suppressions=scripts/tests/chiptest/tsan-linux-suppressions.txt"
+            LSAN_OPTIONS: detect_leaks=1
 
         if: github.actor != 'restyled-io[bot]'
         runs-on: ubuntu-latest
@@ -132,6 +133,7 @@ jobs:
             BUILD_VARIANT: ${{matrix.build_variant}}
             CHIP_TOOL_VARIANT: ${{matrix.chip_tool}}
             TSAN_OPTIONS: "halt_on_error=1"
+            LSAN_OPTIONS: detect_leaks=1 suppressions=scripts/tests/chiptest/lsan-mac-suppressions.txt
 
         if: github.actor != 'restyled-io[bot]'
         runs-on: macos-latest

--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -1,0 +1,20 @@
+# Looks like some Objective C class bits are leaked, which is probably OK since
+# those are singletons.
+leak:realizeClassWithoutSwift
+leak:objc_initializeClassPair_internal
+
+# TODO: Under [NSManagedObjectContext executeFetchRequest] there are managed object bits that seem to be leaky.
+leak:class_addMethod
+leak:class_addIvar
+
+# TODO: Leaks of blocks from dispatch source handlers that need to be investigated.
+leak:_Block_copy
+
+# TODO: OpenSSL random byte generation creates some sort of pools that we seem to never clean up.  This seems to be happening a _lot_.
+leak:drbg_ctr_init
+leak:rand_pool_new
+leak:RAND_priv_bytes
+leak:drbg_bytes
+
+# TODO: OpenSSL ERR_get_state seems to leak.
+leak:ERR_get_state


### PR DESCRIPTION
#### Problem
Leak detection may not be enabled by default for ASan (e.g. on Darwin).

#### Change overview
Enable it in CI.

#### Testing
Will see how CI does.