### PR TITLE
Increase cloudbuild disk size from 200G to 500G for smoke tests

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -110,4 +110,4 @@ artifacts:
 # building instead of docker download/checkout/bootstrap)
 options:
     machineType: "E2_HIGHCPU_32"
-    diskSizeGb: 200
+    diskSizeGb: 500


### PR DESCRIPTION
#### Problem
Image 0.5.84 increased significantly for chip-build-vscode and we seem to be right at the edge on the amount of available space.

Builds fail with:

```
Step #4 - "Linux": 2022-07-06 18:25:45 WARNING ninja: error: WriteFile(__third_party_connectedhomeip_src_lib_core_gen_chip_buildconfig___third_party_connectedhomeip_build_toolchain_linux_linux_x64_gcc__rule.rsp): Unable to close the file. No space left on device
```

#### Change overview
Increase disk size

#### Testing
N/A (external build)