### PR TITLE
Set the DeviceInstanceInfoProvider instance to the platform implementation.

### DIFF
--- a/src/platform/Darwin/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/Darwin/DeviceInstanceInfoProviderImpl.cpp
@@ -18,10 +18,7 @@
 
 #include "DeviceInstanceInfoProviderImpl.h"
 
-#include <platform/CHIPDeviceConfig.h>
-#include <platform/CHIPDeviceError.h>
 #include <platform/Darwin/PosixConfig.h>
-#include <platform/internal/GenericDeviceInstanceInfoProvider.ipp>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Darwin/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/Darwin/DeviceInstanceInfoProviderImpl.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <platform/Darwin/ConfigurationManagerImpl.h>
 #include <platform/internal/GenericDeviceInstanceInfoProvider.h>
 
 namespace chip {
@@ -29,14 +30,15 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
 
-private:
-    friend DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl();
-    static DeviceInstanceInfoProviderImpl sInstance;
+    DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl & configManager) :
+        Internal::GenericDeviceInstanceInfoProvider<Internal::PosixConfig>(configManager)
+    {}
 };
 
 inline DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl()
 {
-    return DeviceInstanceInfoProviderImpl::sInstance;
+    static DeviceInstanceInfoProviderImpl sInstance(ConfigurationManagerImpl::GetDefaultInstance());
+    return sInstance;
 }
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -24,6 +24,11 @@
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#if !CHIP_DISABLE_PLATFORM_KVS
+#include <platform/Darwin/DeviceInstanceInfoProviderImpl.h>
+#include <platform/DeviceInstanceInfoProvider.h>
+#endif
+
 #include <platform/Darwin/DiagnosticDataProviderImpl.h>
 #include <platform/PlatformManager.h>
 
@@ -45,6 +50,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 #if !CHIP_DISABLE_PLATFORM_KVS
     err = Internal::PosixConfig::Init();
     SuccessOrExit(err);
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 #endif // CHIP_DISABLE_PLATFORM_KVS
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());

--- a/src/platform/Linux/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/Linux/DeviceInstanceInfoProviderImpl.cpp
@@ -18,10 +18,7 @@
 
 #include "DeviceInstanceInfoProviderImpl.h"
 
-#include <platform/CHIPDeviceConfig.h>
-#include <platform/CHIPDeviceError.h>
 #include <platform/Linux/PosixConfig.h>
-#include <platform/internal/GenericDeviceInstanceInfoProvider.ipp>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Linux/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/Linux/DeviceInstanceInfoProviderImpl.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <platform/Linux/ConfigurationManagerImpl.h>
 #include <platform/internal/GenericDeviceInstanceInfoProvider.h>
 
 namespace chip {
@@ -29,14 +30,15 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
 
-private:
-    friend DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl();
-    static DeviceInstanceInfoProviderImpl sInstance;
+    DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl & configManager) :
+        Internal::GenericDeviceInstanceInfoProvider<Internal::PosixConfig>(configManager)
+    {}
 };
 
 inline DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl()
 {
-    return DeviceInstanceInfoProviderImpl::sInstance;
+    static DeviceInstanceInfoProviderImpl sInstance(ConfigurationManagerImpl::GetDefaultInstance());
+    return sInstance;
 }
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -29,6 +29,8 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/DeviceControlServer.h>
+#include <platform/DeviceInstanceInfoProvider.h>
+#include <platform/Linux/DeviceInstanceInfoProviderImpl.h>
 #include <platform/Linux/DiagnosticDataProviderImpl.h>
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.ipp>
@@ -175,6 +177,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.

--- a/src/platform/Tizen/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/Tizen/DeviceInstanceInfoProviderImpl.cpp
@@ -18,10 +18,7 @@
 
 #include "DeviceInstanceInfoProviderImpl.h"
 
-#include <platform/CHIPDeviceConfig.h>
-#include <platform/CHIPDeviceError.h>
 #include <platform/Tizen/PosixConfig.h>
-#include <platform/internal/GenericDeviceInstanceInfoProvider.ipp>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/Tizen/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/Tizen/DeviceInstanceInfoProviderImpl.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <platform/Tizen/ConfigurationManagerImpl.h>
 #include <platform/internal/GenericDeviceInstanceInfoProvider.h>
 
 namespace chip {
@@ -29,14 +30,15 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
 
-private:
-    friend DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl();
-    static DeviceInstanceInfoProviderImpl sInstance;
+    DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl & configManager) :
+        Internal::GenericDeviceInstanceInfoProvider<Internal::PosixConfig>(configManager)
+    {}
 };
 
 inline DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl()
 {
-    return DeviceInstanceInfoProviderImpl::sInstance;
+    static DeviceInstanceInfoProviderImpl sInstance(ConfigurationManagerImpl::GetDefaultInstance());
+    return sInstance;
 }
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Tizen/PlatformManagerImpl.cpp
+++ b/src/platform/Tizen/PlatformManagerImpl.cpp
@@ -25,7 +25,9 @@
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/PlatformManager.h>
+#include <platform/Tizen/DeviceInstanceInfoProviderImpl.h>
 #include <platform/Tizen/DiagnosticDataProviderImpl.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.ipp>
 
@@ -39,6 +41,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     return Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_InitChipStack();
 }

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -19,9 +19,7 @@
 #include "DeviceInstanceInfoProviderImpl.h"
 
 #include <platform/CHIPDeviceConfig.h>
-#include <platform/CHIPDeviceError.h>
 #include <platform/android/AndroidConfig.h>
-#include <platform/internal/GenericDeviceInstanceInfoProvider.ipp>
 
 namespace chip {
 namespace DeviceLayer {

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <platform/android/ConfigurationManagerImpl.h>
 #include <platform/internal/GenericDeviceInstanceInfoProvider.h>
 
 namespace chip {
@@ -30,15 +31,15 @@ public:
     CHIP_ERROR GetProductId(uint16_t & productId) override;
     CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
 
-private:
-    friend DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl();
-    static DeviceInstanceInfoProviderImpl sInstance;
+    DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl & configManager) :
+        Internal::GenericDeviceInstanceInfoProvider<Internal::AndroidConfig>(configManager)
+    {}
 };
 
 inline DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl()
 {
-    return DeviceInstanceInfoProviderImpl::sInstance;
+    static DeviceInstanceInfoProviderImpl sInstance(ConfigurationManagerImpl::GetDefaultInstance());
+    return sInstance;
 }
-
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/android/PlatformManagerImpl.cpp
+++ b/src/platform/android/PlatformManagerImpl.cpp
@@ -26,7 +26,9 @@
 
 #include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
+#include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/PlatformManager.h>
+#include <platform/android/DeviceInstanceInfoProviderImpl.h>
 #include <platform/android/DiagnosticDataProviderImpl.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.ipp>
 
@@ -46,6 +48,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     SuccessOrExit(err);
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.

--- a/src/platform/webos/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/webos/DeviceInstanceInfoProviderImpl.cpp
@@ -18,9 +18,6 @@
 
 #include "DeviceInstanceInfoProviderImpl.h"
 
-#include <platform/CHIPDeviceConfig.h>
-#include <platform/CHIPDeviceError.h>
-#include <platform/internal/GenericDeviceInstanceInfoProvider.ipp>
 #include <platform/webos/PosixConfig.h>
 
 namespace chip {

--- a/src/platform/webos/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/webos/DeviceInstanceInfoProviderImpl.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <platform/internal/GenericDeviceInstanceInfoProvider.h>
+#include <platform/webos/ConfigurationManagerImpl.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -29,14 +30,15 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
 
-private:
-    friend DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl();
-    static DeviceInstanceInfoProviderImpl sInstance;
+    DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl & configManager) :
+        Internal::GenericDeviceInstanceInfoProvider<Internal::PosixConfig>(configManager)
+    {}
 };
 
 inline DeviceInstanceInfoProviderImpl & DeviceInstanceInfoProviderMgrImpl()
 {
-    return DeviceInstanceInfoProviderImpl::sInstance;
+    static DeviceInstanceInfoProviderImpl sInstance(ConfigurationManagerImpl::GetDefaultInstance());
+    return sInstance;
 }
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/webos/PlatformManagerImpl.cpp
+++ b/src/platform/webos/PlatformManagerImpl.cpp
@@ -29,9 +29,11 @@
 #include <lib/support/CHIPMem.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/DeviceControlServer.h>
+#include <platform/DeviceInstanceInfoProvider.h>
 #include <platform/PlatformManager.h>
 #include <platform/internal/GenericPlatformManagerImpl_POSIX.ipp>
 #include <platform/webos/DeviceInfoProviderImpl.h>
+#include <platform/webos/DeviceInstanceInfoProviderImpl.h>
 #include <platform/webos/DiagnosticDataProviderImpl.h>
 
 #include <thread>
@@ -166,6 +168,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
     SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());
+    SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.


### PR DESCRIPTION
#### Problem
In the #19514 there was a mistake made.
Within some platforms, the DeviceInstanceInfoProvider was set to a generic one instead of the platform implementation.

#### Change overview
To resolve this issue, the DeviceInstanceInfoProvider has been set to the proper one in PlatformManager implementation for
Android, Darwin, Linux, Tizen, and WebOS.

Fixes: https://github.com/project-chip/connectedhomeip/issues/20590

#### Testing
Tested in CI
