### PR TITLE
use the 0.5.85 version of imx docker image in the CI

### DIFF
--- a/.github/workflows/examples-linux-imx.yaml
+++ b/.github/workflows/examples-linux-imx.yaml
@@ -31,12 +31,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            # TODO: this image SHOULD use a newer version.
-            #
-            # NOTE: After https://github.com/project-chip/connectedhomeip/pull/19941
-            #       the image became large enough that github CI runs out of space.
-            #       The image has increased from aroud 2.5GB to 10+GB
-            image: connectedhomeip/chip-build-imx:0.5.79
+            image: connectedhomeip/chip-build-imx:0.5.85
 
         steps:
             - uses: Wandalen/wretry.action@v1.0.15


### PR DESCRIPTION
The previous version of imx docker image run out of CI space.
The 0.5.85 version has removed two SDKs.