### PR TITLE
[chip-tool] Add read-all command to read all events and attributes from a given endpoint (could be wildcard) onto a single transaction

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -411,3 +411,29 @@ private:
     chip::Optional<bool> mKeepSubscriptions;
     chip::Optional<std::vector<bool>> mIsUrgents;
 };
+
+class ReadAll : public ReadCommand
+{
+public:
+    ReadAll(CredentialIssuerCommands * credsIssuerConfig) : ReadCommand("read-all", credsIssuerConfig)
+    {
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
+        ReadCommand::AddArguments();
+    }
+
+    ~ReadAll() {}
+
+    void OnDone(chip::app::ReadClient * aReadClient) override
+    {
+        InteractionModelReports::CleanupReadClient(aReadClient);
+        SetCommandExitStatus(mError);
+    }
+
+    CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
+    {
+        return ReadCommand::ReadAll(device, endpointIds, mFabricFiltered);
+    }
+
+private:
+    chip::Optional<bool> mFabricFiltered;
+};

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -137,6 +137,7 @@ void registerClusterAny(Commands & commands, CredentialIssuerCommands * credsIss
         make_unique<SubscribeAttribute>(credsIssuerConfig), //
         make_unique<ReadEvent>(credsIssuerConfig),       //
         make_unique<SubscribeEvent>(credsIssuerConfig),     //
+        make_unique<ReadAll>(credsIssuerConfig),         //
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -107,6 +107,9 @@ protected:
                            const chip::Optional<bool> & keepSubscriptions        = chip::NullOptional,
                            const chip::Optional<std::vector<bool>> & isUrgents   = chip::NullOptional);
 
+    CHIP_ERROR ReadAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                       const chip::Optional<bool> & fabricFiltered = chip::Optional<bool>(true));
+
     void Shutdown() { mReadClients.clear(); }
 
     void CleanupReadClient(chip::app::ReadClient * aReadClient);

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -17356,6 +17356,7 @@ void registerClusterAny(Commands & commands, CredentialIssuerCommands * credsIss
         make_unique<SubscribeAttribute>(credsIssuerConfig), //
         make_unique<ReadEvent>(credsIssuerConfig),          //
         make_unique<SubscribeEvent>(credsIssuerConfig),     //
+        make_unique<ReadAll>(credsIssuerConfig),            //
     };
 
     commands.Register(clusterName, clusterCommands);


### PR DESCRIPTION
#### Problem

There is no `chip-tool` command to read both attributes and events at the same time.

Fix #20111 

#### Change overview
 * Add `read-all` command
 * Update generated code


#### Testing
`chip-tool any read-all 0x12344321 0xFFFF`