### PR TITLE
Target interactive Linux example build in CI

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -70,7 +70,7 @@ jobs:
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
                         --target linux-arm64-all-clusters \
-                        --target linux-arm64-chip-tool-no-interactive-ipv6only \
+                        --target linux-arm64-chip-tool-ipv6only \
                         --target linux-arm64-lock \
                         --target linux-arm64-minmdns \
                         --target linux-arm64-thermostat-no-ble \
@@ -80,8 +80,8 @@ jobs:
               timeout-minutes: 5
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
-                    linux arm64 chip-tool-no-interactive-ipv6only \
-                    out/linux-arm64-chip-tool-no-interactive-ipv6only/chip-tool \
+                    linux arm64 chip-tool-ipv6only \
+                    out/linux-arm64-chip-tool-ipv6only/chip-tool \
                     /tmp/bloat_reports/
             - name: Bloat report - thermostat
               timeout-minutes: 5


### PR DESCRIPTION
#### Problem
* Targets in linux-example-arm should be updated after removing `no-interactive` build in #20389

#### Change overview
* Use `interactive` build in linux-example-arm workflow.

#### Testing
* Tested in CI