### PR TITLE
[BL602] Update button, not use dts to init

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/src/LEDWidget.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/LEDWidget.cpp
@@ -141,7 +141,7 @@ bool LEDWidget::IsTurnedOn()
 void LEDWidget::SetColor(uint8_t Hue, uint8_t Saturation)
 {
     uint8_t red, green, blue;
-    uint8_t brightness = mState ? mDefaultOnBrightness : 0;
+    uint8_t brightness = mDefaultOnBrightness;
     mHue               = static_cast<uint16_t>(Hue) * 360 / 254;        // mHue [0, 360]
     mSaturation        = static_cast<uint16_t>(Saturation) * 100 / 254; // mSaturation [0 , 100]
 

--- a/examples/platform/bouffalolab/bl602/InitPlatform.cpp
+++ b/examples/platform/bouffalolab/bl602/InitPlatform.cpp
@@ -282,12 +282,7 @@ void InitPlatform(void)
 {
     bl_sys_init();
 
-    uint32_t fdt = 0, offset = 0;
-    if (0 == get_dts_addr("gpio", &fdt, &offset))
-    {
-        hal_gpio_init_from_dts(fdt, offset);
-        fdt_button_module_init((const void *) fdt, (int) offset);
-    }
+    hal_button_module_init(8,1000,4800,5000);
     Platform_Light_Init();
     aos_register_event_filter(EV_KEY, event_cb_key_event, NULL);
 }

--- a/examples/platform/bouffalolab/bl602/InitPlatform.cpp
+++ b/examples/platform/bouffalolab/bl602/InitPlatform.cpp
@@ -282,7 +282,7 @@ void InitPlatform(void)
 {
     bl_sys_init();
 
-    hal_button_module_init(8,1000,4800,5000);
+    hal_button_module_init(8, 1000, 4800, 5000);
     Platform_Light_Init();
     aos_register_event_filter(EV_KEY, event_cb_key_event, NULL);
 }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Update button to support factory reset.

#### Change overview
Update button to support factory reset.

#### Testing
How was this tested? (at least one bullet point required)
* Long press the reset button for at least 5s, the light will blink.
