### PR TITLE
[nrfconnect] return CHIP_NO_ERROR and not CHIP_ERROR_NOT_IMPLEMENTED in implemente…

### DIFF
--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -218,7 +218,7 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetSetupPasscode(uint32_t & se
 {
     ReturnErrorCodeIf(mFactoryData.passcode == 0, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
     setupPasscode = mFactoryData.passcode;
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    return CHIP_NO_ERROR;
 }
 
 template <class FlashFactoryData>


### PR DESCRIPTION
…d function GetSetupPasscode()

#### Problem

GetSetupPasscode() is implemented but returns CHIP_ERROR_NOT_IMPLEMENTED in success case.

The device is thus not using the setup code set in production.

This PR should be cherry-picked onto SVE branch in my opinion.

#### Change overview

return CHIP_NO_ERROR in success case.

#### Testing

Checked on nRF based device:

Before PR:
```
00> rtt:~$ [00:00:00.242,523] <inf> chip: [DL]  Setup Pin Code (0 for UNKNOWN/ERROR): 0
00> rtt:~$ [00:00:00.242,645] <inf> chip: [DL]  Setup Discriminator (0xFFFF for UNKNOWN/ERROR): 3890 (0xF32)
00> rtt:~$ [00:00:00.242,767] <inf> chip: [DL]  Manufacturing Date: 2022/07/04
00> rtt:~$ [00:00:00.242,858] <inf> chip: [DL]  Device Type: 65535 (0xFFFF)
00> rtt:~$ rtt:~$ [00:00:00.242,980] <err> chip: [SVR]GetCommissionableDataProvider()->GetSetupPasscode() failed: 2d
00> rtt:~$ [00:00:00.243,072] <inf> chip: [SVR]*** Using default EXAMPLE passcode 20202021 ***
```

After PR:
```
00> rtt:~$ [00:00:00.244,354] <inf> chip: [DL]Device Configuration:
00> rtt:~$ [00:00:00.244,415] <inf> chip: [DL]  Serial Number: 1
00> rtt:~$ [00:00:00.244,506] <inf> chip: [DL]  Vendor Id: 4646 (0x1226)
00> rtt:~$ [00:00:00.244,598] <inf> chip: [DL]  Product Id: 1 (0x1)
00> rtt:~$ rtt:~$ [00:00:00.244,689] <inf> chip: [DL]  Hardware Version: 1
00> rtt:~$ [00:00:00.244,781] <inf> chip: [DL]  Setup Pin Code (0 for UNKNOWN/ERROR): 20232022
00> rtt:~$ [00:00:00.244,903] <inf> chip: [DL]  Setup Discriminator (0xFFFF for UNKNOWN/ERROR): 3890 (0xF32)
00> rtt:~$ [00:00:00.245,025] <inf> chip: [DL]  Manufacturing Date: 2022/07/04
00> rtt:~$ [00:00:00.245,147] <inf> chip: [DL]  Device Type: 65535 (0xFFFF)
00> rtt:~$ [00:00:00.245,300] <inf> chip: [SVR]SetupQRCode: [MT:6V8A0M.R02077I39G00]
00> rtt:~$ rtt:~$ [00:00:00.245,452] <inf> chip: [SVR]Copy/paste the below URL in a browser to see the QR Code:
00> rtt:~$ [00:00:00.245,574] <inf> chip: [SVR]https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A6V8A0M.R02077I39G00
00> rtt:~$ [00:00:00.245,758] <inf> chip: [SVR]Manual pairing code: [36331812340]

```