### PR TITLE
Update darwin framework tool build

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -24,7 +24,7 @@ if (config_use_interactive_mode) {
 
 assert(chip_build_tools)
 
-action("build-darwin-framwork") {
+action("build-darwin-framework") {
   script = "${chip_root}/scripts/build/build_darwin_framework.py"
 
   inputs = [ "${chip_root}/src/darwin/Framework/Matter.xcodeproj" ]
@@ -51,7 +51,8 @@ config("config") {
     "${chip_root}/examples/darwin-framework-tool/commands/common",
     "${chip_root}/zzz_generated/darwin-framework-tool",
     "${chip_root}/zzz_generated/controller-clusters",
-    "${chip_root}/examples/chip-tool/commands/clusters/ComplexArgument.h",
+    "${chip_root}/examples/chip-tool",
+    "${chip_root}/zzz_generated/chip-tool",
     "${root_out_dir}/macos_framework_output",
   ]
 
@@ -70,13 +71,11 @@ config("config") {
 
 executable("darwin-framework-tool") {
   sources = [
-    # We have to include privilege-storage.cpp here, not in the "Darwin
-    # framework" library, because otherwise the weak symbols from
-    # RequiredPrivilege.cpp mean we never actually pull in the function from
-    # privilege-storage.cpp.
-    "${chip_root}/src/app/util/privilege-storage.cpp",
+    "${chip_root}/examples/chip-tool/commands/common/Command.cpp",
+    "${chip_root}/examples/chip-tool/commands/common/Command.h",
+    "${chip_root}/examples/chip-tool/commands/common/Commands.cpp",
+    "${chip_root}/examples/chip-tool/commands/common/Commands.h",
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp",
-    "${chip_root}/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h",
     "commands/clusters/ClusterCommandBridge.h",
     "commands/clusters/ModelCommandBridge.mm",
     "commands/clusters/ReportCommandBridge.h",
@@ -99,11 +98,20 @@ executable("darwin-framework-tool") {
   ]
 
   deps = [
-    ":build-darwin-framwork",
-    "${chip_root}/examples/chip-tool:chip-tool-utils",
-    "${chip_root}/src/app/server",
-    "${chip_root}/src/lib",
-    "${chip_root}/src/platform",
+    ":build-darwin-framework",
+    "${chip_root}/src/app/tests/suites/commands/delay",
+
+    # IM is needed for MTRError
+    "${chip_root}/src/app/tests/suites/commands/interaction_model",
+
+    # Log is needed by tests UserPrompt and Log
+    "${chip_root}/src/app/tests/suites/commands/log",
+
+    # System is needed by tests FactoryReset etc..
+    "${chip_root}/src/app/tests/suites/commands/system",
+
+    # pics is needed by tests
+    "${chip_root}/src/app/tests/suites/pics",
     "${chip_root}/third_party/inipp",
     "${chip_root}/third_party/jsoncpp",
   ]

--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -21,8 +21,6 @@
 #import "MTRError_Utils.h"
 #import <Matter/Matter.h>
 
-#include <lib/support/UnitTestUtils.h>
-
 #include "ModelCommandBridge.h"
 
 class ClusterCommand : public ModelCommand {
@@ -97,7 +95,7 @@ public:
                                      }];
 
             if (mRepeatDelayInMs.HasValue()) {
-                chip::test_utils::SleepMillis(mRepeatDelayInMs.Value());
+                [NSThread sleepForTimeInterval:((double) mRepeatDelayInMs.Value()) / 1000];
             }
         }
         return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
Darwin-framework-tool is building libCHIP and linking to it via examples/chip-tool:chip-tool-utils and depending on source files. 

#### Change overview
- Target only files necessary for Darwin-chip-tool since it is mostly is reliant on Matter.framework.

#### Testing
- Compiled
- Ran commands
