### PR TITLE
[ota] Fix crash on complete OTA transfer

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -638,7 +638,6 @@ void DefaultOTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTA
     {
     case OTADownloader::State::kComplete:
         mOtaRequestorDriver->UpdateDownloaded();
-        mBdxMessenger.Reset();
         break;
     case OTADownloader::State::kIdle:
         if (reason != OTAChangeReasonEnum::kSuccess)


### PR DESCRIPTION
#### Problem
The previous fix for exchange context leak did not take into account that the BDX transfer exchange is automatically
closed after sending BlockEOFAck.

#### Change overview
From now on release the exchange manually only in error conditions.

#### Testing
Test with Linux OTA requestor app that the OTA completes successfully.