### PR TITLE
[K32W0] Update Docker image to accomodate SDK 2.6.6

### DIFF
--- a/integrations/docker/images/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/chip-build-k32w/Dockerfile
@@ -13,14 +13,13 @@ RUN set -x \
 WORKDIR /opt/sdk
 # Setup the K32W SDK
 RUN set -x \
-    && wget -O /tmp/sdk.jar https://mcuxpresso.nxp.com/eclipse/sdk/2.6.4/plugins/com.nxp.mcuxpresso.sdk.sdk_2.x_k32w061dk6_2.6.4.201911251446.jar \
-    && unzip /tmp/sdk.jar \
-    && unzip sdks/1190028246d9243d9a9e27ca783413a8.zip -d sdks \
-    && rm -rf sdks/1190028246d9243d9a9e27ca783413a8.zip \
+    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_6_6_K32W061DK6.zip \
+    && unzip SDK_2_6_6_K32W061DK6.zip \
+    && rm -rf SDK_2_6_6_K32W061DK6.zip \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}
 
-COPY --from=build /opt/sdk/sdks/ /opt/sdk/sdks/
+COPY --from=build /opt/sdk/ /opt/sdk/
 
-ENV NXP_K32W061_SDK_ROOT=/opt/sdk/sdks
+ENV NXP_K32W0_SDK_ROOT=/opt/sdk

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.86 Version bump reason: [Ameba] Set matter_enable_persistentstorage_audit as disabled by default
+0.5.87 Version bump reason: K32W0-SDK 2.6.6 update


### PR DESCRIPTION
Update NXP Docker image to accommodate NXP SDK 2.6.6