### PR TITLE
TlvJson does not support TLV::kTLVType_List

### DIFF
--- a/src/lib/support/jsontlv/TlvJson.cpp
+++ b/src/lib/support/jsontlv/TlvJson.cpp
@@ -188,6 +188,7 @@ CHIP_ERROR TlvToJson(TLV::TLVReader & reader, KeyContext context, Json::Value & 
         // list indices of the elements in the respective collections.
         //
 
+    case TLV::kTLVType_List:
     case TLV::kTLVType_Array: {
         TLV::TLVType containerType;
 


### PR DESCRIPTION
#### Problem

The difference between `TLV::kTLVType_List` and `TLV::kTLVType_Array` is very unclear to me but `TLVJson.cpp` fails if it encounters a `TLV::kTLVType_List` type.

#### Change overview
 * Add `TLV::kTLVType_List` case to fallback on `TLV::kTLVType_Array`
