### PR TITLE
add CI for Bouffalolab BL602 

### DIFF
--- a/.github/workflows/examples-bl602.yaml
+++ b/.github/workflows/examples-bl602.yaml
@@ -1,0 +1,79 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Build example - BL602
+
+on:
+  push:
+  pull_request:
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}-${{ (github.event_name == 'pull_request' && github.event.number) || (github.event_name == 'workflow_dispatch' && github.run_number) || github.sha }}
+  cancel-in-progress: true
+
+jobs:
+  bl602:
+    name: BL602
+    timeout-minutes: 90
+
+    runs-on: ubuntu-latest
+    if: github.actor != 'restyled-io[bot]'
+
+    container:
+      image: connectedhomeip/chip-build:latest
+      volumes:
+        - "/tmp/bloat_reports:/tmp/bloat_reports"
+    steps:
+      - uses: Wandalen/wretry.action@v1.0.15
+        name: Checkout
+        with:
+          action: actions/checkout@v3
+          with: |
+            token: ${{ github.token }}
+          attempt_limit: 3
+          attempt_delay: 2000
+      - name: Checkout submodules
+        run: scripts/checkout_submodules.py --shallow --platform bl602
+
+      - name: Set up environment for size reports
+        if: ${{ !env.ACT }}
+        env:
+          GH_CONTEXT: ${{ toJson(github) }}
+        run: scripts/tools/memory/gh_sizes_environment.py "${GH_CONTEXT}"
+
+      - name: Build example BL602 Lighting App
+        timeout-minutes: 30
+        run: |
+          ./scripts/run_in_build_env.sh \
+            "./scripts/build/build_examples.py --target bl602-light build"
+
+      - name: Get Lighting size stats
+        run: |
+          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py bl602 bl602 lighting-app \
+            out/bl602-light/chip-bl602-lighting-example.out /tmp/bloat_reports/
+
+      - name: Build example BL602 Lighting App with RPCs
+        timeout-minutes: 30
+        run: |
+          scripts/examples/gn_bl602_example.sh lighting-app ./out/bl602-light-rpc 'import("//with_pw_rpc.gni")'
+          .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py bl602 bl602+rpc lighting-app \
+            out/bl602-light-rpc/chip-bl602-lighting-example.out /tmp/bloat_reports/
+
+      - name: Uploading Size Reports
+        uses: actions/upload-artifact@v2
+        if: ${{ !env.ACT }}
+        with:
+          name: Size,BL602-Examples,${{ env.GH_EVENT_PR }},${{ env.GH_EVENT_HASH }},${{ env.GH_EVENT_PARENT }},${{ github.event_name }}
+          path: |
+            /tmp/bloat_reports/

--- a/scripts/tools/memory/platform/bl602.cfg
+++ b/scripts/tools/memory/platform/bl602.cfg
@@ -1,0 +1,40 @@
+# Copyright (c) 2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Memory tools default configuation for Bouffalolab BL602.
+
+{
+    'section': {
+        # By default, only these sections will be included
+        # when operating by sections.
+        'default': ['.text', '.data', '.bss']
+    },
+    # 'symbol': {
+    #     'free': {
+    #         # These symbols mark the start or end of areas where memory that
+    #         # does not belong to any symbol is considered unused (rather than
+    #         # a gap that may be in use for some non-symbol purpose, e.g. string
+    #         # constants or alignment).
+    #         'start': [],
+    #         'end': [],
+    #     }
+    # },
+    # 'region': {
+    #     # Regions are sets of sections that can be used for aggregate reports.
+    #     'sections': {
+    #         'FLASH': [],
+    #         'RAM': []
+    #     }
+    # },
+}


### PR DESCRIPTION
#### Problem
No CI for BL602 platform.

#### Change overview
add CI for BL602 to build lighting-app examples.

#### Testing
test using self created docker image and pass the "Build example - BL602" job.
