### PR TITLE
Disable pigweed clang build on Mac M1

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -210,7 +210,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
   declare_args() {
     # Enable building chip with clang.
-    enable_host_clang_build = enable_default_builds && host_os != "win"
+    # Disabled on Mac arm64 but note that the "gcc" build uses Apple clang.
+    enable_host_clang_build = enable_default_builds && host_os != "win" &&
+                              (host_os != "mac" || host_cpu != "arm64")
 
     # Enable building chip with gcc.
     enable_host_gcc_build = enable_default_builds && host_os != "win"


### PR DESCRIPTION

#### Problem

gn_build.sh fails on M1

#### Change overview

This build's dependencies are not met on Mac ARM64 as there's no arm64
clang package available from pigweed yet.

#### Testing

gn_build.sh