### PR TITLE
[session] Fix #20649 - initialize active and session timestamps on session creation.

### DIFF
--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -46,6 +46,7 @@ void SecureSession::Activate(const ScopedNodeId & localNode, const ScopedNodeId 
     mPeerSessionId   = peerSessionId;
     mRemoteMRPConfig = config;
     SetFabricIndex(peerNode.GetFabricIndex());
+    MarkActiveRx(); // Initialize SessionTimestamp and ActiveTimestamp per spec.
 
     Retain(); // This ref is released inside MarkForEviction
     MoveToState(State::kActive);

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -304,8 +304,13 @@ private:
     uint16_t mPeerSessionId = 0;
 
     PeerAddress mPeerAddress;
-    System::Clock::Timestamp mLastActivityTime     = System::SystemClock().GetMonotonicTimestamp(); ///< Timestamp of last tx or rx
-    System::Clock::Timestamp mLastPeerActivityTime = System::SystemClock().GetMonotonicTimestamp(); ///< Timestamp of last rx
+
+    /// Timestamp of last tx or rx. @see SessionTimestamp in the spec
+    System::Clock::Timestamp mLastActivityTime = System::SystemClock().GetMonotonicTimestamp();
+
+    /// Timestamp of last rx. @see ActiveTimestamp in the spec
+    System::Clock::Timestamp mLastPeerActivityTime = System::SystemClock().GetMonotonicTimestamp();
+
     ReliableMessageProtocolConfig mRemoteMRPConfig = GetDefaultMRPConfig();
     CryptoContext mCryptoContext;
     SessionMessageCounter mSessionMessageCounter;


### PR DESCRIPTION
#### Problem
Fix #20649

#### Change overview
Initialize active and peer active time when session is first activated.

#### Testing
CI