### PR TITLE
[Darwin] Change the check for the ble advertisement data size from >=…

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -174,7 +174,7 @@ namespace DeviceLayer {
                 NSData * serviceData = [servicesData objectForKey:serviceUUID];
 
                 NSUInteger length = [serviceData length];
-                if (length >= 7) {
+                if (length == 8) {
                     const uint8_t * bytes = (const uint8_t *) [serviceData bytes];
                     uint8_t opCode = bytes[0];
                     uint16_t discriminator = (bytes[1] | (bytes[2] << 8)) & 0xfff;


### PR DESCRIPTION
… 7 to == 8

#### Problem

In  #8112 the code that checks for the length of the BLE advertisement has been changed from `==7` to `>=7` to allow for test devices with compliant advertisement and test devices without compliant advertisement.
It has been long enough that we can change it to `== 8` now.

#### Change overview
 * Check that the ble advertisement data is 8 bytes-long
