### PR TITLE
[zephyr] Do not initialize real time clock

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -236,11 +236,6 @@ if (CONFIG_CHIP_ENABLE_DNSSD_SRP)
     chip_gn_arg_string("chip_mdns" "platform")
 endif()
 
-if (CONFIG_CHIP_FIRMWARE_BUILD_UNIX_TIME)
-    string(TIMESTAMP CHIP_FIRMWARE_BUILD_UNIX_TIME "%s")
-    chip_gn_arg_string("chip_device_config_firmware_build_unix_time" ${CHIP_FIRMWARE_BUILD_UNIX_TIME})
-endif()
-
 if (CHIP_PROJECT_CONFIG)
     chip_gn_arg_string("chip_project_config_include"        ${CHIP_PROJECT_CONFIG})
     chip_gn_arg_string("chip_system_project_config_include" ${CHIP_PROJECT_CONFIG})

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -229,13 +229,6 @@ config CHIP_MALLOC_SYS_HEAP_SIZE
 
 endif
 
-config CHIP_FIRMWARE_BUILD_UNIX_TIME
-	bool "Make Unix time of compilation available in source code"
-	default y
-	help
-	  When enabled, the Unix time of the firmware build is exposed to the
-	  source code and used to initialize the last known UTC time.
-
 config APP_LINK_WITH_CHIP
 	bool "Link 'app' with Connected Home over IP"
 	default y

--- a/scripts/examples/nrfconnect_example.sh
+++ b/scripts/examples/nrfconnect_example.sh
@@ -23,7 +23,7 @@ BOARD="$2"
 shift 2
 
 # Disable debug symbols and firmware build time to increase ccache hit ratio in CI
-COMMON_CI_FLAGS=(-DCONFIG_CHIP_DEBUG_SYMBOLS=n -DCONFIG_CHIP_FIRMWARE_BUILD_UNIX_TIME=n)
+COMMON_CI_FLAGS=(-DCONFIG_CHIP_DEBUG_SYMBOLS=n)
 
 if [[ ! -f "$APP/nrfconnect/CMakeLists.txt" || -z "$BOARD" ]]; then
     echo "Usage: $0 <application> <board>" >&2

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -41,9 +41,6 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     # Time the firmware was built.
     chip_device_config_firmware_build_time = ""
 
-    # Unix time the firmware was built at (seconds since the epoch)
-    chip_device_config_firmware_build_unix_time = ""
-
     # Use OpenThread ftd or mtd library
     chip_device_config_thread_ftd = chip_openthread_ftd
 
@@ -141,9 +138,6 @@ if (chip_device_platform != "none" && chip_device_platform != "external") {
     }
     if (chip_device_config_firmware_build_time != "") {
       defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_TIME=\"${chip_device_config_firmware_build_time}\"" ]
-    }
-    if (chip_device_config_firmware_build_unix_time != "") {
-      defines += [ "CHIP_DEVICE_CONFIG_FIRMWARE_BUILD_UNIX_TIME=${chip_device_config_firmware_build_unix_time}" ]
     }
 
     if (chip_use_transitional_commissionable_data_provider) {


### PR DESCRIPTION
#### Problem
When there was no support for Last Known UTC Time in the common code we added a similar but incomplete solution to the Zephyr platform code that initializes the real time clock to the firmware build time.

That solution is incorrect as it doesn't allow for updating the Last Known UTC Time, so we should rather return an error if no time synchronization is in place.

#### Change overview
By default, do not initialize real time clock and use common Last Known UTC Time mechanism to validate operational certificates.

#### Testing
Verified that the commissioning passes and logs inform about using Last Known UTC Time during CASE.
