### PR TITLE
Python: Delete key wasn't actually persisting

### DIFF
--- a/src/controller/python/chip/storage/__init__.py
+++ b/src/controller/python/chip/storage/__init__.py
@@ -165,6 +165,7 @@ class PersistentStorage:
 
     def DeleteSdkKey(self, key: str):
         del(self.jsonData['sdk-config'][key])
+        self.Sync()
 
     def GetUnderlyingStorageAdapter(self):
         return self._storageAdapterObj


### PR DESCRIPTION
The Python implementation of the `PersistentStorageDelegate::SyncDeleteKey` API was not actually syncing the deleted key back to the underlying JSON file, resulting in the deletion not actually 'sticking' despite passing the storage audit.

#### Testing

As part of bringing up server-side feature logic on the REPL, noticed that we were getting odd messages about an aborted fabric despite successfully completing commissioning and the audit.

After doing the above, the issue went away.