### PR TITLE
[EFR32] Fix 2 door lock edge cases

### DIFF
--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -158,6 +158,7 @@ public:
                                 uint32_t localEndTime, DlOperatingMode operatingMode);
 
     bool IsValidUserIndex(uint16_t userIndex);
+    bool IsCredentialIndexGreaterThanZero(uint16_t credentialIndex, DlCredentialType type);
     bool IsValidCredentialIndex(uint16_t credentialIndex, DlCredentialType type);
     bool IsValidWeekdayScheduleIndex(uint8_t scheduleIndex);
     bool IsValidYeardayScheduleIndex(uint8_t scheduleIndex);

--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -158,7 +158,6 @@ public:
                                 uint32_t localEndTime, DlOperatingMode operatingMode);
 
     bool IsValidUserIndex(uint16_t userIndex);
-    bool IsCredentialIndexGreaterThanZero(uint16_t credentialIndex, DlCredentialType type);
     bool IsValidCredentialIndex(uint16_t credentialIndex, DlCredentialType type);
     bool IsValidWeekdayScheduleIndex(uint8_t scheduleIndex);
     bool IsValidYeardayScheduleIndex(uint8_t scheduleIndex);

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -104,17 +104,6 @@ bool LockManager::IsValidUserIndex(uint16_t userIndex)
     return (userIndex < kMaxUsers);
 }
 
-bool LockManager::IsCredentialIndexGreaterThanZero(uint16_t credentialIndex, DlCredentialType type)
-{
-    // Programming PIN index is the only index allowed to be 0
-    if (DlCredentialType::kProgrammingPIN == type)
-    {
-        return (0 == credentialIndex);
-    }
-
-    return (credentialIndex > 0);
-}
-
 bool LockManager::IsValidCredentialIndex(uint16_t credentialIndex, DlCredentialType type)
 {
     // appclusters, 5.2.6.3.1: 0 is allowed index for Programming PIN credential only
@@ -417,11 +406,7 @@ bool LockManager::GetCredential(chip::EndpointId endpointId, uint16_t credential
                                 EmberAfPluginDoorLockCredentialInfo & credential)
 {
 
-    VerifyOrReturnValue(IsCredentialIndexGreaterThanZero(credentialIndex, credentialType), false); // indices are one-indexed except ProgrammingPin
-
-    credentialIndex--;
-
-    VerifyOrReturnValue(IsValidCredentialIndex(credentialIndex, credentialType), false);
+    VerifyOrReturnValue(IsValidCredentialIndex(--credentialIndex, credentialType), false); // indices are one-indexed
 
     ChipLogProgress(Zcl, "Lock App: LockManager::GetCredential [credentialType=%u], credentialIndex=%d",
                     to_underlying(credentialType), credentialIndex);
@@ -464,11 +449,7 @@ bool LockManager::SetCredential(chip::EndpointId endpointId, uint16_t credential
                                 const chip::ByteSpan & credentialData)
 {
 
-    VerifyOrReturnValue(IsCredentialIndexGreaterThanZero(credentialIndex, credentialType), false); // indices are one-indexed except ProgrammingPin
-
-    credentialIndex--;
-
-    VerifyOrReturnValue(IsValidCredentialIndex(credentialIndex, credentialType), false);
+    VerifyOrReturnValue(IsValidCredentialIndex(--credentialIndex, credentialType), false); // indices are one-indexed
 
     ChipLogProgress(Zcl,
                     "Door Lock App: LockManager::SetCredential "


### PR DESCRIPTION
#### Problem
1. When an invalid pinCode is sent with a lock command, and DUT is already locked, a SUCCESS is returned. Expected outcome is that failure is returned because the pinCode is invalid.

2. When clear fabric from credentials is called with the ProgrammingPin credential, an error is returned. Expected outcome is that success is returned.

#### Change overview
1. Remove any checking of lockState in the setLockState function, because the SUCCESS/FAILURE of the function does not depend on the lockState. Also removed a `return true` statement in the case where the current state is the same as the new state command received.

2. Removed the check for the lower bound of the credentialIndex. This is encapsulated in IsValidCredentialIndex, because credentialIndex is unsigned. All door-lock indices are one-indexed, except for ProgrammingPin.. I wonder if this is overlooked in the spec.

#### Testing
Ran through DRLK  TC 2.2 on EFR32, thread network. 
