### PR TITLE
Blacklist nrf52840dongle-all-clusters - runst out of flash

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -418,7 +418,7 @@ def NrfTargets():
     ]
 
     # Enable nrf52840dongle for all-clusters and lighting app only
-    yield target.Extend('nrf52840dongle-all-clusters', board=NrfBoard.NRF52840DONGLE, app=NrfApp.ALL_CLUSTERS)
+    yield target.Extend('nrf52840dongle-all-clusters', board=NrfBoard.NRF52840DONGLE, app=NrfApp.ALL_CLUSTERS).GlobBlacklist('Out of flash when linking')
     yield target.Extend('nrf52840dongle-all-clusters-minimal', board=NrfBoard.NRF52840DONGLE, app=NrfApp.ALL_CLUSTERS_MINIMAL)
     yield target.Extend('nrf52840dongle-light', board=NrfBoard.NRF52840DONGLE, app=NrfApp.LIGHT)
 

--- a/scripts/build/testdata/all_targets_except_host.txt
+++ b/scripts/build/testdata/all_targets_except_host.txt
@@ -214,7 +214,7 @@ nrf-nrf52840dk-lock
 nrf-nrf52840dk-pump
 nrf-nrf52840dk-pump-controller
 nrf-nrf52840dk-shell
-nrf-nrf52840dongle-all-clusters
+nrf-nrf52840dongle-all-clusters (NOGLOB: Out of flash when linking)
 nrf-nrf52840dongle-all-clusters-minimal
 nrf-nrf52840dongle-light
 nrf-nrf5340dk-all-clusters

--- a/scripts/build/testdata/glob_star_targets_except_host.txt
+++ b/scripts/build/testdata/glob_star_targets_except_host.txt
@@ -94,7 +94,6 @@ nrf-nrf52840dk-lock
 nrf-nrf52840dk-pump
 nrf-nrf52840dk-pump-controller
 nrf-nrf52840dk-shell
-nrf-nrf52840dongle-all-clusters
 nrf-nrf52840dongle-all-clusters-minimal
 nrf-nrf52840dongle-light
 nrf-nrf5340dk-all-clusters


### PR DESCRIPTION
#### Problem
Build running out of flash.

#### Change overview
Blacklist build from glob pattern (no autobuild)

#### Testing
Local compile with globe, no compile errors (target not built)
