### PR TITLE
[EFR32] Fix Storage audit - Allow storing null pointer of size 0

### DIFF
--- a/src/platform/EFR32/EFR32Config.cpp
+++ b/src/platform/EFR32/EFR32Config.cpp
@@ -346,7 +346,7 @@ CHIP_ERROR EFR32Config::WriteConfigValueBin(Key key, const uint8_t * data, size_
 
     VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
-    // Only write NULL pointer if the given size is 0
+    // Only write NULL pointer if the given size is 0, since in that case, nothing is read at the pointer
     if ((data != NULL) || (dataLen == 0))
     {
         // Write the binary data to nvm3.

--- a/src/platform/EFR32/EFR32Config.cpp
+++ b/src/platform/EFR32/EFR32Config.cpp
@@ -236,7 +236,6 @@ CHIP_ERROR EFR32Config::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSiz
     // Get nvm3 object info.
     err = MapNvm3Error(nvm3_getObjectInfo(nvm3_defaultHandle, key, &objectType, &dataLen));
     SuccessOrExit(err);
-    VerifyOrExit(dataLen > 0, err = CHIP_ERROR_INVALID_STRING_LENGTH);
 
     if (buf != NULL)
     {
@@ -325,7 +324,7 @@ CHIP_ERROR EFR32Config::WriteConfigValueStr(Key key, const char * str)
 
 CHIP_ERROR EFR32Config::WriteConfigValueStr(Key key, const char * str, size_t strLen)
 {
-    CHIP_ERROR err;
+    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
 
     VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
@@ -336,10 +335,6 @@ CHIP_ERROR EFR32Config::WriteConfigValueStr(Key key, const char * str, size_t st
         err = MapNvm3Error(nvm3_writeData(nvm3_defaultHandle, key, str, (strLen > 0) ? strLen : 1));
         SuccessOrExit(err);
     }
-    else
-    {
-        nvm3_deleteObject(nvm3_defaultHandle, key); // no error checking here.
-    }
 
 exit:
     return err;
@@ -347,22 +342,16 @@ exit:
 
 CHIP_ERROR EFR32Config::WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen)
 {
-    CHIP_ERROR err;
+    CHIP_ERROR err = CHIP_ERROR_INVALID_ARGUMENT;
 
     VerifyOrExit(ValidConfigKey(key), err = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND); // Verify key id.
 
-    if (data != NULL)
+    // Only write NULL pointer if the given size is 0
+    if ((data != NULL) || (dataLen == 0))
     {
-        if (dataLen > 0)
-        {
-            // Write the binary data to nvm3.
-            err = MapNvm3Error(nvm3_writeData(nvm3_defaultHandle, key, data, dataLen));
-            SuccessOrExit(err);
-        }
-    }
-    else
-    {
-        nvm3_deleteObject(nvm3_defaultHandle, key); // no error checking here.
+        // Write the binary data to nvm3.
+        err = MapNvm3Error(nvm3_writeData(nvm3_defaultHandle, key, data, dataLen));
+        SuccessOrExit(err);
     }
 
 exit:

--- a/src/platform/EFR32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/EFR32/KeyValueStoreManagerImpl.cpp
@@ -126,8 +126,6 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
                                           size_t offset_bytes) const
 {
     VerifyOrReturnError(key != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(value != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(value != 0, CHIP_ERROR_INVALID_ARGUMENT);
 
     uint32_t nvm3Key;
     CHIP_ERROR err = MapKvsKeyToNvm3(key, nvm3Key);
@@ -146,7 +144,6 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)
 {
     VerifyOrReturnError(key != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(value != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     uint32_t nvm3Key;
     CHIP_ERROR err = MapKvsKeyToNvm3(key, nvm3Key, /* isSlotNeeded */ true);


### PR DESCRIPTION
#### Problem
Fixes #20284

#### Change overview
Change platform implementation to allow the storage and reading of a Nullpointer if the given size is also 0.

#### Testing
Build with audit enable
`./scripts/examples/gn_efr32_example.sh examples/lighting-app/efr32/ out/lighting_app BRD4164A chip_support_enable_storage_api_audit=true`

Audit success if printed.
```
<info  > [SVR] Server initializing...
<error > [ATM] ==== PersistentStorageDelegate API audit: SUCCESS ====
```
