### PR TITLE
Clean up path usage in build files

### DIFF
--- a/build/chip/linux/gdbus_library.gni
+++ b/build/chip/linux/gdbus_library.gni
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-glib_config = rebase_path(":glib")
-gen_dbus_wrapper = rebase_path("gen_gdbus_wrapper.py")
+glib_config = get_label_info(":glib", "label_no_toolchain")
+gen_dbus_wrapper = get_path_info("gen_gdbus_wrapper.py", "abspath")
 
 # Runs gdbus-codegen and defines the resulting library.
 #

--- a/examples/all-clusters-app/tizen/BUILD.gn
+++ b/examples/all-clusters-app/tizen/BUILD.gn
@@ -60,7 +60,7 @@ executable("chip-all-clusters-app") {
 
 tizen_sdk_package("chip-all-clusters-app:tpk") {
   deps = [ ":chip-all-clusters-app" ]
-  manifest = rebase_path("tizen-manifest.xml")
+  manifest = "tizen-manifest.xml"
   sign_security_profile = "CHIP"
 }
 

--- a/examples/all-clusters-minimal-app/tizen/BUILD.gn
+++ b/examples/all-clusters-minimal-app/tizen/BUILD.gn
@@ -60,7 +60,7 @@ executable("chip-all-clusters-minimal-app") {
 
 tizen_sdk_package("chip-all-clusters-minimal-app:tpk") {
   deps = [ ":chip-all-clusters-minimal-app" ]
-  manifest = rebase_path("tizen-manifest.xml")
+  manifest = "tizen-manifest.xml"
   sign_security_profile = "CHIP"
 }
 

--- a/examples/lighting-app/tizen/BUILD.gn
+++ b/examples/lighting-app/tizen/BUILD.gn
@@ -41,7 +41,7 @@ executable("chip-lighting-app") {
 
 tizen_sdk_package("chip-lighting-app:tpk") {
   deps = [ ":chip-lighting-app" ]
-  manifest = rebase_path("tizen-manifest.xml")
+  manifest = "tizen-manifest.xml"
   sign_security_profile = "CHIP"
 }
 

--- a/src/controller/data_model/BUILD.gn
+++ b/src/controller/data_model/BUILD.gn
@@ -33,24 +33,25 @@ if (current_os == "android") {
     script = "${chip_root}/scripts/codegen.py"
 
     _idl_file = "controller-clusters.matter"
-    _output_files = exec_script("${chip_root}/scripts/codegen.py",
-                                [
-                                  "--generator",
-                                  "java",
-                                  "--log-level",
-                                  "fatal",
-                                  "--name-only",
-                                  rebase_path("controller-clusters.matter"),
-                                ],
-                                "list lines",
-                                [ "controller-clusters.matter" ])
+    _output_files =
+        exec_script("${chip_root}/scripts/codegen.py",
+                    [
+                      "--generator",
+                      "java",
+                      "--log-level",
+                      "fatal",
+                      "--name-only",
+                      rebase_path("controller-clusters.matter", root_build_dir),
+                    ],
+                    "list lines",
+                    [ "controller-clusters.matter" ])
 
     args = [
       "--generator",
       "java",
       "--output-dir",
-      rebase_path(target_gen_dir),
-      rebase_path(_idl_file),
+      rebase_path(target_gen_dir, root_build_dir),
+      rebase_path(_idl_file, root_build_dir),
     ]
 
     deps = [ "${chip_root}/scripts/idl" ]

--- a/third_party/tizen/tizen_sdk.gni
+++ b/third_party/tizen/tizen_sdk.gni
@@ -18,7 +18,7 @@ import("//build_overrides/tizen.gni")
 
 import("${build_root}/config/tizen/config.gni")
 
-tizen_manifest_parser = rebase_path("tizen_manifest_parser.py")
+tizen_manifest_parser = get_path_info("tizen_manifest_parser.py", "abspath")
 
 template("tizen_sdk") {
   forward_variables_from(invoker,
@@ -74,7 +74,9 @@ template("tizen_sdk_package") {
              "should be used for signing TPK package.")
 
   # Extract data from Tizen XML manifest.
-  manifest = exec_script(tizen_manifest_parser, [ invoker.manifest ], "json")
+  manifest = exec_script(tizen_manifest_parser,
+                         [ rebase_path(invoker.manifest, root_build_dir) ],
+                         "json")
   manifest_package = manifest["package"]
   manifest_apps = manifest["apps"]
 


### PR DESCRIPTION
### Problem

Templates should rebase paths to the build dir before passing them to
scripts as scripts generally do not understand GN's // syntax for
specifying paths relative to the root.

In other cases, paths should be left alone so that build file relative
paths can be specified. This is needed for consistency; all GN builtins
accept both relative-to-BUILD.gn paths (default) and
relative-to-GN-root (//) paths.

For command line arguments, paths should be specified relative to
the build directory, which will be the working directory of the script.

#### Change overview

- Allow & use relative paths in template arguments
- Remove most uses of rebase_path() to create filesystem-absolute paths.

  This is rarely needed and can introduce long absolute paths that are different for each developer.

  These are replaced with:

  - BUILD.gn relative paths
  - GN-rooted (//) paths
  
    `get_path_info(path, "abspath")` converts a BUILD.gn relative path to a GN-rooted path
    `get_label_info(label, "label_no_toolchain")` converts a BUILD.gn relative label to a GN-rooted label

#### Testing

CI
