### PR TITLE
[chip-tool] Add subscribe-all command

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -458,3 +458,49 @@ private:
     chip::Optional<std::vector<chip::DataVersion>> mDataVersions;
     chip::Optional<chip::EventNumber> mEventNumber;
 };
+
+class SubscribeAll : public SubscribeCommand
+{
+public:
+    SubscribeAll(CredentialIssuerCommands * credsIssuerConfig) : SubscribeCommand("subscribe-all", credsIssuerConfig)
+    {
+        AddArgument("cluster-ids", 0, UINT32_MAX, &mClusterIds,
+                    "Comma-separated list of cluster ids to read from (e.g. \"6\" or \"8,0x201\").\n  Allowed to be 0xFFFFFFFF to "
+                    "indicate a wildcard cluster.");
+        AddArgument("attribute-ids", 0, UINT32_MAX, &mAttributeIds,
+                    "Comma-separated list of attribute ids to read (e.g. \"0\" or \"1,0xFFFC,0xFFFD\").\n  Allowed to be "
+                    "0xFFFFFFFF to indicate a wildcard attribute.");
+        AddArgument("event-ids", 0, UINT32_MAX, &mEventIds,
+                    "Comma-separated list of event ids to read (e.g. \"0\" or \"1,2,3\").\n  Allowed to be "
+                    "0xFFFFFFFF to indicate a wildcard event.");
+        AddArgument("min-interval", 0, UINT16_MAX, &mMinInterval,
+                    "The requested minimum interval between reports. Sets MinIntervalFloor in the Subscribe Request.");
+        AddArgument("max-interval", 0, UINT16_MAX, &mMaxInterval,
+                    "The requested maximum interval between reports. Sets MaxIntervalCeiling in the Subscribe Request.");
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered,
+                    "Boolean indicating whether to do a fabric-filtered read. Defaults to true.");
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
+        AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
+                    "false - Terminate existing subscriptions from initiator.\n  true - Leave existing subscriptions in place.");
+        SubscribeCommand::AddArguments();
+    }
+
+    ~SubscribeAll() {}
+
+    CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
+    {
+        return SubscribeCommand::SubscribeAll(device, endpointIds, mClusterIds, mAttributeIds, mEventIds, mMinInterval,
+                                              mMaxInterval, mFabricFiltered, mEventNumber, mKeepSubscriptions);
+    }
+
+private:
+    std::vector<chip::ClusterId> mClusterIds;
+    std::vector<chip::AttributeId> mAttributeIds;
+    std::vector<chip::EventId> mEventIds;
+
+    uint16_t mMinInterval;
+    uint16_t mMaxInterval;
+    chip::Optional<bool> mFabricFiltered;
+    chip::Optional<chip::EventNumber> mEventNumber;
+    chip::Optional<bool> mKeepSubscriptions;
+};

--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -418,7 +418,20 @@ class ReadAll : public ReadCommand
 public:
     ReadAll(CredentialIssuerCommands * credsIssuerConfig) : ReadCommand("read-all", credsIssuerConfig)
     {
-        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered);
+        AddArgument("cluster-ids", 0, UINT32_MAX, &mClusterIds,
+                    "Comma-separated list of cluster ids to read from (e.g. \"6\" or \"8,0x201\").\n  Allowed to be 0xFFFFFFFF to "
+                    "indicate a wildcard cluster.");
+        AddArgument("attribute-ids", 0, UINT32_MAX, &mAttributeIds,
+                    "Comma-separated list of attribute ids to read (e.g. \"0\" or \"1,0xFFFC,0xFFFD\").\n  Allowed to be "
+                    "0xFFFFFFFF to indicate a wildcard attribute.");
+        AddArgument("event-ids", 0, UINT32_MAX, &mEventIds,
+                    "Comma-separated list of event ids to read (e.g. \"0\" or \"1,2,3\").\n  Allowed to be "
+                    "0xFFFFFFFF to indicate a wildcard event.");
+        AddArgument("fabric-filtered", 0, 1, &mFabricFiltered,
+                    "Boolean indicating whether to do a fabric-filtered read. Defaults to true.");
+        AddArgument("data-versions", 0, UINT32_MAX, &mDataVersions,
+                    "Comma-separated list of data versions for the clusters being read.");
+        AddArgument("event-min", 0, UINT64_MAX, &mEventNumber);
         ReadCommand::AddArguments();
     }
 
@@ -432,9 +445,16 @@ public:
 
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
-        return ReadCommand::ReadAll(device, endpointIds, mFabricFiltered);
+        return ReadCommand::ReadAll(device, endpointIds, mClusterIds, mAttributeIds, mEventIds, mFabricFiltered, mDataVersions,
+                                    mEventNumber);
     }
 
 private:
+    std::vector<chip::ClusterId> mClusterIds;
+    std::vector<chip::AttributeId> mAttributeIds;
+    std::vector<chip::EventId> mEventIds;
+
     chip::Optional<bool> mFabricFiltered;
+    chip::Optional<std::vector<chip::DataVersion>> mDataVersions;
+    chip::Optional<chip::EventNumber> mEventNumber;
 };

--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -138,6 +138,7 @@ void registerClusterAny(Commands & commands, CredentialIssuerCommands * credsIss
         make_unique<ReadEvent>(credsIssuerConfig),       //
         make_unique<SubscribeEvent>(credsIssuerConfig),     //
         make_unique<ReadAll>(credsIssuerConfig),         //
+        make_unique<SubscribeAll>(credsIssuerConfig),         //
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -449,11 +449,14 @@ void InteractionModelReports::CleanupReadClient(ReadClient * aReadClient)
         mReadClients.end());
 }
 
-CHIP_ERROR InteractionModelReports::ReadAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
-                                            std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
-                                            std::vector<chip::EventId> eventIds, const chip::Optional<bool> & fabricFiltered,
-                                            const chip::Optional<std::vector<chip::DataVersion>> & dataVersions,
-                                            const chip::Optional<chip::EventNumber> & eventNumber)
+CHIP_ERROR InteractionModelReports::ReportAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                                              std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
+                                              std::vector<chip::EventId> eventIds,
+                                              chip::app::ReadClient::InteractionType interactionType, uint16_t minInterval,
+                                              uint16_t maxInterval, const chip::Optional<bool> & fabricFiltered,
+                                              const chip::Optional<std::vector<chip::DataVersion>> & dataVersions,
+                                              const chip::Optional<chip::EventNumber> & eventNumber,
+                                              const chip::Optional<bool> & keepSubscriptions)
 {
     const size_t endpointCount  = endpointIds.size();
     const size_t clusterCount   = clusterIds.size();
@@ -461,6 +464,7 @@ CHIP_ERROR InteractionModelReports::ReadAll(chip::DeviceProxy * device, std::vec
     const size_t eventCount     = eventIds.size();
 
     // TODO Add data version supports
+    // TODO Add isUrgents supports
 
     VerifyOrReturnError(endpointCount > 0 && endpointCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(clusterCount > 0 && clusterCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
@@ -468,7 +472,26 @@ CHIP_ERROR InteractionModelReports::ReadAll(chip::DeviceProxy * device, std::vec
     VerifyOrReturnError(eventCount > 0 && eventCount <= kMaxAllowedPaths, CHIP_ERROR_INVALID_ARGUMENT);
 
     const bool hasSameIdsCount = (clusterCount == (attributeCount + eventCount)) && (clusterCount == endpointCount);
-    VerifyOrReturnError(hasSameIdsCount, CHIP_ERROR_INVALID_ARGUMENT);
+    if (!hasSameIdsCount)
+    {
+        ChipLogError(chipTool,
+                     "\nCommand targetting a combination of attribute and event paths needs to have has many clusters and "
+                     "endpoints than the number of attribute and events combined.\n"
+                     "For example if there are 2 attributes and 1 event, the command expects 3 clusters and 3 endpoints.\n"
+                     "Clusters and endpoints ids will be consumed first to populate the attribute paths of the request, and then "
+                     "to populate the event paths of the request.\n\n"
+                     "For example the following arguments:\n"
+                     "\tcluster-ids: 6,6,0X28\n"
+                     "\tendpoint-ids: 1,1,0\n"
+                     "\tattribute-ids: 0,0x4001\n"
+                     "\tevent-ids: 0\n"
+                     "\n"
+                     "will create the following paths:\n"
+                     "\t{cluster: 6, endpoint: 1, attribute: 0}\n"
+                     "\t{cluster: 6, endpoint: 1, attribute: 0x4001}\n"
+                     "\t{cluster: 0x28, endpoint: 0, event: 0}\n");
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
 
     AttributePathParams attributePathParams[kMaxAllowedPaths];
     EventPathParams eventPathParams[kMaxAllowedPaths];
@@ -537,8 +560,18 @@ CHIP_ERROR InteractionModelReports::ReadAll(chip::DeviceProxy * device, std::vec
         params.mIsFabricFiltered = fabricFiltered.Value();
     }
 
+    if (interactionType == ReadClient::InteractionType::Subscribe)
+    {
+        params.mMinIntervalFloorSeconds   = minInterval;
+        params.mMaxIntervalCeilingSeconds = maxInterval;
+        if (keepSubscriptions.HasValue())
+        {
+            params.mKeepSubscriptions = keepSubscriptions.Value();
+        }
+    }
+
     auto client = std::make_unique<ReadClient>(InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                               mBufferedReadAdapter, ReadClient::InteractionType::Read);
+                                               mBufferedReadAdapter, interactionType);
     ReturnErrorOnFailure(client->SendRequest(params));
     mReadClients.push_back(std::move(client));
     return CHIP_NO_ERROR;

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -112,7 +112,31 @@ protected:
                        std::vector<chip::EventId> eventIds,
                        const chip::Optional<bool> & fabricFiltered                         = chip::Optional<bool>(true),
                        const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional,
-                       const chip::Optional<chip::EventNumber> & eventNumber               = chip::NullOptional);
+                       const chip::Optional<chip::EventNumber> & eventNumber               = chip::NullOptional)
+    {
+        return ReportAll(device, endpointIds, clusterIds, attributeIds, eventIds, chip::app::ReadClient::InteractionType::Read, 0,
+                         0, fabricFiltered, dataVersions, eventNumber);
+    }
+
+    CHIP_ERROR SubscribeAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                            std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
+                            std::vector<chip::EventId> eventIds, uint16_t minInterval = 0, uint16_t maxInterval = 0,
+                            const chip::Optional<bool> & fabricFiltered           = chip::Optional<bool>(true),
+                            const chip::Optional<chip::EventNumber> & eventNumber = chip::NullOptional,
+                            const chip::Optional<bool> & keepSubscriptions        = chip::NullOptional)
+    {
+        return ReportAll(device, endpointIds, clusterIds, attributeIds, eventIds, chip::app::ReadClient::InteractionType::Subscribe,
+                         minInterval, maxInterval, fabricFiltered, chip::NullOptional, eventNumber, keepSubscriptions);
+    }
+
+    CHIP_ERROR ReportAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
+                         std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
+                         std::vector<chip::EventId> eventIds, chip::app::ReadClient::InteractionType interactionType,
+                         uint16_t minInterval = 0, uint16_t maxInterval = 0,
+                         const chip::Optional<bool> & fabricFiltered                         = chip::Optional<bool>(true),
+                         const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional,
+                         const chip::Optional<chip::EventNumber> & eventNumber               = chip::NullOptional,
+                         const chip::Optional<bool> & keepSubscriptions                      = chip::NullOptional);
 
     void Shutdown() { mReadClients.clear(); }
 

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -108,7 +108,11 @@ protected:
                            const chip::Optional<std::vector<bool>> & isUrgents   = chip::NullOptional);
 
     CHIP_ERROR ReadAll(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds,
-                       const chip::Optional<bool> & fabricFiltered = chip::Optional<bool>(true));
+                       std::vector<chip::ClusterId> clusterIds, std::vector<chip::AttributeId> attributeIds,
+                       std::vector<chip::EventId> eventIds,
+                       const chip::Optional<bool> & fabricFiltered                         = chip::Optional<bool>(true),
+                       const chip::Optional<std::vector<chip::DataVersion>> & dataVersions = chip::NullOptional,
+                       const chip::Optional<chip::EventNumber> & eventNumber               = chip::NullOptional);
 
     void Shutdown() { mReadClients.clear(); }
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -13133,6 +13133,7 @@ void registerClusterAny(Commands & commands, CredentialIssuerCommands * credsIss
         make_unique<ReadEvent>(credsIssuerConfig),          //
         make_unique<SubscribeEvent>(credsIssuerConfig),     //
         make_unique<ReadAll>(credsIssuerConfig),            //
+        make_unique<SubscribeAll>(credsIssuerConfig),       //
     };
 
     commands.Register(clusterName, clusterCommands);


### PR DESCRIPTION
#### Problem

There is no command in `chip-tool` to subscribe to both an attribute and an event into a single interaction.

#fix #20479

#### Change overview
 * Update `read-all` to be more granular. The user can choose which attributes and events that needs to be read
 * Add `subscribe-all` command to `chip-tool`

#### Testing
It was tested by the commands:
```
$ ./out/debug/standalone/chip-tool any read-all 6,6,0x28 0,0x4001 0 0x12344321 1,1,0
$ ./out/debug/standalone/chip-tool any subscribe-all 6,6,0x28 0,0x4001 0 1 5 0x12344321 1,1,0
```
