### PR TITLE
Fix Test_TC_LVL_6_1

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_LVL_6_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_LVL_6_1.yaml
@@ -89,9 +89,9 @@ tests:
       arguments:
           values:
               - name: "optionMask"
-                value: 0
+                value: 1
               - name: "optionOverride"
-                value: 0
+                value: 1
 
     - label: "Physically verify that the device has stopped transitioning"
       cluster: "LogCommands"
@@ -141,9 +141,9 @@ tests:
       arguments:
           values:
               - name: "optionMask"
-                value: 0
+                value: 1
               - name: "optionOverride"
-                value: 0
+                value: 1
 
     - label: "Physically verify that the device has stopped transitioning"
       cluster: "LogCommands"

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -15612,8 +15612,8 @@ private:
             VerifyOrDo(!ShouldSkip("LVL.S.C03.Rsp"), return ContinueOnChipMainThread(CHIP_NO_ERROR));
             ListFreer listFreer;
             chip::app::Clusters::LevelControl::Commands::Stop::Type value;
-            value.optionMask     = 0U;
-            value.optionOverride = 0U;
+            value.optionMask     = 1U;
+            value.optionOverride = 1U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), LevelControl::Id, LevelControl::Commands::Stop::Id, value,
                                chip::NullOptional
 
@@ -15661,8 +15661,8 @@ private:
             LogStep(11, "Sends stop command to DUT");
             ListFreer listFreer;
             chip::app::Clusters::LevelControl::Commands::Stop::Type value;
-            value.optionMask     = 0U;
-            value.optionOverride = 0U;
+            value.optionMask     = 1U;
+            value.optionOverride = 1U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), LevelControl::Id, LevelControl::Commands::Stop::Id, value,
                                chip::NullOptional
 


### PR DESCRIPTION
#### Problem
fixes https://github.com/CHIP-Specifications/chip-certification-tool/issues/399
Light is off due to the move-to-level-with-on-off sent before in the test case. Then the move command is send with optionsMask and option Override to 1. So it is done even if the lights are off. However stop command is sent with args 0, 0 for the options override. The command is received successfully, but the action is ignored has onoff state (light) is off and the option is 0

The test waits for user input before reading the current Level. If done as soon as the prompt arrives you could read the right values but the stop action never actually happened. A user entering the input with a certain delay will read a value outside of the accepted range.

#### Change overview
make sure the stop command action is executed by setting the options override to 1

#### Testing
Manually test chip-tool tests Test_TC_LVL_6_1 --nodeId 2518
