### PR TITLE
Reenable logging for lock-app by converting to Thread MTD

### DIFF
--- a/examples/lock-app/cc13x2x7_26x2x7/args.gni
+++ b/examples/lock-app/cc13x2x7_26x2x7/args.gni
@@ -29,7 +29,7 @@ lwip_debug = false
 chip_enable_ota_requestor = true
 
 # Disable CHIP Logging
-chip_progress_logging = false
+#chip_progress_logging = false
 chip_detail_logging = false
 chip_automation_logging = false
 
@@ -40,7 +40,7 @@ chip_config_network_layer_ble = true
 # INCLUDE_xSemaphoreGetMutexHolder
 chip_stack_lock_tracking = "none"
 
-chip_openthread_ftd = true
+chip_openthread_ftd = false
 
 matter_device_vid = "0xFFF1"
 matter_device_pid = "0x8006"

--- a/scripts/build/builders/cc13x2x7_26x2x7.py
+++ b/scripts/build/builders/cc13x2x7_26x2x7.py
@@ -85,6 +85,7 @@ class cc13x2x7_26x2x7Builder(GnBuilder):
             pass
         elif self.openthread_ftd:
             args.append('chip_openthread_ftd=true')
+            args.append('chip_progress_logging=false')
         else:
             args.append('chip_openthread_ftd=false')
 

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -158,7 +158,7 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-minimal-app/cc13x2x7_26x2x7 '--args=ti_sysconfig_root="TEST_TI_SYSCONFIG_ROOT"' {out}/cc13x2x7_26x2x7-all-clusters-minimal
 
 # Generating cc13x2x7_26x2x7-lock-ftd
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/cc13x2x7_26x2x7 '--args=ti_sysconfig_root="TEST_TI_SYSCONFIG_ROOT" chip_openthread_ftd=true' {out}/cc13x2x7_26x2x7-lock-ftd
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/cc13x2x7_26x2x7 '--args=ti_sysconfig_root="TEST_TI_SYSCONFIG_ROOT" chip_openthread_ftd=true chip_progress_logging=false' {out}/cc13x2x7_26x2x7-lock-ftd
 
 # Generating cc13x2x7_26x2x7-lock-mtd
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/cc13x2x7_26x2x7 '--args=ti_sysconfig_root="TEST_TI_SYSCONFIG_ROOT" chip_openthread_ftd=false' {out}/cc13x2x7_26x2x7-lock-mtd


### PR DESCRIPTION
#### Problem
Resolves build failure when progress logging is enabled.

#### Change overview
Convert lock-app to MTD

#### Testing
Verified CC13x2 lock app successfully builds.