### PR TITLE
Don't sweat interactive mode in build_examples.py

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -278,7 +278,6 @@ def HostTargets():
     builder.AppendVariant(name="clang", use_clang=True),
     builder.AppendVariant(name="test", extra_tests=True),
 
-    builder.WhitelistVariantNameForGlob('no-interactive-ipv6only')
     builder.WhitelistVariantNameForGlob('ipv6only')
 
     for target in app_targets:
@@ -289,12 +288,7 @@ def HostTargets():
             builder.targets.append(target)
 
     for target in builder.AllVariants():
-        if cross_compile and 'chip-tool' in target.name and 'arm64' in target.name and '-no-interactive' not in target.name:
-            # Interactive builds will not compile by default on arm cross compiles
-            # because libreadline is not part of the default sysroot
-            yield target.GlobBlacklist('Arm crosscompile does not support libreadline-dev')
-        else:
-            yield target
+        yield target
 
     # Without extra build variants
     yield target_native.Extend('chip-cert', app=HostApp.CERT_TOOL)

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -31,10 +31,15 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/bridge-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-bridge-ipv6only'
 
-# Generating linux-arm64-chip-tool-no-interactive-ipv6only
+# Generating linux-arm64-chip-tool
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false config_use_interactive_mode=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-no-interactive-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool'
+
+# Generating linux-arm64-chip-tool-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only'
 
 # Generating linux-arm64-light
 bash -c '
@@ -177,9 +182,6 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-chip-tool-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
 
-# Generating linux-x64-chip-tool-no-interactive-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_inet_config_enable_ipv4=false config_use_interactive_mode=false' {out}/linux-x64-chip-tool-no-interactive-ipv6only
-
 # Generating linux-x64-chip-tool-nodeps
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false' {out}/linux-x64-chip-tool-nodeps
 
@@ -276,8 +278,11 @@ ninja -C {out}/linux-arm64-bridge
 # Building linux-arm64-bridge-ipv6only
 ninja -C {out}/linux-arm64-bridge-ipv6only
 
-# Building linux-arm64-chip-tool-no-interactive-ipv6only
-ninja -C {out}/linux-arm64-chip-tool-no-interactive-ipv6only
+# Building linux-arm64-chip-tool
+ninja -C {out}/linux-arm64-chip-tool
+
+# Building linux-arm64-chip-tool-ipv6only
+ninja -C {out}/linux-arm64-chip-tool-ipv6only
 
 # Building linux-arm64-light
 ninja -C {out}/linux-arm64-light
@@ -377,9 +382,6 @@ ninja -C {out}/linux-x64-chip-tool
 
 # Building linux-x64-chip-tool-ipv6only
 ninja -C {out}/linux-x64-chip-tool-ipv6only
-
-# Building linux-x64-chip-tool-no-interactive-ipv6only
-ninja -C {out}/linux-x64-chip-tool-no-interactive-ipv6only
 
 # Building linux-x64-chip-tool-nodeps
 ninja -C {out}/linux-x64-chip-tool-nodeps


### PR DESCRIPTION
#### Problem

build_examples.py tries to avoid interactive mode on certain platforms.

#### Change overview

As of 3340fc2b62c ("Switch from readline to editline (#20330)") there is
no longer an issue with respect to the availability of libreadline.

Remove the special handling.

#### Testing

CI