### PR TITLE
Add a way to disable openthread in build_examples.py

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -32,6 +32,7 @@
 #include <new>
 #include <platform/DiagnosticDataProvider.h>
 #include <platform/PlatformManager.h>
+#include <signal.h>
 #include <system/SystemPacketBuffer.h>
 #include <transport/SessionManager.h>
 #include <transport/raw/PeerAddress.h>

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -270,6 +270,7 @@ def HostTargets():
     builder.AppendVariant(name="ipv6only", enable_ipv4=False),
     builder.AppendVariant(name="no-ble", enable_ble=False),
     builder.AppendVariant(name="no-wifi", enable_wifi=False),
+    builder.AppendVariant(name="no-thread", enable_thread=False),
     builder.AppendVariant(name="tsan", conflicts=['asan'], use_tsan=True),
     builder.AppendVariant(name="asan", conflicts=['tsan'], use_asan=True),
     builder.AppendVariant(name="libfuzzer", requires=[
@@ -304,6 +305,10 @@ def HostTargets():
                                use_platform_mdns=True).GlobBlacklist("Reduce default build variants")
     yield target_native.Extend('address-resolve-tool-platform-mdns-ipv6only', app=HostApp.ADDRESS_RESOLVE,
                                use_platform_mdns=True, enable_ipv4=False).GlobBlacklist("Reduce default build variants")
+
+    nodeps_args = dict(enable_ipv4=False, enable_ble=False, enable_wifi=False, enable_thread=False)
+    yield target_native.Extend('chip-tool-nodeps', app=HostApp.CHIP_TOOL, **nodeps_args)
+    yield target_native.Extend('all-clusters-app-nodeps', app=HostApp.ALL_CLUSTERS, **nodeps_args)
 
     test_target = Target(HostBoard.NATIVE.PlatformName(), HostBuilder)
     for board in [HostBoard.NATIVE, HostBoard.FAKE]:

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -192,9 +192,11 @@ class HostBoard(Enum):
 
 class HostBuilder(GnBuilder):
 
-    def __init__(self, root, runner, app: HostApp, board=HostBoard.NATIVE, enable_ipv4=True,
-                 enable_ble=True, enable_wifi=True, use_tsan=False,  use_asan=False, separate_event_loop=True,
-                 use_libfuzzer=False, use_clang=False, interactive_mode=True, extra_tests=False,
+    def __init__(self, root, runner, app: HostApp, board=HostBoard.NATIVE,
+                 enable_ipv4=True, enable_ble=True, enable_wifi=True,
+                 enable_thread=True, use_tsan=False, use_asan=False,
+                 separate_event_loop=True, use_libfuzzer=False, use_clang=False,
+                 interactive_mode=True, extra_tests=False,
                  use_platform_mdns=False, enable_rpcs=False):
         super(HostBuilder, self).__init__(
             root=os.path.join(root, 'examples', app.ExamplePath()),
@@ -215,6 +217,9 @@ class HostBuilder(GnBuilder):
 
         if not enable_wifi:
             self.extra_gn_options.append('chip_enable_wifi=false')
+
+        if not enable_thread:
+            self.extra_gn_options.append('chip_enable_openthread=false')
 
         if use_tsan:
             self.extra_gn_options.append('is_tsan=true')

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -153,6 +153,9 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root} {ou
 # Generating linux-x64-all-clusters
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux {out}/linux-x64-all-clusters
 
+# Generating linux-x64-all-clusters-app-nodeps
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false' {out}/linux-x64-all-clusters-app-nodeps
+
 # Generating linux-x64-all-clusters-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-all-clusters-ipv6only
 
@@ -179,6 +182,9 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 
 # Generating linux-x64-chip-tool-no-interactive-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_inet_config_enable_ipv4=false config_use_interactive_mode=false' {out}/linux-x64-chip-tool-no-interactive-ipv6only
+
+# Generating linux-x64-chip-tool-nodeps
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false' {out}/linux-x64-chip-tool-nodeps
 
 # Generating linux-x64-light
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux {out}/linux-x64-light
@@ -351,6 +357,9 @@ ninja -C {out}/linux-x64-address-resolve-tool src/lib/address_resolve:address-re
 # Building linux-x64-all-clusters
 ninja -C {out}/linux-x64-all-clusters
 
+# Building linux-x64-all-clusters-app-nodeps
+ninja -C {out}/linux-x64-all-clusters-app-nodeps
+
 # Building linux-x64-all-clusters-ipv6only
 ninja -C {out}/linux-x64-all-clusters-ipv6only
 
@@ -377,6 +386,9 @@ ninja -C {out}/linux-x64-chip-tool-ipv6only
 
 # Building linux-x64-chip-tool-no-interactive-ipv6only
 ninja -C {out}/linux-x64-chip-tool-no-interactive-ipv6only
+
+# Building linux-x64-chip-tool-nodeps
+ninja -C {out}/linux-x64-chip-tool-nodeps
 
 # Building linux-x64-light
 ninja -C {out}/linux-x64-light


### PR DESCRIPTION
#### Problem

Linux builds have several library dependencies that are on by default, with no way to turn them off via build_examples.

#### Change overview

Enable a build that has no runtime dependencies other than libc:

 0x0000000000000001 (NEEDED)             Shared library: [libdl.so.2]
 0x0000000000000001 (NEEDED)             Shared library: [libpthread.so.0]
 0x0000000000000001 (NEEDED)             Shared library: [librt.so.1]
 0x0000000000000001 (NEEDED)             Shared library: [libm.so.6]
 0x0000000000000001 (NEEDED)             Shared library: [libc.so.6]

This makes it easy to deploy on embedded Linux without installing other
libraries.

#### Testing

 ./scripts/build/build_examples.py --target linux-arm64-chip-tool-ipv6only-no-ble-no-wifi-no-thread-asan-clang build
 ./scripts/build/build_examples.py --target linux-arm64-all-clusters-ipv6only-no-ble-no-wifi-no-thread-asan-clang build
