### PR TITLE
[chip-cert] Updated support for HEX encoding to certificate tool.

### DIFF
--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -169,28 +169,40 @@ void ToolChipDN::PrintDN(FILE * file, const char * name) const
 
 namespace {
 
-CertFormat DetectCertFormat(uint8_t * cert, uint32_t certLen)
+CertFormat DetectCertFormat(const uint8_t * cert, uint32_t certLen)
 {
     static const uint8_t chipRawPrefix[] = { 0x15, 0x30, 0x01 };
-    static const char * chipB64Prefix    = "FTAB";
-    static const size_t chipB64PrefixLen = strlen(chipB64Prefix);
     static const char * chipHexPrefix    = "153001";
-    static const size_t chipHexPrefixLen = strlen(chipHexPrefix);
+    static const char * chipB64Prefix    = "FTAB";
+    static const uint8_t derRawPrefix[]  = { 0x30, 0x82 };
+    static const char * derHexPrefix     = "30820";
     static const char * pemMarker        = "-----BEGIN CERTIFICATE-----";
 
-    if (certLen > sizeof(chipRawPrefix) && memcmp(cert, chipRawPrefix, sizeof(chipRawPrefix)) == 0)
+    VerifyOrReturnError(cert != nullptr, kCertFormat_Unknown);
+
+    if ((certLen > sizeof(chipRawPrefix)) && (memcmp(cert, chipRawPrefix, sizeof(chipRawPrefix)) == 0))
     {
         return kCertFormat_Chip_Raw;
     }
 
-    if (certLen > chipB64PrefixLen && memcmp(cert, chipB64Prefix, chipB64PrefixLen) == 0)
+    if ((certLen > strlen(chipHexPrefix)) && (memcmp(cert, chipHexPrefix, strlen(chipHexPrefix)) == 0))
+    {
+        return kCertFormat_Chip_Hex;
+    }
+
+    if ((certLen > strlen(chipB64Prefix)) && (memcmp(cert, chipB64Prefix, strlen(chipB64Prefix)) == 0))
     {
         return kCertFormat_Chip_Base64;
     }
 
-    if (certLen > chipHexPrefixLen && memcmp(cert, chipHexPrefix, chipHexPrefixLen) == 0)
+    if ((certLen > sizeof(derRawPrefix)) && (memcmp(cert, derRawPrefix, sizeof(derRawPrefix)) == 0))
     {
-        return kCertFormat_Chip_Hex;
+        return kCertFormat_X509_DER;
+    }
+
+    if ((certLen > strlen(derHexPrefix)) && (memcmp(cert, derHexPrefix, strlen(derHexPrefix)) == 0))
+    {
+        return kCertFormat_X509_Hex;
     }
 
     if (ContainsPEMMarker(pemMarker, cert, certLen))
@@ -198,7 +210,7 @@ CertFormat DetectCertFormat(uint8_t * cert, uint32_t certLen)
         return kCertFormat_X509_PEM;
     }
 
-    return kCertFormat_X509_DER;
+    return kCertFormat_Unknown;
 }
 
 bool SetCertSerialNumber(X509 * cert)
@@ -538,17 +550,30 @@ bool ReadCert(const char * fileName, X509 * cert, CertFormat & certFmt)
     VerifyTrueOrExit(res);
 
     certFmt = DetectCertFormat(certBuf.get(), certLen);
+    if (certFmt == kCertFormat_Unknown)
+    {
+        fprintf(stderr, "Unrecognized Cert Format in File: %s\n", fileName);
+        return false;
+    }
+
+    if ((certFmt == kCertFormat_X509_Hex) || (certFmt == kCertFormat_Chip_Hex))
+    {
+        size_t len = chip::Encoding::HexToBytes(Uint8::to_char(certBuf.get()), certLen, certBuf.get(), certLen);
+        VerifyOrReturnError(CanCastTo<uint32_t>(2 * len), false);
+        VerifyOrReturnError(2 * len == certLen, false);
+        certLen = static_cast<uint32_t>(len);
+    }
 
     if (certFmt == kCertFormat_X509_PEM)
     {
         res = ReadCertPEM(fileName, cert);
         VerifyTrueOrExit(res);
     }
-    else if (certFmt == kCertFormat_X509_DER)
+    else if ((certFmt == kCertFormat_X509_DER) || (certFmt == kCertFormat_X509_Hex))
     {
-        const uint8_t * outCert = certBuf.get();
-
         VerifyOrReturnError(chip::CanCastTo<int>(certLen), false);
+
+        const uint8_t * outCert = certBuf.get();
 
         if (d2i_X509(&cert, &outCert, static_cast<int>(certLen)) == nullptr)
         {
@@ -561,14 +586,6 @@ bool ReadCert(const char * fileName, X509 * cert, CertFormat & certFmt)
         if (certFmt == kCertFormat_Chip_Base64)
         {
             res = Base64Decode(certBuf.get(), certLen, certBuf.get(), certLen, certLen);
-            VerifyTrueOrExit(res);
-        }
-        else if (certFmt == kCertFormat_Chip_Hex)
-        {
-            const char * certChars = reinterpret_cast<const char *>(certBuf.get());
-
-            certLen = static_cast<uint32_t>(Encoding::HexToBytes(certChars, certLen, certBuf.get(), certLen));
-            res     = (certLen > 0);
             VerifyTrueOrExit(res);
         }
 
@@ -640,6 +657,7 @@ bool X509ToChipCert(X509 * cert, MutableByteSpan & chipCert)
     }
 
 exit:
+    OPENSSL_free(derCert);
     return res;
 }
 
@@ -678,13 +696,37 @@ exit:
 
 bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt)
 {
-    bool res    = true;
-    FILE * file = nullptr;
+    bool res          = true;
+    FILE * file       = nullptr;
+    uint8_t * derCert = nullptr;
 
-    VerifyOrExit(cert != nullptr, res = false);
+    VerifyOrReturnError(cert != nullptr, false);
+    VerifyOrReturnError(certFmt != kCertFormat_Unknown, false);
 
-    res = OpenFile(fileName, file, true);
-    VerifyTrueOrExit(res);
+    if (IsChipCertFormat(certFmt))
+    {
+        uint8_t chipCertBuf[kMaxCHIPCertLength];
+        MutableByteSpan chipCert(chipCertBuf);
+
+        VerifyOrReturnError(X509ToChipCert(cert, chipCert), false);
+
+        return WriteChipCert(fileName, chipCert, certFmt);
+    }
+
+    if (certFmt == kCertFormat_X509_Hex)
+    {
+        int derCertLen = i2d_X509(cert, &derCert);
+        if (derCertLen < 0)
+        {
+            ReportOpenSSLErrorAndExit("i2d_X509", res = false);
+        }
+
+        VerifyOrExit(CanCastTo<uint32_t>(derCertLen), res = false);
+        VerifyOrExit(WriteDataIntoFile(fileName, derCert, static_cast<uint32_t>(derCertLen), kDataFormat_Hex), res = false);
+        ExitNow(res = true);
+    }
+
+    VerifyOrExit(OpenFile(fileName, file, true), res = false);
 
     if (certFmt == kCertFormat_X509_PEM)
     {
@@ -700,109 +742,34 @@ bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt)
             ReportOpenSSLErrorAndExit("i2d_X509_fp", res = false);
         }
     }
-    else if (certFmt == kCertFormat_Chip_Raw || certFmt == kCertFormat_Chip_Base64 || certFmt == kCertFormat_Chip_Hex)
+    else
     {
-        uint8_t * certToWrite = nullptr;
-        size_t certToWriteLen = 0;
-        uint32_t certLen;
-        uint32_t chipCertDecodedLen = HEX_ENCODED_LENGTH(kMaxCHIPCertLength);
-        std::unique_ptr<uint8_t[]> chipCertDecoded(new uint8_t[chipCertDecodedLen]);
-        uint8_t chipCertBuf[kMaxCHIPCertLength];
-        MutableByteSpan chipCert(chipCertBuf);
-
-        res = X509ToChipCert(cert, chipCert);
-        VerifyTrueOrExit(res);
-        certLen = static_cast<uint32_t>(chipCert.size());
-
-        if (certFmt == kCertFormat_Chip_Base64)
-        {
-            chipCertDecodedLen = BASE64_ENCODED_LEN(certLen);
-            res = Base64Encode(chipCert.data(), certLen, chipCertDecoded.get(), chipCertDecodedLen, chipCertDecodedLen);
-            VerifyTrueOrExit(res);
-
-            certToWrite    = chipCertDecoded.get();
-            certToWriteLen = chipCertDecodedLen;
-        }
-        else if (certFmt == kCertFormat_Chip_Hex)
-        {
-            char * certHex = reinterpret_cast<char *>(chipCertDecoded.get());
-
-            chipCertDecodedLen = HEX_ENCODED_LENGTH(certLen);
-            SuccessOrExit(Encoding::BytesToLowercaseHexBuffer(chipCert.data(), certLen, certHex, chipCertDecodedLen));
-
-            certToWrite    = chipCertDecoded.get();
-            certToWriteLen = chipCertDecodedLen;
-        }
-        else
-        {
-            certToWrite    = chipCert.data();
-            certToWriteLen = chipCert.size();
-        }
-
-        if (fwrite(certToWrite, 1, certToWriteLen, file) != certToWriteLen)
-        {
-            fprintf(stderr, "Unable to write to %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
-            ExitNow(res = false);
-        }
+        fprintf(stderr, "Unsupported certificate format\n");
+        ExitNow(res = false);
     }
 
     printf("\r\n");
 
 exit:
+    OPENSSL_free(derCert);
     CloseFile(file);
     return res;
 }
 
 bool WriteChipCert(const char * fileName, const ByteSpan & chipCert, CertFormat certFmt)
 {
-    bool res                    = true;
-    FILE * file                 = nullptr;
-    const uint8_t * certToWrite = nullptr;
-    uint32_t certLen            = static_cast<uint32_t>(chipCert.size());
-    size_t certToWriteLen       = 0;
-    uint32_t chipCertDecodedLen = HEX_ENCODED_LENGTH(kMaxCHIPCertLength); // Maximum possible encoding size
-    std::unique_ptr<uint8_t[]> chipCertDecoded(new uint8_t[chipCertDecodedLen]);
+    DataFormat dataFormat = kDataFormat_Unknown;
 
-    VerifyOrReturnError(certFmt == kCertFormat_Chip_Raw || certFmt == kCertFormat_Chip_Base64 || certFmt == kCertFormat_Chip_Hex,
-                        false);
+    VerifyOrReturnError(IsChipCertFormat(certFmt), false);
 
-    if (certFmt == kCertFormat_Chip_Base64)
-    {
-        chipCertDecodedLen = BASE64_ENCODED_LEN(certLen);
-        res                = Base64Encode(chipCert.data(), certLen, chipCertDecoded.get(), chipCertDecodedLen, chipCertDecodedLen);
-        VerifyTrueOrExit(res);
-
-        certToWrite    = chipCertDecoded.get();
-        certToWriteLen = chipCertDecodedLen;
-    }
-    else if (certFmt == kCertFormat_Chip_Hex)
-    {
-        char * certHex     = reinterpret_cast<char *>(chipCertDecoded.get());
-        chipCertDecodedLen = HEX_ENCODED_LENGTH(certLen);
-
-        SuccessOrExit(Encoding::BytesToLowercaseHexBuffer(chipCert.data(), certLen, certHex, chipCertDecodedLen));
-
-        certToWrite    = chipCertDecoded.get();
-        certToWriteLen = chipCertDecodedLen;
-    }
+    if (certFmt == kCertFormat_Chip_Raw)
+        dataFormat = kDataFormat_Raw;
+    else if (certFmt == kCertFormat_Chip_Base64)
+        dataFormat = kDataFormat_Base64;
     else
-    {
-        certToWrite    = chipCert.data();
-        certToWriteLen = chipCert.size();
-    }
+        dataFormat = kDataFormat_Hex;
 
-    res = OpenFile(fileName, file, true);
-    VerifyTrueOrExit(res);
-
-    if (fwrite(certToWrite, 1, certToWriteLen, file) != certToWriteLen)
-    {
-        fprintf(stderr, "Unable to write to %s: %s\n", fileName, strerror(ferror(file) ? errno : ENOSPC));
-        ExitNow(res = false);
-    }
-
-exit:
-    CloseFile(file);
-    return res;
+    return WriteDataIntoFile(fileName, chipCert.data(), static_cast<uint32_t>(chipCert.size()), dataFormat);
 }
 
 bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey, const struct tm & validFrom,

--- a/src/tools/chip-cert/Cmd_ConvertCert.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertCert.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -42,6 +42,7 @@ OptionDef gCmdOptionDefs[] =
 {
     { "x509-pem",   kNoArgument, 'p' },
     { "x509-der",   kNoArgument, 'd' },
+    { "x509-hex",   kNoArgument, 'X' },
     { "chip",       kNoArgument, 'c' },
     { "chip-hex",   kNoArgument, 'x' },
     { "chip-b64",   kNoArgument, 'b' },
@@ -56,6 +57,10 @@ const char * const gCmdOptionHelp =
     "  -d, --x509-der\n"
     "\n"
     "       Output certificate in X.509 DER format.\n"
+    "\n"
+    "  -X, --x509-hex\n"
+    "\n"
+    "       Output certificate in X.509 DER hex encoded format.\n"
     "\n"
     "  -c, --chip\n"
     "\n"
@@ -110,7 +115,7 @@ OptionSet * gCmdOptionSets[] =
 
 const char * gInFileName  = nullptr;
 const char * gOutFileName = nullptr;
-CertFormat gOutCertFormat = kCertFormat_Chip_Base64;
+CertFormat gOutCertFormat = kCertFormat_Default;
 
 bool HandleOption(const char * progName, OptionSet * optSet, int id, const char * name, const char * arg)
 {
@@ -121,6 +126,9 @@ bool HandleOption(const char * progName, OptionSet * optSet, int id, const char 
         break;
     case 'd':
         gOutCertFormat = kCertFormat_X509_DER;
+        break;
+    case 'X':
+        gOutCertFormat = kCertFormat_X509_Hex;
         break;
     case 'x':
         gOutCertFormat = kCertFormat_Chip_Hex;

--- a/src/tools/chip-cert/Cmd_GenAttCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenAttCert.cpp
@@ -577,7 +577,7 @@ bool Cmd_GenAttCert(int argc, char * argv[])
 
     if (gOutKeyFileName != nullptr)
     {
-        res = WritePrivateKey(gOutKeyFileName, newKey.get(), kKeyFormat_X509_PEM);
+        res = WriteKey(gOutKeyFileName, newKey.get(), kKeyFormat_X509_PEM);
         VerifyTrueOrExit(res);
     }
 

--- a/src/tools/chip-cert/Cmd_GenCD.cpp
+++ b/src/tools/chip-cert/Cmd_GenCD.cpp
@@ -1188,17 +1188,9 @@ bool Cmd_GenCD(int argc, char * argv[])
         }
 
         // Write to file.
-        {
-            FILE * file = nullptr;
-
-            VerifyOrReturnError(OpenFile(gSignedCDFileName, file, true), false);
-
-            if (fwrite(signedMessage.data(), 1, signedMessage.size(), file) != signedMessage.size())
-            {
-                fprintf(stderr, "Unable to write to %s: %s\n", gSignedCDFileName, strerror(ferror(file) ? errno : ENOSPC));
-                return false;
-            }
-        }
+        VerifyOrReturnError(WriteDataIntoFile(gSignedCDFileName, signedMessage.data(), static_cast<uint32_t>(signedMessage.size()),
+                                              kDataFormat_Raw),
+                            false);
     }
     return true;
 }

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -93,9 +93,12 @@ enum CertFormat
     kCertFormat_Unknown = 0,
     kCertFormat_X509_DER,
     kCertFormat_X509_PEM,
+    kCertFormat_X509_Hex,
     kCertFormat_Chip_Raw,
     kCertFormat_Chip_Base64,
     kCertFormat_Chip_Hex,
+
+    kCertFormat_Default = kCertFormat_Chip_Base64,
 };
 
 enum KeyFormat
@@ -103,11 +106,32 @@ enum KeyFormat
     kKeyFormat_Unknown = 0,
     kKeyFormat_X509_DER,
     kKeyFormat_X509_PEM,
-    kKeyFormat_X509_PUBKEY_PEM,
+    kKeyFormat_X509_Hex,
+    kKeyFormat_X509_Pubkey_PEM,
     kKeyFormat_Chip_Raw,
     kKeyFormat_Chip_Base64,
-    kKeyFormat_Chip_Hex
+    kKeyFormat_Chip_Hex,
+    kKeyFormat_Chip_Pubkey_Raw,
+    kKeyFormat_Chip_Pubkey_Base64,
+    kKeyFormat_Chip_Pubkey_Hex,
+
+    kKeyFormat_Default = kKeyFormat_Chip_Base64,
 };
+
+enum DataFormat
+{
+    kDataFormat_Unknown = 0,
+    kDataFormat_Raw,
+    kDataFormat_Hex,
+    kDataFormat_Base64,
+};
+
+extern bool IsChipCertFormat(CertFormat certFormat);
+extern bool IsX509PrivateKeyFormat(KeyFormat keyFormat);
+extern bool IsChipPrivateKeyFormat(KeyFormat keyFormat);
+extern bool IsPrivateKeyFormat(KeyFormat keyFormat);
+extern bool IsChipPublicKeyFormat(KeyFormat keyFormat);
+extern bool IsPublicKeyFormat(KeyFormat keyFormat);
 
 enum AttCertType
 {
@@ -281,6 +305,7 @@ public:
     bool IsSignatureError() { return (mEnabled && mFlags.Has(CertErrorFlags::kSignature)); }
 
     bool IsCertOversized() { return (mEnabled && mFlags.Has(CertErrorFlags::kCertOversized)); }
+    uint32_t GetExtraCertLength() { return IsCertOversized() ? kExtraBufferLengthForOvesizedCert : 0; }
     bool IsSerialNumberPresent() { return (!mEnabled || !mFlags.Has(CertErrorFlags::kSerialNumberMissing)); }
     bool IsIssuerPresent() { return (!mEnabled || !mFlags.Has(CertErrorFlags::kIssuerMissing)); }
     bool IsValidityNotBeforePresent() { return (!mEnabled || !mFlags.Has(CertErrorFlags::kValidityNotBeforeMissing)); }
@@ -349,6 +374,8 @@ private:
         kExtExtendedKeyUsageMissing = 0x0000800000000000,
     };
 
+    static constexpr uint32_t kExtraBufferLengthForOvesizedCert = 300;
+
     bool mEnabled = false;
     chip::BitFlags<CertErrorFlags> mFlags;
 };
@@ -397,7 +424,7 @@ extern bool MakeAttCert(AttCertType attCertType, const char * subjectCN, uint16_
 extern bool GenerateKeyPair(EVP_PKEY * key);
 extern bool GenerateKeyPair_Secp256k1(EVP_PKEY * key);
 extern bool ReadKey(const char * fileName, EVP_PKEY * key, bool ignorErrorIfUnsupportedCurve = false);
-extern bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt);
+extern bool WriteKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt);
 extern bool SerializeKeyPair(EVP_PKEY * key, chip::Crypto::P256SerializedKeypair & serializedKeypair);
 
 extern bool X509ToChipCert(X509 * cert, chip::MutableByteSpan & chipCert);
@@ -409,6 +436,7 @@ extern bool IsBase64String(const char * str, uint32_t strLen);
 extern bool ContainsPEMMarker(const char * marker, const uint8_t * data, uint32_t dataLen);
 extern bool ParseDateTime(const char * str, struct tm & date);
 extern bool ReadFileIntoMem(const char * fileName, uint8_t * data, uint32_t & dataLen);
+extern bool WriteDataIntoFile(const char * fileName, const uint8_t * data, size_t dataLen, DataFormat dataFmt);
 extern bool OpenFile(const char * fileName, FILE *& file, bool toWrite = false);
 extern void CloseFile(FILE *& file);
 


### PR DESCRIPTION
#### Problem
#20147  introduced support for HEX format for the certificate data in the chip-cert tool.
Need to add HEX format support for other data structures and some code refactoring is needed.

#### Change overview
  - Added HEX format support for the DER encoded data.
  - Added HEX format support for the Certification Declaration (CD) data.
  - Added support for only Public Key (without Private Key) including public key in HEX format.
  - Code refactored.

#### Testing
Manual testing of all chip-cert tool commands.