### PR TITLE
Cleanup p6 SDK compiler options

### DIFF
--- a/examples/all-clusters-app/p6/BUILD.gn
+++ b/examples/all-clusters-app/p6/BUILD.gn
@@ -41,10 +41,10 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script =
+      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 

--- a/examples/all-clusters-minimal-app/p6/BUILD.gn
+++ b/examples/all-clusters-minimal-app/p6/BUILD.gn
@@ -41,10 +41,10 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script =
+      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 

--- a/examples/lighting-app/p6/BUILD.gn
+++ b/examples/lighting-app/p6/BUILD.gn
@@ -41,10 +41,10 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script =
+      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 

--- a/examples/lock-app/p6/BUILD.gn
+++ b/examples/lock-app/p6/BUILD.gn
@@ -38,10 +38,10 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script =
+      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 

--- a/examples/ota-requestor-app/p6/BUILD.gn
+++ b/examples/ota-requestor-app/p6/BUILD.gn
@@ -40,10 +40,10 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script =
+      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 

--- a/third_party/p6/BUILD.gn
+++ b/third_party/p6/BUILD.gn
@@ -26,22 +26,25 @@ assert(p6_target_project != "", "p6_target_project must be specified")
 config("p6_sdk_config") {
   # Pull out includes from generated json
   # Treat these includes as system includes, so warnings in them are not fatal.
-  _include_dirs = []
-  foreach(inc, mtb_json.includes) {
+  _system_include_dirs = []
+  foreach(include_dir, mtb_json.includes) {
     # Strip off leading -I part
-    _include_dirs += [ "/" + rebase_path(string_replace(inc, "-I", "", 1),
-                                         "/",
-                                         "${p6_sdk_build_root}/p6_sdk/") ]
+    include_dir = string_replace(include_dir, "-I", "", 1)
+
+    # Path is relative to SDK
+    include_dir = "${p6_sdk_build_root}/p6_sdk/${include_dir}"
+
+    _system_include_dirs += [ include_dir ]
+  }
+
+  cflags = []
+  foreach(include_dir, _system_include_dirs) {
+    cflags += [ "-isystem" + rebase_path(include_dir, root_build_dir) ]
   }
 
   # Also add project include path (passed in from project build)
   proj_path = get_label_info(p6_target_project, "dir")
-  _include_dirs += [ "/" + rebase_path("${proj_path}/include", "/", ".") ]
-
-  cflags = []
-  foreach(include_dir, _include_dirs) {
-    cflags += [ "-isystem" + include_dir ]
-  }
+  include_dirs = [ "${proj_path}/include" ]
 
   # Pull out defines from generated json
   defines = []
@@ -53,7 +56,10 @@ config("p6_sdk_config") {
   # Pull out static libs (.a files) from generated json
   libs = []
   foreach(lib, mtb_json.libs) {
-    libs += [ "/" + rebase_path(lib, "/", "${p6_sdk_build_root}/p6_sdk/") ]
+    # Path is relative to SDK
+    lib = "${p6_sdk_build_root}/p6_sdk/${lib}"
+
+    libs += [ lib ]
   }
 
   cflags_c = mtb_json.cflags
@@ -65,10 +71,14 @@ config("p6_sdk_config") {
   # OTA app provides it's own linker script
   if (!chip_enable_ota_requestor) {
     linker_script_flags = filter_include(mtb_json.ldflags, [ "-T*" ])
-    foreach(flag, linker_script_flags) {
-      ldflags += [ "-T/" + rebase_path(string_replace(flag, "-T", "", 1),
-                                       "/",
-                                       "${p6_sdk_build_root}/p6_sdk/") ]
+    foreach(linker_script, linker_script_flags) {
+      # Strip off leading -T part
+      linker_script = string_replace(linker_script, "-T", "", 1)
+
+      # Path is relative to SDK
+      linker_script = "${p6_sdk_build_root}/p6_sdk/${linker_script}"
+
+      ldflags += [ "-T" + rebase_path(linker_script, root_build_dir) ]
     }
   }
 

--- a/third_party/p6/p6_sdk.gni
+++ b/third_party/p6/p6_sdk.gni
@@ -85,23 +85,17 @@ template("p6_sdk_sources") {
 
     # Pull out c sources from generated json
     foreach(src, mtb_json_local.c_source) {
-      sources += [ rebase_path(src,
-                               "${p6_project_dir}",
-                               "${p6_sdk_build_root}/p6_sdk/") ]
+      sources += [ "${p6_sdk_build_root}/p6_sdk/${src}" ]
     }
 
     # Pull out cpp sources from generated json
     foreach(src, mtb_json_local.cxx_source) {
-      sources += [ rebase_path(src,
-                               "${p6_project_dir}",
-                               "${p6_sdk_build_root}/p6_sdk/") ]
+      sources += [ "${p6_sdk_build_root}/p6_sdk/${src}" ]
     }
 
     # Pull out .S files from generated json
     foreach(asm, mtb_json_local.asm_source) {
-      sources += [ rebase_path(asm,
-                               "${p6_project_dir}",
-                               "${p6_sdk_build_root}/p6_sdk/") ]
+      sources += [ "${p6_sdk_build_root}/p6_sdk/${asm}" ]
     }
 
     public_deps = []


### PR DESCRIPTION
#### Problem

P6 builds are not re-compiling when CHIPProjectConfig.h changes.

#### Change overview

- Don't use -isystem for project configs as this prevents rebuilds with -MMD and suppresses warnings
- Use relative paths for options as is a best practice

#### Testing

```
scripts/build/build_examples.py --no-log-timestamps --target 'infineon-p6-lock' build
touch ./examples/lock-app/p6/include/CHIPProjectConfig.h
scripts/build/build_examples.py --no-log-timestamps --target 'infineon-p6-lock' build
```
