### PR TITLE
Add attributePath parameter to Door Lock Server's unhandledAttributeC…

### DIFF
--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3576,7 +3576,7 @@ MatterDoorLockClusterServerPreAttributeChangedCallback(const chip::app::Concrete
         break;
 
     default:
-        res = emberAfPluginDoorLockOnUnhandledAttributeChange(attributePath.mEndpointId, attributeType, size, value);
+        res = emberAfPluginDoorLockOnUnhandledAttributeChange(attributePath.mEndpointId, attributePath, attributeType, size, value);
         break;
     }
 
@@ -3666,8 +3666,8 @@ emberAfPluginDoorLockOnUserCodeTemporaryDisableTimeChange(chip::EndpointId Endpo
 }
 
 chip::Protocols::InteractionModel::Status __attribute__((weak))
-emberAfPluginDoorLockOnUnhandledAttributeChange(chip::EndpointId EndpointId, EmberAfAttributeType attrType, uint16_t attrSize,
-                                                uint8_t * attrValue)
+emberAfPluginDoorLockOnUnhandledAttributeChange(chip::EndpointId EndpointId, const chip::app::ConcreteAttributePath & attributePath,
+                                                EmberAfAttributeType attrType, uint16_t attrSize, uint8_t * attrValue)
 {
     return chip::Protocols::InteractionModel::Status::Success;
 }

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -738,6 +738,7 @@ chip::Protocols::InteractionModel::Status emberAfPluginDoorLockOnUserCodeTempora
  * @brief Cluster attribute pre-change callback
  *
  * @param  EndpointId      endpoint for which attribute is changing
+ * @param  attributePath   concrete attribute path that is changing
  * @param  attrType        attribute that is going to be changed
  * @param  attrSize        attribute value storage size
  * @param  attrValue       attribute value to set
@@ -746,6 +747,7 @@ chip::Protocols::InteractionModel::Status emberAfPluginDoorLockOnUserCodeTempora
  * @retval any other InteractionModel::Status value to forbid attribute change
  */
 chip::Protocols::InteractionModel::Status emberAfPluginDoorLockOnUnhandledAttributeChange(chip::EndpointId EndpointId,
+                                                                                          const chip::app::ConcreteAttributePath & attributePath,
                                                                                           EmberAfAttributeType attrType,
                                                                                           uint16_t attrSize, uint8_t * attrValue);
 

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -746,10 +746,9 @@ chip::Protocols::InteractionModel::Status emberAfPluginDoorLockOnUserCodeTempora
  * @retval InteractionModel::Status::Success if attribute change is possible
  * @retval any other InteractionModel::Status value to forbid attribute change
  */
-chip::Protocols::InteractionModel::Status emberAfPluginDoorLockOnUnhandledAttributeChange(chip::EndpointId EndpointId,
-                                                                                          const chip::app::ConcreteAttributePath & attributePath,
-                                                                                          EmberAfAttributeType attrType,
-                                                                                          uint16_t attrSize, uint8_t * attrValue);
+chip::Protocols::InteractionModel::Status
+emberAfPluginDoorLockOnUnhandledAttributeChange(chip::EndpointId EndpointId, const chip::app::ConcreteAttributePath & attributePath,
+                                                EmberAfAttributeType attrType, uint16_t attrSize, uint8_t * attrValue);
 
 // =============================================================================
 // Plugin callbacks that are called by cluster server and should be implemented


### PR DESCRIPTION
Addd attributePath parameter to Door Lock Server's emberAfPluginDoorLockOnUnhandledAttributeChanged API

#### Problem
API function needs attributePath parameter to allow application to determine which attribute is being changed.

#### Change overview
Add attributePath parameter API call

#### Testing
No existing code is affected (e.g., API is not currently used by any examples).

Fixes #18681 