### PR TITLE
Cleanup Linux platform source includes

### DIFF
--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -70,26 +70,30 @@ static_library("Linux") {
     "Logging.cpp",
     "NetworkCommissioningDriver.h",
     "NetworkCommissioningEthernetDriver.cpp",
-    "NetworkCommissioningWiFiDriver.cpp",
     "PlatformManagerImpl.cpp",
     "PlatformManagerImpl.h",
     "PosixConfig.cpp",
     "PosixConfig.h",
     "SystemPlatformConfig.h",
     "SystemTimeSupport.cpp",
-    "bluez/AdapterIterator.cpp",
-    "bluez/AdapterIterator.h",
-    "bluez/ChipDeviceScanner.cpp",
-    "bluez/ChipDeviceScanner.h",
-    "bluez/Helper.cpp",
-    "bluez/Helper.h",
-    "bluez/MainLoop.cpp",
-    "bluez/MainLoop.h",
-    "bluez/Types.h",
   ]
 
   if (chip_enable_openthread) {
     sources += [ "NetworkCommissioningThreadDriver.cpp" ]
+  }
+
+  if (chip_enable_ble) {
+    sources += [
+      "bluez/AdapterIterator.cpp",
+      "bluez/AdapterIterator.h",
+      "bluez/ChipDeviceScanner.cpp",
+      "bluez/ChipDeviceScanner.h",
+      "bluez/Helper.cpp",
+      "bluez/Helper.h",
+      "bluez/MainLoop.cpp",
+      "bluez/MainLoop.h",
+      "bluez/Types.h",
+    ]
   }
 
   deps = [ "${chip_root}/src/setup_payload" ]
@@ -135,7 +139,10 @@ static_library("Linux") {
   }
 
   if (chip_enable_wifi) {
-    sources += [ "GlibTypeDeleter.h" ]
+    sources += [
+      "GlibTypeDeleter.h",
+      "NetworkCommissioningWiFiDriver.cpp",
+    ]
 
     public_deps += [ "dbus/wpa" ]
   }

--- a/src/platform/Linux/NetworkCommissioningEthernetDriver.cpp
+++ b/src/platform/Linux/NetworkCommissioningEthernetDriver.cpp
@@ -34,7 +34,7 @@ NetworkIterator * LinuxEthernetDriver::GetNetworks()
 {
     auto ret = new EthernetNetworkIterator();
     ConnectivityUtils::GetEthInterfaceName(SafePointerCast<char *>(ret->interfaceName), sizeof(ret->interfaceName));
-    ret->interfaceNameLen = strnlen(SafePointerCast<char *>(ret->interfaceName), sizeof(ret->interfaceName));
+    ret->interfaceNameLen = static_cast<uint8_t>(strnlen(SafePointerCast<char *>(ret->interfaceName), sizeof(ret->interfaceName)));
     return ret;
 }
 


### PR DESCRIPTION
#### Problem

Linux platform is including network commissioning code that is only relevant for commissionable apps.

#### Change overview

This moves BLE and WiFi includes inside the chip_enable_ble and chip_enable_wifi conditionals and moves Ethernet includes into the commissionable app code where it's being called.

#### Testing

Tested chip-tool and relevant app Linux builds.  All succeed.