### PR TITLE
Define the unknown enum value for cluster enums.

### DIFF
--- a/examples/lock-app/cyw30739/src/LockManager.cpp
+++ b/examples/lock-app/cyw30739/src/LockManager.cpp
@@ -623,6 +623,8 @@ const char * LockManager::lockStateToString(DlLockState lockState) const
         return "Locked";
     case DlLockState::kUnlocked:
         return "Unlocked";
+    case DlLockState::kUnknownEnumValue:
+        break;
     }
 
     return "Unknown";

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -619,6 +619,8 @@ const char * LockManager::lockStateToString(DlLockState lockState) const
         return "Locked";
     case DlLockState::kUnlocked:
         return "Unlocked";
+    case DlLockState::kUnknownEnumValue:
+        break;
     }
 
     return "Unknown";

--- a/examples/lock-app/linux/src/LockEndpoint.cpp
+++ b/examples/lock-app/linux/src/LockEndpoint.cpp
@@ -385,6 +385,8 @@ const char * LockEndpoint::lockStateToString(DlLockState lockState) const
         return "Locked";
     case DlLockState::kUnlocked:
         return "Unlocked";
+    case DlLockState::kUnknownEnumValue:
+        break;
     }
 
     return "Unknown";

--- a/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
+++ b/src/app/clusters/diagnostic-logs-server/diagnostic-logs-server.cpp
@@ -38,6 +38,13 @@ void DiagnosticLogsCommandHandler::InvokeCommand(HandlerContext & handlerContext
 {
     HandleCommand<chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::DecodableType>(
         handlerContext, [&](auto & _u, auto & payload) {
+            if (payload.requestedProtocol == chip::app::Clusters::DiagnosticLogs::LogsTransferProtocol::kUnknownEnumValue)
+            {
+                handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath,
+                                                         chip::Protocols::InteractionModel::Status::InvalidCommand);
+                return;
+            }
+
             switch (payload.intent)
             {
             case chip::app::Clusters::DiagnosticLogs::LogsIntent::kEndUserSupport: {
@@ -86,6 +93,11 @@ void DiagnosticLogsCommandHandler::InvokeCommand(HandlerContext & handlerContext
                 handlerContext.mCommandHandler.AddResponse(handlerContext.mRequestPath, response);
             }
             break;
+            case chip::app::Clusters::DiagnosticLogs::LogsIntent::kUnknownEnumValue: {
+                handlerContext.mCommandHandler.AddStatus(handlerContext.mRequestPath,
+                                                         chip::Protocols::InteractionModel::Status::InvalidCommand);
+                break;
+            }
             }
         });
 }
@@ -94,6 +106,7 @@ bool emberAfDiagnosticLogsClusterRetrieveLogsRequestCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::DiagnosticLogs::Commands::RetrieveLogsRequest::DecodableType & commandData)
 {
+    // TODO: Shouldn't the default "no-op" impl return some sort of error?
     EmberAfStatus status = EMBER_ZCL_STATUS_SUCCESS;
     emberAfSendImmediateDefaultResponse(status);
     return true;

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -2944,6 +2944,8 @@ DlLockDataType DoorLockServer::credentialTypeToLockDataType(DlCredentialType cre
     case DlCredentialType::kFace:
         // So far there's no distinct data type for face credentials
         return DlLockDataType::kUnspecified;
+    case DlCredentialType::kUnknownEnumValue:
+        return DlLockDataType::kUnspecified;
     }
 
     return DlLockDataType::kUnspecified;

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -289,6 +289,9 @@ void DefaultOTARequestor::OnApplyUpdateResponse(void * context, const ApplyUpdat
         requestorCore->mOtaRequestorDriver->UpdateDiscontinued();
         requestorCore->RecordNewUpdateState(OTAUpdateStateEnum::kIdle, OTAChangeReasonEnum::kSuccess);
         break;
+    case OTAApplyUpdateAction::kUnknownEnumValue:
+        OnApplyUpdateFailure(context, CHIP_ERROR_INVALID_ARGUMENT);
+        break;
     }
 }
 

--- a/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
+++ b/src/app/clusters/pump-configuration-and-control-server/pump-configuration-and-control-server.cpp
@@ -229,6 +229,11 @@ static void updateAttributeLinks(EndpointId endpoint)
         }
     }
     break;
+
+    case PumpOperationMode::kUnknownEnumValue: {
+        // Not expected; see check in MatterPumpConfigurationAndControlClusterServerPreAttributeChangedCallback.
+        break;
+    }
     }
 
     if (isPumpStatusAvailable)
@@ -384,8 +389,18 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
-        default:
+        case PumpControlMode::kProportionalPressure:
+            if (!IsFeatureSupported(attributePath.mEndpointId, Attributes::MinCompPressure::Get, Attributes::MaxCompPressure::Get))
+            {
+                status = Protocols::InteractionModel::Status::ConstraintError;
+            }
+            break;
+        case PumpControlMode::kAutomatic:
             status = Protocols::InteractionModel::Status::Success;
+            break;
+        case PumpControlMode::kUnknownEnumValue:
+            status = Protocols::InteractionModel::Status::ConstraintError;
+            break;
         }
     }
     break;
@@ -410,8 +425,13 @@ chip::Protocols::InteractionModel::Status MatterPumpConfigurationAndControlClust
                 status = Protocols::InteractionModel::Status::ConstraintError;
             }
             break;
-        default:
+        case PumpOperationMode::kLocal:
+        case PumpOperationMode::kNormal:
             status = Protocols::InteractionModel::Status::Success;
+            break;
+        case PumpOperationMode::kUnknownEnumValue:
+            status = Protocols::InteractionModel::Status::ConstraintError;
+            break;
         }
 
         break;

--- a/src/app/zap-templates/templates/app/cluster-enums.zapt
+++ b/src/app/zap-templates/templates/app/cluster-enums.zapt
@@ -24,7 +24,7 @@ enum class {{asType label}} : {{asUnderlyingZclType name}} {
 {{#zcl_enum_items}}
 k{{asUpperCamelCase label}} = {{asHex value 2}},
 {{/zcl_enum_items}}
-// kUnknownEnumValue = {{first_unused_enum_value mode="first_unused"}},
+kUnknownEnumValue = {{first_unused_enum_value mode="first_unused"}},
 };
 {{#if (isWeaklyTypedEnum label)}}
 #else // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1283,6 +1283,9 @@ CHIP_ERROR DeviceCommissioner::ConvertFromOperationalCertStatus(OperationalCrede
         return CHIP_ERROR_INVALID_ARGUMENT;
     case OperationalCertStatus::kInvalidFabricIndex:
         return CHIP_ERROR_INVALID_FABRIC_INDEX;
+    case OperationalCertStatus::kUnknownEnumValue:
+        // Is this a reasonable value?
+        return CHIP_ERROR_CERT_LOAD_FAILED;
     }
 
     return CHIP_ERROR_CERT_LOAD_FAILED;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-enums.h
@@ -35,13 +35,13 @@ namespace Identify {
 // Enum for IdentifyEffectIdentifier
 enum class IdentifyEffectIdentifier : uint8_t
 {
-    kBlink         = 0x00,
-    kBreathe       = 0x01,
-    kOkay          = 0x02,
-    kChannelChange = 0x0B,
-    kFinishEffect  = 0xFE,
-    kStopEffect    = 0xFF,
-    // kUnknownEnumValue = 3,
+    kBlink            = 0x00,
+    kBreathe          = 0x01,
+    kOkay             = 0x02,
+    kChannelChange    = 0x0B,
+    kFinishEffect     = 0xFE,
+    kStopEffect       = 0xFF,
+    kUnknownEnumValue = 3,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using IdentifyEffectIdentifier = EmberAfIdentifyEffectIdentifier;
@@ -55,8 +55,8 @@ static IdentifyEffectIdentifier __attribute__((unused)) kIdentifyEffectIdentifie
 // Enum for IdentifyEffectVariant
 enum class IdentifyEffectVariant : uint8_t
 {
-    kDefault = 0x00,
-    // kUnknownEnumValue = 1,
+    kDefault          = 0x00,
+    kUnknownEnumValue = 1,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using IdentifyEffectVariant = EmberAfIdentifyEffectVariant;
@@ -70,13 +70,13 @@ static IdentifyEffectVariant __attribute__((unused)) kIdentifyEffectVariantkUnkn
 // Enum for IdentifyIdentifyType
 enum class IdentifyIdentifyType : uint8_t
 {
-    kNone         = 0x00,
-    kVisibleLight = 0x01,
-    kVisibleLED   = 0x02,
-    kAudibleBeep  = 0x03,
-    kDisplay      = 0x04,
-    kActuator     = 0x05,
-    // kUnknownEnumValue = 6,
+    kNone             = 0x00,
+    kVisibleLight     = 0x01,
+    kVisibleLED       = 0x02,
+    kAudibleBeep      = 0x03,
+    kDisplay          = 0x04,
+    kActuator         = 0x05,
+    kUnknownEnumValue = 6,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using IdentifyIdentifyType                                                                 = EmberAfIdentifyIdentifyType;
@@ -113,7 +113,7 @@ enum class OnOffDelayedAllOffEffectVariant : uint8_t
     kFadeToOffIn0p8Seconds                                = 0x00,
     kNoFade                                               = 0x01,
     k50PercentDimDownIn0p8SecondsThenFadeToOffIn12Seconds = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnknownEnumValue                                     = 3,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using OnOffDelayedAllOffEffectVariant                                                      = EmberAfOnOffDelayedAllOffEffectVariant;
@@ -128,7 +128,7 @@ static OnOffDelayedAllOffEffectVariant __attribute__((unused)) kOnOffDelayedAllO
 enum class OnOffDyingLightEffectVariant : uint8_t
 {
     k20PercenterDimUpIn0p5SecondsThenFadeToOffIn1Second = 0x00,
-    // kUnknownEnumValue = 1,
+    kUnknownEnumValue                                   = 1,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using OnOffDyingLightEffectVariant = EmberAfOnOffDyingLightEffectVariant;
@@ -142,9 +142,9 @@ static OnOffDyingLightEffectVariant __attribute__((unused)) kOnOffDyingLightEffe
 // Enum for OnOffEffectIdentifier
 enum class OnOffEffectIdentifier : uint8_t
 {
-    kDelayedAllOff = 0x00,
-    kDyingLight    = 0x01,
-    // kUnknownEnumValue = 2,
+    kDelayedAllOff    = 0x00,
+    kDyingLight       = 0x01,
+    kUnknownEnumValue = 2,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using OnOffEffectIdentifier = EmberAfOnOffEffectIdentifier;
@@ -158,7 +158,7 @@ enum class OnOffStartUpOnOff : uint8_t
     kOff                 = 0x00,
     kOn                  = 0x01,
     kTogglePreviousOnOff = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnknownEnumValue    = 3,
 };
 
 // Bitmap for OnOffControl
@@ -191,9 +191,9 @@ namespace LevelControl {
 // Enum for MoveMode
 enum class MoveMode : uint8_t
 {
-    kUp   = 0x00,
-    kDown = 0x01,
-    // kUnknownEnumValue = 2,
+    kUp               = 0x00,
+    kDown             = 0x01,
+    kUnknownEnumValue = 2,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using MoveMode                                                                         = EmberAfMoveMode;
@@ -206,9 +206,9 @@ static MoveMode __attribute__((unused)) kMoveModekUnknownEnumValue              
 // Enum for StepMode
 enum class StepMode : uint8_t
 {
-    kUp   = 0x00,
-    kDown = 0x01,
-    // kUnknownEnumValue = 2,
+    kUp               = 0x00,
+    kDown             = 0x01,
+    kUnknownEnumValue = 2,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using StepMode                                                                         = EmberAfStepMode;
@@ -241,30 +241,30 @@ namespace AccessControl {
 // Enum for AuthMode
 enum class AuthMode : uint8_t
 {
-    kPase  = 0x01,
-    kCase  = 0x02,
-    kGroup = 0x03,
-    // kUnknownEnumValue = 0,
+    kPase             = 0x01,
+    kCase             = 0x02,
+    kGroup            = 0x03,
+    kUnknownEnumValue = 0,
 };
 
 // Enum for ChangeTypeEnum
 enum class ChangeTypeEnum : uint8_t
 {
-    kChanged = 0x00,
-    kAdded   = 0x01,
-    kRemoved = 0x02,
-    // kUnknownEnumValue = 3,
+    kChanged          = 0x00,
+    kAdded            = 0x01,
+    kRemoved          = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for Privilege
 enum class Privilege : uint8_t
 {
-    kView       = 0x01,
-    kProxyView  = 0x02,
-    kOperate    = 0x03,
-    kManage     = 0x04,
-    kAdminister = 0x05,
-    // kUnknownEnumValue = 0,
+    kView             = 0x01,
+    kProxyView        = 0x02,
+    kOperate          = 0x03,
+    kManage           = 0x04,
+    kAdminister       = 0x05,
+    kUnknownEnumValue = 0,
 };
 } // namespace AccessControl
 
@@ -273,41 +273,41 @@ namespace BridgedActions {
 // Enum for ActionErrorEnum
 enum class ActionErrorEnum : uint8_t
 {
-    kUnknown     = 0x00,
-    kInterrupted = 0x01,
-    // kUnknownEnumValue = 2,
+    kUnknown          = 0x00,
+    kInterrupted      = 0x01,
+    kUnknownEnumValue = 2,
 };
 
 // Enum for ActionStateEnum
 enum class ActionStateEnum : uint8_t
 {
-    kInactive = 0x00,
-    kActive   = 0x01,
-    kPaused   = 0x02,
-    kDisabled = 0x03,
-    // kUnknownEnumValue = 4,
+    kInactive         = 0x00,
+    kActive           = 0x01,
+    kPaused           = 0x02,
+    kDisabled         = 0x03,
+    kUnknownEnumValue = 4,
 };
 
 // Enum for ActionTypeEnum
 enum class ActionTypeEnum : uint8_t
 {
-    kOther        = 0x00,
-    kScene        = 0x01,
-    kSequence     = 0x02,
-    kAutomation   = 0x03,
-    kException    = 0x04,
-    kNotification = 0x05,
-    kAlarm        = 0x06,
-    // kUnknownEnumValue = 7,
+    kOther            = 0x00,
+    kScene            = 0x01,
+    kSequence         = 0x02,
+    kAutomation       = 0x03,
+    kException        = 0x04,
+    kNotification     = 0x05,
+    kAlarm            = 0x06,
+    kUnknownEnumValue = 7,
 };
 
 // Enum for EndpointListTypeEnum
 enum class EndpointListTypeEnum : uint8_t
 {
-    kOther = 0x00,
-    kRoom  = 0x01,
-    kZone  = 0x02,
-    // kUnknownEnumValue = 3,
+    kOther            = 0x00,
+    kRoom             = 0x01,
+    kZone             = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Bitmap for CommandBits
@@ -336,20 +336,20 @@ namespace OtaSoftwareUpdateProvider {
 // Enum for OTAApplyUpdateAction
 enum class OTAApplyUpdateAction : uint8_t
 {
-    kProceed         = 0x00,
-    kAwaitNextAction = 0x01,
-    kDiscontinue     = 0x02,
-    // kUnknownEnumValue = 3,
+    kProceed          = 0x00,
+    kAwaitNextAction  = 0x01,
+    kDiscontinue      = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for OTADownloadProtocol
 enum class OTADownloadProtocol : uint8_t
 {
-    kBDXSynchronous  = 0x00,
-    kBDXAsynchronous = 0x01,
-    kHttps           = 0x02,
-    kVendorSpecific  = 0x03,
-    // kUnknownEnumValue = 4,
+    kBDXSynchronous   = 0x00,
+    kBDXAsynchronous  = 0x01,
+    kHttps            = 0x02,
+    kVendorSpecific   = 0x03,
+    kUnknownEnumValue = 4,
 };
 
 // Enum for OTAQueryStatus
@@ -359,7 +359,7 @@ enum class OTAQueryStatus : uint8_t
     kBusy                         = 0x01,
     kNotAvailable                 = 0x02,
     kDownloadProtocolNotSupported = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue             = 4,
 };
 } // namespace OtaSoftwareUpdateProvider
 
@@ -371,18 +371,18 @@ enum class OTAAnnouncementReason : uint8_t
     kSimpleAnnouncement    = 0x00,
     kUpdateAvailable       = 0x01,
     kUrgentUpdateAvailable = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnknownEnumValue      = 3,
 };
 
 // Enum for OTAChangeReasonEnum
 enum class OTAChangeReasonEnum : uint8_t
 {
-    kUnknown         = 0x00,
-    kSuccess         = 0x01,
-    kFailure         = 0x02,
-    kTimeOut         = 0x03,
-    kDelayByProvider = 0x04,
-    // kUnknownEnumValue = 5,
+    kUnknown          = 0x00,
+    kSuccess          = 0x01,
+    kFailure          = 0x02,
+    kTimeOut          = 0x03,
+    kDelayByProvider  = 0x04,
+    kUnknownEnumValue = 5,
 };
 
 // Enum for OTAUpdateStateEnum
@@ -397,7 +397,7 @@ enum class OTAUpdateStateEnum : uint8_t
     kDelayedOnApply       = 0x06,
     kRollingBack          = 0x07,
     kDelayedOnUserConsent = 0x08,
-    // kUnknownEnumValue = 9,
+    kUnknownEnumValue     = 9,
 };
 } // namespace OtaSoftwareUpdateRequestor
 
@@ -409,27 +409,27 @@ namespace TimeFormatLocalization {
 // Enum for CalendarType
 enum class CalendarType : uint8_t
 {
-    kBuddhist  = 0x00,
-    kChinese   = 0x01,
-    kCoptic    = 0x02,
-    kEthiopian = 0x03,
-    kGregorian = 0x04,
-    kHebrew    = 0x05,
-    kIndian    = 0x06,
-    kIslamic   = 0x07,
-    kJapanese  = 0x08,
-    kKorean    = 0x09,
-    kPersian   = 0x0A,
-    kTaiwanese = 0x0B,
-    // kUnknownEnumValue = 12,
+    kBuddhist         = 0x00,
+    kChinese          = 0x01,
+    kCoptic           = 0x02,
+    kEthiopian        = 0x03,
+    kGregorian        = 0x04,
+    kHebrew           = 0x05,
+    kIndian           = 0x06,
+    kIslamic          = 0x07,
+    kJapanese         = 0x08,
+    kKorean           = 0x09,
+    kPersian          = 0x0A,
+    kTaiwanese        = 0x0B,
+    kUnknownEnumValue = 12,
 };
 
 // Enum for HourFormat
 enum class HourFormat : uint8_t
 {
-    k12hr = 0x00,
-    k24hr = 0x01,
-    // kUnknownEnumValue = 2,
+    k12hr             = 0x00,
+    k24hr             = 0x01,
+    kUnknownEnumValue = 2,
 };
 } // namespace TimeFormatLocalization
 
@@ -438,10 +438,10 @@ namespace UnitLocalization {
 // Enum for TempUnit
 enum class TempUnit : uint8_t
 {
-    kFahrenheit = 0x00,
-    kCelsius    = 0x01,
-    kKelvin     = 0x02,
-    // kUnknownEnumValue = 3,
+    kFahrenheit       = 0x00,
+    kCelsius          = 0x01,
+    kKelvin           = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Bitmap for UnitLocalizationFeature
@@ -470,35 +470,35 @@ enum class BatChargeFault : uint8_t
     kChargerOverVoltage  = 0x08,
     kChargerUnderVoltage = 0x09,
     kSafetyTimeout       = 0x0A,
-    // kUnknownEnumValue = 11,
+    kUnknownEnumValue    = 11,
 };
 
 // Enum for BatChargeLevel
 enum class BatChargeLevel : uint8_t
 {
-    kOk       = 0x00,
-    kWarning  = 0x01,
-    kCritical = 0x02,
-    // kUnknownEnumValue = 3,
+    kOk               = 0x00,
+    kWarning          = 0x01,
+    kCritical         = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for BatChargeState
 enum class BatChargeState : uint8_t
 {
-    kUnknown        = 0x00,
-    kIsCharging     = 0x01,
-    kIsAtFullCharge = 0x02,
-    kIsNotCharging  = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknown          = 0x00,
+    kIsCharging       = 0x01,
+    kIsAtFullCharge   = 0x02,
+    kIsNotCharging    = 0x03,
+    kUnknownEnumValue = 4,
 };
 
 // Enum for BatFault
 enum class BatFault : uint8_t
 {
-    kUnspecfied = 0x00,
-    kOverTemp   = 0x01,
-    kUnderTemp  = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnspecfied       = 0x00,
+    kOverTemp         = 0x01,
+    kUnderTemp        = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for BatReplaceability
@@ -508,34 +508,34 @@ enum class BatReplaceability : uint8_t
     kNotReplaceable     = 0x01,
     kUserReplaceable    = 0x02,
     kFactoryReplaceable = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue   = 4,
 };
 
 // Enum for PowerSourceStatus
 enum class PowerSourceStatus : uint8_t
 {
-    kUnspecfied  = 0x00,
-    kActive      = 0x01,
-    kStandby     = 0x02,
-    kUnavailable = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnspecfied       = 0x00,
+    kActive           = 0x01,
+    kStandby          = 0x02,
+    kUnavailable      = 0x03,
+    kUnknownEnumValue = 4,
 };
 
 // Enum for WiredCurrentType
 enum class WiredCurrentType : uint8_t
 {
-    kAc = 0x00,
-    kDc = 0x01,
-    // kUnknownEnumValue = 2,
+    kAc               = 0x00,
+    kDc               = 0x01,
+    kUnknownEnumValue = 2,
 };
 
 // Enum for WiredFault
 enum class WiredFault : uint8_t
 {
-    kUnspecfied   = 0x00,
-    kOverVoltage  = 0x01,
-    kUnderVoltage = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnspecfied       = 0x00,
+    kOverVoltage      = 0x01,
+    kUnderVoltage     = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Bitmap for PowerSourceFeature
@@ -558,16 +558,16 @@ enum class CommissioningError : uint8_t
     kInvalidAuthentication = 0x02,
     kNoFailSafe            = 0x03,
     kBusyWithOtherAdmin    = 0x04,
-    // kUnknownEnumValue = 5,
+    kUnknownEnumValue      = 5,
 };
 
 // Enum for RegulatoryLocationType
 enum class RegulatoryLocationType : uint8_t
 {
-    kIndoor        = 0x00,
-    kOutdoor       = 0x01,
-    kIndoorOutdoor = 0x02,
-    // kUnknownEnumValue = 3,
+    kIndoor           = 0x00,
+    kOutdoor          = 0x01,
+    kIndoorOutdoor    = 0x02,
+    kUnknownEnumValue = 3,
 };
 } // namespace GeneralCommissioning
 
@@ -589,18 +589,18 @@ enum class NetworkCommissioningStatus : uint8_t
     kIPV6Failed             = 0x0A,
     kIPBindFailed           = 0x0B,
     kUnknownError           = 0x0C,
-    // kUnknownEnumValue = 13,
+    kUnknownEnumValue       = 13,
 };
 
 // Enum for WiFiBand
 enum class WiFiBand : uint8_t
 {
-    k2g4  = 0x00,
-    k3g65 = 0x01,
-    k5g   = 0x02,
-    k6g   = 0x03,
-    k60g  = 0x04,
-    // kUnknownEnumValue = 5,
+    k2g4              = 0x00,
+    k3g65             = 0x01,
+    k5g               = 0x02,
+    k6g               = 0x03,
+    k60g              = 0x04,
+    kUnknownEnumValue = 5,
 };
 
 // Bitmap for NetworkCommissioningFeature
@@ -627,29 +627,29 @@ namespace DiagnosticLogs {
 // Enum for LogsIntent
 enum class LogsIntent : uint8_t
 {
-    kEndUserSupport = 0x00,
-    kNetworkDiag    = 0x01,
-    kCrashLogs      = 0x02,
-    // kUnknownEnumValue = 3,
+    kEndUserSupport   = 0x00,
+    kNetworkDiag      = 0x01,
+    kCrashLogs        = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for LogsStatus
 enum class LogsStatus : uint8_t
 {
-    kSuccess   = 0x00,
-    kExhausted = 0x01,
-    kNoLogs    = 0x02,
-    kBusy      = 0x03,
-    kDenied    = 0x04,
-    // kUnknownEnumValue = 5,
+    kSuccess          = 0x00,
+    kExhausted        = 0x01,
+    kNoLogs           = 0x02,
+    kBusy             = 0x03,
+    kDenied           = 0x04,
+    kUnknownEnumValue = 5,
 };
 
 // Enum for LogsTransferProtocol
 enum class LogsTransferProtocol : uint8_t
 {
-    kResponsePayload = 0x00,
-    kBdx             = 0x01,
-    // kUnknownEnumValue = 2,
+    kResponsePayload  = 0x00,
+    kBdx              = 0x01,
+    kUnknownEnumValue = 2,
 };
 } // namespace DiagnosticLogs
 
@@ -665,7 +665,7 @@ enum class BootReasonType : uint8_t
     kHardwareWatchdogReset   = 0x04,
     kSoftwareUpdateCompleted = 0x05,
     kSoftwareReset           = 0x06,
-    // kUnknownEnumValue = 7,
+    kUnknownEnumValue        = 7,
 };
 
 // Need to convert consumers to using the new enum classes, so we
@@ -685,7 +685,7 @@ enum class HardwareFaultType : uint8_t
     kUserInterfaceFault     = 0x08,
     kNonVolatileMemoryError = 0x09,
     kTamperDetected         = 0x0A,
-    // kUnknownEnumValue = 11,
+    kUnknownEnumValue       = 11,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using HardwareFaultType                                                                = EmberAfHardwareFaultType;
@@ -698,12 +698,12 @@ static HardwareFaultType __attribute__((unused)) kHardwareFaultTypekUnknownEnumV
 // Enum for InterfaceType
 enum class InterfaceType : uint8_t
 {
-    kUnspecified = 0x00,
-    kWiFi        = 0x01,
-    kEthernet    = 0x02,
-    kCellular    = 0x03,
-    kThread      = 0x04,
-    // kUnknownEnumValue = 5,
+    kUnspecified      = 0x00,
+    kWiFi             = 0x01,
+    kEthernet         = 0x02,
+    kCellular         = 0x03,
+    kThread           = 0x04,
+    kUnknownEnumValue = 5,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using InterfaceType                                                                    = EmberAfInterfaceType;
@@ -720,7 +720,7 @@ enum class NetworkFaultType : uint8_t
     kHardwareFailure  = 0x01,
     kNetworkJammed    = 0x02,
     kConnectionFailed = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue = 4,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using NetworkFaultType                                                                 = EmberAfNetworkFaultType;
@@ -733,14 +733,14 @@ static NetworkFaultType __attribute__((unused)) kNetworkFaultTypekUnknownEnumVal
 // Enum for RadioFaultType
 enum class RadioFaultType : uint8_t
 {
-    kUnspecified   = 0x00,
-    kWiFiFault     = 0x01,
-    kCellularFault = 0x02,
-    kThreadFault   = 0x03,
-    kNFCFault      = 0x04,
-    kBLEFault      = 0x05,
-    kEthernetFault = 0x06,
-    // kUnknownEnumValue = 7,
+    kUnspecified      = 0x00,
+    kWiFiFault        = 0x01,
+    kCellularFault    = 0x02,
+    kThreadFault      = 0x03,
+    kNFCFault         = 0x04,
+    kBLEFault         = 0x05,
+    kEthernetFault    = 0x06,
+    kUnknownEnumValue = 7,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using RadioFaultType                                                                   = EmberAfRadioFaultType;
@@ -762,11 +762,11 @@ namespace ThreadNetworkDiagnostics {
 // Enum for NetworkFault
 enum class NetworkFault : uint8_t
 {
-    kUnspecified     = 0x00,
-    kLinkDown        = 0x01,
-    kHardwareFailure = 0x02,
-    kNetworkJammed   = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnspecified      = 0x00,
+    kLinkDown         = 0x01,
+    kHardwareFailure  = 0x02,
+    kNetworkJammed    = 0x03,
+    kUnknownEnumValue = 4,
 };
 
 // Need to convert consumers to using the new enum classes, so we
@@ -775,14 +775,14 @@ enum class NetworkFault : uint8_t
 // Enum for RoutingRole
 enum class RoutingRole : uint8_t
 {
-    kUnspecified     = 0x00,
-    kUnassigned      = 0x01,
-    kSleepyEndDevice = 0x02,
-    kEndDevice       = 0x03,
-    kReed            = 0x04,
-    kRouter          = 0x05,
-    kLeader          = 0x06,
-    // kUnknownEnumValue = 7,
+    kUnspecified      = 0x00,
+    kUnassigned       = 0x01,
+    kSleepyEndDevice  = 0x02,
+    kEndDevice        = 0x03,
+    kReed             = 0x04,
+    kRouter           = 0x05,
+    kLeader           = 0x06,
+    kUnknownEnumValue = 7,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using RoutingRole                                                                      = EmberAfRoutingRole;
@@ -792,9 +792,9 @@ static RoutingRole __attribute__((unused)) kRoutingRolekUnknownEnumValue        
 // Enum for ThreadConnectionStatus
 enum class ThreadConnectionStatus : uint8_t
 {
-    kConnected    = 0x00,
-    kNotConnected = 0x01,
-    // kUnknownEnumValue = 2,
+    kConnected        = 0x00,
+    kNotConnected     = 0x01,
+    kUnknownEnumValue = 2,
 };
 
 // Bitmap for ThreadNetworkDiagnosticsFeature
@@ -816,7 +816,7 @@ enum class AssociationFailureCause : uint8_t
     kAssociationFailed    = 0x01,
     kAuthenticationFailed = 0x02,
     kSsidNotFound         = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue     = 4,
 };
 
 // Need to convert consumers to using the new enum classes, so we
@@ -825,13 +825,13 @@ enum class AssociationFailureCause : uint8_t
 // Enum for SecurityType
 enum class SecurityType : uint8_t
 {
-    kUnspecified = 0x00,
-    kNone        = 0x01,
-    kWep         = 0x02,
-    kWpa         = 0x03,
-    kWpa2        = 0x04,
-    kWpa3        = 0x05,
-    // kUnknownEnumValue = 6,
+    kUnspecified      = 0x00,
+    kNone             = 0x01,
+    kWep              = 0x02,
+    kWpa              = 0x03,
+    kWpa2             = 0x04,
+    kWpa3             = 0x05,
+    kUnknownEnumValue = 6,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using SecurityType                                                                     = EmberAfSecurityType;
@@ -841,9 +841,9 @@ static SecurityType __attribute__((unused)) kSecurityTypekUnknownEnumValue      
 // Enum for WiFiConnectionStatus
 enum class WiFiConnectionStatus : uint8_t
 {
-    kConnected    = 0x00,
-    kNotConnected = 0x01,
-    // kUnknownEnumValue = 2,
+    kConnected        = 0x00,
+    kNotConnected     = 0x01,
+    kUnknownEnumValue = 2,
 };
 
 // Need to convert consumers to using the new enum classes, so we
@@ -852,13 +852,13 @@ enum class WiFiConnectionStatus : uint8_t
 // Enum for WiFiVersionType
 enum class WiFiVersionType : uint8_t
 {
-    k80211a  = 0x00,
-    k80211b  = 0x01,
-    k80211g  = 0x02,
-    k80211n  = 0x03,
-    k80211ac = 0x04,
-    k80211ax = 0x05,
-    // kUnknownEnumValue = 6,
+    k80211a           = 0x00,
+    k80211b           = 0x01,
+    k80211g           = 0x02,
+    k80211n           = 0x03,
+    k80211ac          = 0x04,
+    k80211ax          = 0x05,
+    kUnknownEnumValue = 6,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using WiFiVersionType                                                                  = EmberAfWiFiVersionType;
@@ -874,17 +874,17 @@ namespace EthernetNetworkDiagnostics {
 // Enum for PHYRateType
 enum class PHYRateType : uint8_t
 {
-    k10m   = 0x00,
-    k100m  = 0x01,
-    k1000m = 0x02,
-    k25g   = 0x03,
-    k5g    = 0x04,
-    k10g   = 0x05,
-    k40g   = 0x06,
-    k100g  = 0x07,
-    k200g  = 0x08,
-    k400g  = 0x09,
-    // kUnknownEnumValue = 10,
+    k10m              = 0x00,
+    k100m             = 0x01,
+    k1000m            = 0x02,
+    k25g              = 0x03,
+    k5g               = 0x04,
+    k10g              = 0x05,
+    k40g              = 0x06,
+    k100g             = 0x07,
+    k200g             = 0x08,
+    k400g             = 0x09,
+    kUnknownEnumValue = 10,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using PHYRateType                                                                      = EmberAfPHYRateType;
@@ -909,7 +909,7 @@ enum class CommissioningWindowStatus : uint8_t
     kWindowNotOpen      = 0x00,
     kEnhancedWindowOpen = 0x01,
     kBasicWindowOpen    = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnknownEnumValue   = 3,
 };
 
 // Need to convert consumers to using the new enum classes, so we
@@ -921,7 +921,7 @@ enum class StatusCode : uint8_t
     kBusy               = 0x01,
     kPAKEParameterError = 0x02,
     kWindowNotOpen      = 0x03,
-    // kUnknownEnumValue = 0,
+    kUnknownEnumValue   = 0,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using StatusCode                                                                       = EmberAfStatusCode;
@@ -945,7 +945,7 @@ enum class OperationalCertStatus : uint8_t
     kFabricConflict        = 0x09,
     kLabelConflict         = 0x0A,
     kInvalidFabricIndex    = 0x0B,
-    // kUnknownEnumValue = 7,
+    kUnknownEnumValue      = 7,
 };
 } // namespace OperationalCredentials
 
@@ -954,9 +954,9 @@ namespace GroupKeyManagement {
 // Enum for GroupKeySecurityPolicy
 enum class GroupKeySecurityPolicy : uint8_t
 {
-    kTrustFirst   = 0x00,
-    kCacheAndSync = 0x01,
-    // kUnknownEnumValue = 2,
+    kTrustFirst       = 0x00,
+    kCacheAndSync     = 0x01,
+    kUnknownEnumValue = 2,
 };
 } // namespace GroupKeyManagement
 
@@ -1000,37 +1000,37 @@ enum class DlAlarmCode : uint8_t
     kDoorForcedOpen          = 0x06,
     kDoorAjar                = 0x07,
     kForcedUser              = 0x08,
-    // kUnknownEnumValue = 2,
+    kUnknownEnumValue        = 2,
 };
 
 // Enum for DlCredentialRule
 enum class DlCredentialRule : uint8_t
 {
-    kSingle = 0x00,
-    kDouble = 0x01,
-    kTri    = 0x02,
-    // kUnknownEnumValue = 3,
+    kSingle           = 0x00,
+    kDouble           = 0x01,
+    kTri              = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for DlCredentialType
 enum class DlCredentialType : uint8_t
 {
-    kProgrammingPIN = 0x00,
-    kPin            = 0x01,
-    kRfid           = 0x02,
-    kFingerprint    = 0x03,
-    kFingerVein     = 0x04,
-    kFace           = 0x05,
-    // kUnknownEnumValue = 6,
+    kProgrammingPIN   = 0x00,
+    kPin              = 0x01,
+    kRfid             = 0x02,
+    kFingerprint      = 0x03,
+    kFingerVein       = 0x04,
+    kFace             = 0x05,
+    kUnknownEnumValue = 6,
 };
 
 // Enum for DlDataOperationType
 enum class DlDataOperationType : uint8_t
 {
-    kAdd    = 0x00,
-    kClear  = 0x01,
-    kModify = 0x02,
-    // kUnknownEnumValue = 3,
+    kAdd              = 0x00,
+    kClear            = 0x01,
+    kModify           = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for DlDoorState
@@ -1042,22 +1042,22 @@ enum class DlDoorState : uint8_t
     kDoorForcedOpen       = 0x03,
     kDoorUnspecifiedError = 0x04,
     kDoorAjar             = 0x05,
-    // kUnknownEnumValue = 6,
+    kUnknownEnumValue     = 6,
 };
 
 // Enum for DlLockDataType
 enum class DlLockDataType : uint8_t
 {
-    kUnspecified     = 0x00,
-    kProgrammingCode = 0x01,
-    kUserIndex       = 0x02,
-    kWeekDaySchedule = 0x03,
-    kYearDaySchedule = 0x04,
-    kHolidaySchedule = 0x05,
-    kPin             = 0x06,
-    kRfid            = 0x07,
-    kFingerprint     = 0x08,
-    // kUnknownEnumValue = 9,
+    kUnspecified      = 0x00,
+    kProgrammingCode  = 0x01,
+    kUserIndex        = 0x02,
+    kWeekDaySchedule  = 0x03,
+    kYearDaySchedule  = 0x04,
+    kHolidaySchedule  = 0x05,
+    kPin              = 0x06,
+    kRfid             = 0x07,
+    kFingerprint      = 0x08,
+    kUnknownEnumValue = 9,
 };
 
 // Enum for DlLockOperationType
@@ -1067,16 +1067,16 @@ enum class DlLockOperationType : uint8_t
     kUnlock             = 0x01,
     kNonAccessUserEvent = 0x02,
     kForcedUserEvent    = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue   = 4,
 };
 
 // Enum for DlLockState
 enum class DlLockState : uint8_t
 {
-    kNotFullyLocked = 0x00,
-    kLocked         = 0x01,
-    kUnlocked       = 0x02,
-    // kUnknownEnumValue = 3,
+    kNotFullyLocked   = 0x00,
+    kLocked           = 0x01,
+    kUnlocked         = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for DlLockType
@@ -1093,7 +1093,7 @@ enum class DlLockType : uint8_t
     kInterconnectedLock = 0x08,
     kDeadLatch          = 0x09,
     kDoorFurniture      = 0x0A,
-    // kUnknownEnumValue = 11,
+    kUnknownEnumValue   = 11,
 };
 
 // Enum for DlOperatingMode
@@ -1104,7 +1104,7 @@ enum class DlOperatingMode : uint8_t
     kPrivacy            = 0x02,
     kNoRemoteLockUnlock = 0x03,
     kPassage            = 0x04,
-    // kUnknownEnumValue = 5,
+    kUnknownEnumValue   = 5,
 };
 
 // Enum for DlOperationError
@@ -1115,7 +1115,7 @@ enum class DlOperationError : uint8_t
     kDisabledUserDenied  = 0x02,
     kRestricted          = 0x03,
     kInsufficientBattery = 0x04,
-    // kUnknownEnumValue = 5,
+    kUnknownEnumValue    = 5,
 };
 
 // Enum for DlOperationSource
@@ -1131,7 +1131,7 @@ enum class DlOperationSource : uint8_t
     kRemote            = 0x07,
     kRfid              = 0x08,
     kBiometric         = 0x09,
-    // kUnknownEnumValue = 10,
+    kUnknownEnumValue  = 10,
 };
 
 // Enum for DlStatus
@@ -1144,7 +1144,7 @@ enum class DlStatus : uint8_t
     kInvalidField      = 0x85,
     kResourceExhausted = 0x89,
     kNotFound          = 0x8B,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue  = 4,
 };
 
 // Enum for DlUserStatus
@@ -1153,7 +1153,7 @@ enum class DlUserStatus : uint8_t
     kAvailable        = 0x00,
     kOccupiedEnabled  = 0x01,
     kOccupiedDisabled = 0x03,
-    // kUnknownEnumValue = 2,
+    kUnknownEnumValue = 2,
 };
 
 // Enum for DlUserType
@@ -1169,7 +1169,7 @@ enum class DlUserType : uint8_t
     kExpiringUser           = 0x07,
     kScheduleRestrictedUser = 0x08,
     kRemoteOnlyUser         = 0x09,
-    // kUnknownEnumValue = 10,
+    kUnknownEnumValue       = 10,
 };
 
 // Enum for DoorLockOperationEventCode
@@ -1190,7 +1190,7 @@ enum class DoorLockOperationEventCode : uint8_t
     kScheduleUnlock        = 0x0C,
     kManualLock            = 0x0D,
     kManualUnlock          = 0x0E,
-    // kUnknownEnumValue = 15,
+    kUnknownEnumValue      = 15,
 };
 
 // Enum for DoorLockProgrammingEventCode
@@ -1203,7 +1203,7 @@ enum class DoorLockProgrammingEventCode : uint8_t
     kPinChanged           = 0x04,
     kIdAdded              = 0x05,
     kIdDeleted            = 0x06,
-    // kUnknownEnumValue = 7,
+    kUnknownEnumValue     = 7,
 };
 
 // Enum for DoorLockSetPinOrIdStatus
@@ -1213,7 +1213,7 @@ enum class DoorLockSetPinOrIdStatus : uint8_t
     kGeneralFailure     = 0x01,
     kMemoryFull         = 0x02,
     kDuplicateCodeError = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue   = 4,
 };
 
 // Enum for DoorLockUserStatus
@@ -1223,7 +1223,7 @@ enum class DoorLockUserStatus : uint8_t
     kOccupiedEnabled  = 0x01,
     kOccupiedDisabled = 0x03,
     kNotSupported     = 0xFF,
-    // kUnknownEnumValue = 2,
+    kUnknownEnumValue = 2,
 };
 
 // Enum for DoorLockUserType
@@ -1235,7 +1235,7 @@ enum class DoorLockUserType : uint8_t
     kMasterUser          = 0x03,
     kNonAccessUser       = 0x04,
     kNotSupported        = 0xFF,
-    // kUnknownEnumValue = 5,
+    kUnknownEnumValue    = 5,
 };
 
 // Bitmap for DlCredentialRuleMask
@@ -1439,7 +1439,7 @@ enum class EndProductType : uint8_t
     kSwingingShutter           = 0x16,
     kSlidingShutter            = 0x17,
     kUnknown                   = 0xFF,
-    // kUnknownEnumValue = 24,
+    kUnknownEnumValue          = 24,
 };
 
 // Enum for Type
@@ -1456,7 +1456,7 @@ enum class Type : uint8_t
     kTiltBlindLiftAndTilt      = 0x08,
     kProjectorScreen           = 0x09,
     kUnknown                   = 0xFF,
-    // kUnknownEnumValue = 10,
+    kUnknownEnumValue          = 10,
 };
 
 // Bitmap for ConfigStatus
@@ -1530,17 +1530,17 @@ enum class PumpControlMode : uint8_t
     kConstantFlow         = 0x03,
     kConstantTemperature  = 0x05,
     kAutomatic            = 0x07,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue     = 4,
 };
 
 // Enum for PumpOperationMode
 enum class PumpOperationMode : uint8_t
 {
-    kNormal  = 0x00,
-    kMinimum = 0x01,
-    kMaximum = 0x02,
-    kLocal   = 0x03,
-    // kUnknownEnumValue = 4,
+    kNormal           = 0x00,
+    kMinimum          = 0x01,
+    kMaximum          = 0x02,
+    kLocal            = 0x03,
+    kUnknownEnumValue = 4,
 };
 
 // Bitmap for PumpStatus
@@ -1569,7 +1569,7 @@ enum class SetpointAdjustMode : uint8_t
     kHeatSetpoint         = 0x00,
     kCoolSetpoint         = 0x01,
     kHeatAndCoolSetpoints = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnknownEnumValue     = 3,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using SetpointAdjustMode                                                               = EmberAfSetpointAdjustMode;
@@ -1585,16 +1585,16 @@ enum class ThermostatControlSequence : uint8_t
     kHeatingWithReheat           = 0x03,
     kCoolingAndHeating           = 0x04,
     kCoolingAndHeatingWithReheat = 0x05,
-    // kUnknownEnumValue = 6,
+    kUnknownEnumValue            = 6,
 };
 
 // Enum for ThermostatRunningMode
 enum class ThermostatRunningMode : uint8_t
 {
-    kOff  = 0x00,
-    kCool = 0x03,
-    kHeat = 0x04,
-    // kUnknownEnumValue = 1,
+    kOff              = 0x00,
+    kCool             = 0x03,
+    kHeat             = 0x04,
+    kUnknownEnumValue = 1,
 };
 
 // Enum for ThermostatSystemMode
@@ -1607,7 +1607,7 @@ enum class ThermostatSystemMode : uint8_t
     kEmergencyHeating = 0x05,
     kPrecooling       = 0x06,
     kFanOnly          = 0x07,
-    // kUnknownEnumValue = 2,
+    kUnknownEnumValue = 2,
 };
 
 // Bitmap for DayOfWeek
@@ -1653,20 +1653,20 @@ enum class FanModeSequenceType : uint8_t
     kOffLowHighAuto    = 0x03,
     kOffOnAuto         = 0x04,
     kOffOn             = 0x05,
-    // kUnknownEnumValue = 6,
+    kUnknownEnumValue  = 6,
 };
 
 // Enum for FanModeType
 enum class FanModeType : uint8_t
 {
-    kOff    = 0x00,
-    kLow    = 0x01,
-    kMedium = 0x02,
-    kHigh   = 0x03,
-    kOn     = 0x04,
-    kAuto   = 0x05,
-    kSmart  = 0x06,
-    // kUnknownEnumValue = 7,
+    kOff              = 0x00,
+    kLow              = 0x01,
+    kMedium           = 0x02,
+    kHigh             = 0x03,
+    kOn               = 0x04,
+    kAuto             = 0x05,
+    kSmart            = 0x06,
+    kUnknownEnumValue = 7,
 };
 
 // Bitmap for FanControlFeature
@@ -1715,7 +1715,7 @@ enum class ColorLoopAction : uint8_t
     kDeactivate                            = 0x00,
     kActivateFromColorLoopStartEnhancedHue = 0x01,
     kActivateFromEnhancedCurrentHue        = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnknownEnumValue                      = 3,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using ColorLoopAction                                                                  = EmberAfColorLoopAction;
@@ -1728,9 +1728,9 @@ static ColorLoopAction __attribute__((unused)) kColorLoopActionkUnknownEnumValue
 // Enum for ColorLoopDirection
 enum class ColorLoopDirection : uint8_t
 {
-    kDecrementHue = 0x00,
-    kIncrementHue = 0x01,
-    // kUnknownEnumValue = 2,
+    kDecrementHue     = 0x00,
+    kIncrementHue     = 0x01,
+    kUnknownEnumValue = 2,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using ColorLoopDirection                                                               = EmberAfColorLoopDirection;
@@ -1746,7 +1746,7 @@ enum class ColorMode : uint8_t
     kCurrentHueAndCurrentSaturation = 0x00,
     kCurrentXAndCurrentY            = 0x01,
     kColorTemperature               = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnknownEnumValue               = 3,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using ColorMode                                                                        = EmberAfColorMode;
@@ -1763,7 +1763,7 @@ enum class HueDirection : uint8_t
     kLongestDistance  = 0x01,
     kUp               = 0x02,
     kDown             = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue = 4,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using HueDirection                                                                     = EmberAfHueDirection;
@@ -1776,10 +1776,10 @@ static HueDirection __attribute__((unused)) kHueDirectionkUnknownEnumValue      
 // Enum for HueMoveMode
 enum class HueMoveMode : uint8_t
 {
-    kStop = 0x00,
-    kUp   = 0x01,
-    kDown = 0x03,
-    // kUnknownEnumValue = 2,
+    kStop             = 0x00,
+    kUp               = 0x01,
+    kDown             = 0x03,
+    kUnknownEnumValue = 2,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using HueMoveMode                                                                      = EmberAfHueMoveMode;
@@ -1792,9 +1792,9 @@ static HueMoveMode __attribute__((unused)) kHueMoveModekUnknownEnumValue        
 // Enum for HueStepMode
 enum class HueStepMode : uint8_t
 {
-    kUp   = 0x01,
-    kDown = 0x03,
-    // kUnknownEnumValue = 0,
+    kUp               = 0x01,
+    kDown             = 0x03,
+    kUnknownEnumValue = 0,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using HueStepMode                                                                      = EmberAfHueStepMode;
@@ -1807,10 +1807,10 @@ static HueStepMode __attribute__((unused)) kHueStepModekUnknownEnumValue        
 // Enum for SaturationMoveMode
 enum class SaturationMoveMode : uint8_t
 {
-    kStop = 0x00,
-    kUp   = 0x01,
-    kDown = 0x03,
-    // kUnknownEnumValue = 2,
+    kStop             = 0x00,
+    kUp               = 0x01,
+    kDown             = 0x03,
+    kUnknownEnumValue = 2,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using SaturationMoveMode                                                               = EmberAfSaturationMoveMode;
@@ -1823,9 +1823,9 @@ static SaturationMoveMode __attribute__((unused)) kSaturationMoveModekUnknownEnu
 // Enum for SaturationStepMode
 enum class SaturationStepMode : uint8_t
 {
-    kUp   = 0x01,
-    kDown = 0x03,
-    // kUnknownEnumValue = 0,
+    kUp               = 0x01,
+    kDown             = 0x03,
+    kUnknownEnumValue = 0,
 };
 #else  // CHIP_USE_ENUM_CLASS_FOR_IM_ENUM
 using SaturationStepMode                                                               = EmberAfSaturationStepMode;
@@ -1870,9 +1870,9 @@ namespace IlluminanceMeasurement {
 // Enum for LightSensorType
 enum class LightSensorType : uint8_t
 {
-    kPhotodiode = 0x00,
-    kCmos       = 0x01,
-    // kUnknownEnumValue = 2,
+    kPhotodiode       = 0x00,
+    kCmos             = 0x01,
+    kUnknownEnumValue = 2,
 };
 } // namespace IlluminanceMeasurement
 
@@ -1905,17 +1905,17 @@ namespace Channel {
 // Enum for ChannelStatusEnum
 enum class ChannelStatusEnum : uint8_t
 {
-    kSuccess         = 0x00,
-    kMultipleMatches = 0x01,
-    kNoMatches       = 0x02,
-    // kUnknownEnumValue = 3,
+    kSuccess          = 0x00,
+    kMultipleMatches  = 0x01,
+    kNoMatches        = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for LineupInfoTypeEnum
 enum class LineupInfoTypeEnum : uint8_t
 {
-    kMso = 0x00,
-    // kUnknownEnumValue = 1,
+    kMso              = 0x00,
+    kUnknownEnumValue = 1,
 };
 
 // Bitmap for ChannelFeature
@@ -1931,10 +1931,10 @@ namespace TargetNavigator {
 // Enum for TargetNavigatorStatusEnum
 enum class TargetNavigatorStatusEnum : uint8_t
 {
-    kSuccess        = 0x00,
-    kTargetNotFound = 0x01,
-    kNotAllowed     = 0x02,
-    // kUnknownEnumValue = 3,
+    kSuccess          = 0x00,
+    kTargetNotFound   = 0x01,
+    kNotAllowed       = 0x02,
+    kUnknownEnumValue = 3,
 };
 } // namespace TargetNavigator
 
@@ -1949,17 +1949,17 @@ enum class MediaPlaybackStatusEnum : uint8_t
     kNotActive              = 0x03,
     kSpeedOutOfRange        = 0x04,
     kSeekOutOfRange         = 0x05,
-    // kUnknownEnumValue = 6,
+    kUnknownEnumValue       = 6,
 };
 
 // Enum for PlaybackStateEnum
 enum class PlaybackStateEnum : uint8_t
 {
-    kPlaying    = 0x00,
-    kPaused     = 0x01,
-    kNotPlaying = 0x02,
-    kBuffering  = 0x03,
-    // kUnknownEnumValue = 4,
+    kPlaying          = 0x00,
+    kPaused           = 0x01,
+    kNotPlaying       = 0x02,
+    kBuffering        = 0x03,
+    kUnknownEnumValue = 4,
 };
 } // namespace MediaPlayback
 
@@ -1968,19 +1968,19 @@ namespace MediaInput {
 // Enum for InputTypeEnum
 enum class InputTypeEnum : uint8_t
 {
-    kInternal  = 0x00,
-    kAux       = 0x01,
-    kCoax      = 0x02,
-    kComposite = 0x03,
-    kHdmi      = 0x04,
-    kInput     = 0x05,
-    kLine      = 0x06,
-    kOptical   = 0x07,
-    kVideo     = 0x08,
-    kScart     = 0x09,
-    kUsb       = 0x0A,
-    kOther     = 0x0B,
-    // kUnknownEnumValue = 12,
+    kInternal         = 0x00,
+    kAux              = 0x01,
+    kCoax             = 0x02,
+    kComposite        = 0x03,
+    kHdmi             = 0x04,
+    kInput            = 0x05,
+    kLine             = 0x06,
+    kOptical          = 0x07,
+    kVideo            = 0x08,
+    kScart            = 0x09,
+    kUsb              = 0x0A,
+    kOther            = 0x0B,
+    kUnknownEnumValue = 12,
 };
 
 // Bitmap for MediaInputFeature
@@ -2084,7 +2084,7 @@ enum class CecKeyCode : uint8_t
     kF4Yellow                  = 0x74,
     kF5                        = 0x75,
     kData                      = 0x76,
-    // kUnknownEnumValue = 14,
+    kUnknownEnumValue          = 14,
 };
 
 // Enum for KeypadInputStatusEnum
@@ -2093,7 +2093,7 @@ enum class KeypadInputStatusEnum : uint8_t
     kSuccess                  = 0x00,
     kUnsupportedKey           = 0x01,
     kInvalidKeyInCurrentState = 0x02,
-    // kUnknownEnumValue = 3,
+    kUnknownEnumValue         = 3,
 };
 
 // Bitmap for KeypadInputFeature
@@ -2110,37 +2110,37 @@ namespace ContentLauncher {
 // Enum for ContentLaunchStatusEnum
 enum class ContentLaunchStatusEnum : uint8_t
 {
-    kSuccess         = 0x00,
-    kUrlNotAvailable = 0x01,
-    kAuthFailed      = 0x02,
-    // kUnknownEnumValue = 3,
+    kSuccess          = 0x00,
+    kUrlNotAvailable  = 0x01,
+    kAuthFailed       = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Enum for MetricTypeEnum
 enum class MetricTypeEnum : uint8_t
 {
-    kPixels     = 0x00,
-    kPercentage = 0x01,
-    // kUnknownEnumValue = 2,
+    kPixels           = 0x00,
+    kPercentage       = 0x01,
+    kUnknownEnumValue = 2,
 };
 
 // Enum for ParameterEnum
 enum class ParameterEnum : uint8_t
 {
-    kActor      = 0x00,
-    kChannel    = 0x01,
-    kCharacter  = 0x02,
-    kDirector   = 0x03,
-    kEvent      = 0x04,
-    kFranchise  = 0x05,
-    kGenre      = 0x06,
-    kLeague     = 0x07,
-    kPopularity = 0x08,
-    kProvider   = 0x09,
-    kSport      = 0x0A,
-    kSportsTeam = 0x0B,
-    kType       = 0x0C,
-    // kUnknownEnumValue = 13,
+    kActor            = 0x00,
+    kChannel          = 0x01,
+    kCharacter        = 0x02,
+    kDirector         = 0x03,
+    kEvent            = 0x04,
+    kFranchise        = 0x05,
+    kGenre            = 0x06,
+    kLeague           = 0x07,
+    kPopularity       = 0x08,
+    kProvider         = 0x09,
+    kSport            = 0x0A,
+    kSportsTeam       = 0x0B,
+    kType             = 0x0C,
+    kUnknownEnumValue = 13,
 };
 
 // Bitmap for ContentLauncherFeature
@@ -2163,13 +2163,13 @@ namespace AudioOutput {
 // Enum for OutputTypeEnum
 enum class OutputTypeEnum : uint8_t
 {
-    kHdmi      = 0x00,
-    kBt        = 0x01,
-    kOptical   = 0x02,
-    kHeadphone = 0x03,
-    kInternal  = 0x04,
-    kOther     = 0x05,
-    // kUnknownEnumValue = 6,
+    kHdmi             = 0x00,
+    kBt               = 0x01,
+    kOptical          = 0x02,
+    kHeadphone        = 0x03,
+    kInternal         = 0x04,
+    kOther            = 0x05,
+    kUnknownEnumValue = 6,
 };
 
 // Bitmap for AudioOutputFeature
@@ -2184,10 +2184,10 @@ namespace ApplicationLauncher {
 // Enum for ApplicationLauncherStatusEnum
 enum class ApplicationLauncherStatusEnum : uint8_t
 {
-    kSuccess         = 0x00,
-    kAppNotAvailable = 0x01,
-    kSystemBusy      = 0x02,
-    // kUnknownEnumValue = 3,
+    kSuccess          = 0x00,
+    kAppNotAvailable  = 0x01,
+    kSystemBusy       = 0x02,
+    kUnknownEnumValue = 3,
 };
 
 // Bitmap for ApplicationLauncherFeature
@@ -2206,7 +2206,7 @@ enum class ApplicationStatusEnum : uint8_t
     kActiveVisibleFocus    = 0x01,
     kActiveHidden          = 0x02,
     kActiveVisibleNotFocus = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnknownEnumValue      = 4,
 };
 } // namespace ApplicationBasic
 
@@ -2221,11 +2221,11 @@ namespace TestCluster {
 // Enum for SimpleEnum
 enum class SimpleEnum : uint8_t
 {
-    kUnspecified = 0x00,
-    kValueA      = 0x01,
-    kValueB      = 0x02,
-    kValueC      = 0x03,
-    // kUnknownEnumValue = 4,
+    kUnspecified      = 0x00,
+    kValueA           = 0x01,
+    kValueB           = 0x02,
+    kValueC           = 0x03,
+    kUnknownEnumValue = 4,
 };
 
 // Bitmap for Bitmap16MaskMap


### PR DESCRIPTION
And fix various bits of code that did not handle unexpected enum
values.

#### Problem
We don't have a good way, for enum class enums, to test for the "not a known value" case.

#### Change overview
Add a way.

#### Testing
No behavior changes except some error handling bits.

@Morozov-5F Could you please review the door lock changes?

@tlykkeberg-grundfos @ReneJosefsen Could you please review the pump changes?

@tcarmelveilleux Could you please review the OTA and diagnostic logs changes?