### PR TITLE
Reset error state when shutting down chip-tool commands.

### DIFF
--- a/examples/chip-tool/commands/clusters/ClusterCommand.h
+++ b/examples/chip-tool/commands/clusters/ClusterCommand.h
@@ -124,6 +124,12 @@ public:
         }
     }
 
+    void Shutdown() override
+    {
+        mError = CHIP_NO_ERROR;
+        ModelCommand::Shutdown();
+    }
+
 protected:
     ClusterCommand(const char * commandName, CredentialIssuerCommands * credsIssuerConfig) :
         InteractionModelCommands(this), ModelCommand(commandName, credsIssuerConfig)

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -98,6 +98,7 @@ public:
     {
         // We don't shut down InteractionModelReports here; we leave it for
         // Cleanup to handle.
+        mError = CHIP_NO_ERROR;
         ModelCommand::Shutdown();
     }
 

--- a/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
+++ b/examples/chip-tool/commands/clusters/WriteAttributeCommand.h
@@ -149,6 +149,12 @@ public:
                                                            dataVersion);
     }
 
+    void Shutdown() override
+    {
+        mError = CHIP_NO_ERROR;
+        ModelCommand::Shutdown();
+    }
+
 protected:
     WriteAttribute(const char * attributeName, CredentialIssuerCommands * credsIssuerConfig) :
         InteractionModelWriter(this), ModelCommand("write", credsIssuerConfig)

--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -101,6 +101,12 @@ public:
         return CHIP_NO_ERROR;
     }
 
+    void Shutdown() override
+    {
+        mError = nil;
+        ModelCommand::Shutdown();
+    }
+
 protected:
     ClusterCommand(const char * _Nonnull commandName)
         : ModelCommand(commandName)

--- a/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.mm
@@ -53,4 +53,8 @@ CHIP_ERROR ModelCommand::RunCommand()
     return CHIP_NO_ERROR;
 }
 
-void ModelCommand::Shutdown() { ResetArguments(); }
+void ModelCommand::Shutdown()
+{
+    ResetArguments();
+    CHIPCommandBridge::Shutdown();
+}


### PR DESCRIPTION
Some commands store an error status.  If they fail, the next invocation of the
same command in interactive mode will also claim to have failed, even if it
succeeded, because the error status carries over.

The fix is to reset the error status on Shutdown of the command.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran a Read command that failed because the server was shut down, then ran the same Read after restarting the server.