### PR TITLE
Fix CATValues == operator

### DIFF
--- a/src/lib/core/CASEAuthTag.h
+++ b/src/lib/core/CASEAuthTag.h
@@ -114,9 +114,8 @@ struct CATValues
 
     bool operator==(const CATValues & other) const
     {
-        // Two sets of CATs confer equal permissions if for each defined value
-        // in one set, a corresponding value exists in the other set.  If this
-        // is true, we consider the sets equal.
+        // Two sets of CATs confer equal permissions if the sets are exactly equal.
+        // Ignoring kUndefinedCAT values, evaluate this.
         if (this->GetNumTagsPresent() != other.GetNumTagsPresent())
         {
             return false;

--- a/src/lib/core/CASEAuthTag.h
+++ b/src/lib/core/CASEAuthTag.h
@@ -28,9 +28,10 @@ namespace chip {
 
 typedef uint32_t CASEAuthTag;
 
-static constexpr CASEAuthTag kUndefinedCAT = 0;
-static constexpr NodeId kTagIdentifierMask = 0x0000'0000'FFFF'0000ULL;
-static constexpr NodeId kTagVersionMask    = 0x0000'0000'0000'FFFFULL;
+static constexpr CASEAuthTag kUndefinedCAT    = 0;
+static constexpr NodeId kTagIdentifierMask    = 0x0000'0000'FFFF'0000ULL;
+static constexpr uint32_t kTagIdentifierShift = 16;
+static constexpr NodeId kTagVersionMask       = 0x0000'0000'0000'FFFFULL;
 
 // Maximum number of CASE Authenticated Tags (CAT) in the CHIP certificate subject.
 static constexpr size_t kMaxSubjectCATAttributeCount = CHIP_CONFIG_CERT_MAX_RDN_ATTRIBUTES - 2;
@@ -39,14 +40,65 @@ struct CATValues
 {
     std::array<CASEAuthTag, kMaxSubjectCATAttributeCount> values = { kUndefinedCAT };
 
-    /* @brief Returns size of the CAT values array.
+    /* @brief Returns maximum number of CAT values that the array can contain.
      */
     static constexpr size_t size() { return std::tuple_size<decltype(values)>::value; }
+
+    /**
+     * @return the number of CATs present in the set (values not equal to kUndefinedCAT)
+     */
+    size_t GetNumTagsPresent() const
+    {
+        size_t count = 0;
+        for (auto cat : values)
+        {
+            count += (cat != kUndefinedCAT) ? 1 : 0;
+        }
+        return count;
+    }
+
+    /**
+     * @return true if `tag` is in the set exactly, false otherwise.
+     */
+    bool Contains(CASEAuthTag tag) const
+    {
+        for (auto candidate : values)
+        {
+            if ((candidate != kUndefinedCAT) && (candidate == tag))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @brief Returns true if this set contains any version of the `identifier`
+     *
+     * @param identifier - CAT identifier to find
+     * @return true if the identifier is in the set, false otherwise
+     */
+    bool ContainsIdentifier(uint16_t identifier) const
+    {
+        for (auto candidate : values)
+        {
+            uint16_t candidate_identifier = static_cast<uint16_t>((candidate & kTagIdentifierMask) >> kTagIdentifierShift);
+            if ((candidate != kUndefinedCAT) && (identifier == candidate_identifier))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     /* @brief Returns true if subject input checks against one of the CATs in the values array.
      */
     bool CheckSubjectAgainstCATs(NodeId subject) const
     {
+        VerifyOrReturnError(IsCASEAuthTag(subject), false);
+
         for (auto cat : values)
         {
             // All valid CAT values are always in the beginning of the array followed by kUndefinedCAT values.
@@ -60,54 +112,30 @@ struct CATValues
         return false;
     }
 
-    bool operator==(const CATValues & that) const
+    bool operator==(const CATValues & other) const
     {
         // Two sets of CATs confer equal permissions if for each defined value
         // in one set, a corresponding value exists in the other set.  If this
         // is true, we consider the sets equal.
-        for (const auto & cat : values)
+        if (this->GetNumTagsPresent() != other.GetNumTagsPresent())
         {
-            if (cat == kUndefinedCAT)
-            {
-                continue;
-            }
-            bool miss = true;
-            for (const auto candidate : that.values)
-            {
-                if (candidate == cat)
-                {
-                    miss = false;
-                    break;
-                }
-            }
-            if (miss)
-            {
-                return !miss;
-            }
+            return false;
         }
-        for (const auto & cat : that.values)
+        for (auto cat : this->values)
         {
             if (cat == kUndefinedCAT)
             {
                 continue;
             }
-            bool miss = true;
-            for (const auto candidate : values)
+
+            if (!other.Contains(cat))
             {
-                if (candidate == cat)
-                {
-                    miss = false;
-                    break;
-                }
-            }
-            if (miss)
-            {
-                return !miss;
+                return false;
             }
         }
         return true;
     }
-    bool operator!=(const CATValues & that) const { return !(*this == that); }
+    bool operator!=(const CATValues & other) const { return !(*this == other); }
 
     static constexpr size_t kSerializedLength = kMaxSubjectCATAttributeCount * sizeof(CASEAuthTag);
     typedef uint8_t Serialized[kSerializedLength];
@@ -148,6 +176,16 @@ constexpr CASEAuthTag CASEAuthTagFromNodeId(NodeId aNodeId)
 constexpr bool IsValidCASEAuthTag(CASEAuthTag aCAT)
 {
     return (aCAT & kTagVersionMask) > 0;
+}
+
+constexpr uint16_t GetCASEAuthTagIdentifier(CASEAuthTag aCAT)
+{
+    return static_cast<uint16_t>((aCAT & kTagIdentifierMask) >> kTagIdentifierShift);
+}
+
+constexpr uint16_t GetCASEAuthTagVersion(CASEAuthTag aCAT)
+{
+    return static_cast<uint16_t>(aCAT & kTagVersionMask);
 }
 
 } // namespace chip

--- a/src/lib/core/CASEAuthTag.h
+++ b/src/lib/core/CASEAuthTag.h
@@ -23,6 +23,7 @@
 #include <lib/core/CHIPEncoding.h>
 #include <lib/core/NodeId.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/SortUtils.h>
 
 namespace chip {
 
@@ -60,7 +61,9 @@ struct CATValues
         return false;
     }
 
-    bool operator==(const CATValues & that) const { return values == that.values; }
+    bool operator==(const CATValues & that) const { return this->Sorted().values == that.Sorted().values; }
+    bool operator!=(const CATValues & that) const { return !(*this == that); }
+    bool operator<(const CATValues & that) const { return this->Sorted().values < that.Sorted().values; }
 
     static constexpr size_t kSerializedLength = kMaxSubjectCATAttributeCount * sizeof(CASEAuthTag);
     typedef uint8_t Serialized[kSerializedLength];
@@ -83,6 +86,16 @@ struct CATValues
             values[i] = Encoding::LittleEndian::Read32(p);
         }
         return CHIP_NO_ERROR;
+    }
+
+private:
+    static bool Cmp(const CASEAuthTag & a, const CASEAuthTag & b) { return a < b; }
+    void Sort() { Sorting::BubbleSort(this->values.begin(), this->size(), Cmp); }
+    CATValues Sorted() const
+    {
+        auto sorted = *this;
+        sorted.Sort();
+        return sorted;
     }
 };
 

--- a/src/lib/core/tests/BUILD.gn
+++ b/src/lib/core/tests/BUILD.gn
@@ -22,6 +22,7 @@ chip_test_suite("tests") {
   output_name = "libCoreTests"
 
   test_sources = [
+    "TestCATValues.cpp",
     "TestCHIPCallback.cpp",
     "TestCHIPErrorStr.cpp",
     "TestCHIPTLV.cpp",

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -1,7 +1,6 @@
 /*
  *
  *    Copyright (c) 2022 Project CHIP Authors
- *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -127,7 +127,6 @@ void TestSubjectMatching(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, !a.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0x0001'0002'0003'0004ull)));
     NL_TEST_ASSERT(inSuite, !a.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0x0001'0002'2222'0002ull)));
 
-
     auto b = CATValues{ { 0x1111'0001 } };
     NL_TEST_ASSERT(inSuite, b.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'1111'0001ull)));
     NL_TEST_ASSERT(inSuite, !b.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'1111'0002ull)));

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -1,0 +1,176 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    Copyright (c) 2013-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for the CHIP TLV implementation.
+ *
+ */
+
+#include <lib/support/UnitTestRegistration.h>
+#include <nlbyteorder.h>
+#include <nlunit-test.h>
+
+#include <lib/core/CASEAuthTag.h>
+
+using namespace chip;
+
+void TestEqualityOperator(nlTestSuite * inSuite, void * inContext)
+{
+    {
+        auto a = CATValues{ { 1, 2, 3 } };
+        auto b = CATValues{ { 1, 3, 2 } };
+        auto c = CATValues{ { 2, 1, 3 } };
+        auto d = CATValues{ { 2, 3, 1 } };
+        auto e = CATValues{ { 3, 1, 2 } };
+        auto f = CATValues{ { 3, 2, 1 } };
+        NL_TEST_ASSERT(inSuite, a == a);
+        NL_TEST_ASSERT(inSuite, a == b);
+        NL_TEST_ASSERT(inSuite, a == c);
+        NL_TEST_ASSERT(inSuite, a == d);
+        NL_TEST_ASSERT(inSuite, a == e);
+        NL_TEST_ASSERT(inSuite, a == f);
+        NL_TEST_ASSERT(inSuite, b == a);
+        NL_TEST_ASSERT(inSuite, b == b);
+        NL_TEST_ASSERT(inSuite, b == c);
+        NL_TEST_ASSERT(inSuite, b == d);
+        NL_TEST_ASSERT(inSuite, b == e);
+        NL_TEST_ASSERT(inSuite, b == f);
+        NL_TEST_ASSERT(inSuite, c == a);
+        NL_TEST_ASSERT(inSuite, c == b);
+        NL_TEST_ASSERT(inSuite, c == c);
+        NL_TEST_ASSERT(inSuite, c == d);
+        NL_TEST_ASSERT(inSuite, c == e);
+        NL_TEST_ASSERT(inSuite, c == f);
+        NL_TEST_ASSERT(inSuite, d == a);
+        NL_TEST_ASSERT(inSuite, d == b);
+        NL_TEST_ASSERT(inSuite, d == c);
+        NL_TEST_ASSERT(inSuite, d == d);
+        NL_TEST_ASSERT(inSuite, d == e);
+        NL_TEST_ASSERT(inSuite, d == f);
+        NL_TEST_ASSERT(inSuite, e == a);
+        NL_TEST_ASSERT(inSuite, e == b);
+        NL_TEST_ASSERT(inSuite, e == c);
+        NL_TEST_ASSERT(inSuite, e == d);
+        NL_TEST_ASSERT(inSuite, e == e);
+        NL_TEST_ASSERT(inSuite, e == f);
+        NL_TEST_ASSERT(inSuite, f == a);
+        NL_TEST_ASSERT(inSuite, f == b);
+        NL_TEST_ASSERT(inSuite, f == c);
+        NL_TEST_ASSERT(inSuite, f == d);
+        NL_TEST_ASSERT(inSuite, f == e);
+        NL_TEST_ASSERT(inSuite, f == f);
+    }
+    {
+        auto a = CATValues{ { kUndefinedCAT, kUndefinedCAT, kUndefinedCAT } };
+        auto b = CATValues{ { kUndefinedCAT, kUndefinedCAT, kUndefinedCAT } };
+        NL_TEST_ASSERT(inSuite, a == b);
+    }
+}
+
+void TestInequalityOperator(nlTestSuite * inSuite, void * inContext)
+{
+    {
+        auto a = CATValues{ { 1, 2, 3 } };
+        auto b = CATValues{ { 4, 5, 6 } };
+        NL_TEST_ASSERT(inSuite, a != b);
+    }
+    {
+        auto a = CATValues{ { 1, 2, 3 } };
+        auto b = CATValues{ { 1, 1, 1 } };
+        NL_TEST_ASSERT(inSuite, a != b);
+    }
+    {
+        auto a = CATValues{ { 1, 2, 3 } };
+        auto b = CATValues{ { 1, 2, kUndefinedCAT } };
+        NL_TEST_ASSERT(inSuite, a != b);
+    }
+}
+
+void TestLessThanOperator(nlTestSuite * inSuite, void * inContext)
+{
+    {
+        auto a = CATValues{ { 3, 4, 5 } };
+        auto b = CATValues{ { 4, 5, 6 } };
+        auto c = CATValues{ { 3, 4, 6 } };
+        NL_TEST_ASSERT(inSuite, a < b);
+        NL_TEST_ASSERT(inSuite, a < c);
+    }
+    {
+        auto a = CATValues{ { 1, 1, 1 } };
+        auto b = CATValues{ { 1, 1, 2 } };
+        auto c = CATValues{ { 2, 1, 1 } };
+        NL_TEST_ASSERT(inSuite, a < b);
+        NL_TEST_ASSERT(inSuite, a < c);
+    }
+    {
+        auto a = CATValues{ { 3, 2, 6 } };
+        auto b = CATValues{ { 2, 4, 7 } };
+        auto c = CATValues{ { 3, 2, 7 } };
+        NL_TEST_ASSERT(inSuite, a < b);
+        NL_TEST_ASSERT(inSuite, a < c);
+    }
+}
+
+// Test Suite
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("Equality operator", TestEqualityOperator),
+    NL_TEST_DEF("Inequality operator", TestInequalityOperator),
+    NL_TEST_DEF("Less Than operator", TestLessThanOperator),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+int TestCATValues_Setup(void * inContext)
+{
+    return SUCCESS;
+}
+
+/**
+ *  Tear down the test suite.
+ */
+int TestCATValues_Teardown(void * inContext)
+{
+    return SUCCESS;
+}
+
+int TestCATValues(void)
+{
+    // clang-format off
+    nlTestSuite theSuite =
+    {
+        "CATValues",
+        &sTests[0],
+        TestCATValues_Setup,
+        TestCATValues_Teardown,
+    };
+    // clang-format on
+
+    nlTestRunner(&theSuite, nullptr);
+
+    return (nlTestRunnerStats(&theSuite));
+}
+
+CHIP_REGISTER_TEST_SUITE(TestCATValues)

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -24,7 +24,6 @@
  */
 
 #include <lib/support/UnitTestRegistration.h>
-#include <nlbyteorder.h>
 #include <nlunit-test.h>
 
 #include <lib/core/CASEAuthTag.h>

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -17,11 +17,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *      This file implements unit tests for the CHIP TLV implementation.
- *
- */
 
 #include <lib/support/UnitTestRegistration.h>
 #include <nlunit-test.h>

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -16,7 +16,6 @@
  *    limitations under the License.
  */
 
-
 #include <lib/support/UnitTestRegistration.h>
 #include <nlunit-test.h>
 
@@ -27,97 +26,100 @@ using namespace chip;
 void TestEqualityOperator(nlTestSuite * inSuite, void * inContext)
 {
     {
-        auto a = CATValues{ { 1, 2, 3 } };
-        auto b = CATValues{ { 1, 3, 2 } };
-        auto c = CATValues{ { 2, 1, 3 } };
-        auto d = CATValues{ { 2, 3, 1 } };
-        auto e = CATValues{ { 3, 1, 2 } };
-        auto f = CATValues{ { 3, 2, 1 } };
-        NL_TEST_ASSERT(inSuite, a == a);
-        NL_TEST_ASSERT(inSuite, a == b);
-        NL_TEST_ASSERT(inSuite, a == c);
-        NL_TEST_ASSERT(inSuite, a == d);
-        NL_TEST_ASSERT(inSuite, a == e);
-        NL_TEST_ASSERT(inSuite, a == f);
-        NL_TEST_ASSERT(inSuite, b == a);
-        NL_TEST_ASSERT(inSuite, b == b);
-        NL_TEST_ASSERT(inSuite, b == c);
-        NL_TEST_ASSERT(inSuite, b == d);
-        NL_TEST_ASSERT(inSuite, b == e);
-        NL_TEST_ASSERT(inSuite, b == f);
-        NL_TEST_ASSERT(inSuite, c == a);
-        NL_TEST_ASSERT(inSuite, c == b);
-        NL_TEST_ASSERT(inSuite, c == c);
-        NL_TEST_ASSERT(inSuite, c == d);
-        NL_TEST_ASSERT(inSuite, c == e);
-        NL_TEST_ASSERT(inSuite, c == f);
-        NL_TEST_ASSERT(inSuite, d == a);
-        NL_TEST_ASSERT(inSuite, d == b);
-        NL_TEST_ASSERT(inSuite, d == c);
-        NL_TEST_ASSERT(inSuite, d == d);
-        NL_TEST_ASSERT(inSuite, d == e);
-        NL_TEST_ASSERT(inSuite, d == f);
-        NL_TEST_ASSERT(inSuite, e == a);
-        NL_TEST_ASSERT(inSuite, e == b);
-        NL_TEST_ASSERT(inSuite, e == c);
-        NL_TEST_ASSERT(inSuite, e == d);
-        NL_TEST_ASSERT(inSuite, e == e);
-        NL_TEST_ASSERT(inSuite, e == f);
-        NL_TEST_ASSERT(inSuite, f == a);
-        NL_TEST_ASSERT(inSuite, f == b);
-        NL_TEST_ASSERT(inSuite, f == c);
-        NL_TEST_ASSERT(inSuite, f == d);
-        NL_TEST_ASSERT(inSuite, f == e);
-        NL_TEST_ASSERT(inSuite, f == f);
+        auto a                 = CATValues{ { 1, 2, 3 } };
+        auto b                 = CATValues{ { 1, 3, 2 } };
+        auto c                 = CATValues{ { 2, 1, 3 } };
+        auto d                 = CATValues{ { 2, 3, 1 } };
+        auto e                 = CATValues{ { 3, 1, 2 } };
+        auto f                 = CATValues{ { 3, 2, 1 } };
+        CATValues candidates[] = { a, b, c, d, e, f };
+        for (auto & outer : candidates)
+        {
+            for (auto & inner : candidates)
+            {
+                NL_TEST_ASSERT(inSuite, inner == outer);
+            }
+        }
     }
     {
-        auto a = CATValues{ { kUndefinedCAT, kUndefinedCAT, kUndefinedCAT } };
-        auto b = CATValues{ { kUndefinedCAT, kUndefinedCAT, kUndefinedCAT } };
-        NL_TEST_ASSERT(inSuite, a == b);
+        auto a                 = CATValues{ { 1, 2 } };
+        auto b                 = CATValues{ { 1, 1, 2 } };
+        auto c                 = CATValues{ { 1, 2, 2 } };
+        auto d                 = CATValues{ { 1, 2, 1 } };
+        auto e                 = CATValues{ { 2, 1 } };
+        auto f                 = CATValues{ { 2, 1, 1 } };
+        auto g                 = CATValues{ { 2, 2, 1 } };
+        auto h                 = CATValues{ { 2, 1, 2 } };
+        CATValues candidates[] = { a, b, c, d, e, f, g, h };
+        for (auto & outer : candidates)
+        {
+            for (auto & inner : candidates)
+            {
+                NL_TEST_ASSERT(inSuite, inner == outer);
+            }
+        }
+    }
+    {
+        auto a                 = CATValues{ { 1 } };
+        auto b                 = CATValues{ { 1, 1 } };
+        auto c                 = CATValues{ { 1, 1, 1 } };
+        CATValues candidates[] = { a, b, c };
+        for (auto & outer : candidates)
+        {
+            for (auto & inner : candidates)
+            {
+                NL_TEST_ASSERT(inSuite, inner == outer);
+            }
+        }
+    }
+    {
+        auto a                 = CATValues{ {} };
+        auto b                 = CATValues{ {} };
+        CATValues candidates[] = { a, b };
+        for (auto & outer : candidates)
+        {
+            for (auto & inner : candidates)
+            {
+                NL_TEST_ASSERT(inSuite, inner == outer);
+            }
+        }
     }
 }
 
 void TestInequalityOperator(nlTestSuite * inSuite, void * inContext)
 {
+    auto a                 = CATValues{ { 1 } };
+    auto b                 = CATValues{ { 1, 2 } };
+    auto c                 = CATValues{ { 1, 2, 3 } };
+    auto d                 = CATValues{ { 2 } };
+    auto e                 = CATValues{ { 2, 3 } };
+    auto f                 = CATValues{ { 2, 3, 4 } };
+    auto g                 = CATValues{ { 3 } };
+    auto h                 = CATValues{ { 3, 4 } };
+    auto i                 = CATValues{ { 3, 4, 5 } };
+    auto j                 = CATValues{ { 4 } };
+    auto k                 = CATValues{ { 4, 5 } };
+    auto l                 = CATValues{ { 4, 5, 6 } };
+    auto m                 = CATValues{ { 5 } };
+    auto n                 = CATValues{ { 5, 6 } };
+    auto o                 = CATValues{ { 5, 6, 7 } };
+    auto p                 = CATValues{ { 6 } };
+    auto q                 = CATValues{ { 6, 7 } };
+    auto r                 = CATValues{ { 6, 7, 8 } };
+    auto s                 = CATValues{ { 7 } };
+    auto t                 = CATValues{ { 7, 8 } };
+    auto u                 = CATValues{ { 7, 8, 9 } };
+    CATValues candidates[] = { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u };
+    for (auto & outer : candidates)
     {
-        auto a = CATValues{ { 1, 2, 3 } };
-        auto b = CATValues{ { 4, 5, 6 } };
-        NL_TEST_ASSERT(inSuite, a != b);
-    }
-    {
-        auto a = CATValues{ { 1, 2, 3 } };
-        auto b = CATValues{ { 1, 1, 1 } };
-        NL_TEST_ASSERT(inSuite, a != b);
-    }
-    {
-        auto a = CATValues{ { 1, 2, 3 } };
-        auto b = CATValues{ { 1, 2, kUndefinedCAT } };
-        NL_TEST_ASSERT(inSuite, a != b);
-    }
-}
-
-void TestLessThanOperator(nlTestSuite * inSuite, void * inContext)
-{
-    {
-        auto a = CATValues{ { 3, 4, 5 } };
-        auto b = CATValues{ { 4, 5, 6 } };
-        auto c = CATValues{ { 3, 4, 6 } };
-        NL_TEST_ASSERT(inSuite, a < b);
-        NL_TEST_ASSERT(inSuite, a < c);
-    }
-    {
-        auto a = CATValues{ { 1, 1, 1 } };
-        auto b = CATValues{ { 1, 1, 2 } };
-        auto c = CATValues{ { 2, 1, 1 } };
-        NL_TEST_ASSERT(inSuite, a < b);
-        NL_TEST_ASSERT(inSuite, a < c);
-    }
-    {
-        auto a = CATValues{ { 3, 2, 6 } };
-        auto b = CATValues{ { 2, 4, 7 } };
-        auto c = CATValues{ { 3, 2, 7 } };
-        NL_TEST_ASSERT(inSuite, a < b);
-        NL_TEST_ASSERT(inSuite, a < c);
+        for (auto & inner : candidates)
+        {
+            if (&inner == &outer)
+            {
+                continue;
+            }
+            NL_TEST_ASSERT(inSuite, inner != outer);
+        }
     }
 }
 
@@ -131,7 +133,6 @@ static const nlTest sTests[] =
 {
     NL_TEST_DEF("Equality operator", TestEqualityOperator),
     NL_TEST_DEF("Inequality operator", TestInequalityOperator),
-    NL_TEST_DEF("Less Than operator", TestLessThanOperator),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/lib/core/tests/TestCATValues.cpp
+++ b/src/lib/core/tests/TestCATValues.cpp
@@ -26,44 +26,13 @@ using namespace chip;
 void TestEqualityOperator(nlTestSuite * inSuite, void * inContext)
 {
     {
-        auto a                 = CATValues{ { 1, 2, 3 } };
-        auto b                 = CATValues{ { 1, 3, 2 } };
-        auto c                 = CATValues{ { 2, 1, 3 } };
-        auto d                 = CATValues{ { 2, 3, 1 } };
-        auto e                 = CATValues{ { 3, 1, 2 } };
-        auto f                 = CATValues{ { 3, 2, 1 } };
+        auto a                 = CATValues{ { 0x1111'0001, 0x2222'0002, 0x3333'0003 } };
+        auto b                 = CATValues{ { 0x1111'0001, 0x3333'0003, 0x2222'0002 } };
+        auto c                 = CATValues{ { 0x2222'0002, 0x1111'0001, 0x3333'0003 } };
+        auto d                 = CATValues{ { 0x2222'0002, 0x3333'0003, 0x1111'0001 } };
+        auto e                 = CATValues{ { 0x3333'0003, 0x1111'0001, 0x2222'0002 } };
+        auto f                 = CATValues{ { 0x3333'0003, 0x2222'0002, 0x1111'0001 } };
         CATValues candidates[] = { a, b, c, d, e, f };
-        for (auto & outer : candidates)
-        {
-            for (auto & inner : candidates)
-            {
-                NL_TEST_ASSERT(inSuite, inner == outer);
-            }
-        }
-    }
-    {
-        auto a                 = CATValues{ { 1, 2 } };
-        auto b                 = CATValues{ { 1, 1, 2 } };
-        auto c                 = CATValues{ { 1, 2, 2 } };
-        auto d                 = CATValues{ { 1, 2, 1 } };
-        auto e                 = CATValues{ { 2, 1 } };
-        auto f                 = CATValues{ { 2, 1, 1 } };
-        auto g                 = CATValues{ { 2, 2, 1 } };
-        auto h                 = CATValues{ { 2, 1, 2 } };
-        CATValues candidates[] = { a, b, c, d, e, f, g, h };
-        for (auto & outer : candidates)
-        {
-            for (auto & inner : candidates)
-            {
-                NL_TEST_ASSERT(inSuite, inner == outer);
-            }
-        }
-    }
-    {
-        auto a                 = CATValues{ { 1 } };
-        auto b                 = CATValues{ { 1, 1 } };
-        auto c                 = CATValues{ { 1, 1, 1 } };
-        CATValues candidates[] = { a, b, c };
         for (auto & outer : candidates)
         {
             for (auto & inner : candidates)
@@ -88,27 +57,27 @@ void TestEqualityOperator(nlTestSuite * inSuite, void * inContext)
 
 void TestInequalityOperator(nlTestSuite * inSuite, void * inContext)
 {
-    auto a                 = CATValues{ { 1 } };
-    auto b                 = CATValues{ { 1, 2 } };
-    auto c                 = CATValues{ { 1, 2, 3 } };
-    auto d                 = CATValues{ { 2 } };
-    auto e                 = CATValues{ { 2, 3 } };
-    auto f                 = CATValues{ { 2, 3, 4 } };
-    auto g                 = CATValues{ { 3 } };
-    auto h                 = CATValues{ { 3, 4 } };
-    auto i                 = CATValues{ { 3, 4, 5 } };
-    auto j                 = CATValues{ { 4 } };
-    auto k                 = CATValues{ { 4, 5 } };
-    auto l                 = CATValues{ { 4, 5, 6 } };
-    auto m                 = CATValues{ { 5 } };
-    auto n                 = CATValues{ { 5, 6 } };
-    auto o                 = CATValues{ { 5, 6, 7 } };
-    auto p                 = CATValues{ { 6 } };
-    auto q                 = CATValues{ { 6, 7 } };
-    auto r                 = CATValues{ { 6, 7, 8 } };
-    auto s                 = CATValues{ { 7 } };
-    auto t                 = CATValues{ { 7, 8 } };
-    auto u                 = CATValues{ { 7, 8, 9 } };
+    auto a                 = CATValues{ { 0x1111'0001 } };
+    auto b                 = CATValues{ { 0x1111'0001, 0x2222'0002 } };
+    auto c                 = CATValues{ { 0x1111'0001, 0x2222'0002, 0x3333'0003 } };
+    auto d                 = CATValues{ { 0x2222'0002 } };
+    auto e                 = CATValues{ { 0x2222'0002, 0x3333'0003 } };
+    auto f                 = CATValues{ { 0x2222'0002, 0x3333'0003, 0x4444'0004 } };
+    auto g                 = CATValues{ { 0x3333'0003 } };
+    auto h                 = CATValues{ { 0x3333'0003, 0x4444'0004 } };
+    auto i                 = CATValues{ { 0x3333'0003, 0x4444'0004, 0x5555'0005 } };
+    auto j                 = CATValues{ { 0x4444'0004 } };
+    auto k                 = CATValues{ { 0x4444'0004, 0x5555'0005 } };
+    auto l                 = CATValues{ { 0x4444'0004, 0x5555'0005, 0x6666'0006 } };
+    auto m                 = CATValues{ { 0x5555'0005 } };
+    auto n                 = CATValues{ { 0x5555'0005, 0x6666'0006 } };
+    auto o                 = CATValues{ { 0x5555'0005, 0x6666'0006, 0x7777'0007 } };
+    auto p                 = CATValues{ { 0x6666'0006 } };
+    auto q                 = CATValues{ { 0x6666'0006, 0x7777'0007 } };
+    auto r                 = CATValues{ { 0x6666'0006, 0x7777'0007, 0x8888'0008 } };
+    auto s                 = CATValues{ { 0x7777'0007 } };
+    auto t                 = CATValues{ { 0x7777'0007, 0x8888'0008 } };
+    auto u                 = CATValues{ { 0x7777'0007, 0x8888'0008, 0x9999'0009 } };
     CATValues candidates[] = { a, b, c, d, e, f, g, h, i, j, k, l, m, n, o, p, q, r, s, t, u };
     for (auto & outer : candidates)
     {
@@ -123,6 +92,65 @@ void TestInequalityOperator(nlTestSuite * inSuite, void * inContext)
     }
 }
 
+void TestMembership(nlTestSuite * inSuite, void * inContext)
+{
+    auto a = CATValues{ { 0x1111'0001 } };
+    auto b = CATValues{ { 0x1111'0001, 0x2222'0002 } };
+    auto c = CATValues{ { 0x1111'0001, 0x2222'0002, 0x3333'0003 } };
+
+    NL_TEST_ASSERT(inSuite, a.Contains(0x1111'0001));
+    NL_TEST_ASSERT(inSuite, a.GetNumTagsPresent() == 1);
+    NL_TEST_ASSERT(inSuite, !a.Contains(0x1111'0002));
+    NL_TEST_ASSERT(inSuite, !a.Contains(0x2222'0002));
+    NL_TEST_ASSERT(inSuite, a.ContainsIdentifier(0x1111));
+    NL_TEST_ASSERT(inSuite, !a.ContainsIdentifier(0x2222));
+
+    NL_TEST_ASSERT(inSuite, b.Contains(0x1111'0001));
+    NL_TEST_ASSERT(inSuite, b.Contains(0x2222'0002));
+    NL_TEST_ASSERT(inSuite, b.GetNumTagsPresent() == 2);
+    NL_TEST_ASSERT(inSuite, b.ContainsIdentifier(0x1111));
+    NL_TEST_ASSERT(inSuite, b.ContainsIdentifier(0x2222));
+
+    NL_TEST_ASSERT(inSuite, c.Contains(0x1111'0001));
+    NL_TEST_ASSERT(inSuite, c.Contains(0x2222'0002));
+    NL_TEST_ASSERT(inSuite, c.Contains(0x3333'0003));
+    NL_TEST_ASSERT(inSuite, c.GetNumTagsPresent() == 3);
+    NL_TEST_ASSERT(inSuite, c.ContainsIdentifier(0x1111));
+    NL_TEST_ASSERT(inSuite, c.ContainsIdentifier(0x2222));
+    NL_TEST_ASSERT(inSuite, c.ContainsIdentifier(0x3333));
+}
+
+void TestSubjectMatching(nlTestSuite * inSuite, void * inContext)
+{
+    // Check operational node IDs don't match
+    auto a = CATValues{ { 0x2222'0002 } };
+    NL_TEST_ASSERT(inSuite, !a.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0x0001'0002'0003'0004ull)));
+    NL_TEST_ASSERT(inSuite, !a.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0x0001'0002'2222'0002ull)));
+
+
+    auto b = CATValues{ { 0x1111'0001 } };
+    NL_TEST_ASSERT(inSuite, b.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'1111'0001ull)));
+    NL_TEST_ASSERT(inSuite, !b.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'1111'0002ull)));
+
+    auto c = CATValues{ { 0x1111'0001, 0x2222'0002 } };
+    NL_TEST_ASSERT(inSuite, c.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'2222'0001ull)));
+    NL_TEST_ASSERT(inSuite, c.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'2222'0002ull)));
+    NL_TEST_ASSERT(inSuite, !c.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'2222'0003ull)));
+
+    auto d = CATValues{ { 0x1111'0001, 0x2222'0002, 0x3333'0003 } };
+    NL_TEST_ASSERT(inSuite, d.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'0001ull)));
+    NL_TEST_ASSERT(inSuite, d.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'0002ull)));
+    NL_TEST_ASSERT(inSuite, d.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'0003ull)));
+    NL_TEST_ASSERT(inSuite, !d.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'0004ull)));
+    NL_TEST_ASSERT(inSuite, !d.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'ffffull)));
+
+    auto e = CATValues{ { 0x1111'0001, 0x2222'0002, 0x3333'ffff } };
+    NL_TEST_ASSERT(inSuite, e.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'0001ull)));
+    NL_TEST_ASSERT(inSuite, e.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'0002ull)));
+    NL_TEST_ASSERT(inSuite, e.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'0003ull)));
+    NL_TEST_ASSERT(inSuite, e.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'0004ull)));
+    NL_TEST_ASSERT(inSuite, e.CheckSubjectAgainstCATs(static_cast<chip::NodeId>(0xFFFF'FFFD'3333'ffffull)));
+}
 // Test Suite
 
 /**
@@ -133,6 +161,8 @@ static const nlTest sTests[] =
 {
     NL_TEST_DEF("Equality operator", TestEqualityOperator),
     NL_TEST_DEF("Inequality operator", TestInequalityOperator),
+    NL_TEST_DEF("Set operations", TestMembership),
+    NL_TEST_DEF("Subject matching for ACL", TestSubjectMatching),
     NL_TEST_SENTINEL()
 };
 // clang-format on


### PR DESCRIPTION
#### Problem

CATValues == was using std::array equality, but this considers order of the data, which is not relevant for CATs.

#### Change overview

Fix CATValues equality by sorting entries first before evaluating.  Also add != and < operators for convenience.

Fixes #20252 

#### Testing

Added unit tests for the new and corrected operators.