### PR TITLE
Fix python PersistentStorageDelegate to latest API description

### DIFF
--- a/src/controller/python/ChipDeviceController-StorageDelegate.cpp
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.cpp
@@ -86,10 +86,11 @@ CHIP_ERROR StorageAdapter::SyncGetKeyValue(const char * key, void * value, uint1
     }
 
     uint16_t tmpSize = size;
+    bool isFound     = false;
 
-    mGetKeyCb(mContext, key, (char *) value, &tmpSize);
+    mGetKeyCb(mContext, key, (char *) value, &tmpSize, &isFound);
 
-    if (tmpSize == 0)
+    if (!isFound)
     {
         ChipLogDetail(Controller, "Key Not Found\n");
         return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
@@ -107,8 +108,8 @@ CHIP_ERROR StorageAdapter::SyncGetKeyValue(const char * key, void * value, uint1
 
 CHIP_ERROR StorageAdapter::SyncSetKeyValue(const char * key, const void * value, uint16_t size)
 {
+    ReturnErrorCodeIf(((value == nullptr) && (size != 0)), CHIP_ERROR_INVALID_ARGUMENT);
     ChipLogDetail(Controller, "StorageAdapter::SetKeyValue: Key = %s, Value = %p (%u)", key, value, size);
-    mStorage[key] = std::string(static_cast<const char *>(value), size);
     mSetKeyCb(mContext, key, value, size);
     return CHIP_NO_ERROR;
 }

--- a/src/controller/python/ChipDeviceController-StorageDelegate.h
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.h
@@ -68,8 +68,6 @@ private:
     SetGetKeyValueCb mGetKeyCb;
     SyncDeleteKeyValueCb mDeleteKeyCb;
     PyObject * mContext;
-
-    std::map<std::string, std::string> mStorage;
 };
 
 } // namespace Python

--- a/src/controller/python/ChipDeviceController-StorageDelegate.h
+++ b/src/controller/python/ChipDeviceController-StorageDelegate.h
@@ -45,7 +45,7 @@ namespace Python {
 using PyObject = void;
 
 using SyncSetKeyValueCb    = void (*)(PyObject * appContext, const char * key, const void * value, uint16_t size);
-using SetGetKeyValueCb     = void (*)(PyObject * appContext, const char * key, char * value, uint16_t * size);
+using SetGetKeyValueCb     = void (*)(PyObject * appContext, const char * key, char * value, uint16_t * size, bool * isFound);
 using SyncDeleteKeyValueCb = void (*)(PyObject * appContext, const char * key);
 
 class StorageAdapter : public PersistentStorageDelegate

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -35,7 +35,7 @@ import builtins
 _SyncSetKeyValueCbFunct = CFUNCTYPE(
     None, py_object, c_char_p, POINTER(c_char),  c_uint16)
 _SyncGetKeyValueCbFunct = CFUNCTYPE(
-    None, py_object, c_char_p, POINTER(c_char), POINTER(c_uint16))
+    None, py_object, c_char_p, POINTER(c_char), POINTER(c_uint16), POINTER(c_bool))
 _SyncDeleteKeyValueCbFunct = CFUNCTYPE(None, py_object, c_char_p)
 
 
@@ -45,7 +45,7 @@ def _OnSyncSetKeyValueCb(storageObj, key: str, value, size):
 
 
 @_SyncGetKeyValueCbFunct
-def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
+def _OnSyncGetKeyValueCb(storageObj, key: str, value, size, is_found):
     ''' This does not adhere to the API requirements of
     PersistentStorageDelegate::SyncGetKeyValue, but that is okay since
     the C++ storage binding layer is capable of adapting results from
@@ -57,7 +57,7 @@ def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
     except Exception as ex:
         keyValue = None
 
-    if (keyValue):
+    if (keyValue is not None):
         sizeOfValue = size[0]
         sizeToCopy = min(sizeOfValue, len(keyValue))
 
@@ -74,13 +74,15 @@ def _OnSyncGetKeyValueCb(storageObj, key: str, value, size):
         # will use the value in size[0] to determine if it should
         # return CHIP_ERROR_BUFFER_TOO_SMALL.
         size[0] = len(keyValue)
+        is_found[0] = True;
     else:
+        is_found[0] = False;
         size[0] = 0
 
 
 @_SyncDeleteKeyValueCbFunct
 def _OnSyncDeleteKeyValueCb(storageObj, key):
-    storageObj.SetSdkKey(key.decode("utf-8"), None)
+    storageObj.DeleteSdkKey(key.decode("utf-8"))
 
 
 class PersistentStorage:
@@ -151,7 +153,7 @@ class PersistentStorage:
             raise ValueError("Invalid Key")
 
         if (value is None):
-            del(self.jsonData['sdk-config'][key])
+            self.jsonData['sdk-config'][key] = None
         else:
             self.jsonData['sdk-config'][key] = base64.b64encode(
                 value).decode("utf-8")
@@ -160,6 +162,9 @@ class PersistentStorage:
 
     def GetSdkKey(self, key: str):
         return base64.b64decode(self.jsonData['sdk-config'][key])
+
+    def DeleteSdkKey(self, key: str):
+        del(self.jsonData['sdk-config'][key])
 
     def GetUnderlyingStorageAdapter(self):
         return self._storageAdapterObj

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -74,9 +74,9 @@ def _OnSyncGetKeyValueCb(storageObj, key: str, value, size, is_found):
         # will use the value in size[0] to determine if it should
         # return CHIP_ERROR_BUFFER_TOO_SMALL.
         size[0] = len(keyValue)
-        is_found[0] = True;
+        is_found[0] = True
     else:
-        is_found[0] = False;
+        is_found[0] = False
         size[0] = 0
 
 

--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -153,7 +153,7 @@ class PersistentStorage:
             raise ValueError("Invalid Key")
 
         if (value is None):
-            self.jsonData['sdk-config'][key] = None
+            raise ValueError('value is not expected to be None')
         else:
             self.jsonData['sdk-config'][key] = base64.b64encode(
                 value).decode("utf-8")


### PR DESCRIPTION
#### Problem
* Python `PersistentStorageDelegate` was not able to:
  * Store values that were 0 or given a `nullptr`.
  * Find values with size of 0.

#### Change overview
* Fix python `PersistentStorageDelegate` to adhere to latest API description

#### Testing
* Hacking `scripts/build_python.sh` to compile with `chip_support_enable_storage_api_audit=true`, and adding call to `CHIPDeviceControllerFactory` to audit persistent storage, confirmed that chip-repl now passes the audit
