### PR TITLE
[IME] AddressSanitizer: SEGV on unknown address when calling Server::…

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -45,11 +45,15 @@ InteractionModelEngine * InteractionModelEngine::GetInstance()
 
 CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable)
 {
+    VerifyOrReturnError(mpExchangeMgr == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mpFabricTable == nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(apExchangeMgr != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(apFabricTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+
     mpExchangeMgr = apExchangeMgr;
     mpFabricTable = apFabricTable;
 
     ReturnErrorOnFailure(mpExchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::InteractionModel::Id, this));
-    VerifyOrReturnError(mpFabricTable != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     mReportingEngine.Init();
     mMagic++;
@@ -61,6 +65,9 @@ CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeM
 
 void InteractionModelEngine::Shutdown()
 {
+    VerifyOrReturn(mpExchangeMgr != nullptr);
+    VerifyOrReturn(mpFabricTable != nullptr);
+
     CommandHandlerInterface * handlerIter = mCommandHandlerList;
 
     //
@@ -122,6 +129,9 @@ void InteractionModelEngine::Shutdown()
     mEventPathPool.ReleaseAll();
     mDataVersionFilterPool.ReleaseAll();
     mpExchangeMgr->UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::InteractionModel::Id);
+
+    mpExchangeMgr = nullptr;
+    mpFabricTable = nullptr;
 }
 
 uint32_t InteractionModelEngine::GetNumActiveReadHandlers() const

--- a/src/app/tests/TestInteractionModelEngine.cpp
+++ b/src/app/tests/TestInteractionModelEngine.cpp
@@ -98,6 +98,8 @@ void TestInteractionModelEngine::TestAttributePathParamsPushRelease(nlTestSuite 
 
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 0);
+
+    InteractionModelEngine::GetInstance()->Shutdown();
 }
 
 void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuite * apSuite, void * apContext)
@@ -221,6 +223,8 @@ void TestInteractionModelEngine::TestRemoveDuplicateConcreteAttribute(nlTestSuit
     InteractionModelEngine::GetInstance()->RemoveDuplicateConcreteAttributePath(attributePathParamsList);
     NL_TEST_ASSERT(apSuite, GetAttributePathListLength(attributePathParamsList) == 2);
     InteractionModelEngine::GetInstance()->ReleaseAttributePathList(attributePathParamsList);
+
+    InteractionModelEngine::GetInstance()->Shutdown();
 }
 
 } // namespace app
@@ -238,11 +242,25 @@ const nlTest sTests[] =
 // clang-format on
 
 // clang-format off
+
+/**
+ *  Set up the test suite.
+ */
+int Test_Setup(void * inContext)
+{
+    VerifyOrReturnError(TestContext::Initialize(inContext) == SUCCESS, FAILURE);
+
+    // The interaction model engine has been inited in AppContext::Init so shutdown it first.
+    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
+
+    return SUCCESS;
+}
+
 nlTestSuite sSuite =
 {
     "TestInteractionModelEngine",
     &sTests[0],
-    TestContext::Initialize,
+    &Test_Setup,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -2776,11 +2776,25 @@ const nlTest sTests[] =
 // clang-format on
 
 // clang-format off
+
+/**
+ *  Set up the test suite.
+ */
+int Test_Setup(void * inContext)
+{
+    VerifyOrReturnError(TestContext::Initialize(inContext) == SUCCESS, FAILURE);
+
+    // The interaction model engine has been inited in AppContext::Init so shutdown it first.
+    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
+
+    return SUCCESS;
+}
+
 nlTestSuite sSuite =
 {
     "TestReadInteraction",
     &sTests[0],
-    TestContext::Initialize,
+    &Test_Setup,
     TestContext::Finalize
 };
 // clang-format on

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -520,6 +520,9 @@ void TestWriteInteraction::TestWriteRoundtrip(nlTestSuite * apSuite, void * apCo
 {
     TestContext & ctx = *static_cast<TestContext *>(apContext);
 
+    // The interaction model engine has been inited in AppContext::Init so shutdown it first.
+    chip::app::InteractionModelEngine::GetInstance()->Shutdown();
+
     CHIP_ERROR err = CHIP_NO_ERROR;
 
     Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
@@ -582,6 +585,7 @@ const nlTest sTests[] =
  */
 int Test_Setup(void * inContext)
 {
+    ChipLogError(chipTool, "Doing setup....");
     VerifyOrReturnError(CHIP_NO_ERROR == chip::Platform::MemoryInit(), FAILURE);
 
     VerifyOrReturnError(TestContext::Initialize(inContext) == SUCCESS, FAILURE);


### PR DESCRIPTION
…Shutdown

#### Problem

When the server  code in `src/app/server` fails to start properly, for example because of some corrupted files in the KVS calling `Server::Shutdown` results into a crash.

For example one my box, the server fails to load properly with the following error message:
```
[1657637457744] [57896:38405541] CHIP: [DMG] DefaultAclStorage: failed ../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/platform/Darwin/KeyValueStoreManagerImpl.mm:247: CHIP Error 0x00000019: Buffer too small
[1657637457744] [57896:38405541] CHIP: [SVR] ERROR setting up transport: ../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/platform/Darwin/KeyValueStoreManagerImpl.mm:247: CHIP Error 0x00000019: Buffer too small
```

Then when I'm trying to stop the server cleanly I got:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==56232==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000098 (pc 0x000109e42536 bp 0x7ffee6397ed0 sp 0x7ffee6397ec0 T0)
==56232==The signal is caused by a READ memory access.
==56232==Hint: address points to the zero page.
    #0 0x109e42536 in chip::Messaging::ExchangeManager::UnsolicitedMessageHandlerSlot::IsInUse() const ExchangeMgr.h:206
    #1 0x109e41f22 in chip::Messaging::ExchangeManager::UnregisterUMH(chip::Protocols::Id, short) ExchangeMgr.cpp:177
    #2 0x109e41c4c in chip::Messaging::ExchangeManager::UnregisterUnsolicitedMessageHandlerForProtocol(chip::Protocols::Id) ExchangeMgr.cpp:135
    #3 0x109b9728a in chip::app::InteractionModelEngine::Shutdown() InteractionModelEngine.cpp:124
    #4 0x109fafd5d in chip::Server::Shutdown() Server.cpp:426
    #5 0x1098b7db1 in ChipLinuxAppMainLoop() AppMain.cpp:356
    #6 0x10986a510 in main main.cpp:30
    #7 0x7fff20383f5c in start+0x0 (libdyld.dylib:x86_64+0x15f5c)
```

It happens because someone `InteractionModelEngine::Shutdown` is dereferencing its `mpExchangeMgr` pointer which is not initialized.


#### Change overview
* Add a "State" to the IME and use it.

#### Testing
Properly stopping the server app does not crash anymore.