### PR TITLE
[Tizen] Change advertised struct size

### DIFF
--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -65,9 +65,6 @@ static constexpr unsigned kNewConnectionScanTimeoutMs = 10000;
 /* Tizen Default Connect Timeout */
 constexpr System::Clock::Timeout kConnectTimeoutMs = System::Clock::Seconds16(10);
 
-const int BtpServiceDataLenMax =
-    7; // OpCode(1) + Discriminator(2) + VendorId(2) + ProductId(2), 5.2.3.8.6. Advertising Data, CHIP Specification
-
 static void __AdapterStateChangedCb(int result, bt_adapter_state_e adapterState, void * userData)
 {
     ChipLogProgress(DeviceLayer, "Adapter State Changed: %s", adapterState == BT_ADAPTER_ENABLED ? "Enabled" : "Disabled");
@@ -584,9 +581,9 @@ exit:
 
 int BLEManagerImpl::StartAdvertising()
 {
-    int ret                                 = BT_ERROR_NONE;
-    CHIP_ERROR err                          = CHIP_NO_ERROR;
-    char service_data[BtpServiceDataLenMax] = {
+    int ret                                                    = BT_ERROR_NONE;
+    CHIP_ERROR err                                             = CHIP_NO_ERROR;
+    char service_data[sizeof(ChipBLEDeviceIdentificationInfo)] = {
         0x0,
     }; // need to fill advertising data. 5.2.3.8.6. Advertising Data, CHIP Specification
     ChipBLEDeviceIdentificationInfo deviceIdInfo = {


### PR DESCRIPTION
#### Problem
The Tizen device wasn't recognized as a chip device via BLE. The problem was with the advertised struct size. It was a hardcoded value, while the test checks if received data has a size of ChipBLEDeviceIdentificationInfo struct. 

#### Change overview
Use the size of the struct as data length. 

#### Testing
Deploy and start examples/lighting-app on the Tizen device.
```bash
./scripts/build/build_examples.py --target tizen-arm-light --enable-flashbundle build
sdb install ./out/tizen-arm-light/package/out/org.tizen.matter.example.lighting-1.0.0.tpk  
sdb root on
sdb shell
app_launcher -s org.tizen.matter.example.lighting vendor-id 65521 product-id 32769 discriminator 42 passcode 1234
```
On PC run:
``` bash
./out/linux-x64-chip-tool/chip-tool pairing ble-wifi 0x01 <ssid> <password> 1234 42
```
