### PR TITLE
Remove <signal.h> include from Linux/PlatformManagerImpl.cpp

### DIFF
--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -41,7 +41,6 @@
 #include <vector>
 
 #include <inttypes.h>
-#include <signal.h>
 #include <stdint.h>
 #include <string.h>
 #include <sys/types.h>

--- a/src/lib/shell/streamer_mbed.cpp
+++ b/src/lib/shell/streamer_mbed.cpp
@@ -22,7 +22,6 @@
 
 #include <lib/shell/streamer.h>
 
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 

--- a/src/lib/shell/streamer_stdio.cpp
+++ b/src/lib/shell/streamer_stdio.cpp
@@ -22,7 +22,6 @@
 
 #include <lib/shell/streamer.h>
 
-#include <signal.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <termios.h>

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -42,7 +42,6 @@
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 #include <netinet/in.h>
-#include <signal.h>
 #include <unistd.h>
 
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30

--- a/src/platform/webos/PlatformManagerImpl.cpp
+++ b/src/platform/webos/PlatformManagerImpl.cpp
@@ -43,7 +43,6 @@
 #include <linux/rtnetlink.h>
 #include <net/if.h>
 #include <netinet/in.h>
-#include <signal.h>
 #include <unistd.h>
 
 #if __GLIBC__ == 2 && __GLIBC_MINOR__ < 30


### PR DESCRIPTION
#### Problem

Pull request #19064 moved all signal code out of the Linux platform manager into examples/all-clusters-app/linux/main-common.cpp, which is a much more appropriate location.

However, Linux/PlatformManagerImpl.cpp and other code is still needlessly including signal.h.

#### Change overview

Remove this include to reduce temptation for adding code back to the platform managers that could modify the signal mask.

#### Testing

Tested to build without error from top-level on Linux platform.  CI will verify no other breakages.