### PR TITLE
Fix UpdateNOC session invalidation and opcreds timing

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -41,7 +41,7 @@ CHIP_ERROR TestCommand::WaitForCommissionee(const char * identity,
     // or is just starting out fresh outright. Let's make sure we're not re-using any cached CASE sessions
     // that will now be stale and mismatched with the peer, causing subsequent interactions to fail.
     //
-    GetCommissioner(identity).SessionMgr()->ExpireAllPairings(chip::ScopedNodeId(value.nodeId, fabricIndex));
+    GetCommissioner(identity).SessionMgr()->ExpireAllSessions(chip::ScopedNodeId(value.nodeId, fabricIndex));
 
     SetIdentity(identity);
     return GetCommissioner(identity).GetConnectedDevice(value.nodeId, &mOnDeviceConnectedCallback,

--- a/src/app/CommandHandler.h
+++ b/src/app/CommandHandler.h
@@ -227,6 +227,25 @@ public:
      */
     Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }
 
+    /**
+     * @brief Flush acks right away for a slow command
+     *
+     * Some commands that do heavy lifting of storage/crypto should
+     * ack right away to improve reliability and reduce needless retries. This
+     * method can be manually called in commands that are especially slow to
+     * immediately schedule an acknowledgement (if needed) since the delayed
+     * stand-alone ack timer may actually not hit soon enough due to blocking command
+     * execution.
+     *
+     */
+    void FlushAcksRightAwayOnSlowCommand()
+    {
+        VerifyOrReturn(mpExchangeCtx != nullptr);
+        auto * msgContext = mpExchangeCtx->GetReliableMessageContext();
+        VerifyOrReturn(msgContext != nullptr);
+        msgContext->FlushAcks();
+    }
+
     Access::SubjectDescriptor GetSubjectDescriptor() const { return mpExchangeCtx->GetSessionHandle()->GetSubjectDescriptor(); }
 
 private:

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -55,7 +55,7 @@ void CommissioningWindowManager::OnPlatformEvent(const DeviceLayer::ChipDeviceEv
         DeviceLayer::SystemLayer().CancelTimer(HandleCommissioningWindowTimeout, this);
         mCommissioningTimeoutTimerArmed = false;
         Cleanup();
-        mServer->GetSecureSessionManager().ExpireAllPASEPairings();
+        mServer->GetSecureSessionManager().ExpireAllPASESessions();
         // That should have cleared out mPASESession.
 #if CONFIG_NETWORK_LAYER_BLE
         mServer->GetBleLayerObject()->CloseAllBleConnections();

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -298,7 +298,7 @@ void DeviceController::Shutdown()
         // sessions.  It just shuts down any ongoing CASE session establishment
         // we're in the middle of as initiator.  Maybe it should shut down
         // existing sessions too?
-        mSystemState->SessionMgr()->ExpireAllPairingsForFabric(mFabricIndex);
+        mSystemState->SessionMgr()->ExpireAllSessionsForFabric(mFabricIndex);
 
         FabricTable * fabricTable = mSystemState->Fabrics();
         if (fabricTable != nullptr)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -288,11 +288,14 @@ public:
         return mSystemState->Fabrics();
     }
 
+    // TODO(#20452): This should be removed/renamed once #20452 is fixed
     void ReleaseOperationalDevice(NodeId remoteNodeId);
 
     OperationalCredentialsDelegate * GetOperationalCredentialsDelegate() { return mOperationalCredentialsDelegate; }
 
     /**
+     * TODO(#20452): This needs to be refactored to reflect what it actually does (which is not disconnecting anything)
+     *
      * TEMPORARY - DO NOT USE or if you use please request review on why/how to
      * officially support such an API.
      *

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -188,6 +188,8 @@ ChipError::StorageType pychip_GetConnectedDeviceByNodeId(chip::Controller::Devic
                                                          DeviceAvailableFunc callback);
 ChipError::StorageType pychip_GetDeviceBeingCommissioned(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId,
                                                          CommissioneeDeviceProxy ** proxy);
+ChipError::StorageType pychip_ExpireSessions(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId);
+
 uint64_t pychip_GetCommandSenderHandle(chip::DeviceProxy * device);
 
 chip::ChipError::StorageType pychip_InteractionModel_ShutdownSubscription(SubscriptionId subscriptionId);
@@ -644,6 +646,15 @@ ChipError::StorageType pychip_GetDeviceBeingCommissioned(chip::Controller::Devic
                                                          CommissioneeDeviceProxy ** proxy)
 {
     return devCtrl->GetDeviceBeingCommissioned(nodeId, proxy).AsInteger();
+}
+
+// This is a method called VERY seldom, just for RemoveFabric/UpdateNOC
+ChipError::StorageType pychip_ExpireSessions(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId)
+{
+    VerifyOrReturnError((devCtrl != nullptr) && (devCtrl->SessionMgr() != nullptr), CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
+    (void) devCtrl->ReleaseOperationalDevice(nodeId);
+    devCtrl->SessionMgr()->ExpireAllSessions(ScopedNodeId(nodeId, devCtrl->GetFabricIndex()));
+    return CHIP_NO_ERROR.AsInteger();
 }
 
 ChipError::StorageType pychip_DeviceCommissioner_CloseBleConnection(chip::Controller::DeviceCommissioner * devCtrl)

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -270,6 +270,21 @@ class ChipDeviceController():
                 self.devCtrl)
         )
 
+    def ExpireSessions(self, nodeid):
+        """Close all sessions with `nodeid` (if any existed) so that sessions get re-established.
+
+        This is needed to properly handle operations that invalidate a node's state, such as
+        UpdateNOC.
+
+        WARNING: ONLY CALL THIS IF YOU UNDERSTAND THE SIDE-EFFECTS
+        """
+        self.CheckIsActive()
+
+        res = self._ChipStack.Call(lambda: self._dmLib.pychip_ExpireSessions(self.devCtrl, nodeid))
+        if res != 0:
+            raise self._ChipStack.ErrorToException(res)
+
+    # TODO: This needs to be called MarkSessionDefunct
     def CloseSession(self, nodeid):
         self.CheckIsActive()
 
@@ -1105,6 +1120,9 @@ class ChipDeviceController():
             self._dmLib.pychip_GetDeviceBeingCommissioned.argtypes = [
                 c_void_p, c_uint64, c_void_p]
             self._dmLib.pychip_GetDeviceBeingCommissioned.restype = c_uint32
+
+            self._dmLib.pychip_ExpireSessions.argtypes = [c_void_p, c_uint64]
+            self._dmLib.pychip_ExpireSessions.restype = c_uint32
 
             self._dmLib.pychip_DeviceCommissioner_CloseBleConnection.argtypes = [
                 c_void_p]

--- a/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
+++ b/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
@@ -119,6 +119,9 @@ async def UpdateNOC(devCtrl, existingNodeId, newNodeId):
         await devCtrl.SendCommand(existingNodeId, 0, generalCommissioning.Commands.ArmFailSafe(0), timedRequestTimeoutMs=1000)
         return False
 
+    # Forget our session since the peer deleted it
+    devCtrl.ExpireSessions(existingNodeId)
+
     resp = await devCtrl.SendCommand(newNodeId, 0, generalCommissioning.Commands.CommissioningComplete())
     if resp.errorCode is not generalCommissioning.Enums.CommissioningError.kOk:
         # Expiring the failsafe timer in an attempt to clean up.

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -588,7 +588,7 @@ void ExchangeContext::AbortAllOtherCommunicationOnFabric()
 
     SetIgnoreSessionRelease(true);
 
-    GetExchangeMgr()->GetSessionManager()->ExpireAllPairingsForFabric(mSession->GetFabricIndex());
+    GetExchangeMgr()->GetSessionManager()->ExpireAllSessionsForFabric(mSession->GetFabricIndex());
 
     mSession.GrabExpiredSession(session.Value());
 

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -121,7 +121,7 @@ void SessionManager::Shutdown()
 
 /**
  * @brief Notification that a fabric was removed.
- *        This function doesn't call ExpireAllPairingsForFabric
+ *        This function doesn't call ExpireAllSessionsForFabric
  *        since the CASE session might still be open to send a response
  *        on the removed fabric.
  */
@@ -342,7 +342,7 @@ CHIP_ERROR SessionManager::SendPreparedMessage(const SessionHandle & sessionHand
     return CHIP_ERROR_INCORRECT_STATE;
 }
 
-void SessionManager::ExpireAllPairings(const ScopedNodeId & node)
+void SessionManager::ExpireAllSessions(const ScopedNodeId & node)
 {
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetPeer() == node)
@@ -353,11 +353,11 @@ void SessionManager::ExpireAllPairings(const ScopedNodeId & node)
     });
 }
 
-void SessionManager::ExpireAllPairingsForFabric(FabricIndex fabric)
+void SessionManager::ExpireAllSessionsForFabric(FabricIndex fabricIndex)
 {
-    ChipLogDetail(Inet, "Expiring all connections for fabric %d!!", fabric);
+    ChipLogDetail(Inet, "Expiring all sessions for fabric 0x%x!!", static_cast<unsigned>(fabricIndex));
     mSecureSessions.ForEachSession([&](auto session) {
-        if (session->GetFabricIndex() == fabric)
+        if (session->GetFabricIndex() == fabricIndex)
         {
             session->MarkForEviction();
         }
@@ -365,9 +365,9 @@ void SessionManager::ExpireAllPairingsForFabric(FabricIndex fabric)
     });
 }
 
-void SessionManager::ExpireAllPASEPairings()
+void SessionManager::ExpireAllPASESessions()
 {
-    ChipLogDetail(Inet, "Expiring all PASE pairings");
+    ChipLogDetail(Inet, "Expiring all PASE sessions");
     mSecureSessions.ForEachSession([&](auto session) {
         if (session->GetSecureSessionType() == Transport::SecureSession::Type::kPASE)
         {

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -174,9 +174,9 @@ public:
     Optional<SessionHandle> AllocateSession(Transport::SecureSession::Type secureSessionType,
                                             const ScopedNodeId & sessionEvictionHint);
 
-    void ExpireAllPairings(const ScopedNodeId & node);
-    void ExpireAllPairingsForFabric(FabricIndex fabric);
-    void ExpireAllPASEPairings();
+    void ExpireAllSessions(const ScopedNodeId & node);
+    void ExpireAllSessionsForFabric(FabricIndex fabricIndex);
+    void ExpireAllPASESessions();
 
     /**
      * @brief


### PR DESCRIPTION
#### Problem
- UpdateNOC did not clear session of previous fabric like spec intended
  (#20379)
- All OpCreds cluster slow commands did not try to early-ack to avoid
  MRP timeouts (#19132)

Fixes #20379
Fixes #19132

#### Change overview
- Fixes UpdateNOC expiring all sessions for the updated node
- Adds `FlushAcksRightAwayOnSlowCommand` to CommandHandler to flush acks
  on slow commands
- Adds Python tests for UpdateNOC behavior of session expiring
- Adds `ExpireSessions` to Python for testing

#### Testing
- Unit tests all pass
- Cert tests pass
- With the session clearing, previous Python tests failed, until
  I fixed them with the new `ExpireSessions` API
- Observed standalone acks immediately sent on opcreds cluster commands
