### PR TITLE
Fix missmatch Endpoint/Cluster configuration (see issue #20665)

### DIFF
--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -341,7 +341,7 @@ static void InitServer(intptr_t context)
     // Set starting endpoint id where dynamic endpoints will be assigned, which
     // will be the next consecutive endpoint id after the last fixed endpoint.
     gFirstDynamicEndpointId = static_cast<chip::EndpointId>(
-        static_cast<int>(emberAfEndpointFromIndex(static_cast<uint16_t>(emberAfFixedEndpointCount() - 1))) + 1);
+        static_cast<int>(emberAfEndpointFromIndex(static_cast<uint16_t>(emberAfFixedEndpointCount() - 1))));
     gCurrentEndpointId = gFirstDynamicEndpointId;
 
     // Disable last fixed endpoint, which is used as a placeholder for all of the


### PR DESCRIPTION
Fixes #20665.

### What the problem is (not just xref to the issue)
The problem is that the README and the configuration of the cluster mismatch.
The README states that the dynamic endpoints should be on a specific location (please refer to the issue as I described it there), but the Cluster and Endpoints are configured all off by one, due to the + 1 at the end of the changed line. I guess its just a simple copy past mistake.

### How this PR fixes the problem
If you remove the + 1 then the endpoints are in the expected order and match the order of the bridge-app/linux example.
Or you could change the README to match the endpoint positions.

### How it was tested
I recompiled it and tested if the parts-list attribute of the descriptor cluster fixes the order of the endpoints and it does.