### PR TITLE
Cherry pick - scenes.cpp type fix

### DIFF
--- a/src/app/clusters/scenes/scenes.cpp
+++ b/src/app/clusters/scenes/scenes.cpp
@@ -810,7 +810,7 @@ bool emberAfPluginScenesServerParseAddScene(
     }
 
 #if defined(MATTER_CLUSTER_SCENE_NAME_SUPPORT) && MATTER_CLUSTER_SCENE_NAME_SUPPORT
-    emberAfCopyString(entry.name, sceneName, ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH);
+    emberAfCopyString(entry.name, Uint8::from_const_char(sceneName.data()), ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH);
 #endif
 
     // When adding a new scene, wipe out all of the extensions before parsing the


### PR DESCRIPTION
#### Problem
* Interop is missing scenes.cpp type fix from #20291.

#### Change overview
* Cherry pick #20291 into interop.

#### Testing
```
./examples/chef/chef.py --use_zzz -bcer -d rootnode_heatingcoolingunit_ncdGai1E5a -t esp32
```