### PR TITLE
Uncomment check around inclusion of CryptoBuildConfig.h

### DIFF
--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -22,9 +22,9 @@
 
 #pragma once
 
-//#if CHIP_HAVE_CONFIG_H
+#if CHIP_HAVE_CONFIG_H
 #include <crypto/CryptoBuildConfig.h>
-//#endif
+#endif
 
 #include <system/SystemConfig.h>
 


### PR DESCRIPTION
#### Problem
Some platforms still do not build with these configs.

#### Change overview
Remove comment conditional inclusion of CryptoBuildConfig.h removed in prior commit.

#### Testing
Local build
CI
