### PR TITLE
Fix management of mRunScheduled state in reporting engine.

### DIFF
--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -539,6 +539,7 @@ exit:
 void Engine::Run(System::Layer * aSystemLayer, void * apAppState)
 {
     Engine * const pEngine = reinterpret_cast<Engine *>(apAppState);
+    pEngine->mRunScheduled = false;
     pEngine->Run();
 }
 
@@ -574,8 +575,6 @@ void Engine::Run()
     uint32_t numReadHandled = 0;
 
     InteractionModelEngine * imEngine = InteractionModelEngine::GetInstance();
-
-    mRunScheduled = false;
 
     // We may be deallocating read handlers as we go.  Track how many we had
     // initially, so we make sure to go through all of them.

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -70,11 +70,6 @@ public:
 #endif
 
     /**
-     * Main work-horse function that executes the run-loop.
-     */
-    void Run();
-
-    /**
      * Should be invoked when the device receives a Status report, or when the Report data request times out.
      * This allows the engine to do some clean-up.
      *
@@ -131,6 +126,11 @@ public:
 #endif
 
 private:
+    /**
+     * Main work-horse function that executes the run-loop.
+     */
+    void Run();
+
     friend class TestReportingEngine;
 
     struct AttributePathParamsWithGeneration : public AttributePathParams


### PR DESCRIPTION
Without this change, we can schedule a reporting run, then do a sync
Run (due to urgent events), then (unnecessarily) schedule another
reporting run.

#### Problem
See above.

#### Change overview
Make sure to unset our "run scheduled" boolean only when we actually call the async callback.

#### Testing
Verified that this fixes the test from https://github.com/project-chip/connectedhomeip/pull/20692 on the SHA where that test crashes.