### PR TITLE
[EFR32] [sve-cherry-pick] Force key value store to save pending keys before reboot

### DIFF
--- a/src/platform/EFR32/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/EFR32/KeyValueStoreManagerImpl.cpp
@@ -105,6 +105,11 @@ CHIP_ERROR KeyValueStoreManagerImpl::MapKvsKeyToNvm3(const char * key, uint32_t 
     return err;
 }
 
+void KeyValueStoreManagerImpl::ForceKeyMapSave()
+{
+    OnScheduledKeyMapSave(nullptr, nullptr);
+}
+
 void KeyValueStoreManagerImpl::OnScheduledKeyMapSave(System::Layer * systemLayer, void * appState)
 {
     EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_KvsStringKeyMap,

--- a/src/platform/EFR32/KeyValueStoreManagerImpl.h
+++ b/src/platform/EFR32/KeyValueStoreManagerImpl.h
@@ -46,8 +46,11 @@ public:
 
     static constexpr size_t kMaxEntries = KVS_MAX_ENTRIES;
 
+    static void ForceKeyMapSave();
+
 private:
     static void OnScheduledKeyMapSave(System::Layer * systemLayer, void * appState);
+
     void ScheduleKeyMapSave(void);
     bool IsValidKvsNvm3Key(const uint32_t nvm3Key) const;
     CHIP_ERROR MapKvsKeyToNvm3(const char * key, uint32_t & nvm3Key, bool isSlotNeeded = false) const;

--- a/src/platform/EFR32/OTAImageProcessorImpl.h
+++ b/src/platform/EFR32/OTAImageProcessorImpl.h
@@ -46,7 +46,7 @@ private:
     //////////// Actual handlers for the OTAImageProcessorInterface ///////////////
     static void HandlePrepareDownload(intptr_t context);
     static void HandleFinalize(intptr_t context);
-    static void HandleApply(chip::System::Layer * systemLayer, void *);
+    static void HandleApply(intptr_t context);
     static void HandleAbort(intptr_t context);
     static void HandleProcessBlock(intptr_t context);
     CHIP_ERROR ProcessHeader(ByteSpan & block);


### PR DESCRIPTION
#### Problem
Scheduling HandleApply() through StartTimer triggers a crash in ReliableMessageManager. The call itself is not likely to be the root cause but there's no time for proper investigation before SVE so removing the call for now. 

#### Change overview
Force key value store to save pending keys before reboot -- this eliminates the need to schedule HandleApply() through StartTimer. 

#### Testing
Verified OTA update scenario on BRD4161.