### PR TITLE
Fix flashbundle name (it is based on project name) for nrf projects

### DIFF
--- a/scripts/build/builders/nrf.py
+++ b/scripts/build/builders/nrf.py
@@ -72,9 +72,9 @@ class NrfApp(Enum):
 
     def _FlashBundlePrefix(self):
         if self == NrfApp.ALL_CLUSTERS:
-            return 'chip-nrfconnect-all-clusters-example'
+            return 'chip-nrfconnect-all-clusters-app-example'
         elif self == NrfApp.ALL_CLUSTERS_MINIMAL:
-            return 'chip-nrfconnect-all-clusters-minimal-example'
+            return 'chip-nrfconnect-all-clusters-minimal-app-example'
         elif self == NrfApp.LIGHT:
             return 'chip-nrfconnect-lighting-example'
         elif self == NrfApp.LOCK:


### PR DESCRIPTION
#### Problem
NRF connect does not build artifacts with flashbundles:

```
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/out/nrf-nrf52840dk-all-clusters/chip-nrfconnect-all-clusters-example.flashbundle.txt'
```

#### Change overview
Fix the name

#### Testing
```
./scripts/build/build_examples.py --target nrf-nrf52840dk-all-clusters --enable-flashbundle build --copy-artifacts-to out/artifacts
```

now passes