### PR TITLE
Groups cluster: Check that keys are set before AddGroup.

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -68,6 +68,9 @@ using namespace app::Clusters;
 using namespace app::Clusters::Groups;
 using namespace chip::Credentials;
 
+/**
+ * @brief Checks if group-endpoint association exist for the given fabric
+ */
 static bool GroupExists(FabricIndex fabricIndex, EndpointId endpointId, GroupId groupId)
 {
     GroupDataProvider * provider = GetGroupDataProvider();
@@ -76,13 +79,40 @@ static bool GroupExists(FabricIndex fabricIndex, EndpointId endpointId, GroupId 
     return provider->HasEndpoint(fabricIndex, groupId, endpointId);
 }
 
+/**
+ * @brief Checks if there are key set associated with the given GroupId
+ */
+static bool KeyExists(FabricIndex fabricIndex, GroupId groupId)
+{
+    GroupDataProvider * provider = GetGroupDataProvider();
+    VerifyOrReturnError(nullptr != provider, false);
+    GroupDataProvider::GroupKey entry;
+
+    auto it    = provider->IterateGroupKeys(fabricIndex);
+    bool found = false;
+    while (it->Next(entry) && !found)
+    {
+        found = (entry.group_id == groupId);
+    }
+    it->Release();
+
+    if (found)
+    {
+        GroupDataProvider::KeySet keys;
+        found = (CHIP_NO_ERROR == provider->GetKeySet(fabricIndex, entry.keyset_id, keys));
+    }
+    return found;
+}
+
 static EmberAfStatus GroupAdd(FabricIndex fabricIndex, EndpointId endpointId, GroupId groupId, const CharSpan & groupName)
 {
     VerifyOrReturnError(IsFabricGroupId(groupId), EMBER_ZCL_STATUS_CONSTRAINT_ERROR);
 
     GroupDataProvider * provider = GetGroupDataProvider();
     VerifyOrReturnError(nullptr != provider, EMBER_ZCL_STATUS_NOT_FOUND);
+    VerifyOrReturnError(KeyExists(fabricIndex, groupId), EMBER_ZCL_STATUS_UNSUPPORTED_ACCESS);
 
+    // Add a new entry to the GroupTable
     CHIP_ERROR err = provider->SetGroupInfo(fabricIndex, GroupDataProvider::GroupInfo(groupId, groupName));
     if (CHIP_NO_ERROR == err)
     {

--- a/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
+++ b/src/app/tests/suites/TestGroupKeyManagementCluster.yaml
@@ -41,40 +41,6 @@ tests:
       response:
           value: 2
 
-    - label: "Add Group 1"
-      cluster: "Groups"
-      endpoint: 1
-      command: "AddGroup"
-      arguments:
-          values:
-              - name: "GroupId"
-                value: 0x0101
-              - name: "GroupName"
-                value: "Group #1"
-      response:
-          values:
-              - name: "status"
-                value: 0
-              - name: "GroupId"
-                value: 0x0101
-
-    - label: "Add Group 2"
-      cluster: "Groups"
-      endpoint: 1
-      command: "AddGroup"
-      arguments:
-          values:
-              - name: "GroupId"
-                value: 0x0102
-              - name: "GroupName"
-                value: "Group #2"
-      response:
-          values:
-              - name: "status"
-                value: 0
-              - name: "GroupId"
-                value: 0x0102
-
     - label: "KeySet Write 1"
       command: "KeySetWrite"
       arguments:
@@ -165,6 +131,40 @@ tests:
                   { FabricIndex: 1, GroupId: 0x0101, GroupKeySetID: 0x01a1 },
                   { FabricIndex: 1, GroupId: 0x0102, GroupKeySetID: 0x01a2 },
               ]
+
+    - label: "Add Group 1"
+      cluster: "Groups"
+      endpoint: 1
+      command: "AddGroup"
+      arguments:
+          values:
+              - name: "GroupId"
+                value: 0x0101
+              - name: "GroupName"
+                value: "Group #1"
+      response:
+          values:
+              - name: "status"
+                value: 0
+              - name: "GroupId"
+                value: 0x0101
+
+    - label: "Add Group 2"
+      cluster: "Groups"
+      endpoint: 1
+      command: "AddGroup"
+      arguments:
+          values:
+              - name: "GroupId"
+                value: 0x0102
+              - name: "GroupName"
+                value: "Group #2"
+      response:
+          values:
+              - name: "status"
+                value: 0
+              - name: "GroupId"
+                value: 0x0102
 
     - label: "Read GroupTable"
       command: "readAttribute"

--- a/src/app/tests/suites/TestGroupMessaging.yaml
+++ b/src/app/tests/suites/TestGroupMessaging.yaml
@@ -41,40 +41,6 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "Add Group 1 (endpoint 1)"
-      cluster: "Groups"
-      command: "AddGroup"
-      endpoint: 1
-      arguments:
-          values:
-              - name: "groupId"
-                value: 0x0101
-              - name: "groupName"
-                value: "Group #1"
-      response:
-          values:
-              - name: "status"
-                value: 0
-              - name: "groupId"
-                value: 0x0101
-
-    - label: "Add Group 2 (endpoint 0)"
-      cluster: "Groups"
-      command: "AddGroup"
-      endpoint: 0
-      arguments:
-          values:
-              - name: "groupId"
-                value: 0x0102
-              - name: "groupName"
-                value: "Group #2"
-      response:
-          values:
-              - name: "status"
-                value: 0
-              - name: "groupId"
-                value: 0x0102
-
     - label: "KeySet Write 1"
       cluster: "Group Key Management"
       command: "KeySetWrite"
@@ -121,6 +87,40 @@ tests:
                   { FabricIndex: 0, GroupId: 0x0101, GroupKeySetID: 0x01a1 },
                   { FabricIndex: 0, GroupId: 0x0102, GroupKeySetID: 0x01a2 },
               ]
+
+    - label: "Add Group 1 (endpoint 1)"
+      cluster: "Groups"
+      command: "AddGroup"
+      endpoint: 1
+      arguments:
+          values:
+              - name: "groupId"
+                value: 0x0101
+              - name: "groupName"
+                value: "Group #1"
+      response:
+          values:
+              - name: "status"
+                value: 0
+              - name: "groupId"
+                value: 0x0101
+
+    - label: "Add Group 2 (endpoint 0)"
+      cluster: "Groups"
+      command: "AddGroup"
+      endpoint: 0
+      arguments:
+          values:
+              - name: "groupId"
+                value: 0x0102
+              - name: "groupName"
+                value: "Group #2"
+      response:
+          values:
+              - name: "status"
+                value: 0
+              - name: "groupId"
+                value: 0x0102
 
     - label: "Install ACLs"
       cluster: "Access Control"
@@ -169,7 +169,7 @@ tests:
       arguments:
           values:
               - name: "ms"
-                value: 100
+                value: 1000
 
       # Test Pair 2 : Validates previous group write attribute with a unicast to read
     - label: "Read back Attribute"
@@ -290,42 +290,6 @@ tests:
               - name: "nodeId"
                 value: nodeId2
 
-    - label: "Add Group 1 (endpoint 1) for gamma"
-      identity: "gamma"
-      cluster: "Groups"
-      command: "AddGroup"
-      endpoint: 1
-      arguments:
-          values:
-              - name: "groupId"
-                value: 0x0101
-              - name: "groupName"
-                value: "Group #1"
-      response:
-          values:
-              - name: "status"
-                value: 0
-              - name: "groupId"
-                value: 0x0101
-
-    - label: "Add Group 2 (endpoint 0) for gamma"
-      identity: "gamma"
-      cluster: "Groups"
-      command: "AddGroup"
-      endpoint: 0
-      arguments:
-          values:
-              - name: "groupId"
-                value: 0x0102
-              - name: "groupName"
-                value: "Group #2"
-      response:
-          values:
-              - name: "status"
-                value: 0
-              - name: "groupId"
-                value: 0x0102
-
     - label: "KeySet Write 1 for gamma"
       identity: "gamma"
       cluster: "Group Key Management"
@@ -375,6 +339,42 @@ tests:
                   { FabricIndex: 0, GroupId: 0x0101, GroupKeySetID: 0x01a1 },
                   { FabricIndex: 0, GroupId: 0x0102, GroupKeySetID: 0x01a2 },
               ]
+
+    - label: "Add Group 1 (endpoint 1) for gamma"
+      identity: "gamma"
+      cluster: "Groups"
+      command: "AddGroup"
+      endpoint: 1
+      arguments:
+          values:
+              - name: "groupId"
+                value: 0x0101
+              - name: "groupName"
+                value: "Group #1"
+      response:
+          values:
+              - name: "status"
+                value: 0
+              - name: "groupId"
+                value: 0x0101
+
+    - label: "Add Group 2 (endpoint 0) for gamma"
+      identity: "gamma"
+      cluster: "Groups"
+      command: "AddGroup"
+      endpoint: 0
+      arguments:
+          values:
+              - name: "groupId"
+                value: 0x0102
+              - name: "groupName"
+                value: "Group #2"
+      response:
+          values:
+              - name: "status"
+                value: 0
+              - name: "groupId"
+                value: 0x0102
 
     - label: "Install ACLs for gamma"
       identity: "gamma"

--- a/src/app/tests/suites/TestGroupsCluster.yaml
+++ b/src/app/tests/suites/TestGroupsCluster.yaml
@@ -46,20 +46,66 @@ tests:
       arguments:
           values:
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
       response:
           values:
               - name: "status"
                 value: 0x8B
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
+
+    - label: "Add First Group (no keys)"
+      command: "AddGroup"
+      arguments:
+          values:
+              - name: "groupId"
+                value: 0x0101
+              - name: "groupName"
+                value: "Group #1"
+      response:
+          values:
+              - name: "status"
+                value: 0x7e
+              - name: "groupId"
+                value: 0x0101
+
+    - label: "Add KeySet"
+      cluster: "Group Key Management"
+      endpoint: 0
+      command: "KeySetWrite"
+      arguments:
+          values:
+              - name: "GroupKeySet"
+                value:
+                    {
+                        GroupKeySetID: 0x01a1,
+                        GroupKeySecurityPolicy: 0,
+                        EpochKey0: "\xa0\xa1\xa2\xa3\xa4\xa5\xa6\xa7\xa8\xa9\xaa\xab\xac\xad\xae\xaf",
+                        EpochStartTime0: 1110000,
+                        EpochKey1: "\xb0\xb1\xb2\xb3\xb4\xb5\xb6\xb7\xb8\xb9\xba\xbb\xbc\xbd\xbe\xbf",
+                        EpochStartTime1: 1110001,
+                        EpochKey2: "\xc0\xc1\xc2\xc3\xc4\xc5\xc6\xc7\xc8\xc9\xca\xcb\xcc\xcd\xce\xcf",
+                        EpochStartTime2: 1110002,
+                    }
+
+    - label: "Write Group Keys"
+      cluster: "Group Key Management"
+      endpoint: 0
+      command: "writeAttribute"
+      attribute: "GroupKeyMap"
+      arguments:
+          value:
+              [
+                  { FabricIndex: 1, GroupId: 0x0101, GroupKeySetID: 0x01a1 },
+                  { FabricIndex: 1, GroupId: 0x0102, GroupKeySetID: 0x01a1 },
+              ]
 
     - label: "Add First Group (new)"
       command: "AddGroup"
       arguments:
           values:
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
               - name: "groupName"
                 value: "Group #1"
       response:
@@ -67,20 +113,20 @@ tests:
               - name: "status"
                 value: 0
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
 
     - label: "View First Group (new)"
       command: "ViewGroup"
       arguments:
           values:
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
       response:
           values:
               - name: "status"
                 value: 0
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
               - name: "groupName"
                 value: "Group #1"
 
@@ -89,13 +135,13 @@ tests:
       arguments:
           values:
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
       response:
           values:
               - name: "status"
                 value: 0x8B
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
 
     - label: "Get Group Membership 1 (all)"
       command: "GetGroupMembership"
@@ -108,16 +154,14 @@ tests:
               - name: "capacity"
                 value: null
               - name: "groupList"
-                value: [0x01]
+                value: [0x0101]
 
     - label: "Add Second Group (new)"
-      # https://github.com/project-chip/connectedhomeip/issues/11312
-      disabled: true
       command: "AddGroup"
       arguments:
           values:
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
               - name: "groupName"
                 value: "Group #2"
       response:
@@ -125,22 +169,20 @@ tests:
               - name: "status"
                 value: 0
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
 
     - label: "View Second Group (new)"
-      # https://github.com/project-chip/connectedhomeip/issues/11312
-      disabled: true
       command: "ViewGroup"
       arguments:
           values:
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
       response:
           values:
               - name: "status"
                 value: 0
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
               - name: "groupName"
                 value: "Group #2"
 
@@ -179,47 +221,43 @@ tests:
       arguments:
           values:
               - name: "groupId"
-                value: 0x01
+                value: 0x0101
       response:
           values:
               - name: "status"
                 value: 0
               - name: "groupId"
-                value: 0x01
+                value: 0x0101
               - name: "groupName"
                 value: "Group #1"
 
     - label: "View Second Group (existing)"
-      # https://github.com/project-chip/connectedhomeip/issues/11312
-      disabled: true
       command: "ViewGroup"
       arguments:
           values:
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
       response:
           values:
               - name: "status"
                 value: 0
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
               - name: "groupName"
                 value: "Group #2"
 
     - label: "Get Group Membership 2"
-      # https://github.com/project-chip/connectedhomeip/issues/11312
-      disabled: true
       command: "GetGroupMembership"
       arguments:
           values:
               - name: "groupList"
-                value: [0x02, 0x03, 0x7fff]
+                value: [0x0102, 0x0103, 0x7fff]
       response:
           values:
               - name: "capacity"
                 value: null
               - name: "groupList"
-                value: [0x7fff]
+                value: [0x0102]
 
     - label: "View Group 3 (new)"
       # https://github.com/project-chip/connectedhomeip/issues/11312
@@ -256,41 +294,39 @@ tests:
       arguments:
           values:
               - name: "groupId"
-                value: 0x04
+                value: 0x0104
       response:
           values:
               - name: "status"
                 value: 0x8B
               - name: "groupId"
-                value: 0x04
+                value: 0x0104
 
     - label: "Remove Second Group (existing)"
-      # https://github.com/project-chip/connectedhomeip/issues/11312
-      disabled: true
       command: "RemoveGroup"
       arguments:
           values:
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
       response:
           values:
               - name: "status"
                 value: 0
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
 
     - label: "View First Group (not removed)"
       command: "ViewGroup"
       arguments:
           values:
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
       response:
           values:
               - name: "status"
                 value: 0
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
               - name: "groupName"
                 value: "Group #1"
 
@@ -299,13 +335,13 @@ tests:
       arguments:
           values:
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
       response:
           values:
               - name: "status"
                 value: 0x8B
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
 
     - label: "View Group 3 (not removed)"
       # https://github.com/project-chip/connectedhomeip/issues/11312
@@ -329,13 +365,13 @@ tests:
       arguments:
           values:
               - name: "groupList"
-                value: [0x01, 0x02, 0x1111, 0x03]
+                value: [0x01, 0x0101, 0x0102, 0x03]
       response:
           values:
               - name: "capacity"
                 value: null
               - name: "groupList"
-                value: [0x01]
+                value: [0x0101]
 
     - label: "Remove All"
       command: "RemoveAllGroups"
@@ -345,26 +381,26 @@ tests:
       arguments:
           values:
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
       response:
           values:
               - name: "status"
                 value: 0x8B
               - name: "groupId"
-                value: 0x0001
+                value: 0x0101
 
     - label: "View Second Group (still removed)"
       command: "ViewGroup"
       arguments:
           values:
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
       response:
           values:
               - name: "status"
                 value: 0x8B
               - name: "groupId"
-                value: 0x1111
+                value: 0x0102
 
     - label: "View Group 3 (removed)"
       command: "ViewGroup"
@@ -384,7 +420,7 @@ tests:
       arguments:
           values:
               - name: "groupList"
-                value: [0x01, 0x02, 0x1111, 0x03, 0x7fff]
+                value: [0x01, 0x0101, 0x0102, 0x03, 0x7fff]
       response:
           values:
               - name: "capacity"

--- a/zzz_generated/chip-tool/zap-generated/test/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/test/Commands.h
@@ -61404,6 +61404,15 @@ private:
             break;
         case 1:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 2:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 3:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 4:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
@@ -61411,7 +61420,7 @@ private:
                 VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
             }
             break;
-        case 2:
+        case 5:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
@@ -61419,15 +61428,6 @@ private:
                 VerifyOrReturn(CheckValue("status", value.status, 0U));
                 VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
             }
-            break;
-        case 3:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 4:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 5:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -61512,6 +61512,15 @@ private:
             break;
         case 23:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 24:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 25:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 26:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
@@ -61519,7 +61528,7 @@ private:
                 VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
             }
             break;
-        case 24:
+        case 27:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
@@ -61527,15 +61536,6 @@ private:
                 VerifyOrReturn(CheckValue("status", value.status, 0U));
                 VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
             }
-            break;
-        case 25:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 26:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 27:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
         case 28:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
@@ -61627,27 +61627,7 @@ private:
             return WaitForCommissionee(kIdentityAlpha, value);
         }
         case 1: {
-            LogStep(1, "Add Group 1 (endpoint 1)");
-            ListFreer listFreer;
-            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
-            value.groupId   = 257U;
-            value.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
-            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
-
-            );
-        }
-        case 2: {
-            LogStep(2, "Add Group 2 (endpoint 0)");
-            ListFreer listFreer;
-            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
-            value.groupId   = 258U;
-            value.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
-            return SendCommand(kIdentityAlpha, GetEndpoint(0), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
-
-            );
-        }
-        case 3: {
-            LogStep(3, "KeySet Write 1");
+            LogStep(1, "KeySet Write 1");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type value;
 
@@ -61681,8 +61661,8 @@ private:
 
             );
         }
-        case 4: {
-            LogStep(4, "KeySet Write 2");
+        case 2: {
+            LogStep(2, "KeySet Write 2");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type value;
 
@@ -61716,8 +61696,8 @@ private:
 
             );
         }
-        case 5: {
-            LogStep(5, "Write Group Keys");
+        case 3: {
+            LogStep(3, "Write Group Keys");
             ListFreer listFreer;
             chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type> value;
 
@@ -61738,6 +61718,26 @@ private:
             }
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), GroupKeyManagement::Id,
                                   GroupKeyManagement::Attributes::GroupKeyMap::Id, value, chip::NullOptional, chip::NullOptional);
+        }
+        case 4: {
+            LogStep(4, "Add Group 1 (endpoint 1)");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
+            value.groupId   = 257U;
+            value.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
+
+            );
+        }
+        case 5: {
+            LogStep(5, "Add Group 2 (endpoint 0)");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
+            value.groupId   = 258U;
+            value.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
+            return SendCommand(kIdentityAlpha, GetEndpoint(0), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
+
+            );
         }
         case 6: {
             LogStep(6, "Install ACLs");
@@ -61782,7 +61782,7 @@ private:
             LogStep(9, "Wait for write 1");
             ListFreer listFreer;
             chip::app::Clusters::DelayCommands::Commands::WaitForMs::Type value;
-            value.ms = 100UL;
+            value.ms = 1000UL;
             return WaitForMs(kIdentityAlpha, value);
         }
         case 10: {
@@ -61886,27 +61886,7 @@ private:
             return WaitForCommissionee(kIdentityGamma, value);
         }
         case 23: {
-            LogStep(23, "Add Group 1 (endpoint 1) for gamma");
-            ListFreer listFreer;
-            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
-            value.groupId   = 257U;
-            value.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
-            return SendCommand(kIdentityGamma, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
-
-            );
-        }
-        case 24: {
-            LogStep(24, "Add Group 2 (endpoint 0) for gamma");
-            ListFreer listFreer;
-            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
-            value.groupId   = 258U;
-            value.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
-            return SendCommand(kIdentityGamma, GetEndpoint(0), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
-
-            );
-        }
-        case 25: {
-            LogStep(25, "KeySet Write 1 for gamma");
+            LogStep(23, "KeySet Write 1 for gamma");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type value;
 
@@ -61940,8 +61920,8 @@ private:
 
             );
         }
-        case 26: {
-            LogStep(26, "KeySet Write 2 for gamma");
+        case 24: {
+            LogStep(24, "KeySet Write 2 for gamma");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type value;
 
@@ -61975,8 +61955,8 @@ private:
 
             );
         }
-        case 27: {
-            LogStep(27, "Write Group Keys for gamma");
+        case 25: {
+            LogStep(25, "Write Group Keys for gamma");
             ListFreer listFreer;
             chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type> value;
 
@@ -61997,6 +61977,26 @@ private:
             }
             return WriteAttribute(kIdentityGamma, GetEndpoint(0), GroupKeyManagement::Id,
                                   GroupKeyManagement::Attributes::GroupKeyMap::Id, value, chip::NullOptional, chip::NullOptional);
+        }
+        case 26: {
+            LogStep(26, "Add Group 1 (endpoint 1) for gamma");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
+            value.groupId   = 257U;
+            value.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
+            return SendCommand(kIdentityGamma, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
+
+            );
+        }
+        case 27: {
+            LogStep(27, "Add Group 2 (endpoint 0) for gamma");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
+            value.groupId   = 258U;
+            value.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
+            return SendCommand(kIdentityGamma, GetEndpoint(0), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
+
+            );
         }
         case 28: {
             LogStep(28, "Install ACLs for gamma");
@@ -62118,7 +62118,7 @@ private:
 class TestGroupsClusterSuite : public TestCommand
 {
 public:
-    TestGroupsClusterSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestGroupsCluster", 19, credsIssuerConfig)
+    TestGroupsClusterSuite(CredentialIssuerCommands * credsIssuerConfig) : TestCommand("TestGroupsCluster", 27, credsIssuerConfig)
     {
         AddArgument("nodeId", 0, UINT64_MAX, &mNodeId);
         AddArgument("cluster", &mCluster);
@@ -62170,7 +62170,7 @@ private:
                 chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("status", value.status, 139U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 1U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
             }
             break;
         case 3:
@@ -62178,30 +62178,45 @@ private:
             {
                 chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 0U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 1U));
+                VerifyOrReturn(CheckValue("status", value.status, 126U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
             }
             break;
         case 4:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 5:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 6:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 0U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
+            }
+            break;
+        case 7:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("status", value.status, 0U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 1U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
                 VerifyOrReturn(CheckValueAsString("groupName", value.groupName, chip::CharSpan("Group #1", 8)));
             }
             break;
-        case 5:
+        case 8:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("status", value.status, 139U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 4369U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
             }
             break;
-        case 6:
+        case 9:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType value;
@@ -62210,46 +62225,18 @@ private:
                 {
                     auto iter_0 = value.groupList.begin();
                     VerifyOrReturn(CheckNextListItemDecodes<decltype(value.groupList)>("groupList", iter_0, 0));
-                    VerifyOrReturn(CheckValue("groupList[0]", iter_0.GetValue(), 1U));
+                    VerifyOrReturn(CheckValue("groupList[0]", iter_0.GetValue(), 257U));
                     VerifyOrReturn(CheckNoMoreListItems<decltype(value.groupList)>("groupList", iter_0, 1));
                 }
-            }
-            break;
-        case 7:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 32767U));
-            }
-            break;
-        case 8:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 0U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 1U));
-                VerifyOrReturn(CheckValueAsString("groupName", value.groupName, chip::CharSpan("Group #1", 8)));
-            }
-            break;
-        case 9:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 135U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 0U));
             }
             break;
         case 10:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType value;
+                chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 4U));
+                VerifyOrReturn(CheckValue("status", value.status, 0U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
             }
             break;
         case 11:
@@ -62258,8 +62245,8 @@ private:
                 chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("status", value.status, 0U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 1U));
-                VerifyOrReturn(CheckValueAsString("groupName", value.groupName, chip::CharSpan("Group #1", 8)));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
+                VerifyOrReturn(CheckValueAsString("groupName", value.groupName, chip::CharSpan("Group #2", 8)));
             }
             break;
         case 12:
@@ -62268,10 +62255,30 @@ private:
                 chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
                 VerifyOrReturn(CheckValue("status", value.status, 139U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 4369U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 32767U));
             }
             break;
         case 13:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 0U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
+                VerifyOrReturn(CheckValueAsString("groupName", value.groupName, chip::CharSpan("Group #1", 8)));
+            }
+            break;
+        case 14:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 0U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
+                VerifyOrReturn(CheckValueAsString("groupName", value.groupName, chip::CharSpan("Group #2", 8)));
+            }
+            break;
+        case 15:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType value;
@@ -62280,33 +62287,93 @@ private:
                 {
                     auto iter_0 = value.groupList.begin();
                     VerifyOrReturn(CheckNextListItemDecodes<decltype(value.groupList)>("groupList", iter_0, 0));
-                    VerifyOrReturn(CheckValue("groupList[0]", iter_0.GetValue(), 1U));
+                    VerifyOrReturn(CheckValue("groupList[0]", iter_0.GetValue(), 258U));
                     VerifyOrReturn(CheckNoMoreListItems<decltype(value.groupList)>("groupList", iter_0, 1));
                 }
-            }
-            break;
-        case 14:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 15:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 1U));
             }
             break;
         case 16:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
-                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
+                chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType value;
                 VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 139U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 4369U));
+                VerifyOrReturn(CheckValue("status", value.status, 135U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 0U));
             }
             break;
         case 17:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 260U));
+            }
+            break;
+        case 18:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::RemoveGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 0U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
+            }
+            break;
+        case 19:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 0U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
+                VerifyOrReturn(CheckValueAsString("groupName", value.groupName, chip::CharSpan("Group #1", 8)));
+            }
+            break;
+        case 20:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
+            }
+            break;
+        case 21:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValueNull("capacity", value.capacity));
+                {
+                    auto iter_0 = value.groupList.begin();
+                    VerifyOrReturn(CheckNextListItemDecodes<decltype(value.groupList)>("groupList", iter_0, 0));
+                    VerifyOrReturn(CheckValue("groupList[0]", iter_0.GetValue(), 257U));
+                    VerifyOrReturn(CheckNoMoreListItems<decltype(value.groupList)>("groupList", iter_0, 1));
+                }
+            }
+            break;
+        case 22:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            break;
+        case 23:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
+            }
+            break;
+        case 24:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 139U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
+            }
+            break;
+        case 25:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::ViewGroupResponse::DecodableType value;
@@ -62315,7 +62382,7 @@ private:
                 VerifyOrReturn(CheckValue("groupId", value.groupId, 32767U));
             }
             break;
-        case 18:
+        case 26:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::Groups::Commands::GetGroupMembershipResponse::DecodableType value;
@@ -62363,44 +62430,112 @@ private:
             LogStep(2, "View First Group (not found)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
-            value.groupId = 1U;
+            value.groupId = 257U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
                                chip::NullOptional
 
             );
         }
         case 3: {
-            LogStep(3, "Add First Group (new)");
+            LogStep(3, "Add First Group (no keys)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::AddGroup::Type value;
-            value.groupId   = 1U;
+            value.groupId   = 257U;
             value.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
 
             );
         }
         case 4: {
-            LogStep(4, "View First Group (new)");
+            LogStep(4, "Add KeySet");
             ListFreer listFreer;
-            chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
-            value.groupId = 1U;
-            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
-                               chip::NullOptional
+            chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type value;
+
+            value.groupKeySet.groupKeySetID = 417U;
+            value.groupKeySet.groupKeySecurityPolicy =
+                static_cast<chip::app::Clusters::GroupKeyManagement::GroupKeySecurityPolicy>(0);
+            value.groupKeySet.epochKey0.SetNonNull();
+            value.groupKeySet.epochKey0.Value() = chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "\240\241\242\243\244\245\246\247\250\251\252\253\254\255\256\257garbage: not in length on purpose"),
+                16);
+            value.groupKeySet.epochStartTime0.SetNonNull();
+            value.groupKeySet.epochStartTime0.Value() = 1110000ULL;
+            value.groupKeySet.epochKey1.SetNonNull();
+            value.groupKeySet.epochKey1.Value() = chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "\260\261\262\263\264\265\266\267\270\271\272\273\274\275\276\277garbage: not in length on purpose"),
+                16);
+            value.groupKeySet.epochStartTime1.SetNonNull();
+            value.groupKeySet.epochStartTime1.Value() = 1110001ULL;
+            value.groupKeySet.epochKey2.SetNonNull();
+            value.groupKeySet.epochKey2.Value() = chip::ByteSpan(
+                chip::Uint8::from_const_char(
+                    "\300\301\302\303\304\305\306\307\310\311\312\313\314\315\316\317garbage: not in length on purpose"),
+                16);
+            value.groupKeySet.epochStartTime2.SetNonNull();
+            value.groupKeySet.epochStartTime2.Value() = 1110002ULL;
+
+            return SendCommand(kIdentityAlpha, GetEndpoint(0), GroupKeyManagement::Id,
+                               GroupKeyManagement::Commands::KeySetWrite::Id, value, chip::NullOptional
 
             );
         }
         case 5: {
-            LogStep(5, "View Second Group (not found)");
+            LogStep(5, "Write Group Keys");
+            ListFreer listFreer;
+            chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type> value;
+
+            {
+                auto * listHolder_0 = new ListHolder<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(2);
+                listFreer.add(listHolder_0);
+
+                listHolder_0->mList[0].groupId       = 257U;
+                listHolder_0->mList[0].groupKeySetID = 417U;
+                listHolder_0->mList[0].fabricIndex   = 1U;
+
+                listHolder_0->mList[1].groupId       = 258U;
+                listHolder_0->mList[1].groupKeySetID = 417U;
+                listHolder_0->mList[1].fabricIndex   = 1U;
+
+                value = chip::app::DataModel::List<chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type>(
+                    listHolder_0->mList, 2);
+            }
+            return WriteAttribute(kIdentityAlpha, GetEndpoint(0), GroupKeyManagement::Id,
+                                  GroupKeyManagement::Attributes::GroupKeyMap::Id, value, chip::NullOptional, chip::NullOptional);
+        }
+        case 6: {
+            LogStep(6, "Add First Group (new)");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
+            value.groupId   = 257U;
+            value.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
+
+            );
+        }
+        case 7: {
+            LogStep(7, "View First Group (new)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
-            value.groupId = 4369U;
+            value.groupId = 257U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
                                chip::NullOptional
 
             );
         }
-        case 6: {
-            LogStep(6, "Get Group Membership 1 (all)");
+        case 8: {
+            LogStep(8, "View Second Group (not found)");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
+            value.groupId = 258U;
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
+                               chip::NullOptional
+
+            );
+        }
+        case 9: {
+            LogStep(9, "Get Group Membership 1 (all)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::GetGroupMembership::Type value;
 
@@ -62410,8 +62545,28 @@ private:
 
             );
         }
-        case 7: {
-            LogStep(7, "View Group 3 (not found)");
+        case 10: {
+            LogStep(10, "Add Second Group (new)");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
+            value.groupId   = 258U;
+            value.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
+
+            );
+        }
+        case 11: {
+            LogStep(11, "View Second Group (new)");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
+            value.groupId = 258U;
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
+                               chip::NullOptional
+
+            );
+        }
+        case 12: {
+            LogStep(12, "View Group 3 (not found)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
             value.groupId = 32767U;
@@ -62420,18 +62575,46 @@ private:
 
             );
         }
-        case 8: {
-            LogStep(8, "View First Group (existing)");
+        case 13: {
+            LogStep(13, "View First Group (existing)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
-            value.groupId = 1U;
+            value.groupId = 257U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
                                chip::NullOptional
 
             );
         }
-        case 9: {
-            LogStep(9, "Remove Group 0 (invalid)");
+        case 14: {
+            LogStep(14, "View Second Group (existing)");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
+            value.groupId = 258U;
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
+                               chip::NullOptional
+
+            );
+        }
+        case 15: {
+            LogStep(15, "Get Group Membership 2");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::GetGroupMembership::Type value;
+
+            {
+                auto * listHolder_0 = new ListHolder<chip::GroupId>(3);
+                listFreer.add(listHolder_0);
+                listHolder_0->mList[0] = 258U;
+                listHolder_0->mList[1] = 259U;
+                listHolder_0->mList[2] = 32767U;
+                value.groupList        = chip::app::DataModel::List<chip::GroupId>(listHolder_0->mList, 3);
+            }
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::GetGroupMembership::Id, value,
+                               chip::NullOptional
+
+            );
+        }
+        case 16: {
+            LogStep(16, "Remove Group 0 (invalid)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::RemoveGroup::Type value;
             value.groupId = 0U;
@@ -62440,38 +62623,48 @@ private:
 
             );
         }
-        case 10: {
-            LogStep(10, "Remove Group 4 (not found)");
+        case 17: {
+            LogStep(17, "Remove Group 4 (not found)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::RemoveGroup::Type value;
-            value.groupId = 4U;
+            value.groupId = 260U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::RemoveGroup::Id, value,
                                chip::NullOptional
 
             );
         }
-        case 11: {
-            LogStep(11, "View First Group (not removed)");
+        case 18: {
+            LogStep(18, "Remove Second Group (existing)");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::RemoveGroup::Type value;
+            value.groupId = 258U;
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::RemoveGroup::Id, value,
+                               chip::NullOptional
+
+            );
+        }
+        case 19: {
+            LogStep(19, "View First Group (not removed)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
-            value.groupId = 1U;
+            value.groupId = 257U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
                                chip::NullOptional
 
             );
         }
-        case 12: {
-            LogStep(12, "View Second Group (removed)");
+        case 20: {
+            LogStep(20, "View Second Group (removed)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
-            value.groupId = 4369U;
+            value.groupId = 258U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
                                chip::NullOptional
 
             );
         }
-        case 13: {
-            LogStep(13, "Get Group Membership 3");
+        case 21: {
+            LogStep(21, "Get Group Membership 3");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::GetGroupMembership::Type value;
 
@@ -62479,8 +62672,8 @@ private:
                 auto * listHolder_0 = new ListHolder<chip::GroupId>(4);
                 listFreer.add(listHolder_0);
                 listHolder_0->mList[0] = 1U;
-                listHolder_0->mList[1] = 2U;
-                listHolder_0->mList[2] = 4369U;
+                listHolder_0->mList[1] = 257U;
+                listHolder_0->mList[2] = 258U;
                 listHolder_0->mList[3] = 3U;
                 value.groupList        = chip::app::DataModel::List<chip::GroupId>(listHolder_0->mList, 4);
             }
@@ -62489,8 +62682,8 @@ private:
 
             );
         }
-        case 14: {
-            LogStep(14, "Remove All");
+        case 22: {
+            LogStep(22, "Remove All");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::RemoveAllGroups::Type value;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::RemoveAllGroups::Id, value,
@@ -62498,28 +62691,28 @@ private:
 
             );
         }
-        case 15: {
-            LogStep(15, "View First Group (removed)");
+        case 23: {
+            LogStep(23, "View First Group (removed)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
-            value.groupId = 1U;
+            value.groupId = 257U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
                                chip::NullOptional
 
             );
         }
-        case 16: {
-            LogStep(16, "View Second Group (still removed)");
+        case 24: {
+            LogStep(24, "View Second Group (still removed)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
-            value.groupId = 4369U;
+            value.groupId = 258U;
             return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::ViewGroup::Id, value,
                                chip::NullOptional
 
             );
         }
-        case 17: {
-            LogStep(17, "View Group 3 (removed)");
+        case 25: {
+            LogStep(25, "View Group 3 (removed)");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::ViewGroup::Type value;
             value.groupId = 32767U;
@@ -62528,8 +62721,8 @@ private:
 
             );
         }
-        case 18: {
-            LogStep(18, "Get Group Membership 4");
+        case 26: {
+            LogStep(26, "Get Group Membership 4");
             ListFreer listFreer;
             chip::app::Clusters::Groups::Commands::GetGroupMembership::Type value;
 
@@ -62537,8 +62730,8 @@ private:
                 auto * listHolder_0 = new ListHolder<chip::GroupId>(5);
                 listFreer.add(listHolder_0);
                 listHolder_0->mList[0] = 1U;
-                listHolder_0->mList[1] = 2U;
-                listHolder_0->mList[2] = 4369U;
+                listHolder_0->mList[1] = 257U;
+                listHolder_0->mList[2] = 258U;
                 listHolder_0->mList[3] = 3U;
                 listHolder_0->mList[4] = 32767U;
                 value.groupList        = chip::app::DataModel::List<chip::GroupId>(listHolder_0->mList, 5);
@@ -62612,29 +62805,11 @@ private:
             break;
         case 3:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 0U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
-            }
             break;
         case 4:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            {
-                chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
-                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
-                VerifyOrReturn(CheckValue("status", value.status, 0U));
-                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
-            }
             break;
         case 5:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 6:
-            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
-            break;
-        case 7:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::Clusters::GroupKeyManagement::Commands::KeySetReadResponse::DecodableType value;
@@ -62655,13 +62830,13 @@ private:
                     CheckValue("groupKeySet.epochStartTime2.Value()", value.groupKeySet.epochStartTime2.Value(), 1110002ULL));
             }
             break;
-        case 8:
+        case 6:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), EMBER_ZCL_STATUS_CONSTRAINT_ERROR));
             break;
-        case 9:
+        case 7:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             break;
-        case 10:
+        case 8:
             VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
             {
                 chip::app::DataModel::DecodableList<
@@ -62680,6 +62855,24 @@ private:
                     VerifyOrReturn(CheckValue("groupKeyMap[1].fabricIndex", iter_0.GetValue().fabricIndex, 1U));
                     VerifyOrReturn(CheckNoMoreListItems<decltype(value)>("groupKeyMap", iter_0, 2));
                 }
+            }
+            break;
+        case 9:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 0U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 257U));
+            }
+            break;
+        case 10:
+            VerifyOrReturn(CheckValue("status", chip::to_underlying(status.mStatus), 0));
+            {
+                chip::app::Clusters::Groups::Commands::AddGroupResponse::DecodableType value;
+                VerifyOrReturn(CheckDecodeValue(chip::app::DataModel::Decode(*data, value)));
+                VerifyOrReturn(CheckValue("status", value.status, 0U));
+                VerifyOrReturn(CheckValue("groupId", value.groupId, 258U));
             }
             break;
         case 11:
@@ -62817,27 +63010,7 @@ private:
                                  GroupKeyManagement::Attributes::MaxGroupKeysPerFabric::Id, true, chip::NullOptional);
         }
         case 3: {
-            LogStep(3, "Add Group 1");
-            ListFreer listFreer;
-            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
-            value.groupId   = 257U;
-            value.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
-            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
-
-            );
-        }
-        case 4: {
-            LogStep(4, "Add Group 2");
-            ListFreer listFreer;
-            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
-            value.groupId   = 258U;
-            value.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
-            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
-
-            );
-        }
-        case 5: {
-            LogStep(5, "KeySet Write 1");
+            LogStep(3, "KeySet Write 1");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type value;
 
@@ -62871,8 +63044,8 @@ private:
 
             );
         }
-        case 6: {
-            LogStep(6, "KeySet Write 2");
+        case 4: {
+            LogStep(4, "KeySet Write 2");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetWrite::Type value;
 
@@ -62906,8 +63079,8 @@ private:
 
             );
         }
-        case 7: {
-            LogStep(7, "KeySet Read");
+        case 5: {
+            LogStep(5, "KeySet Read");
             ListFreer listFreer;
             chip::app::Clusters::GroupKeyManagement::Commands::KeySetRead::Type value;
             value.groupKeySetID = 417U;
@@ -62916,8 +63089,8 @@ private:
 
             );
         }
-        case 8: {
-            LogStep(8, "Write Group Keys (invalid)");
+        case 6: {
+            LogStep(6, "Write Group Keys (invalid)");
             ListFreer listFreer;
             chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type> value;
 
@@ -62935,8 +63108,8 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), GroupKeyManagement::Id,
                                   GroupKeyManagement::Attributes::GroupKeyMap::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 9: {
-            LogStep(9, "Write Group Keys");
+        case 7: {
+            LogStep(7, "Write Group Keys");
             ListFreer listFreer;
             chip::app::DataModel::List<const chip::app::Clusters::GroupKeyManagement::Structs::GroupKeyMapStruct::Type> value;
 
@@ -62958,10 +63131,30 @@ private:
             return WriteAttribute(kIdentityAlpha, GetEndpoint(0), GroupKeyManagement::Id,
                                   GroupKeyManagement::Attributes::GroupKeyMap::Id, value, chip::NullOptional, chip::NullOptional);
         }
-        case 10: {
-            LogStep(10, "Read Group Keys");
+        case 8: {
+            LogStep(8, "Read Group Keys");
             return ReadAttribute(kIdentityAlpha, GetEndpoint(0), GroupKeyManagement::Id,
                                  GroupKeyManagement::Attributes::GroupKeyMap::Id, true, chip::NullOptional);
+        }
+        case 9: {
+            LogStep(9, "Add Group 1");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
+            value.groupId   = 257U;
+            value.groupName = chip::Span<const char>("Group #1garbage: not in length on purpose", 8);
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
+
+            );
+        }
+        case 10: {
+            LogStep(10, "Add Group 2");
+            ListFreer listFreer;
+            chip::app::Clusters::Groups::Commands::AddGroup::Type value;
+            value.groupId   = 258U;
+            value.groupName = chip::Span<const char>("Group #2garbage: not in length on purpose", 8);
+            return SendCommand(kIdentityAlpha, GetEndpoint(1), Groups::Id, Groups::Commands::AddGroup::Id, value, chip::NullOptional
+
+            );
         }
         case 11: {
             LogStep(11, "Read GroupTable");


### PR DESCRIPTION
#### Problem
* Fixes [#20401](https://github.com/project-chip/connectedhomeip/issues/20401): Group keys needs to be added before groups.

#### Change overview
* Added check in AddGroup to verify that keys exists for the new endpoint/group.
* Group, and GroupKeyManagement YAML tests updated accordingly.

#### Testing
Group, and GroupKeyManagement tests executed successfully.
