### PR TITLE
[EFR32] Adds fix for access point not found and retry logic for connecting again

### DIFF
--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, 
     wfx_wifi_provision_t wifiConfig = {};
     memcpy(wifiConfig.ssid, ssid, ssidLen);
     memcpy(wifiConfig.passkey, key, keyLen);
-    wifiConfig.security = WFX_SEC_WPA2;
+    wifiConfig.security = WFX_SEC_WPA_WPA2_MIXED;
 
     ChipLogProgress(NetworkProvisioning, "Setting up connection for WiFi SSID: %.*s", static_cast<int>(ssidLen), ssid);
     // Configure the WFX WiFi interface.


### PR DESCRIPTION
Problem
The access point is not found error shown during the commissioning.

Fixes added
Added fix for access point not found an issue
Added the retry logic for connecting to access point


Testing
Tested with AP which is causing the issue. And some sanity testing related to the door lock application using WF200 and EFR32