### PR TITLE
Fixed server initialisation order

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -179,9 +179,6 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
         deviceInfoprovider->SetStorageDelegate(mDeviceStorage);
     }
 
-    // This initializes clusters, so should come after lower level initialization.
-    InitDataModelHandler(&mExchangeMgr);
-
     // Init transport before operations with secure session mgr.
     err = mTransports.Init(UdpListenParameters(DeviceLayer::UDPEndPointManager())
                                .SetAddressType(IPAddressType::kIPv6)
@@ -246,6 +243,9 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
                                                        &logStorageResources[0], &sGlobalEventIdCounter);
     }
 #endif // CHIP_CONFIG_ENABLE_SERVER_IM_EVENT
+
+    // This initializes clusters, so should come after lower level initialization.
+    InitDataModelHandler(&mExchangeMgr);
 
 #if defined(CHIP_APP_USE_ECHO)
     err = InitEchoHandler(&mExchangeMgr);


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* LogError `E (1624) chip[ZCL]: GeneralDiagnostics: Failed to record BootReason event: 3`. 
* On bootup matter plugins is being initialised before EventManagementState changes from `ShutDown` to `Idel`.  

#### Change overview
Moved `InitDataModelHandler` after  EventManagement initialisation.

#### Testing
How was this tested? (at least one bullet point required)
* Manually tested commissioning and cluster control
