### PR TITLE
Fix session allocation loop when shutting down with an open commissioning window.

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -112,6 +112,9 @@ void SessionManager::Shutdown()
         mFabricTable = nullptr;
     }
 
+    // Ensure that we don't create new sessions as we iterate our session table.
+    mState = State::kNotReady;
+
     mSecureSessions.ForEachSession([&](auto session) {
         session->MarkForEviction();
         return Loop::Continue;
@@ -119,7 +122,6 @@ void SessionManager::Shutdown()
 
     mMessageCounterManager = nullptr;
 
-    mState        = State::kNotReady;
     mSystemLayer  = nullptr;
     mTransportMgr = nullptr;
     mCB           = nullptr;
@@ -386,6 +388,7 @@ void SessionManager::ExpireAllPASESessions()
 Optional<SessionHandle> SessionManager::AllocateSession(SecureSession::Type secureSessionType,
                                                         const ScopedNodeId & sessionEvictionHint)
 {
+    VerifyOrReturnValue(mState == State::kInitialized, NullOptional);
     return mSecureSessions.CreateNewSecureSession(secureSessionType, sessionEvictionHint);
 }
 


### PR DESCRIPTION
After #20487 if we shut down with a commissioning window open we end up in a
loop where the session manager shutdown marks the tentative PASE session for
eviction, we treat that as a commissioning error and start listening for PASE
again, creating a new session, etc.  With a heap pool this ends up happening to
work in that we keep evicting the new sessions until we hit the 20-attempt limit
and close the commissioning window.  With a non-heap pool, I sort of wonder what
happens, exactly.

The fix here is in two parts, with either part enough on its own to fix the
behavior described above:

1) Shut down the commissioning window manager earlier, before we shut down the
   session manager.  And correspondingly move its initialization during server
   init later.

2) Once session manager starts shutdown, refuse to create any new sessions.

#### Problem
<details>
<summary>Stacks like this if I start all-clusters-app in uncommissioned state and then Ctrl-C it:</summary>

```
  * frame #0: 0x00000001005c8060 chip-all-clusters-app`chip::Transport::SecureSession::SecureSession(this=0x0000611000032040, table=0x00000001008883d0, secureSessionType=kPASE, localSessionId=15119) at SecureSession.h:92:5
    frame #1: 0x00000001005c800b chip-all-clusters-app`chip::Transport::SecureSession* chip::Platform::New<chip::Transport::SecureSession, chip::Transport::SecureSessionTable&, chip::Transport::SecureSession::Type&, unsigned short&>(args=0x00000001008883d0, args=0x00007ff7bfefd5c0, args=0x00007ff7bfefd5f2) at CHIPMem.h:148:24
    frame #2: 0x00000001005c50a3 chip-all-clusters-app`chip::Transport::SecureSession* chip::HeapObjectPool<chip::Transport::SecureSession>::CreateObject<chip::Transport::SecureSessionTable&, chip::Transport::SecureSession::Type&, unsigned short&>(this=0x00000001008883d8, args=0x00000001008883d0, args=0x00007ff7bfefd5c0, args=0x00007ff7bfefd5f2) at Pool.h:324:22
    frame #3: 0x00000001005c45b1 chip-all-clusters-app`chip::Transport::SecureSessionTable::CreateNewSecureSession(this=0x00000001008883d0, secureSessionType=kPASE, sessionEvictionHint=(mNodeId = 0, mFabricIndex = '\0')) at SecureSessionTable.cpp:76:30
    frame #4: 0x00000001005d4dde chip-all-clusters-app`chip::SessionManager::AllocateSession(this=0x0000000100888378, secureSessionType=kPASE, sessionEvictionHint=0x00007ff7bfefdac0) at SessionManager.cpp:389:28
    frame #5: 0x00000001006d35d0 chip-all-clusters-app`chip::PairingSession::AllocateSecureSession(this=0x000000010088a730, sessionManager=0x0000000100888378, sessionEvictionHint=0x00007ff7bfefdac0) at PairingSession.cpp:28:34
    frame #6: 0x00000001006bec54 chip-all-clusters-app`chip::PASESession::Init(this=0x000000010088a730, sessionManager=0x0000000100888378, setupCode=0, delegate=0x000000010088a700) at PASESession.cpp:118:5
    frame #7: 0x00000001006bf78b chip-all-clusters-app`chip::PASESession::WaitForPairing(this=0x000000010088a730, sessionManager=0x0000000100888378, verifier=0x00007ff7bfefe280, pbkdf2IterCount=1000, salt=0x00007ff7bfefe470, mrpLocalConfig=Optional<chip::ReliableMessageProtocolConfig> @ 0x00007ff7bfefe490, delegate=0x000000010088a700) at PASESession.cpp:166:22
    frame #8: 0x00000001006ec891 chip-all-clusters-app`chip::CommissioningWindowManager::AdvertiseAndListenForPASE(this=0x000000010088a700) at CommissioningWindowManager.cpp:244:9
    frame #9: 0x00000001006ea318 chip-all-clusters-app`chip::CommissioningWindowManager::HandleFailedAttempt(this=0x000000010088a700, err=(mError = 2, mFile = "../../src/protocols/secure_channel/PASESession.cpp", mLine = 75)) at CommissioningWindowManager.cpp:126:15
    frame #10: 0x00000001006eb06e chip-all-clusters-app`chip::CommissioningWindowManager::OnSessionEstablishmentError(this=0x000000010088a700, err=(mError = 2, mFile = "../../src/protocols/secure_channel/PASESession.cpp", mLine = 75)) at CommissioningWindowManager.cpp:112:5
    frame #11: 0x00000001006be55b chip-all-clusters-app`chip::PASESession::OnSessionReleased(this=0x000000010088a730) at PASESession.cpp:75:16
    frame #12: 0x00000001007067dc chip-all-clusters-app`chip::SessionHolderWithDelegate::SessionReleased(this=0x000000010088a750) at SessionHolder.h:98:19
    frame #13: 0x00000001005e4a79 chip-all-clusters-app`chip::Transport::Session::NotifySessionReleased(this=0x000061100003f9c0) at Session.h:120:31
    frame #14: 0x00000001005bfe9f chip-all-clusters-app`chip::Transport::SecureSession::MarkForEviction(this=0x000061100003f9c0) at SecureSession.cpp:140:9
    frame #15: 0x00000001005e5809 chip-all-clusters-app`auto chip::SessionManager::Shutdown(this=0x00007ff7bfeff100, session=0x000061100003f9c0)::$_0::operator()<chip::Transport::SecureSession*>(chip::Transport::SecureSession*) const at SessionManager.cpp:116:18
    frame #16: 0x00000001005e57ad chip-all-clusters-app`chip::internal::LambdaProxy<chip::Transport::SecureSession, chip::SessionManager::Shutdown()::$_0>::Call(context=0x00007ff7bfeff100, target=0x000061100003f9c0) at Pool.h:126:16
    frame #17: 0x00000001003f92e8 chip-all-clusters-app`chip::internal::HeapObjectList::ForEachNode(this=0x00000001008883e8, context=0x00007ff7bfeff100, lambda=(chip-all-clusters-app`chip::internal::LambdaProxy<chip::Transport::SecureSession, chip::SessionManager::Shutdown()::$_0>::Call(void*, void*) at Pool.h:125))(void*, void*)) at Pool.cpp:127:17
    frame #18: 0x00000001005e56c4 chip-all-clusters-app`chip::Loop chip::HeapObjectPool<chip::Transport::SecureSession>::ForEachActiveObject<chip::SessionManager::Shutdown(this=0x00000001008883d8, function=0x00007ff7bfeff220)::$_0>(chip::SessionManager::Shutdown()::$_0&&) at Pool.h:396:25
    frame #19: 0x00000001005cfb91 chip-all-clusters-app`chip::Loop chip::Transport::SecureSessionTable::ForEachSession<chip::SessionManager::Shutdown()::$_0>(this=0x00000001008883d0, function=0x00007ff7bfeff220)::$_0&&) at SecureSessionTable.h:84:25
    frame #20: 0x00000001005cef72 chip-all-clusters-app`chip::SessionManager::Shutdown(this=0x0000000100888378) at SessionManager.cpp:115:21
```

</details>

#### Change overview
See above.

#### Testing
See above about hitting Ctrl-C.  With this PR there is no repeated listening for PASE, no 
```
[1657772763786] [55269:28665263] CHIP: [SVR] Commissioning failed (attempt 15): ../../../examples/all-clusters-app/linux/third_party/connectedhomeip/src/protocols/secure_channel/PASESession.cpp:75: CHIP Error 0x00000002: Connection aborted
```
bits.  Just clean shutdown.
