### PR TITLE
RPC: Add RPC to set temporary spake values (#19411)

### DIFF
--- a/examples/common/pigweed/protos/device_service.options
+++ b/examples/common/pigweed/protos/device_service.options
@@ -2,3 +2,5 @@ chip.rpc.DeviceInfo.serial_number max_size:32  // length defined in chip spec 8.
 chip.rpc.DeviceState.fabric_info max_count:2
 chip.rpc.PairingInfo.qr_code max_size:256
 chip.rpc.PairingInfo.qr_code_url max_size:256
+chip.rpc.SpakeInfo.verifier max_size:97  // kSpake2p_VerifierSerialized_Length
+chip.rpc.SpakeInfo.salt max_size:32      // kSpake2p_Max_PBKDF_Salt_Length

--- a/examples/common/pigweed/protos/device_service.proto
+++ b/examples/common/pigweed/protos/device_service.proto
@@ -11,6 +11,12 @@ message PairingInfo {
   string qr_code_url = 4;
 }
 
+message SpakeInfo {
+  optional bytes verifier = 1;
+  optional bytes salt = 2;
+  optional uint32 iteration_count = 3;
+}
+
 // type lengths defined in chip spec 8.2.3.1
 message DeviceInfo {
   uint32 vendor_id = 1;
@@ -43,4 +49,6 @@ service Device {
   rpc SetPairingState(PairingState) returns (pw.protobuf.Empty){}
   rpc GetPairingState(pw.protobuf.Empty) returns (PairingState){}
   rpc SetPairingInfo(PairingInfo) returns (pw.protobuf.Empty){}
+  rpc GetSpakeInfo(pw.protobuf.Empty) returns (SpakeInfo){}
+  rpc SetSpakeInfo(SpakeInfo) returns (pw.protobuf.Empty){}
 }


### PR DESCRIPTION
#### Problem
Spake RPCs needed in te9 branch for testing

#### Change overview
CP #19411 from master

#### Testing
built esp32-m5stack-all-clusters-rpc, and verified spake rpc worked.
