### PR TITLE
[size-opt] Optimize DefaultStorageKeyAllocator code size

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorStorage.cpp
@@ -40,6 +40,7 @@ constexpr size_t kProviderListMaxSerializedSize = kProviderMaxSerializedSize * C
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreDefaultProviders(const ProviderLocationList & providers)
 {
+    DefaultStorageKeyAllocator key;
     uint8_t buffer[kProviderListMaxSerializedSize];
     TLV::TLVWriter writer;
     TLV::TLVType outerType;
@@ -55,16 +56,16 @@ CHIP_ERROR DefaultOTARequestorStorage::StoreDefaultProviders(const ProviderLocat
 
     ReturnErrorOnFailure(writer.EndContainer(outerType));
 
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTADefaultProviders(), buffer,
-                                               static_cast<uint16_t>(writer.GetLengthWritten()));
+    return mPersistentStorage->SyncSetKeyValue(key.OTADefaultProviders(), buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadDefaultProviders(ProviderLocationList & providers)
 {
+    DefaultStorageKeyAllocator key;
     uint8_t buffer[kProviderListMaxSerializedSize];
     MutableByteSpan bufferSpan(buffer);
 
-    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator::OTADefaultProviders(), bufferSpan));
+    ReturnErrorOnFailure(Load(key.OTADefaultProviders(), bufferSpan));
 
     TLV::TLVReader reader;
     TLV::TLVType outerType;
@@ -87,27 +88,30 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadDefaultProviders(ProviderLocationList
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreCurrentProviderLocation(const ProviderLocationType & provider)
 {
+    DefaultStorageKeyAllocator key;
     uint8_t buffer[kProviderMaxSerializedSize];
     TLV::TLVWriter writer;
 
     writer.Init(buffer);
     ReturnErrorOnFailure(provider.EncodeForRead(writer, TLV::AnonymousTag(), provider.fabricIndex));
 
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTACurrentProvider(), buffer,
-                                               static_cast<uint16_t>(writer.GetLengthWritten()));
+    return mPersistentStorage->SyncSetKeyValue(key.OTACurrentProvider(), buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearCurrentProviderLocation()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTACurrentProvider());
+    DefaultStorageKeyAllocator key;
+
+    return mPersistentStorage->SyncDeleteKeyValue(key.OTACurrentProvider());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocationType & provider)
 {
+    DefaultStorageKeyAllocator key;
     uint8_t buffer[kProviderMaxSerializedSize];
     MutableByteSpan bufferSpan(buffer);
 
-    ReturnErrorOnFailure(Load(DefaultStorageKeyAllocator::OTACurrentProvider(), bufferSpan));
+    ReturnErrorOnFailure(Load(key.OTACurrentProvider(), bufferSpan));
 
     TLV::TLVReader reader;
 
@@ -120,52 +124,67 @@ CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentProviderLocation(ProviderLocat
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreUpdateToken(ByteSpan updateToken)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTAUpdateToken(), updateToken.data(),
-                                               static_cast<uint16_t>(updateToken.size()));
+    DefaultStorageKeyAllocator key;
+
+    return mPersistentStorage->SyncSetKeyValue(key.OTAUpdateToken(), updateToken.data(), static_cast<uint16_t>(updateToken.size()));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearUpdateToken()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTAUpdateToken());
+    DefaultStorageKeyAllocator key;
+
+    return mPersistentStorage->SyncDeleteKeyValue(key.OTAUpdateToken());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadUpdateToken(MutableByteSpan & updateToken)
 {
-    return Load(DefaultStorageKeyAllocator::OTAUpdateToken(), updateToken);
+    DefaultStorageKeyAllocator key;
+
+    return Load(key.OTAUpdateToken(), updateToken);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreCurrentUpdateState(OTAUpdateStateEnum currentUpdateState)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState(), &currentUpdateState,
-                                               sizeof(currentUpdateState));
+    DefaultStorageKeyAllocator key;
+
+    return mPersistentStorage->SyncSetKeyValue(key.OTACurrentUpdateState(), &currentUpdateState, sizeof(currentUpdateState));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadCurrentUpdateState(OTAUpdateStateEnum & currentUpdateState)
 {
+    DefaultStorageKeyAllocator key;
     uint16_t size = static_cast<uint16_t>(sizeof(currentUpdateState));
-    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState(), &currentUpdateState, size);
+
+    return mPersistentStorage->SyncGetKeyValue(key.OTACurrentUpdateState(), &currentUpdateState, size);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearCurrentUpdateState()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTACurrentUpdateState());
+    DefaultStorageKeyAllocator key;
+
+    return mPersistentStorage->SyncDeleteKeyValue(key.OTACurrentUpdateState());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::StoreTargetVersion(uint32_t targetVersion)
 {
-    return mPersistentStorage->SyncSetKeyValue(DefaultStorageKeyAllocator::OTATargetVersion(), &targetVersion,
-                                               sizeof(targetVersion));
+    DefaultStorageKeyAllocator key;
+
+    return mPersistentStorage->SyncSetKeyValue(key.OTATargetVersion(), &targetVersion, sizeof(targetVersion));
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::LoadTargetVersion(uint32_t & targetVersion)
 {
+    DefaultStorageKeyAllocator key;
     uint16_t size = static_cast<uint16_t>(sizeof(targetVersion));
-    return mPersistentStorage->SyncGetKeyValue(DefaultStorageKeyAllocator::OTATargetVersion(), &targetVersion, size);
+
+    return mPersistentStorage->SyncGetKeyValue(key.OTATargetVersion(), &targetVersion, size);
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::ClearTargetVersion()
 {
-    return mPersistentStorage->SyncDeleteKeyValue(DefaultStorageKeyAllocator::OTATargetVersion());
+    DefaultStorageKeyAllocator key;
+
+    return mPersistentStorage->SyncDeleteKeyValue(key.OTATargetVersion());
 }
 
 CHIP_ERROR DefaultOTARequestorStorage::Load(const char * key, MutableByteSpan & buffer)

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -43,7 +43,7 @@ public:
     const char * KeyName() { return mKeyName; }
 
     // Fabric Table
-    const char * FabricIndexInfo() { return Format("g/fidx"); }
+    const char * FabricIndexInfo() { return SetConst("g/fidx"); }
     const char * FabricNOC(FabricIndex fabric) { return Format("f/%x/n", fabric); }
     const char * FabricICAC(FabricIndex fabric) { return Format("f/%x/i", fabric); }
     const char * FabricRCAC(FabricIndex fabric) { return Format("f/%x/r", fabric); }
@@ -51,18 +51,18 @@ public:
     const char * FabricOpKey(FabricIndex fabric) { return Format("f/%x/o", fabric); }
 
     // Fail-safe handling
-    const char * FailSafeCommitMarkerKey() { return Format("g/fs/c"); }
-    static const char * FailSafeNetworkConfig() { return "g/fs/n"; }
+    const char * FailSafeCommitMarkerKey() { return SetConst("g/fs/c"); }
+    const char * FailSafeNetworkConfig() { return SetConst("g/fs/n"); }
 
     // LastKnownGoodTime
-    const char * LastKnownGoodTimeKey() { return Format("g/lkgt"); }
+    const char * LastKnownGoodTimeKey() { return SetConst("g/lkgt"); }
 
     // Session resumption
     const char * FabricSession(FabricIndex fabric, NodeId nodeId)
     {
         return Format("f/%x/s/%08" PRIX32 "%08" PRIX32, fabric, static_cast<uint32_t>(nodeId >> 32), static_cast<uint32_t>(nodeId));
     }
-    const char * SessionResumptionIndex() { return Format("g/sri"); }
+    const char * SessionResumptionIndex() { return SetConst("g/sri"); }
     const char * SessionResumption(const char * resumptionIdBase64) { return Format("g/s/%s", resumptionIdBase64); }
 
     // Access Control
@@ -73,8 +73,8 @@ public:
     const char * AccessControlExtensionEntry(FabricIndex fabric) { return Format("f/%x/ac/1", fabric); }
 
     // Group Message Counters
-    const char * GroupDataCounter() { return Format("g/gdc"); }
-    const char * GroupControlCounter() { return Format("g/gcc"); }
+    const char * GroupDataCounter() { return SetConst("g/gdc"); }
+    const char * GroupControlCounter() { return SetConst("g/gcc"); }
 
     // Device Information Provider
     const char * UserLabelLengthKey(EndpointId endpoint) { return Format("g/userlbl/%x", endpoint); }
@@ -83,7 +83,7 @@ public:
     // Group Data Provider
 
     // List of fabric indices that have endpoint-to-group associations defined.
-    const char * GroupFabricList() { return Format("g/gfl"); }
+    const char * GroupFabricList() { return SetConst("g/gfl"); }
     const char * FabricGroups(chip::FabricIndex fabric) { return Format("f/%x/g", fabric); }
     const char * FabricGroup(chip::FabricIndex fabric, chip::GroupId group) { return Format("f/%x/g/%x", fabric, group); }
     const char * FabricGroupKey(chip::FabricIndex fabric, uint16_t index) { return Format("f/%x/gk/%x", fabric, index); }
@@ -102,17 +102,17 @@ public:
 
     // TODO: Should store fabric-specific parts of the binding list under keys
     // starting with "f/%x/".
-    const char * BindingTable() { return Format("g/bt"); }
+    const char * BindingTable() { return SetConst("g/bt"); }
     const char * BindingTableEntry(uint8_t index) { return Format("g/bt/%x", index); }
 
-    static const char * OTADefaultProviders() { return "g/o/dp"; }
-    static const char * OTACurrentProvider() { return "g/o/cp"; }
-    static const char * OTAUpdateToken() { return "g/o/ut"; }
-    static const char * OTACurrentUpdateState() { return "g/o/us"; }
-    static const char * OTATargetVersion() { return "g/o/tv"; }
+    const char * OTADefaultProviders() { return SetConst("g/o/dp"); }
+    const char * OTACurrentProvider() { return SetConst("g/o/cp"); }
+    const char * OTAUpdateToken() { return SetConst("g/o/ut"); }
+    const char * OTACurrentUpdateState() { return SetConst("g/o/us"); }
+    const char * OTATargetVersion() { return SetConst("g/o/tv"); }
 
     // Event number counter.
-    const char * IMEventNumber() { return Format("g/im/ec"); }
+    const char * IMEventNumber() { return SetConst("g/im/ec"); }
 
 protected:
     // The ENFORCE_FORMAT args are "off by one" because this is a class method,
@@ -121,13 +121,16 @@ protected:
     {
         va_list args;
         va_start(args, format);
-        vsnprintf(mKeyName, sizeof(mKeyName), format, args);
+        vsnprintf(mKeyNameBuffer, sizeof(mKeyNameBuffer), format, args);
         va_end(args);
-        return mKeyName;
+        return mKeyName = mKeyNameBuffer;
     }
 
+    const char * SetConst(const char * keyName) { return mKeyName = keyName; }
+
 private:
-    char mKeyName[PersistentStorageDelegate::kKeyLengthMax + 1] = { 0 };
+    const char * mKeyName                                             = nullptr;
+    char mKeyNameBuffer[PersistentStorageDelegate::kKeyLengthMax + 1] = { 0 };
 };
 
 } // namespace chip


### PR DESCRIPTION
#### Problem
It turns out that calling `DefaultStorageKeyAllocator::Format()` for each key costs non-negligible amount of flash while it's not really needed for constant keys.

#### Change overview
Change `DefaultStorageKeyAllocator` so that using constant keys can be easily optimized by compilers.
That small optimization saves almost 1kB of flash on some ARM examples.
Changed static methods of the class to non-static to unify the way the class is used.

#### Testing
Unit tests + tested commissioning and control after the device reboot.
