### PR TITLE
Android tv-casting-app: Add support for additional Media commands to JNI library

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -31,8 +31,71 @@ public class TvCastingApp {
 
   public native void init();
 
+  /*
+   * CONTENT LAUNCHER CLUSTER
+   */
   public native boolean contentLauncherLaunchURL(
       String contentUrl, String contentDisplayStr, Object launchURLHandler);
+
+  /*
+   * LEVEL CONTROL CLUSTER
+   */
+  public native boolean levelControl_step(
+      byte stepMode,
+      byte stepSize,
+      short transitionTime,
+      byte optionMask,
+      byte optionOverridem,
+      Object responseHandler);
+
+  public native boolean levelControl_moveToLevel(
+      byte level,
+      short transitionTime,
+      byte optionMask,
+      byte optionOverridem,
+      Object responseHandler);
+
+  /*
+   * MEDIA PLAYBACK CLUSTER
+   */
+  public native boolean mediaPlayback_play(Object responseHandler);
+
+  public native boolean mediaPlayback_pause(Object responseHandler);
+
+  public native boolean mediaPlayback_stopPlayback(Object responseHandler);
+
+  public native boolean mediaPlayback_next(Object responseHandler);
+
+  public native boolean mediaPlayback_seek(long position, Object responseHandler);
+
+  public native boolean mediaPlayback_skipForward(
+      long deltaPositionMilliseconds, Object responseHandler);
+
+  public native boolean mediaPlayback_skipBackward(
+      long deltaPositionMilliseconds, Object responseHandler);
+
+  /*
+   * APPLICATION LAUNCHER CLUSTER
+   */
+  public native boolean applicationLauncher_launchApp(
+      short catalogVendorId, String applicationId, String data, Object responseHandler);
+
+  public native boolean applicationLauncher_stopApp(
+      short catalogVendorId, String applicationId, Object responseHandler);
+
+  public native boolean applicationLauncher_hideApp(
+      short catalogVendorId, String applicationId, Object responseHandler);
+
+  /*
+   * TARGET NAVIGATOR CLUSTER
+   */
+  public native boolean targetNavigator_navigateTarget(
+      byte target, String data, Object responseHandler);
+
+  /*
+   * KEYPAD INPUT CLUSTER
+   */
+  public native boolean keypadInput_sendKey(byte keyCode, Object responseHandler);
 
   static {
     System.loadLibrary("TvCastingApp");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/Constants.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/Constants.h
@@ -1,0 +1,40 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+#pragma once
+
+enum MediaCommandName
+{
+    ContentLauncher_LaunchURL,
+    ContentLauncher_LaunchContent,
+    LevelControl_Step,
+    LevelControl_MoveToLevel,
+    MediaPlayback_Play,
+    MediaPlayback_Pause,
+    MediaPlayback_StopPlayback,
+    MediaPlayback_Next,
+    MediaPlayback_Seek,
+    MediaPlayback_SkipForward,
+    MediaPlayback_SkipBackward,
+    ApplicationLauncher_LaunchApp,
+    ApplicationLauncher_StopApp,
+    ApplicationLauncher_HideApp,
+    TargetNavigator_NavigateTarget,
+    KeypadInput_SendKey,
+
+    MEDIA_COMMAND_COUNT
+};

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -18,6 +18,7 @@
 
 #include "TvCastingApp-JNI.h"
 #include "CastingServer.h"
+#include "Constants.h"
 #include "JNIDACProvider.h"
 
 #include <app/server/Server.h>
@@ -122,24 +123,386 @@ JNI_METHOD(void, init)(JNIEnv *, jobject)
 }
 
 JNI_METHOD(jboolean, contentLauncherLaunchURL)
-(JNIEnv * env, jobject, jstring contentUrl, jstring contentDisplayStr, jobject jLaunchURLResponseHandler)
+(JNIEnv * env, jobject, jstring contentUrl, jstring contentDisplayStr, jobject jResponseHandler)
 {
     ChipLogProgress(AppServer, "JNI_METHOD contentLauncherLaunchURL called");
     const char * nativeContentUrl        = env->GetStringUTFChars(contentUrl, 0);
     const char * nativeContentDisplayStr = env->GetStringUTFChars(contentDisplayStr, 0);
 
-    CHIP_ERROR err = TvCastingAppJNIMgr().getLaunchURLResponseHandler().SetUp(env, jLaunchURLResponseHandler);
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ContentLauncher_LaunchURL);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI::SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->ContentLauncherLaunchURL(nativeContentUrl, nativeContentDisplayStr, [](CHIP_ERROR err) {
-        TvCastingAppJNIMgr().getLaunchURLResponseHandler().Handle(err);
+        TvCastingAppJNIMgr().getMediaCommandResponseHandler(ContentLauncher_LaunchURL).Handle(err);
     });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer::ContentLauncherLaunchURL failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     env->ReleaseStringUTFChars(contentUrl, nativeContentUrl);
     env->ReleaseStringUTFChars(contentDisplayStr, nativeContentDisplayStr);
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, levelControl_step)
+(JNIEnv * env, jobject, jbyte stepMode, jbyte stepSize, jshort transitionTime, jbyte optionMask, jbyte optionOverride,
+ jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD levelControl_step called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(LevelControl_Step);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->LevelControl_Step(static_cast<chip::app::Clusters::LevelControl::StepMode>(stepMode),
+                                                          static_cast<uint8_t>(stepSize), static_cast<uint16_t>(transitionTime),
+                                                          static_cast<uint8_t>(optionMask), static_cast<uint8_t>(optionOverride),
+                                                          [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.LevelControl_Step failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, levelControl_moveToLevel)
+(JNIEnv * env, jobject, jbyte level, jshort transitionTime, jbyte optionMask, jbyte optionOverride, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD levelControl_moveToLevel called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(LevelControl_MoveToLevel);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->LevelControl_MoveToLevel(
+        static_cast<uint8_t>(level), static_cast<uint16_t>(transitionTime), static_cast<uint8_t>(optionMask),
+        static_cast<uint8_t>(optionOverride), [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.LevelControl_MoveToLevel failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, mediaPlayback_play)
+(JNIEnv * env, jobject, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_play called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Play);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->MediaPlayback_Play([&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.MediaPlayback_Play failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, mediaPlayback_pause)
+(JNIEnv * env, jobject, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_pause called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Pause);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->MediaPlayback_Pause([&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.MediaPlayback_Pause failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, mediaPlayback_stopPlayback)
+(JNIEnv * env, jobject, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_stopPlayback called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_StopPlayback);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->MediaPlayback_StopPlayback(
+        [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.MediaPlayback_StopPlayback failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, mediaPlayback_next)
+(JNIEnv * env, jobject, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_next called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Next);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->MediaPlayback_Next([&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.MediaPlayback_Next failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, mediaPlayback_seek)
+(JNIEnv * env, jobject, jlong position, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_seek called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Seek);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->MediaPlayback_Seek(static_cast<uint64_t>(position),
+                                                           [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.MediaPlayback_Seek failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, mediaPlayback_skipForward)
+(JNIEnv * env, jobject, jlong deltaPositionMilliseconds, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_skipForward called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_SkipForward);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->MediaPlayback_SkipForward(
+        static_cast<uint64_t>(deltaPositionMilliseconds), [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.MediaPlayback_SkipForward failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, mediaPlayback_skipBackward)
+(JNIEnv * env, jobject, jlong deltaPositionMilliseconds, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_skipBackward called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_SkipBackward);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->MediaPlayback_SkipBackward(
+        static_cast<uint64_t>(deltaPositionMilliseconds), [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.MediaPlayback_SkipBackward failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, applicationLauncher_launchApp)
+(JNIEnv * env, jobject, jshort catalogVendorId, jstring applicationId, jbyteArray data, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD applicationLauncher_launchApp called");
+
+    chip::app::Clusters::ApplicationLauncher::Structs::Application::Type application;
+    application.catalogVendorId      = static_cast<uint16_t>(catalogVendorId);
+    const char * nativeApplicationId = env->GetStringUTFChars(applicationId, 0);
+    application.applicationId        = CharSpan::fromCharString(nativeApplicationId);
+    JniByteArray dataByteArray(env, data);
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_LaunchApp);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->ApplicationLauncher_LaunchApp(
+        application, chip::MakeOptional(dataByteArray.byteSpan()),
+        [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.ApplicationLauncher_LaunchApp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    env->ReleaseStringUTFChars(applicationId, nativeApplicationId);
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, applicationLauncher_stopApp)
+(JNIEnv * env, jobject, jshort catalogVendorId, jstring applicationId, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD applicationLauncher_stopApp called");
+
+    chip::app::Clusters::ApplicationLauncher::Structs::Application::Type application;
+    application.catalogVendorId      = static_cast<uint16_t>(catalogVendorId);
+    const char * nativeApplicationId = env->GetStringUTFChars(applicationId, 0);
+    application.applicationId        = CharSpan::fromCharString(nativeApplicationId);
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_StopApp);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->ApplicationLauncher_StopApp(
+        application, [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.ApplicationLauncher_StopApp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    env->ReleaseStringUTFChars(applicationId, nativeApplicationId);
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, applicationLauncher_hideApp)
+(JNIEnv * env, jobject, jshort catalogVendorId, jstring applicationId, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD applicationLauncher_hideApp called");
+
+    chip::app::Clusters::ApplicationLauncher::Structs::Application::Type application;
+    application.catalogVendorId      = static_cast<uint16_t>(catalogVendorId);
+    const char * nativeApplicationId = env->GetStringUTFChars(applicationId, 0);
+    application.applicationId        = CharSpan::fromCharString(nativeApplicationId);
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_HideApp);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->ApplicationLauncher_HideApp(
+        application, [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.ApplicationLauncher_HideApp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    env->ReleaseStringUTFChars(applicationId, nativeApplicationId);
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, targetNavigator_navigateTarget)
+(JNIEnv * env, jobject, jbyte target, jstring data, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD targetNavigator_navigateTarget called");
+
+    const char * nativeData = env->GetStringUTFChars(data, 0);
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(TargetNavigator_NavigateTarget);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->TargetNavigator_NavigateTarget(
+        static_cast<uint8_t>(target), chip::MakeOptional(CharSpan::fromCharString(nativeData)),
+        [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.TargetNavigator_NavigateTarget failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    env->ReleaseStringUTFChars(data, nativeData);
+exit:
+    if (err != CHIP_NO_ERROR)
+    {
+        return false;
+    }
+
+    return true;
+}
+
+JNI_METHOD(jboolean, keypadInput_sendKey)
+(JNIEnv * env, jobject, jbyte keyCode, jobject jResponseHandler)
+{
+    ChipLogProgress(AppServer, "JNI_METHOD keypadInput_sendKey called");
+
+    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(KeypadInput_SendKey);
+    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
+
+    err = CastingServer::GetInstance()->KeypadInput_SendKey(static_cast<chip::app::Clusters::KeypadInput::CecKeyCode>(keyCode),
+                                                            [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    VerifyOrExit(CHIP_NO_ERROR == err,
+                 ChipLogError(AppServer, "CastingServer.KeypadInput_SendKey failed %" CHIP_ERROR_FORMAT, err.Format()));
 
 exit:
     if (err != CHIP_NO_ERROR)

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.h
@@ -20,21 +20,25 @@
 
 #include <jni.h>
 
+#include "Constants.h"
 #include "MatterCallbackHandler-JNI.h"
 
 class TvCastingAppJNI
 {
 public:
-    MatterCallbackHandlerJNI & getLaunchURLResponseHandler() { return mLaunchURLResponseHandler; }
     MatterCallbackHandlerJNI & getCommissioningCompleteHandler() { return mCommissioningCompleteHandler; }
+    MatterCallbackHandlerJNI & getMediaCommandResponseHandler(enum MediaCommandName name)
+    {
+        return mMediaCommandResponseHandler[name];
+    }
 
 private:
     friend TvCastingAppJNI & TvCastingAppJNIMgr();
 
     static TvCastingAppJNI sInstance;
 
-    MatterCallbackHandlerJNI mLaunchURLResponseHandler;
     MatterCallbackHandlerJNI mCommissioningCompleteHandler;
+    MatterCallbackHandlerJNI mMediaCommandResponseHandler[MEDIA_COMMAND_COUNT];
 };
 
 inline class TvCastingAppJNI & TvCastingAppJNIMgr()

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -24,6 +24,7 @@ shared_library("jni") {
 
   sources = [
     "${chip_root}/examples/tv-casting-app/tv-casting-common/include/CHIPProjectAppConfig.h",
+    "App/app/src/main/jni/cpp/Constants.h",
     "App/app/src/main/jni/cpp/JNIDACProvider.cpp",
     "App/app/src/main/jni/cpp/JNIDACProvider.h",
     "App/app/src/main/jni/cpp/MatterCallbackHandler-JNI.cpp",

--- a/examples/tv-casting-app/android/README.md
+++ b/examples/tv-casting-app/android/README.md
@@ -9,12 +9,12 @@ the TV.
 
 <hr>
 
--   [Requirements for building](#requirements)
-    -   [ABIs and TARGET_CPU](#abi)
-    -   [Gradle & JDK Version](#jdk)
--   [Preparing for build](#preparing)
--   [Building & Installing the app](#building-installing)
--   [Running the app on Android](#running-the-app-on-android)
+-   [Matter TV Casting Android App Example](#matter-tv-casting-android-app-example)
+    -   [Requirements for building](#requirements-for-building)
+        -   [ABIs and TARGET_CPU](#abis-and-target_cpu)
+        -   [Gradle & JDK Version](#gradle--jdk-version)
+    -   [Preparing for build](#preparing-for-build)
+    -   [Building & Installing the app](#building--installing-the-app)
 
 <hr>
 
@@ -79,17 +79,17 @@ This is the simplest option. In the command line, run the following command from
 the top Matter directory:
 
 ```shell
-./scripts/build/build_examples.py --target android-arm64-chip-tv-casting-app build
+./scripts/build/build_examples.py --target android-arm64-tv-casting-app build
 ```
 
 See the table above for other values of `TARGET_CPU`.
 
 The debug Android package `app-debug.apk` will be generated at
-`out/android-$TARGET_CPU-chip-tv-casting-app/outputs/apk/debug/`, and can be
+`out/android-$TARGET_CPU-tv-casting-app/outputs/apk/debug/`, and can be
 installed with
 
 ```shell
-adb install out/android-$TARGET_CPU-chip-tv-casting-app/outputs/apk/debug/app-debug.apk
+adb install out/android-$TARGET_CPU-tv-casting-app/outputs/apk/debug/app-debug.apk
 ```
 
 You can use Android Studio to edit the Android app itself and run it after

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -458,8 +458,8 @@ def AndroidTargets():
     yield target.Extend('arm-tv-server', board=AndroidBoard.ARM, app=AndroidApp.TV_SERVER)
     yield target.Extend('x86-tv-server', board=AndroidBoard.X86, app=AndroidApp.TV_SERVER)
     yield target.Extend('x64-tv-server', board=AndroidBoard.X64, app=AndroidApp.TV_SERVER)
-    yield target.Extend('arm64-tv-casting-app', board=AndroidBoard.ARM64, app=AndroidApp.TV_SERVER)
-    yield target.Extend('arm-tv-casting-app', board=AndroidBoard.ARM, app=AndroidApp.TV_SERVER)
+    yield target.Extend('arm64-tv-casting-app', board=AndroidBoard.ARM64, app=AndroidApp.TV_CASTING_APP)
+    yield target.Extend('arm-tv-casting-app', board=AndroidBoard.ARM, app=AndroidApp.TV_CASTING_APP)
 
 
 def MbedTargets():

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -62,7 +62,7 @@ bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 python3 third_party/android_deps/set_up_android_deps.py
 
 # Generating android-arm-tv-casting-app
-gn gen --check --fail-on-unused-args {out}/android-arm-tv-casting-app '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_config_network_layer_ble=false ' --root={root}/examples/tv-app/android/
+gn gen --check --fail-on-unused-args {out}/android-arm-tv-casting-app '--args=target_os="android" target_cpu="arm" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_config_network_layer_ble=false ' --root={root}/examples/tv-casting-app/android/
 
 # Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
@@ -98,7 +98,7 @@ bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
 python3 third_party/android_deps/set_up_android_deps.py
 
 # Generating android-arm64-tv-casting-app
-gn gen --check --fail-on-unused-args {out}/android-arm64-tv-casting-app '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_config_network_layer_ble=false ' --root={root}/examples/tv-app/android/
+gn gen --check --fail-on-unused-args {out}/android-arm64-tv-casting-app '--args=target_os="android" target_cpu="arm64" android_ndk_root="TEST_ANDROID_NDK_HOME" android_sdk_root="TEST_ANDROID_HOME" chip_config_network_layer_ble=false ' --root={root}/examples/tv-casting-app/android/
 
 # Accepting NDK licenses @ tools
 bash -c 'yes | TEST_ANDROID_HOME/tools/bin/sdkmanager --licenses >/dev/null'
@@ -1262,27 +1262,20 @@ cp {out}/android-arm-chip-tool/lib/src/platform/android/AndroidPlatform.jar {roo
 ninja -C {out}/android-arm-tv-casting-app
 
 # Prepare Native libs android-arm-tv-casting-app
-mkdir -p {root}/examples/tv-app/android/App/app/libs/jniLibs/armeabi-v7a
+mkdir -p {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/armeabi-v7a
 
-cp {out}/android-arm-tv-casting-app/lib/jni/armeabi-v7a/libSetupPayloadParser.so {root}/examples/tv-app/android/App/app/libs/jniLibs/armeabi-v7a/libSetupPayloadParser.so
+cp {out}/android-arm-tv-casting-app/lib/jni/armeabi-v7a/libc++_shared.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/armeabi-v7a/libc++_shared.so
 
-cp {out}/android-arm-tv-casting-app/lib/jni/armeabi-v7a/libc++_shared.so {root}/examples/tv-app/android/App/app/libs/jniLibs/armeabi-v7a/libc++_shared.so
+cp {out}/android-arm-tv-casting-app/lib/jni/armeabi-v7a/libTvCastingApp.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/armeabi-v7a/libTvCastingApp.so
 
-cp {out}/android-arm-tv-casting-app/lib/jni/armeabi-v7a/libTvApp.so {root}/examples/tv-app/android/App/app/libs/jniLibs/armeabi-v7a/libTvApp.so
+cp {out}/android-arm-tv-casting-app/lib/third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar {root}/examples/tv-casting-app/android/App/app/libs/AndroidPlatform.jar
 
-cp {out}/android-arm-tv-casting-app/lib/third_party/connectedhomeip/src/setup_payload/java/SetupPayloadParser.jar {root}/examples/tv-app/android/App/app/libs/SetupPayloadParser.jar
+cp {out}/android-arm-tv-casting-app/lib/third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar {root}/examples/tv-casting-app/android/App/app/libs/CHIPAppServer.jar
 
-cp {out}/android-arm-tv-casting-app/lib/third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar {root}/examples/tv-app/android/App/app/libs/AndroidPlatform.jar
+cp {out}/android-arm-tv-casting-app/lib/TvCastingApp.jar {root}/examples/tv-casting-app/android/App/app/libs/TvCastingApp.jar
 
-cp {out}/android-arm-tv-casting-app/lib/third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar {root}/examples/tv-app/android/App/app/libs/CHIPAppServer.jar
-
-cp {out}/android-arm-tv-casting-app/lib/TvApp.jar {root}/examples/tv-app/android/App/app/libs/TvApp.jar
-
-# Building Example android-arm-tv-casting-app, module platform-app
-{root}/examples/tv-app/android/App/gradlew -p {root}/examples/tv-app/android/App/ -PmatterBuildSrcDir={out}/android-arm-tv-casting-app -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm-tv-casting-app/platform-app :platform-app:assembleDebug
-
-# Building Example android-arm-tv-casting-app, module content-app
-{root}/examples/tv-app/android/App/gradlew -p {root}/examples/tv-app/android/App/ -PmatterBuildSrcDir={out}/android-arm-tv-casting-app -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm-tv-casting-app/content-app :content-app:assembleDebug
+# Building Example android-arm-tv-casting-app
+{root}/examples/tv-casting-app/android/App/gradlew -p {root}/examples/tv-casting-app/android/App/ -PmatterBuildSrcDir={out}/android-arm-tv-casting-app -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm-tv-casting-app assembleDebug
 
 # Building JNI android-arm-tv-server
 ninja -C {out}/android-arm-tv-server
@@ -1356,27 +1349,20 @@ cp {out}/android-arm64-chip-tool/lib/src/platform/android/AndroidPlatform.jar {r
 ninja -C {out}/android-arm64-tv-casting-app
 
 # Prepare Native libs android-arm64-tv-casting-app
-mkdir -p {root}/examples/tv-app/android/App/app/libs/jniLibs/arm64-v8a
+mkdir -p {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/arm64-v8a
 
-cp {out}/android-arm64-tv-casting-app/lib/jni/arm64-v8a/libSetupPayloadParser.so {root}/examples/tv-app/android/App/app/libs/jniLibs/arm64-v8a/libSetupPayloadParser.so
+cp {out}/android-arm64-tv-casting-app/lib/jni/arm64-v8a/libc++_shared.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/arm64-v8a/libc++_shared.so
 
-cp {out}/android-arm64-tv-casting-app/lib/jni/arm64-v8a/libc++_shared.so {root}/examples/tv-app/android/App/app/libs/jniLibs/arm64-v8a/libc++_shared.so
+cp {out}/android-arm64-tv-casting-app/lib/jni/arm64-v8a/libTvCastingApp.so {root}/examples/tv-casting-app/android/App/app/libs/jniLibs/arm64-v8a/libTvCastingApp.so
 
-cp {out}/android-arm64-tv-casting-app/lib/jni/arm64-v8a/libTvApp.so {root}/examples/tv-app/android/App/app/libs/jniLibs/arm64-v8a/libTvApp.so
+cp {out}/android-arm64-tv-casting-app/lib/third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar {root}/examples/tv-casting-app/android/App/app/libs/AndroidPlatform.jar
 
-cp {out}/android-arm64-tv-casting-app/lib/third_party/connectedhomeip/src/setup_payload/java/SetupPayloadParser.jar {root}/examples/tv-app/android/App/app/libs/SetupPayloadParser.jar
+cp {out}/android-arm64-tv-casting-app/lib/third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar {root}/examples/tv-casting-app/android/App/app/libs/CHIPAppServer.jar
 
-cp {out}/android-arm64-tv-casting-app/lib/third_party/connectedhomeip/src/platform/android/AndroidPlatform.jar {root}/examples/tv-app/android/App/app/libs/AndroidPlatform.jar
+cp {out}/android-arm64-tv-casting-app/lib/TvCastingApp.jar {root}/examples/tv-casting-app/android/App/app/libs/TvCastingApp.jar
 
-cp {out}/android-arm64-tv-casting-app/lib/third_party/connectedhomeip/src/app/server/java/CHIPAppServer.jar {root}/examples/tv-app/android/App/app/libs/CHIPAppServer.jar
-
-cp {out}/android-arm64-tv-casting-app/lib/TvApp.jar {root}/examples/tv-app/android/App/app/libs/TvApp.jar
-
-# Building Example android-arm64-tv-casting-app, module platform-app
-{root}/examples/tv-app/android/App/gradlew -p {root}/examples/tv-app/android/App/ -PmatterBuildSrcDir={out}/android-arm64-tv-casting-app -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm64-tv-casting-app/platform-app :platform-app:assembleDebug
-
-# Building Example android-arm64-tv-casting-app, module content-app
-{root}/examples/tv-app/android/App/gradlew -p {root}/examples/tv-app/android/App/ -PmatterBuildSrcDir={out}/android-arm64-tv-casting-app -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm64-tv-casting-app/content-app :content-app:assembleDebug
+# Building Example android-arm64-tv-casting-app
+{root}/examples/tv-casting-app/android/App/gradlew -p {root}/examples/tv-casting-app/android/App/ -PmatterBuildSrcDir={out}/android-arm64-tv-casting-app -PmatterSdkSourceBuild=false -PbuildDir={out}/android-arm64-tv-casting-app assembleDebug
 
 # Building JNI android-arm64-tv-server
 ninja -C {out}/android-arm64-tv-server


### PR DESCRIPTION
#### Problem
1. The Android tv-casting library does not support sending Media commands other than the Content Launcher: LaunchURL.
2. Build for the android tv-casting-app was misconfigured (in https://github.com/project-chip/connectedhomeip/pull/20422)

#### Change overview
1. Fix the build for the android tv-casting-app
2. Add support to the JNI layer to allow sending Matter Media commands beyond LaunchURL.
TBD: UI updates to the Android tv-casting-app to send these new commands will be added in a follow-up PR (to let this PR be readable/reviewable)

#### Testing
Built and tested the android tv-casting-app to ensure it can still send the Content Launcher Launch URL command.