### PR TITLE
[chip-tool] Make sure the multiple arguments separator for multiple w…

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -55,7 +55,7 @@ bool Command::InitArguments(int argc, char ** argv)
         }
     }
 
-    VerifyOrExit((size_t)(argc) >= mandatoryArgsCount && (argvExtraArgsCount == 0 || (argvExtraArgsCount && optionalArgsCount)),
+    VerifyOrExit((size_t) (argc) >= mandatoryArgsCount && (argvExtraArgsCount == 0 || (argvExtraArgsCount && optionalArgsCount)),
                  ChipLogError(chipTool, "InitArgs: Wrong arguments number: %d instead of %u", argc,
                               static_cast<unsigned int>(mandatoryArgsCount)));
 
@@ -312,7 +312,11 @@ bool Command::InitArgument(size_t argIndex, char * argValue)
         while (ss.good())
         {
             std::string valueAsString;
-            getline(ss, valueAsString, ',');
+            // By default the parameter separator is ";" in order to not collapse with the argument itself if it contains commas
+            // (e.g a struct argument with multiple fields). In case one needs to use ";" it can be overriden with the following
+            // environment variable.
+            constexpr const char * kSeparatorVariable = "CHIPTOOL_CUSTOM_ARGUMENTS_SEPARATOR";
+            getline(ss, valueAsString, getenv(kSeparatorVariable) ? getenv(kSeparatorVariable)[0] : ';');
 
             CustomArgument * customArgument = new CustomArgument();
             vectorArgument->push_back(customArgument);


### PR DESCRIPTION
…rite onto a single transation does not collide with the comma separator from the argument value itself

#### Problem

This is a followup to #19566 where the comma separator used for multiple arguments for a write transition are colliding with the argument value itself if the value contains comma.

#### Change overview
 * Use ";" by default and allow it to be overridden if needed

#### Testing
 * `./out/debug/standalone/chip-tool fixedlabel write-by-id 0 '[{"0":"foo", "1":"world"}]' 0x12344321 0`
 * `./out/debug/standalone/chip-tool fixedlabel write-by-id 0,0 '[{"0":"foo", "1":"world"}];[{"0":"foo2", "1": "world2"}]' 0x12344321 0`
 * `./out/debug/standalone/chip-tool any write-by-id 0x6,0x7 0x4001,0x0 '5;false' 0x12344321 1,1 `