### PR TITLE
Fix HeapObjectPool node leaks.

### DIFF
--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -118,7 +118,6 @@ Loop HeapObjectList::ForEachNode(void * context, Lambda lambda)
 {
     ++mIterationDepth;
     Loop result            = Loop::Finish;
-    bool anyReleased       = false;
     HeapObjectListNode * p = mNext;
     while (p != this)
     {
@@ -130,14 +129,10 @@ Loop HeapObjectList::ForEachNode(void * context, Lambda lambda)
                 break;
             }
         }
-        if (p->mObject == nullptr)
-        {
-            anyReleased = true;
-        }
         p = p->mNext;
     }
     --mIterationDepth;
-    if (mIterationDepth == 0 && anyReleased)
+    if (mIterationDepth == 0 && mHaveDeferredNodeRemovals)
     {
         // Remove nodes for released objects.
         p = mNext;
@@ -151,6 +146,8 @@ Loop HeapObjectList::ForEachNode(void * context, Lambda lambda)
             }
             p = next;
         }
+
+        mHaveDeferredNodeRemovals = false;
     }
     return result;
 }

--- a/src/lib/support/Pool.h
+++ b/src/lib/support/Pool.h
@@ -151,7 +151,7 @@ struct HeapObjectListNode
 
 struct HeapObjectList : HeapObjectListNode
 {
-    HeapObjectList() : mIterationDepth(0) { mNext = mPrev = this; }
+    HeapObjectList() { mNext = mPrev = this; }
 
     void Append(HeapObjectListNode * node)
     {
@@ -170,7 +170,8 @@ struct HeapObjectList : HeapObjectListNode
         return const_cast<HeapObjectList *>(this)->ForEachNode(context, reinterpret_cast<Lambda>(lambda));
     }
 
-    size_t mIterationDepth;
+    size_t mIterationDepth         = 0;
+    bool mHaveDeferredNodeRemovals = false;
 };
 
 #endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
@@ -364,6 +365,10 @@ public:
                 {
                     node->Remove();
                     Platform::Delete(node);
+                }
+                else
+                {
+                    mObjects.mHaveDeferredNodeRemovals = true;
                 }
 
                 DecreaseUsage();


### PR DESCRIPTION
Leaking scenario 1 (which was discovered in practice): An iteration on a pool
that removes the element it's iterating and then does a Loop::Break.  In that
case we would break out of the loop in ForEachNode before setting anyReleased to
true, which would cause the cleanup code to not run when the iteration depth
went to 0 and the node to leak.  This might have been fixed by reordering the
setting of anyReleased and the break from the loop, except:

Leaking scenario 2: Outer iteration iterates over the whole pool.  When
iterating the last element of the pool, it starts an inner iteration, which
releases all but that last element.  Then the two iterations complete.  In this
situation, the inner iteration would have anyReleased true, but not do any
cleanup because it's a nested iteration, while the outer iteration would have
anyReleased false (because the releases all happened behind its cursor, so it
did not see any of them) and hence would not do any cleanup either.

The fix is to just keep track of the "we need to do post-iteration cleanup"
state in a member.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran with LSan and did not see the leaks I was seeing before.  Apart from that, will be tested by CI.