### PR TITLE
Enable darwin framework tool tests.

### DIFF
--- a/.github/workflows/darwin-tests.yaml
+++ b/.github/workflows/darwin-tests.yaml
@@ -96,23 +96,22 @@ jobs:
                         build \
                         --copy-artifacts-to objdir-clone \
                      "
-            # Disable for now
-            # - name: Run Tests
-            #   timeout-minutes: 65
-            #   run: |
-            #       ./scripts/run_in_build_env.sh \
-            #       "./scripts/tests/run_test_suite.py \
-            #          --chip-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT}/darwin-framework-tool \
-            #          --target-skip-glob '{TestGroupMessaging}' \
-            #          run \
-            #          --iterations 1 \
-            #          --test-timeout-seconds 120 \
-            #          --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
-            #          --lock-app ./out/darwin-x64-lock-${BUILD_VARIANT}/chip-lock-app \
-            #          --ota-provider-app ./out/darwin-x64-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
-            #          --ota-requestor-app ./out/darwin-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
-            #          --tv-app ./out/darwin-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
-            #       "
+            - name: Run Tests
+              timeout-minutes: 65
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                  "./scripts/tests/run_test_suite.py \
+                     --chip-tool ./out/darwin-x64-darwin-framework-tool-${BUILD_VARIANT}/darwin-framework-tool \
+                     --target-skip-glob '{TestGroupMessaging}' \
+                     run \
+                     --iterations 1 \
+                     --test-timeout-seconds 120 \
+                     --all-clusters-app ./out/darwin-x64-all-clusters-${BUILD_VARIANT}/chip-all-clusters-app \
+                     --lock-app ./out/darwin-x64-lock-${BUILD_VARIANT}/chip-lock-app \
+                     --ota-provider-app ./out/darwin-x64-ota-provider-${BUILD_VARIANT}/chip-ota-provider-app \
+                     --ota-requestor-app ./out/darwin-x64-ota-requestor-${BUILD_VARIANT}/chip-ota-requestor-app \
+                     --tv-app ./out/darwin-x64-tv-app-${BUILD_VARIANT}/chip-tv-app \
+                  "
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() && !env.ACT }}

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -83,6 +83,7 @@ executable("darwin-framework-tool") {
     "commands/common/CHIPCommandBridge.mm",
     "commands/common/CHIPCommandStorageDelegate.mm",
     "commands/common/CHIPToolKeypair.mm",
+    "commands/common/MTRDevice_Externs.h",
     "commands/common/MTRError.mm",
     "commands/common/MTRError_Utils.h",
     "commands/common/MTRLogging.h",

--- a/examples/darwin-framework-tool/commands/common/MTRDevice_Externs.h
+++ b/examples/darwin-framework-tool/commands/common/MTRDevice_Externs.h
@@ -1,0 +1,43 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#ifndef MTR_DEVICE_EXTERNS_H
+#define MTR_DEVICE_EXTERNS_H
+
+#import <Foundation/Foundation.h>
+#import <Matter/Matter.h>
+
+#include <app/ConcreteAttributePath.h>
+#include <app/ConcreteCommandPath.h>
+#include <app/DeviceProxy.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MTRBaseDevice (InternalIntrospection)
+
+/**
+ * Invalidate the CASE session, so an attempt to getConnectedDevice for this
+ * device id will have to create a new CASE session.  Ideally this API will go
+ * away.
+ */
+- (void)invalidateCASESession;
+
+@end
+
+NS_ASSUME_NONNULL_END
+
+#endif /* MTR_DEVICE_EXTERNS_H */

--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -19,7 +19,6 @@
 #pragma once
 
 #include "../common/CHIPCommandBridge.h"
-#include <app/tests/suites/commands/delay/DelayCommands.h>
 #include <app/tests/suites/commands/log/LogCommands.h>
 #include <app/tests/suites/commands/system/SystemCommands.h>
 #include <app/tests/suites/include/ConstraintsChecker.h>
@@ -31,11 +30,18 @@
 
 #import <Matter/Matter.h>
 
+#import "MTRDevice_Externs.h"
 #import "MTRError_Utils.h"
 
 class TestCommandBridge;
 
 NS_ASSUME_NONNULL_BEGIN
+namespace {
+const char basePath[] = "./src/app/tests/suites/commands/delay/scripts/";
+const char * getScriptsFolder() { return basePath; }
+} // namespace
+
+constexpr const char * kDefaultKey = "default";
 
 @interface TestPairingDelegate : NSObject <MTRDevicePairingDelegate>
 @property TestCommandBridge * commandBridge;
@@ -59,7 +65,6 @@ class TestCommandBridge : public CHIPCommandBridge,
                           public ValueChecker,
                           public ConstraintsChecker,
                           public PICSChecker,
-                          public DelayCommands,
                           public LogCommands,
                           public SystemCommands {
 public:
@@ -101,16 +106,50 @@ public:
         SetCommandExitStatus(err);
     }
 
-    /////////// DelayCommands Interface /////////
-    void OnWaitForMs() override
+    /////////// DelayCommands /////////
+    // This function is a modified version of the one in DelayCommands.cpp and is needed here in order to
+    // skip compilation of DelayCommands, which needs to link against SDK internals.
+    CHIP_ERROR WaitForMs(
+        const char * _Nullable identity, const chip::app::Clusters::DelayCommands::Commands::WaitForMs::Type & value)
     {
-        dispatch_async(mCallbackQueue, ^{
+        dispatch_time_t delayTime = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(value.ms * NSEC_PER_MSEC));
+        dispatch_after(delayTime, mCallbackQueue, ^(void) {
             NextTest();
         });
+        return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR WaitForCommissionee(const char * _Nullable identity,
-        const chip::app::Clusters::DelayCommands::Commands::WaitForCommissionee::Type & value) override
+    // This function is identical to DelayCommands.cpp and is needed here in order to
+    // skip compilation of DelayCommands, which needs to link against SDK internals.
+    CHIP_ERROR WaitForMessage(
+        const char * _Nullable identity, const chip::app::Clusters::DelayCommands::Commands::WaitForMessage::Type & value)
+    {
+        VerifyOrReturnError(!value.message.empty(), CHIP_ERROR_INVALID_ARGUMENT);
+
+        const char * scriptDir = getScriptsFolder();
+        constexpr const char * scriptName = "WaitForMessage.py";
+        const char * registerKeyValue = value.registerKey.HasValue() ? value.registerKey.Value().data() : kDefaultKey;
+        const size_t registerKeyLen = value.registerKey.HasValue() ? value.registerKey.Value().size() : strlen(kDefaultKey);
+
+        char command[128];
+        VerifyOrReturnError(
+            snprintf(command, sizeof(command), "%s%s %.*s %.*s", scriptDir, scriptName, static_cast<int>(registerKeyLen),
+                registerKeyValue, static_cast<int>(value.message.size()), value.message.data())
+                >= 0,
+            CHIP_ERROR_INTERNAL);
+        return RunInternal(command);
+    }
+
+    // This function is identical to DelayCommands.cpp and is needed here in order to
+    // skip compilation of DelayCommands, which needs to link against SDK internals.
+    CHIP_ERROR RunInternal(const char * _Nonnull command)
+    {
+        VerifyOrReturnError(system(command) == 0, CHIP_ERROR_INTERNAL);
+        return ContinueOnChipMainThread(CHIP_NO_ERROR);
+    }
+
+    CHIP_ERROR WaitForCommissionee(
+        const char * _Nullable identity, const chip::app::Clusters::DelayCommands::Commands::WaitForCommissionee::Type & value)
     {
         MTRDeviceController * controller = GetCommissioner(identity);
         VerifyOrReturnError(controller != nil, CHIP_ERROR_INCORRECT_STATE);
@@ -119,8 +158,9 @@ public:
 
         // Invalidate our existing CASE session; otherwise getConnectedDevice
         // will just hand it right back to us without establishing a new CASE
-        // session.
+        // session when a reboot is done on the server.
         if (GetDevice(identity) != nil) {
+            [GetDevice(identity) invalidateCASESession];
             mConnectedDevices[identity] = nil;
         }
 


### PR DESCRIPTION
#### Problem
CI tests are not running for darwin-framework-tool.
- Fixes #20460

#### Change overview
- Enables running tests for darwin-framework-tool

#### Testing
- Ran a several tests that were having issues previously
- Allow CI to catch any further issues .
