### PR TITLE
Cherry-pick Increase cloudbuild disk size from 200G to 500G for smoke tests (#20391)

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -110,4 +110,4 @@ artifacts:
 # building instead of docker download/checkout/bootstrap)
 options:
     machineType: "E2_HIGHCPU_32"
-    diskSizeGb: 200
+    diskSizeGb: 500


### PR DESCRIPTION
#### Problem
* Cloud disk space is running out on builds for smoke tests.

#### Change overview
* 2022-07-06  Increase cloudbuild disk size from 200G to 500G for smoke tests (#20391)

#### Testing
N/A (external build)
