### PR TITLE
[python] Move string encoding to ChipDeviceCtrl.py

### DIFF
--- a/src/controller/python/chip-device-ctrl.py
+++ b/src/controller/python/chip-device-ctrl.py
@@ -552,8 +552,7 @@ class DeviceMgrCmd(Cmd):
             print("Device is assigned with nodeid = {}".format(nodeid))
 
             if args[0] == "-ip" and len(args) >= 3:
-                self.devCtrl.EstablishPASESessionIP(args[1].encode(
-                    "utf-8"), int(args[2]), nodeid)
+                self.devCtrl.EstablishPASESessionIP(args[1], int(args[2]), nodeid)
             else:
                 print("Usage:")
                 self.do_help("paseonly")
@@ -614,8 +613,7 @@ class DeviceMgrCmd(Cmd):
             print("Device is assigned with nodeid = {}".format(nodeid))
 
             if args[0] == "-ip" and len(args) >= 3:
-                self.devCtrl.CommissionIP(args[1].encode(
-                    "utf-8"), int(args[2]), nodeid)
+                self.devCtrl.CommissionIP(args[1], int(args[2]), nodeid)
             elif args[0] == "-ble" and len(args) >= 3:
                 self.devCtrl.ConnectBLE(int(args[1]), int(args[2]), nodeid)
             elif args[0] in ['-qr', '-code'] and len(args) >= 2:
@@ -948,7 +946,7 @@ class DeviceMgrCmd(Cmd):
                 self.do_help("set-pairing-wifi-credential")
                 return
             self.devCtrl.SetWiFiCredentials(
-                args[0].encode("utf-8"), args[1].encode("utf-8"))
+                args[0], args[1])
         except Exception as ex:
             print(str(ex))
             return

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -278,13 +278,13 @@ class ChipDeviceController():
                 self.devCtrl, nodeid)
         )
 
-    def EstablishPASESessionIP(self, ipaddr, setupPinCode, nodeid):
+    def EstablishPASESessionIP(self, ipaddr: str, setupPinCode: int, nodeid: int):
         self.CheckIsActive()
 
         self.state = DCState.RENDEZVOUS_ONGOING
         return self._ChipStack.CallAsync(
             lambda: self._dmLib.pychip_DeviceController_EstablishPASESessionIP(
-                self.devCtrl, ipaddr, setupPinCode, nodeid)
+                self.devCtrl, ipaddr.encode("utf-8"), setupPinCode, nodeid)
         )
 
     def Commission(self, nodeid):
@@ -345,7 +345,7 @@ class ChipDeviceController():
             return False
         return self._ChipStack.commissioningEventRes == 0
 
-    def CommissionIP(self, ipaddr, setupPinCode, nodeid):
+    def CommissionIP(self, ipaddr: str, setupPinCode: int, nodeid: int):
         self.CheckIsActive()
 
         # IP connection will run through full commissioning, so we need to wait
@@ -356,7 +356,7 @@ class ChipDeviceController():
 
         self._ChipStack.CallAsync(
             lambda: self._dmLib.pychip_DeviceController_ConnectIP(
-                self.devCtrl, ipaddr, setupPinCode, nodeid)
+                self.devCtrl, ipaddr.encode("utf-8"), setupPinCode, nodeid)
         )
         if not self._ChipStack.commissioningCompleteEvent.isSet():
             # Error 50 is a timeout
@@ -374,18 +374,18 @@ class ChipDeviceController():
         self.SetThreadOperationalDataset(threadOperationalDataset)
         return self.ConnectBLE(discriminator, setupPinCode, nodeId)
 
-    def CommissionWiFi(self, discriminator, setupPinCode, nodeId, ssid, credentials):
+    def CommissionWiFi(self, discriminator, setupPinCode, nodeId, ssid: str, credentials: str):
         ''' Commissions a WiFi device over BLE
         '''
         self.SetWiFiCredentials(ssid, credentials)
         return self.ConnectBLE(discriminator, setupPinCode, nodeId)
 
-    def SetWiFiCredentials(self, ssid, credentials):
+    def SetWiFiCredentials(self, ssid: str, credentials: str):
         self.CheckIsActive()
 
         return self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_SetWiFiCredentials(
-                ssid, credentials)
+                ssid.encode("utf-8"), credentials.encode("utf-8"))
         )
 
     def SetThreadOperationalDataset(self, threadOperationalDataset):

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -188,7 +188,7 @@ class BaseTestHelper:
             time.sleep(0.2)
         if time.time() > timeout:
             return None
-        return ctypes.string_at(addrStrStorage)
+        return ctypes.string_at(addrStrStorage).decode("utf-8")
 
     def TestDiscovery(self, discriminator: int):
         self.logger.info(
@@ -207,7 +207,7 @@ class BaseTestHelper:
         self.logger.info(
             "Attempting to establish PASE session with device id: {} addr: {}".format(str(nodeid), ip))
         if self.devCtrl.EstablishPASESessionIP(
-                ip.encode("utf-8"), setuppin, nodeid) is not None:
+                ip, setuppin, nodeid) is not None:
             self.logger.info(
                 "Failed to establish PASE session with device id: {} addr: {}".format(str(nodeid), ip))
             return False
@@ -261,7 +261,7 @@ class BaseTestHelper:
 
     def TestCommissioning(self, ip: str, setuppin: int, nodeid: int):
         self.logger.info("Commissioning device {}".format(ip))
-        if not self.devCtrl.CommissionIP(ip.encode("utf-8"), setuppin, nodeid):
+        if not self.devCtrl.CommissionIP(ip, setuppin, nodeid):
             self.logger.info(
                 "Failed to finish commissioning device {}".format(ip))
             return False
@@ -483,7 +483,7 @@ class BaseTestHelper:
         self.devCtrl2 = self.fabricAdmin2.NewController(
             self.controllerNodeId, self.paaTrustStorePath)
 
-        if not self.devCtrl2.CommissionIP(ip.encode("utf-8"), setuppin, nodeid):
+        if not self.devCtrl2.CommissionIP(ip, setuppin, nodeid):
             self.logger.info(
                 "Failed to finish key exchange with device {}".format(ip))
             return False

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -67,8 +67,6 @@ def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: 
 
     if address_override:
         address = address_override
-    else:
-        address = address.decode("utf-8")
 
     logger.info("Testing commissioning")
     FailIfNot(test.TestCommissioning(ip=address,


### PR DESCRIPTION
#### Problem
With #19792 `SetWiFiCredentials()` changed from taking string arguments to byte arrays. This shifts responsibility to choose the right encoding to the caller, which seems not ideal. 

#### Change overview
Exposing a Pythonic API and encode the string in `ChipDeviceCtrl.py`.


#### Testing
Manually using `chip-repl`.