### PR TITLE
Use ISO8601 delimiters for displaying the manufacturing date.

### DIFF
--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -719,7 +719,7 @@ void GenericConfigurationManagerImpl<ConfigClass>::LogDeviceConfig()
         err = deviceInstanceInfoProvider->GetManufacturingDate(year, month, dayOfMonth);
         if (err == CHIP_NO_ERROR)
         {
-            ChipLogProgress(DeviceLayer, "  Manufacturing Date: %04u/%02u/%02u", year, month, dayOfMonth);
+            ChipLogProgress(DeviceLayer, "  Manufacturing Date: %04u-%02u-%02u", year, month, dayOfMonth);
         }
         else
         {


### PR DESCRIPTION
#### Problem

Spec uses ISO8601 for dates.

The / delimiter is not a regular delimiter for ISO8601.

#### Change overview

Change / for - in displaying the manufacturing date.

#### Testing

Not tested, 2 char change.