### PR TITLE
[QPG] Initialize OTA Requestor 3 seconds after Thread attach

### DIFF
--- a/examples/lighting-app/qpg/include/CHIPProjectConfig.h
+++ b/examples/lighting-app/qpg/include/CHIPProjectConfig.h
@@ -47,7 +47,7 @@
 /**
  * CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID
  *
- * 0xFFF1: Test vendor.
+ * 0xFFF1: Test Vendor.
  */
 #define CHIP_DEVICE_CONFIG_DEVICE_VENDOR_ID 0xFFF1
 

--- a/examples/lighting-app/qpg/src/AppTask.cpp
+++ b/examples/lighting-app/qpg/src/AppTask.cpp
@@ -44,9 +44,9 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
-using namespace chip::TLV;
-using namespace chip::Credentials;
-using namespace chip::DeviceLayer;
+using namespace ::chip::TLV;
+using namespace ::chip::Credentials;
+using namespace ::chip::DeviceLayer;
 
 #include <platform/CHIPDeviceLayer.h>
 
@@ -242,9 +242,6 @@ CHIP_ERROR AppTask::Init()
     nativeParams.openThreadInstancePtr = chip::DeviceLayer::ThreadStackMgrImpl().OTInstance();
     initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
-
-    // Init OTA engine
-    InitializeOTARequestor();
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -92,15 +92,15 @@ void UnlockOpenThreadTask(void)
 CHIP_ERROR AppTask::StartAppTask()
 {
     sAppEventQueue = xQueueCreateStatic(APP_EVENT_QUEUE_SIZE, sizeof(AppEvent), sAppEventQueueBuffer, &sAppEventQueueStruct);
-    if (sAppEventQueue == NULL)
+    if (sAppEventQueue == nullptr)
     {
         ChipLogError(NotSpecified, "Failed to allocate app event queue");
         return CHIP_ERROR_NO_MEMORY;
     }
 
     // Start App task.
-    sAppTaskHandle = xTaskCreateStatic(AppTaskMain, APP_TASK_NAME, ArraySize(appStack), NULL, 1, appStack, &appTaskStruct);
-    if (sAppTaskHandle == NULL)
+    sAppTaskHandle = xTaskCreateStatic(AppTaskMain, APP_TASK_NAME, ArraySize(appStack), nullptr, 1, appStack, &appTaskStruct);
+    if (sAppTaskHandle == nullptr)
     {
         return CHIP_ERROR_NO_MEMORY;
     }
@@ -145,9 +145,6 @@ CHIP_ERROR AppTask::Init()
     initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
-    // Init OTA engine
-    InitializeOTARequestor();
-
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
 
@@ -167,7 +164,7 @@ void AppTask::AppTaskMain(void * pvParameter)
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "AppTask.Init() failed: %" CHIP_ERROR_FORMAT, err.Format());
-        // appError(err);
+        return;
     }
 
     ChipLogProgress(NotSpecified, "App Task started");

--- a/examples/platform/qpg/ota/ota.cpp
+++ b/examples/platform/qpg/ota/ota.cpp
@@ -65,6 +65,7 @@ bool OtaHeaderValidationCb(qvCHIP_Ota_ImageHeader_t imageHeader)
 
 void InitializeOTARequestor(void)
 {
+    ChipLogDetail(DeviceLayer, "Initialising OTA Requestor");
     // Initialize and interconnect the Requestor and Image Processor objects
     SetRequestorInstance(&gRequestorCore);
 

--- a/examples/shell/qpg/BUILD.gn
+++ b/examples/shell/qpg/BUILD.gn
@@ -41,6 +41,7 @@ qpg_executable("shell_app") {
 
   sources = [
     "${examples_plat_dir}/app/main.cpp",
+    "${examples_plat_dir}/ota/ota.cpp",
     "src/AppTask.cpp",
   ]
 
@@ -58,7 +59,10 @@ qpg_executable("shell_app") {
   #chip datamodel is given [import("${chip_root}/src/app/chip_data_model.gni")]
   deps += [ "${chip_root}/examples/lock-app/lock-common" ]
 
-  include_dirs = [ "include" ]
+  include_dirs = [
+    "include",
+    "${examples_plat_dir}/ota",
+  ]
 
   defines = []
 

--- a/src/platform/qpg/ConnectivityManagerImpl.h
+++ b/src/platform/qpg/ConnectivityManagerImpl.h
@@ -1,6 +1,7 @@
 /*
  *
  *    Copyright (c) 2020 Project CHIP Authors
+ *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -98,7 +99,7 @@ inline ConnectivityManager & ConnectivityMgr(void)
  * Returns the platform-specific implementation of the ConnectivityManager singleton object.
  *
  * Chip applications can use this to gain access to features of the ConnectivityManager
- * that are specific to the ESP32 platform.
+ * that are specific to the QPG platform.
  */
 inline ConnectivityManagerImpl & ConnectivityMgrImpl(void)
 {


### PR DESCRIPTION
#### Problem
OTA Requestor is not able to send it's NotifyApplied message if the Thread attachment has not been done

#### Change overview
Delaying OTA Requestor init untill Thread network is attached + IP connectivity is reached

#### Testing
* TC-SU-2.6
* chip-tool, ota-provider + QPG lighting app
* Execute OTA flow
* Check NotifyApplied is received by provider