### PR TITLE
Fix setting port to 0 in Server

### DIFF
--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -252,7 +252,14 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     SuccessOrExit(err);
 #endif
 
-    app::DnssdServer::Instance().SetSecuredPort(mOperationalServicePort);
+    //
+    // We need to advertise the port that we're listening to for unsolicited messages over UDP. However, we have both a IPv4
+    // and IPv6 endpoint to pick from. Given that the listen port passed in may be set to 0 (which then has the kernel select
+    // a valid port at bind time), that will result in two possible ports being provided back from the resultant endpoint
+    // initializations. Since IPv6 is POR for Matter, let's go ahead and pick that port.
+    //
+    app::DnssdServer::Instance().SetSecuredPort(mTransports.GetTransport().GetImplAtIndex<0>().GetBoundPort());
+
     app::DnssdServer::Instance().SetUnsecuredPort(mUserDirectedCommissioningPort);
     app::DnssdServer::Instance().SetInterfaceId(mInterfaceId);
 

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -66,6 +66,10 @@ namespace chip {
 
 constexpr size_t kMaxBlePendingPackets = 1;
 
+//
+// NOTE: Please do not alter the order of template specialization here as the logic
+//       in the Server impl depends on this.
+//
 using ServerTransportMgr = chip::TransportMgr<chip::Transport::UDP
 #if INET_CONFIG_ENABLE_IPV4
                                               ,


### PR DESCRIPTION
When setting `ServerInitParams::operationalServicePort` to 0 before calling `Server::Init()`, commissioning would fail due to a failure to discover the commissionnee. This was because DNS-SD was advertising port 0 instead of the actual bound port.

### Fix

Extract the actual bound port from the IPv6 endpoint in the transport manager. This mirrors a similar setup that exists in `ChipDeviceControllerFactory::Init`.

#### Testing

Commissioning fails with chip-tool if I passed in `--secured-device-port 0` to the all-clusters-app.

After the changes, commissioning passes.