### PR TITLE
[Darwin] Darwin BLE crash when trying to talk to a device after netwo…

### DIFF
--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -70,6 +70,7 @@ namespace DeviceLayer {
         void BleConnectionDelegateImpl::NewConnection(Ble::BleLayer * bleLayer, void * appState, const uint16_t deviceDiscriminator)
         {
             ChipLogProgress(Ble, "%s", __FUNCTION__);
+            CancelConnection();
             ble = [[BleConnection alloc] initWithDiscriminator:deviceDiscriminator];
             [ble setBleLayer:bleLayer];
             ble.appState = appState;
@@ -81,8 +82,10 @@ namespace DeviceLayer {
         CHIP_ERROR BleConnectionDelegateImpl::CancelConnection()
         {
             ChipLogProgress(Ble, "%s", __FUNCTION__);
-            [ble stop];
-            ble = nil;
+            if (ble) {
+                [ble stop];
+                ble = nil;
+            }
             return CHIP_NO_ERROR;
         }
     } // namespace Internal
@@ -386,7 +389,7 @@ namespace DeviceLayer {
         return;
     }
 
-    [_centralManager cancelPeripheralConnection:_peripheral];
+    _mBleLayer->CloseAllBleConnections();
     _peripheral = nil;
 }
 


### PR DESCRIPTION
…rk join failure

#### Problem

Issue #19138 found a crash on darwin when trying to commission a device over BLE using wrong WiFi credentials.

What happens is that on the first commissioning attempt a PASE session is established over BLE and is kept open (which is fine).
On second attempt at running the command `pairing code-wifi 1 abc def MT:-24J042C00KA0648G00` the process should re-start from the beginning and establish a new PASE session. It almost works, and the platform specific BLE code does so. Sadly the underlying connection in the blue layer is not closed properly and it tries to send an ack onto a peripheral for which the connection has been closed, which results into accessing a dangling pointer and so it crashes.

Fix #19138

For reviewer, `_mBleLayer->CloseAllBleConnections()` ends up calling `cancelPeripheralConnection` in https://github.com/project-chip/connectedhomeip/blob/master/src/platform/Darwin/BlePlatformDelegateImpl.mm#L107

#### Change overview
 * Close the BLE session both at the platform level but also at the ble layer level when a new session is started

#### Testing
I have verified locally that it does not crash anymore.