### PR TITLE
[Zephyr] Fix potential data race on multicast configuration

### DIFF
--- a/src/platform/Zephyr/ThreadStackManagerImpl.cpp
+++ b/src/platform/Zephyr/ThreadStackManagerImpl.cpp
@@ -48,13 +48,21 @@ CHIP_ERROR ThreadStackManagerImpl::_InitThreadStack()
 
     UDPEndPointImplSockets::SetJoinMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
         const otIp6Address otAddress = ToOpenThreadIP6Address(address);
-        const auto otError           = otIp6SubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
+
+        ThreadStackMgr().LockThreadStack();
+        const auto otError = otIp6SubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
+        ThreadStackMgr().UnlockThreadStack();
+
         return MapOpenThreadError(otError);
     });
 
     UDPEndPointImplSockets::SetLeaveMulticastGroupHandler([](InterfaceId, const IPAddress & address) {
         const otIp6Address otAddress = ToOpenThreadIP6Address(address);
-        const auto otError           = otIp6UnsubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
+
+        ThreadStackMgr().LockThreadStack();
+        const auto otError = otIp6UnsubscribeMulticastAddress(openthread_get_default_instance(), &otAddress);
+        ThreadStackMgr().UnlockThreadStack();
+
         return MapOpenThreadError(otError);
     });
 


### PR DESCRIPTION

#### Problem
OpenThread functions for joining or leaving multicast groups would be called without holding the Thread stack lock.

#### Change overview
Add missing locks.

#### Testing
Verified that `groups add-group/remove-group` commands still work as expected.
