### PR TITLE
Fix chip-tool storage escaping

### DIFF
--- a/examples/chip-tool/config/PersistentStorage.cpp
+++ b/examples/chip-tool/config/PersistentStorage.cpp
@@ -57,8 +57,8 @@ std::string EscapeKey(const std::string & key)
 
     for (char c : key)
     {
-        // Replace spaces, non-printable chars and `=` with hex-escaped (C-style) characters.
-        if ((c <= 0x20) || (c == '=') || (c >= 0x7F))
+        // Replace spaces, non-printable chars, `=` and the escape itself with hex-escaped (C-style) characters.
+        if ((c <= 0x20) || (c == '=') || (c == '\\') || (c >= 0x7F))
         {
             char escaped[5] = { 0 };
             snprintf(escaped, sizeof(escaped), "\\x%02x", (static_cast<unsigned>(c) & 0xff));


### PR DESCRIPTION
#### Problem

- PR #20239 got merged before some @bluebin14 had time to review and
  a bug exists where having the escape in a key can collide with
  an escaped key.

#### Change overview
- Adds the escape character to the escaping set

#### Testing
- Adding key `key=` and `key\x3d` leads to different stored
keys
```
key\x3d=MQ==
key\x5cx3d=MQ==
```

- All unit tests pass, integration tests pass
