### PR TITLE
[tv-casting-app] Add skeleton support for tests command into chip-tv-casting-app

### DIFF
--- a/examples/tv-casting-app/linux/BUILD.gn
+++ b/examples/tv-casting-app/linux/BUILD.gn
@@ -17,8 +17,13 @@ import("//build_overrides/chip.gni")
 import("args.gni")
 
 import("${chip_root}/build/chip/tools.gni")
+import("${chip_root}/examples/tv-casting-app/linux/tv-casting-app.gni")
 
 assert(chip_build_tools)
+
+config("config") {
+  defines = [ "CONFIG_ENABLE_YAML_TESTS=${config_enable_yaml_tests}" ]
+}
 
 executable("chip-tv-casting-app") {
   sources = [
@@ -39,6 +44,20 @@ executable("chip-tv-casting-app") {
     "${chip_root}/third_party/jsoncpp",
   ]
 
+  if (config_enable_yaml_tests) {
+    sources += [ "tests/TestCommand.cpp" ]
+
+    deps += [
+      "${chip_root}/src/app/tests/suites/commands/commissioner",
+      "${chip_root}/src/app/tests/suites/commands/delay",
+      "${chip_root}/src/app/tests/suites/commands/discovery",
+      "${chip_root}/src/app/tests/suites/commands/interaction_model",
+      "${chip_root}/src/app/tests/suites/commands/log",
+      "${chip_root}/src/app/tests/suites/commands/system",
+      "${chip_root}/src/app/tests/suites/pics",
+    ]
+  }
+
   include_dirs =
       [ "${chip_root}/examples/tv-casting-app/tv-casting-common/include" ]
 
@@ -47,6 +66,8 @@ executable("chip-tv-casting-app") {
   if (chip_build_libshell) {
     cflags += [ "-DENABLE_CHIP_SHELL" ]
   }
+
+  public_configs = [ ":config" ]
 
   output_dir = root_out_dir
 }

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -20,6 +20,7 @@
 #include "commands/common/Commands.h"
 #include "commands/example/ExampleCredentialIssuerCommands.h"
 #include <zap-generated/cluster/Commands.h>
+#include <zap-generated/test/Commands.h>
 
 #include "CastingServer.h"
 #include "CastingUtils.h"
@@ -149,6 +150,7 @@ int main(int argc, char * argv[])
         [](System::Layer *, void *) { chip::DeviceLayer::PlatformMgr().ScheduleWork(InitCommissioningFlow); }, nullptr);
 
     registerClusters(gCommands, &gCredIssuerCommands);
+    registerCommandsTests(gCommands, &gCredIssuerCommands);
     registerClusterSubscriptions(gCommands, &gCredIssuerCommands);
 
     if (argc > 1)

--- a/examples/tv-casting-app/linux/tests/TestCommand.cpp
+++ b/examples/tv-casting-app/linux/tests/TestCommand.cpp
@@ -1,0 +1,43 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include <commands/tests/TestCommand.h>
+
+CHIP_ERROR TestCommand::RunCommand()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR TestCommand::WaitForCommissionee(const char * identity,
+                                            const chip::app::Clusters::DelayCommands::Commands::WaitForCommissionee::Type & value)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+void TestCommand::OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device) {}
+
+void TestCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error) {}
+
+void TestCommand::ExitAsync(intptr_t context) {}
+
+void TestCommand::Exit(std::string message, CHIP_ERROR err) {}
+
+CHIP_ERROR TestCommand::ContinueOnChipMainThread(CHIP_ERROR err)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}

--- a/examples/tv-casting-app/linux/tv-casting-app.gni
+++ b/examples/tv-casting-app/linux/tv-casting-app.gni
@@ -1,0 +1,20 @@
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+
+declare_args() {
+  config_enable_yaml_tests = true
+}

--- a/examples/tv-casting-app/linux/tv-casting-app.gni
+++ b/examples/tv-casting-app/linux/tv-casting-app.gni
@@ -16,5 +16,5 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 declare_args() {
-  config_enable_yaml_tests = true
+  config_enable_yaml_tests = false
 }

--- a/examples/tv-casting-app/tv-casting-common/commands/common/CHIPCommand.cpp
+++ b/examples/tv-casting-app/tv-casting-common/commands/common/CHIPCommand.cpp
@@ -28,6 +28,9 @@
 #include "TraceHandlers.h"
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
 
+// This is unused but it is needed by the CHIPCommand interface at the moment.
+chip::Controller::DeviceCommissioner gCommissioner;
+
 CHIP_ERROR CHIPCommand::Run()
 {
     CHIP_ERROR err = StartWaiting(GetWaitDuration());
@@ -82,4 +85,9 @@ CHIP_ERROR CHIPCommand::StartWaiting(chip::System::Clock::Timeout duration)
 void CHIPCommand::StopWaiting()
 {
     Shutdown();
+}
+
+chip::Controller::DeviceCommissioner & CHIPCommand::GetCommissioner(const char * identity)
+{
+    return gCommissioner;
 }


### PR DESCRIPTION
#### Problem

The `tv-casting-app` is meant to be used in conjunction with the `tv-app` and the TV tests are generally targeting this combo.
This PR adds some glue to have a way to do `chip-tv-casting-app tests TV_ChannelCluster` once the `tv-casting-app` has been commissioned already.
There are certainly more changes to do to make it works the way it should, and this is why it is turned off by default by a compile flags.

#### Change overview
 * Links the `tv-casting-app` to the generated YAML tests

#### Testing
I have successfully run `chip-tv-casting-app tests TV_KeypadInputCluster` and observed that `chip-tv-casting-app tests TV_ChannelCluster` fails on an unsupported access. This suggest the current skeleton is enough to move forward.