### PR TITLE
Crypto refactoring and ECKey usage distinction

### DIFF
--- a/examples/tv-app/android/java/JNIDACProvider.cpp
+++ b/examples/tv-app/android/java/JNIDACProvider.cpp
@@ -135,14 +135,13 @@ CHIP_ERROR JNIDACProvider::GetProductAttestationIntermediateCert(MutableByteSpan
     return GetJavaByteByMethod(mGetProductAttestationIntermediateCertMethod, out_pai_buffer);
 }
 
-// TODO: This should be moved to a method of P256Keypair
 CHIP_ERROR LoadKeypairFromRaw(ByteSpan private_key, ByteSpan public_key, Crypto::P256Keypair & keypair)
 {
-    Crypto::P256SerializedKeypair serialized_keypair;
-    ReturnErrorOnFailure(serialized_keypair.SetLength(private_key.size() + public_key.size()));
-    memcpy(serialized_keypair.Bytes(), public_key.data(), public_key.size());
-    memcpy(serialized_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
-    return keypair.Deserialize(serialized_keypair);
+    Crypto::P256PlaintextKeypair plaintext_keypair;
+    ReturnErrorOnFailure(plaintext_keypair.SetLength(private_key.size() + public_key.size()));
+    memcpy(plaintext_keypair.Bytes(), public_key.data(), public_key.size());
+    memcpy(plaintext_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
+    return keypair.Initialize(plaintext_keypair);
 }
 
 CHIP_ERROR JNIDACProvider::SignWithDeviceAttestationKey(const ByteSpan & message_to_sign, MutableByteSpan & out_signature_buffer)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/JNIDACProvider.cpp
@@ -135,14 +135,13 @@ CHIP_ERROR JNIDACProvider::GetProductAttestationIntermediateCert(MutableByteSpan
     return GetJavaByteByMethod(mGetProductAttestationIntermediateCertMethod, out_pai_buffer);
 }
 
-// TODO: This should be moved to a method of P256Keypair
 CHIP_ERROR LoadKeypairFromRaw(ByteSpan private_key, ByteSpan public_key, Crypto::P256Keypair & keypair)
 {
-    Crypto::P256SerializedKeypair serialized_keypair;
-    ReturnErrorOnFailure(serialized_keypair.SetLength(private_key.size() + public_key.size()));
-    memcpy(serialized_keypair.Bytes(), public_key.data(), public_key.size());
-    memcpy(serialized_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
-    return keypair.Deserialize(serialized_keypair);
+    Crypto::P256PlaintextKeypair plaintext_keypair;
+    ReturnErrorOnFailure(plaintext_keypair.SetLength(private_key.size() + public_key.size()));
+    memcpy(plaintext_keypair.Bytes(), public_key.data(), public_key.size());
+    memcpy(plaintext_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
+    return keypair.Initialize(plaintext_keypair);
 }
 
 CHIP_ERROR JNIDACProvider::SignWithDeviceAttestationKey(const ByteSpan & message_to_sign, MutableByteSpan & out_signature_buffer)

--- a/src/app/tests/suites/credentials/TestHarnessDACProvider.cpp
+++ b/src/app/tests/suites/credentials/TestHarnessDACProvider.cpp
@@ -92,14 +92,13 @@ ByteSpan ReadValue(Json::Value jsonValue, uint8_t * buffer, size_t bufferLen)
     return ByteSpan(buffer, bytesLen);
 }
 
-// TODO: This should be moved to a method of P256Keypair
 CHIP_ERROR LoadKeypairFromRaw(ByteSpan private_key, ByteSpan public_key, Crypto::P256Keypair & keypair)
 {
-    Crypto::P256SerializedKeypair serialized_keypair;
-    ReturnErrorOnFailure(serialized_keypair.SetLength(private_key.size() + public_key.size()));
-    memcpy(serialized_keypair.Bytes(), public_key.data(), public_key.size());
-    memcpy(serialized_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
-    return keypair.Deserialize(serialized_keypair);
+    Crypto::P256PlaintextKeypair plaintext_keypair;
+    ReturnErrorOnFailure(plaintext_keypair.SetLength(private_key.size() + public_key.size()));
+    memcpy(plaintext_keypair.Bytes(), public_key.data(), public_key.size());
+    memcpy(plaintext_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
+    return keypair.Deserialize(plaintext_keypair);
 }
 
 } // namespace

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -649,16 +649,16 @@ CHIP_ERROR FabricTable::AddNewFabricForTest(const ByteSpan & rootCert, const Byt
     CHIP_ERROR err = CHIP_ERROR_INTERNAL;
 
     Crypto::P256Keypair injectedOpKey;
-    Crypto::P256SerializedKeypair injectedOpKeysSerialized;
+    Crypto::P256PlaintextKeypair injectedOpKeysPlaintext;
 
     Crypto::P256Keypair * opKey = nullptr;
     if (!opKeySpan.empty())
     {
-        VerifyOrReturnError(opKeySpan.size() == injectedOpKeysSerialized.Capacity(), CHIP_ERROR_INVALID_ARGUMENT);
+        VerifyOrReturnError(opKeySpan.size() == injectedOpKeysPlaintext.Capacity(), CHIP_ERROR_INVALID_ARGUMENT);
 
-        memcpy(injectedOpKeysSerialized.Bytes(), opKeySpan.data(), opKeySpan.size());
-        SuccessOrExit(err = injectedOpKeysSerialized.SetLength(opKeySpan.size()));
-        SuccessOrExit(err = injectedOpKey.Deserialize(injectedOpKeysSerialized));
+        memcpy(injectedOpKeysPlaintext.Bytes(), opKeySpan.data(), opKeySpan.size());
+        SuccessOrExit(err = injectedOpKeysPlaintext.SetLength(opKeySpan.size()));
+        SuccessOrExit(err = injectedOpKey.Initialize(injectedOpKeysPlaintext));
         opKey = &injectedOpKey;
     }
 

--- a/src/credentials/FabricTable.cpp
+++ b/src/credentials/FabricTable.cpp
@@ -1350,7 +1350,7 @@ Crypto::P256Keypair * FabricTable::AllocateEphemeralKeypairForCASE()
         return mOperationalKeystore->AllocateEphemeralKeypairForCASE();
     }
 
-    return Platform::New<Crypto::P256Keypair>();
+    return Platform::New<Crypto::P256Keypair>(SupportedECKeyUsages::DERIVING);
 }
 
 void FabricTable::ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair)

--- a/src/credentials/TestOnlyLocalCertificateAuthority.h
+++ b/src/credentials/TestOnlyLocalCertificateAuthority.h
@@ -56,11 +56,11 @@ public:
 
     TestOnlyLocalCertificateAuthority & Init()
     {
-        Crypto::P256SerializedKeypair emptyKeypair;
+        Crypto::P256PlaintextKeypair emptyKeypair;
         return Init(emptyKeypair);
     }
 
-    TestOnlyLocalCertificateAuthority & Init(Crypto::P256SerializedKeypair & rootKeyPair)
+    TestOnlyLocalCertificateAuthority & Init(Crypto::P256PlaintextKeypair & rootKeyPair)
     {
         SuccessOrExit(mCurrentStatus);
 
@@ -69,13 +69,14 @@ public:
 
         if (rootKeyPair.Length() != 0)
         {
-            mCurrentStatus = mRootKeypair->Deserialize(rootKeyPair);
-            SuccessOrExit(mCurrentStatus);
+            mCurrentStatus = mRootKeypair->Initialize(rootKeyPair);
         }
         else
         {
-            mRootKeypair->Initialize();
+            mCurrentStatus = mRootKeypair->Initialize();
         }
+        SuccessOrExit(mCurrentStatus);
+
         mCurrentStatus = GenerateRootCert(*mRootKeypair.get());
         SuccessOrExit(mCurrentStatus);
     exit:

--- a/src/credentials/examples/DeviceAttestationCredsExample.cpp
+++ b/src/credentials/examples/DeviceAttestationCredsExample.cpp
@@ -30,14 +30,13 @@ namespace Examples {
 
 namespace {
 
-// TODO: This should be moved to a method of P256Keypair
 CHIP_ERROR LoadKeypairFromRaw(ByteSpan private_key, ByteSpan public_key, Crypto::P256Keypair & keypair)
 {
-    Crypto::P256SerializedKeypair serialized_keypair;
-    ReturnErrorOnFailure(serialized_keypair.SetLength(private_key.size() + public_key.size()));
-    memcpy(serialized_keypair.Bytes(), public_key.data(), public_key.size());
-    memcpy(serialized_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
-    return keypair.Deserialize(serialized_keypair);
+    Crypto::P256PlaintextKeypair plaintext_keypair;
+    ReturnErrorOnFailure(plaintext_keypair.SetLength(private_key.size() + public_key.size()));
+    memcpy(plaintext_keypair.Bytes(), public_key.data(), public_key.size());
+    memcpy(plaintext_keypair.Bytes() + public_key.size(), private_key.data(), private_key.size());
+    return keypair.Initialize(plaintext_keypair);
 }
 
 class ExampleDACProvider : public DeviceAttestationCredentialsProvider

--- a/src/credentials/tests/TestCertificationDeclaration.cpp
+++ b/src/credentials/tests/TestCertificationDeclaration.cpp
@@ -270,12 +270,12 @@ static void TestCD_CMSSignAndVerify(nlTestSuite * inSuite, void * inContext)
 
     // Test with known key
     P256Keypair keypair2;
-    P256SerializedKeypair serializedKeypair;
-    memcpy(serializedKeypair, sTestCMS_SignerSerializedKeypair, sizeof(sTestCMS_SignerSerializedKeypair));
-    serializedKeypair.SetLength(sizeof(sTestCMS_SignerSerializedKeypair));
+    P256PlaintextKeypair plaintextKeypair;
+    memcpy(plaintextKeypair, sTestCMS_SignerSerializedKeypair, sizeof(sTestCMS_SignerSerializedKeypair));
+    plaintextKeypair.SetLength(sizeof(sTestCMS_SignerSerializedKeypair));
     cdContentIn   = ByteSpan(sTestCMS_CDContent02);
     signedMessage = MutableByteSpan(signedMessageBuf);
-    NL_TEST_ASSERT(inSuite, keypair2.Deserialize(serializedKeypair) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair2.Initialize(plaintextKeypair) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, CMS_Sign(cdContentIn, signerKeyId, keypair2, signedMessage) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, CMS_Verify(signedMessage, keypair2.Pubkey(), cdContentOut) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, cdContentIn.data_equal(cdContentOut));

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -88,10 +88,10 @@ private:
  */
 static CHIP_ERROR LoadTestFabric_Node01_01(nlTestSuite * inSuite, FabricTable & fabricTable, bool doCommit)
 {
-    Crypto::P256SerializedKeypair opKeysSerialized;
+    Crypto::P256PlaintextKeypair opKeysPlaintext;
     FabricIndex fabricIndex;
-    memcpy((uint8_t *) (opKeysSerialized), TestCerts::sTestCert_Node01_01_PublicKey, TestCerts::sTestCert_Node01_01_PublicKey_Len);
-    memcpy((uint8_t *) (opKeysSerialized) + TestCerts::sTestCert_Node01_01_PublicKey_Len, TestCerts::sTestCert_Node01_01_PrivateKey,
+    memcpy((uint8_t *) (opKeysPlaintext), TestCerts::sTestCert_Node01_01_PublicKey, TestCerts::sTestCert_Node01_01_PublicKey_Len);
+    memcpy((uint8_t *) (opKeysPlaintext) + TestCerts::sTestCert_Node01_01_PublicKey_Len, TestCerts::sTestCert_Node01_01_PrivateKey,
            TestCerts::sTestCert_Node01_01_PrivateKey_Len);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root01_Chip, TestCerts::sTestCert_Root01_Chip_Len);
@@ -99,9 +99,9 @@ static CHIP_ERROR LoadTestFabric_Node01_01(nlTestSuite * inSuite, FabricTable & 
     ByteSpan nocSpan(TestCerts::sTestCert_Node01_01_Chip, TestCerts::sTestCert_Node01_01_Chip_Len);
 
     NL_TEST_ASSERT(inSuite,
-                   opKeysSerialized.SetLength(TestCerts::sTestCert_Node01_01_PublicKey_Len +
-                                              TestCerts::sTestCert_Node01_01_PrivateKey_Len) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, gFabric1OpKey.Deserialize(opKeysSerialized) == CHIP_NO_ERROR);
+                   opKeysPlaintext.SetLength(TestCerts::sTestCert_Node01_01_PublicKey_Len +
+                                             TestCerts::sTestCert_Node01_01_PrivateKey_Len) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, gFabric1OpKey.Initialize(opKeysPlaintext) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcacSpan) == CHIP_NO_ERROR);
 
@@ -123,10 +123,10 @@ static CHIP_ERROR LoadTestFabric_Node01_01(nlTestSuite * inSuite, FabricTable & 
  */
 static CHIP_ERROR LoadTestFabric_Node02_01(nlTestSuite * inSuite, FabricTable & fabricTable, bool doCommit)
 {
-    Crypto::P256SerializedKeypair opKeysSerialized;
+    Crypto::P256PlaintextKeypair opKeysPlaintext;
     FabricIndex fabricIndex;
-    memcpy((uint8_t *) (opKeysSerialized), TestCerts::sTestCert_Node02_01_PublicKey, TestCerts::sTestCert_Node02_01_PublicKey_Len);
-    memcpy((uint8_t *) (opKeysSerialized) + TestCerts::sTestCert_Node02_01_PublicKey_Len, TestCerts::sTestCert_Node02_01_PrivateKey,
+    memcpy((uint8_t *) (opKeysPlaintext), TestCerts::sTestCert_Node02_01_PublicKey, TestCerts::sTestCert_Node02_01_PublicKey_Len);
+    memcpy((uint8_t *) (opKeysPlaintext) + TestCerts::sTestCert_Node02_01_PublicKey_Len, TestCerts::sTestCert_Node02_01_PrivateKey,
            TestCerts::sTestCert_Node02_01_PrivateKey_Len);
 
     ByteSpan rcacSpan(TestCerts::sTestCert_Root02_Chip, TestCerts::sTestCert_Root02_Chip_Len);
@@ -134,9 +134,9 @@ static CHIP_ERROR LoadTestFabric_Node02_01(nlTestSuite * inSuite, FabricTable & 
     ByteSpan nocSpan(TestCerts::sTestCert_Node02_01_Chip, TestCerts::sTestCert_Node02_01_Chip_Len);
 
     NL_TEST_ASSERT(inSuite,
-                   opKeysSerialized.SetLength(TestCerts::sTestCert_Node02_01_PublicKey_Len +
+                   opKeysPlaintext.SetLength(TestCerts::sTestCert_Node02_01_PublicKey_Len +
                                               TestCerts::sTestCert_Node02_01_PrivateKey_Len) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(inSuite, gFabric2OpKey.Deserialize(opKeysSerialized) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, gFabric2OpKey.Initialize(opKeysPlaintext) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcacSpan) == CHIP_NO_ERROR);
 

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -1862,15 +1862,14 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
         NL_TEST_ASSERT(inSuite, fabricTableHolder.Init(&storage) == CHIP_NO_ERROR);
         FabricTable & fabricTable = fabricTableHolder.GetFabricTable();
 
-        Crypto::P256ECDSASignature sig;
-        uint8_t message[] = { 'm', 's', 'g' };
+        Crypto::P256ECDHDerivedSecret secret;
 
         Crypto::P256Keypair * ephemeralKeypair = fabricTable.AllocateEphemeralKeypairForCASE();
         NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
         NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize());
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));
+        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDH_derive_secret(ephemeralKeypair->Pubkey(), secret));
+        NL_TEST_ASSERT(inSuite, secret.Length() > 0);
 
         fabricTable.ReleaseEphemeralKeypair(ephemeralKeypair);
     }
@@ -1889,15 +1888,14 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
 
         NL_TEST_ASSERT_SUCCESS(inSuite, fabricTable.Init(initParams));
 
-        Crypto::P256ECDSASignature sig;
-        uint8_t message[] = { 'm', 's', 'g' };
+        Crypto::P256ECDHDerivedSecret secret;
 
         Crypto::P256Keypair * ephemeralKeypair = fabricTable.AllocateEphemeralKeypairForCASE();
         NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
         NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize());
 
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
-        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));
+        NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDH_derive_secret(ephemeralKeypair->Pubkey(), secret));
+        NL_TEST_ASSERT(inSuite, secret.Length() > 0);
 
         fabricTable.ReleaseEphemeralKeypair(ephemeralKeypair);
 

--- a/src/credentials/tests/TestFabricTable.cpp
+++ b/src/credentials/tests/TestFabricTable.cpp
@@ -135,7 +135,7 @@ static CHIP_ERROR LoadTestFabric_Node02_01(nlTestSuite * inSuite, FabricTable & 
 
     NL_TEST_ASSERT(inSuite,
                    opKeysPlaintext.SetLength(TestCerts::sTestCert_Node02_01_PublicKey_Len +
-                                              TestCerts::sTestCert_Node02_01_PrivateKey_Len) == CHIP_NO_ERROR);
+                                             TestCerts::sTestCert_Node02_01_PrivateKey_Len) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, gFabric2OpKey.Initialize(opKeysPlaintext) == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite, fabricTable.AddNewPendingTrustedRootCert(rcacSpan) == CHIP_NO_ERROR);

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -353,15 +353,9 @@ template <typename PK, typename Plaintext, typename Serialized, typename Sig, ty
 class ECKeypair
 {
 public:
-    ECKeypair()
-    {
-        mUsage = SupportedECKeyUsages::SIGNING;
-    }
+    ECKeypair() { mUsage = SupportedECKeyUsages::SIGNING; }
 
-    ECKeypair(SupportedECKeyUsages usage)
-    {
-        mUsage = usage;
-    }
+    ECKeypair(SupportedECKeyUsages usage) { mUsage = usage; }
 
     virtual ~ECKeypair() {}
 
@@ -445,7 +439,8 @@ struct alignas(size_t) P256KeypairContext
     uint8_t mBytes[kMAX_P256Keypair_Context_Size];
 };
 
-class P256Keypair : public ECKeypair<P256PublicKey, P256PlaintextKeypair, P256SerializedKeypair, P256ECDSASignature, P256ECDHDerivedSecret>
+class P256Keypair
+    : public ECKeypair<P256PublicKey, P256PlaintextKeypair, P256SerializedKeypair, P256ECDSASignature, P256ECDHDerivedSecret>
 {
 public:
     P256Keypair() {}

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -173,6 +173,12 @@ enum class SupportedECKeyTypes : uint8_t
     ECP256R1 = 0,
 };
 
+enum class SupportedECKeyUsages : uint8_t
+{
+    SIGNING  = 0, // Key supports ECDSA operations and rejects ECDH operations
+    DERIVING = 1, // Key supports ECDH operations and rejects ECDSA operations
+};
+
 /** @brief Safely clears the first `len` bytes of memory area `buf`.
  * @param buf Pointer to a memory buffer holding secret data that must be cleared.
  * @param len Specifies secret data size in bytes.
@@ -344,7 +350,17 @@ template <typename PK, typename Serialized, typename Sig, typename Secret>
 class ECKeypair
 {
 public:
-    virtual ~ECPKeypair() {}
+    ECKeypair()
+    {
+        mUsage = SupportedECKeyUsages::SIGNING;
+    }
+
+    ECKeypair(SupportedECKeyUsages usage)
+    {
+        mUsage = usage;
+    }
+
+    virtual ~ECKeypair() {}
 
     /**
      * @brief Initialize the keypair.
@@ -397,6 +413,7 @@ public:
     virtual void Clear() = 0;
 
 protected:
+    SupportedECKeyUsages mUsage;
     bool mInitialized = false;
     PK mPublicKey;
 };
@@ -411,6 +428,7 @@ class P256Keypair : public ECKeypair<P256PublicKey, P256SerializedKeypair, P256E
 public:
     P256Keypair() {}
 
+    P256Keypair(SupportedECKeyUsages usage) : ECKeypair(usage) {}
 
     ~P256Keypair() override;
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -988,6 +988,13 @@ exit:
     return error;
 }
 
+CHIP_ERROR P256Keypair::Initialize(P256PlaintextKeypair & input)
+{
+    // For crypto libraries who don't manage keys, plaintext and serialised
+    // format is the same.
+    return Deserialize(static_cast<P256SerializedKeypair &>(input));
+}
+
 CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
 {
     CHIP_ERROR error = CHIP_NO_ERROR;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -583,11 +583,11 @@ CHIP_ERROR DRBG_get_bytes(uint8_t * out_buffer, const size_t out_length)
     return CHIP_NO_ERROR;
 }
 
-ECName MapECName(SupportedECPKeyTypes keyType)
+ECName MapECName(SupportedECKeyTypes keyType)
 {
     switch (keyType)
     {
-    case SupportedECPKeyTypes::ECP256R1:
+    case SupportedECKeyTypes::ECP256R1:
         return ECName::P256v1;
     default:
         return ECName::None;

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -629,7 +629,7 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
 
     static_assert(P256ECDSASignature::Capacity() >= kP256_ECDSA_Signature_Length_Raw, "P256ECDSASignature must be large enough");
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit((mUsage == SupportedECKeyUsages::SIGNING), CHIP_ERROR_WRONG_KEY_TYPE);
+    VerifyOrExit((mUsage == SupportedECKeyUsages::SIGNING), error = CHIP_ERROR_WRONG_KEY_TYPE);
     nid = _nidForCurve(MapECName(mPublicKey.Type()));
     VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -850,7 +850,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
 
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit((mUsage == SupportedECKeyUsages::DERIVING), CHIP_ERROR_WRONG_KEY_TYPE);
+    VerifyOrExit((mUsage == SupportedECKeyUsages::DERIVING), error = CHIP_ERROR_WRONG_KEY_TYPE);
 
     local_key = EVP_PKEY_new();
     VerifyOrExit(local_key != nullptr, error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -629,6 +629,7 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
 
     static_assert(P256ECDSASignature::Capacity() >= kP256_ECDSA_Signature_Length_Raw, "P256ECDSASignature must be large enough");
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit((mUsage == SupportedECKeyUsages::SIGNING), CHIP_ERROR_WRONG_KEY_TYPE);
     nid = _nidForCurve(MapECName(mPublicKey.Type()));
     VerifyOrExit(nid != NID_undef, error = CHIP_ERROR_INVALID_ARGUMENT);
 
@@ -849,6 +850,7 @@ CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_k
     VerifyOrExit(ec_key != nullptr, error = CHIP_ERROR_INTERNAL);
 
     VerifyOrExit(mInitialized, error = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit((mUsage == SupportedECKeyUsages::DERIVING), CHIP_ERROR_WRONG_KEY_TYPE);
 
     local_key = EVP_PKEY_new();
     VerifyOrExit(local_key != nullptr, error = CHIP_ERROR_INTERNAL);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -875,6 +875,13 @@ exit:
 #endif
 }
 
+CHIP_ERROR P256Keypair::Initialize(P256PlaintextKeypair & input)
+{
+    // For crypto libraries who don't manage keys, plaintext and serialised
+    // format is the same.
+    return Deserialize(static_cast<P256SerializedKeypair &>(input));
+}
+
 CHIP_ERROR P256Keypair::Serialize(P256SerializedKeypair & output) const
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -1135,7 +1135,6 @@ exit:
 typedef struct Spake2p_Context
 {
 #if defined(MBEDTLS_USE_TINYCRYPT)
-    const mbedtls_md_info_t * md_info;
     uECC_word_t M[2 * NUM_ECC_WORDS];
     uECC_word_t N[2 * NUM_ECC_WORDS];
     uECC_word_t X[2 * NUM_ECC_WORDS];
@@ -1150,7 +1149,6 @@ typedef struct Spake2p_Context
     uECC_word_t tempbn[NUM_ECC_WORDS];
 #else
     mbedtls_ecp_group curve;
-    const mbedtls_md_info_t * md_info;
     mbedtls_ecp_point M;
     mbedtls_ecp_point N;
     mbedtls_ecp_point X;
@@ -1205,8 +1203,7 @@ CHIP_ERROR Spake2p_P256_SHA256_HKDF_HMAC::InitInternal(void)
     result = mbedtls_ecp_group_load(&context->curve, MBEDTLS_ECP_DP_SECP256R1);
     VerifyOrExit(result == 0, error = CHIP_ERROR_INTERNAL);
 
-    context->md_info = mbedtls_md_info_from_type(MBEDTLS_MD_SHA256);
-    VerifyOrExit(context->md_info != nullptr, error = CHIP_ERROR_INTERNAL);
+    VerifyOrExit(mbedtls_md_info_from_type(MBEDTLS_MD_SHA256) != nullptr, error = CHIP_ERROR_INTERNAL);
 
     mbedtls_ecp_point_init(&context->M);
     mbedtls_ecp_point_init(&context->N);

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -555,6 +555,7 @@ CHIP_ERROR P256Keypair::ECDSA_sign_msg(const uint8_t * msg, const size_t msg_len
 {
     VerifyOrReturnError(mInitialized, CHIP_ERROR_INCORRECT_STATE);
     VerifyOrReturnError((msg != nullptr) && (msg_length > 0), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError((mUsage == SupportedECKeyUsages::SIGNING), CHIP_ERROR_WRONG_KEY_TYPE);
 
     uint8_t digest[kSHA256_Hash_Length];
     memset(&digest[0], 0, sizeof(digest));
@@ -711,6 +712,7 @@ exit:
 CHIP_ERROR P256Keypair::ECDH_derive_secret(const P256PublicKey & remote_public_key, P256ECDHDerivedSecret & out_secret) const
 {
 #if defined(MBEDTLS_ECDH_C)
+    VerifyOrReturnError((mUsage == SupportedECKeyUsages::DERIVING), CHIP_ERROR_WRONG_KEY_TYPE);
 
 #if defined(MBEDTLS_USE_TINYCRYPT)
     CHIP_ERROR error     = CHIP_NO_ERROR;

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -514,11 +514,11 @@ static int uECC_is_rng_set(void)
 
 #endif
 
-mbedtls_ecp_group_id MapECPGroupId(SupportedECPKeyTypes keyType)
+mbedtls_ecp_group_id MapECPGroupId(SupportedECKeyTypes keyType)
 {
     switch (keyType)
     {
-    case SupportedECPKeyTypes::ECP256R1:
+    case SupportedECKeyTypes::ECP256R1:
         return MBEDTLS_ECP_DP_SECP256R1;
     default:
         return MBEDTLS_ECP_DP_NONE;

--- a/src/crypto/PersistentStorageOperationalKeystore.cpp
+++ b/src/crypto/PersistentStorageOperationalKeystore.cpp
@@ -301,7 +301,7 @@ Crypto::P256Keypair * PersistentStorageOperationalKeystore::AllocateEphemeralKey
     // DO NOT CUT AND PASTE without considering the ReleaseEphemeralKeypair().
     // If allocating a derived class, then `ReleaseEphemeralKeypair` MUST
     // de-allocate the derived class after up-casting the base class pointer.
-    return Platform::New<Crypto::P256Keypair>();
+    return Platform::New<Crypto::P256Keypair>(SupportedECKeyUsages::DERIVING);
 }
 
 void PersistentStorageOperationalKeystore::ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair)

--- a/src/crypto/hsm/CHIPCryptoPALHsm.h
+++ b/src/crypto/hsm/CHIPCryptoPALHsm.h
@@ -116,7 +116,13 @@ private:
 class P256KeypairHSM : public P256Keypair
 {
 public:
-    P256KeypairHSM()
+    P256KeypairHSM() : P256Keypair()
+    {
+        provisioned_key = false;
+        keyid           = 0;
+    }
+
+    P256KeypairHSM(SupportedECKeyUsages usage) : P256Keypair(usage)
     {
         provisioned_key = false;
         keyid           = 0;

--- a/src/crypto/hsm/CHIPCryptoPALHsm.h
+++ b/src/crypto/hsm/CHIPCryptoPALHsm.h
@@ -132,6 +132,8 @@ public:
 
     virtual CHIP_ERROR Initialize() override;
 
+    virtual CHIP_ERROR Initialize(P256PlaintextKeypair & input) override;
+
     virtual CHIP_ERROR Serialize(P256SerializedKeypair & output) const override;
 
     virtual CHIP_ERROR Deserialize(P256SerializedKeypair & input) override;

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
@@ -121,6 +121,14 @@ CHIP_ERROR P256KeypairHSM::Initialize()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR P256Keypair::Initialize(P256PlaintextKeypair & input)
+{
+    // Todo: support initialising a key from plaintext bytes when running
+    // FabricTable / CASE unit tests with plaintext keys on a device with
+    // this implementation
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR P256KeypairHSM::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature) const
 {
     CHIP_ERROR error                  = CHIP_ERROR_INTERNAL;

--- a/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
+++ b/src/crypto/hsm/nxp/CHIPCryptoPALHsm_SE05X_P256.cpp
@@ -140,6 +140,7 @@ CHIP_ERROR P256KeypairHSM::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length
     VerifyOrReturnError(msg_length > 0, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(out_signature != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(keyid != kKeyId_NotInitialized, CHIP_ERROR_HSM);
+    VerifyOrReturnError((mUsage == SupportedECKeyUsages::SIGNING), CHIP_ERROR_WRONG_KEY_TYPE);
 
     ChipLogDetail(Crypto, "ECDSA_sign_msg: Using SE05X for Ecc Sign!");
 
@@ -262,6 +263,7 @@ CHIP_ERROR P256KeypairHSM::ECDH_derive_secret(const P256PublicKey & remote_publi
     size_t secret_length = (out_secret.Length() == 0) ? out_secret.Capacity() : out_secret.Length();
 
     VerifyOrReturnError(keyid != kKeyId_NotInitialized, CHIP_ERROR_HSM);
+    VerifyOrReturnError((mUsage == SupportedECKeyUsages::DERIVING), CHIP_ERROR_WRONG_KEY_TYPE);
 
     ChipLogDetail(Crypto, "ECDH_derive_secret: Using SE05X for ECDH !");
 

--- a/src/crypto/tests/CHIPCryptoPALTest.cpp
+++ b/src/crypto/tests/CHIPCryptoPALTest.cpp
@@ -1161,11 +1161,11 @@ static void TestECDSA_ValidationHashInvalidParam(nlTestSuite * inSuite, void * i
 static void TestECDSA_InvalidUsage(nlTestSuite * inSuite, void * inContext)
 {
     HeapChecker heapChecker(inSuite);
-    Test_P256Keypair keypair1(SupportedECKeyUsages::DERIVING);
+    Test_P256Keypair keypair(SupportedECKeyUsages::DERIVING);
     const char * msg  = "Hello World!";
     size_t msg_length = strlen(msg);
 
-    NL_TEST_ASSERT(inSuite, keypair1.Initialize() == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
     // Try to sign, and see that we're not allowed to
     P256ECDSASignature signature;

--- a/src/crypto/tests/TestPersistentStorageOpKeyStore.cpp
+++ b/src/crypto/tests/TestPersistentStorageOpKeyStore.cpp
@@ -202,15 +202,15 @@ void TestEphemeralKeys(nlTestSuite * inSuite, void * inContext)
     PersistentStorageOperationalKeystore opKeyStore;
     NL_TEST_ASSERT_SUCCESS(inSuite, opKeyStore.Init(&storage));
 
-    Crypto::P256ECDSASignature sig;
-    uint8_t message[] = { 'm', 's', 'g' };
+    Crypto::P256ECDHDerivedSecret secret;
 
     Crypto::P256Keypair * ephemeralKeypair = opKeyStore.AllocateEphemeralKeypairForCASE();
     NL_TEST_ASSERT(inSuite, ephemeralKeypair != nullptr);
     NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Initialize());
 
-    NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDSA_sign_msg(message, sizeof(message), sig));
-    NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->Pubkey().ECDSA_validate_msg_signature(message, sizeof(message), sig));
+    // Test self-derivation just to check we got a valid key
+    NL_TEST_ASSERT_SUCCESS(inSuite, ephemeralKeypair->ECDH_derive_secret(ephemeralKeypair->Pubkey(), secret));
+    NL_TEST_ASSERT(inSuite, secret.Length() > 0);
 
     opKeyStore.ReleaseEphemeralKeypair(ephemeralKeypair);
 

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.h
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.h
@@ -33,6 +33,8 @@ public:
 
     CHIP_ERROR Initialize() override;
 
+    CHIP_ERROR Initialize(chip::Crypto::P256PlaintextKeypair & input) override;
+
     CHIP_ERROR Serialize(chip::Crypto::P256SerializedKeypair & output) const override;
 
     CHIP_ERROR Deserialize(chip::Crypto::P256SerializedKeypair & input) override;

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -49,6 +49,14 @@ CHIP_ERROR MTRP256KeypairBridge::Initialize()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR MTRP256KeypairBridge::Initialize(P256PlaintextKeypair & input)
+{
+    // Todo: support initialising a key from plaintext bytes when running
+    // FabricTable / CASE unit tests with plaintext keys on a device with
+    // this implementation
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR MTRP256KeypairBridge::Serialize(P256SerializedKeypair & output) const
 {
     if (!HasKeypair()) {

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -91,8 +91,7 @@ CHIP_ERROR MTRP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg_
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    if (mUsage != SupportedECKeyUsages::SIGNING)
-    {
+    if (mUsage != SupportedECKeyUsages::SIGNING) {
         MTR_LOG_ERROR("ECDSA sign msg failure: keypair initialised with wrong usage.");
         return CHIP_ERROR_WRONG_KEY_TYPE;
     }
@@ -144,8 +143,7 @@ CHIP_ERROR MTRP256KeypairBridge::ECDH_derive_secret(
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
-    if (mUsage != SupportedECKeyUsages::DERIVING)
-    {
+    if (mUsage != SupportedECKeyUsages::DERIVING) {
         return CHIP_ERROR_WRONG_KEY_TYPE;
     }
 

--- a/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRP256KeypairBridge.mm
@@ -82,6 +82,13 @@ CHIP_ERROR MTRP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg_
         MTR_LOG_ERROR("ECDSA sign msg failure: no keypair to sign with.");
         return CHIP_ERROR_INCORRECT_STATE;
     }
+
+    if (mUsage != SupportedECKeyUsages::SIGNING)
+    {
+        MTR_LOG_ERROR("ECDSA sign msg failure: keypair initialised with wrong usage.");
+        return CHIP_ERROR_WRONG_KEY_TYPE;
+    }
+
     NSData * msgData = [NSData dataWithBytes:msg length:msg_length];
     NSData * signature;
     if ([mKeypair respondsToSelector:@selector(signMessageECDSA_DER:)]) {
@@ -127,6 +134,11 @@ CHIP_ERROR MTRP256KeypairBridge::ECDH_derive_secret(
 {
     if (!HasKeypair()) {
         return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    if (mUsage != SupportedECKeyUsages::DERIVING)
+    {
+        return CHIP_ERROR_WRONG_KEY_TYPE;
     }
 
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;

--- a/src/platform/ESP32/ESP32FactoryDataProvider.cpp
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.cpp
@@ -32,11 +32,11 @@ static constexpr uint32_t kDACPublicKeySize  = 65;
 
 CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P256Keypair & keypair)
 {
-    Crypto::P256SerializedKeypair serializedKeypair;
-    ReturnErrorOnFailure(serializedKeypair.SetLength(privateKey.size() + publicKey.size()));
-    memcpy(serializedKeypair.Bytes(), publicKey.data(), publicKey.size());
-    memcpy(serializedKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
-    return keypair.Deserialize(serializedKeypair);
+    Crypto::P256PlaintextKeypair plaintextKeypair;
+    ReturnErrorOnFailure(plaintextKeypair.SetLength(privateKey.size() + publicKey.size()));
+    memcpy(plaintextKeypair.Bytes(), publicKey.data(), publicKey.size());
+    memcpy(plaintextKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
+    return keypair.Initialize(plaintextKeypair);
 }
 } // namespace
 

--- a/src/platform/android/CHIPP256KeypairBridge.cpp
+++ b/src/platform/android/CHIPP256KeypairBridge.cpp
@@ -115,6 +115,11 @@ CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
+    if (mUsage != SupportedECKeyUsages::SIGNING)
+    {
+        return CHIP_ERROR_WRONG_KEY_TYPE;
+    }
+
     CHIP_ERROR err = CHIP_NO_ERROR;
     jbyteArray jniMsg;
     jobject signedResult = nullptr;
@@ -148,6 +153,11 @@ CHIP_ERROR CHIPP256KeypairBridge::ECDH_derive_secret(const P256PublicKey & remot
     if (!HasKeypair())
     {
         return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    if (mUsage != SupportedECKeyUsages::DERIVING)
+    {
+        return CHIP_ERROR_WRONG_KEY_TYPE;
     }
 
     // Not required for Java SDK.

--- a/src/platform/android/CHIPP256KeypairBridge.cpp
+++ b/src/platform/android/CHIPP256KeypairBridge.cpp
@@ -76,6 +76,14 @@ CHIP_ERROR CHIPP256KeypairBridge::Initialize()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR CHIPP256KeypairBridge::Initialize(P256PlaintextKeypair & input)
+{
+    // Todo: support initialising a key from plaintext bytes when running
+    // FabricTable / CASE unit tests with plaintext keys on a device with
+    // this implementation
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR CHIPP256KeypairBridge::Serialize(P256SerializedKeypair & output) const
 {
     if (!HasKeypair())

--- a/src/platform/android/CHIPP256KeypairBridge.h
+++ b/src/platform/android/CHIPP256KeypairBridge.h
@@ -46,6 +46,8 @@ public:
 
     CHIP_ERROR Initialize() override;
 
+    CHIP_ERROR Initialize(chip::Crypto::P256PlaintextKeypair & input) override;
+
     CHIP_ERROR Serialize(chip::Crypto::P256SerializedKeypair & output) const override;
 
     CHIP_ERROR Deserialize(chip::Crypto::P256SerializedKeypair & input) override;

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -26,11 +26,11 @@ namespace {
 
 CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P256Keypair & keypair)
 {
-    Crypto::P256SerializedKeypair serializedKeypair;
-    ReturnErrorOnFailure(serializedKeypair.SetLength(privateKey.size() + publicKey.size()));
-    memcpy(serializedKeypair.Bytes(), publicKey.data(), publicKey.size());
-    memcpy(serializedKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
-    return keypair.Deserialize(serializedKeypair);
+    Crypto::P256PlaintextKeypair plaintextKeypair;
+    ReturnErrorOnFailure(plaintextKeypair.SetLength(privateKey.size() + publicKey.size()));
+    memcpy(plaintextKeypair.Bytes(), publicKey.data(), publicKey.size());
+    memcpy(plaintextKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
+    return keypair.Initialize(plaintextKeypair);
 }
 } // namespace
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -135,7 +135,7 @@ public:
         return mKeypair->ECDSA_sign_msg(message.data(), message.size(), outSignature);
     }
 
-    Crypto::P256Keypair * AllocateEphemeralKeypairForCASE() override { return Platform::New<Crypto::P256Keypair>(); }
+    Crypto::P256Keypair * AllocateEphemeralKeypairForCASE() override { return Platform::New<Crypto::P256Keypair>(SupportedECKeyUsages::DERIVING); }
 
     void ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair) override { Platform::Delete<Crypto::P256Keypair>(keypair); }
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -135,7 +135,10 @@ public:
         return mKeypair->ECDSA_sign_msg(message.data(), message.size(), outSignature);
     }
 
-    Crypto::P256Keypair * AllocateEphemeralKeypairForCASE() override { return Platform::New<Crypto::P256Keypair>(SupportedECKeyUsages::DERIVING); }
+    Crypto::P256Keypair * AllocateEphemeralKeypairForCASE() override
+    {
+        return Platform::New<Crypto::P256Keypair>(SupportedECKeyUsages::DERIVING);
+    }
 
     void ReleaseEphemeralKeypair(Crypto::P256Keypair * keypair) override { Platform::Delete<Crypto::P256Keypair>(keypair); }
 

--- a/src/protocols/secure_channel/tests/TestCASESession.cpp
+++ b/src/protocols/secure_channel/tests/TestCASESession.cpp
@@ -199,19 +199,19 @@ CHIP_ERROR InitCredentialSets()
 
     FabricInfo commissionerFabric;
     {
-        P256SerializedKeypair opKeysSerialized;
+        P256PlaintextKeypair opKeysPlaintext;
 
         // TODO: Rename gCommissioner* to gInitiator*
-        memcpy((uint8_t *) (opKeysSerialized), sTestCert_Node01_02_PublicKey, sTestCert_Node01_02_PublicKey_Len);
-        memcpy((uint8_t *) (opKeysSerialized) + sTestCert_Node01_02_PublicKey_Len, sTestCert_Node01_02_PrivateKey,
+        memcpy((uint8_t *) (opKeysPlaintext), sTestCert_Node01_02_PublicKey, sTestCert_Node01_02_PublicKey_Len);
+        memcpy((uint8_t *) (opKeysPlaintext) + sTestCert_Node01_02_PublicKey_Len, sTestCert_Node01_02_PrivateKey,
                sTestCert_Node01_02_PrivateKey_Len);
 
-        ReturnErrorOnFailure(opKeysSerialized.SetLength(sTestCert_Node01_02_PublicKey_Len + sTestCert_Node01_02_PrivateKey_Len));
+        ReturnErrorOnFailure(opKeysPlaintext.SetLength(sTestCert_Node01_02_PublicKey_Len + sTestCert_Node01_02_PrivateKey_Len));
 
         chip::ByteSpan rcacSpan(sTestCert_Root01_Chip, sTestCert_Root01_Chip_Len);
         chip::ByteSpan icacSpan(sTestCert_ICA01_Chip, sTestCert_ICA01_Chip_Len);
         chip::ByteSpan nocSpan(sTestCert_Node01_02_Chip, sTestCert_Node01_02_Chip_Len);
-        chip::ByteSpan opKeySpan(opKeysSerialized.ConstBytes(), opKeysSerialized.Length());
+        chip::ByteSpan opKeySpan(opKeysPlaintext.ConstBytes(), opKeysPlaintext.Length());
 
         ReturnErrorOnFailure(
             gCommissionerFabrics.AddNewFabricForTest(rcacSpan, icacSpan, nocSpan, opKeySpan, &gCommissionerFabricIndex));
@@ -227,16 +227,16 @@ CHIP_ERROR InitCredentialSets()
     FabricInfo deviceFabric;
 
     {
-        P256SerializedKeypair opKeysSerialized;
+        P256PlaintextKeypair opKeysPlaintext;
 
         auto deviceOpKey = Platform::MakeUnique<Crypto::P256Keypair>();
-        memcpy((uint8_t *) (opKeysSerialized), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
-        memcpy((uint8_t *) (opKeysSerialized) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
+        memcpy((uint8_t *) (opKeysPlaintext), sTestCert_Node01_01_PublicKey, sTestCert_Node01_01_PublicKey_Len);
+        memcpy((uint8_t *) (opKeysPlaintext) + sTestCert_Node01_01_PublicKey_Len, sTestCert_Node01_01_PrivateKey,
                sTestCert_Node01_01_PrivateKey_Len);
 
-        ReturnErrorOnFailure(opKeysSerialized.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
+        ReturnErrorOnFailure(opKeysPlaintext.SetLength(sTestCert_Node01_01_PublicKey_Len + sTestCert_Node01_01_PrivateKey_Len));
 
-        ReturnErrorOnFailure(deviceOpKey->Deserialize(opKeysSerialized));
+        ReturnErrorOnFailure(deviceOpKey->Initialize(opKeysPlaintext));
 
         // Use an injected operational key for device
         gDeviceOperationalKeystore.Init(1, std::move(deviceOpKey));

--- a/src/tools/chip-cert/Cmd_GenCD.cpp
+++ b/src/tools/chip-cert/Cmd_GenCD.cpp
@@ -1156,9 +1156,9 @@ bool Cmd_GenCD(int argc, char * argv[])
         // Initialize P256Keypair from EVP_PKEY.
         P256Keypair keypair;
         {
-            P256SerializedKeypair serializedKeypair;
-            VerifyOrReturnError(SerializeKeyPair(key.get(), serializedKeypair), false);
-            VerifyOrReturnError(keypair.Deserialize(serializedKeypair) == CHIP_NO_ERROR, false);
+            P256PlaintextKeypair plaintextKeypair;
+            VerifyOrReturnError(ExportKeyPair(key.get(), plaintextKeypair), false);
+            VerifyOrReturnError(keypair.Initialize(plaintextKeypair) == CHIP_NO_ERROR, false);
         }
 
         // Encode CD TLV content.

--- a/src/tools/chip-cert/KeyUtils.cpp
+++ b/src/tools/chip-cert/KeyUtils.cpp
@@ -41,12 +41,12 @@ namespace {
 KeyFormat DetectKeyFormat(const uint8_t * key, uint32_t keyLen)
 {
     static uint32_t p256PlaintextKeypairLen = kP256_PublicKey_Length + kP256_PrivateKey_Length;
-    static const char * ecPEMMarker          = "-----BEGIN EC PRIVATE KEY-----";
-    static const char * pkcs8PEMMarker       = "-----BEGIN PRIVATE KEY-----";
-    static const char * ecPUBPEMMarker       = "-----BEGIN PUBLIC KEY-----";
-    static const char * chipHexPrefix        = "04c2";
-    static const size_t chipHexPrefixLen     = strlen(chipHexPrefix);
-    static const size_t chipHexMinLen        = HEX_ENCODED_LENGTH(p256PlaintextKeypairLen);
+    static const char * ecPEMMarker         = "-----BEGIN EC PRIVATE KEY-----";
+    static const char * pkcs8PEMMarker      = "-----BEGIN PRIVATE KEY-----";
+    static const char * ecPUBPEMMarker      = "-----BEGIN PUBLIC KEY-----";
+    static const char * chipHexPrefix       = "04c2";
+    static const size_t chipHexPrefixLen    = strlen(chipHexPrefix);
+    static const size_t chipHexMinLen       = HEX_ENCODED_LENGTH(p256PlaintextKeypairLen);
 
     if (keyLen == p256PlaintextKeypairLen)
     {
@@ -286,7 +286,7 @@ bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt)
     FILE * file            = nullptr;
     uint8_t * keyToWrite   = nullptr;
     uint32_t keyToWriteLen = 0;
-    P256PlaintextKeypair   plaintextKeypair;
+    P256PlaintextKeypair plaintextKeypair;
     uint32_t chipKeySize        = plaintextKeypair.Capacity();
     uint32_t chipKeyDecodedSize = HEX_ENCODED_LENGTH(chipKeySize);
     std::unique_ptr<uint8_t[]> chipKey(new uint8_t[chipKeySize]);

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -398,7 +398,7 @@ extern bool GenerateKeyPair(EVP_PKEY * key);
 extern bool GenerateKeyPair_Secp256k1(EVP_PKEY * key);
 extern bool ReadKey(const char * fileName, EVP_PKEY * key, bool ignorErrorIfUnsupportedCurve = false);
 extern bool WritePrivateKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt);
-extern bool SerializeKeyPair(EVP_PKEY * key, chip::Crypto::P256SerializedKeypair & serializedKeypair);
+extern bool ExportKeyPair(EVP_PKEY * key, chip::Crypto::P256PlaintextKeypair & plaintextKeypair);
 
 extern bool X509ToChipCert(X509 * cert, chip::MutableByteSpan & chipCert);
 

--- a/src/transport/tests/TestSecureSession.cpp
+++ b/src/transport/tests/TestSecureSession.cpp
@@ -38,10 +38,10 @@ void SecureChannelInitTest(nlTestSuite * inSuite, void * inContext)
 {
     CryptoContext channel;
 
-    P256Keypair keypair;
+    P256Keypair keypair(SupportedECKeyUsages::DERIVING);
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    P256Keypair keypair2;
+    P256Keypair keypair2(SupportedECKeyUsages::DERIVING);
     NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     // Test all combinations of invalid parameters
@@ -86,10 +86,10 @@ void SecureChannelEncryptTest(nlTestSuite * inSuite, void * inContext)
     CryptoContext::NonceStorage nonce;
     CryptoContext::BuildNonce(nonce, packetHeader.GetSecurityFlags(), packetHeader.GetMessageCounter(), 0);
 
-    P256Keypair keypair;
+    P256Keypair keypair(SupportedECKeyUsages::DERIVING);
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    P256Keypair keypair2;
+    P256Keypair keypair2(SupportedECKeyUsages::DERIVING);
     NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     // Test uninitialized channel
@@ -130,10 +130,10 @@ void SecureChannelDecryptTest(nlTestSuite * inSuite, void * inContext)
 
     const char * salt = "Test Salt";
 
-    P256Keypair keypair;
+    P256Keypair keypair(SupportedECKeyUsages::DERIVING);
     NL_TEST_ASSERT(inSuite, keypair.Initialize() == CHIP_NO_ERROR);
 
-    P256Keypair keypair2;
+    P256Keypair keypair2(SupportedECKeyUsages::DERIVING);
     NL_TEST_ASSERT(inSuite, keypair2.Initialize() == CHIP_NO_ERROR);
 
     NL_TEST_ASSERT(inSuite,


### PR DESCRIPTION
#### Problem
* Semantically different usage of the ECPKeypair's Serialize/Deserialize methods, where usage is mixed between converting to/from storage representation and to/from plaintext representation.
* No check against using an ECPKeypair for both ECDSA and ECDH, something which is warned against frequently

#### Change overview
* Rename ECPKey to ECPublicKey, ECPKeypair to ECKeypair and SupportedECPKeyTypes to SupportedECKeyTypes
* Refactor out intermediate abstract class P256KeypairBase since it had no use anywhere
* Refactor common class members to the base ECKeypair class instead of the top-level P256Keypair
* Introduced concept of `SupportedECKeyUsages` which restricts an ECKeypair to be used for either signing (ECDSA) or deriving (ECDH), and implemented checks in the presently shipping crypto backends. A default-initialised ECKeypair will be able to be used for signatures only.
* Refactored the semantic difference between plaintext keys and storage representation by introducing a new overloaded function `Initialize(P256SerializedKeypair)` which takes the role of 'constructing a P256Keypair object from a plaintext key'. This makes it easier to track and potentially refactor the remaining usages of `Serialize` and `Deserialize` later on, which now exclusively mean converting to/from storage representation. That will also facilitate implementing alternate crypto backends which come with their own storage implementation.

#### Testing
How was this tested? (at least one bullet point required)
* Refactor covered by existing testing
* Usage limitation tested by new testcases
