### PR TITLE
darwin-framework-tool: Remove racy access to readline

### DIFF
--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -32,8 +32,6 @@ constexpr const char * kInteractiveModeStopCommand = "quit()";
 
 namespace {
 
-bool gIsCommandRunning = NO;
-
 void ClearLine()
 {
     printf("\r\x1B[0J"); // Move cursor to the beginning of the line and clear from cursor to end of the screen
@@ -44,10 +42,6 @@ void ENFORCE_FORMAT(3, 0) LoggingCallback(const char * module, uint8_t category,
     ClearLine();
     chip::Logging::Platform::LogV(module, category, msg, args);
     ClearLine();
-
-    if (gIsCommandRunning == NO) {
-        rl_forced_update_display();
-    }
 }
 } // namespace
 
@@ -104,9 +98,7 @@ bool InteractiveStartCommand::ParseCommand(char * command)
     std::stringstream ss(command);
     while (ss >> std::quoted(arg)) {
         if (argsCount == kInteractiveModeArgumentsMaxLength) {
-            gIsCommandRunning = YES;
             ChipLogError(chipTool, "Too many arguments. Ignoring.");
-            gIsCommandRunning = NO;
             return YES;
         }
 
@@ -116,9 +108,7 @@ bool InteractiveStartCommand::ParseCommand(char * command)
     }
 
     ClearLine();
-    gIsCommandRunning = YES;
     mHandler->RunInteractive(argsCount, args);
-    gIsCommandRunning = NO;
 
     // Do not delete arg[0]
     while (--argsCount)


### PR DESCRIPTION
### Problem
It's not safe to access line editing state from the IO thread while
inside readline() on the main thread. This is causing crashes
and the following tsan diagnostic:
```
AddressSanitizer:DEADLYSIGNAL
=================================================================
==31949==ERROR: AddressSanitizer: SEGV on unknown address 0x000000000000 (pc 0x00010d676bfb bp 0x7ff7b44e0c10 sp 0x7ff7b44e0be0 T0)
==31949==The signal is caused by a WRITE memory access.
==31949==Hint: address points to the zero page.
    #0 0x10d676bfb in tty_put editline.c:179
    #1 0x10d676b67 in tty_puts editline.c:193
    #2 0x10d677251 in redisplay editline.c:634
    #3 0x10d67783a in rl_forced_update_display editline.c:1415
    #4 0x10d53f8f3 in (anonymous namespace)::LoggingCallback(char const*, unsigned char, char const*, __va_list_tag*) InteractiveCommands.mm:49
    #5 0x10d65cfdc in chip::Logging::LogV(unsigned char, unsigned char, char const*, __va_list_tag*) CHIPLogging.cpp:221
    #6 0x10d65ce07 in chip::Logging::Log(unsigned char, unsigned char, char const*, ...) CHIPLogging.cpp:172
    #7 0x10ba59dd6 in CHIPCommandBridge::ShutdownCommissioner() CHIPCommandBridge.mm:137
    #8 0x10ba59983 in CHIPCommandBridge::MaybeTearDownStack() CHIPCommandBridge.mm:117
    #9 0x10ba57469 in CHIPCommandBridge::Run() CHIPCommandBridge.mm:54
    #10 0x10d611720 in Commands::RunCommand(int, char**, bool) Commands.cpp:147
    #11 0x10d60fdbd in Commands::Run(int, char**) Commands.cpp:51
    #12 0x10bb92586 in main main.mm:41
    #13 0x7ffb2fcaf23b  (<unknown module>)

==31949==Register values:
rax = 0x0000000000000000  rbx = 0x00007ff7b44e0d00  rcx = 0x000010000000000d  rdx = 0x0000000000000000  
rdi = 0x000000000000000d  rsi = 0x00000000000120a8  rbp = 0x00007ff7b44e0c10  rsp = 0x00007ff7b44e0be0  
 r8 = 0x00007ff854d72f88   r9 = 0x0000000000000000  r10 = 0x00000000ffffff00  r11 = 0x00007ff854d72f80  
r12 = 0x00007ff7b44e2540  r13 = 0x000000010eaeace0  r14 = 0x000000010bb92410  r15 = 0x00007ff7b44e2540  
AddressSanitizer can not provide additional info.
SUMMARY: AddressSanitizer: SEGV editline.c:179 in tty_put
==31949==ABORTING
zsh: abort      ./out/darwin-x64-darwin-framework-tool-no-ble-asan/darwin-framework-tool  
```

### Change overview

Remove the code that attempts to redraw readline after printing logs.
This avoids segfaults during logging at the cost of those logs
overwriting the prompt (this is not trivial to fix as readline
is a blocking API).

### Testing

- Run chip-tool interactive.
- Quit interactive and verify issue is resolved.
