### PR TITLE
Fix the QR code link with the correct value in the documentation

### DIFF
--- a/docs/guides/mbedos_commissioning.md
+++ b/docs/guides/mbedos_commissioning.md
@@ -108,7 +108,7 @@ to the UART console.
 
         ```
         [INFO][CHIP]: [SVR]Copy/paste the below URL in a browser to see the QR Code:
-        [INFO][CHIP]: [SVR]https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AYNJV7VSC00CMVH7SR00
+        [INFO][CHIP]: [SVR]https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3AYNJV7VSC00CMVH7SR00
         ```
 
 -   Open URL from the console to display the QR in a web browser.

--- a/docs/guides/nrfconnect_android_commissioning.md
+++ b/docs/guides/nrfconnect_android_commissioning.md
@@ -151,7 +151,7 @@ To prepare the accessory device for commissioning, complete the following steps:
 3.  Find a message similar to the following one in the application logs:
 
         I: 615 [SVR]Copy/paste the below URL in a browser to see the QR Code:
-        I: 621 [SVR]https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AW0GU2OTB00KA0648G00
+        I: 621 [SVR]https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3AW0GU2OTB00KA0648G00
 
 4.  Open the URL in a web browser to have the commissioning QR code generated.
 5.  Press the appropriate button on the device to start the Bluetooth LE

--- a/docs/guides/nrfconnect_examples_cli.md
+++ b/docs/guides/nrfconnect_examples_cli.md
@@ -127,7 +127,7 @@ To print all the onboardingcodes:
 ```shell
 uart:~$ matter onboardingcodes none
 QRCode:             MT:W0GU2OTB00KA0648G00
-QRCodeUrl:          https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AW0GU2OTB00KA0648G00
+QRCodeUrl:          https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3AW0GU2OTB00KA0648G00
 ManualPairingCode:  34970112332
 ```
 
@@ -152,7 +152,7 @@ in a web browser. Takes no arguments.
 
 ```shell
 uart:~$ matter onboardingcodes none qrcodeurl
-https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3AW0GU2OTB00KA0648G00
+https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3AW0GU2OTB00KA0648G00
 ```
 
 #### manualpairingcode

--- a/docs/guides/nxp_k32w_android_commissioning.md
+++ b/docs/guides/nxp_k32w_android_commissioning.md
@@ -461,7 +461,7 @@ To prepare the accessory device for commissioning, complete the following steps:
 
         ```
         I: 666[SVR] Copy/paste the below URL in a browser to see the QR Code:
-                https://dhrishi.github.io/connectedhomeip/qrcode.html?data=CH%3AI34DV%2A-00%200C9SS0
+                https://project-chip.github.io/connectedhomeip/qrcode.html?data=CH%3AI34DV%2A-00%200C9SS0
         ```
 
 5.  Open the URL in a web browser to have the commissioning QR code generated.

--- a/src/app/tests/suites/certification/Test_TC_DD_1_8.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_1_8.yaml
@@ -41,12 +41,12 @@ tests:
           [1653306603.740798][13293:13293] CHIP:-: ==== Onboarding payload for Standard Commissioning Flow ====
           [1653306603.740846][13293:13293] CHIP:SVR: SetupQRCode: [MT:-24J042C00KA0648G00]
           [1653306603.740877][13293:13293] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1653306603.740898][13293:13293] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J042C00KA0648G00
+          [1653306603.740898][13293:13293] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J042C00KA0648G00
           [1653306603.740929][13293:13293] CHIP:SVR: Manual pairing code: [34970112332]
           [1653306603.740951][13293:13293] CHIP:-: ==== Onboarding payload for Custom Commissioning Flows ====
           [1653306603.741000][13293:13293] CHIP:SVR: SetupQRCode: [MT:-24J0YXE00KA0648G00]
           [1653306603.741028][13293:13293] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1653306603.741049][13293:13293] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0YXE00KA0648G00
+          [1653306603.741049][13293:13293] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0YXE00KA0648G00
           [1653306603.741081][13293:13293] CHIP:SVR: Manual pairing code: [749701123365521327694]
 
           CHIP:DL:   Setup Discriminator (0xFFFF for UNKNOWN/ERROR): 3841 (0xF01)
@@ -54,11 +54,11 @@ tests:
           CHIP:DL:   Device Type: 65535 (0xFFFF)
           CHIP:SVR: SetupQRCode: [MT:-24J0CEK01KA0648G00]
           CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0CEK01KA0648G00
+          CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0CEK01KA0648G00
           CHIP:SVR: Manual pairing code: [34970112332]
           CHIP:SVR: SetupQRCode: [MT:-24J048N01KA0648G00]
            CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-           CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J048N01KA0648G00
+           CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J048N01KA0648G00
 
 
 

--- a/src/app/tests/suites/certification/Test_TC_DD_3_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_11.yaml
@@ -44,7 +44,7 @@ tests:
           [1651101335.733693][22353:22353] CHIP:-: ==== Onboarding payload for Standard Commissioning Flow ====
           [1651101335.734598][22353:22353] CHIP:SVR: SetupQRCode: [MT:-24J042C00KA0648G00]
           [1651101335.735182][22353:22353] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1651101335.735618][22353:22353] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J042C00KA0648G00
+          [1651101335.735618][22353:22353] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J042C00KA0648G00
 
 
           ubuntu@ubuntu:~/apps$ ./chip-tool payload parse-setup-payload MT:-24J0YXE00KA0648G00

--- a/src/app/tests/suites/certification/Test_TC_DD_3_15.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_15.yaml
@@ -42,7 +42,7 @@ tests:
           [1651108891.390744][30833:30833] CHIP:-: ==== Onboarding payload for Standard Commissioning Flow ====
           [1651108891.390809][30833:30833] CHIP:SVR: SetupQRCode: [MT:-24J0AFN00KA0648G00]
           [1651108891.390848][30833:30833] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1651108891.390876][30833:30833] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0AFN00KA0648G00
+          [1651108891.390876][30833:30833] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0AFN00KA0648G00
           [1651108891.390917][30833:30833] CHIP:SVR: Manual pairing code: [34970112332]
       disabled: true
 
@@ -91,12 +91,12 @@ tests:
           [1651109167.022753][30980:30980] CHIP:-: ==== Onboarding payload for Standard Commissioning Flow ====
           [1651109167.022825][30980:30980] CHIP:SVR: SetupQRCode: [MT:-24J0AFN00KA0648G00]
           [1651109167.022868][30980:30980] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1651109167.022898][30980:30980] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0AFN00KA0648G00
+          [1651109167.022898][30980:30980] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0AFN00KA0648G00
           [1651109167.022942][30980:30980] CHIP:SVR: Manual pairing code: [34970112332]
           [1651109167.022974][30980:30980] CHIP:-: ==== Onboarding payload for Custom Commissioning Flows ====
           [1651109167.023050][30980:30980] CHIP:SVR: SetupQRCode: [MT:-24J029Q00KA0648G00]
           [1651109167.023090][30980:30980] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1651109167.023120][30980:30980] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J029Q00KA0648G00
+          [1651109167.023120][30980:30980] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J029Q00KA0648G00
           [1651109167.023167][30980:30980] CHIP:SVR: Manual pairing code: [749701123365521327694]
       disabled: true
 

--- a/src/app/tests/suites/certification/Test_TC_DD_3_16.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_16.yaml
@@ -42,7 +42,7 @@ tests:
           [1651180718.960671][13218:13218] CHIP:-: ==== Onboarding payload for Standard Commissioning Flow ====
           [1651180718.960729][13218:13218] CHIP:SVR: SetupQRCode: [MT:-24J0AFN00KA0648G00]
           [1651180718.960760][13218:13218] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1651180718.960781][13218:13218] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0AFN00KA0648G00
+          [1651180718.960781][13218:13218] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0AFN00KA0648G00
           [1651180718.960814][13218:13218] CHIP:SVR: Manual pairing code: [34970112332]
       disabled: true
 

--- a/src/app/tests/suites/certification/Test_TC_DD_3_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DD_3_5.yaml
@@ -41,12 +41,12 @@ tests:
           [1653471956.972509][10713:10713] CHIP:-: ==== Onboarding payload for Standard Commissioning Flow ====
           [1653471956.972546][10713:10713] CHIP:SVR: SetupQRCode: [MT:-24J0CEK01KA0648G00]
           [1653471956.972579][10713:10713] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1653471956.972600][10713:10713] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0CEK01KA0648G00
+          [1653471956.972600][10713:10713] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J0CEK01KA0648G00
           [1653471956.972632][10713:10713] CHIP:SVR: Manual pairing code: [34970112332]
           [1653471956.972654][10713:10713] CHIP:-: ==== Onboarding payload for Custom Commissioning Flows ====
           [1653471956.972715][10713:10713] CHIP:SVR: SetupQRCode: [MT:-24J048N01KA0648G00]
           [1653471956.972748][10713:10713] CHIP:SVR: Copy/paste the below URL in a browser to see the QR Code:
-          [1653471956.972769][10713:10713] CHIP:SVR: https://dhrishi.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J048N01KA0648G00
+          [1653471956.972769][10713:10713] CHIP:SVR: https://project-chip.github.io/connectedhomeip/qrcode.html?data=MT%3A-24J048N01KA0648G00
           [1653471956.972803][10713:10713] CHIP:SVR: Manual pairing code: [749701123365521327694]
 
 


### PR DESCRIPTION
#### Problem
The docs are still not pointing to `project-chip` gh-pages branch

#### Change overview
Update the QR code link in the documents

#### Testing
NA