### PR TITLE
EFR32 Device Attestation Credentials provider bugfix.

### DIFF
--- a/examples/platform/efr32/EFR32DeviceAttestationCreds.cpp
+++ b/examples/platform/efr32/EFR32DeviceAttestationCreds.cpp
@@ -74,8 +74,8 @@ public:
         uint8_t signature[64] = { 0 };
         size_t signature_size = sizeof(signature);
 
-        psa_status_t err = psa_sign_hash(key_id, PSA_ALG_ECDSA(PSA_ALG_SHA_256), digest_to_sign.data(), digest_to_sign.size(),
-                                         signature, signature_size, &signature_size);
+        psa_status_t err = psa_sign_message(key_id, PSA_ALG_ECDSA(PSA_ALG_SHA_256), digest_to_sign.data(), digest_to_sign.size(),
+                                            signature, signature_size, &signature_size);
         VerifyOrReturnError(!err, CHIP_ERROR_INTERNAL);
 
         return CopySpanToMutableSpan(ByteSpan(signature, signature_size), out_buffer);


### PR DESCRIPTION
#### Problem
[SignWithDeviceAttestationKey now receives the full message](https://github.com/project-chip/connectedhomeip/pull/20078), instead of the message hash. The signature calculation therefore has to be modified accordingly.

#### Change overview
Signature calculation changed from `psa_sign_hash` to `psa_sign_message`.

#### Testing
Tested on EFR32. This changes only had effect on EFR32, and only if the flag `chip_build_platform_attestation_credentials_provider` is set to true.