### PR TITLE
remove two yocto SDKs to decrease imx docker image size

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -74,9 +74,7 @@ RUN chown -R $USERNAME:$USERNAME /opt/ameba/ambd_sdk_with_chip_non_NDA/
 # NXP uses a patch_sdk script to change SDK files
 RUN chown -R $USERNAME:$USERNAME /opt/sdk/sdks/
 
-RUN chown -R $USERNAME:$USERNAME /opt/fsl-imx-xwayland/5.10-hardknott/
 RUN chown -R $USERNAME:$USERNAME /opt/fsl-imx-xwayland/5.15-kirkstone/
-RUN chown -R $USERNAME:$USERNAME /opt/fsl-imx-wayland/5.15-kirkstone/
 
 # Add access to openocd for VSCode debugging
 RUN chown -R $USERNAME:$USERNAME /opt/openocd

--- a/integrations/docker/images/chip-build-imx/Dockerfile
+++ b/integrations/docker/images/chip-build-imx/Dockerfile
@@ -9,13 +9,6 @@ RUN set -x \
     && : # last line
 WORKDIR /opt
 RUN set -x \
-    && wget --quiet -O fsl-l5.10.52-2.1.0-sdk.tar.gz https://www.nxp.com/lgfiles/IMM/fsl-l5.10.52-2.1.0-sdk.tar.gz \
-    && tar zxvf fsl-l5.10.52-2.1.0-sdk.tar.gz \
-    && ./fsl-imx-xwayland-glibc-x86_64-imx-image-core-cortexa53-crypto-imx8mmevk-toolchain-5.10-hardknott.sh -y \
-    && wget --quiet https://www.nxp.com/lgfiles/IMM/fsl-imx-wayland-glibc-x86_64-imx-image-multimedia-cortexa7t2hf-neon-imx6ullevk-toolchain-5.15-kirkstone.sh \
-    && chmod a+x fsl-imx-wayland-glibc-x86_64-imx-image-multimedia-cortexa7t2hf-neon-imx6ullevk-toolchain-5.15-kirkstone.sh \
-    && ./fsl-imx-wayland-glibc-x86_64-imx-image-multimedia-cortexa7t2hf-neon-imx6ullevk-toolchain-5.15-kirkstone.sh -y \
-    && rm -rf fsl-imx-wayland-glibc-x86_64-imx-image-multimedia-cortexa7t2hf-neon-imx6ullevk-toolchain-5.15-kirkstone.sh \
     && wget --quiet https://www.nxp.com/lgfiles/IMM/fsl-imx-xwayland-glibc-x86_64-imx-image-multimedia-armv8a-imx8mmevk-toolchain-5.15-kirkstone.sh \
     && chmod a+x fsl-imx-xwayland-glibc-x86_64-imx-image-multimedia-armv8a-imx8mmevk-toolchain-5.15-kirkstone.sh \
     && ./fsl-imx-xwayland-glibc-x86_64-imx-image-multimedia-armv8a-imx8mmevk-toolchain-5.15-kirkstone.sh -y \
@@ -25,6 +18,5 @@ RUN set -x \
 FROM connectedhomeip/chip-build:${VERSION}
 
 COPY --from=build /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
-COPY --from=build /opt/fsl-imx-wayland /opt/fsl-imx-wayland
 
-ENV IMX_SDK_ROOT=/opt/fsl-imx-xwayland/5.10-hardknott/
+ENV IMX_SDK_ROOT=/opt/fsl-imx-xwayland/5.15-kirkstone/

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -44,7 +44,6 @@ COPY --from=ameba /opt/ameba /opt/ameba
 COPY --from=k32w /opt/sdk/sdks /opt/sdk/sdks
 
 COPY --from=imx /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
-COPY --from=imx /opt/fsl-imx-wayland /opt/fsl-imx-wayland
 
 COPY --from=ti /opt/ti/sysconfig_1.11.0 /opt/ti/sysconfig_1.11.0
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.84 Version bump reason: two more Yocto SDKs are to be integrated into the imx docker image
+0.5.85 Version bump reason: remove two Yocto SDKs to decrease the imx docker image size


### PR DESCRIPTION
With all three SDKs installed, the imx docker image becomes 33.5GB and
exceeds the size limit of github CI.

remove two SDKs and keep the the SDK of 5.15 kernel for i.MX 8mm
devices. The generated docker image is now 17GB.