### PR TITLE
[EFR32] Bump the silabs submodule pointer, update documentation

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -761,6 +761,7 @@ LTE
 LTS
 LwIP
 LwIP's
+LZMA
 macaddr
 machineType
 MacOS
@@ -884,6 +885,7 @@ NodeId
 nongnu
 nordicsemi
 NotAvailable
+NotifyUpdateApplied
 notValue
 npm
 nRF


### PR DESCRIPTION
#### Problem
Need pre-built bootloader binaries for EFR32

#### Change overview
Bump the silabs submodule pointer to include an update with pre-built bootloader binaries. Update documentation.

#### Testing
No executable code changes. Tested compilation.