### PR TITLE
Fix lambda return type inference

### DIFF
--- a/src/protocols/secure_channel/CASEServer.cpp
+++ b/src/protocols/secure_channel/CASEServer.cpp
@@ -162,7 +162,7 @@ void CASEServer::OnSessionEstablishmentError(CHIP_ERROR err)
     // from a SessionDelegate::OnSessionReleased callback. Schedule the preparation as an async work item.
     //
     mSessionManager->SystemLayer()->ScheduleWork(
-        [](auto * systemLayer, auto * appState) {
+        [](auto * systemLayer, auto * appState) -> void {
             CASEServer * _this = static_cast<CASEServer *>(appState);
             _this->PrepareForSessionEstablishment();
         },


### PR DESCRIPTION
Some compilers (some ARM-based Linux compilers) have difficulty inferring the return type of lambdas that don't explicitly state their return type. This causes issues when passing lambdas as arguments into
functions that expect a specific function signature.

This fixes this specific instance in CASEServer that has this problem:

```
src/protocols/secure_channel/CASEServer.cpp:165:9: error: no viable conversion from '(lambda at src/protocols/secure_channel/CASEServer.cpp:165:9)' to 'TimerCompleteCallback' (aka 'void (*)(chip::System::Layer *, void *)')
        [](auto * systemLayer, auto * appState) {
        ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
src/protocols/secure_channel/CASEServer.cpp:165:9: note: candidate template ignored: could not match 'type-parameter-0-1 *' against 'void *'
src/system/SystemLayer.h:145:59: note: passing argument to parameter 'aComplete' here
    virtual CHIP_ERROR ScheduleWork(TimerCompleteCallback aComplete, void * aAppState) = 0;
                                                          ^
1 error generated.
```