### PR TITLE
[chip-tool] Properly shutdown all opened commissioners

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -165,16 +165,9 @@ void CHIPCommand::MaybeTearDownStack()
     // since the CHIP thread and event queue have been stopped, preventing any thread
     // races.
     //
-    ShutdownCommissioner(kIdentityNull);
-    ShutdownCommissioner(kIdentityAlpha);
-    ShutdownCommissioner(kIdentityBeta);
-    ShutdownCommissioner(kIdentityGamma);
-
-    std::string name        = GetIdentity();
-    chip::FabricId fabricId = strtoull(name.c_str(), nullptr, 0);
-    if (fabricId >= kIdentityOtherFabricId)
+    for (auto it = mCommissioners.begin(); it != mCommissioners.end(); it++)
     {
-        ShutdownCommissioner(name);
+        ShutdownCommissioner(it->first);
     }
 
     StopTracing();


### PR DESCRIPTION
#### Problem

Not all commissioners are closed properly when during `chip-tool` shutdown.
Fix #20608

It happens because the arguments are cleaned right before the call to `MaybeTearDownStack` and so the optional argument `mCommissionerName` does not have a value anymore, which ends up defaulting to `alpha`

#### Change overview
 * Properly shutdown all the registered commissioners
