### PR TITLE
Rename commissioner/commissionable find to discover

### DIFF
--- a/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
+++ b/src/app/tests/suites/commands/discovery/DiscoveryCommands.cpp
@@ -28,7 +28,7 @@ DiscoveryCommands::FindCommissionable(const char * identity,
     ReturnErrorOnFailure(SetupDiscoveryCommands());
 
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kNone, (uint64_t) 0);
-    return mDNSResolver.FindCommissionableNodes(filter);
+    return mDNSResolver.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR DiscoveryCommands::FindCommissionableByShortDiscriminator(
@@ -39,7 +39,7 @@ CHIP_ERROR DiscoveryCommands::FindCommissionableByShortDiscriminator(
 
     uint64_t shortDiscriminator = static_cast<uint64_t>((value.value >> 8) & 0x0F);
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kShortDiscriminator, shortDiscriminator);
-    return mDNSResolver.FindCommissionableNodes(filter);
+    return mDNSResolver.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR DiscoveryCommands::FindCommissionableByLongDiscriminator(
@@ -49,7 +49,7 @@ CHIP_ERROR DiscoveryCommands::FindCommissionableByLongDiscriminator(
     ReturnErrorOnFailure(SetupDiscoveryCommands());
 
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kLongDiscriminator, value.value);
-    return mDNSResolver.FindCommissionableNodes(filter);
+    return mDNSResolver.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR DiscoveryCommands::FindCommissionableByCommissioningMode(
@@ -59,7 +59,7 @@ CHIP_ERROR DiscoveryCommands::FindCommissionableByCommissioningMode(
     ReturnErrorOnFailure(SetupDiscoveryCommands());
 
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kCommissioningMode);
-    return mDNSResolver.FindCommissionableNodes(filter);
+    return mDNSResolver.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR DiscoveryCommands::FindCommissionableByVendorId(
@@ -68,7 +68,7 @@ CHIP_ERROR DiscoveryCommands::FindCommissionableByVendorId(
     ReturnErrorOnFailure(SetupDiscoveryCommands());
 
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kVendorId, value.value);
-    return mDNSResolver.FindCommissionableNodes(filter);
+    return mDNSResolver.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR DiscoveryCommands::FindCommissionableByDeviceType(
@@ -77,7 +77,7 @@ CHIP_ERROR DiscoveryCommands::FindCommissionableByDeviceType(
     ReturnErrorOnFailure(SetupDiscoveryCommands());
 
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kDeviceType, value.value);
-    return mDNSResolver.FindCommissionableNodes(filter);
+    return mDNSResolver.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR
@@ -87,7 +87,7 @@ DiscoveryCommands::FindCommissioner(const char * identity,
     ReturnErrorOnFailure(SetupDiscoveryCommands());
 
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kCommissioner, 1);
-    return mDNSResolver.FindCommissioners(filter);
+    return mDNSResolver.DiscoverCommissioners(filter);
 }
 
 CHIP_ERROR
@@ -97,7 +97,7 @@ DiscoveryCommands::FindCommissionerByVendorId(
     ReturnErrorOnFailure(SetupDiscoveryCommands());
 
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kVendorId, value.value);
-    return mDNSResolver.FindCommissioners(filter);
+    return mDNSResolver.DiscoverCommissioners(filter);
 }
 
 CHIP_ERROR DiscoveryCommands::FindCommissionerByDeviceType(
@@ -106,7 +106,7 @@ CHIP_ERROR DiscoveryCommands::FindCommissionerByDeviceType(
     ReturnErrorOnFailure(SetupDiscoveryCommands());
 
     chip::Dnssd::DiscoveryFilter filter(chip::Dnssd::DiscoveryFilterType::kDeviceType, value.value);
-    return mDNSResolver.FindCommissioners(filter);
+    return mDNSResolver.DiscoverCommissioners(filter);
 }
 
 CHIP_ERROR DiscoveryCommands::SetupDiscoveryCommands()

--- a/src/controller/CHIPCommissionableNodeController.cpp
+++ b/src/controller/CHIPCommissionableNodeController.cpp
@@ -39,13 +39,13 @@ CHIP_ERROR CommissionableNodeController::DiscoverCommissioners(Dnssd::DiscoveryF
         ReturnErrorOnFailure(mDNSResolver.Init(DeviceLayer::UDPEndPointManager()));
 #endif
         mDNSResolver.SetCommissioningDelegate(this);
-        return mDNSResolver.FindCommissioners(discoveryFilter);
+        return mDNSResolver.DiscoverCommissioners(discoveryFilter);
     }
 
 #if CONFIG_DEVICE_LAYER
     ReturnErrorOnFailure(mResolver->Init(DeviceLayer::UDPEndPointManager()));
 #endif
-    return mResolver->FindCommissioners(discoveryFilter);
+    return mResolver->DiscoverCommissioners(discoveryFilter);
 }
 
 CommissionableNodeController::~CommissionableNodeController()

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1410,7 +1410,7 @@ void DeviceCommissioner::OnSessionEstablishmentTimeoutCallback(System::Layer * a
 CHIP_ERROR DeviceCommissioner::DiscoverCommissionableNodes(Dnssd::DiscoveryFilter filter)
 {
     ReturnErrorOnFailure(SetUpNodeDiscovery());
-    return mDNSResolver.FindCommissionableNodes(filter);
+    return mDNSResolver.DiscoverCommissionableNodes(filter);
 }
 
 const Dnssd::DiscoveredNodeData * DeviceCommissioner::GetDiscoveredDevice(int idx)

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -36,12 +36,15 @@ public:
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override {}
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override {}
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override { return ResolveNodeIdStatus; }
-    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return FindCommissionersStatus; }
-    CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return DiscoverCommissionersStatus; }
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
 
-    CHIP_ERROR InitStatus              = CHIP_NO_ERROR;
-    CHIP_ERROR ResolveNodeIdStatus     = CHIP_NO_ERROR;
-    CHIP_ERROR FindCommissionersStatus = CHIP_NO_ERROR;
+    CHIP_ERROR InitStatus                  = CHIP_NO_ERROR;
+    CHIP_ERROR ResolveNodeIdStatus         = CHIP_NO_ERROR;
+    CHIP_ERROR DiscoverCommissionersStatus = CHIP_NO_ERROR;
 };
 
 } // namespace
@@ -156,10 +159,10 @@ void TestDiscoverCommissioners_InitError_ReturnsError(nlTestSuite * inSuite, voi
     NL_TEST_ASSERT(inSuite, controller.DiscoverCommissioners() != CHIP_NO_ERROR);
 }
 
-void TestDiscoverCommissioners_FindCommissionersError_ReturnsError(nlTestSuite * inSuite, void * inContext)
+void TestDiscoverCommissioners_DiscoverCommissionersError_ReturnsError(nlTestSuite * inSuite, void * inContext)
 {
     MockResolver resolver;
-    resolver.FindCommissionersStatus = CHIP_ERROR_INTERNAL;
+    resolver.DiscoverCommissionersStatus = CHIP_ERROR_INTERNAL;
     CommissionableNodeController controller(&resolver);
     NL_TEST_ASSERT(inSuite, controller.DiscoverCommissioners() != CHIP_NO_ERROR);
 }
@@ -176,7 +179,7 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestDiscoverCommissioners_HappyCase", TestDiscoverCommissioners_HappyCase),
     NL_TEST_DEF("TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter", TestDiscoverCommissioners_HappyCaseWithDiscoveryFilter),
     NL_TEST_DEF("TestDiscoverCommissioners_InitError_ReturnsError", TestDiscoverCommissioners_InitError_ReturnsError),
-    NL_TEST_DEF("TestDiscoverCommissioners_FindCommissionersError_ReturnsError", TestDiscoverCommissioners_FindCommissionersError_ReturnsError),
+    NL_TEST_DEF("TestDiscoverCommissioners_DiscoverCommissionersError_ReturnsError", TestDiscoverCommissioners_DiscoverCommissionersError_ReturnsError),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -593,16 +593,16 @@ CHIP_ERROR DiscoveryImplPlatform::ResolveNodeId(const PeerId & peerId, Inet::IPA
     return mResolverProxy.ResolveNodeId(peerId, type);
 }
 
-CHIP_ERROR DiscoveryImplPlatform::FindCommissionableNodes(DiscoveryFilter filter)
+CHIP_ERROR DiscoveryImplPlatform::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     ReturnErrorOnFailure(InitImpl());
-    return mResolverProxy.FindCommissionableNodes(filter);
+    return mResolverProxy.DiscoverCommissionableNodes(filter);
 }
 
-CHIP_ERROR DiscoveryImplPlatform::FindCommissioners(DiscoveryFilter filter)
+CHIP_ERROR DiscoveryImplPlatform::DiscoverCommissioners(DiscoveryFilter filter)
 {
     ReturnErrorOnFailure(InitImpl());
-    return mResolverProxy.FindCommissioners(filter);
+    return mResolverProxy.DiscoverCommissioners(filter);
 }
 
 DiscoveryImplPlatform & DiscoveryImplPlatform::GetInstance()
@@ -643,7 +643,7 @@ ResolverProxy::~ResolverProxy()
     Shutdown();
 }
 
-CHIP_ERROR ResolverProxy::FindCommissionableNodes(DiscoveryFilter filter)
+CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
     mDelegate->Retain();
@@ -667,7 +667,7 @@ CHIP_ERROR ResolverProxy::FindCommissionableNodes(DiscoveryFilter filter)
                            Inet::InterfaceId::Null(), HandleNodeBrowse, mDelegate);
 }
 
-CHIP_ERROR ResolverProxy::FindCommissioners(DiscoveryFilter filter)
+CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
 {
     VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
     mDelegate->Retain();

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -55,8 +55,8 @@ public:
         mResolverProxy.SetCommissioningDelegate(delegate);
     }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
-    CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
-    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 
     static DiscoveryImplPlatform & GetInstance();
 

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -378,7 +378,7 @@ public:
      * Whenever a new matching node is found and a resolver delegate has been registered,
      * the node information is passed to the delegate's `OnNodeDiscoveryComplete` method.
      */
-    virtual CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) = 0;
+    virtual CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) = 0;
 
     /**
      * Finds all commissioner nodes matching the given filter.
@@ -386,7 +386,7 @@ public:
      * Whenever a new matching node is found and a resolver delegate has been registered,
      * the node information is passed to the delegate's `OnNodeDiscoveryComplete` method.
      */
-    virtual CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) = 0;
+    virtual CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) = 0;
 
     /**
      * Provides the system-wide implementation of the service resolver

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -150,8 +150,8 @@ public:
     }
 
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
-    CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
-    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 
 private:
     ResolverDelegateProxy * mDelegate                            = nullptr;

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -277,8 +277,8 @@ public:
     void SetOperationalDelegate(OperationalResolveDelegate * delegate) override { mOperationalDelegate = delegate; }
     void SetCommissioningDelegate(CommissioningResolveDelegate * delegate) override { mCommissioningDelegate = delegate; }
     CHIP_ERROR ResolveNodeId(const PeerId & peerId, Inet::IPAddressType type) override;
-    CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
-    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
 
 private:
     OperationalResolveDelegate * mOperationalDelegate     = nullptr;
@@ -621,12 +621,12 @@ void MinMdnsResolver::ExpireIncrementalResolvers()
     }
 }
 
-CHIP_ERROR MinMdnsResolver::FindCommissionableNodes(DiscoveryFilter filter)
+CHIP_ERROR MinMdnsResolver::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     return BrowseNodes(DiscoveryType::kCommissionableNode, filter);
 }
 
-CHIP_ERROR MinMdnsResolver::FindCommissioners(DiscoveryFilter filter)
+CHIP_ERROR MinMdnsResolver::DiscoverCommissioners(DiscoveryFilter filter)
 {
     return BrowseNodes(DiscoveryType::kCommissionerNode, filter);
 }
@@ -696,18 +696,18 @@ CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId, Inet::IPAddressTy
     return chip::Dnssd::Resolver::Instance().ResolveNodeId(peerId, type);
 }
 
-CHIP_ERROR ResolverProxy::FindCommissionableNodes(DiscoveryFilter filter)
+CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
     chip::Dnssd::Resolver::Instance().SetCommissioningDelegate(mDelegate);
-    return chip::Dnssd::Resolver::Instance().FindCommissionableNodes(filter);
+    return chip::Dnssd::Resolver::Instance().DiscoverCommissionableNodes(filter);
 }
 
-CHIP_ERROR ResolverProxy::FindCommissioners(DiscoveryFilter filter)
+CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
 {
     VerifyOrReturnError(mDelegate != nullptr, CHIP_ERROR_INCORRECT_STATE);
     chip::Dnssd::Resolver::Instance().SetCommissioningDelegate(mDelegate);
-    return chip::Dnssd::Resolver::Instance().FindCommissioners(filter);
+    return chip::Dnssd::Resolver::Instance().DiscoverCommissioners(filter);
 }
 
 } // namespace Dnssd

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -37,8 +37,11 @@ public:
         ChipLogError(Discovery, "Failed to resolve node ID: dnssd resolving not available");
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
-    CHIP_ERROR FindCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR FindCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
+    CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
 };
 
 NoneResolver gResolver;
@@ -60,12 +63,12 @@ CHIP_ERROR ResolverProxy::ResolveNodeId(const PeerId & peerId, Inet::IPAddressTy
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ResolverProxy::FindCommissionableNodes(DiscoveryFilter filter)
+CHIP_ERROR ResolverProxy::DiscoverCommissionableNodes(DiscoveryFilter filter)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
-CHIP_ERROR ResolverProxy::FindCommissioners(DiscoveryFilter filter)
+CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/lib/shell/commands/Dns.cpp
+++ b/src/lib/shell/commands/Dns.cpp
@@ -188,7 +188,7 @@ CHIP_ERROR BrowseCommissionableHandler(int argc, char ** argv)
 
     streamer_printf(streamer_get(), "Browsing commissionable nodes...\r\n");
 
-    return sResolverProxy.FindCommissionableNodes(filter);
+    return sResolverProxy.DiscoverCommissionableNodes(filter);
 }
 
 CHIP_ERROR BrowseCommissionerHandler(int argc, char ** argv)
@@ -203,7 +203,7 @@ CHIP_ERROR BrowseCommissionerHandler(int argc, char ** argv)
 
     streamer_printf(streamer_get(), "Browsing commissioners...\r\n");
 
-    return sResolverProxy.FindCommissioners(filter);
+    return sResolverProxy.DiscoverCommissioners(filter);
 }
 
 CHIP_ERROR BrowseHandler(int argc, char ** argv)


### PR DESCRIPTION
#### Problem

There is mixed nomenclature for finding/discovering matter nodes. This PR will unify that.
The "discover" name will align with the DiscoveryFilter parameter used by these functions.

#### Change overview

- renamed FindCommissionableNodes and FindCommissioners functions

#### Testing

CI will test