### PR TITLE
Fix invalid null delegate usage attempts in media clusters

### DIFF
--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -2189,7 +2189,7 @@ endpoint 0 {
     ram      attribute lastNetworkingStatus;
     ram      attribute lastNetworkID;
     ram      attribute lastConnectErrorValue;
-    ram      attribute featureMap default = 2;
+    ram      attribute featureMap default = 4;
     ram      attribute clusterRevision default = 1;
   }
 

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -1,5 +1,5 @@
 {
-  "featureLevel": 71,
+  "featureLevel": 75,
   "creator": "zap",
   "keyValuePairs": [
     {
@@ -19,14 +19,16 @@
     {
       "pathRelativity": "relativeToZap",
       "path": "../../../src/app/zap-templates/zcl/zcl.json",
-      "version": "ZCL Test Data",
-      "type": "zcl-properties"
+      "type": "zcl-properties",
+      "category": "matter",
+      "version": 1,
+      "description": "Matter SDK ZCL data"
     },
     {
       "pathRelativity": "relativeToZap",
       "path": "../../../src/app/zap-templates/app-templates.json",
-      "version": "chip-v1",
-      "type": "gen-templates-json"
+      "type": "gen-templates-json",
+      "version": "chip-v1"
     }
   ],
   "endpointTypes": [
@@ -2131,7 +2133,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "2",
+              "defaultValue": "4",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,
@@ -6954,166 +6956,6 @@
               "singleton": 0,
               "bounded": 0,
               "defaultValue": "3",
-              "reportable": 1,
-              "minInterval": 0,
-              "maxInterval": 65344,
-              "reportableChange": 0
-            }
-          ]
-        },
-        {
-          "name": "IAS Zone",
-          "code": 1280,
-          "mfgCode": null,
-          "define": "IAS_ZONE_CLUSTER",
-          "side": "client",
-          "enabled": 0,
-          "commands": [
-            {
-              "name": "ZoneEnrollResponse",
-              "code": 0,
-              "mfgCode": null,
-              "source": "client",
-              "incoming": 1,
-              "outgoing": 0
-            }
-          ],
-          "attributes": [
-            {
-              "name": "ClusterRevision",
-              "code": 65533,
-              "mfgCode": null,
-              "side": "client",
-              "type": "int16u",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "2",
-              "reportable": 1,
-              "minInterval": 0,
-              "maxInterval": 65344,
-              "reportableChange": 0
-            }
-          ]
-        },
-        {
-          "name": "IAS Zone",
-          "code": 1280,
-          "mfgCode": null,
-          "define": "IAS_ZONE_CLUSTER",
-          "side": "server",
-          "enabled": 0,
-          "commands": [
-            {
-              "name": "ZoneStatusChangeNotification",
-              "code": 0,
-              "mfgCode": null,
-              "source": "server",
-              "incoming": 0,
-              "outgoing": 1
-            },
-            {
-              "name": "ZoneEnrollRequest",
-              "code": 1,
-              "mfgCode": null,
-              "source": "server",
-              "incoming": 0,
-              "outgoing": 1
-            }
-          ],
-          "attributes": [
-            {
-              "name": "zone state",
-              "code": 0,
-              "mfgCode": null,
-              "side": "server",
-              "type": "enum8",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "0x00",
-              "reportable": 1,
-              "minInterval": 0,
-              "maxInterval": 65344,
-              "reportableChange": 0
-            },
-            {
-              "name": "zone type",
-              "code": 1,
-              "mfgCode": null,
-              "side": "server",
-              "type": "enum16",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "",
-              "reportable": 1,
-              "minInterval": 0,
-              "maxInterval": 65344,
-              "reportableChange": 0
-            },
-            {
-              "name": "zone status",
-              "code": 2,
-              "mfgCode": null,
-              "side": "server",
-              "type": "bitmap16",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "0x0000",
-              "reportable": 1,
-              "minInterval": 0,
-              "maxInterval": 65344,
-              "reportableChange": 0
-            },
-            {
-              "name": "IAS CIE address",
-              "code": 16,
-              "mfgCode": null,
-              "side": "server",
-              "type": "node_id",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "",
-              "reportable": 1,
-              "minInterval": 0,
-              "maxInterval": 65344,
-              "reportableChange": 0
-            },
-            {
-              "name": "Zone ID",
-              "code": 17,
-              "mfgCode": null,
-              "side": "server",
-              "type": "int8u",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "0xff",
-              "reportable": 1,
-              "minInterval": 0,
-              "maxInterval": 65344,
-              "reportableChange": 0
-            },
-            {
-              "name": "ClusterRevision",
-              "code": 65533,
-              "mfgCode": null,
-              "side": "server",
-              "type": "int16u",
-              "included": 1,
-              "storageOption": "RAM",
-              "singleton": 0,
-              "bounded": 0,
-              "defaultValue": "2",
               "reportable": 1,
               "minInterval": 0,
               "maxInterval": 65344,

--- a/examples/tv-app/tv-common/tv-app.zap
+++ b/examples/tv-app/tv-common/tv-app.zap
@@ -2345,7 +2345,7 @@
               "storageOption": "RAM",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "2",
+              "defaultValue": "4",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -143,7 +143,7 @@ bool emberAfAccountLoginClusterLoginCallback(app::CommandHandler * command, cons
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
-    if (!delegate->HandleLogin(tempAccountIdentifier, setupPin)) 
+    if (!delegate->HandleLogin(tempAccountIdentifier, setupPin))
     {
         status = EMBER_ZCL_STATUS_NOT_AUTHORIZED;
     }

--- a/src/app/clusters/account-login-server/account-login-server.cpp
+++ b/src/app/clusters/account-login-server/account-login-server.cpp
@@ -152,7 +152,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfAccountLoginClusterLoginCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        status = EMBER_ZCL_STATUS_FAILURE;
     }
     emberAfSendImmediateDefaultResponse(status);
     return true;
@@ -177,7 +177,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfAccountLoginClusterLogoutCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        status = EMBER_ZCL_STATUS_FAILURE;
     }
 
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -179,9 +179,9 @@ bool emberAfAudioOutputClusterRenameOutputCallback(app::CommandHandler * command
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
 
-    if (!HasFeature(endpoint, AudioOutputFeature::kNameUpdates)) {
-        ChipLogError(Zcl, "AudioOutput no name updates feature")
-        err = CHIP_ERROR_INCORRECT_STATE;
+    if (!HasFeature(endpoint, AudioOutputFeature::kNameUpdates))
+    {
+        ChipLogError(Zcl, "AudioOutput no name updates feature") err = CHIP_ERROR_INCORRECT_STATE;
         ExitNow();
     }
 

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -181,14 +181,21 @@ bool emberAfAudioOutputClusterRenameOutputCallback(app::CommandHandler * command
 
     if (!HasFeature(endpoint, AudioOutputFeature::kNameUpdates))
     {
-        ChipLogError(Zcl, "AudioOutput no name updates feature") err = CHIP_ERROR_INCORRECT_STATE;
+        ChipLogError(Zcl, "AudioOutput no name updates feature");
+        err = CHIP_ERROR_INCORRECT_STATE;
         ExitNow();
     }
 
-    bool success = delegate->HandleRenameOutput(index, name);
-    Protocols::InteractionModel::Status status =
-        success ? Protocols::InteractionModel::Status::Success : Protocols::InteractionModel::Status::Failure;
+    Protocols::InteractionModel::Status status;
 
+    if (delegate->HandleRenameOutput(index, name))
+    {
+        status = Protocols::InteractionModel::Status::Success;
+    }
+    else
+    {
+        status = Protocols::InteractionModel::Status::Failure;
+    }
     command->AddStatus(commandPath, status);
 
 exit:

--- a/src/app/clusters/audio-output-server/audio-output-server.cpp
+++ b/src/app/clusters/audio-output-server/audio-output-server.cpp
@@ -229,7 +229,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfAudioOutputClusterSelectOutputCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        status = EMBER_ZCL_STATUS_FAILURE;
     }
 
     emberAfSendImmediateDefaultResponse(status);

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -255,14 +255,19 @@ exit:
 bool emberAfChannelClusterChangeChannelByNumberCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                                         const Commands::ChangeChannelByNumber::DecodableType & commandData)
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    EndpointId endpoint = commandPath.mEndpointId;
-
-    auto & majorNumber = commandData.majorNumber;
-    auto & minorNumber = commandData.minorNumber;
+    CHIP_ERROR err       = CHIP_NO_ERROR;
+    EndpointId endpoint  = commandPath.mEndpointId;
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    auto & majorNumber   = commandData.majorNumber;
+    auto & minorNumber   = commandData.minorNumber;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
+
+    if (!delegate->HandleChangeChannelByNumber(majorNumber, minorNumber))
+    {
+        status = EMBER_ZCL_STATUS_FAILURE;
+    }
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -271,8 +276,6 @@ exit:
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
     }
 
-    bool success         = delegate->HandleChangeChannelByNumber(majorNumber, minorNumber);
-    EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }
@@ -280,12 +283,18 @@ exit:
 bool emberAfChannelClusterSkipChannelCallback(app::CommandHandler * command, const app::ConcreteCommandPath & commandPath,
                                               const Commands::SkipChannel::DecodableType & commandData)
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    EndpointId endpoint = commandPath.mEndpointId;
-    auto & count        = commandData.count;
+    CHIP_ERROR err       = CHIP_NO_ERROR;
+    EndpointId endpoint  = commandPath.mEndpointId;
+    EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
+    auto & count         = commandData.count;
 
     Delegate * delegate = GetDelegate(endpoint);
     VerifyOrExit(isDelegateNull(delegate, endpoint) != true, err = CHIP_ERROR_INCORRECT_STATE);
+
+    if (!delegate->HandleSkipChannel(count))
+    {
+        status = EMBER_ZCL_STATUS_FAILURE;
+    }
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -294,8 +303,6 @@ exit:
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
     }
 
-    bool success         = delegate->HandleSkipChannel(count);
-    EmberAfStatus status = success ? EMBER_ZCL_STATUS_SUCCESS : EMBER_ZCL_STATUS_FAILURE;
     emberAfSendImmediateDefaultResponse(status);
     return true;
 }

--- a/src/app/clusters/channel-server/channel-server.cpp
+++ b/src/app/clusters/channel-server/channel-server.cpp
@@ -273,7 +273,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfChannelClusterChangeChannelByNumberCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        status = EMBER_ZCL_STATUS_FAILURE;
     }
 
     emberAfSendImmediateDefaultResponse(status);
@@ -300,7 +300,7 @@ exit:
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Zcl, "emberAfChannelClusterSkipChannelCallback error: %s", err.AsString());
-        emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);
+        status = EMBER_ZCL_STATUS_FAILURE;
     }
 
     emberAfSendImmediateDefaultResponse(status);

--- a/zzz_generated/tv-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/tv-app/zap-generated/endpoint_config.h
@@ -272,7 +272,7 @@
             { 0x00000005, ZAP_TYPE(ENUM8), 1, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_EMPTY_DEFAULT() },   /* LastNetworkingStatus */    \
             { 0x00000006, ZAP_TYPE(OCTET_STRING), 33, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_EMPTY_DEFAULT() }, /* LastNetworkID */     \
             { 0x00000007, ZAP_TYPE(INT32S), 4, ZAP_ATTRIBUTE_MASK(NULLABLE), ZAP_EMPTY_DEFAULT() }, /* LastConnectErrorValue */    \
-            { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(2) },                        /* FeatureMap */               \
+            { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(4) },                        /* FeatureMap */               \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(1) },                          /* ClusterRevision */          \
                                                                                                                                    \
             /* Endpoint: 0, Cluster: Diagnostic Logs (server) */                                                                   \


### PR DESCRIPTION
#### Problem
@andreilitvin  pointed out that in media cluster code quote: _"Delegate null check was not valid: even if null check failed, delegate use was still attempted."_

#### Change overview
see above

#### Issue(s) fixed:
[20683](https://github.com/project-chip/connectedhomeip/issues/20683)

#### Testing
Run `./scripts/run_in_build_env.sh \  
                  "./scripts/tests/run_test_suite.py \
                     --chip-tool ./out/debug/standalone/chip-tool \
                     run \
                     --iterations 1 \
                     --all-clusters-app ./out/debug/standalone/chip-all-clusters-app \
                     --tv-app ./out/debug/standalone/chip-tv-app \
                  "`