### PR TITLE
Fix status of fabric-scoped commands running in PASE

### DIFF
--- a/src/app/data-model/Nullable.h
+++ b/src/app/data-model/Nullable.h
@@ -79,7 +79,7 @@ struct Nullable : protected Optional<T>
         return true;
     }
 
-    // The only fabric-scoped objects in the spec are events and structs inside lists, and neither one can be nullable.
+    // The only fabric-scoped objects in the spec are commands, events and structs inside lists, and none of those can be nullable.
     static constexpr bool kIsFabricScoped = false;
 
     bool operator==(const Nullable & other) const { return Optional<T>::operator==(other); }

--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -173,5 +173,68 @@ bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand)
     return false;
 }
 
+// TODO(#20811): Actually generate the following based on ZAP metadata
+// See https://github.com/project-chip/zap/issues/609
+bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)
+{
+    // Maybe it would be smaller code to codegen a table and walk over it?
+    // Not sure.
+    switch (aCluster)
+    {
+    case Clusters::Groups::Id: {
+        switch (aCommand)
+        {
+        case Clusters::Groups::Commands::AddGroup::Id:
+        case Clusters::Groups::Commands::ViewGroup::Id:
+        case Clusters::Groups::Commands::GetGroupMembership::Id:
+        case Clusters::Groups::Commands::RemoveGroup::Id:
+        case Clusters::Groups::Commands::RemoveAllGroups::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    case Clusters::GroupKeyManagement::Id: {
+        switch (aCommand)
+        {
+        case Clusters::GroupKeyManagement::Commands::KeySetWrite::Id:
+        case Clusters::GroupKeyManagement::Commands::KeySetRead::Id:
+        case Clusters::GroupKeyManagement::Commands::KeySetRemove::Id:
+        case Clusters::GroupKeyManagement::Commands::KeySetReadAllIndices::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    case Clusters::GeneralCommissioning::Id: {
+        switch (aCommand)
+        {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    case Clusters::Scenes::Id: {
+        // Entire cluster is fabric-scoped.
+        return true;
+    }
+    case Clusters::OperationalCredentials::Id: {
+        switch (aCommand)
+        {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id:
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    default:
+        break;
+    }
+
+    return false;
+}
+
 } // namespace app
 } // namespace chip

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -215,6 +215,7 @@ public:
 } // namespace Clusters
 
 bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand);
+bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand);
 
 } // namespace app
 } // namespace chip

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -151,7 +151,7 @@ class ChipDeviceController():
                 self._ChipStack.callbackRes = self._ChipStack.ErrorToException(
                     err)
             else:
-                print("Established CASE with Device")
+                print("Established secure session with Device")
             if self.state != DCState.COMMISSIONING:
                 # During Commissioning, HandleKeyExchangeComplete will also be called,
                 # in this case the async operation should be marked as finished by
@@ -939,7 +939,7 @@ class ChipDeviceController():
             print(f"CommandResponse {res}")
             return (0, res)
         except InteractionModelError as ex:
-            return (int(ex.state), None)
+            return (int(ex.status), None)
 
     def ZCLReadAttribute(self, cluster, attribute, nodeid, endpoint, groupid, blocking=True):
         self.CheckIsActive()

--- a/src/controller/python/chip/interaction_model/__init__.py
+++ b/src/controller/python/chip/interaction_model/__init__.py
@@ -74,12 +74,12 @@ class Status(enum.IntEnum):
 
 
 class InteractionModelError(ChipStackException):
-    def __init__(self, state: Status):
-        self._state = state
+    def __init__(self, status: Status):
+        self._status = status
 
     def __str__(self):
-        return f"InteractionModelError: {self._state.name} (0x{self._state.value:x})"
+        return f"InteractionModelError: {self._status.name} (0x{self._status.value:x})"
 
     @property
-    def state(self) -> Status:
-        return self._state
+    def status(self) -> Status:
+        return self._status

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -1012,3 +1012,17 @@ class BaseTestHelper:
             self.logger.exception(f"Failed to finish API test: {ex}")
             return False
         return True
+
+    def TestFabricScopedCommandDuringPase(self, nodeid: int):
+        '''Validates that fabric-scoped commands fail during PASE with UNSUPPORTED_ACCESS
+
+        The nodeid is the PASE pseudo-node-ID used during PASE establishment
+        '''
+        status = None
+        try:
+            response = asyncio.run(self.devCtrl.SendCommand(
+                nodeid, 0, Clusters.OperationalCredentials.Commands.UpdateFabricLabel("roboto")))
+        except IM.InteractionModelError as ex:
+            status = ex.status
+
+        return status == IM.Status.UnsupportedAccess

--- a/src/controller/python/test/test_scripts/split_commissioning_test.py
+++ b/src/controller/python/test/test_scripts/split_commissioning_test.py
@@ -108,6 +108,10 @@ def main():
                                 nodeid=2),
               "Failed to establish PASE connection with device 2")
 
+    logger.info("Attempting to execute a fabric-scoped command during PASE before AddNOC")
+    FailIfNot(test.TestFabricScopedCommandDuringPase(nodeid=1),
+              "Did not get UNSUPPORTED_ACCESS for fabric-scoped command during PASE")
+
     FailIfNot(test.TestCommissionOnly(nodeid=1),
               "Failed to commission device 1")
 

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -20695,5 +20695,68 @@ bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand)
     return false;
 }
 
+// TODO(#20811): Actually generate the following based on ZAP metadata
+// See https://github.com/project-chip/zap/issues/609
+bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)
+{
+    // Maybe it would be smaller code to codegen a table and walk over it?
+    // Not sure.
+    switch (aCluster)
+    {
+    case Clusters::Groups::Id: {
+        switch (aCommand)
+        {
+        case Clusters::Groups::Commands::AddGroup::Id:
+        case Clusters::Groups::Commands::ViewGroup::Id:
+        case Clusters::Groups::Commands::GetGroupMembership::Id:
+        case Clusters::Groups::Commands::RemoveGroup::Id:
+        case Clusters::Groups::Commands::RemoveAllGroups::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    case Clusters::GroupKeyManagement::Id: {
+        switch (aCommand)
+        {
+        case Clusters::GroupKeyManagement::Commands::KeySetWrite::Id:
+        case Clusters::GroupKeyManagement::Commands::KeySetRead::Id:
+        case Clusters::GroupKeyManagement::Commands::KeySetRemove::Id:
+        case Clusters::GroupKeyManagement::Commands::KeySetReadAllIndices::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    case Clusters::GeneralCommissioning::Id: {
+        switch (aCommand)
+        {
+        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    case Clusters::Scenes::Id: {
+        // Entire cluster is fabric-scoped.
+        return true;
+    }
+    case Clusters::OperationalCredentials::Id: {
+        switch (aCommand)
+        {
+        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id:
+        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    default:
+        break;
+    }
+
+    return false;
+}
+
 } // namespace app
 } // namespace chip

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -27783,6 +27783,7 @@ public:
 } // namespace Clusters
 
 bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand);
+bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand);
 
 } // namespace app
 } // namespace chip


### PR DESCRIPTION
#### Problem
- Fabric-scoped commands under PASE did not fail as intended
  with an UNSUPPORTED_ACCESS. Instead, they went by but the command
  handler saw invalid fabric index.
- Spec indicates that fabric-scoped commands must return
  UNSUPPORTED_ACCESS when executed over PASE before AddNOC causes
  a fabric association.

Issue #20811

#### Change overview
- Add all known fabric-scoped command to a new getter to 
  cluster-objects-src.zapt. Real code-gen will be done
  as a follow-up when ZAP has support in XML and helpers 
  for fabric-scoped command labeling
- Update IM engine command handler to properly return the error
  as expected.
- Add integration test to validate this new condition. This
  cannot easily be unit-tested without a lot of work, due 
  to requiring a PASE session, but a good integration test is
  possible.
- Fix Python handling of non-success error codes which was
  broken.

#### Testing

- Unit tests all pass
- Integration tests pass
- New integration test added
