### PR TITLE
Conditionally implement TriggerOTA in RPC builds

### DIFF
--- a/examples/common/pigweed/rpc_services/Device.h
+++ b/examples/common/pigweed/rpc_services/Device.h
@@ -223,6 +223,7 @@ public:
 
     virtual pw::Status TriggerOta(const pw_protobuf_Empty & request, pw_protobuf_Empty & response)
     {
+#if CONFIG_CHIP_OTA_REQUESTOR
         chip::DeviceLayer::PlatformMgr().ScheduleWork(
             [](intptr_t) {
                 chip::OTARequestorInterface * requestor = chip::GetRequestorInstance();
@@ -237,6 +238,10 @@ public:
             },
             reinterpret_cast<intptr_t>(nullptr));
         return pw::OkStatus();
+#else
+        ChipLogError(AppServer, "Trigger OTA requested, but OTA requestor not compiled in.");
+        return pw::Status::Unimplemented();
+#endif
     }
 
     virtual pw::Status SetPairingState(const chip_rpc_PairingState & request, pw_protobuf_Empty & response)


### PR DESCRIPTION
#### Problem
Linker error when compiling esp32-devkitc-temperature-measurement-rpc:

```
app/esp32/third_party/connectedhomeip/examples/common/pigweed/rpc_services/Device.h:228: undefined reference to `chip::GetRequestorInstance()'
```

#### Change overview
Conditionally use OTA requestor only if OTA requestor is enabled.

#### Testing
Compilation succeeds after the patch.