### PR TITLE
Add missing interaction model error codes to MTRError.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRError.h
+++ b/src/darwin/Framework/CHIP/MTRError.h
@@ -98,6 +98,9 @@ typedef NS_ERROR_ENUM(MTRInteractionErrorDomain, MTRInteractionErrorCode){
     MTRInteractionErrorCodeNoUpstreamSubscription = 0xc5,
     MTRInteractionErrorCodeNeedsTimedInteraction  = 0xc6,
     MTRInteractionErrorCodeUnsupportedEvent       = 0xc7,
+    MTRInteractionErrorCodePathsExhausted         = 0xc8,
+    MTRInteractionErrorCodeTimedRequestMismatch   = 0xc9,
+    MTRInteractionErrorCodeFailsafeRequired       = 0xca,
 };
 // clang-format on
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/20172
