### PR TITLE
Update ZAP metadata in ZCL files.

### DIFF
--- a/scripts/tools/check_zcl_file_sync.py
+++ b/scripts/tools/check_zcl_file_sync.py
@@ -49,6 +49,11 @@ def main():
     base_data["xmlFile"].sort()
     ext_data["xmlFile"].sort()
 
+    # remove the description. That is expected to be different, so we
+    # will completely exclude it from the comparison.
+    del base_data["description"]
+    del ext_data["description"]
+
     if base_data == ext_data:
         return 0
 

--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -1,5 +1,7 @@
 {
-    "version": "ZCL Test Data",
+    "description": "Matter SDK ZCL data with some extensions",
+    "category": "matter",
+    "version": 1,
     "xmlRoot": [
         ".",
         "./data-model/chip/",

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -1,5 +1,7 @@
 {
-    "version": "ZCL Test Data",
+    "description": "Matter SDK ZCL data",
+    "category": "matter",
+    "version": 1,
     "xmlRoot": [".", "./data-model/chip/", "./data-model/silabs/"],
     "_comment": "Ensure access-control-definitions.xml is first in xmlFile array",
     "xmlFile": [


### PR DESCRIPTION
#### Problem

With Matter nearing release, the category of the ZCL data needs
to be differentiated, so zigbee pro stacks use "zigbee" category
and Matter stack uses "matter" category.

None of this affects generation, but it affects the user flow in
the UI, where user might be upgrading old Matter or old ZigbeePro
file, and this meta info helps determine which metafiles are
the ones that should be used for the upgrades.

It's important that this change makes it into the Matter SDK before
it becomes any kind of GA release to the customers, otherwise
when zap is upgrading from one to another version of Matter, it
will have to do guessing or ask the user for what to do.

#### Change overview

A single "version" which was a human readable field, is now changed into: 
  "version" - an incremental integer
  "category" - a managed enum
  "description" - a human readable field

#### Testing

* reran the zap_regen_all and saw that there were no changes to the actual code that matters.
