### PR TITLE
Bl602 update 0708

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/bouffalolab/bl602/include/CHIPProjectConfig.h
@@ -145,13 +145,6 @@
 #define CHIP_DEVICE_CONFIG_TEST_SERIAL_NUMBER "TEST_SN"
 
 /**
- * CHIP_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS
- *
- * Enable recording UTC timestamps.
- */
-#define CHIP_CONFIG_EVENT_LOGGING_UTC_TIMESTAMPS 1
-
-/**
  * CHIP_DEVICE_CONFIG_EVENT_LOGGING_DEBUG_BUFFER_SIZE
  *
  * A size, in bytes, of the individual debug event logging buffer.

--- a/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.cpp
+++ b/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.cpp
@@ -1,6 +1,7 @@
 /*
  *
  *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,56 +17,14 @@
  */
 
 #include <app/clusters/ota-requestor/OTADownloader.h>
-#include <app/clusters/ota-requestor/OTARequestorInterface.h>
 
 #include "OTAImageProcessorImpl.h"
-#include "lib/core/CHIPError.h"
+extern "C" {
 #include <hal_sys.h>
 #include <hosal_ota.h>
-
-#define TAG "OTAImageProcessor"
-using namespace chip::System;
-using namespace ::chip::DeviceLayer::Internal;
+}
 
 namespace chip {
-namespace {
-
-void HandleRestart(Layer * systemLayer, void * appState)
-{
-    hal_reboot();
-
-    return;
-}
-} // namespace
-
-bool OTAImageProcessorImpl::IsFirstImageRun()
-{
-    OTARequestorInterface * requestor = chip::GetRequestorInstance();
-    if (requestor == nullptr)
-    {
-        return false;
-    }
-
-    return requestor->GetCurrentUpdateState() == OTARequestorInterface::OTAUpdateStateEnum::kApplying;
-}
-
-CHIP_ERROR OTAImageProcessorImpl::ConfirmCurrentImage()
-{
-    OTARequestorInterface * requestor = chip::GetRequestorInstance();
-    if (requestor == nullptr)
-    {
-        return CHIP_ERROR_INTERNAL;
-    }
-
-    uint32_t currentVersion;
-    ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(currentVersion));
-    if (currentVersion != requestor->GetTargetVersion())
-    {
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    return CHIP_NO_ERROR;
-}
 
 CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
 {
@@ -93,21 +52,26 @@ CHIP_ERROR OTAImageProcessorImpl::Abort()
 
 CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
 {
+    if ((nullptr == block.data()) || block.empty())
+    {
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    // Store block data for HandleProcessBlock to access
     CHIP_ERROR err = SetBlock(block);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(SoftwareUpdate, "Cannot set block data: %" CHIP_ERROR_FORMAT, err.Format());
-        return err;
     }
+
     DeviceLayer::PlatformMgr().ScheduleWork(HandleProcessBlock, reinterpret_cast<intptr_t>(this));
     return CHIP_NO_ERROR;
 }
 
 void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
 {
-    int err = 0;
-
     auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+
     if (imageProcessor == nullptr)
     {
         ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
@@ -119,35 +83,45 @@ void OTAImageProcessorImpl::HandlePrepareDownload(intptr_t context)
         return;
     }
 
-    err = hosal_ota_start();
-    if (err != 0)
-    {
-        return;
-    }
-
-    imageProcessor->offset = 0;
+    imageProcessor->mParams.downloadedBytes = 0;
+    imageProcessor->mParams.totalFileBytes  = 0;
     imageProcessor->mHeaderParser.Init();
+
     imageProcessor->mDownloader->OnPreparedForDownload(CHIP_NO_ERROR);
 }
 
 void OTAImageProcessorImpl::HandleFinalize(intptr_t context)
 {
-    int err               = 0;
     auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+
     if (imageProcessor == nullptr)
     {
-        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
         return;
     }
 
-    err = hosal_ota_finish(0, 0);
-    if (err != 0)
+    if (hosal_ota_finish(1, 0) < 0)
     {
-        log_info("HandleApply: %d!", err);
-        return;
+        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
+        ChipLogProgress(SoftwareUpdate, "OTA image verification error");
+    }
+    else
+    {
+        ChipLogProgress(SoftwareUpdate, "OTA image downloaded");
     }
 
     imageProcessor->ReleaseBlock();
+}
+
+void OTAImageProcessorImpl::HandleApply(intptr_t context)
+{
+    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+
+    if (imageProcessor == nullptr)
+    {
+        return;
+    }
+
+    hal_reboot();
 }
 
 void OTAImageProcessorImpl::HandleAbort(intptr_t context)
@@ -155,17 +129,20 @@ void OTAImageProcessorImpl::HandleAbort(intptr_t context)
     auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
     if (imageProcessor == nullptr)
     {
-        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
         return;
     }
+
+    hosal_ota_finish(1, 0);
+
     imageProcessor->ReleaseBlock();
 }
 
 void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
 {
-    int err = 0;
-
+    OTAImageHeader header;
+    CHIP_ERROR error;
     auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
+
     if (imageProcessor == nullptr)
     {
         ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
@@ -177,63 +154,77 @@ void OTAImageProcessorImpl::HandleProcessBlock(intptr_t context)
         return;
     }
 
-    ByteSpan block = ByteSpan(imageProcessor->mBlock.data(), imageProcessor->mBlock.size());
-
-    CHIP_ERROR error = imageProcessor->ProcessHeader(block);
-    if (error != CHIP_NO_ERROR)
+    ByteSpan block = imageProcessor->mBlock;
+    if (imageProcessor->mHeaderParser.IsInitialized())
     {
-        log_info("Failed to process OTA image header");
-        imageProcessor->mDownloader->EndDownload(error);
-        return;
+
+        error = imageProcessor->mHeaderParser.AccumulateAndDecode(block, header);
+        if (CHIP_ERROR_BUFFER_TOO_SMALL == error)
+        {
+            return;
+        }
+        else if (CHIP_NO_ERROR != error)
+        {
+            ChipLogError(SoftwareUpdate, "Matter image header parser error %s", chip::ErrorStr(error));
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_INVALID_FILE_IDENTIFIER);
+            imageProcessor->mHeaderParser.Clear();
+            return;
+        }
+
+        ChipLogProgress(SoftwareUpdate, "Image Header software version: %ld payload size: %lu", header.mSoftwareVersion,
+                        (long unsigned int) header.mPayloadSize);
+        imageProcessor->mParams.totalFileBytes = header.mPayloadSize;
+        imageProcessor->mHeaderParser.Clear();
+
+        if (hosal_ota_start(header.mPayloadSize) < 0)
+        {
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_OPEN_FAILED);
+            return;
+        }
     }
 
-    err = hosal_ota_update(imageProcessor->offset, block.data(), block.size());
-    if (err != 0)
+    if (imageProcessor->mParams.totalFileBytes)
     {
-        log_info("Update ota failed.\r\n");
-        imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
-        return;
+        if (hosal_ota_update(imageProcessor->mParams.totalFileBytes, imageProcessor->mParams.downloadedBytes,
+                             (uint8_t *) block.data(), block.size()) < 0)
+        {
+            imageProcessor->mDownloader->EndDownload(CHIP_ERROR_WRITE_FAILED);
+            return;
+        }
+        imageProcessor->mParams.downloadedBytes += block.size();
     }
 
-    imageProcessor->offset += block.size();
-
-    imageProcessor->mParams.downloadedBytes += block.size();
     imageProcessor->mDownloader->FetchNextData();
 }
 
-void OTAImageProcessorImpl::HandleApply(intptr_t context)
-{
-    auto * imageProcessor = reinterpret_cast<OTAImageProcessorImpl *>(context);
-
-    hal_reboot();
-}
-
+// Store block data for HandleProcessBlock to access
 CHIP_ERROR OTAImageProcessorImpl::SetBlock(ByteSpan & block)
 {
-    if (!IsSpanUsable(block))
+    if ((block.data() == nullptr) || block.empty())
     {
-        ReleaseBlock();
         return CHIP_NO_ERROR;
     }
+
+    // Allocate memory for block data if we don't have enough already
     if (mBlock.size() < block.size())
     {
-        if (!mBlock.empty())
-        {
-            ReleaseBlock();
-        }
-        uint8_t * mBlock_ptr = static_cast<uint8_t *>(chip::Platform::MemoryAlloc(block.size()));
-        if (mBlock_ptr == nullptr)
+        ReleaseBlock();
+
+        mBlock = MutableByteSpan(static_cast<uint8_t *>(chip::Platform::MemoryAlloc(block.size())), block.size());
+        if (mBlock.data() == nullptr)
         {
             return CHIP_ERROR_NO_MEMORY;
         }
-        mBlock = MutableByteSpan(mBlock_ptr, block.size());
     }
+
+    // Store the actual block data
     CHIP_ERROR err = CopySpanToMutableSpan(block, mBlock);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(SoftwareUpdate, "Cannot copy block data: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
+
     return CHIP_NO_ERROR;
 }
 
@@ -243,25 +234,8 @@ CHIP_ERROR OTAImageProcessorImpl::ReleaseBlock()
     {
         chip::Platform::MemoryFree(mBlock.data());
     }
+
     mBlock = MutableByteSpan();
-    return CHIP_NO_ERROR;
-}
-
-CHIP_ERROR OTAImageProcessorImpl::ProcessHeader(ByteSpan & block)
-{
-    if (mHeaderParser.IsInitialized())
-    {
-        OTAImageHeader header;
-        CHIP_ERROR error = mHeaderParser.AccumulateAndDecode(block, header);
-
-        // Need more data to decode the header
-        ReturnErrorCodeIf(error == CHIP_ERROR_BUFFER_TOO_SMALL, CHIP_NO_ERROR);
-        ReturnErrorOnFailure(error);
-
-        mParams.totalFileBytes = header.mPayloadSize;
-        mHeaderParser.Clear();
-    }
-
     return CHIP_NO_ERROR;
 }
 

--- a/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.h
+++ b/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.h
@@ -1,6 +1,7 @@
 /*
  *
  *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -17,7 +18,7 @@
 
 #pragma once
 
-#include <app/clusters/ota-requestor/BDXDownloader.h>
+#include <app/clusters/ota-requestor/OTADownloader.h>
 #include <lib/core/OTAImageHeader.h>
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/OTAImageProcessor.h>
@@ -33,24 +34,31 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
-    void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; };
-    bool IsFirstImageRun() override;
-    CHIP_ERROR ConfirmCurrentImage() override;
+    bool IsFirstImageRun() override { return false; }
+    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
+
+    void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 
 private:
+    //////////// Actual handlers for the OTAImageProcessorInterface ///////////////
     static void HandlePrepareDownload(intptr_t context);
     static void HandleFinalize(intptr_t context);
+    static void HandleApply(intptr_t context);
     static void HandleAbort(intptr_t context);
     static void HandleProcessBlock(intptr_t context);
-    static void HandleApply(intptr_t context);
 
+    /**
+     * Called to allocate memory for mBlock if necessary and set it to block
+     */
     CHIP_ERROR SetBlock(ByteSpan & block);
-    CHIP_ERROR ReleaseBlock();
-    CHIP_ERROR ProcessHeader(ByteSpan & block);
 
-    OTADownloader * mDownloader = nullptr;
+    /**
+     * Called to release allocated memory for mBlock
+     */
+    CHIP_ERROR ReleaseBlock();
+
     MutableByteSpan mBlock;
-    uint32_t offset = 0;
+    OTADownloader * mDownloader;
     OTAImageHeaderParser mHeaderParser;
 };
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Not use utc logging timestamp.
* Update ota impl.

#### Change overview
Not use utc logging timestamp, and update ota impl to fix ota image header parse not correct.

#### Testing
How was this tested? (at least one bullet point required)
* use ota provider to test bl602 ota function, and make sure ota image apply successfully.
