### PR TITLE
Fix OT UDP receive and UDP close racing

### DIFF
--- a/src/inet/UDPEndPoint.cpp
+++ b/src/inet/UDPEndPoint.cpp
@@ -125,8 +125,8 @@ void UDPEndPoint::Close()
 {
     if (mState != State::kClosed)
     {
-        CloseImpl();
         mState = State::kClosed;
+        CloseImpl();
     }
 }
 

--- a/src/inet/UDPEndPointImplLwIP.cpp
+++ b/src/inet/UDPEndPointImplLwIP.cpp
@@ -250,6 +250,7 @@ void UDPEndPointImplLwIP::CloseImpl()
         CHIP_ERROR err = GetSystemLayer().ScheduleLambda([this] { Release(); });
         if (err != CHIP_NO_ERROR)
         {
+            ChipLogError(Inet, "Unable scedule lambda: %" CHIP_ERROR_FORMAT, err.Format());
             // There is nothing we can do here, accept the chance of racing
             Release();
         }

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -273,6 +273,7 @@ void UDPEndPointImplOT::CloseImpl()
         CHIP_ERROR err = GetSystemLayer().ScheduleLambda([this] { Release(); });
         if (err != CHIP_NO_ERROR)
         {
+            ChipLogError(Inet, "Unable scedule lambda: %" CHIP_ERROR_FORMAT, err.Format());
             // There is nothing we can do here, accept the chance of racing
             Release();
         }

--- a/src/inet/UDPEndPointImplOpenThread.cpp
+++ b/src/inet/UDPEndPointImplOpenThread.cpp
@@ -54,6 +54,9 @@ void UDPEndPointImplOT::handleUdpReceive(void * aContext, otMessage * aMessage, 
     char destStr[Inet::IPAddress::kMaxStringLength];
 #endif
 
+    if (ep->mState == State::kClosed)
+        return;
+
     if (msgLen > System::PacketBuffer::kMaxSizeWithoutReserve)
     {
         ChipLogError(Inet, "UDP message too long, discarding. Size received %d", msgLen);
@@ -261,6 +264,18 @@ void UDPEndPointImplOT::CloseImpl()
     if (otUdpIsOpen(mOTInstance, &mSocket))
     {
         otUdpClose(mOTInstance, &mSocket);
+
+        // In case that there is a UDPEndPointImplOT::handleUdpReceive event
+        // pending in the event queue (SystemLayer::ScheduleLambda), we
+        // schedule a release call to the end of the queue, to ensure that the
+        // queued pointer to UDPEndPointImplOT is not dangling.
+        Retain();
+        CHIP_ERROR err = GetSystemLayer().ScheduleLambda([this] { Release(); });
+        if (err != CHIP_NO_ERROR)
+        {
+            // There is nothing we can do here, accept the chance of racing
+            Release();
+        }
     }
     UnlockOpenThread();
 }


### PR DESCRIPTION
#### Problem
Fix #20478 

#### Change overview
#20535 introduces a racing between UDP receive and UDP close racing, the `ep` pointer inside the event queue (captured by the lambda) may dangling after UDP close.

This PR fixes it by appending a `Release` call to the end of event queue when closing the UDP endpoint, which guarantee that there is no future UDP receive event after this `Release`

#### Testing
Tested by CI