### PR TITLE
Fabric-scoping support in IDL parsing

### DIFF
--- a/scripts/idl/README.md
+++ b/scripts/idl/README.md
@@ -94,6 +94,10 @@ server cluster AccessControl = 31 {
   // These defaults can be modified to any of view/operate/manage/administer roles.
   attribute access(read: manage, write: administer) int32u customAcl = 3;
 
+  // Attributes may be fabric-scoped as well by tagging them as `fabric`.
+  fabric readonly attribute int16u myFabricAttr = 22;
+  fabric attribute(read: view, write: administer) int16u someFabricRWAttribute = 33;
+
   // attributes may be read-only as well
   readonly attribute int16u clusterRevision = 65533;
 
@@ -118,7 +122,13 @@ server cluster AccessControl = 31 {
   command access(invoke: administer) Off(): DefaultSuccess = 4;
 
   // command invocation can require timed invoke usage
-  timed command RequiresTimedInvok(): DefaultSuccess = 4;
+  timed command RequiresTimedInvok(): DefaultSuccess = 5;
+
+  // commands may be fabric scoped
+  fabric command RequiresTimedInvok(): DefaultSuccess = 6;
+
+  // commands may have multiple attributes
+  fabric timed command RequiresTimedInvok(): DefaultSuccess = 7;
 }
 
 // A client cluster represents something that is used by an app

--- a/scripts/idl/matter_grammar.lark
+++ b/scripts/idl/matter_grammar.lark
@@ -26,9 +26,13 @@ attribute_access: "access"i "(" (attribute_access_entry ("," attribute_access_en
 
 attribute_with_access: attribute_access? struct_field
 
-attribute: attribute_tag* "attribute"i attribute_with_access ";"
+shared_tag: "fabric"i -> shared_tag_fabric
+shared_tags: shared_tag* -> shared_tags
+
+attribute: shared_tags attribute_tags "attribute"i attribute_with_access ";"
 attribute_tag: "readonly"i -> attr_readonly
              | "nosubscribe"i -> attr_nosubscribe
+attribute_tags: attribute_tag* -> attribute_tags
 
 request_struct: "request"i struct
 
@@ -38,12 +42,11 @@ response_struct: "response"i "struct"i id "=" positive_integer "{" (struct_field
 command_attribute: "timed"i -> timed_command
 command_attributes: command_attribute*
 
-
 command_access: "access"i "(" ("invoke"i ":" access_privilege)? ")"
 
 command_with_access: "command"i command_access? id
 
-command: command_attributes command_with_access "(" id? ")" ":" id "=" positive_integer ";"
+command: shared_tags command_attributes command_with_access "(" id? ")" ":" id "=" positive_integer ";"
 
 cluster: cluster_side "cluster"i id "=" positive_integer "{" (enum|bitmap|event|attribute|struct|request_struct|response_struct|command)* "}"
 ?cluster_side: "server"i -> server_cluster

--- a/scripts/idl/matter_idl_parser.py
+++ b/scripts/idl/matter_idl_parser.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import enum
 import logging
 
 from lark import Lark
@@ -13,6 +14,10 @@ except:
     sys.path.append(os.path.abspath(os.path.dirname(__file__)))
 
     from matter_idl_types import *
+
+
+class SharedTag(enum.Enum):
+    FABRIC_SCOPED = enum.auto()
 
 
 class AddServerClusterToEndpointTransform:
@@ -128,6 +133,12 @@ class MatterIdlTransformer(Transformer):
         else:
             raise Error("Unexpected size for data type")
 
+    def shared_tag_fabric(self, _):
+        return SharedTag.FABRIC_SCOPED
+
+    def shared_tags(self, entries):
+        return entries
+
     @v_args(inline=True)
     def constant_entry(self, id, number):
         return ConstantEntry(name=id, code=number)
@@ -158,6 +169,9 @@ class MatterIdlTransformer(Transformer):
 
     def attr_nosubscribe(self, _):
         return AttributeTag.NOSUBSCRIBE
+
+    def attribute_tags(self, tags):
+        return tags
 
     def critical_priority(self, _):
         return EventPriority.CRITICAL
@@ -204,14 +218,23 @@ class MatterIdlTransformer(Transformer):
         return init_args
 
     def command(self, args):
-        # A command has 4 arguments if no input or
-        # 5 arguments if input parameter is available
-        param_in = None
-        if len(args) > 4:
-            param_in = args[2]
+        # The command takes 5 arguments if no input argument, 6 if input
+        # argument is provided
+        if len(args) != 6:
+            args.insert(3, None)
+
+        attr = args[1]  # direct command attributes
+        for shared_attr in args[0]:
+            if shared_attr == SharedTag.FABRIC_SCOPED:
+                attr.add(CommandAttribute.FABRIC_SCOPED)
+            else:
+                raise Exception("Unknown shared tag: %r" % shared_attr)
 
         return Command(
-            attributes=args[0], input_param=param_in, output_param=args[-2], code=args[-1], **args[1])
+            attributes=attr,
+            input_param=args[3], output_param=args[4], code=args[5],
+            **args[2]
+        )
 
     def event_access(self, privilege):
         return privilege[0]
@@ -291,9 +314,17 @@ class MatterIdlTransformer(Transformer):
         # handle escapes, skip the start and end quotes
         return s.value[1:-1].encode('utf-8').decode('unicode-escape')
 
-    def attribute(self, args):
-        tags = set(args[:-1])
-        (definition, acl) = args[-1]
+    @v_args(inline=True)
+    def attribute(self, shared_tags, tags, definition_tuple):
+
+        tags = set(tags)
+        (definition, acl) = definition_tuple
+
+        for shared_attr in shared_tags:
+            if shared_attr == SharedTag.FABRIC_SCOPED:
+                tags.add(AttributeTag.FABRIC_SCOPED)
+            else:
+                raise Exception("Unknown shared tag: %r" % shared_attr)
 
         # until we support write only (and need a bit of a reshuffle)
         # if the 'attr_readonly == READABLE' is not in the list, we make things
@@ -396,6 +427,12 @@ def CreateParser(skip_meta: bool = False):
     """
     Generates a parser that will process a ".matter" file into a IDL
     """
+
+    # NOTE: LALR parser is fast. While Earley could parse more ambigous grammars,
+    #       earley is much slower:
+    #    - 0.39s LALR parsing of all-clusters-app.matter
+    #    - 2.26s Earley parsing of the same thing.
+    # For this reason, every attempt should be made to make the grammar context free
     return ParserWithLines(Lark.open('matter_grammar.lark', rel_to=__file__, start='idl', parser='lalr', propagate_positions=True), skip_meta)
 
 

--- a/scripts/idl/matter_idl_types.py
+++ b/scripts/idl/matter_idl_types.py
@@ -28,12 +28,14 @@ class FieldAttribute(enum.Enum):
 
 class CommandAttribute(enum.Enum):
     TIMED_INVOKE = enum.auto()
+    FABRIC_SCOPED = enum.auto()
 
 
 class AttributeTag(enum.Enum):
     READABLE = enum.auto()
     WRITABLE = enum.auto()
     NOSUBSCRIBE = enum.auto()
+    FABRIC_SCOPED = enum.auto()
 
 
 class AttributeStorage(enum.Enum):


### PR DESCRIPTION
#### Problem
Need fabric scope support

#### Change overview
`fabric attribute`
`fabric command`

kept lalr parsing because it is fast, so this means:
  - `fabric readonly attribute` is ok, but `readonly fabric attribute` is not.
  - `fabric timed command` is ok, but `timed fabric command` is not
 
 Basically `fabric` must come first.

#### Testing
Unit tests