### PR TITLE
In DefaultOTARequestorDriver::GetMaxDownloadBlockSize(), return maxDownloadBlockSize instead of 1024

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -98,7 +98,7 @@ bool DefaultOTARequestorDriver::CanConsent()
 
 uint16_t DefaultOTARequestorDriver::GetMaxDownloadBlockSize()
 {
-    return 1024;
+    return maxDownloadBlockSize;
 }
 
 void DefaultOTARequestorDriver::SetMaxDownloadBlockSize(uint16_t blockSize)


### PR DESCRIPTION
#### Problem

`DefaultOTARequestorDriver::GetMaxDownloadBlockSize()` was hardcoded to always return `1024`.

Fixes: https://github.com/project-chip/connectedhomeip/issues/20898

#### Change overview
Update `DefaultOTARequestorDriver::GetMaxDownloadBlockSize()` to return `maxDownloadBlockSize`.

#### Testing

Verified OTA Query image successfully transfers an image.
