### PR TITLE
Fix SessionManager::Shutdown to actually shut-down sessions

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -111,6 +111,12 @@ void SessionManager::Shutdown()
         mFabricTable->RemoveFabricDelegate(this);
         mFabricTable = nullptr;
     }
+
+    mSecureSessions.ForEachSession([&](auto session) {
+        session->MarkForEviction();
+        return Loop::Continue;
+    });
+
     mMessageCounterManager = nullptr;
 
     mState        = State::kNotReady;


### PR DESCRIPTION
`SessionManager::Shutdown()` wasn't actually shutting down any sessions that were resident in the session table.

This meant that they would only get torn down on program termination, which causes issues in the Python REPL since it results in Log prints being emitted after we've actually disconnected the logging subsystem. This has been a great way to actually catch objects that should be torn down as part of Shutdown, but weren't.