### PR TITLE
Resolve crasher in Matter.framework when parsing query image params

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -158,7 +158,9 @@ void MTROTAProviderDelegateBridge::ConvertToQueryImageParams(
     }
 
     if (commandData.location.HasValue()) {
-        commandParams.location = [NSString stringWithUTF8String:commandData.location.Value().data()];
+        commandParams.location = [[NSString alloc] initWithBytes:commandData.location.Value().data()
+                                                          length:commandData.location.Value().size()
+                                                        encoding:NSUTF8StringEncoding];
     }
 
     if (commandData.requestorCanConsent.HasValue()) {


### PR DESCRIPTION
#### Problem
When matter framework calls `ConvertToQueryImageParams` to convert data from SDK to Objective-C class, the framework crashes on conversion of location because `ByteSpan` can have extraneous data. 

#### Change overview
- Convert ByteSpan to NSData and then to NSString.

#### Testing
- Ran scenario that causes crash and no longer reproduces.  
