### PR TITLE
Fix CryptoBuildConfig.h usage

### DIFF
--- a/.github/workflows/unit_integration_test.yaml
+++ b/.github/workflows/unit_integration_test.yaml
@@ -75,12 +75,13 @@ jobs:
                   if_true: "${{ github.sha }}"
                   if_false: "pull-${{ github.event.pull_request.number }}"
             - name: Setup Build
+              # TODO: If rotating_device_id is ever removed/combined, we have to cover boringssl otherwise
               run: |
                   case $BUILD_TYPE in
                      "main") GN_ARGS='';;
                      "clang") GN_ARGS='is_clang=true';;
                      "mbedtls") GN_ARGS='chip_crypto="mbedtls"';;
-                     "rotating_device_id") GN_ARGS='chip_enable_rotating_device_id=true';;
+                     "rotating_device_id") GN_ARGS='chip_crypto="boringssl" chip_enable_rotating_device_id=true';;
                      *) ;;
                   esac
 

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -24,7 +24,15 @@ buildconfig_header("crypto_buildconfig") {
   header = "CryptoBuildConfig.h"
   header_dir = "crypto"
 
-  defines = []
+  chip_crypto_mbedtls = chip_crypto == "mbedtls"
+  chip_crypto_openssl = chip_crypto == "openssl"
+  chip_crypto_boringssl = chip_crypto == "boringssl"
+
+  defines = [
+    "CHIP_CRYPTO_MBEDTLS=${chip_crypto_mbedtls}",
+    "CHIP_CRYPTO_OPENSSL=${chip_crypto_openssl}",
+    "CHIP_CRYPTO_BORINGSSL=${chip_crypto_boringssl}",
+  ]
 
   if (chip_with_se05x == 1) {
     defines += [ "CHIP_CRYPTO_HSM=1" ]
@@ -37,18 +45,6 @@ buildconfig_header("crypto_buildconfig") {
   if (chip_with_se05x_da == 1) {
     defines += [ "ENABLE_HSM_DEVICE_ATTESTATION=1" ]
   }
-}
-
-config("crypto_config") {
-  chip_crypto_mbedtls = chip_crypto == "mbedtls"
-  chip_crypto_openssl = chip_crypto == "openssl"
-  chip_crypto_boringssl = chip_crypto == "boringssl"
-
-  defines = [
-    "CHIP_CRYPTO_MBEDTLS=${chip_crypto_mbedtls}",
-    "CHIP_CRYPTO_OPENSSL=${chip_crypto_openssl}",
-    "CHIP_CRYPTO_BORINGSSL=${chip_crypto_boringssl}",
-  ]
 }
 
 if (chip_crypto == "openssl") {
@@ -76,6 +72,8 @@ static_library("crypto") {
     "RandUtils.h",
   ]
 
+  public_configs = []
+
   cflags = [ "-Wconversion" ]
 
   public_deps = [
@@ -85,8 +83,6 @@ static_library("crypto") {
     "${chip_root}/src/lib/support",
     "${nlassert_root}:nlassert",
   ]
-
-  public_configs = [ ":crypto_config" ]
 
   if (chip_crypto == "mbedtls") {
     sources += [ "CHIPCryptoPALmbedTLS.cpp" ]

--- a/src/crypto/CHIPCryptoPAL.h
+++ b/src/crypto/CHIPCryptoPAL.h
@@ -22,9 +22,9 @@
 
 #pragma once
 
-//#if CHIP_HAVE_CONFIG_H
+#if CHIP_HAVE_CONFIG_H
 #include <crypto/CryptoBuildConfig.h>
-//#endif
+#endif // CHIP_HAVE_CONFIG_H
 
 #include <system/SystemConfig.h>
 

--- a/src/crypto/tests/AES_CCM_128_test_vectors.h
+++ b/src/crypto/tests/AES_CCM_128_test_vectors.h
@@ -25,6 +25,10 @@
 
 #include <lib/core/CHIPError.h>
 
+#if CHIP_HAVE_CONFIG_H
+#include <crypto/CryptoBuildConfig.h>
+#endif // CHIP_HAVE_CONFIG_H
+
 struct ccm_128_test_vector
 {
     const uint8_t * pt;


### PR DESCRIPTION
#### Problem
PR #20824 moved some defines out of CryptoBuildConfig.h by mistake.

This caused some defines to be globalized but only in GN builds.

Fixes #20883

#### Change overview
This PR brings back the defines in CryptoBuildConfig.h and
fixes what's needed for that to build

#### Testing
- Unit tests still pass
- Integration tests still pass
