### PR TITLE
Clean up P6 SDK paths

### DIFF
--- a/build_overrides/p6.gni
+++ b/build_overrides/p6.gni
@@ -16,3 +16,8 @@ declare_args() {
   # Root directory for p6 SDK build files.
   p6_sdk_build_root = "//third_party/p6"
 }
+
+declare_args() {
+  # Root directory for p6 SDK sources.
+  p6_sdk_root = "${p6_sdk_build_root}/p6_sdk"
+}

--- a/examples/all-clusters-app/p6/BUILD.gn
+++ b/examples/all-clusters-app/p6/BUILD.gn
@@ -41,8 +41,7 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  linker_script =
-      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
 
   ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
@@ -100,21 +99,21 @@ p6_sdk_sources("all_clusters_app_sdk_sources") {
 
   if (chip_enable_ota_requestor) {
     sources += [
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     ]
     include_dirs += [
-      "${chip_root}/third_party/p6/p6_sdk/ota/config",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+      "${p6_sdk_root}/ota/config",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
     ]
     public_configs += [ ":p6_ota_config" ]
   }

--- a/examples/all-clusters-minimal-app/p6/BUILD.gn
+++ b/examples/all-clusters-minimal-app/p6/BUILD.gn
@@ -41,8 +41,7 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  linker_script =
-      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
 
   ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
@@ -100,21 +99,21 @@ p6_sdk_sources("all_clusters_app_sdk_sources") {
 
   if (chip_enable_ota_requestor) {
     sources += [
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     ]
     include_dirs += [
-      "${chip_root}/third_party/p6/p6_sdk/ota/config",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+      "${p6_sdk_root}/ota/config",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
     ]
     public_configs += [ ":p6_ota_config" ]
   }

--- a/examples/build_overrides/p6.gni
+++ b/examples/build_overrides/p6.gni
@@ -16,3 +16,8 @@ declare_args() {
   # Root directory for P6 SDK.
   p6_sdk_build_root = "//third_party/connectedhomeip/third_party/p6"
 }
+
+declare_args() {
+  # Root directory for p6 SDK sources.
+  p6_sdk_root = "${p6_sdk_build_root}/p6_sdk"
+}

--- a/examples/lighting-app/p6/BUILD.gn
+++ b/examples/lighting-app/p6/BUILD.gn
@@ -41,8 +41,7 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  linker_script =
-      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
 
   ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
@@ -99,21 +98,21 @@ p6_sdk_sources("lighting_app_sdk_sources") {
 
   if (chip_enable_ota_requestor) {
     sources += [
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     ]
     include_dirs += [
-      "${chip_root}/third_party/p6/p6_sdk/ota/config",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+      "${p6_sdk_root}/ota/config",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
     ]
     public_configs += [ ":p6_ota_config" ]
   }

--- a/examples/lock-app/p6/BUILD.gn
+++ b/examples/lock-app/p6/BUILD.gn
@@ -38,8 +38,7 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  linker_script =
-      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
 
   ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
@@ -96,21 +95,21 @@ p6_sdk_sources("lock_app_sdk_sources") {
 
   if (chip_enable_ota_requestor) {
     sources += [
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     ]
     include_dirs += [
-      "${chip_root}/third_party/p6/p6_sdk/ota/config",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+      "${p6_sdk_root}/ota/config",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
     ]
     public_configs += [ ":p6_ota_config" ]
   }

--- a/examples/ota-requestor-app/p6/BUILD.gn
+++ b/examples/ota-requestor-app/p6/BUILD.gn
@@ -40,8 +40,7 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  linker_script =
-      "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
 
   ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
@@ -88,14 +87,14 @@ p6_sdk_sources("ota_requestor_app_sdk_sources") {
     "${chip_root}/src/platform/P6",
     "${p6_project_dir}/include",
     "${examples_plat_dir}",
-    "${chip_root}/third_party/p6/p6_sdk/ota/config",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+    "${p6_sdk_root}/ota/config",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
   ]
 
   defines = [
@@ -105,12 +104,12 @@ p6_sdk_sources("ota_requestor_app_sdk_sources") {
   ]
 
   sources = [
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     "${p6_project_dir}/include/CHIPProjectConfig.h",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
   ]
 
   public_configs = [

--- a/third_party/p6/BUILD.gn
+++ b/third_party/p6/BUILD.gn
@@ -32,7 +32,7 @@ config("p6_sdk_config") {
     include_dir = string_replace(include_dir, "-I", "", 1)
 
     # Path is relative to SDK
-    include_dir = "${p6_sdk_build_root}/p6_sdk/${include_dir}"
+    include_dir = "${p6_sdk_root}/${include_dir}"
 
     _system_include_dirs += [ include_dir ]
   }
@@ -57,7 +57,7 @@ config("p6_sdk_config") {
   libs = []
   foreach(lib, mtb_json.libs) {
     # Path is relative to SDK
-    lib = "${p6_sdk_build_root}/p6_sdk/${lib}"
+    lib = "${p6_sdk_root}/${lib}"
 
     libs += [ lib ]
   }
@@ -76,7 +76,7 @@ config("p6_sdk_config") {
       linker_script = string_replace(linker_script, "-T", "", 1)
 
       # Path is relative to SDK
-      linker_script = "${p6_sdk_build_root}/p6_sdk/${linker_script}"
+      linker_script = "${p6_sdk_root}/${linker_script}"
 
       ldflags += [ "-T" + rebase_path(linker_script, root_build_dir) ]
     }

--- a/third_party/p6/p6_sdk.gni
+++ b/third_party/p6/p6_sdk.gni
@@ -27,9 +27,8 @@ if (is_debug) {
   debug_str = "Release"
 }
 
-mtb_json = read_file(
-        "$p6_sdk_build_root/p6_sdk/build/${p6_board}/$debug_str/GCC_ARM.json",
-        "json")
+mtb_json = read_file("${p6_sdk_root}/build/${p6_board}/$debug_str/GCC_ARM.json",
+                     "json")
 
 # Defines an p6 SDK build target.
 #
@@ -85,17 +84,17 @@ template("p6_sdk_sources") {
 
     # Pull out c sources from generated json
     foreach(src, mtb_json_local.c_source) {
-      sources += [ "${p6_sdk_build_root}/p6_sdk/${src}" ]
+      sources += [ "${p6_sdk_root}/${src}" ]
     }
 
     # Pull out cpp sources from generated json
     foreach(src, mtb_json_local.cxx_source) {
-      sources += [ "${p6_sdk_build_root}/p6_sdk/${src}" ]
+      sources += [ "${p6_sdk_root}/${src}" ]
     }
 
     # Pull out .S files from generated json
     foreach(asm, mtb_json_local.asm_source) {
-      sources += [ "${p6_sdk_build_root}/p6_sdk/${asm}" ]
+      sources += [ "${p6_sdk_root}/${asm}" ]
     }
 
     public_deps = []


### PR DESCRIPTION
#### Problem

P6 SDK sources are specified relative to `${chip_root}` which prevents
alternate repository layouts.

#### Change overview

Introduce a new variable p6_sdk_root for the actual root of the SDK
repository and use this to specify SDK paths.

This avoids forcing locating the SDK submodule at a particular location
in the Matter SDK directory, as projects may want to use a different
layout.

#### Testing

CI