### PR TITLE
Enforce constraints for sizes of labelstruct label and value lengths

### DIFF
--- a/src/app/tests/suites/TestUserLabelClusterConstraints.yaml
+++ b/src/app/tests/suites/TestUserLabelClusterConstraints.yaml
@@ -34,10 +34,13 @@ tests:
       arguments:
           value:
               [
-                  { label: "this is longer than sixteen characters", value: "bedroom 2" },
+                  {
+                      label: "this is longer than sixteen characters",
+                      value: "bedroom 2",
+                  },
               ]
       response:
-        error: FAILURE
+          error: FAILURE
 
     - label: "Attempt to write overly long item for value"
       command: "writeAttribute"
@@ -45,8 +48,10 @@ tests:
       arguments:
           value:
               [
-                  { label: "test", value: "this is longer than sixteen characters" },
+                  {
+                      label: "test",
+                      value: "this is longer than sixteen characters",
+                  },
               ]
       response:
-        error: FAILURE
-
+          error: FAILURE

--- a/src/app/tests/suites/TestUserLabelClusterConstraints.yaml
+++ b/src/app/tests/suites/TestUserLabelClusterConstraints.yaml
@@ -1,0 +1,52 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: User Label Cluster Tests
+
+config:
+    nodeId: 0x12344321
+    cluster: "User Label"
+    endpoint: 0
+
+tests:
+    - label: "Wait for the commissioned device to be retrieved"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId
+
+    - label: "Attempt to write overly long item for label"
+      command: "writeAttribute"
+      attribute: "label list"
+      arguments:
+          value:
+              [
+                  { label: "this is longer than sixteen characters", value: "bedroom 2" },
+              ]
+      response:
+        error: FAILURE
+
+    - label: "Attempt to write overly long item for value"
+      command: "writeAttribute"
+      attribute: "label list"
+      arguments:
+          value:
+              [
+                  { label: "test", value: "this is longer than sixteen characters" },
+              ]
+      response:
+        error: FAILURE
+

--- a/src/app/tests/suites/tests.js
+++ b/src/app/tests/suites/tests.js
@@ -714,6 +714,7 @@ function getTests() {
         "TestSystemCommands",
         "TestBinding",
         "TestUserLabelCluster",
+        "TestUserLabelClusterConstraints",
         "TestArmFailSafe",
         "TestFanControl",
     ];

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -207,6 +207,7 @@ public:
         printf("TestSystemCommands\n");
         printf("TestBinding\n");
         printf("TestUserLabelCluster\n");
+        printf("TestUserLabelClusterConstraints\n");
         printf("TestArmFailSafe\n");
         printf("TestFanControl\n");
         printf("TestMultiAdmin\n");
@@ -52284,6 +52285,118 @@ private:
     }
 };
 
+class TestUserLabelClusterConstraintsSuite : public TestCommand
+{
+public:
+    TestUserLabelClusterConstraintsSuite(CredentialIssuerCommands * credsIssuerConfig) :
+        TestCommand("TestUserLabelClusterConstraints", 3, credsIssuerConfig)
+    {
+        AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
+        AddArgument("cluster", &mCluster);
+        AddArgument("endpoint", 0, UINT16_MAX, &mEndpoint);
+        AddArgument("timeout", 0, UINT16_MAX, &mTimeout);
+    }
+
+    ~TestUserLabelClusterConstraintsSuite() {}
+
+    chip::System::Clock::Timeout GetWaitDuration() const override
+    {
+        return chip::System::Clock::Seconds16(mTimeout.ValueOr(kTimeoutInSeconds));
+    }
+
+private:
+    chip::Optional<chip::NodeId> mNodeId;
+    chip::Optional<chip::CharSpan> mCluster;
+    chip::Optional<chip::EndpointId> mEndpoint;
+    chip::Optional<uint16_t> mTimeout;
+
+    chip::EndpointId GetEndpoint(chip::EndpointId endpoint) { return mEndpoint.HasValue() ? mEndpoint.Value() : endpoint; }
+
+    //
+    // Tests methods
+    //
+
+    void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override
+    {
+        bool shouldContinue = false;
+
+        switch (mTestIndex - 1)
+        {
+        case 0:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            shouldContinue = true;
+            break;
+        case 1:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            break;
+        case 2:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            break;
+        default:
+            LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
+        }
+
+        if (shouldContinue)
+        {
+            ContinueOnChipMainThread(CHIP_NO_ERROR);
+        }
+    }
+
+    CHIP_ERROR DoTestStep(uint16_t testIndex) override
+    {
+        using namespace chip::app::Clusters;
+        switch (testIndex)
+        {
+        case 0: {
+            LogStep(0, "Wait for the commissioned device to be retrieved");
+            ListFreer listFreer;
+            chip::app::Clusters::DelayCommands::Commands::WaitForCommissionee::Type value;
+            value.nodeId = mNodeId.HasValue() ? mNodeId.Value() : 305414945ULL;
+            return WaitForCommissionee(kIdentityAlpha, value);
+        }
+        case 1: {
+            LogStep(1, "Attempt to write overly long item for label");
+            ListFreer listFreer;
+            chip::app::DataModel::List<const chip::app::Clusters::UserLabel::Structs::LabelStruct::Type> value;
+
+            {
+                auto * listHolder_0 = new ListHolder<chip::app::Clusters::UserLabel::Structs::LabelStruct::Type>(1);
+                listFreer.add(listHolder_0);
+
+                listHolder_0->mList[0].label =
+                    chip::Span<const char>("this is longer than sixteen charactersgarbage: not in length on purpose", 38);
+                listHolder_0->mList[0].value = chip::Span<const char>("bedroom 2garbage: not in length on purpose", 9);
+
+                value =
+                    chip::app::DataModel::List<chip::app::Clusters::UserLabel::Structs::LabelStruct::Type>(listHolder_0->mList, 1);
+            }
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(0), UserLabel::Id, UserLabel::Attributes::LabelList::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        case 2: {
+            LogStep(2, "Attempt to write overly long item for value");
+            ListFreer listFreer;
+            chip::app::DataModel::List<const chip::app::Clusters::UserLabel::Structs::LabelStruct::Type> value;
+
+            {
+                auto * listHolder_0 = new ListHolder<chip::app::Clusters::UserLabel::Structs::LabelStruct::Type>(1);
+                listFreer.add(listHolder_0);
+
+                listHolder_0->mList[0].label = chip::Span<const char>("testgarbage: not in length on purpose", 4);
+                listHolder_0->mList[0].value =
+                    chip::Span<const char>("this is longer than sixteen charactersgarbage: not in length on purpose", 38);
+
+                value =
+                    chip::app::DataModel::List<chip::app::Clusters::UserLabel::Structs::LabelStruct::Type>(listHolder_0->mList, 1);
+            }
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(0), UserLabel::Id, UserLabel::Attributes::LabelList::Id, value,
+                                  chip::NullOptional, chip::NullOptional);
+        }
+        }
+        return CHIP_NO_ERROR;
+    }
+};
+
 class TestArmFailSafeSuite : public TestCommand
 {
 public:
@@ -87413,6 +87526,7 @@ void registerCommandsTests(Commands & commands, CredentialIssuerCommands * creds
         make_unique<TestSystemCommandsSuite>(credsIssuerConfig),
         make_unique<TestBindingSuite>(credsIssuerConfig),
         make_unique<TestUserLabelClusterSuite>(credsIssuerConfig),
+        make_unique<TestUserLabelClusterConstraintsSuite>(credsIssuerConfig),
         make_unique<TestArmFailSafeSuite>(credsIssuerConfig),
         make_unique<TestFanControlSuite>(credsIssuerConfig),
         make_unique<TestMultiAdminSuite>(credsIssuerConfig),


### PR DESCRIPTION
#### Problem

Server will allow structs with members larger than 16 characters, but reading the values back will get truncated.

Fixes #19851

#### Change overview
Add constraint checking into our writer logic.

#### Testing
Manually tried to write an overly large value, saw back a FAILURE response.
Added a yaml integration test