### PR TITLE
[Darwin] Fix memory leak of OTA Provider delegate bridge in MTRDeviceController

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -156,6 +156,11 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         _operationalCredentialsDelegate = nullptr;
     }
 
+    if (_otaProviderDelegateBridge) {
+        delete _otaProviderDelegateBridge;
+        _otaProviderDelegateBridge = nullptr;
+    }
+
     if (_pairingDelegateBridge) {
         delete _pairingDelegateBridge;
         _pairingDelegateBridge = nullptr;


### PR DESCRIPTION
#### Problem
There is a memory leak in `MTRDeviceController`

#### Change overview
Fix it

#### Testing
Tree compiles
