### PR TITLE
Chef - Fix typo in installation package node -> nodejs

### DIFF
--- a/examples/chef/chef.py
+++ b/examples/chef/chef.py
@@ -343,7 +343,7 @@ def main(argv: Sequence[str]) -> None:
         if sys.platform == "linux" or sys.platform == "linux2":
             flush_print("Installing ZAP OS package dependencies")
             install_deps_cmd = """\
-            sudo apt-get install node node-yargs npm
+            sudo apt-get install nodejs node-yargs npm
             libpixman-1-dev libcairo2-dev libpango1.0-dev node-pre-gyp
             libjpeg9-dev libgif-dev node-typescript"""
             shell.run_cmd(unwrap_cmd(install_deps_cmd))


### PR DESCRIPTION
#### Problem
* There's a typo in the installation packages when attempting to bootstrap Zap on a linux machine.

#### Change overview
* Fix typo `apt-get install node` -> `apt-get install nodejs`

#### Testing
`./chef.py --bootstrap_zap`