### PR TITLE
Add a helper to generate valid random PINs to the Darwin framework.

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/OpenCommissioningWindowCommand.mm
+++ b/examples/darwin-framework-tool/commands/pairing/OpenCommissioningWindowCommand.mm
@@ -30,7 +30,7 @@ CHIP_ERROR OpenCommissioningWindowCommand::RunCommand()
         pairingCode = [controller openPairingWindowWithPIN:mNodeId
                                                   duration:mCommissioningWindowTimeoutMs
                                              discriminator:mDiscriminator
-                                                  setupPIN:arc4random()
+                                                  setupPIN:[MTRSetupPayload generateRandomPIN]
                                                      error:&error];
     }
 

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -72,6 +72,11 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
 
     if (setupPIN.HasValue())
     {
+        if (!SetupPayload::IsValidSetupPIN(setupPIN.Value()))
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT;
+        }
+
         mCommissioningWindowOption = CommissioningWindowOption::kTokenWithProvidedPIN;
         mSetupPayload.setUpPINCode = setupPIN.Value();
     }

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/MultiAdmin/MultiAdminViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/MultiAdmin/MultiAdminViewController.m
@@ -199,7 +199,7 @@ static NSString * const DEFAULT_DISCRIMINATOR = @"3840";
 
 - (IBAction)openPairingWindow:(id)sender
 {
-    uint32_t setupPIN = arc4random();
+    NSUInteger setupPIN = [MTRSetupPayload generateRandomPIN];
     [_deviceSelector forSelectedDevices:^(uint64_t deviceId) {
         if (MTRGetConnectedDeviceWithID(deviceId, ^(MTRBaseDevice * _Nullable chipDevice, NSError * _Nullable error) {
                 if (chipDevice) {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -583,7 +583,13 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         return rv;
     }
 
-    setupPIN &= ((1 << chip::kSetupPINCodeFieldLengthInBits) - 1);
+    if (!chip::CanCastTo<uint32_t>(setupPIN) || !chip::SetupPayload::IsValidSetupPIN(static_cast<uint32_t>(setupPIN))) {
+        MTR_LOG_ERROR("Error: Setup pin %lu is not valid", setupPIN);
+        if (error) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INVALID_INTEGER_VALUE];
+        }
+        return rv;
+    }
 
     dispatch_sync(_chipWorkQueue, ^{
         VerifyOrReturn([self checkIsRunning:error]);

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -62,6 +62,10 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 @property (nonatomic, strong) NSString * serialNumber;
 - (nullable NSArray<MTROptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error;
 
+/**
+ * Generate a random Matter-valid setup PIN.
+ */
++ (NSUInteger)generateRandomPIN;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -108,6 +108,25 @@
     return allOptionalData;
 }
 
++ (NSUInteger)generateRandomPIN
+{
+    do {
+        // Make sure the thing we generate is in the right range.
+        uint32_t setupPIN = arc4random_uniform(chip::kSetupPINCodeMaximumValue) + 1;
+        if (chip::SetupPayload::IsValidSetupPIN(setupPIN)) {
+            return setupPIN;
+        }
+
+        // We got pretty unlikely with our random number generation.  Just try
+        // again.  The chance that this loop does not terminate in a reasonable
+        // amount of time is astronomically low, assuming arc4random_uniform is not
+        // broken.
+    } while (1);
+
+    // Not reached.
+    return chip::kSetupPINCodeUndefinedValue;
+}
+
 #pragma mark - NSSecureCoding
 
 static NSString * const MTRSetupPayloadCodingKeyVersion = @"MTRSP.ck.version";

--- a/src/protocols/secure_channel/PASESession.h
+++ b/src/protocols/secure_channel/PASESession.h
@@ -49,9 +49,6 @@ extern const char * kSpake2pR2ISessionInfo;
 
 constexpr uint16_t kPBKDFParamRandomNumberSize = 32;
 
-constexpr uint32_t kSetupPINCodeMaximumValue   = 99999998;
-constexpr uint32_t kSetupPINCodeUndefinedValue = 0;
-
 using namespace Crypto;
 
 struct PASESessionSerialized;

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -111,6 +111,20 @@ bool PayloadContents::isValidManualCode() const
     return CheckPayloadCommonConstraints();
 }
 
+bool PayloadContents::IsValidSetupPIN(uint32_t setupPIN)
+{
+    // SHALL be restricted to the values 0x0000001 to 0x5F5E0FE (00000001 to 99999998 in decimal), excluding the invalid Passcode
+    // values.
+    if (setupPIN == kSetupPINCodeUndefinedValue || setupPIN > kSetupPINCodeMaximumValue || setupPIN == 11111111 ||
+        setupPIN == 22222222 || setupPIN == 33333333 || setupPIN == 44444444 || setupPIN == 55555555 || setupPIN == 66666666 ||
+        setupPIN == 77777777 || setupPIN == 88888888 || setupPIN == 12345678 || setupPIN == 87654321)
+    {
+        return false;
+    }
+
+    return true;
+}
+
 bool PayloadContents::CheckPayloadCommonConstraints() const
 {
     // A version not equal to 0 would be invalid for v1 and would indicate new format (e.g. version 2)
@@ -119,11 +133,7 @@ bool PayloadContents::CheckPayloadCommonConstraints() const
         return false;
     }
 
-    // SHALL be restricted to the values 0x0000001 to 0x5F5E0FE (00000001 to 99999998 in decimal), excluding the invalid Passcode
-    // values.
-    if (setUpPINCode < 0x0000001 || setUpPINCode > 0x5F5E0FE || setUpPINCode == 11111111 || setUpPINCode == 22222222 ||
-        setUpPINCode == 33333333 || setUpPINCode == 44444444 || setUpPINCode == 55555555 || setUpPINCode == 66666666 ||
-        setUpPINCode == 77777777 || setUpPINCode == 88888888 || setUpPINCode == 12345678 || setUpPINCode == 87654321)
+    if (!IsValidSetupPIN(setUpPINCode))
     {
         return false;
     }

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -72,6 +72,9 @@ constexpr uint8_t kBPKFSaltTag             = 0x02;
 constexpr uint8_t kNumberOFDevicesTag      = 0x03;
 constexpr uint8_t kCommissioningTimeoutTag = 0x04;
 
+constexpr uint32_t kSetupPINCodeMaximumValue   = 99999998;
+constexpr uint32_t kSetupPINCodeUndefinedValue = 0;
+
 // clang-format off
 const int kTotalPayloadDataSizeInBits =
     kVersionFieldLengthInBits +
@@ -123,6 +126,8 @@ struct PayloadContents
     bool isValidManualCode() const;
     bool isShortDiscriminator = false;
     bool operator==(PayloadContents & input) const;
+
+    static bool IsValidSetupPIN(uint32_t setupPIN);
 
 private:
     bool CheckPayloadCommonConstraints() const;

--- a/src/tools/spake2p/Cmd_GenVerifier.cpp
+++ b/src/tools/spake2p/Cmd_GenVerifier.cpp
@@ -37,6 +37,7 @@
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/CHIPMem.h>
 #include <protocols/secure_channel/PASESession.h>
+#include <setup_payload/SetupPayload.h>
 
 namespace {
 


### PR DESCRIPTION
Adds a public SDK API to test whether a PIN is valid, and uses it in
the Darwin framework and in CommissioningWindowOpener so we don't try
to open commissioning windows for invalid PINs.

Fixes https://github.com/project-chip/connectedhomeip/issues/20662

#### Problem
CommissiningWindowOpener will happily open a commissioning window for an invalid PIN, but then not be able to provide a setup payload.

#### Change overview
Add argument validity checks for valid PINs, add a utility for generating them.

#### Testing
Tested that existing tests pass and iOS CHIPTool no longer fails to open commissioning windows ~25% of the time.