### PR TITLE
[chip-tool] Add an option to continue running tests even after a test…

### DIFF
--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -49,6 +49,8 @@ public:
         TestRunner(commandName, testsCount), CHIPCommand(commandName, credsIssuerConfig),
         mOnDeviceConnectedCallback(OnDeviceConnectedFn, this), mOnDeviceConnectionFailureCallback(OnDeviceConnectionFailureFn, this)
     {
+        AddArgument("continueOnFailure", 0, 1, &mContinueOnFailure,
+                    "Boolean indicating if the test runner should continue execution if a test fails. Default to false.");
         AddArgument("delayInMs", 0, UINT64_MAX, &mDelayInMs);
         AddArgument("PICS", &mPICSFilePath);
     }
@@ -100,4 +102,8 @@ protected:
     // as it still used by the stack afterward. So a task is scheduled to run to close the
     // test suite as soon as possible, and pending events are ignored in between.
     bool mContinueProcessing = true;
+
+    // When set to true, the test runner continue to run after a test failure.
+    chip::Optional<bool> mContinueOnFailure;
+    std::vector<std::string> mErrorMessages;
 };


### PR DESCRIPTION
… failure

#### Problem

It may be sometimes useful to continue running tests even after a test failure. This is in order to know which tests are failing from the test suite, instead of only seeing the first error.

#### Change overview
 * Add a `continueOnFailure` optional argument to the test runner

#### Testing
It was tested running the `Test_TC_OO_1` test suite:
```
$ ./out/debug/standalone/chip-tool tests Test_TC_OO_1_1 --continueOnFailure 0
```
This one stops on the first error.

```
$ ./out/debug/standalone/chip-tool tests Test_TC_OO_1_1 --continueOnFailure 1
```
This one continues and accumulates errors if any.