### PR TITLE
[chip-tool] Interactive mode does not work great with complex/custom …

### DIFF
--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -99,7 +99,7 @@ bool InteractiveStartCommand::ParseCommand(char * command)
     std::string arg;
 
     std::stringstream ss(command);
-    while (ss >> std::quoted(arg))
+    while (ss >> std::quoted(arg, '\''))
     {
         if (argsCount == kInteractiveModeArgumentsMaxLength)
         {

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -96,7 +96,7 @@ bool InteractiveStartCommand::ParseCommand(char * command)
     std::string arg;
 
     std::stringstream ss(command);
-    while (ss >> std::quoted(arg)) {
+    while (ss >> std::quoted(arg, '\'')) {
         if (argsCount == kInteractiveModeArgumentsMaxLength) {
             ChipLogError(chipTool, "Too many arguments. Ignoring.");
             return YES;


### PR DESCRIPTION
…arguments using json formatting

#### Problem

In #19238 "double" quotes supports has been added to the interactive mode in order to pass string that may contains spaces instead of them being splitter into 2 arguments.

In this PR I would like to replace double quotes by double quote does not works great when one is trying to copy-paste complex json arguments to the command line such as:

`$ chip-tool accesscontrol write acl '[{"fabricIndex": 1, "privilege": 5, "authMode": 2, "subjects": [112233,1111], "targets":null},{"fabricIndex": 1, "privilege": 3, "authMode": 3, "subjects": [3333], "targets":null}]' 0x12344321 0`

One would need to escape all the `"` characters to make it works properly, while using single quotes means such strings can be copy pasted without escaping and if one wants to pass an SSID that contains space, it should be 'My SSID' in stead of "My SSSID" which is a much easier and readable change.

#### Change overview
 * Use single quote character as the delimiter for std::quoted and not double quotes.

#### Testing

I tried to convert use the previous write all command into interactive mode.