### PR TITLE
Remove kSessionEstablished event

### DIFF
--- a/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-app/ameba/main/DeviceCallbacks.cpp
@@ -71,9 +71,6 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         OnInternetConnectivityChange(event);
         break;
 
-    case DeviceEventType::kSessionEstablished:
-        OnSessionEstablished(event);
-        break;
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
             (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
@@ -137,14 +134,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {
         ChipLogProgress(DeviceLayer, "Lost IPv6 connectivity...");
-    }
-}
-
-void DeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
-{
-    if (event->SessionEstablished.IsCommissioner)
-    {
-        ChipLogProgress(DeviceLayer, "Commissioner detected!");
     }
 }
 

--- a/examples/all-clusters-app/ameba/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-app/ameba/main/include/DeviceCallbacks.h
@@ -39,7 +39,6 @@ public:
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
-    void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnOnOffPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
 };

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -120,14 +120,6 @@ void DeviceEventCallback(const ChipDeviceEvent * event, intptr_t arg)
 {
     switch (event->Type)
     {
-    case DeviceEventType::kSessionEstablished: {
-        if (event->SessionEstablished.IsCommissioner)
-        {
-            PLAT_LOG("Commissioning session established");
-        }
-    }
-    break;
-
     case DeviceEventType::kCHIPoBLEConnectionEstablished:
         PLAT_LOG("CHIPoBLE connection established");
         break;

--- a/examples/all-clusters-minimal-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/all-clusters-minimal-app/ameba/main/DeviceCallbacks.cpp
@@ -60,9 +60,6 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         OnInternetConnectivityChange(event);
         break;
 
-    case DeviceEventType::kSessionEstablished:
-        OnSessionEstablished(event);
-        break;
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
             (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
@@ -114,14 +111,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {
         ChipLogProgress(DeviceLayer, "Lost IPv6 connectivity...");
-    }
-}
-
-void DeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
-{
-    if (event->SessionEstablished.IsCommissioner)
-    {
-        ChipLogProgress(DeviceLayer, "Commissioner detected!");
     }
 }
 

--- a/examples/all-clusters-minimal-app/ameba/main/include/DeviceCallbacks.h
+++ b/examples/all-clusters-minimal-app/ameba/main/include/DeviceCallbacks.h
@@ -39,7 +39,6 @@ public:
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
-    void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnOnOffPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
 };

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -120,14 +120,6 @@ void DeviceEventCallback(const ChipDeviceEvent * event, intptr_t arg)
 {
     switch (event->Type)
     {
-    case DeviceEventType::kSessionEstablished: {
-        if (event->SessionEstablished.IsCommissioner)
-        {
-            PLAT_LOG("Commissioning session established");
-        }
-    }
-    break;
-
     case DeviceEventType::kCHIPoBLEConnectionEstablished:
         PLAT_LOG("CHIPoBLE connection established");
         break;

--- a/examples/chef/esp32/main/main.cpp
+++ b/examples/chef/esp32/main/main.cpp
@@ -98,13 +98,6 @@ void DeviceEventCallback(const ChipDeviceEvent * event, intptr_t arg)
 
         break;
 
-    case DeviceEventType::kSessionEstablished:
-        if (event->SessionEstablished.IsCommissioner)
-        {
-            ChipLogProgress(Shell, "Commissioner detected!");
-        }
-        break;
-
     case DeviceEventType::kCHIPoBLEConnectionEstablished:
         ChipLogProgress(Shell, "CHIPoBLE connection established");
         break;

--- a/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/lighting-app/ameba/main/DeviceCallbacks.cpp
@@ -69,9 +69,6 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         OnInternetConnectivityChange(event);
         break;
 
-    case DeviceEventType::kSessionEstablished:
-        OnSessionEstablished(event);
-        break;
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
             (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
@@ -118,14 +115,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {
         printf("Lost IPv6 connectivity...");
-    }
-}
-
-void DeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
-{
-    if (event->SessionEstablished.IsCommissioner)
-    {
-        printf("Commissioner detected!");
     }
 }
 

--- a/examples/lighting-app/ameba/main/include/DeviceCallbacks.h
+++ b/examples/lighting-app/ameba/main/include/DeviceCallbacks.h
@@ -39,6 +39,5 @@ public:
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
-    void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
 };

--- a/examples/lighting-app/bouffalolab/bl602/include/DeviceCallbacks.h
+++ b/examples/lighting-app/bouffalolab/bl602/include/DeviceCallbacks.h
@@ -39,7 +39,6 @@ public:
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
-    void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnOnOffPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnLevelControlAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnColorControlAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);

--- a/examples/lighting-app/bouffalolab/bl602/src/DeviceCallbacks.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/DeviceCallbacks.cpp
@@ -57,10 +57,6 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         OnInternetConnectivityChange(event);
         break;
 
-    case DeviceEventType::kSessionEstablished:
-        OnSessionEstablished(event);
-        break;
-
     case DeviceEventType::kCHIPoBLEConnectionEstablished:
         log_info("CHIPoBLE connection established\r\n");
         break;
@@ -149,14 +145,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {
         log_info("Lost IPv6 connectivity...\r\n");
-    }
-}
-
-void DeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
-{
-    if (event->SessionEstablished.IsCommissioner)
-    {
-        log_info("Commissioner detected!\r\n");
     }
 }
 

--- a/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
+++ b/examples/ota-requestor-app/ameba/main/DeviceCallbacks.cpp
@@ -71,9 +71,6 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
         OnInternetConnectivityChange(event);
         break;
 
-    case DeviceEventType::kSessionEstablished:
-        OnSessionEstablished(event);
-        break;
     case DeviceEventType::kInterfaceIpAddressChanged:
         if ((event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV4_Assigned) ||
             (event->InterfaceIpAddressChanged.Type == InterfaceIpChangeType::kIpV6_Assigned))
@@ -137,14 +134,6 @@ void DeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent * event
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {
         ChipLogProgress(DeviceLayer, "Lost IPv6 connectivity...");
-    }
-}
-
-void DeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
-{
-    if (event->SessionEstablished.IsCommissioner)
-    {
-        ChipLogProgress(DeviceLayer, "Commissioner detected!");
     }
 }
 

--- a/examples/ota-requestor-app/ameba/main/include/DeviceCallbacks.h
+++ b/examples/ota-requestor-app/ameba/main/include/DeviceCallbacks.h
@@ -39,7 +39,6 @@ public:
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
-    void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnOnOffPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
 };

--- a/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
@@ -54,10 +54,6 @@ void CommonDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, i
         OnInternetConnectivityChange(event);
         break;
 
-    case DeviceEventType::kSessionEstablished:
-        OnSessionEstablished(event);
-        break;
-
     case DeviceEventType::kCHIPoBLEConnectionEstablished:
         ESP_LOGI(TAG, "CHIPoBLE connection established");
         break;
@@ -162,13 +158,5 @@ void CommonDeviceCallbacks::OnInternetConnectivityChange(const ChipDeviceEvent *
     else if (event->InternetConnectivityChange.IPv6 == kConnectivity_Lost)
     {
         ESP_LOGE(TAG, "Lost IPv6 connectivity...");
-    }
-}
-
-void CommonDeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
-{
-    if (event->SessionEstablished.IsCommissioner)
-    {
-        ESP_LOGI(TAG, "Commissioner detected!");
     }
 }

--- a/examples/platform/esp32/common/CommonDeviceCallbacks.h
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.h
@@ -28,7 +28,6 @@ public:
 
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
-    void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
 };
 
 class DeviceCallbacksDelegate

--- a/examples/pump-app/cc13x2x7_26x2x7/main/DeviceCallbacks.cpp
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/DeviceCallbacks.cpp
@@ -56,10 +56,6 @@ void DeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, intptr_
                  event->ServiceProvisioningChange.ServiceConfigUpdated);
         break;
 
-    case DeviceEventType::kSessionEstablished:
-        OnSessionEstablished(event);
-        break;
-
     case DeviceEventType::kCHIPoBLEConnectionEstablished:
         PLAT_LOG("CHIPoBLE connection established");
         break;
@@ -190,14 +186,6 @@ void DeviceCallbacks::OnThreadConnectivityChange(const ChipDeviceEvent * event)
     else if (event->ThreadConnectivityChange.Result == kConnectivity_NoChange)
     {
         PLAT_LOG("## No change in Thread connectivity...");
-    }
-}
-
-void DeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
-{
-    if (event->SessionEstablished.IsCommissioner)
-    {
-        PLAT_LOG("Commissioner detected!");
     }
 }
 

--- a/examples/pump-app/cc13x2x7_26x2x7/main/include/DeviceCallbacks.h
+++ b/examples/pump-app/cc13x2x7_26x2x7/main/include/DeviceCallbacks.h
@@ -43,7 +43,6 @@ public:
 private:
     void OnInternetConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnThreadConnectivityChange(const chip::DeviceLayer::ChipDeviceEvent * event);
-    void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnIdentifyPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnOnOffPostAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);
     void OnLevelControlAttributeChangeCallback(chip::EndpointId endpointId, chip::AttributeId attributeId, uint8_t * value);

--- a/examples/tv-app/android/java/DeviceCallbacks.cpp
+++ b/examples/tv-app/android/java/DeviceCallbacks.cpp
@@ -80,19 +80,9 @@ void DeviceCallbacks::OnPlatformEvent(const ChipDeviceEvent * event)
     case DeviceEventType::kCommissioningComplete:
         OnCommissioningComplete(event);
         break;
-    case DeviceEventType::kSessionEstablished:
-        OnSessionEstablished(event);
-        break;
     }
 }
 
-void DeviceCallbacks::OnSessionEstablished(const ChipDeviceEvent * event)
-{
-    if (event->SessionEstablished.IsCommissioner)
-    {
-        ChipLogProgress(AppServer, "Commissioner detected!");
-    }
-}
 void DeviceCallbacks::OnCommissioningComplete(const ChipDeviceEvent * event)
 {
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();

--- a/examples/tv-app/android/java/DeviceCallbacks.h
+++ b/examples/tv-app/android/java/DeviceCallbacks.h
@@ -30,6 +30,5 @@ public:
 private:
     jobject mProvider                      = nullptr;
     jmethodID mCommissioningCompleteMethod = nullptr;
-    void OnSessionEstablished(const chip::DeviceLayer::ChipDeviceEvent * event);
     void OnCommissioningComplete(const chip::DeviceLayer::ChipDeviceEvent * event);
 };

--- a/src/include/platform/CHIPDeviceEvent.h
+++ b/src/include/platform/CHIPDeviceEvent.h
@@ -162,13 +162,6 @@ enum PublicEventTypes
     kSEDIntervalChange,
 
     /**
-     * Security Session Established
-     *
-     * Signals that an external entity has established a new security session with the device.
-     */
-    kSessionEstablished,
-
-    /**
      * CHIPoBLE Connection Established
      *
      * Signals that an external entity has established a new CHIPoBLE connection with the device.


### PR DESCRIPTION
#### Problem
As far as I can tell this event is not dispatched by anyone. This is just creating distraction when reading code. (Similarly to #20278)

#### Change overview
 * Remove `kSessionEstablished`

