### PR TITLE
Fail darwin-framework-tool pairing commands once the SDK says it's failed.

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/PairingDelegateBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/PairingDelegateBridge.mm
@@ -33,6 +33,7 @@
         break;
     case MTRPairingStatusFailed:
         ChipLogError(chipTool, "Secure Pairing Failed");
+        _commandBridge->SetCommandExitStatus(CHIP_ERROR_INCORRECT_STATE);
         break;
     case MTRPairingStatusUnknown:
         ChipLogError(chipTool, "Uknown Pairing Status");


### PR DESCRIPTION
That's what chip-tool does.  Without this, darwin-framework-tool ends
up sitting there until the (2-minute) command timeout.

Fixes https://github.com/project-chip/connectedhomeip/issues/20589

#### Problem
See #20589

#### Change overview
Fail out once we know we have failed.

#### Testing
Tried pairing with incorrect passcode and verified it fails out after 30-40 seconds, not 2 minutes.