### PR TITLE
[OTA] Set MRP Active Retry interval for ota-provider-app on Linux

### DIFF
--- a/examples/ota-provider-app/linux/include/CHIPProjectAppConfig.h
+++ b/examples/ota-provider-app/linux/include/CHIPProjectAppConfig.h
@@ -32,3 +32,16 @@
 
 // Allows app options (ports) to be configured on launch of app
 #define CHIP_DEVICE_ENABLE_PORT_PARAMS 1
+
+/**
+ *  @def CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
+ *
+ *  @brief
+ *    Active retransmit interval, or time to wait before retransmission after
+ *    subsequent failures in milliseconds.
+ *
+ *  This is the default value, that might be adjusted by end device depending on its
+ *  needs (e.g. sleeping period) using Service Discovery TXT record CRA key.
+ *
+ */
+#define CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL (2000_ms32)


### PR DESCRIPTION
#### Problem
Currently the ota-provider-app uses the default value of 300ms for MRP Active Retry interval. This value is too low for Thread networks where a packet/ACK round-trip time routinely exceeds 300ms. This results in hundreds of re-transmissions during OTA downloads.

#### Change overview
Set MRP Active Retry interval for ota-provider-app on Linux to 2000ms

#### Testing
Tested OTA Software update with an EFR32 BRD4161 in the following network configuration:
ota-provider-app(Linux)---ethernet---OTBR---thread---EndDevice
The number of re-transmissions went from an average of 1050 to 8.