### PR TITLE
Fix incorrect return codes in door lock cluster

### DIFF
--- a/scripts/tests/chiptest/__init__.py
+++ b/scripts/tests/chiptest/__init__.py
@@ -21,32 +21,34 @@ from .test_definition import ApplicationPaths, TestDefinition, TestTarget
 
 
 def target_for_name(name: str):
-    if name.startswith('TV_') or name.startswith('Test_TC_MC_'):
+    if name.startswith("TV_") or name.startswith("Test_TC_MC_"):
         return TestTarget.TV
-    if name.startswith('DL_') or name.startswith('Test_TC_DL_'):
+    if name.startswith("DL_") or name.startswith("Test_TC_DLRK_"):
         return TestTarget.LOCK
-    if name.startswith('OTA_'):
+    if name.startswith("OTA_"):
         return TestTarget.OTA
     return TestTarget.ALL_CLUSTERS
 
 
 def tests_with_command(chip_tool: str, is_manual: bool):
     """Executes `chip_tool` binary to see what tests are available, using cmd
-       to get the list.
+    to get the list.
     """
-    cmd = 'list'
+    cmd = "list"
     if is_manual:
-        cmd += '-manual'
+        cmd += "-manual"
 
-    result = subprocess.run([chip_tool, 'tests', cmd], capture_output=True)
+    result = subprocess.run([chip_tool, "tests", cmd], capture_output=True)
 
-    for name in result.stdout.decode('utf8').split('\n'):
+    for name in result.stdout.decode("utf8").split("\n"):
         if not name:
             continue
 
         target = target_for_name(name)
 
-        yield TestDefinition(run_name=name, name=name, target=target, is_manual=is_manual)
+        yield TestDefinition(
+            run_name=name, name=name, target=target, is_manual=is_manual
+        )
 
 
 def AllTests(chip_tool: str):
@@ -58,6 +60,10 @@ def AllTests(chip_tool: str):
 
 
 __all__ = [
-    'TestTarget', 'TestDefinition', 'AllTests', 'ApplicationPaths',
-    'linux', 'runner',
+    "TestTarget",
+    "TestDefinition",
+    "AllTests",
+    "ApplicationPaths",
+    "linux",
+    "runner",
 ]

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -230,7 +230,7 @@ bool DoorLockServer::GetNumberOfHolidaySchedulesSupported(chip::EndpointId endpo
                         Attributes::NumberOfHolidaySchedulesSupported::Get, numberOfHolidaySchedules);
 }
 
-void DoorLockServer::SetUserCommandHandler(chip::app::CommandHandler * commandObj,
+void DoorLockServer::setUserCommandHandler(chip::app::CommandHandler * commandObj,
                                            const chip::app::ConcreteCommandPath & commandPath,
                                            const chip::app::Clusters::DoorLock::Commands::SetUser::DecodableType & commandData)
 {
@@ -271,7 +271,8 @@ void DoorLockServer::SetUserCommandHandler(chip::app::CommandHandler * commandOb
 
     if (!userIndexValid(commandPath.mEndpointId, userIndex))
     {
-        emberAfDoorLockClusterPrintln("[SetUser] User index out of bounds [userIndex=%d]", userIndex);
+        emberAfDoorLockClusterPrintln("[SetUser] User index out of bounds [endpointId=%d,userIndex=%d]", commandPath.mEndpointId,
+                                      userIndex);
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
@@ -282,6 +283,27 @@ void DoorLockServer::SetUserCommandHandler(chip::app::CommandHandler * commandOb
         emberAfDoorLockClusterPrintln(
             "[SetUser] Unable to set user: userName too long [endpointId=%d,userIndex=%d,userNameSize=%u]", commandPath.mEndpointId,
             userIndex, static_cast<unsigned int>(userName.Value().size()));
+
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        return;
+    }
+
+    if (!userStatus.IsNull() &&
+        (userStatus.Value() < DlUserStatus::kAvailable || userStatus.Value() > DlUserStatus::kOccupiedDisabled))
+    {
+        emberAfDoorLockClusterPrintln(
+            "[SetUser] Unable to set the user: user status is out of range [endpointId=%d,userIndex=%d,userStatus=%u]",
+            commandPath.mEndpointId, userIndex, to_underlying(userStatus.Value()));
+
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
+        return;
+    }
+
+    if (!userType.IsNull() && (userType.Value() < DlUserType::kUnrestrictedUser || userType.Value() > DlUserType::kRemoteOnlyUser))
+    {
+        emberAfDoorLockClusterPrintln(
+            "[SetUser] Unable to set the user: user type is out of range [endpointId=%d,userIndex=%d,userType=%u]",
+            commandPath.mEndpointId, userIndex, to_underlying(userType.Value()));
 
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
@@ -299,20 +321,21 @@ void DoorLockServer::SetUserCommandHandler(chip::app::CommandHandler * commandOb
                             userType, credentialRule);
         break;
     case DlDataOperationType::kClear:
+    default:
         // appclusters, 5.2.4.34: SetUser command allow only kAdd/kModify, we should respond with INVALID_COMMAND if we got kClear
+        // or anything else
         status = EMBER_ZCL_STATUS_INVALID_COMMAND;
+        emberAfDoorLockClusterPrintln("[SetUser] Invalid operation type [endpointId=%d,operationType=%u]", commandPath.mEndpointId,
+                                      to_underlying(operationType));
         break;
     }
 
     emberAfSendImmediateDefaultResponse(status);
 }
 
-void DoorLockServer::GetUserCommandHandler(chip::app::CommandHandler * commandObj,
-                                           const chip::app::ConcreteCommandPath & commandPath,
-                                           const chip::app::Clusters::DoorLock::Commands::GetUser::DecodableType & commandData)
+void DoorLockServer::getUserCommandHandler(chip::app::CommandHandler * commandObj,
+                                           const chip::app::ConcreteCommandPath & commandPath, uint16_t userIndex)
 {
-    auto & userIndex = commandData.userIndex;
-
     emberAfDoorLockClusterPrintln("[GetUser] Incoming command [endpointId=%d,userIndex=%d]", commandPath.mEndpointId, userIndex);
 
     if (!SupportsUSR(commandPath.mEndpointId))
@@ -412,11 +435,9 @@ exit:
     }
 }
 
-void DoorLockServer::ClearUserCommandHandler(chip::app::CommandHandler * commandObj,
-                                             const chip::app::ConcreteCommandPath & commandPath,
-                                             const chip::app::Clusters::DoorLock::Commands::ClearUser::DecodableType & commandData)
+void DoorLockServer::clearUserCommandHandler(chip::app::CommandHandler * commandObj,
+                                             const chip::app::ConcreteCommandPath & commandPath, uint16_t userIndex)
 {
-    auto & userIndex = commandData.userIndex;
     emberAfDoorLockClusterPrintln("[ClearUser] Incoming command [endpointId=%d,userIndex=%d]", commandPath.mEndpointId, userIndex);
 
     if (!SupportsUSR(commandPath.mEndpointId))
@@ -485,7 +506,7 @@ void DoorLockServer::ClearUserCommandHandler(chip::app::CommandHandler * command
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
 
-void DoorLockServer::SetCredentialCommandHandler(
+void DoorLockServer::setCredentialCommandHandler(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::SetCredential::DecodableType & commandData)
 {
@@ -534,27 +555,15 @@ void DoorLockServer::SetCredentialCommandHandler(
         emberAfDoorLockClusterPrintln("[SetCredential] Credential index is out of range [endpointId=%d,credentialType=%u"
                                       ",credentialIndex=%d]",
                                       commandPath.mEndpointId, to_underlying(credentialType), credentialIndex);
-        sendSetCredentialResponse(commandObj, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
+        sendSetCredentialResponse(commandObj, commandPath, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
         return;
     }
 
     // appclusters, 5.2.4.40.3: If the credential data length is out of bounds we should return INVALID_COMMAND
-    size_t minSize, maxSize;
-    if (!getCredentialRange(commandPath.mEndpointId, credentialType, minSize, maxSize))
+    auto status = credentialLengthWithinRange(commandPath.mEndpointId, credentialType, credentialData);
+    if (DlStatus::kSuccess != status)
     {
-        emberAfDoorLockClusterPrintln(
-            "[SetCredential] Unable to get min/max range for credential: internal error [endpointId=%d,credentialIndex=%d]",
-            commandPath.mEndpointId, credentialIndex);
-        sendSetCredentialResponse(commandObj, DlStatus::kFailure, 0, nextAvailableCredentialSlot);
-        return;
-    }
-    if (credentialData.size() < minSize || credentialData.size() > maxSize)
-    {
-        emberAfDoorLockClusterPrintln("[SetCredential] Credential data size is out of range "
-                                      "[endpointId=%d,credentialType=%u,minLength=%u,maxLength=%u,length=%u]",
-                                      commandPath.mEndpointId, to_underlying(credentialType), static_cast<unsigned int>(minSize),
-                                      static_cast<unsigned int>(maxSize), static_cast<unsigned int>(credentialData.size()));
-        sendSetCredentialResponse(commandObj, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
+        sendSetCredentialResponse(commandObj, commandPath, status, 0, nextAvailableCredentialSlot);
         return;
     }
 
@@ -567,7 +576,7 @@ void DoorLockServer::SetCredentialCommandHandler(
             emberAfDoorLockClusterPrintln("[SetCredential] Unable to get the credential to exclude duplicated entry "
                                           "[endpointId=%d,credentialType=%u,credentialIndex=%d]",
                                           commandPath.mEndpointId, to_underlying(credentialType), i);
-            sendSetCredentialResponse(commandObj, DlStatus::kFailure, 0, nextAvailableCredentialSlot);
+            sendSetCredentialResponse(commandObj, commandPath, DlStatus::kFailure, 0, nextAvailableCredentialSlot);
             return;
         }
         if (DlCredentialStatus::kAvailable != currentCredential.status && currentCredential.credentialType == credentialType &&
@@ -578,7 +587,7 @@ void DoorLockServer::SetCredentialCommandHandler(
                 "[endpointId=%d,credentialType=%u,dataLength=%u,existingCredentialIndex=%d,credentialIndex=%d]",
                 commandPath.mEndpointId, to_underlying(credentialType), static_cast<unsigned int>(credentialData.size()), i,
                 credentialIndex);
-            sendSetCredentialResponse(commandObj, DlStatus::kDuplicate, 0, nextAvailableCredentialSlot);
+            sendSetCredentialResponse(commandObj, commandPath, DlStatus::kDuplicate, 0, nextAvailableCredentialSlot);
             return;
         }
     }
@@ -590,7 +599,27 @@ void DoorLockServer::SetCredentialCommandHandler(
             "[SetCredential] Unable to check if credential exists: app error [endpointId=%d,credentialIndex=%d]",
             commandPath.mEndpointId, credentialIndex);
 
-        sendSetCredentialResponse(commandObj, DlStatus::kFailure, 0, nextAvailableCredentialSlot);
+        sendSetCredentialResponse(commandObj, commandPath, DlStatus::kFailure, 0, nextAvailableCredentialSlot);
+        return;
+    }
+
+    // OPTIMIZE: We can unify the checks for enum validity here and in set user command handler
+    if (!userStatus.IsNull() &&
+        (userStatus.Value() < DlUserStatus::kAvailable || userStatus.Value() > DlUserStatus::kOccupiedDisabled))
+    {
+        emberAfDoorLockClusterPrintln("[SetCredential] Unable to set the credential: user status is out of range "
+                                      "[endpointId=%d,credentialIndex=%d,userStatus=%u]",
+                                      commandPath.mEndpointId, credentialIndex, to_underlying(userStatus.Value()));
+        sendSetCredentialResponse(commandObj, commandPath, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
+        return;
+    }
+
+    if (!userType.IsNull() && (userType.Value() < DlUserType::kUnrestrictedUser || userType.Value() > DlUserType::kRemoteOnlyUser))
+    {
+        emberAfDoorLockClusterPrintln("[SetCredential] Unable to set the credential: user type is out of range "
+                                      "[endpointId=%d,credentialIndex=%d,userType=%u]",
+                                      commandPath.mEndpointId, credentialIndex, to_underlying(userType.Value()));
+        sendSetCredentialResponse(commandObj, commandPath, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
         return;
     }
 
@@ -599,9 +628,9 @@ void DoorLockServer::SetCredentialCommandHandler(
     case DlDataOperationType::kAdd: {
         uint16_t createdUserIndex = 0;
 
-        DlStatus status = createCredential(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
-                                           existingCredential, credentialData, userIndex, userStatus, userType, createdUserIndex);
-        sendSetCredentialResponse(commandObj, status, createdUserIndex, nextAvailableCredentialSlot);
+        status = createCredential(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
+                                  existingCredential, credentialData, userIndex, userStatus, userType, createdUserIndex);
+        sendSetCredentialResponse(commandObj, commandPath, status, createdUserIndex, nextAvailableCredentialSlot);
         return;
     }
     case DlDataOperationType::kModify: {
@@ -612,41 +641,36 @@ void DoorLockServer::SetCredentialCommandHandler(
                                           "[endpointId=%d,credentialIndex=%d]",
                                           commandPath.mEndpointId, credentialIndex);
 
-            sendSetCredentialResponse(commandObj, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
+            sendSetCredentialResponse(commandObj, commandPath, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
             return;
         }
 
         // if userIndex is NULL then we're changing the programming user PIN
         if (userIndex.IsNull())
         {
-            auto status = modifyProgrammingPIN(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
-                                               existingCredential, credentialData);
-            sendSetCredentialResponse(commandObj, status, 0, nextAvailableCredentialSlot);
+            status = modifyProgrammingPIN(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
+                                          existingCredential, credentialData);
+            sendSetCredentialResponse(commandObj, commandPath, status, 0, nextAvailableCredentialSlot);
             return;
         }
 
-        auto status = modifyCredential(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
-                                       existingCredential, credentialData, userIndex.Value(), userStatus, userType);
-        sendSetCredentialResponse(commandObj, status, 0, nextAvailableCredentialSlot);
+        status = modifyCredential(commandPath.mEndpointId, fabricIdx, sourceNodeId, credentialIndex, credentialType,
+                                  existingCredential, credentialData, userIndex.Value(), userStatus, userType);
+        sendSetCredentialResponse(commandObj, commandPath, status, 0, nextAvailableCredentialSlot);
         return;
     }
     case DlDataOperationType::kClear:
+    default:
         // appclusters, 5.2.4.40: set credential command supports only Add and Modify operational type.
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
-        return;
+        sendSetCredentialResponse(commandObj, commandPath, DlStatus::kInvalidField, 0, nextAvailableCredentialSlot);
     }
-
-    emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
 
-void DoorLockServer::GetCredentialStatusCommandHandler(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::DecodableType & commandData)
+void DoorLockServer::getCredentialStatusCommandHandler(chip::app::CommandHandler * commandObj,
+                                                       const chip::app::ConcreteCommandPath & commandPath,
+                                                       DlCredentialType credentialType, uint16_t credentialIndex)
 {
     emberAfDoorLockClusterPrintln("[GetCredentialStatus] Incoming command [endpointId=%d]", commandPath.mEndpointId);
-
-    const auto & credentialType  = commandData.credential.credentialType;
-    const auto & credentialIndex = commandData.credential.credentialIndex;
 
     if (!credentialTypeSupported(commandPath.mEndpointId, credentialType))
     {
@@ -726,7 +750,7 @@ void DoorLockServer::GetCredentialStatusCommandHandler(
                                   nextCredentialIndex);
 }
 
-void DoorLockServer::ClearCredentialCommandHandler(
+void DoorLockServer::clearCredentialCommandHandler(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData)
 {
@@ -767,9 +791,10 @@ void DoorLockServer::ClearCredentialCommandHandler(
         clearCredential(commandPath.mEndpointId, modifier, sourceNodeId, credentialType, credentialIndex, false));
 }
 
-void DoorLockServer::SetWeekDayScheduleCommandHandler(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::DecodableType & commandData)
+void DoorLockServer::setWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                      const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                                      uint16_t userIndex, const chip::BitMask<DlDaysMaskMap> & daysMask,
+                                                      uint8_t startHour, uint8_t startMinute, uint8_t endHour, uint8_t endMinute)
 {
     auto endpointId = commandPath.mEndpointId;
     if (!SupportsSchedules(endpointId))
@@ -797,20 +822,12 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
         return;
     }
 
-    auto weekDayIndex     = commandData.weekDayIndex;
-    auto userIndex        = commandData.userIndex;
-    const auto & daysMask = commandData.daysMask;
-    auto startHour        = commandData.startHour;
-    auto startMinute      = commandData.startMinute;
-    auto endHour          = commandData.endHour;
-    auto endMinute        = commandData.endMinute;
-
     if (!weekDayIndexValid(endpointId, weekDayIndex) || !userIndexValid(endpointId, userIndex))
     {
         emberAfDoorLockClusterPrintln(
             "[SetWeekDaySchedule] Unable to add schedule - index out of range [endpointId=%d,weekDayIndex=%d,userIndex=%d]",
             endpointId, weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
@@ -819,7 +836,7 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - user does not exist "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d]",
                                       endpointId, weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
 
@@ -832,12 +849,13 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
         rawDaysMask = static_cast<uint8_t>(rawDaysMask >> 1);
     }
 
+    // TODO: Check that bits are within range
     if (setBitsInDaysMask == 0 || setBitsInDaysMask > 1)
     {
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - daysMask is out of range "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d,daysMask=%x]",
                                       endpointId, weekDayIndex, userIndex, daysMask.Raw());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
@@ -847,7 +865,7 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - start time out of range "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d,startTime=\"%d:%d\",endTime=\"%d:%d\"]",
                                       endpointId, weekDayIndex, userIndex, startHour, startMinute, endHour, endMinute);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
@@ -856,7 +874,7 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
         emberAfDoorLockClusterPrintln("[SetWeekDaySchedule] Unable to add schedule - invalid time "
                                       "[endpointId=%d,weekDayIndex=%d,userIndex=%d,startTime=\"%d:%d\",endTime=\"%d:%d\"]",
                                       endpointId, weekDayIndex, userIndex, startHour, startMinute, endHour, endMinute);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
@@ -882,9 +900,9 @@ void DoorLockServer::SetWeekDayScheduleCommandHandler(
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
 
-void DoorLockServer::GetWeekDayScheduleCommandHandler(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::DecodableType & commandData)
+void DoorLockServer::getWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                      const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                                      uint16_t userIndex)
 {
     auto endpointId = commandPath.mEndpointId;
     if (!SupportsSchedules(endpointId))
@@ -895,9 +913,6 @@ void DoorLockServer::GetWeekDayScheduleCommandHandler(
     }
 
     emberAfDoorLockClusterPrintln("[GetWeekDaySchedule] Incoming command [endpointId=%d]", endpointId);
-
-    auto weekDayIndex = commandData.weekDayIndex;
-    auto userIndex    = commandData.userIndex;
 
     if (!weekDayIndexValid(endpointId, weekDayIndex) || !userIndexValid(endpointId, userIndex))
     {
@@ -912,7 +927,7 @@ void DoorLockServer::GetWeekDayScheduleCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[GetWeekDaySchedule] User does not exist [endpointId=%d,weekDayIndex=%d,userIndex=%d]",
                                       endpointId, weekDayIndex, userIndex);
-        sendGetWeekDayScheduleResponse(commandObj, commandPath, weekDayIndex, userIndex, DlStatus::kNotFound);
+        sendGetWeekDayScheduleResponse(commandObj, commandPath, weekDayIndex, userIndex, DlStatus::kFailure);
         return;
     }
 
@@ -928,9 +943,9 @@ void DoorLockServer::GetWeekDayScheduleCommandHandler(
                                    scheduleInfo.startHour, scheduleInfo.startMinute, scheduleInfo.endHour, scheduleInfo.endMinute);
 }
 
-void DoorLockServer::ClearWeekDayScheduleCommandHandler(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::DecodableType & commandData)
+void DoorLockServer::clearWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                        const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                                        uint16_t userIndex)
 {
     auto endpointId = commandPath.mEndpointId;
     if (!SupportsSchedules(endpointId))
@@ -958,9 +973,6 @@ void DoorLockServer::ClearWeekDayScheduleCommandHandler(
         return;
     }
 
-    auto weekDayIndex = commandData.weekDayIndex;
-    auto userIndex    = commandData.userIndex;
-
     if (!userIndexValid(endpointId, userIndex) || (!weekDayIndexValid(endpointId, weekDayIndex) && 0xFE != weekDayIndex))
     {
         emberAfDoorLockClusterPrintln(
@@ -974,7 +986,7 @@ void DoorLockServer::ClearWeekDayScheduleCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[ClearWeekDaySchedule] User does not exist [endpointId=%d,weekDayIndex=%d,userIndex=%d]",
                                       endpointId, weekDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
 
@@ -1008,9 +1020,9 @@ void DoorLockServer::ClearWeekDayScheduleCommandHandler(
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
 
-void DoorLockServer::SetYearDayScheduleCommandHandler(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::DecodableType & commandData)
+void DoorLockServer::setYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                      const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                                      uint16_t userIndex, uint32_t localStartTime, uint32_t localEndTime)
 {
     auto endpointId = commandPath.mEndpointId;
     if (!SupportsSchedules(endpointId))
@@ -1038,17 +1050,12 @@ void DoorLockServer::SetYearDayScheduleCommandHandler(
         return;
     }
 
-    auto yearDayIndex  = commandData.yearDayIndex;
-    auto userIndex     = commandData.userIndex;
-    auto localStarTime = commandData.localStartTime;
-    auto localEndTime  = commandData.localEndTime;
-
     if (!yearDayIndexValid(endpointId, yearDayIndex) || !userIndexValid(endpointId, userIndex))
     {
         emberAfDoorLockClusterPrintln(
             "[SetYearDaySchedule] Unable to add schedule - index out of range [endpointId=%d,yearDayIndex=%d,userIndex=%d]",
             endpointId, yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
@@ -1057,21 +1064,21 @@ void DoorLockServer::SetYearDayScheduleCommandHandler(
         emberAfDoorLockClusterPrintln("[SetYearDaySchedule] Unable to add schedule - user does not exist "
                                       "[endpointId=%d,yearDayIndex=%d,userIndex=%d]",
                                       endpointId, yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
 
-    if (localEndTime <= localStarTime)
+    if (localEndTime <= localStartTime)
     {
         emberAfDoorLockClusterPrintln("[SetYearDaySchedule] Unable to add schedule - schedule ends earlier than starts"
                                       "[endpointId=%d,yearDayIndex=%d,userIndex=%d,localStarTime=%" PRIu32 ",localEndTime=%" PRIu32
                                       "]",
-                                      endpointId, yearDayIndex, userIndex, localStarTime, localEndTime);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+                                      endpointId, yearDayIndex, userIndex, localStartTime, localEndTime);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
-    auto status = emberAfPluginDoorLockSetSchedule(endpointId, yearDayIndex, userIndex, DlScheduleStatus::kOccupied, localStarTime,
+    auto status = emberAfPluginDoorLockSetSchedule(endpointId, yearDayIndex, userIndex, DlScheduleStatus::kOccupied, localStartTime,
                                                    localEndTime);
     if (DlStatus::kSuccess != status)
     {
@@ -1085,7 +1092,7 @@ void DoorLockServer::SetYearDayScheduleCommandHandler(
 
     emberAfDoorLockClusterPrintln("[SetYearDaySchedule] Successfully created new schedule "
                                   "[endpointId=%d,yearDayIndex=%d,userIndex=%d,localStartTime=%" PRIu32 ",endTime=%" PRIu32 "]",
-                                  endpointId, yearDayIndex, userIndex, localStarTime, localEndTime);
+                                  endpointId, yearDayIndex, userIndex, localStartTime, localEndTime);
 
     sendRemoteLockUserChange(endpointId, DlLockDataType::kYearDaySchedule, DlDataOperationType::kAdd, sourceNodeId, fabricIdx,
                              userIndex, static_cast<uint16_t>(yearDayIndex));
@@ -1093,9 +1100,9 @@ void DoorLockServer::SetYearDayScheduleCommandHandler(
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
 
-void DoorLockServer::GetYearDayScheduleCommandHandler(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::DecodableType & commandData)
+void DoorLockServer::getYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                      const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                                      uint16_t userIndex)
 {
     auto endpointId = commandPath.mEndpointId;
     if (!SupportsSchedules(endpointId))
@@ -1105,9 +1112,6 @@ void DoorLockServer::GetYearDayScheduleCommandHandler(
         return;
     }
     emberAfDoorLockClusterPrintln("[GetYearDaySchedule] incoming command [endpointId=%d]", endpointId);
-
-    auto yearDayIndex = commandData.yearDayIndex;
-    auto userIndex    = commandData.userIndex;
 
     if (!yearDayIndexValid(endpointId, yearDayIndex) || !userIndexValid(endpointId, userIndex))
     {
@@ -1122,7 +1126,7 @@ void DoorLockServer::GetYearDayScheduleCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[GetYearDaySchedule] User does not exist [endpointId=%d,yearDayIndex=%d,userIndex=%d]",
                                       endpointId, yearDayIndex, userIndex);
-        sendGetYearDayScheduleResponse(commandObj, commandPath, yearDayIndex, userIndex, DlStatus::kNotFound);
+        sendGetYearDayScheduleResponse(commandObj, commandPath, yearDayIndex, userIndex, DlStatus::kFailure);
         return;
     }
 
@@ -1138,9 +1142,9 @@ void DoorLockServer::GetYearDayScheduleCommandHandler(
                                    scheduleInfo.localStartTime, scheduleInfo.localEndTime);
 }
 
-void DoorLockServer::ClearYearDayScheduleCommandHandler(
-    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-    const chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::DecodableType & commandData)
+void DoorLockServer::clearYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                        const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                                        uint16_t userIndex)
 {
     auto endpointId = commandPath.mEndpointId;
     if (!SupportsSchedules(endpointId))
@@ -1167,9 +1171,6 @@ void DoorLockServer::ClearYearDayScheduleCommandHandler(
         return;
     }
 
-    auto yearDayIndex = commandData.yearDayIndex;
-    auto userIndex    = commandData.userIndex;
-
     if (!userIndexValid(endpointId, userIndex) || (!yearDayIndexValid(endpointId, yearDayIndex) && 0xFE != yearDayIndex))
     {
         emberAfDoorLockClusterPrintln(
@@ -1183,7 +1184,7 @@ void DoorLockServer::ClearYearDayScheduleCommandHandler(
     {
         emberAfDoorLockClusterPrintln("[ClearYearDaySchedule] User does not exist [endpointId=%d,yearDayIndex=%d,userIndex=%d]",
                                       endpointId, yearDayIndex, userIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_NOT_FOUND);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
         return;
     }
 
@@ -1344,7 +1345,8 @@ bool DoorLockServer::credentialIndexValid(chip::EndpointId endpointId, DlCredent
     return true;
 }
 
-bool DoorLockServer::getCredentialRange(chip::EndpointId endpointId, DlCredentialType type, size_t & minSize, size_t & maxSize)
+DlStatus DoorLockServer::credentialLengthWithinRange(chip::EndpointId endpointId, DlCredentialType type,
+                                                     const chip::ByteSpan & credentialData)
 {
     bool statusMin = true, statusMax = true;
     uint8_t minLen, maxLen;
@@ -1361,20 +1363,26 @@ bool DoorLockServer::getCredentialRange(chip::EndpointId endpointId, DlCredentia
         statusMax = GetAttribute(endpointId, Attributes::MaxRFIDCodeLength::Id, Attributes::MaxRFIDCodeLength::Get, maxLen);
         break;
     default:
-        return false;
+        return DlStatus::kFailure;
     }
 
     if (!statusMin || !statusMax)
     {
         ChipLogError(Zcl, "Unable to read attributes to get min/max length for credentials [endpointId=%d,credentialType=%u]",
                      endpointId, to_underlying(type));
-        return false;
+        return DlStatus::kFailure;
     }
 
-    minSize = minLen;
-    maxSize = maxLen;
+    if (credentialData.size() < minLen || credentialData.size() > maxLen)
+    {
+        emberAfDoorLockClusterPrintln("Credential data size is out of range "
+                                      "[endpointId=%d,credentialType=%u,minLength=%u,maxLength=%u,length=%u]",
+                                      endpointId, to_underlying(type), minLen, maxLen,
+                                      static_cast<unsigned int>(credentialData.size()));
+        return DlStatus::kInvalidField;
+    }
 
-    return true;
+    return DlStatus::kSuccess;
 }
 
 bool DoorLockServer::getMaxNumberOfCredentials(chip::EndpointId endpointId, DlCredentialType credentialType,
@@ -2257,32 +2265,21 @@ DlStatus DoorLockServer::modifyCredential(chip::EndpointId endpointId, chip::Fab
     return status;
 }
 
-CHIP_ERROR DoorLockServer::sendSetCredentialResponse(chip::app::CommandHandler * commandObj, DlStatus status, uint16_t userIndex,
-                                                     uint16_t nextCredentialIndex)
+void DoorLockServer::sendSetCredentialResponse(chip::app::CommandHandler * commandObj,
+                                               const chip::app::ConcreteCommandPath & commandPath, DlStatus status,
+                                               uint16_t userIndex, uint16_t nextCredentialIndex)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    using ResponseFields = Commands::SetCredentialResponse::Fields;
-
-    app::ConcreteCommandPath path = { emberAfCurrentEndpoint(), ::Id, Commands::SetCredentialResponse::Id };
-    TLV::TLVWriter * writer       = nullptr;
-    SuccessOrExit(err = commandObj->PrepareCommand(path));
-    VerifyOrExit((writer = commandObj->GetCommandDataIBTLVWriter()) != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
-    SuccessOrExit(err = writer->Put(TLV::ContextTag(to_underlying(ResponseFields::kStatus)), status));
-
+    Commands::SetCredentialResponse::Type command{};
+    command.status = status;
     if (0 != userIndex)
     {
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(to_underlying(ResponseFields::kUserIndex)), userIndex));
+        command.userIndex.SetNonNull(userIndex);
     }
-
     if (0 != nextCredentialIndex)
     {
-        SuccessOrExit(err = writer->Put(TLV::ContextTag(to_underlying(ResponseFields::kNextCredentialIndex)), nextCredentialIndex));
+        command.nextCredentialIndex.SetNonNull(nextCredentialIndex);
     }
-    SuccessOrExit(err = commandObj->FinishCommand());
-
-exit:
-    return err;
+    commandObj->AddResponse(commandPath, command);
 }
 
 bool DoorLockServer::credentialTypeSupported(chip::EndpointId endpointId, DlCredentialType type)
@@ -2951,9 +2948,9 @@ DlLockDataType DoorLockServer::credentialTypeToLockDataType(DlCredentialType cre
     return DlLockDataType::kUnspecified;
 }
 
-void DoorLockServer::setHolidaySchedule(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                        uint8_t holidayIndex, uint32_t localStartTime, uint32_t localEndTime,
-                                        DlOperatingMode operatingMode)
+void DoorLockServer::setHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                      const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex,
+                                                      uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode)
 {
     VerifyOrDie(nullptr != commandObj);
 
@@ -2972,7 +2969,7 @@ void DoorLockServer::setHolidaySchedule(chip::app::CommandHandler * commandObj, 
         emberAfDoorLockClusterPrintln(
             "[SetHolidaySchedule] Unable to add schedule - index out of range [endpointId=%d,scheduleIndex=%d]", endpointId,
             holidayIndex);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
@@ -2981,17 +2978,17 @@ void DoorLockServer::setHolidaySchedule(chip::app::CommandHandler * commandObj, 
         emberAfDoorLockClusterPrintln("[SetHolidaySchedule] Unable to add schedule - schedule ends earlier than starts"
                                       "[endpointId=%d,scheduleIndex=%d,localStarTime=%" PRIu32 ",localEndTime=%" PRIu32 "]",
                                       endpointId, holidayIndex, localStartTime, localEndTime);
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
-    if (operatingMode > DlOperatingMode::kPassage)
+    if (operatingMode > DlOperatingMode::kPassage || operatingMode < DlOperatingMode::kNormal)
     {
         emberAfDoorLockClusterPrintln("[SetHolidaySchedule] Unable to add schedule - operating mode is out of range"
                                       "[endpointId=%d,scheduleIndex=%d,localStarTime=%" PRIu32 ",localEndTime=%" PRIu32
                                       ", operatingMode=%d]",
                                       endpointId, holidayIndex, localStartTime, localEndTime, to_underlying(operatingMode));
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_FIELD);
+        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_INVALID_COMMAND);
         return;
     }
 
@@ -3013,8 +3010,8 @@ void DoorLockServer::setHolidaySchedule(chip::app::CommandHandler * commandObj, 
     emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_SUCCESS);
 }
 
-void DoorLockServer::getHolidaySchedule(chip::app::CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
-                                        uint8_t holidayIndex)
+void DoorLockServer::getHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                      const ConcreteCommandPath & commandPath, uint8_t holidayIndex)
 {
     auto endpointId = commandPath.mEndpointId;
     if (!SupportsSchedules(endpointId))
@@ -3047,8 +3044,8 @@ void DoorLockServer::getHolidaySchedule(chip::app::CommandHandler * commandObj, 
                                 scheduleInfo.localEndTime, scheduleInfo.operatingMode);
 }
 
-void DoorLockServer::clearHolidaySchedule(chip::app::CommandHandler * commandObj,
-                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex)
+void DoorLockServer::clearHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                                        const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex)
 {
     auto endpointId = commandPath.mEndpointId;
     if (!SupportsSchedules(endpointId))
@@ -3354,7 +3351,7 @@ bool emberAfDoorLockClusterSetUserCallback(chip::app::CommandHandler * commandOb
                                            const chip::app::ConcreteCommandPath & commandPath,
                                            const chip::app::Clusters::DoorLock::Commands::SetUser::DecodableType & commandData)
 {
-    DoorLockServer::Instance().SetUserCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().setUserCommandHandler(commandObj, commandPath, commandData);
     return true;
 }
 
@@ -3362,7 +3359,7 @@ bool emberAfDoorLockClusterGetUserCallback(chip::app::CommandHandler * commandOb
                                            const chip::app::ConcreteCommandPath & commandPath,
                                            const chip::app::Clusters::DoorLock::Commands::GetUser::DecodableType & commandData)
 {
-    DoorLockServer::Instance().GetUserCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().getUserCommandHandler(commandObj, commandPath, commandData.userIndex);
     return true;
 }
 
@@ -3370,7 +3367,7 @@ bool emberAfDoorLockClusterClearUserCallback(chip::app::CommandHandler * command
                                              const chip::app::ConcreteCommandPath & commandPath,
                                              const chip::app::Clusters::DoorLock::Commands::ClearUser::DecodableType & commandData)
 {
-    DoorLockServer::Instance().ClearUserCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().clearUserCommandHandler(commandObj, commandPath, commandData.userIndex);
     return true;
 }
 
@@ -3378,7 +3375,7 @@ bool emberAfDoorLockClusterSetCredentialCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::SetCredential::DecodableType & commandData)
 {
-    DoorLockServer::Instance().SetCredentialCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().setCredentialCommandHandler(commandObj, commandPath, commandData);
     return true;
 }
 
@@ -3386,7 +3383,8 @@ bool emberAfDoorLockClusterGetCredentialStatusCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::DecodableType & commandData)
 {
-    DoorLockServer::Instance().GetCredentialStatusCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().getCredentialStatusCommandHandler(commandObj, commandPath, commandData.credential.credentialType,
+                                                                 commandData.credential.credentialIndex);
     return true;
 }
 
@@ -3394,7 +3392,7 @@ bool emberAfDoorLockClusterClearCredentialCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData)
 {
-    DoorLockServer::Instance().ClearCredentialCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().clearCredentialCommandHandler(commandObj, commandPath, commandData);
     return true;
 }
 
@@ -3402,7 +3400,9 @@ bool emberAfDoorLockClusterSetWeekDayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().SetWeekDayScheduleCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().setWeekDayScheduleCommandHandler(
+        commandObj, commandPath, commandData.weekDayIndex, commandData.userIndex, commandData.daysMask, commandData.startHour,
+        commandData.startMinute, commandData.endHour, commandData.endMinute);
     return true;
 }
 
@@ -3410,7 +3410,8 @@ bool emberAfDoorLockClusterGetWeekDayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().GetWeekDayScheduleCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().getWeekDayScheduleCommandHandler(commandObj, commandPath, commandData.weekDayIndex,
+                                                                commandData.userIndex);
     return true;
 }
 
@@ -3418,7 +3419,8 @@ bool emberAfDoorLockClusterClearWeekDayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().ClearWeekDayScheduleCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().clearWeekDayScheduleCommandHandler(commandObj, commandPath, commandData.weekDayIndex,
+                                                                  commandData.userIndex);
     return true;
 }
 
@@ -3426,7 +3428,9 @@ bool emberAfDoorLockClusterSetYearDayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().SetYearDayScheduleCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().setYearDayScheduleCommandHandler(commandObj, commandPath, commandData.yearDayIndex,
+                                                                commandData.userIndex, commandData.localStartTime,
+                                                                commandData.localEndTime);
     return true;
 }
 
@@ -3434,7 +3438,8 @@ bool emberAfDoorLockClusterGetYearDayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().GetYearDayScheduleCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().getYearDayScheduleCommandHandler(commandObj, commandPath, commandData.yearDayIndex,
+                                                                commandData.userIndex);
     return true;
 }
 
@@ -3442,7 +3447,8 @@ bool emberAfDoorLockClusterClearYearDayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().ClearYearDayScheduleCommandHandler(commandObj, commandPath, commandData);
+    DoorLockServer::Instance().clearYearDayScheduleCommandHandler(commandObj, commandPath, commandData.yearDayIndex,
+                                                                  commandData.userIndex);
     return true;
 }
 
@@ -3450,8 +3456,9 @@ bool emberAfDoorLockClusterSetHolidayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::SetHolidaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().setHolidaySchedule(commandObj, commandPath, commandData.holidayIndex, commandData.localStartTime,
-                                                  commandData.localEndTime, commandData.operatingMode);
+    DoorLockServer::Instance().setHolidayScheduleCommandHandler(commandObj, commandPath, commandData.holidayIndex,
+                                                                commandData.localStartTime, commandData.localEndTime,
+                                                                commandData.operatingMode);
     return true;
 }
 
@@ -3459,7 +3466,7 @@ bool emberAfDoorLockClusterGetHolidayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::GetHolidaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().getHolidaySchedule(commandObj, commandPath, commandData.holidayIndex);
+    DoorLockServer::Instance().getHolidayScheduleCommandHandler(commandObj, commandPath, commandData.holidayIndex);
     return true;
 }
 
@@ -3467,7 +3474,7 @@ bool emberAfDoorLockClusterClearHolidayScheduleCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DoorLock::Commands::ClearHolidaySchedule::DecodableType & commandData)
 {
-    DoorLockServer::Instance().clearHolidaySchedule(commandObj, commandPath, commandData.holidayIndex);
+    DoorLockServer::Instance().clearHolidayScheduleCommandHandler(commandObj, commandPath, commandData.holidayIndex);
     return true;
 }
 
@@ -3583,9 +3590,9 @@ MatterDoorLockClusterServerPreAttributeChangedCallback(const chip::app::Concrete
     return res;
 }
 
-void emberAfPluginDoorLockServerLockoutEventHandler(void) {}
+void emberAfPluginDoorLockServerLockoutEventHandler() {}
 
-void emberAfPluginDoorLockServerRelockEventHandler(void) {}
+void emberAfPluginDoorLockServerRelockEventHandler() {}
 
 void MatterDoorLockPluginServerInitCallback()
 {

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -117,45 +117,6 @@ public:
     bool GetNumberOfCredentialsSupportedPerUser(chip::EndpointId endpointId, uint8_t & numberOfCredentialsSupportedPerUser);
     bool GetNumberOfHolidaySchedulesSupported(chip::EndpointId endpointId, uint8_t & numberOfHolidaySchedules);
 
-    void SetUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                               const chip::app::Clusters::DoorLock::Commands::SetUser::DecodableType & commandData);
-
-    void GetUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                               const chip::app::Clusters::DoorLock::Commands::GetUser::DecodableType & commandData);
-
-    void ClearUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                 const chip::app::Clusters::DoorLock::Commands::ClearUser::DecodableType & commandData);
-
-    void SetCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                     const chip::app::Clusters::DoorLock::Commands::SetCredential::DecodableType & commandData);
-
-    void GetCredentialStatusCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::DecodableType & commandData);
-
-    void ClearCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                                       const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData);
-
-    void SetWeekDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::DecodableType & commandData);
-    void GetWeekDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::DecodableType & commandData);
-    void ClearWeekDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::DecodableType & commandData);
-
-    void SetYearDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::DecodableType & commandData);
-    void GetYearDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::DecodableType & commandData);
-    void ClearYearDayScheduleCommandHandler(
-        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-        const chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::DecodableType & commandData);
-
     bool HasFeature(chip::EndpointId endpointId, DoorLockFeature feature);
 
     inline bool SupportsPIN(chip::EndpointId endpointId) { return HasFeature(endpointId, DoorLockFeature::kPINCredentials); }
@@ -193,7 +154,7 @@ private:
     bool credentialIndexValid(chip::EndpointId endpointId, DlCredentialType type, uint16_t credentialIndex);
     bool credentialIndexValid(chip::EndpointId endpointId, DlCredentialType type, uint16_t credentialIndex,
                               uint16_t & maxNumberOfCredentials);
-    bool getCredentialRange(chip::EndpointId endpointId, DlCredentialType type, size_t & minSize, size_t & maxSize);
+    DlStatus credentialLengthWithinRange(chip::EndpointId endpointId, DlCredentialType type, const chip::ByteSpan & credentialData);
     bool getMaxNumberOfCredentials(chip::EndpointId endpointId, DlCredentialType credentialType, uint16_t & maxNumberOfCredentials);
 
     bool findOccupiedUserSlot(chip::EndpointId endpointId, uint16_t startIndex, uint16_t & userIndex);
@@ -263,10 +224,12 @@ private:
     bool clearFabricFromCredentials(chip::EndpointId endpointId, DlCredentialType credentialType, chip::FabricIndex fabricToRemove);
     bool clearFabricFromCredentials(chip::EndpointId endpointId, chip::FabricIndex fabricToRemove);
 
-    CHIP_ERROR sendSetCredentialResponse(chip::app::CommandHandler * commandObj, DlStatus status, uint16_t userIndex,
-                                         uint16_t nextCredentialIndex);
+    void sendSetCredentialResponse(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                   DlStatus status, uint16_t userIndex, uint16_t nextCredentialIndex);
 
     // TODO: Maybe use CHIP_APPLICATION_ERROR instead of boolean in class methods?
+    // OPTIMIZE: there are a lot of methods such as this that could be made static which could help reduce the stack footprint
+    // in case of multiple lock endpoints
     bool credentialTypeSupported(chip::EndpointId endpointId, DlCredentialType type);
 
     bool weekDayIndexValid(chip::EndpointId endpointId, uint8_t weekDayIndex);
@@ -304,14 +267,57 @@ private:
 
     DlLockDataType credentialTypeToLockDataType(DlCredentialType credentialType);
 
-    void setHolidaySchedule(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                            uint8_t holidayIndex, uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode);
+    void setUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                               const chip::app::Clusters::DoorLock::Commands::SetUser::DecodableType & commandData);
 
-    void getHolidaySchedule(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                            uint8_t holidayIndex);
+    void getUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                               uint16_t userIndex);
 
-    void clearHolidaySchedule(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
-                              uint8_t holidayIndex);
+    void clearUserCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                 uint16_t userIndex);
+
+    void setCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                     const chip::app::Clusters::DoorLock::Commands::SetCredential::DecodableType & commandData);
+
+    void getCredentialStatusCommandHandler(chip::app::CommandHandler * commandObj,
+                                           const chip::app::ConcreteCommandPath & commandPath, DlCredentialType credentialType,
+                                           uint16_t credentialIndex);
+
+    void clearCredentialCommandHandler(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+                                       const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData);
+
+    void setWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                          uint16_t userIndex, const chip::BitMask<DlDaysMaskMap> & daysMask, uint8_t startHour,
+                                          uint8_t startMinute, uint8_t endHour, uint8_t endMinute);
+
+    void getWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                          uint16_t userIndex);
+
+    void clearWeekDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                            const chip::app::ConcreteCommandPath & commandPath, uint8_t weekDayIndex,
+                                            uint16_t userIndex);
+
+    void setYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                          uint16_t userIndex, uint32_t localStartTime, uint32_t localEndTime);
+    void getYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                          uint16_t userIndex);
+    void clearYearDayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                            const chip::app::ConcreteCommandPath & commandPath, uint8_t yearDayIndex,
+                                            uint16_t userIndex);
+
+    void setHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex,
+                                          uint32_t localStartTime, uint32_t localEndTime, DlOperatingMode operatingMode);
+
+    void getHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex);
+
+    void clearHolidayScheduleCommandHandler(chip::app::CommandHandler * commandObj,
+                                            const chip::app::ConcreteCommandPath & commandPath, uint8_t holidayIndex);
 
     bool RemoteOperationEnabled(chip::EndpointId endpointId) const;
 
@@ -323,8 +329,8 @@ private:
      * @param opType        remote operation type (lock, unlock)
      * @param opHandler     plugin handler for specified command
      * @param pinCode       pin code passed by client
-     * @return true         if locking/unlocking was successfull
-     * @return false        if error happenned during lock/unlock
+     * @return true         if locking/unlocking was successful
+     * @return false        if error happened during lock/unlock
      */
     bool HandleRemoteLockOperation(chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
                                    DlLockOperationType opType, RemoteLockOpHandler opHandler,
@@ -342,7 +348,7 @@ private:
      * @param nodeId        node id
      * @param credList      list of credentials used in lock operation (can be NULL if no credentials were used)
      * @param credListSize  size of credentials list (if 0, then no credentials were used)
-     * @param opSuccess     flags if operation was successfull or not
+     * @param opSuccess     flags if operation was successful or not
      */
     void SendLockOperationEvent(chip::EndpointId endpointId, DlLockOperationType opType, DlOperationSource opSource,
                                 DlOperationError opErr, const Nullable<uint16_t> & userId,
@@ -423,6 +429,57 @@ private:
     friend bool emberAfDoorLockClusterClearHolidayScheduleCallback(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
         const chip::app::Clusters::DoorLock::Commands::ClearHolidaySchedule::DecodableType & commandData);
+
+    friend bool
+    emberAfDoorLockClusterSetUserCallback(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath,
+                                          const chip::app::Clusters::DoorLock::Commands::SetUser::DecodableType & commandData);
+
+    friend bool
+    emberAfDoorLockClusterGetUserCallback(chip::app::CommandHandler * commandObj,
+                                          const chip::app::ConcreteCommandPath & commandPath,
+                                          const chip::app::Clusters::DoorLock::Commands::GetUser::DecodableType & commandData);
+
+    friend bool
+    emberAfDoorLockClusterClearUserCallback(chip::app::CommandHandler * commandObj,
+                                            const chip::app::ConcreteCommandPath & commandPath,
+                                            const chip::app::Clusters::DoorLock::Commands::ClearUser::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterSetCredentialCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::SetCredential::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterGetCredentialStatusCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::GetCredentialStatus::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterClearCredentialCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::ClearCredential::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterSetWeekDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::SetWeekDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterGetWeekDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::GetWeekDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterClearWeekDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::ClearWeekDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterSetYearDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::SetYearDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterGetYearDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::DecodableType & commandData);
+
+    friend bool emberAfDoorLockClusterClearYearDayScheduleCallback(
+        chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+        const chip::app::Clusters::DoorLock::Commands::ClearYearDaySchedule::DecodableType & commandData);
 
     EmberEventControl AutolockEvent; /**< for automatic relock scheduling */
 

--- a/src/app/tests/suites/DL_LockUnlock.yaml
+++ b/src/app/tests/suites/DL_LockUnlock.yaml
@@ -38,7 +38,7 @@ tests:
       response:
           value: 2
 
-    - label: "Try to unlock the door without a PIN"
+    - label: "Try to lock the door without a PIN"
       command: "LockDoor"
       timedInteractionTimeoutMs: 10000
 

--- a/src/app/tests/suites/DL_Schedules.yaml
+++ b/src/app/tests/suites/DL_Schedules.yaml
@@ -192,7 +192,7 @@ tests:
               - name: "endMinute"
                 value: 00
       response:
-          error: NOT_FOUND
+          error: FAILURE
 
     - label: "Create Week Day schedule with 0 days mask"
       command: "SetWeekDaySchedule"
@@ -488,7 +488,7 @@ tests:
               - name: "userIndex"
                 value: 2
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     #
     # Excercise SetYearDay schedules with invalid parameters
@@ -566,7 +566,7 @@ tests:
               - name: "localEndTime"
                 value: 12345689
       response:
-          error: NOT_FOUND
+          error: FAILURE
 
     - label: "Create Year Day schedule with start hour later that end hour"
       command: "SetYearDaySchedule"
@@ -581,7 +581,7 @@ tests:
               - name: "localEndTime"
                 value: 12345688
       response:
-          error: INVALID_FIELD
+          error: INVALID_COMMAND
 
     - label: "Make sure that previous operations did not create a schedule"
       command: "GetYearDaySchedule"
@@ -686,7 +686,7 @@ tests:
               - name: "userIndex"
                 value: 2
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     #
     # Excercise Set Holiday schedules with invalid parameters
@@ -962,7 +962,7 @@ tests:
               - name: "userIndex"
                 value: 2
       response:
-          error: NOT_FOUND
+          error: FAILURE
 
     - label: "Make sure that week day schedule was not deleted"
       command: "GetWeekDaySchedule"
@@ -1087,7 +1087,7 @@ tests:
               - name: "userIndex"
                 value: 2
       response:
-          error: NOT_FOUND
+          error: FAILURE
 
     - label: "Make sure that week day schedule was not deleted"
       command: "GetWeekDaySchedule"
@@ -1799,7 +1799,7 @@ tests:
               - name: "userIndex"
                 value: 1
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     - label: "Make sure clearing first user also cleared year day schedules"
       command: "GetYearDaySchedule"
@@ -1816,7 +1816,7 @@ tests:
               - name: "userIndex"
                 value: 1
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     - label: "Make sure clearing second user also cleared week day schedules"
       command: "GetWeekDaySchedule"
@@ -1833,7 +1833,7 @@ tests:
               - name: "userIndex"
                 value: 2
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     - label: "Make sure clearing second user also cleared year day schedules"
       command: "GetYearDaySchedule"
@@ -1850,7 +1850,7 @@ tests:
               - name: "userIndex"
                 value: 2
               - name: "status"
-                value: 0x8B
+                value: 0x01
 
     # Make sure that all the manipulations did not affect the holiday schedules
     - label: "Make sure that first holiday schedule was not deleted"

--- a/src/app/tests/suites/certification/Test_TC_DLRK_2_7.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DLRK_2_7.yaml
@@ -181,8 +181,7 @@ tests:
                     hasValue: false
 
     - label:
-          "send Get Year Day Schedule Command to DUT and verify NOT_FOUND
-          response"
+          "send Get Year Day Schedule Command to DUT and verify FAILURE response"
       command: "GetYearDaySchedule"
       arguments:
           values:
@@ -197,7 +196,7 @@ tests:
               - name: "userIndex"
                 value: 5
               - name: "status"
-                value: 0x8B
+                value: 0x01
               - name: "LocalStartTime"
                 constraints:
                     hasValue: false

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -57169,7 +57169,7 @@ private:
                                  chip::NullOptional);
         }
         case 3: {
-            LogStep(3, "Try to unlock the door without a PIN");
+            LogStep(3, "Try to lock the door without a PIN");
             ListFreer listFreer;
             chip::app::Clusters::DoorLock::Commands::LockDoor::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), DoorLock::Id, DoorLock::Commands::LockDoor::Id, value,
@@ -57420,7 +57420,7 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
             break;
         case 10:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 11:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
@@ -57519,7 +57519,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 2U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 26:
@@ -57535,10 +57535,10 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
             break;
         case 30:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 31:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_COMMAND));
             break;
         case 32:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -57610,7 +57610,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 2U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 38:
@@ -57742,7 +57742,7 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
             break;
         case 55:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 56:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -57821,7 +57821,7 @@ private:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_INVALID_FIELD));
             break;
         case 63:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_NOT_FOUND));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
             break;
         case 64:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -58314,7 +58314,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 1U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 104:
@@ -58326,7 +58326,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 1U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 105:
@@ -58338,7 +58338,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 2U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 106:
@@ -58350,7 +58350,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 2U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
             }
             break;
         case 107:
@@ -61211,7 +61211,7 @@ private:
 
                 VerifyOrReturn(CheckValue("userIndex", value.userIndex, 5U));
 
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("status", value.status, 1U));
 
                 VerifyOrReturn(CheckConstraintHasValue("value.localStartTime", value.localStartTime, false));
 
@@ -61372,7 +61372,7 @@ private:
             );
         }
         case 9: {
-            LogStep(9, "send Get Year Day Schedule Command to DUT and verify NOT_FOUND response");
+            LogStep(9, "send Get Year Day Schedule Command to DUT and verify FAILURE response");
             ListFreer listFreer;
             chip::app::Clusters::DoorLock::Commands::GetYearDaySchedule::Type value;
             value.yearDayIndex = 10U;


### PR DESCRIPTION
#### Problem
* Fixes #19622
* Fixes #19563

#### Change overview
* Now door lock cluster returns generic failure instead of NOT_FOUND when working with Week Day/Year Day credentials.
* Door lock now checks the enum ranges for Set Credential, Set User and Set Holiday Schedule commands.
* Refactor the door lock cluster a little bit

#### Testing
* Run DL_LockUnlock, DL_Schedules and DL_UsersAndCredentials tests
* Run commands from linked issues to make sure they return appropriate error codes
