### PR TITLE
Clean up P6 SDK paths

### DIFF
--- a/build_overrides/p6.gni
+++ b/build_overrides/p6.gni
@@ -16,3 +16,8 @@ declare_args() {
   # Root directory for p6 SDK build files.
   p6_sdk_build_root = "//third_party/p6"
 }
+
+declare_args() {
+  # Root directory for p6 SDK sources.
+  p6_sdk_root = "${p6_sdk_build_root}/p6_sdk"
+}

--- a/examples/all-clusters-app/p6/BUILD.gn
+++ b/examples/all-clusters-app/p6/BUILD.gn
@@ -41,10 +41,9 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 
@@ -100,21 +99,21 @@ p6_sdk_sources("all_clusters_app_sdk_sources") {
 
   if (chip_enable_ota_requestor) {
     sources += [
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     ]
     include_dirs += [
-      "${chip_root}/third_party/p6/p6_sdk/ota/config",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+      "${p6_sdk_root}/ota/config",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
     ]
     public_configs += [ ":p6_ota_config" ]
   }

--- a/examples/all-clusters-minimal-app/p6/BUILD.gn
+++ b/examples/all-clusters-minimal-app/p6/BUILD.gn
@@ -41,10 +41,9 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 
@@ -100,21 +99,21 @@ p6_sdk_sources("all_clusters_app_sdk_sources") {
 
   if (chip_enable_ota_requestor) {
     sources += [
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     ]
     include_dirs += [
-      "${chip_root}/third_party/p6/p6_sdk/ota/config",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+      "${p6_sdk_root}/ota/config",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
     ]
     public_configs += [ ":p6_ota_config" ]
   }

--- a/examples/build_overrides/p6.gni
+++ b/examples/build_overrides/p6.gni
@@ -16,3 +16,8 @@ declare_args() {
   # Root directory for P6 SDK.
   p6_sdk_build_root = "//third_party/connectedhomeip/third_party/p6"
 }
+
+declare_args() {
+  # Root directory for p6 SDK sources.
+  p6_sdk_root = "${p6_sdk_build_root}/p6_sdk"
+}

--- a/examples/lighting-app/p6/BUILD.gn
+++ b/examples/lighting-app/p6/BUILD.gn
@@ -41,10 +41,9 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 
@@ -99,21 +98,21 @@ p6_sdk_sources("lighting_app_sdk_sources") {
 
   if (chip_enable_ota_requestor) {
     sources += [
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     ]
     include_dirs += [
-      "${chip_root}/third_party/p6/p6_sdk/ota/config",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+      "${p6_sdk_root}/ota/config",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
     ]
     public_configs += [ ":p6_ota_config" ]
   }

--- a/examples/lock-app/p6/BUILD.gn
+++ b/examples/lock-app/p6/BUILD.gn
@@ -38,10 +38,9 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 
@@ -96,21 +95,21 @@ p6_sdk_sources("lock_app_sdk_sources") {
 
   if (chip_enable_ota_requestor) {
     sources += [
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     ]
     include_dirs += [
-      "${chip_root}/third_party/p6/p6_sdk/ota/config",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-      "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+      "${p6_sdk_root}/ota/config",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+      "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
     ]
     public_configs += [ ":p6_ota_config" ]
   }

--- a/examples/ota-requestor-app/p6/BUILD.gn
+++ b/examples/ota-requestor-app/p6/BUILD.gn
@@ -40,10 +40,9 @@ declare_args() {
 }
 
 config("p6_ota_config") {
-  ldflags = [ "-T/" + rebase_path(
-                  "${chip_root}/third_party/p6/p6_sdk/ota/cy8c6xxa_cm4_dual_ota_int.ld",
-                  "/",
-                  "${p6_project_dir}") ]
+  linker_script = "${p6_sdk_root}/ota/cy8c6xxa_cm4_dual_ota_int.ld"
+
+  ldflags = [ "-T" + rebase_path(linker_script, root_build_dir) ]
 
   ldflags += [ "-Wl,--defsym,MCUBOOT_HEADER_SIZE=0x400,--defsym,MCUBOOT_BOOTLOADER_SIZE=0x18000,--defsym,CY_BOOT_PRIMARY_1_SIZE=0x1C0000" ]
 
@@ -88,14 +87,14 @@ p6_sdk_sources("ota_requestor_app_sdk_sources") {
     "${chip_root}/src/platform/P6",
     "${p6_project_dir}/include",
     "${examples_plat_dir}",
-    "${chip_root}/third_party/p6/p6_sdk/ota/config",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/sysflash/",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/include",
+    "${p6_sdk_root}/ota/config",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/include/flash_map_backend/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/sysflash/",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/include",
   ]
 
   defines = [
@@ -105,12 +104,12 @@ p6_sdk_sources("ota_requestor_app_sdk_sources") {
   ]
 
   sources = [
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
-    "${chip_root}/third_party/p6/p6_sdk/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
     "${p6_project_dir}/include/CHIPProjectConfig.h",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/bootutil/src/bootutil_misc.c",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_map.c",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_flash_psoc6.c",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/cy_smif_psoc6.c",
+    "${p6_sdk_root}/libs/anycloud-ota/source/mcuboot/cy_flash_pal/mem_config/mem_config_sfdp.c",
   ]
 
   public_configs = [

--- a/third_party/p6/BUILD.gn
+++ b/third_party/p6/BUILD.gn
@@ -29,9 +29,17 @@ config("p6_sdk_config") {
   _include_dirs = []
   foreach(inc, mtb_json.includes) {
     # Strip off leading -I part
-    _include_dirs += [ "/" + rebase_path(string_replace(inc, "-I", "", 1),
-                                         "/",
-                                         "${p6_sdk_build_root}/p6_sdk/") ]
+    include_dir = string_replace(include_dir, "-I", "", 1)
+
+    # Path is relative to SDK
+    include_dir = "${p6_sdk_root}/${include_dir}"
+
+    _system_include_dirs += [ include_dir ]
+  }
+
+  cflags = []
+  foreach(include_dir, _system_include_dirs) {
+    cflags += [ "-isystem" + rebase_path(include_dir, root_build_dir) ]
   }
 
   # Also add project include path (passed in from project build)
@@ -53,7 +61,10 @@ config("p6_sdk_config") {
   # Pull out static libs (.a files) from generated json
   libs = []
   foreach(lib, mtb_json.libs) {
-    libs += [ "/" + rebase_path(lib, "/", "${p6_sdk_build_root}/p6_sdk/") ]
+    # Path is relative to SDK
+    lib = "${p6_sdk_root}/${lib}"
+
+    libs += [ lib ]
   }
 
   cflags_c = mtb_json.cflags
@@ -65,10 +76,14 @@ config("p6_sdk_config") {
   # OTA app provides it's own linker script
   if (!chip_enable_ota_requestor) {
     linker_script_flags = filter_include(mtb_json.ldflags, [ "-T*" ])
-    foreach(flag, linker_script_flags) {
-      ldflags += [ "-T/" + rebase_path(string_replace(flag, "-T", "", 1),
-                                       "/",
-                                       "${p6_sdk_build_root}/p6_sdk/") ]
+    foreach(linker_script, linker_script_flags) {
+      # Strip off leading -T part
+      linker_script = string_replace(linker_script, "-T", "", 1)
+
+      # Path is relative to SDK
+      linker_script = "${p6_sdk_root}/${linker_script}"
+
+      ldflags += [ "-T" + rebase_path(linker_script, root_build_dir) ]
     }
   }
 

--- a/third_party/p6/p6_sdk.gni
+++ b/third_party/p6/p6_sdk.gni
@@ -27,9 +27,8 @@ if (is_debug) {
   debug_str = "Release"
 }
 
-mtb_json = read_file(
-        "$p6_sdk_build_root/p6_sdk/build/${p6_board}/$debug_str/GCC_ARM.json",
-        "json")
+mtb_json = read_file("${p6_sdk_root}/build/${p6_board}/$debug_str/GCC_ARM.json",
+                     "json")
 
 # Defines an p6 SDK build target.
 #
@@ -85,23 +84,17 @@ template("p6_sdk_sources") {
 
     # Pull out c sources from generated json
     foreach(src, mtb_json_local.c_source) {
-      sources += [ rebase_path(src,
-                               "${p6_project_dir}",
-                               "${p6_sdk_build_root}/p6_sdk/") ]
+      sources += [ "${p6_sdk_root}/${src}" ]
     }
 
     # Pull out cpp sources from generated json
     foreach(src, mtb_json_local.cxx_source) {
-      sources += [ rebase_path(src,
-                               "${p6_project_dir}",
-                               "${p6_sdk_build_root}/p6_sdk/") ]
+      sources += [ "${p6_sdk_root}/${src}" ]
     }
 
     # Pull out .S files from generated json
     foreach(asm, mtb_json_local.asm_source) {
-      sources += [ rebase_path(asm,
-                               "${p6_project_dir}",
-                               "${p6_sdk_build_root}/p6_sdk/") ]
+      sources += [ "${p6_sdk_root}/${asm}" ]
     }
 
     public_deps = []


### PR DESCRIPTION
#### Problem

P6 SDK sources are specified relative to `${chip_root}` which prevents
alternate repository layouts.

#### Change overview

Introduce a new variable p6_sdk_root for the actual root of the SDK
repository and use this to specify SDK paths.

This avoids forcing locating the SDK submodule at a particular location
in the Matter SDK directory, as projects may want to use a different
layout.

#### Testing

CI