### PR TITLE
GCB Queue TTL

### DIFF
--- a/integrations/cloudbuild/README.md
+++ b/integrations/cloudbuild/README.md
@@ -6,7 +6,8 @@ Follow https://cloud.google.com/sdk/docs/install.
 
 #### Local execution
 
-In order to test locally, comment out the `machineType` entry in the build yaml.
+In order to test locally, comment out the `machineType` and `queueTtl` entry in
+the build yaml.
 
 ```
 # Once only setup:

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -32,7 +32,8 @@ steps:
 logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
-timeout: 14400s
+timeout: 21600s
+queueTtl: 21600s
 
 artifacts:
     objects:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -30,6 +30,7 @@ logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
 timeout: 14400s
+queueTtl: 21600s
 
 artifacts:
     objects:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -100,6 +100,7 @@ logsBucket: matter-build-automation-build-logs
 
 # Global timeout for all steps
 timeout: 9000s
+queueTtl: 21600s
 
 artifacts:
     objects:


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* GCB is timing out in queue

#### Change overview
* add [queueTtl](https://cloud.google.com/build/docs/build-config-file-schema#queuettl)
* README for local builder

#### Testing
* The local builder does not accept this parameter, so I ran an actual build on another config with the setting in a test project [here](https://github.com/aBozowski/connectedhomeip/commit/69b10d9a3dbb013ccd0f794b7416bd35243c0c45). The "Execution Details" UI also does not appear to parse this parameter. 
