### PR TITLE
Add arm64 nodeps chip-tool + chip-all-clusters-app build

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -259,6 +259,10 @@ def HostTargets():
         app_targets.append(target.Extend('tv-casting-app', app=HostApp.TV_CASTING))
         app_targets.append(target.Extend('bridge', app=HostApp.BRIDGE))
 
+        nodeps_args = dict(enable_ble=False, enable_wifi=False, enable_thread=False, use_clang=True)
+        app_targets.append(target.Extend('chip-tool-nodeps', app=HostApp.CHIP_TOOL, **nodeps_args))
+        app_targets.append(target.Extend('all-clusters-app-nodeps', app=HostApp.ALL_CLUSTERS, **nodeps_args))
+
     builder = VariantBuilder()
 
     # Possible build variants. Note that number of potential
@@ -299,10 +303,6 @@ def HostTargets():
                                use_platform_mdns=True).GlobBlacklist("Reduce default build variants")
     yield target_native.Extend('address-resolve-tool-platform-mdns-ipv6only', app=HostApp.ADDRESS_RESOLVE,
                                use_platform_mdns=True, enable_ipv4=False).GlobBlacklist("Reduce default build variants")
-
-    nodeps_args = dict(enable_ipv4=False, enable_ble=False, enable_wifi=False, enable_thread=False)
-    yield target_native.Extend('chip-tool-nodeps', app=HostApp.CHIP_TOOL, **nodeps_args)
-    yield target_native.Extend('all-clusters-app-nodeps', app=HostApp.ALL_CLUSTERS, **nodeps_args)
 
     test_target = Target(HostBoard.NATIVE.PlatformName(), HostBuilder)
     yield test_target.Extend(HostBoard.NATIVE.BoardName() + '-tests', board=HostBoard.NATIVE, app=HostApp.TESTS)

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -6,6 +6,16 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters'
 
+# Generating linux-arm64-all-clusters-app-nodeps
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-app-nodeps'
+
+# Generating linux-arm64-all-clusters-app-nodeps-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-app-nodeps-ipv6only'
+
 # Generating linux-arm64-all-clusters-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
@@ -40,6 +50,16 @@ PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only'
+
+# Generating linux-arm64-chip-tool-nodeps
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-nodeps'
+
+# Generating linux-arm64-chip-tool-nodeps-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-nodeps-ipv6only'
 
 # Generating linux-arm64-light
 bash -c '
@@ -156,7 +176,10 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root} {ou
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux {out}/linux-x64-all-clusters
 
 # Generating linux-x64-all-clusters-app-nodeps
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false' {out}/linux-x64-all-clusters-app-nodeps
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '--args=chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true' {out}/linux-x64-all-clusters-app-nodeps
+
+# Generating linux-x64-all-clusters-app-nodeps-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true' {out}/linux-x64-all-clusters-app-nodeps-ipv6only
 
 # Generating linux-x64-all-clusters-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-all-clusters-ipv6only
@@ -183,7 +206,10 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
 
 # Generating linux-x64-chip-tool-nodeps
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false' {out}/linux-x64-chip-tool-nodeps
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true' {out}/linux-x64-chip-tool-nodeps
+
+# Generating linux-x64-chip-tool-nodeps-ipv6only
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true' {out}/linux-x64-chip-tool-nodeps-ipv6only
 
 # Generating linux-x64-light
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux {out}/linux-x64-light
@@ -263,6 +289,12 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Building linux-arm64-all-clusters
 ninja -C {out}/linux-arm64-all-clusters
 
+# Building linux-arm64-all-clusters-app-nodeps
+ninja -C {out}/linux-arm64-all-clusters-app-nodeps
+
+# Building linux-arm64-all-clusters-app-nodeps-ipv6only
+ninja -C {out}/linux-arm64-all-clusters-app-nodeps-ipv6only
+
 # Building linux-arm64-all-clusters-ipv6only
 ninja -C {out}/linux-arm64-all-clusters-ipv6only
 
@@ -283,6 +315,12 @@ ninja -C {out}/linux-arm64-chip-tool
 
 # Building linux-arm64-chip-tool-ipv6only
 ninja -C {out}/linux-arm64-chip-tool-ipv6only
+
+# Building linux-arm64-chip-tool-nodeps
+ninja -C {out}/linux-arm64-chip-tool-nodeps
+
+# Building linux-arm64-chip-tool-nodeps-ipv6only
+ninja -C {out}/linux-arm64-chip-tool-nodeps-ipv6only
 
 # Building linux-arm64-light
 ninja -C {out}/linux-arm64-light
@@ -359,6 +397,9 @@ ninja -C {out}/linux-x64-all-clusters
 # Building linux-x64-all-clusters-app-nodeps
 ninja -C {out}/linux-x64-all-clusters-app-nodeps
 
+# Building linux-x64-all-clusters-app-nodeps-ipv6only
+ninja -C {out}/linux-x64-all-clusters-app-nodeps-ipv6only
+
 # Building linux-x64-all-clusters-ipv6only
 ninja -C {out}/linux-x64-all-clusters-ipv6only
 
@@ -385,6 +426,9 @@ ninja -C {out}/linux-x64-chip-tool-ipv6only
 
 # Building linux-x64-chip-tool-nodeps
 ninja -C {out}/linux-x64-chip-tool-nodeps
+
+# Building linux-x64-chip-tool-nodeps-ipv6only
+ninja -C {out}/linux-x64-chip-tool-nodeps-ipv6only
 
 # Building linux-x64-light
 ninja -C {out}/linux-x64-light


### PR DESCRIPTION
#### Problem

Provide a configuration that can be deployed on Linux without installing any additional libraries.

#### Change overview

Add arm64 support for nodeps build. And switch to clang which also removes the need for shared libstdc++.

#### Testing

```
./scripts/build/build_examples.py  --target-glob 'linux-*nodeps*' build
```