### PR TITLE
Don't try to establish PASE while we are shutting down.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -466,6 +466,8 @@ void DeviceCommissioner::Shutdown()
 
     ChipLogDetail(Controller, "Shutting down the commissioner");
 
+    mSetUpCodePairer.CommissionerShuttingDown();
+
     // Check to see if pairing in progress before shutting down
     CommissioneeDeviceProxy * device = mDeviceInPASEEstablishment;
     if (device != nullptr && device->IsSessionSetupInProgress())

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -308,6 +308,11 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
     ConnectToDiscoveredDevice();
 }
 
+void SetUpCodePairer::CommissionerShuttingDown()
+{
+    ResetDiscoveryState();
+}
+
 bool SetUpCodePairer::TryNextRendezvousParameters()
 {
     if (ConnectToDiscoveredDevice())

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -72,6 +72,10 @@ public:
     void SetBleLayer(Ble::BleLayer * bleLayer) { mBleLayer = bleLayer; };
 #endif // CONFIG_NETWORK_LAYER_BLE
 
+    // Called to notify us that the DeviceCommissioner is shutting down and we
+    // should not try to do any more new work.
+    void CommissionerShuttingDown();
+
 private:
     // DevicePairingDelegate implementation.
     void OnStatusUpdate(DevicePairingDelegate::Status status) override;


### PR DESCRIPTION
Shutdown of a DeviceCommissioner needs to suppress the "try the next
discovered thing on error" behavior of SetUpCodePairer.

Fixes https://github.com/project-chip/connectedhomeip/issues/20271

#### Problem
See #20271

#### Change overview
Make sure we don't try to do PASE to the next discovered thing if we're shutting down.

#### Testing
Checked manually that we don't end up in the situation #20271 ran into.