### PR TITLE
We should not call SetDiagnosticDataProvider within PaltformMgr on ea…

### DIFF
--- a/src/include/platform/DiagnosticDataProvider.h
+++ b/src/include/platform/DiagnosticDataProvider.h
@@ -62,6 +62,8 @@ struct NetworkInterface : public app::Clusters::GeneralDiagnostics::Structs::Net
     NetworkInterface * Next; /* Pointer to the next structure.  */
 };
 
+class DiagnosticDataProviderImpl;
+
 /**
  * Defines the WiFi Diagnostics Delegate class to notify WiFi network events.
  */
@@ -184,11 +186,20 @@ private:
 };
 
 /**
- * Returns a reference to a DiagnosticDataProvider object.
+ * Returns a reference to the public interface of the DiagnosticDataProvider singleton object.
  *
- * Applications should use this to access the features of the DiagnosticDataProvider.
+ * Applications should use this to access features of the DiagnosticDataProvider object
+ * that are common to all platforms.
  */
 DiagnosticDataProvider & GetDiagnosticDataProvider();
+
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+extern DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
 
 /**
  * Sets a reference to a DiagnosticDataProvider object.

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.cpp
@@ -423,5 +423,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Ameba/DiagnosticDataProviderImpl.h
+++ b/src/platform/Ameba/DiagnosticDataProviderImpl.h
@@ -70,5 +70,13 @@ public:
 #endif
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Ameba/PlatformManagerImpl.cpp
+++ b/src/platform/Ameba/PlatformManagerImpl.cpp
@@ -60,7 +60,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     CHIP_ERROR err;
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     // Make sure the LwIP core lock has been initialized
     err = Internal::InitLwIPCoreLock();

--- a/src/platform/CYW30739/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/CYW30739/DiagnosticDataProviderImpl.cpp
@@ -141,5 +141,10 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
 }
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_THREAD */
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/CYW30739/DiagnosticDataProviderImpl.h
+++ b/src/platform/CYW30739/DiagnosticDataProviderImpl.h
@@ -50,5 +50,13 @@ public:
 #endif /* CHIP_DEVICE_CONFIG_ENABLE_THREAD */
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/CYW30739/PlatformManagerImpl.cpp
+++ b/src/platform/CYW30739/PlatformManagerImpl.cpp
@@ -46,7 +46,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SuccessOrExit(err);
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     /* Create the thread object. */
     mThread = wiced_rtos_create_thread();

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
@@ -77,5 +77,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()
     return CHIP_NO_ERROR;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.h
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.h
@@ -44,5 +44,13 @@ public:
     CHIP_ERROR ResetWatermarks() override;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -53,7 +53,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 #endif // CHIP_DISABLE_PLATFORM_KVS
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     mRunLoopSem = dispatch_semaphore_create(0);
 

--- a/src/platform/DiagnosticDataProvider.cpp
+++ b/src/platform/DiagnosticDataProvider.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <lib/support/CodeUtils.h>
+#include <platform/DiagnosticDataProvider.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -37,8 +38,12 @@ DiagnosticDataProvider * gInstance = nullptr;
 
 DiagnosticDataProvider & GetDiagnosticDataProvider()
 {
-    VerifyOrDie(gInstance != nullptr);
-    return *gInstance;
+    if (gInstance != nullptr)
+    {
+        return *gInstance;
+    }
+
+    return GetDiagnosticDataProviderImpl();
 }
 
 void SetDiagnosticDataProvider(DiagnosticDataProvider * diagnosticDataProvider)

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -481,5 +481,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
 }
 #endif // SL_WIFI
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.h
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.h
@@ -73,5 +73,13 @@ public:
 #endif // SL_WIFI
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/EFR32/PlatformManagerImpl.cpp
+++ b/src/platform/EFR32/PlatformManagerImpl.cpp
@@ -51,7 +51,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SuccessOrExit(err);
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     // Initialize LwIP.

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.cpp
@@ -353,5 +353,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/DiagnosticDataProviderImpl.h
+++ b/src/platform/ESP32/DiagnosticDataProviderImpl.h
@@ -68,5 +68,13 @@ public:
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WIFI
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -61,7 +61,6 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
     SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());
 
     esp_err_t err;

--- a/src/platform/Linux/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.cpp
@@ -826,5 +826,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiSecurityType(uint8_t & securityTyp
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/DiagnosticDataProviderImpl.h
+++ b/src/platform/Linux/DiagnosticDataProviderImpl.h
@@ -105,5 +105,13 @@ private:
 #endif
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -176,7 +176,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     // Initialize the configuration system.
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     // Call _InitChipStack() on the generic implementation base class

--- a/src/platform/P6/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/P6/DiagnosticDataProviderImpl.cpp
@@ -543,5 +543,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::WiFiCounters(WiFiStatsCountType type, uin
     return err;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/P6/DiagnosticDataProviderImpl.h
+++ b/src/platform/P6/DiagnosticDataProviderImpl.h
@@ -113,5 +113,13 @@ public:
     app::DataModel::Nullable<bool> mipv6_offpremise;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/P6/PlatformManagerImpl.cpp
+++ b/src/platform/P6/PlatformManagerImpl.cpp
@@ -44,7 +44,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     CHIP_ERROR err;
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     // Make sure the LwIP core lock has been initialized
     err = Internal::InitLwIPCoreLock();

--- a/src/platform/Tizen/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Tizen/DiagnosticDataProviderImpl.cpp
@@ -36,5 +36,10 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
     return sInstance;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Tizen/DiagnosticDataProviderImpl.h
+++ b/src/platform/Tizen/DiagnosticDataProviderImpl.h
@@ -36,5 +36,13 @@ public:
     static DiagnosticDataProviderImpl & GetDefaultInstance();
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Tizen/PlatformManagerImpl.cpp
+++ b/src/platform/Tizen/PlatformManagerImpl.cpp
@@ -40,7 +40,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     return Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_InitChipStack();

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -321,5 +321,10 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
     }
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.h
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.h
@@ -58,5 +58,13 @@ private:
     const BootReasonType mBootReason;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -107,7 +107,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = Internal::ZephyrConfig::Init();
     SuccessOrExit(err);
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
 #if !CONFIG_NORDIC_SECURITY_BACKEND
     // Add entropy source based on Zephyr entropy driver

--- a/src/platform/android/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/android/DiagnosticDataProviderImpl.cpp
@@ -230,5 +230,10 @@ void DiagnosticDataProviderImpl::ReleaseNetworkInterfaces(NetworkInterface * net
     }
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/android/DiagnosticDataProviderImpl.h
+++ b/src/platform/android/DiagnosticDataProviderImpl.h
@@ -53,5 +53,13 @@ public:
     jmethodID mGetNifMethod                      = nullptr;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/android/PlatformManagerImpl.cpp
+++ b/src/platform/android/PlatformManagerImpl.cpp
@@ -47,7 +47,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     err = Internal::AndroidConfig::Init();
     SuccessOrExit(err);
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     // Call _InitChipStack() on the generic implementation base class

--- a/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.cpp
@@ -133,5 +133,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason
     return err;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.h
+++ b/src/platform/bouffalolab/BL602/DiagnosticDataProviderImpl.h
@@ -49,5 +49,13 @@ public:
     CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/bouffalolab/BL602/PlatformManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL602/PlatformManagerImpl.cpp
@@ -189,7 +189,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     CHIP_ERROR err;
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     // Initialize the configuration system.
     err = Internal::BL602Config::Init();

--- a/src/platform/cc13x2_26x2/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc13x2_26x2/DiagnosticDataProviderImpl.cpp
@@ -117,5 +117,10 @@ void DiagnosticDataProviderImpl::ReleaseThreadMetrics(ThreadMetrics * threadMetr
     }
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc13x2_26x2/DiagnosticDataProviderImpl.h
+++ b/src/platform/cc13x2_26x2/DiagnosticDataProviderImpl.h
@@ -42,5 +42,13 @@ public:
     void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc13x2_26x2/PlatformManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/PlatformManagerImpl.cpp
@@ -108,7 +108,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = Internal::CC13X2_26X2Config::Init();
     SuccessOrExit(err);
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     // DMM Addition
     DMMPolicy_Params dmmPolicyParams;

--- a/src/platform/cc32xx/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/cc32xx/DiagnosticDataProviderImpl.cpp
@@ -56,5 +56,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetThreadMetrics(ThreadMetrics ** threadM
 
 void DiagnosticDataProviderImpl::ReleaseThreadMetrics(ThreadMetrics * threadMetrics) {}
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc32xx/DiagnosticDataProviderImpl.h
+++ b/src/platform/cc32xx/DiagnosticDataProviderImpl.h
@@ -42,5 +42,13 @@ public:
     void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc32xx/PlatformManagerImpl.cpp
+++ b/src/platform/cc32xx/PlatformManagerImpl.cpp
@@ -70,7 +70,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = Internal::CC32XXConfig::Init();
     SuccessOrExit(err);
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     // Initialize LwIP.
     tcpip_init(NULL, NULL);

--- a/src/platform/fake/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/fake/DiagnosticDataProviderImpl.cpp
@@ -36,5 +36,10 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
     return sInstance;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/fake/DiagnosticDataProviderImpl.h
+++ b/src/platform/fake/DiagnosticDataProviderImpl.h
@@ -55,5 +55,13 @@ public:
     CHIP_ERROR GetActiveNetworkFaults(GeneralFaults<kMaxNetworkFaults> & networkFaults) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/mbed/DiagnosticDataProviderImpl.cpp
@@ -36,5 +36,10 @@ DiagnosticDataProviderImpl & DiagnosticDataProviderImpl::GetDefaultInstance()
     return sInstance;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/DiagnosticDataProviderImpl.h
+++ b/src/platform/mbed/DiagnosticDataProviderImpl.h
@@ -36,5 +36,13 @@ public:
     static DiagnosticDataProviderImpl & GetDefaultInstance();
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -93,7 +93,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 #endif
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     auto err = System::Clock::InitClock_RealTime();
     SuccessOrExit(err);

--- a/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.cpp
@@ -134,5 +134,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason
     return err;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.h
+++ b/src/platform/nxp/k32w/k32w0/DiagnosticDataProviderImpl.h
@@ -49,5 +49,13 @@ public:
     CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
@@ -112,7 +112,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     }
 
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     mStartTime = System::SystemClock().GetMonotonicTimestamp();
 

--- a/src/platform/nxp/mw320/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/nxp/mw320/DiagnosticDataProviderImpl.cpp
@@ -79,5 +79,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     return CHIP_NO_ERROR;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/mw320/DiagnosticDataProviderImpl.h
+++ b/src/platform/nxp/mw320/DiagnosticDataProviderImpl.h
@@ -44,5 +44,13 @@ public:
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/mw320/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/mw320/PlatformManagerImpl.cpp
@@ -62,7 +62,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     SuccessOrExit(err);
 
     // SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
     // Initialize LwIP.
     // tcpip_init(NULL, NULL);

--- a/src/platform/qpg/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.cpp
@@ -69,5 +69,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetCurrentHeapHighWatermark(uint64_t & cu
     return CHIP_NO_ERROR;
 }
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/qpg/DiagnosticDataProviderImpl.h
+++ b/src/platform/qpg/DiagnosticDataProviderImpl.h
@@ -44,5 +44,13 @@ public:
     CHIP_ERROR GetCurrentHeapHighWatermark(uint64_t & currentHeapHighWatermark) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/qpg/PlatformManagerImpl.cpp
+++ b/src/platform/qpg/PlatformManagerImpl.cpp
@@ -45,7 +45,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = Internal::QPGConfig::Init();
     SuccessOrExit(err);
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     // Initialize LwIP.

--- a/src/platform/webos/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/webos/DiagnosticDataProviderImpl.cpp
@@ -796,5 +796,10 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiSecurityType(uint8_t & securityTyp
 }
 #endif // CHIP_DEVICE_CONFIG_ENABLE_WPA
 
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl()
+{
+    return DiagnosticDataProviderImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/webos/DiagnosticDataProviderImpl.h
+++ b/src/platform/webos/DiagnosticDataProviderImpl.h
@@ -103,5 +103,13 @@ private:
 #endif
 };
 
+/**
+ * Returns the platform-specific implementation of the DiagnosticDataProvider singleton object.
+ *
+ * Applications can use this to gain access to features of the DiagnosticDataProvider
+ * that are specific to the selected platform.
+ */
+DiagnosticDataProvider & GetDiagnosticDataProviderImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/webos/PlatformManagerImpl.cpp
+++ b/src/platform/webos/PlatformManagerImpl.cpp
@@ -166,7 +166,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     // Initialize the configuration system.
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
     SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-    SetDiagnosticDataProvider(&DiagnosticDataProviderImpl::GetDefaultInstance());
     SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 


### PR DESCRIPTION
…ch platform

#### Problem
What is being fixed?  Examples:
* Currently, we call SetDiagnosticDataProvider within PaltformMgr separately on each platform. And this will cause call DiagnosticDataProvider get set up on both client and server side. Actually, this is not needed on the client side.

* Fixes #17400

#### Change overview
Don't call SetDiagnosticDataProvider within PaltformMgr on each platform.

#### Testing
How was this tested? (at least one bullet point required)
* Confirm we can still read information from DiagnosticDataProvider with this change
```
yufengw@yufengw-SEi:~/connectedhomeip/out/debug/standalone$ ./chip-tool wifinetworkdiagnostics read packet-unicast-rx-count 12344321 0 
......
[1657893281.911596][100198:100203] CHIP:EM: Received message of type 0x5 with protocolId (0, 1) and MessageCounter:129609377 on exchange 23658i
[1657893281.911604][100198:100203] CHIP:EM: Found matching exchange: 23658i, Delegate: 0x7f1210009910
[1657893281.911614][100198:100203] CHIP:EM: Rxd Ack; Removing MessageCounter:116147936 from Retrans Table on exchange 23658i
[1657893281.911620][100198:100203] CHIP:EM: Removed CHIP MessageCounter:116147936 from RetransTable on exchange 23658i
[1657893281.911639][100198:100203] CHIP:DMG: ReportDataMessage =
[1657893281.911645][100198:100203] CHIP:DMG: {
[1657893281.911649][100198:100203] CHIP:DMG: 	AttributeReportIBs =
[1657893281.911657][100198:100203] CHIP:DMG: 	[
[1657893281.911662][100198:100203] CHIP:DMG: 		AttributeReportIB =
[1657893281.911674][100198:100203] CHIP:DMG: 		{
[1657893281.911679][100198:100203] CHIP:DMG: 			AttributeDataIB =
[1657893281.911687][100198:100203] CHIP:DMG: 			{
[1657893281.911694][100198:100203] CHIP:DMG: 				DataVersion = 0x79c6ed07,
[1657893281.911698][100198:100203] CHIP:DMG: 				AttributePathIB =
[1657893281.911703][100198:100203] CHIP:DMG: 				{
[1657893281.911708][100198:100203] CHIP:DMG: 					Endpoint = 0x0,
[1657893281.911713][100198:100203] CHIP:DMG: 					Cluster = 0x36,
[1657893281.911719][100198:100203] CHIP:DMG: 					Attribute = 0x0000_0009,
[1657893281.911725][100198:100203] CHIP:DMG: 				}
[1657893281.911733][100198:100203] CHIP:DMG: 					
[1657893281.911741][100198:100203] CHIP:DMG: 				Data = 61, 
[1657893281.911746][100198:100203] CHIP:DMG: 			},
[1657893281.911753][100198:100203] CHIP:DMG: 			
[1657893281.911757][100198:100203] CHIP:DMG: 		},
[1657893281.911763][100198:100203] CHIP:DMG: 		
[1657893281.911767][100198:100203] CHIP:DMG: 	],
[1657893281.911775][100198:100203] CHIP:DMG: 	
[1657893281.911779][100198:100203] CHIP:DMG: 	SuppressResponse = true, 
[1657893281.911784][100198:100203] CHIP:DMG: 	InteractionModelRevision = 1
[1657893281.911788][100198:100203] CHIP:DMG: }
[1657893281.911831][100198:100203] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0036 Attribute 0x0000_0009 DataVersion: 2043079943
[1657893281.911845][100198:100203] CHIP:TOO:   PacketUnicastRxCount: 61
```

