### PR TITLE
Fix validity times on certificates issued by the Darwin framework.

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -384,11 +384,15 @@ CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, Va
     {
         if (context.mEffectiveTime.Get<CurrentChipEpochTime>().count() < cert->mNotBeforeTime)
         {
+            ChipLogDetail(SecureChannel, "Certificate's mNotBeforeTime (%" PRIu32 ") is after current time (%" PRIu32 ")",
+                          cert->mNotBeforeTime, context.mEffectiveTime.Get<CurrentChipEpochTime>().count());
             validityResult = CertificateValidityResult::kNotYetValid;
         }
         else if (cert->mNotAfterTime != kNullCertTime &&
                  context.mEffectiveTime.Get<CurrentChipEpochTime>().count() > cert->mNotAfterTime)
         {
+            ChipLogDetail(SecureChannel, "Certificate's mNotAfterTime (%" PRIu32 ") is before current time (%" PRIu32 ")",
+                          cert->mNotAfterTime, context.mEffectiveTime.Get<CurrentChipEpochTime>().count());
             validityResult = CertificateValidityResult::kExpired;
         }
         else
@@ -407,6 +411,8 @@ CHIP_ERROR ChipCertificateSet::ValidateCert(const ChipCertificateData * cert, Va
         // certificate in question is expired.  Check for this.
         if (cert->mNotAfterTime != 0 && context.mEffectiveTime.Get<LastKnownGoodChipEpochTime>().count() > cert->mNotAfterTime)
         {
+            ChipLogDetail(SecureChannel, "Certificate's mNotAfterTime (%" PRIu32 ") is before last known good time (%" PRIu32 ")",
+                          cert->mNotAfterTime, context.mEffectiveTime.Get<LastKnownGoodChipEpochTime>().count());
             validityResult = CertificateValidityResult::kExpiredAtLastKnownGoodTime;
         }
         else

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -172,10 +172,8 @@ ByteSpan MTROperationalCredentialsDelegate::IntermediateCertSpan() const
 bool MTROperationalCredentialsDelegate::ToChipEpochTime(uint32_t offset, uint32_t & epoch)
 {
     NSDate * date = [NSDate dateWithTimeIntervalSinceNow:offset];
-    unsigned units = NSCalendarUnitYear | NSCalendarUnitMonth | NSCalendarUnitDay | NSCalendarUnitHour | NSCalendarUnitMinute
-        | NSCalendarUnitSecond;
     NSCalendar * calendar = [[NSCalendar alloc] initWithCalendarIdentifier:NSCalendarIdentifierGregorian];
-    NSDateComponents * components = [calendar components:units fromDate:date];
+    NSDateComponents * components = [calendar componentsInTimeZone:[NSTimeZone timeZoneForSecondsFromGMT:0] fromDate:date];
 
     uint16_t year = static_cast<uint16_t>([components year]);
     uint8_t month = static_cast<uint8_t>([components month]);


### PR DESCRIPTION
The Darwin framework was using the current timezone, not UTC, when determining
the Matter epoch time corresponding to a given offset from now.  This caused the
epoch times it computed to be off by the offset from UTC.  In timezones ahead of
UTC, this could easily lead to certificates with mNotBeforeTime set to a value
larger than the current UTC time, which would then cause those certificates to
be considered not-yet-valid.

Fixes https://github.com/project-chip/connectedhomeip/issues/20302

#### Problem
See above.

#### Change overview
Use `componentsInTimeZone` with the UTC timezone to get the right values.

#### Testing
Checked the times logged in ValidateCert per the logging suggested in #20302 and verified that I was getting mNotBeforeTime hours off from "now" (corresponding to my timezone) before this PR and get times that are almost now after this PR.