### PR TITLE
fix GetSerialNumber when CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER is used

### DIFF
--- a/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
+++ b/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
@@ -66,6 +66,7 @@ CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetSerialNumber(char 
         ReturnErrorCodeIf(sizeof(CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER) > bufSize, CHIP_ERROR_BUFFER_TOO_SMALL);
         memcpy(buf, CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER, sizeof(CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER));
         serialNumLen = sizeof(CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER) - 1;
+        err = CHIP_NO_ERROR;
     }
 #endif // CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER
     ReturnErrorOnFailure(err);


### PR DESCRIPTION
#### Problem
fix GetSerialNumber when CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER is used

