### PR TITLE
[Ameba] Implement erase partition in Abort function

### DIFF
--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -425,10 +425,10 @@ void AmebaOTAImageProcessor::HandleApply(intptr_t context)
     ota_update_free(imageProcessor->pOtaTgtHdr);
 #endif
 
-    ChipLogProgress(SoftwareUpdate, "Rebooting in 2 seconds...");
+    ChipLogProgress(SoftwareUpdate, "Rebooting in 10 seconds...");
 
     // Delay action time before calling HandleRestart
-    chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(2 * 1000), HandleRestart, nullptr);
+    chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Milliseconds32(10 * 1000), HandleRestart, nullptr);
 }
 
 void AmebaOTAImageProcessor::HandleRestart(chip::System::Layer * systemLayer, void * appState)

--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -178,13 +178,11 @@ void AmebaOTAImageProcessor::HandleAbort(intptr_t context)
     // Abort OTA procedure
 #if defined(CONFIG_PLATFORM_8721D)
     ChipLogProgress(SoftwareUpdate, "Erasing target partition...");
-    erase_ota_target_flash(imageProcessor->pOtaTgtHdr->FileImgHdr[0].FlashAddr,
-                           imageProcessor->pOtaTgtHdr->FileImgHdr[0].ImgLen);
+    erase_ota_target_flash(imageProcessor->pOtaTgtHdr->FileImgHdr[0].FlashAddr, imageProcessor->pOtaTgtHdr->FileImgHdr[0].ImgLen);
     ChipLogProgress(SoftwareUpdate, "Erased partition OTA%d", imageProcessor->ota_target_index + 1);
 #elif defined(CONFIG_PLATFORM_8710C)
     ChipLogProgress(SoftwareUpdate, "Erasing partition");
-    imageProcessor->NewFWBlkSize =
-        ((0x1AC000 - 1) / 4096) + 1; // Use a fixed image length of 0x1AC000, change in the future
+    imageProcessor->NewFWBlkSize = ((0x1AC000 - 1) / 4096) + 1; // Use a fixed image length of 0x1AC000, change in the future
     ChipLogProgress(SoftwareUpdate, "Erasing %d sectors", imageProcessor->NewFWBlkSize);
     device_mutex_lock(RT_DEV_LOCK_FLASH);
     for (int i = 0; i < imageProcessor->NewFWBlkSize; i++)

--- a/src/platform/Ameba/AmebaOTAImageProcessor.cpp
+++ b/src/platform/Ameba/AmebaOTAImageProcessor.cpp
@@ -161,25 +161,6 @@ void AmebaOTAImageProcessor::HandleFinalize(intptr_t context)
     }
 #endif
 
-    // Update signature
-#if defined(CONFIG_PLATFORM_8721D)
-    if (change_ota_signature(imageProcessor->pOtaTgtHdr, imageProcessor->ota_target_index) != 1)
-    {
-        ota_update_free(imageProcessor->pOtaTgtHdr);
-        ChipLogError(SoftwareUpdate, "OTA update signature failed");
-        return;
-    }
-#elif defined(CONFIG_PLATFORM_8710C)
-    if (update_ota_signature(imageProcessor->signature, imageProcessor->flash_addr) < 0)
-    {
-        ChipLogError(SoftwareUpdate, "OTA update signature failed");
-        return;
-    }
-#endif
-
-#if defined(CONFIG_PLATFORM_8721D)
-    ota_update_free(imageProcessor->pOtaTgtHdr);
-#endif
     imageProcessor->ReleaseBlock();
 
     ChipLogProgress(SoftwareUpdate, "OTA image downloaded and written to flash");
@@ -195,6 +176,25 @@ void AmebaOTAImageProcessor::HandleAbort(intptr_t context)
     }
 
     // Abort OTA procedure
+#if defined(CONFIG_PLATFORM_8721D)
+    ChipLogProgress(SoftwareUpdate, "Erasing target partition...");
+    erase_ota_target_flash(imageProcessor->pOtaTgtHdr->FileImgHdr[0].FlashAddr,
+                           imageProcessor->pOtaTgtHdr->FileImgHdr[0].ImgLen);
+    ChipLogProgress(SoftwareUpdate, "Erased partition OTA%d", imageProcessor->ota_target_index + 1);
+#elif defined(CONFIG_PLATFORM_8710C)
+    ChipLogProgress(SoftwareUpdate, "Erasing partition");
+    imageProcessor->NewFWBlkSize =
+        ((0x1AC000 - 1) / 4096) + 1; // Use a fixed image length of 0x1AC000, change in the future
+    ChipLogProgress(SoftwareUpdate, "Erasing %d sectors", imageProcessor->NewFWBlkSize);
+    device_mutex_lock(RT_DEV_LOCK_FLASH);
+    for (int i = 0; i < imageProcessor->NewFWBlkSize; i++)
+        flash_erase_sector(&flash_ota, imageProcessor->flash_addr + i * 4096);
+    device_mutex_unlock(RT_DEV_LOCK_FLASH);
+#endif
+
+#if defined(CONFIG_PLATFORM_8721D)
+    ota_update_free(imageProcessor->pOtaTgtHdr);
+#endif
 
     imageProcessor->ReleaseBlock();
 }
@@ -401,8 +401,29 @@ void AmebaOTAImageProcessor::HandleApply(intptr_t context)
     auto * imageProcessor = reinterpret_cast<AmebaOTAImageProcessor *>(context);
     if (imageProcessor == nullptr)
     {
+        ChipLogError(SoftwareUpdate, "ImageProcessor context is null");
         return;
     }
+
+    // Update signature
+#if defined(CONFIG_PLATFORM_8721D)
+    if (change_ota_signature(imageProcessor->pOtaTgtHdr, imageProcessor->ota_target_index) != 1)
+    {
+        ota_update_free(imageProcessor->pOtaTgtHdr);
+        ChipLogError(SoftwareUpdate, "OTA update signature failed");
+        return;
+    }
+#elif defined(CONFIG_PLATFORM_8710C)
+    if (update_ota_signature(imageProcessor->signature, imageProcessor->flash_addr) < 0)
+    {
+        ChipLogError(SoftwareUpdate, "OTA update signature failed");
+        return;
+    }
+#endif
+
+#if defined(CONFIG_PLATFORM_8721D)
+    ota_update_free(imageProcessor->pOtaTgtHdr);
+#endif
 
     ChipLogProgress(SoftwareUpdate, "Rebooting in 2 seconds...");
 


### PR DESCRIPTION
#### Problem
- Ameba's OTA abort function needs to erase the downloaded image.
- Signature should be updated during Apply step.
- Delay before reboot is too short, Ameba cannot send out certain events in time.

#### Change overview
- Implement erasing of the downloaded image in HandleAbort function.
- Shifted update signature from HandleFinalize to HandleApply.
- Increased delay before reboot to 10 seconds to allow time for Ameba to send events, for eg state transition from downloading to applying.

#### Testing
- Tested with linux ota-provider with `-a discontinue` flag, abort function successfully erase the downloaded image.
