### PR TITLE
Fix wrong type passed in scenes.cpp

### DIFF
--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -809,7 +809,7 @@ bool emberAfPluginScenesServerParseAddScene(
     }
 
 #if defined(MATTER_CLUSTER_SCENE_NAME_SUPPORT) && MATTER_CLUSTER_SCENE_NAME_SUPPORT
-    emberAfCopyString(entry.name, sceneName, ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH);
+    emberAfCopyString(entry.name, Uint8::from_const_char(sceneName.data()), ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH);
 #endif
 
     // When adding a new scene, wipe out all of the extensions before parsing the


### PR DESCRIPTION
#### Problem
* uint8_t * was changed to CharSpan in (#10354). A function call was not updated and currently has the wrong type passed to it which causes some sample apps to fail to compile.

#### Change overview
* Pass the correct type to `emberAfCopyString()`.
Use `Uint8::from_const_char` to convert from `const char *` to `uint8_t *`

#### Testing
```
./examples/chef/chef.py --use_zzz -bcer -d rootnode_heatingcoolingunit_ncdGai1E5a -t esp32
```