### PR TITLE
Allow set up code pairing to continue even if BLE is compiled out

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -78,7 +78,7 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
         {
             isRunning = true;
         }
-        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err, err);
+        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
     }
 
     if (searchOverAll || payload.rendezvousInformation == RendezvousInformationFlag::kSoftAP)
@@ -87,7 +87,7 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
         {
             isRunning = true;
         }
-        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err, err);
+        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
     }
 
     // We always want to search on network because any node that has already been commissioned will use on-network regardless of the


### PR DESCRIPTION
#### Problem

Currently chip-tool pairing code 9876 'MT:-24J0YXE00KA0648G00' fails
immediately if BLE is compiled out, due to returning
CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE.

#### Change overview

Allow the pairer to continue in this case, so that ethernet pairing can
be used.

#### Testing

chip-tool pairing code 9876 'MT:-24J0YXE00KA0648G00' 
