### PR TITLE
Cherry Pick - RPi builds no longer need `no-interactive` workaround

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -70,7 +70,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-arm64-all-clusters \
-                        --target linux-arm64-chip-tool-no-interactive-ipv6only \
+                        --target linux-arm64-chip-tool-ipv6only \
                         --target linux-arm64-lock \
                         --target linux-arm64-minmdns \
                         --target linux-arm64-thermostat-no-ble \
@@ -80,8 +80,8 @@ jobs:
               timeout-minutes: 5
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    linux arm64 chip-tool-no-interactive-ipv6only \
-                    out/linux-arm64-chip-tool-no-interactive-ipv6only/chip-tool \
+                    linux arm64 chip-tool-ipv6only \
+                    out/linux-arm64-chip-tool-ipv6only/chip-tool \
                     /tmp/bloat_reports/
             - name: Bloat report - thermostat
               timeout-minutes: 5

--- a/.gitmodules
+++ b/.gitmodules
@@ -250,3 +250,6 @@
 	url = https://github.com/bouffalolab/bl_iot_sdk_matter.git
 	branch = bl602_release
 	platforms = bl602
+[submodule "editline"]
+	path = third_party/editline/repo
+	url = https://github.com/troglobit/editline.git

--- a/build_overrides/editline.gni
+++ b/build_overrides/editline.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # Root directory for editline.
+  editline_root = "//third_party/editline"
+}

--- a/examples/build_overrides/editline.gni
+++ b/examples/build_overrides/editline.gni
@@ -1,0 +1,18 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+declare_args() {
+  # Root directory for editline.
+  editline_root = "//third_party/connectedhomeip/third_party/editline"
+}

--- a/examples/chip-tool/BUILD.gn
+++ b/examples/chip-tool/BUILD.gn
@@ -19,6 +19,10 @@ import("${chip_root}/build/chip/tools.gni")
 import("${chip_root}/examples/chip-tool/chip-tool.gni")
 import("${chip_root}/src/lib/core/core.gni")
 
+if (config_use_interactive_mode) {
+  import("//build_overrides/editline.gni")
+}
+
 assert(chip_build_tools)
 
 config("config") {
@@ -35,10 +39,6 @@ config("config") {
   ]
 
   cflags = [ "-Wconversion" ]
-
-  if (config_use_interactive_mode) {
-    libs = [ "readline" ]
-  }
 }
 
 static_library("chip-tool-utils") {
@@ -71,8 +71,11 @@ static_library("chip-tool-utils") {
     "config/PersistentStorage.cpp",
   ]
 
+  deps = []
+
   if (config_use_interactive_mode) {
     sources += [ "commands/interactive/InteractiveCommands.cpp" ]
+    deps += [ "${editline_root}:editline" ]
   }
 
   if (config_enable_yaml_tests) {

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -18,8 +18,7 @@
 
 #include "InteractiveCommands.h"
 
-#include <readline/history.h>
-#include <readline/readline.h>
+#include <editline.h>
 
 char kInteractiveModeName[]                            = "";
 constexpr const char * kInteractiveModePrompt          = ">>> ";

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -1,0 +1,109 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+import("${chip_root}/build/chip/tools.gni")
+import("${chip_root}/examples//chip-tool/chip-tool.gni")
+
+if (config_use_interactive_mode) {
+  import("//build_overrides/editline.gni")
+}
+
+assert(chip_build_tools)
+
+config("config") {
+  include_dirs = [
+    ".",
+    "${chip_root}/src/darwin/Framework/CHIP/zap-generated",
+    "${chip_root}/src/darwin/Framework/CHIP",
+    "${chip_root}/examples/darwin-framework-tool/commands/common",
+    "${chip_root}/zzz_generated/darwin-framework-tool",
+    "${chip_root}/zzz_generated/controller-clusters",
+    "${chip_root}/examples/chip-tool/commands/clusters/ComplexArgument.h",
+    "/tmp/macos_framework_output",
+  ]
+
+  framework_dirs = [ "/tmp/macos_framework_output" ]
+
+  defines = [
+    "CONFIG_ENABLE_YAML_TESTS=${config_enable_yaml_tests}",
+    "CONFIG_USE_INTERACTIVE_MODE=${config_use_interactive_mode}",
+  ]
+
+  cflags = [
+    "-Wconversion",
+    "-fobjc-arc",
+  ]
+}
+
+executable("darwin-framework-tool") {
+  sources = [
+    # We have to include privilege-storage.cpp here, not in the "Darwin
+    # framework" library, because otherwise the weak symbols from
+    # RequiredPrivilege.cpp mean we never actually pull in the function from
+    # privilege-storage.cpp.
+    "${chip_root}/src/app/util/privilege-storage.cpp",
+    "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/ComplexArgumentParser.cpp",
+    "${chip_root}/zzz_generated/controller-clusters/zap-generated/CHIPClusters.h",
+    "commands/clusters/ClusterCommandBridge.h",
+    "commands/clusters/ModelCommandBridge.mm",
+    "commands/clusters/ReportCommandBridge.h",
+    "commands/clusters/WriteAttributeCommandBridge.h",
+    "commands/common/CHIPCommandBridge.mm",
+    "commands/common/CHIPCommandStorageDelegate.mm",
+    "commands/common/CHIPToolKeypair.mm",
+    "commands/common/MTRError.mm",
+    "commands/common/MTRError_Utils.h",
+    "commands/common/MTRLogging.h",
+    "commands/pairing/Commands.h",
+    "commands/pairing/OpenCommissioningWindowCommand.h",
+    "commands/pairing/OpenCommissioningWindowCommand.mm",
+    "commands/pairing/PairingCommandBridge.mm",
+    "commands/pairing/PairingDelegateBridge.mm",
+    "commands/payload/SetupPayloadParseCommand.mm",
+    "commands/storage/Commands.h",
+    "commands/storage/StorageManagementCommand.mm",
+    "main.mm",
+  ]
+
+  if (config_use_interactive_mode) {
+    sources += [ "commands/interactive/InteractiveCommands.mm" ]
+    deps += [ "${editline_root}:editline" ]
+  }
+
+  if (config_enable_yaml_tests) {
+    sources += [ "${chip_root}/zzz_generated/darwin-framework-tool/zap-generated/cluster/MTRTestClustersObjc.mm" ]
+  }
+
+  deps = [
+    "${chip_root}/examples/chip-tool:chip-tool-utils",
+    "${chip_root}/src/app/server",
+    "${chip_root}/src/darwin/Framework/CHIP:static-matter",
+    "${chip_root}/src/lib",
+    "${chip_root}/src/platform",
+    "${chip_root}/third_party/inipp",
+    "${chip_root}/third_party/jsoncpp",
+  ]
+
+  frameworks = [
+    "Matter.framework",
+    "Security.framework",
+  ]
+
+  public_configs = [ ":config" ]
+
+  output_dir = root_out_dir
+}

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -274,7 +274,6 @@ def HostTargets():
     builder.AppendVariant(name="clang", use_clang=True),
     builder.AppendVariant(name="test", extra_tests=True),
 
-    builder.WhitelistVariantNameForGlob('no-interactive-ipv6only')
     builder.WhitelistVariantNameForGlob('ipv6only')
 
     for target in app_targets:
@@ -285,12 +284,7 @@ def HostTargets():
             builder.targets.append(target)
 
     for target in builder.AllVariants():
-        if cross_compile and 'chip-tool' in target.name and 'arm64' in target.name and '-no-interactive' not in target.name:
-            # Interactive builds will not compile by default on arm cross compiles
-            # because libreadline is not part of the default sysroot
-            yield target.GlobBlacklist('Arm crosscompile does not support libreadline-dev')
-        else:
-            yield target
+        yield target
 
     # Without extra build variants
     yield target_native.Extend('chip-cert', app=HostApp.CERT_TOOL)

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -11,10 +11,15 @@ bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
  gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-ipv6only'
 
-# Generating linux-arm64-chip-tool-no-interactive-ipv6only
+# Generating linux-arm64-chip-tool
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false config_use_interactive_mode=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-no-interactive-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool'
+
+# Generating linux-arm64-chip-tool-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only'
 
 # Generating linux-arm64-lock
 bash -c '
@@ -102,9 +107,6 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-chip-tool-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-chip-tool-ipv6only
 
-# Generating linux-x64-chip-tool-no-interactive-ipv6only
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '--args=chip_inet_config_enable_ipv4=false config_use_interactive_mode=false' {out}/linux-x64-chip-tool-no-interactive-ipv6only
-
 # Generating linux-x64-lock
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/linux {out}/linux-x64-lock
 
@@ -165,8 +167,11 @@ ninja -C {out}/linux-arm64-all-clusters
 # Building linux-arm64-all-clusters-ipv6only
 ninja -C {out}/linux-arm64-all-clusters-ipv6only
 
-# Building linux-arm64-chip-tool-no-interactive-ipv6only
-ninja -C {out}/linux-arm64-chip-tool-no-interactive-ipv6only
+# Building linux-arm64-chip-tool
+ninja -C {out}/linux-arm64-chip-tool
+
+# Building linux-arm64-chip-tool-ipv6only
+ninja -C {out}/linux-arm64-chip-tool-ipv6only
 
 # Building linux-arm64-lock
 ninja -C {out}/linux-arm64-lock
@@ -227,9 +232,6 @@ ninja -C {out}/linux-x64-chip-tool
 
 # Building linux-x64-chip-tool-ipv6only
 ninja -C {out}/linux-x64-chip-tool-ipv6only
-
-# Building linux-x64-chip-tool-no-interactive-ipv6only
-ninja -C {out}/linux-x64-chip-tool-no-interactive-ipv6only
 
 # Building linux-x64-lock
 ninja -C {out}/linux-x64-lock

--- a/third_party/editline/BUILD.gn
+++ b/third_party/editline/BUILD.gn
@@ -1,0 +1,33 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+config("editline_config") {
+  include_dirs = [ "repo/include" ]
+}
+
+static_library("editline") {
+  public = [ "repo/include/editline.h" ]
+
+  sources = [
+    "repo/src/complete.c",
+    "repo/src/editline.c",
+    "repo/src/editline.h",
+    "repo/src/sysunix.c",
+    "repo/src/unix.h",
+  ]
+
+  public_configs = [ ":editline_config" ]
+
+  include_dirs = [ "include" ]
+}

--- a/third_party/editline/include/config.h
+++ b/third_party/editline/include/config.h
@@ -1,0 +1,171 @@
+/* config.h.  Generated from config.h.in by configure.  */
+/* config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to 1 if the `closedir' function returns void instead of int. */
+/* #undef CLOSEDIR_VOID */
+
+/* Define to include ANSI arrow keys support. */
+#define CONFIG_ANSI_ARROWS 1
+
+/* Define to enable EOF (Ctrl-D) key. */
+#define CONFIG_EOF 1
+
+/* Define to enable SIGINT (Ctrl-C) key. */
+#define CONFIG_SIGINT 1
+
+/* Define to enable SIGSTOP (Ctrl-Z) key. */
+/* #undef CONFIG_SIGSTOP */
+
+/* Define to enable terminal bell on completion. */
+/* #undef CONFIG_TERMINAL_BELL */
+
+/* Define to skip duplicate lines in the scrollback history. */
+#define CONFIG_UNIQUE_HISTORY 1
+
+/* Define to use the termcap library for terminal size. */
+/* #undef CONFIG_USE_TERMCAP */
+
+/* Define to 1 if `TIOCGWINSZ' requires <sys/ioctl.h>. */
+#define GWINSZ_IN_SYS_IOCTL 1
+
+/* Define to 1 if you have the <dirent.h> header file, and it defines `DIR'.
+ */
+#define HAVE_DIRENT_H 1
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+#define HAVE_DLFCN_H 1
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#define HAVE_INTTYPES_H 1
+
+/* Define to 1 if you have the `curses' library (-lcurses). */
+/* #undef HAVE_LIBCURSES */
+
+/* Define to 1 if you have the `ncurses' library (-lncurses). */
+/* #undef HAVE_LIBNCURSES */
+
+/* Define to 1 if you have the `termcap' library (-ltermcap). */
+/* #undef HAVE_LIBTERMCAP */
+
+/* Define to 1 if you have the `terminfo' library (-lterminfo). */
+/* #undef HAVE_LIBTERMINFO */
+
+/* Define to 1 if you have the `tinfo' library (-ltinfo). */
+/* #undef HAVE_LIBTINFO */
+
+/* Define to 1 if you have the <malloc.h> header file. */
+/* #undef HAVE_MALLOC_H */
+
+/* Define to 1 if you have the <ndir.h> header file, and it defines `DIR'. */
+/* #undef HAVE_NDIR_H */
+
+/* Define to 1 if you have the `perror' function. */
+#define HAVE_PERROR 1
+
+/* Define to 1 if you have the <sgtty.h> header file. */
+#define HAVE_SGTTY_H 1
+
+/* Define to 1 if you have the <signal.h> header file. */
+#define HAVE_SIGNAL_H 1
+
+/* Define to 1 if `stat' has the bug that it succeeds when given the
+   zero-length file name argument. */
+/* #undef HAVE_STAT_EMPTY_STRING_BUG */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#define HAVE_STDINT_H 1
+
+/* Define to 1 if you have the <stdio.h> header file. */
+#define HAVE_STDIO_H 1
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if you have the `strchr' function. */
+#define HAVE_STRCHR 1
+
+/* Define to 1 if you have the `strdup' function. */
+#define HAVE_STRDUP 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+#define HAVE_STRINGS_H 1
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the `strrchr' function. */
+#define HAVE_STRRCHR 1
+
+/* Define to 1 if you have the <sys/dir.h> header file, and it defines `DIR'.
+ */
+/* #undef HAVE_SYS_DIR_H */
+
+/* Define to 1 if you have the <sys/ndir.h> header file, and it defines `DIR'.
+ */
+/* #undef HAVE_SYS_NDIR_H */
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the `tcgetattr' function. */
+#define HAVE_TCGETATTR 1
+
+/* Define to 1 if you have the <termcap.h> header file. */
+#define HAVE_TERMCAP_H 1
+
+/* Define to 1 if you have the <termios.h> header file. */
+#define HAVE_TERMIOS_H 1
+
+/* Define to 1 if you have the <termio.h> header file. */
+#define HAVE_TERMIO_H 1
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#define HAVE_UNISTD_H 1
+
+/* Define to 1 if `lstat' dereferences a symlink specified with a trailing
+   slash. */
+#define LSTAT_FOLLOWS_SLASHED_SYMLINK 1
+
+/* Define to the sub-directory where libtool stores uninstalled libraries. */
+#define LT_OBJDIR ".libs/"
+
+/* Name of package */
+#define PACKAGE "editline"
+
+/* Define to the address where bug reports for this package should be sent. */
+#define PACKAGE_BUGREPORT "https://github.com/troglobit/editline/issues"
+
+/* Define to the full name of this package. */
+#define PACKAGE_NAME "editline"
+
+/* Define to the full name and version of this package. */
+#define PACKAGE_STRING "editline 1.17.1"
+
+/* Define to the one symbol short name of this package. */
+#define PACKAGE_TARNAME "editline"
+
+/* Define to the home page for this package. */
+#define PACKAGE_URL ""
+
+/* Define to the version of this package. */
+#define PACKAGE_VERSION "1.17.1"
+
+/* Define to 1 if the `S_IS*' macros in <sys/stat.h> do not work properly. */
+/* #undef STAT_MACROS_BROKEN */
+
+/* Define to 1 if all of the C90 standard headers exist (not just the ones
+   required in a freestanding environment). This macro is provided for
+   backward compatibility; new code need not use it. */
+#define STDC_HEADERS 1
+
+/* Default to UNIX backend, should be detected. */
+#define SYS_UNIX 1
+
+/* Version number of package */
+#define VERSION "1.17.1"
+
+/* Define to `unsigned int' if <sys/types.h> does not define. */
+/* #undef size_t */


### PR DESCRIPTION
#### Problem
* Master branch no longer produces the `no-interactive` builds for linux on arm64. This makes things inconsistent. For test purposes, we'd like to use the same build.

#### Change overview
* 2022-07-12     Target non-interactive Linux example build in CI (#20635)
* 2022-07-06    Don't sweat interactive mode in build_examples.py (#20389)
* 2022-07-06    Switch from readline to editline (#20330)

#### Testing
* Tested in CI