### PR TITLE
[zephyr] Fix factory recent after recent KVS changes

### DIFF
--- a/src/platform/tests/TestKeyValueStoreMgr.cpp
+++ b/src/platform/tests/TestKeyValueStoreMgr.cpp
@@ -287,7 +287,7 @@ static void TestKeyValueStoreMgr_MultiRead(nlTestSuite * inSuite, void * inConte
 #ifdef __ZEPHYR__
 static void TestKeyValueStoreMgr_DoFactoryReset(nlTestSuite * inSuite, void * inContext)
 {
-    constexpr const char * kStrKey  = "some_string_key";
+    constexpr const char * kStrKey  = "string_with_weird_chars\\=_key";
     constexpr const char * kUintKey = "some_uint_key";
 
     NL_TEST_ASSERT(inSuite, KeyValueStoreMgr().Put(kStrKey, "some_string") == CHIP_NO_ERROR);


### PR DESCRIPTION
#### Problem
I forgot to update the factory reset routine after adding escaping of forbidden characters in KVS keys and the routine is escaping such keys twice which results in a failure.

#### Change overview
Use Zephyr's `settings_delete` call directly in the callback from Zephyr setting enumeration function.

#### Testing
Enhanced unit tests to test the factory reset with escaped keys.
Tested manually on nRF 52840, too.
