### PR TITLE
Add pre-execution command callback.

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -328,9 +328,9 @@ CHIP_ERROR CommandHandler::ProcessCommandDataIB(CommandDataIB::Parser & aCommand
     {
         ChipLogDetail(DataManagement, "Received command for Endpoint=%u Cluster=" ChipLogFormatMEI " Command=" ChipLogFormatMEI,
                       concretePath.mEndpointId, ChipLogValueMEI(concretePath.mClusterId), ChipLogValueMEI(concretePath.mCommandId));
-        SuccessOrExit(MatterPreCommandReceivedCallback(concretePath));
+        SuccessOrExit(MatterPreCommandReceivedCallback(concretePath, GetSubjectDescriptor()));
         mpCallback->DispatchCommand(*this, concretePath, commandDataReader);
-        MatterPostCommandReceivedCallback(concretePath);
+        MatterPostCommandReceivedCallback(concretePath, GetSubjectDescriptor());
     }
 
 exit:
@@ -432,12 +432,11 @@ CHIP_ERROR CommandHandler::ProcessGroupCommandDataIB(CommandDataIB::Parser & aCo
                 continue;
             }
         }
-
-        if ((err = MatterPreCommandReceivedCallback(concretePath)) == CHIP_NO_ERROR)
+        if ((err = MatterPreCommandReceivedCallback(concretePath, GetSubjectDescriptor())) == CHIP_NO_ERROR)
         {
             TLV::TLVReader dataReader(commandDataReader);
             mpCallback->DispatchCommand(*this, concretePath, dataReader);
-            MatterPostCommandReceivedCallback(concretePath);
+            MatterPostCommandReceivedCallback(concretePath, GetSubjectDescriptor());
         }
         else
         {
@@ -675,8 +674,10 @@ void CommandHandler::Abort()
 } // namespace app
 } // namespace chip
 
-CHIP_ERROR __attribute__((weak)) MatterPreCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath)
+CHIP_ERROR __attribute__((weak)) MatterPreCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath,
+                                                                  const chip::Access::SubjectDescriptor & subjectDescriptor)
 {
     return CHIP_NO_ERROR;
 }
-void __attribute__((weak)) MatterPostCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath) {}
+void __attribute__((weak)) MatterPostCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath,
+                                                             const chip::Access::SubjectDescriptor & subjectDescriptor) {}

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -680,4 +680,5 @@ CHIP_ERROR __attribute__((weak)) MatterPreCommandReceivedCallback(const chip::ap
     return CHIP_NO_ERROR;
 }
 void __attribute__((weak)) MatterPostCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath,
-                                                             const chip::Access::SubjectDescriptor & subjectDescriptor) {}
+                                                             const chip::Access::SubjectDescriptor & subjectDescriptor)
+{}

--- a/src/app/util/MatterCallbacks.h
+++ b/src/app/util/MatterCallbacks.h
@@ -29,11 +29,13 @@ void MatterPostAttributeWriteCallback(const chip::app::ConcreteAttributePath & a
  * This callback is called once the message has been determined to be a command, and
  * before the command is dispatched to the receiver.
  */
-CHIP_ERROR MatterPreCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath);
+CHIP_ERROR MatterPreCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath,
+                                            const chip::Access::SubjectDescriptor & subjectDescriptor);
 
 /** @brief Matter Post Command Received
  *
  * This callback is called once the message has been determined to be a command, but
  * after it being dispatched to the receiver.
  */
-void MatterPostCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath);
+void MatterPostCommandReceivedCallback(const chip::app::ConcreteCommandPath & commandPath,
+                                       const chip::Access::SubjectDescriptor & subjectDescriptor);


### PR DESCRIPTION
#### Problem
Sometimes it is required to perform some kind of preparation work before command is handled. As it seems, there's no way for app to be notified before the command is executed.

#### Change overview
This PR adds the callback that could be implemented by application uses Matter. This callback is called before every command gets executed.

Resolve #20361 