### PR TITLE
Increase cloudbuild 'BUILD ALL' timeout to 6 hours

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -32,7 +32,7 @@ steps:
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
-timeout: 14400s
+timeout: 21600s
 
 artifacts:
     objects:


### PR DESCRIPTION
Build all still times out at 4hours with 32 cores. Increase to 6hours before we look into trimming down the build variants.