### PR TITLE
Update darwin-framework-tool to build Matter.framework on changes.

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -27,7 +27,10 @@ assert(chip_build_tools)
 action("build-darwin-framework") {
   script = "${chip_root}/scripts/build/build_darwin_framework.py"
 
-  inputs = [ "${chip_root}/src/darwin/Framework/Matter.xcodeproj" ]
+  inputs = [
+    "${chip_root}/src/darwin/Framework/CHIP",
+    "${chip_root}/src/darwin/Framework/Matter.xcodeproj",
+  ]
 
   args = [
     "--project_path",
@@ -36,13 +39,20 @@ action("build-darwin-framework") {
     "--out_path",
     "macos_framework_output",
     "--target",
-    "Matter",
+    "Matter Framework",
     "--log_path",
     rebase_path("${root_build_dir}/darwin_framework_build.log", root_build_dir),
   ]
 
   output_name = "Matter.framework"
-  outputs = [ "${root_out_dir}/macos_framework_output/${output_name}" ]
+  outputs = [
+    "${root_out_dir}/macos_framework_output/Build/Products/Debug/${output_name}",
+    "${root_build_dir}/darwin_framework_build.log",
+    "${root_out_dir}/macos_framework_output/ModuleCache.noindex/",
+    "${root_out_dir}/macos_framework_output/Logs",
+    "${root_out_dir}/macos_framework_output/Index",
+    "${root_out_dir}/macos_framework_output/Build",
+  ]
 }
 
 config("config") {
@@ -53,10 +63,11 @@ config("config") {
     "${chip_root}/zzz_generated/controller-clusters",
     "${chip_root}/examples/chip-tool",
     "${chip_root}/zzz_generated/chip-tool",
-    "${root_out_dir}/macos_framework_output",
+    "${root_out_dir}/macos_framework_output/Build/Products/Debug/",
   ]
 
-  framework_dirs = [ "${root_out_dir}/macos_framework_output" ]
+  framework_dirs =
+      [ "${root_out_dir}/macos_framework_output/Build/Products/Debug/" ]
 
   defines = [
     "CONFIG_ENABLE_YAML_TESTS=${config_enable_yaml_tests}",
@@ -127,7 +138,7 @@ executable("darwin-framework-tool") {
 
   ldflags = [
     "-rpath",
-    "@executable_path/macos_framework_output/",
+    "@executable_path/macos_framework_output/Build/Products/Debug/",
   ]
 
   frameworks = [


### PR DESCRIPTION
#### Problem
When making changes to Matter.framework, darwin-framework-tool does not re-build the framework. When building we target the project which builds for multiple platforms and takes a very long times. When the building Darwin-framework-tool and the framework portion fails, it has a vague message.

#### Change overview
- Update the framework to have CHIP folder as dependency for any changes that occur in there.
- Update the xcodebuild command to target the "Matter Framework" scheme.
- Update the xcodebuild command to have the derived data in the out folder.
- Update the build Matter.framework log to indicate the proper failure.

#### Testing
- Compiled Darwin-framework-tool
- Modified Matter.framework after compile and re-compiled.
- Timed compilation ~5-6min
- Ran tool to make sure it can still run.