### PR TITLE
Update switch cluster attributes before triggering the related event

### DIFF
--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -29,6 +29,7 @@
 
 using namespace chip;
 using namespace chip::app;
+using namespace chip::app::Clusters;
 using namespace chip::DeviceLayer;
 
 void AllClustersCommandDelegate::OnEventCommandReceived(const char * command)
@@ -228,14 +229,20 @@ void AllClustersCommandDelegate::OnSwitchEventHandler(uint32_t eventId)
 
     if (eventId == Clusters::Switch::Events::SwitchLatched::Id)
     {
+        EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
         Clusters::SwitchServer::Instance().OnSwitchLatch(endpoint, newPosition);
     }
     else if (eventId == Clusters::Switch::Events::InitialPress::Id)
     {
+        EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
         Clusters::SwitchServer::Instance().OnInitialPress(endpoint, newPosition);
     }
     else if (eventId == Clusters::Switch::Events::LongPress::Id)
     {
+        EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
         Clusters::SwitchServer::Instance().OnLongPress(endpoint, newPosition);
     }
     else if (eventId == Clusters::Switch::Events::ShortRelease::Id)
@@ -248,10 +255,14 @@ void AllClustersCommandDelegate::OnSwitchEventHandler(uint32_t eventId)
     }
     else if (eventId == Clusters::Switch::Events::MultiPressOngoing::Id)
     {
+        EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
         Clusters::SwitchServer::Instance().OnMultiPressOngoing(endpoint, newPosition, count);
     }
     else if (eventId == Clusters::Switch::Events::MultiPressComplete::Id)
     {
+        EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, newPosition);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to set CurrentPosition attribute"));
         Clusters::SwitchServer::Instance().OnMultiPressComplete(endpoint, newPosition, count);
     }
     else

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -247,10 +247,14 @@ void AllClustersCommandDelegate::OnSwitchEventHandler(uint32_t eventId)
     }
     else if (eventId == Clusters::Switch::Events::ShortRelease::Id)
     {
+        EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
         Clusters::SwitchServer::Instance().OnShortRelease(endpoint, previousPosition);
     }
     else if (eventId == Clusters::Switch::Events::LongRelease::Id)
     {
+        EmberAfStatus status = Switch::Attributes::CurrentPosition::Set(endpoint, 0);
+        VerifyOrReturn(EMBER_ZCL_STATUS_SUCCESS == status, ChipLogError(NotSpecified, "Failed to reset CurrentPosition attribute"));
         Clusters::SwitchServer::Instance().OnLongRelease(endpoint, previousPosition);
     }
     else if (eventId == Clusters::Switch::Events::MultiPressOngoing::Id)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* CSG found the related Switch attribute was not updated even though the event show the attribute has changed
1.Read the feature map
2.Read the number of positions
3.Send the signal using the above commands
4.Read the events got success
5. Read the current position value it got "0" .  but its not changing the value from 0 to 20.

* Fixes #20892
#### Change overview
Update switch cluster attributes before triggering the related event

#### Testing
How was this tested? (at least one bullet point required)

* Read the current switch position before triggering event
```
yufengwang@yufengwang:~/connectedhomeip/out/debug/standalone$ ./chip-tool switch read current-position 12344321 1
....
[1658178051.064401][3308282:3308287] CHIP:EM: Removed CHIP MessageCounter:153111720 from RetransTable on exchange 65438i
[1658178051.064436][3308282:3308287] CHIP:DMG: ReportDataMessage =
[1658178051.064450][3308282:3308287] CHIP:DMG: {
[1658178051.064461][3308282:3308287] CHIP:DMG: 	AttributeReportIBs =
[1658178051.064480][3308282:3308287] CHIP:DMG: 	[
[1658178051.064491][3308282:3308287] CHIP:DMG: 		AttributeReportIB =
[1658178051.064509][3308282:3308287] CHIP:DMG: 		{
[1658178051.064521][3308282:3308287] CHIP:DMG: 			AttributeDataIB =
[1658178051.064535][3308282:3308287] CHIP:DMG: 			{
[1658178051.064549][3308282:3308287] CHIP:DMG: 				DataVersion = 0xbe0964b3,
[1658178051.064563][3308282:3308287] CHIP:DMG: 				AttributePathIB =
[1658178051.064577][3308282:3308287] CHIP:DMG: 				{
[1658178051.064590][3308282:3308287] CHIP:DMG: 					Endpoint = 0x1,
[1658178051.064604][3308282:3308287] CHIP:DMG: 					Cluster = 0x3b,
[1658178051.064618][3308282:3308287] CHIP:DMG: 					Attribute = 0x0000_0001,
[1658178051.064631][3308282:3308287] CHIP:DMG: 				}
[1658178051.064646][3308282:3308287] CHIP:DMG: 					
[1658178051.064661][3308282:3308287] CHIP:DMG: 				Data = 0, 
[1658178051.064674][3308282:3308287] CHIP:DMG: 			},
[1658178051.064689][3308282:3308287] CHIP:DMG: 			
[1658178051.064701][3308282:3308287] CHIP:DMG: 		},
[1658178051.064716][3308282:3308287] CHIP:DMG: 		
[1658178051.064728][3308282:3308287] CHIP:DMG: 	],
[1658178051.064745][3308282:3308287] CHIP:DMG: 	
[1658178051.064757][3308282:3308287] CHIP:DMG: 	SuppressResponse = true, 
[1658178051.064770][3308282:3308287] CHIP:DMG: 	InteractionModelRevision = 1
[1658178051.064781][3308282:3308287] CHIP:DMG: }
[1658178051.064881][3308282:3308287] CHIP:TOO: Endpoint: 1 Cluster: 0x0000_003B Attribute 0x0000_0001 DataVersion: 3188286643
[1658178051.064927][3308282:3308287] CHIP:TOO:   current position: 0
```

* Trigger the SwitchLatched event
`yufengwang@yufengwang:/tmp$ echo SwitchLatched > /tmp/chip_all_cluster_fifo_3307852 `

*  Confirm the SwitchLatched event has been logged and current position has changed to 20
```
[1658178144.386545][3307852:3307857] CHIP:-: Received payload: "SwitchLatched"
[1658178144.386729][3307852:3307852] CHIP:DMG: Endpoint 1, Cluster 0x0000_003B update version to be0964b4
[1658178144.386763][3307852:3307852] CHIP:ZCL: SwitchServer: OnSwitchLatch
[1658178144.386803][3307852:3307852] CHIP:EVL: LogEvent event number: 0x0000000000000003 priority: 1, endpoint id:  0x1 cluster id: 0x0000_003B event id: 0x0 Sys timestamp: 0x000000005DC85384
```

* Read the current switch position again and confirm it was updated
```
yufengwang@yufengwang:~/connectedhomeip/out/debug/standalone$ ./chip-tool switch read current-position 12344321 1
....
[1658178156.570215][3308859:3308864] CHIP:DMG: ReportDataMessage =
[1658178156.570228][3308859:3308864] CHIP:DMG: {
[1658178156.570238][3308859:3308864] CHIP:DMG: 	AttributeReportIBs =
[1658178156.570257][3308859:3308864] CHIP:DMG: 	[
[1658178156.570268][3308859:3308864] CHIP:DMG: 		AttributeReportIB =
[1658178156.570286][3308859:3308864] CHIP:DMG: 		{
[1658178156.570298][3308859:3308864] CHIP:DMG: 			AttributeDataIB =
[1658178156.570312][3308859:3308864] CHIP:DMG: 			{
[1658178156.570326][3308859:3308864] CHIP:DMG: 				DataVersion = 0xbe0964b4,
[1658178156.570339][3308859:3308864] CHIP:DMG: 				AttributePathIB =
[1658178156.570353][3308859:3308864] CHIP:DMG: 				{
[1658178156.570366][3308859:3308864] CHIP:DMG: 					Endpoint = 0x1,
[1658178156.570380][3308859:3308864] CHIP:DMG: 					Cluster = 0x3b,
[1658178156.570394][3308859:3308864] CHIP:DMG: 					Attribute = 0x0000_0001,
[1658178156.570407][3308859:3308864] CHIP:DMG: 				}
[1658178156.570422][3308859:3308864] CHIP:DMG: 					
[1658178156.570437][3308859:3308864] CHIP:DMG: 				Data = 20, 
[1658178156.570449][3308859:3308864] CHIP:DMG: 			},
[1658178156.570466][3308859:3308864] CHIP:DMG: 			
[1658178156.570477][3308859:3308864] CHIP:DMG: 		},
[1658178156.570493][3308859:3308864] CHIP:DMG: 		
[1658178156.570504][3308859:3308864] CHIP:DMG: 	],
[1658178156.570520][3308859:3308864] CHIP:DMG: 	
[1658178156.570532][3308859:3308864] CHIP:DMG: 	SuppressResponse = true, 
[1658178156.570544][3308859:3308864] CHIP:DMG: 	InteractionModelRevision = 1
[1658178156.570555][3308859:3308864] CHIP:DMG: }
[1658178156.570661][3308859:3308864] CHIP:TOO: Endpoint: 1 Cluster: 0x0000_003B Attribute 0x0000_0001 DataVersion: 3188286644
[1658178156.570718][3308859:3308864] CHIP:TOO:   current position: 20
```

