### PR TITLE
[Ameba] Fixes to pass the PersistentStorage storage_audit

### DIFF
--- a/config/ameba/chip.cmake
+++ b/config/ameba/chip.cmake
@@ -105,6 +105,12 @@ string(APPEND CHIP_GN_ARGS "ameba_cxx = \"arm-none-eabi-c++\"\n")
 string(APPEND CHIP_GN_ARGS "ameba_cpu = \"ameba\"\n")
 string(APPEND CHIP_GN_ARGS "chip_inet_config_enable_ipv4 = false\n")
 
+# Enable persistent storage audit
+if (matter_enable_persistentstorage_audit)
+string(APPEND CHIP_GN_ARGS "chip_support_enable_storage_api_audit = true\n")
+endif (matter_enable_persistentstorage_audit)
+#endif
+
 # Build RPC
 if (matter_enable_rpc)
 #string(APPEND CHIP_GN_ARGS "remove_default_configs = [\"//third_party/connectedhomeip/third_party/pigweed/repo/pw_build:cpp17\"]\n")

--- a/examples/all-clusters-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-app/ameba/chip_main.cmake
@@ -242,9 +242,18 @@ list(
     -DCHIP_DEVICE_LAYER_TARGET=Ameba
     -DUSE_ZAP_CONFIG
     -DCHIP_HAVE_CONFIG_H
+    -DCHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT
     -DMBEDTLS_CONFIG_FILE=<mbedtls_config.h>
     -DMATTER_ALL_CLUSTERS_APP=1
 )
+
+if (matter_enable_persistentstorage_audit)
+list(
+    APPEND chip_main_flags
+
+    -DCHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT
+)
+endif (matter_enable_persistentstorage_audit)
 
 if (matter_enable_rpc)
 list(

--- a/examples/all-clusters-minimal-app/ameba/chip_main.cmake
+++ b/examples/all-clusters-minimal-app/ameba/chip_main.cmake
@@ -228,6 +228,14 @@ list(
     -DMATTER_ALL_CLUSTERS_APP=1
 )
 
+if (matter_enable_persistentstorage_audit)
+list(
+    APPEND chip_main_flags
+
+    -DCHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT
+)
+endif (matter_enable_persistentstorage_audit)
+
 if (matter_enable_rpc)
 list(
     APPEND chip_main_flags

--- a/examples/lighting-app/ameba/chip_main.cmake
+++ b/examples/lighting-app/ameba/chip_main.cmake
@@ -245,6 +245,14 @@ list(
     -DMATTER_LIGHTING_APP=1
 )
 
+if (matter_enable_persistentstorage_audit)
+list(
+    APPEND chip_main_flags
+
+    -DCHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT
+)
+endif (matter_enable_persistentstorage_audit)
+
 if (matter_enable_rpc)
 list(
     APPEND chip_main_flags

--- a/examples/ota-requestor-app/ameba/chip_main.cmake
+++ b/examples/ota-requestor-app/ameba/chip_main.cmake
@@ -80,6 +80,14 @@ list(
     -DMATTER_OTA_REQUESTOR_APP=1
 )
 
+if (matter_enable_persistentstorage_audit)
+list(
+    APPEND chip_main_flags
+
+    -DCHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT
+)
+endif (matter_enable_persistentstorage_audit)
+
 list(
     APPEND chip_main_cpp_flags
 

--- a/examples/pigweed-app/ameba/chip_main.cmake
+++ b/examples/pigweed-app/ameba/chip_main.cmake
@@ -84,6 +84,14 @@ list(
     -DMATTER_PIGWEED_APP=1
 )
 
+if (matter_enable_persistentstorage_audit)
+list(
+    APPEND chip_main_flags
+
+    -DCHIP_SUPPORT_ENABLE_STORAGE_API_AUDIT
+)
+endif (matter_enable_persistentstorage_audit)
+
 list(
     APPEND chip_main_cpp_flags
 

--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -103,12 +103,12 @@ CHIP_ERROR AmebaConfig::ReadConfigValue(Key key, bool & val)
     int32_t success = 0;
 
     success = getPref_bool_new(key.Namespace, key.Name, &intVal);
-    if (!success)
+    if (success != 0)
         ChipLogProgress(DeviceLayer, "getPref_bool_new: %s/%s failed\n", key.Namespace, key.Name);
 
     val = (intVal != 0);
 
-    if (success == 1)
+    if (success == 0)
         return CHIP_NO_ERROR;
     else
         return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
@@ -119,10 +119,10 @@ CHIP_ERROR AmebaConfig::ReadConfigValue(Key key, uint32_t & val)
     int32_t success = 0;
 
     success = getPref_u32_new(key.Namespace, key.Name, &val);
-    if (!success)
+    if (success != 0)
         ChipLogProgress(DeviceLayer, "getPref_u32_new: %s/%s failed\n", key.Namespace, key.Name);
 
-    if (success == 1)
+    if (success == 0)
         return CHIP_NO_ERROR;
     else
         return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
@@ -133,10 +133,10 @@ CHIP_ERROR AmebaConfig::ReadConfigValue(Key key, uint64_t & val)
     int32_t success = 0;
 
     success = getPref_u64_new(key.Namespace, key.Name, &val);
-    if (!success)
+    if (success != 0)
         ChipLogProgress(DeviceLayer, "getPref_u32_new: %s/%s failed\n", key.Namespace, key.Name);
 
-    if (success == 1)
+    if (success == 0)
         return CHIP_NO_ERROR;
     else
         return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
@@ -147,10 +147,10 @@ CHIP_ERROR AmebaConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
     int32_t success = 0;
 
     success = getPref_str_new(key.Namespace, key.Name, buf, bufSize, &outLen);
-    if (!success)
+    if (success != 0)
         ChipLogProgress(DeviceLayer, "getPref_str_new: %s/%s failed\n", key.Namespace, key.Name);
 
-    if (success == 1)
+    if (success == 0)
     {
         return CHIP_NO_ERROR;
     }
@@ -166,10 +166,10 @@ CHIP_ERROR AmebaConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSiz
     int32_t success = 0;
 
     success = getPref_bin_new(key.Namespace, key.Name, buf, bufSize, &outLen);
-    if (!success)
+    if (success != 0)
         ChipLogProgress(DeviceLayer, "getPref_bin_new: %s/%s failed\n", key.Namespace, key.Name);
 
-    if (success == 1)
+    if (success == 0)
     {
         return CHIP_NO_ERROR;
     }

--- a/src/platform/Ameba/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Ameba/KeyValueStoreManagerImpl.cpp
@@ -50,17 +50,21 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
     }
 
     ret = getPref_bin_new(key, key, (uint8_t *) value, value_size, read_bytes_size);
-
-    if (TRUE == ret)
+    switch (ret)
     {
-        err = CHIP_NO_ERROR;
-    }
-    else
-    {
-        err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    case 0:
+        return CHIP_NO_ERROR;
+    case -6:
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    case -7:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    case -8:
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    default:
+        break;
     }
 
-    return err;
+    return CHIP_ERROR_INTERNAL;
 }
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, size_t value_size)
@@ -85,14 +89,22 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Put(const char * key, const void * value, 
 
 CHIP_ERROR KeyValueStoreManagerImpl::_Delete(const char * key)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    int32_t ret = deleteKey(key, key);
+    switch (ret)
+    {
+    case 0:
+        return CHIP_NO_ERROR;
+    case -6:
+        return CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;
+    case -7:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    case -8:
+        return CHIP_ERROR_BUFFER_TOO_SMALL;
+    default:
+        break;
+    }
 
-    if (TRUE == deleteKey(key, key))
-        err = CHIP_NO_ERROR;
-    else
-        err = CHIP_ERROR_INTERNAL;
-
-    return err;
+    return CHIP_ERROR_INTERNAL;
 }
 
 } // namespace PersistedStorage


### PR DESCRIPTION
#### Problem
#20691 

#### Change overview
- Map DCT errors to CHIPError in KeyValueStoreManagerImpl
- Update return values in AmebaConfig
- Add matter_enable_persistentstorage_audit option in CMake files

#### Testing
- Ameba passed the persistent storage audit
