### PR TITLE
Cherry-pick: Revert "[ota] Fix exchange context leak in OTA requestor (#20304)"

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -638,14 +638,12 @@ void DefaultOTARequestor::OnDownloadStateChanged(OTADownloader::State state, OTA
     {
     case OTADownloader::State::kComplete:
         mOtaRequestorDriver->UpdateDownloaded();
-        mBdxMessenger.Reset();
         break;
     case OTADownloader::State::kIdle:
         if (reason != OTAChangeReasonEnum::kSuccess)
         {
             RecordErrorUpdateState(CHIP_ERROR_CONNECTION_ABORTED, reason);
         }
-        mBdxMessenger.Reset();
         break;
     default:
         break;
@@ -825,10 +823,10 @@ CHIP_ERROR DefaultOTARequestor::StartDownload(OperationalDeviceProxy & devicePro
     Optional<SessionHandle> session = deviceProxy.GetSecureSession();
     VerifyOrReturnError(session.HasValue(), CHIP_ERROR_INCORRECT_STATE);
 
-    chip::Messaging::ExchangeContext * exchangeCtx = exchangeMgr->NewContext(session.Value(), &mBdxMessenger);
-    VerifyOrReturnError(exchangeCtx != nullptr, CHIP_ERROR_NO_MEMORY);
+    mExchangeCtx = exchangeMgr->NewContext(session.Value(), &mBdxMessenger);
+    VerifyOrReturnError(mExchangeCtx != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    mBdxMessenger.Init(mBdxDownloader, exchangeCtx);
+    mBdxMessenger.Init(mBdxDownloader, mExchangeCtx);
     mBdxDownloader->SetMessageDelegate(&mBdxMessenger);
     mBdxDownloader->SetStateDelegate(this);
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -175,13 +175,6 @@ private:
             mDownloader  = downloader;
         }
 
-        void Reset()
-        {
-            VerifyOrReturn(mExchangeCtx != nullptr);
-            mExchangeCtx->Close();
-            mExchangeCtx = nullptr;
-        }
-
     private:
         chip::Messaging::ExchangeContext * mExchangeCtx;
         chip::BDXDownloader * mDownloader;
@@ -299,12 +292,13 @@ private:
      */
     static void OnCommissioningCompleteRequestor(const DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
 
-    OTARequestorStorage * mStorage           = nullptr;
-    OTARequestorDriver * mOtaRequestorDriver = nullptr;
-    CASESessionManager * mCASESessionManager = nullptr;
-    OnConnectedAction mOnConnectedAction     = kQueryImage;
-    BDXDownloader * mBdxDownloader           = nullptr; // TODO: this should be OTADownloader
-    BDXMessenger mBdxMessenger;                         // TODO: ideally this is held by the application
+    OTARequestorStorage * mStorage            = nullptr;
+    OTARequestorDriver * mOtaRequestorDriver  = nullptr;
+    CASESessionManager * mCASESessionManager  = nullptr;
+    OnConnectedAction mOnConnectedAction      = kQueryImage;
+    Messaging::ExchangeContext * mExchangeCtx = nullptr;
+    BDXDownloader * mBdxDownloader            = nullptr; // TODO: this should be OTADownloader
+    BDXMessenger mBdxMessenger;                          // TODO: ideally this is held by the application
     uint8_t mUpdateTokenBuffer[kMaxUpdateTokenLen];
     ByteSpan mUpdateToken;
     uint32_t mCurrentVersion = 0;


### PR DESCRIPTION
#### Problem
There is a problem with the OTA DFU in nRF Connect examples in the SVE branch.
We would like to cherry-pick bd132eec091e7e53c5ce5ba4a289e69789b41dba commit that fixes this issue.

#### Change overview
Cherry picking commit: bd132eec091e7e53c5ce5ba4a289e69789b41dba to the SVE branch.
