### PR TITLE
Descope less relevant unit tests from unified build variants

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -391,7 +391,7 @@ jobs:
                           #   use that on Darwin.
                           # * the "host clang" build, which uses the pigweed
                           #   clang.
-                          "default") GN_ARGS='target_os="all" is_asan=true enable_host_clang_build=false enable_host_gcc_mbedtls_build=false';;
+                          "default") GN_ARGS='target_os="all" is_asan=true enable_host_clang_build=false';;
                           "python_lib") GN_ARGS='enable_rtti=true enable_pylib=true';;
                       esac
                       BUILD_TYPE=$BUILD_TYPE scripts/build/gn_gen.sh --args="$GN_ARGS" --export-compile-commands

--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -110,10 +110,11 @@ jobs:
                     chip_build_tests=false \
                     chip_enable_wifi=false \
                     chip_im_force_fabric_quota_check=true \
+                    enable_default_builds=false \
                     enable_host_gcc_build=true \
-                    enable_host_gcc_mbedtls_build=false \
-                    enable_host_clang_build=false \
-                    enable_fake_tests=false
+                    enable_standalone_chip_tool_build=true \
+                    enable_linux_all_clusters_app_build=true \
+                    enable_linux_lighting_app_build=true
             - name: Run Tests
               timeout-minutes: 25
               run: |

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -235,7 +235,11 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     enable_host_gcc_build = enable_default_builds && host_os != "win"
 
     # Enable building chip with gcc & mbedtls.
-    enable_host_gcc_mbedtls_build = enable_default_builds && host_os != "win"
+    enable_host_gcc_mbedtls_build = false
+
+    # Enable limited testing with gcc & mbedtls.
+    enable_host_gcc_mbedtls_crypto_tests =
+        enable_default_builds && host_os != "win"
 
     # Build the chip-cert tool.
     enable_standalone_chip_cert_build =
@@ -349,6 +353,15 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     builds += [ ":host_gcc_mbedtls" ]
   }
 
+  if (enable_host_gcc_mbedtls_crypto_tests) {
+    chip_build("host_gcc_mbedtls_crypto_tests") {
+      test_group = "//src:crypto_tests"
+      toolchain = "${chip_root}/config/mbedtls/toolchain:${host_os}_${host_cpu}_gcc_mbedtls"
+    }
+
+    builds += [ ":host_gcc_mbedtls_crypto_tests" ]
+  }
+
   if (enable_android_builds) {
     chip_build("android_arm") {
       toolchain = "${build_root}/toolchain/android:android_arm"
@@ -376,6 +389,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
   if (enable_fake_tests) {
     chip_build("fake_platform") {
+      test_group = "//src:fake_platform_tests"
       toolchain = "${build_root}/toolchain/fake:fake_${host_cpu}_gcc"
     }
 

--- a/build/chip/chip_build.gni
+++ b/build/chip/chip_build.gni
@@ -20,11 +20,21 @@ template("chip_build") {
   _build_name = target_name
   _toolchain = invoker.toolchain
 
+  if (defined(invoker.test_group) && chip_build_tests) {
+    _build_target = invoker.test_group
+    _check_target = get_label_info(invoker.test_group, "dir") + ":" +
+                    get_label_info(invoker.test_group, "name") + "_run"
+  } else {
+    _build_target = ":default"
+    _check_target = ":check"
+    not_needed(invoker, [ "test_group" ])
+  }
+
   group("${_build_name}") {
-    deps = [ ":default(${_toolchain})" ]
+    deps = [ "${_build_target}(${_toolchain})" ]
   }
 
   group("check_${_build_name}") {
-    deps = [ ":check(${_toolchain})" ]
+    deps = [ "${_check_target}(${_toolchain})" ]
   }
 }

--- a/build/chip/chip_test_group.gni
+++ b/build/chip/chip_test_group.gni
@@ -60,8 +60,8 @@ template("chip_test_group") {
     }
   }
 
-  if (chip_link_tests) {
-    group("${_test_group_name}_run") {
+  group("${_test_group_name}_run") {
+    if (chip_link_tests) {
       deps = []
       foreach(_test, invoker.deps) {
         deps += [ get_label_info(_test, "label_no_toolchain") + "_run" ]

--- a/src/BUILD.gn
+++ b/src/BUILD.gn
@@ -128,4 +128,12 @@ if (chip_build_tests) {
   chip_test_group("fake_platform_tests") {
     deps = [ "${chip_root}/src/lib/dnssd/platform/tests" ]
   }
+
+  # Tests to run with each Crypto PAL
+  chip_test_group("crypto_tests") {
+    deps = [
+      "${chip_root}/src/credentials/tests",
+      "${chip_root}/src/crypto/tests",
+    ]
+  }
 }

--- a/src/crypto/CHIPCryptoPALmbedTLS.cpp
+++ b/src/crypto/CHIPCryptoPALmbedTLS.cpp
@@ -1634,7 +1634,7 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
     VerifyOrExit(mbedResult == 0, (result = CertificateChainValidationResult::kRootFormatInvalid, error = CHIP_ERROR_INTERNAL));
 
     /* Verify the chain against the root */
-    mbedResult = mbedtls_x509_crt_verify(&certChain, &rootCert, NULL, NULL, &flags, NULL, NULL);
+    mbedResult = mbedtls_x509_crt_verify(&certChain, &rootCert, nullptr, nullptr, &flags, nullptr, nullptr);
 
     switch (mbedResult)
     {


### PR DESCRIPTION
#### Problem

`gn_build.sh` runs all tests with MbedTLS + OpenSSL. We've recently added
BoringSSL and doing a full test run across all crypto backends will be costlier
than justified by the coverage increase.

The ultimate goal is to run the CryptoPAL test with BoringSSL from
`gn_build.sh`.

#### Change overview

Switch to more targeted testing of just crypto oriented tests for the
MbedTLS build and just tests that need the fake platform for the fake
platform build.

This reduces the blowup in execution time from running the cartesian
product of configs x tests and saves about 30% of default work done by
gn_build.sh.

#### Testing

`gn_build.sh`