### PR TITLE
Cherrypick: Return CONSTRAINT_ERROR on user labels that are too long (instead of …

### DIFF
--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -129,7 +129,7 @@ CHIP_ERROR UserLabelAttrAccess::WriteLabelList(const ConcreteDataAttributePath &
         LabelList::TypeInfo::DecodableType decodablelist;
 
         ReturnErrorOnFailure(aDecoder.Decode(decodablelist));
-        ReturnErrorCodeIf(!IsValidLabelEntryList(decodablelist), CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorCodeIf(!IsValidLabelEntryList(decodablelist), CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
         auto iter = decodablelist.begin();
         while (iter.Next())
@@ -146,7 +146,7 @@ CHIP_ERROR UserLabelAttrAccess::WriteLabelList(const ConcreteDataAttributePath &
         Structs::LabelStruct::DecodableType entry;
 
         ReturnErrorOnFailure(aDecoder.Decode(entry));
-        ReturnErrorCodeIf(!IsValidLabelEntry(entry), CHIP_ERROR_INVALID_ARGUMENT);
+        ReturnErrorCodeIf(!IsValidLabelEntry(entry), CHIP_IM_GLOBAL_STATUS(ConstraintError));
 
         return provider->AppendUserLabel(endpoint, entry);
     }

--- a/src/app/tests/suites/TestUserLabelClusterConstraints.yaml
+++ b/src/app/tests/suites/TestUserLabelClusterConstraints.yaml
@@ -40,7 +40,7 @@ tests:
                   },
               ]
       response:
-          error: FAILURE
+          error: CONSTRAINT_ERROR
 
     - label: "Attempt to write overly long item for value"
       command: "writeAttribute"
@@ -54,4 +54,4 @@ tests:
                   },
               ]
       response:
-          error: FAILURE
+          error: CONSTRAINT_ERROR

--- a/src/app/tests/suites/certification/Test_TC_ULABEL_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_ULABEL_2_3.yaml
@@ -44,7 +44,7 @@ tests:
                   },
               ]
       response:
-          error: FAILURE
+          error: CONSTRAINT_ERROR
 
     - label: "TH reads LabelList attribute of the DUT"
       PICS: ULABEL.S.A0000
@@ -59,4 +59,4 @@ tests:
                   },
               ]
       response:
-          error: FAILURE
+          error: CONSTRAINT_ERROR

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -31842,10 +31842,10 @@ private:
             shouldContinue = true;
             break;
         case 1:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 2:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         default:
             LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));
@@ -51888,10 +51888,10 @@ private:
             shouldContinue = true;
             break;
         case 1:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         case 2:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_FAILURE));
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
         default:
             LogErrorOnFailure(ContinueOnChipMainThread(CHIP_ERROR_INVALID_ARGUMENT));


### PR DESCRIPTION
…FAILURE) (#20553)

* Mark constraint error as the error to return on overly long values

* Zap regen

* Fix return code

* Update TC-ULABEL-2.3 for using constraint_error

* Zap regen

This CP is to make #20671 pass in sve branch.
Fixes #20671 