### PR TITLE
Switch from readline to editline

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -266,3 +266,6 @@
 	url = https://github.com/SiliconLabs/wiseconnect-wifi-bt-sdk.git
 	branch = master
 	platforms = efr32
+[submodule "editline"]
+	path = third_party/editline/repo
+	url = https://github.com/troglobit/editline.git

--- a/build_overrides/editline.gni
+++ b/build_overrides/editline.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # Root directory for editline.
+  editline_root = "//third_party/editline"
+}

--- a/examples/build_overrides/editline.gni
+++ b/examples/build_overrides/editline.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # Root directory for editline.
+  editline_root = "//third_party/connectedhomeip/third_party/editline"
+}

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -19,6 +19,10 @@ import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/examples/chip-tool/chip-tool.gni")
 import("${chip_root}/src/lib/core/core.gni")
 
+if (config_use_interactive_mode) {
+  import("//build_overrides/editline.gni")
+}
+
 assert(chip_build_tools)
 
 config("config") {
@@ -37,10 +41,6 @@ config("config") {
   ]
 
   cflags = [ "-Wconversion" ]
-
-  if (config_use_interactive_mode) {
-    libs = [ "readline" ]
-  }
 }
 
 static_library("chip-tool-utils") {
@@ -77,8 +77,11 @@ static_library("chip-tool-utils") {
     "config/PersistentStorage.cpp",
   ]
 
+  deps = []
+
   if (config_use_interactive_mode) {
     sources += [ "commands/interactive/InteractiveCommands.cpp" ]
+    deps += [ "${editline_root}:editline" ]
   }
 
   if (config_enable_yaml_tests) {

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -18,9 +18,8 @@
 
 #include "InteractiveCommands.h"
 
+#include <editline.h>
 #include <iomanip>
-#include <readline/history.h>
-#include <readline/readline.h>
 #include <sstream>
 
 char kInteractiveModeName[]                            = "";

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -18,6 +18,10 @@ import("//build_overrides/chip.gni")
 import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/examples//chip-tool/chip-tool.gni")
 
+if (config_use_interactive_mode) {
+  import("//build_overrides/editline.gni")
+}
+
 assert(chip_build_tools)
 
 config("config") {
@@ -43,10 +47,6 @@ config("config") {
     "-Wconversion",
     "-fobjc-arc",
   ]
-
-  if (config_use_interactive_mode) {
-    libs = [ "readline" ]
-  }
 }
 
 executable("darwin-framework-tool") {
@@ -81,6 +81,7 @@ executable("darwin-framework-tool") {
 
   if (config_use_interactive_mode) {
     sources += [ "commands/interactive/InteractiveCommands.mm" ]
+    deps += [ "${editline_root}:editline" ]
   }
 
   if (config_enable_yaml_tests) {

--- a/third_party/editline/BUILD.gn
+++ b/third_party/editline/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("editline_config") {
+  include_dirs = [ "repo/include" ]
+}
+
+static_library("editline") {
+  public = [ "repo/include/editline.h" ]
+
+  sources = [
+    "repo/src/complete.c",
+    "repo/src/editline.c",
+    "repo/src/editline.h",
+    "repo/src/sysunix.c",
+    "repo/src/unix.h",
+  ]
+
+  public_configs = [ ":editline_config" ]
+
+  include_dirs = [ "include" ]
+}

--- a/third_party/editline/include/config.h
+++ b/third_party/editline/include/config.h
@@ -1,0 +1,171 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if the `closedir' function returns void instead of int. */
+/* #undef CLOSEDIR_VOID */
+
+/* Define to include ANSI arrow keys support. */
+#define CONFIG_ANSI_ARROWS 1
+
+/* Define to enable EOF (Ctrl-D) key. */
+#define CONFIG_EOF 1
+
+/* Define to enable SIGINT (Ctrl-C) key. */
+#define CONFIG_SIGINT 1
+
+/* Define to enable SIGSTOP (Ctrl-Z) key. */
+/* #undef CONFIG_SIGSTOP */
+
+/* Define to enable terminal bell on completion. */
+/* #undef CONFIG_TERMINAL_BELL */
+
+/* Define to skip duplicate lines in the scrollback history. */
+#define CONFIG_UNIQUE_HISTORY 1
+
+/* Define to use the termcap library for terminal size. */
+/* #undef CONFIG_USE_TERMCAP */
+
+/* Define to 1 if `TIOCGWINSZ' requires <sys/ioctl.h>. */
+#define GWINSZ_IN_SYS_IOCTL 1
+
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
+ */
+#define HAVE_DIRENT_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `curses' library (-lcurses). */
+/* #undef HAVE_LIBCURSES */
+
+/* Define to 1 if you have the `ncurses' library (-lncurses). */
+/* #undef HAVE_LIBNCURSES */
+
+/* Define to 1 if you have the `termcap' library (-ltermcap). */
+/* #undef HAVE_LIBTERMCAP */
+
+/* Define to 1 if you have the `terminfo' library (-lterminfo). */
+/* #undef HAVE_LIBTERMINFO */
+
+/* Define to 1 if you have the `tinfo' library (-ltinfo). */
+/* #undef HAVE_LIBTINFO */
+
+/* Define to 1 if you have the <malloc.h> header file. */
+/* #undef HAVE_MALLOC_H */
+
+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
+/* #undef HAVE_NDIR_H */
+
+/* Define to 1 if you have the `perror' function. */
+#define HAVE_PERROR 1
+
+/* Define to 1 if you have the <sgtty.h> header file. */
+#define HAVE_SGTTY_H 1
+
+/* Define to 1 if you have the <signal.h> header file. */
+#define HAVE_SIGNAL_H 1
+
+/* Define to 1 if `stat' has the bug that it succeeds when given the
+   zero-length file name argument. */
+/* #undef HAVE_STAT_EMPTY_STRING_BUG */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strchr' function. */
+#define HAVE_STRCHR 1
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strrchr' function. */
+#define HAVE_STRRCHR 1
+
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
+ */
+/* #undef HAVE_SYS_DIR_H */
+
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
+ */
+/* #undef HAVE_SYS_NDIR_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the `tcgetattr' function. */
+#define HAVE_TCGETATTR 1
+
+/* Define to 1 if you have the <termcap.h> header file. */
+#define HAVE_TERMCAP_H 1
+
+/* Define to 1 if you have the <termios.h> header file. */
+#define HAVE_TERMIOS_H 1
+
+/* Define to 1 if you have the <termio.h> header file. */
+#define HAVE_TERMIO_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if `lstat' dereferences a symlink specified with a trailing
+   slash. */
+#define LSTAT_FOLLOWS_SLASHED_SYMLINK 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "editline"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "https://github.com/troglobit/editline/issues"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "editline"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "editline 1.17.1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "editline"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.17.1"
+
+/* Define to 1 if the `S_IS*' macros in <sys/stat.h> do not work properly. */
+/* #undef STAT_MACROS_BROKEN */
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Default to UNIX backend, should be detected. */
+#define SYS_UNIX 1
+
+/* Version number of package */
+#define VERSION "1.17.1"
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */


### PR DESCRIPTION
#### Problem

Readline is GPL'd software and may not be available in the build
environment.

#### Change overview

Vendor editline which is permissively licensed and drop it in as a
replacement for readline.

#### Testing

chip-tool interactive
