### PR TITLE
make DefaultStorageKeyAllocator::Format protected so the class can be extended

### DIFF
--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -114,7 +114,7 @@ public:
     // Event number counter.
     const char * IMEventNumber() { return Format("g/im/ec"); }
 
-private:
+protected:
     // The ENFORCE_FORMAT args are "off by one" because this is a class method,
     // with an implicit "this" as first arg.
     const char * ENFORCE_FORMAT(2, 3) Format(const char * format, ...)
@@ -126,6 +126,7 @@ private:
         return mKeyName;
     }
 
+private:
     char mKeyName[PersistentStorageDelegate::kKeyLengthMax + 1] = { 0 };
 };
 


### PR DESCRIPTION
#### Problem

If integrating the matter PersistentStorageDelegate into an out-of-tree
implementation, it is useful to extend DefaultStorageKeyAllocator to
make it clear to maintainers that there is a single, shared key space
and that keys must avoid collision with those used in the sdk.

However, extending the DefaultStorageKeyAllocator class is awkward
because the Format method is private.

#### Change overview

Make the DefaultStorageKeyAllocator::Format method protected to streamline extending the class.

#### Testing

Tested to build without error from top-level on Linux platform. CI will verify no other breakages.