### PR TITLE
[Linux] Do not filter WiFi scan results if the ssid used for filterin…

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1706,10 +1706,16 @@ void ConnectivityManagerImpl::_OnWpaInterfaceScanDone(GObject * source_object, G
     for (const gchar * bssPath = (bsss != nullptr ? *bsss : nullptr); bssPath != nullptr; bssPath = *(++bsss))
     {
         WiFiScanResponse network;
-        if (_GetBssInfo(bssPath, network) && network.ssidLen == sInterestedSSIDLen &&
-            memcmp(network.ssid, sInterestedSSID, sInterestedSSIDLen) == 0)
+        if (_GetBssInfo(bssPath, network))
         {
-            networkScanned->push_back(network);
+            if (sInterestedSSIDLen == 0)
+            {
+                networkScanned->push_back(network);
+            }
+            else if (network.ssidLen == sInterestedSSIDLen && memcmp(network.ssid, sInterestedSSID, sInterestedSSIDLen) == 0)
+            {
+                networkScanned->push_back(network);
+            }
         }
     }
 


### PR DESCRIPTION
…g is empty

#### Problem

On Linux, `./chip-tool networkcommissioning scan-networks 1 0 --Ssid null` returns `0` entries as described in #18901

Looking at the code it seems that we try to filter and returns only networks with an empty ssid name if no ssid or a `null` said is passed to `scan-networks`.
It could also be me misreading the code, so this is a "tentative" fix for #18901 as I can not verify directly.

#### Change overview
 * Ensure no filtering is applied if no ssid are passed in.
