### PR TITLE
Don't try to use to_underlying for non-enum C++ types.

### DIFF
--- a/examples/darwin-framework-tool/templates/partials/decodable_value.zapt
+++ b/examples/darwin-framework-tool/templates/partials/decodable_value.zapt
@@ -27,7 +27,7 @@
       {{>decodable_value target=(concat ../target "." (asStructPropertyName label)) source=(concat ../source "." (asLowerCamelCase label)) cluster=../cluster depth=(incrementDepth ../depth) }}
     {{/zcl_struct_items_by_struct_name}}
   {{else}}
-    {{#if_chip_enum type}}
+    {{#if_is_strongly_typed_chip_enum type}}
       {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:chip::to_underlying({{source}})];
     {{else}}
       {{#if_is_strongly_typed_bitmap type}}
@@ -39,6 +39,6 @@
       {{else}}
         {{target}} = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:{{source}}];
       {{/if_is_strongly_typed_bitmap}}
-    {{/if_chip_enum}}
+    {{/if_is_strongly_typed_chip_enum}}
   {{/if_is_struct}}
 {{/if}}


### PR DESCRIPTION
Fixes https://github.com/project-chip/zap/issues/591

#### Problem
Using the wrong predicate to determine "this is a C++ enum type"

#### Change overview
Use the right predicate.

#### Testing
Checked that codegen does not change after updating to ZAP tip.