### PR TITLE
Fix broken PaseVerifier codepath and add test

### DIFF
--- a/src/android/CHIPTool/app/src/androidTest/java/com/google/chip/chiptool/CHIPDeviceControllerTest.java
+++ b/src/android/CHIPTool/app/src/androidTest/java/com/google/chip/chiptool/CHIPDeviceControllerTest.java
@@ -1,0 +1,38 @@
+package com.google.chip.chiptool;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import android.content.Context;
+import androidx.test.ext.junit.runners.AndroidJUnit4;
+import androidx.test.platform.app.InstrumentationRegistry;
+import chip.devicecontroller.ChipDeviceController;
+import chip.devicecontroller.PaseVerifierParams;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+/**
+ * Instrumented test, which will execute on an Android device.
+ *
+ * @see <a href="http://d.android.com/tools/testing">Testing documentation</a>
+ */
+@RunWith(AndroidJUnit4.class)
+public class CHIPDeviceControllerTest {
+  @Test
+  public void PaseVerifierTest() {
+    long deviceId = 123L;
+    long setupPincode = 808080L;
+    long iterations = 1000L;
+    byte[] randomSalt = "hEvzbU:%h)?aB,h7+9fn[Lf[BhYB!=TA".getBytes();
+
+    Context appContext = InstrumentationRegistry.getInstrumentation().getTargetContext();
+    ChipDeviceController chipDeviceController = ChipClient.INSTANCE.getDeviceController(appContext);
+
+    PaseVerifierParams params =
+        chipDeviceController.computePaseVerifier(deviceId, setupPincode, iterations, randomSalt);
+
+    assertNotNull(params);
+    assertEquals(params.getSetupPincode(), setupPincode);
+    assertNotNull(params.getPakeVerifier());
+  }
+}

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -143,6 +143,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     initParams.bleLayer = DeviceLayer::ConnectivityMgr().GetBleLayer();
 #endif
     initParams.listenPort                      = listenPort;
+    setupParams.controllerVendorId             = VendorId::NotSpecified;
     setupParams.pairingDelegate                = wrapper.get();
     setupParams.operationalCredentialsDelegate = opCredsIssuer;
     initParams.fabricIndependentStorage        = wrapperStorage;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1224,7 +1224,7 @@ CHIP_ERROR N2J_PaseVerifierParams(JNIEnv * env, jlong setupPincode, jbyteArray p
     SuccessOrExit(err);
 
     env->ExceptionClear();
-    constructor = env->GetMethodID(paramsClass, "<init>", "(JI[B)V");
+    constructor = env->GetMethodID(paramsClass, "<init>", "(J[B)V");
     VerifyOrExit(constructor != nullptr, err = CHIP_JNI_ERROR_METHOD_NOT_FOUND);
 
     outParams = (jobject) env->NewObject(paramsClass, constructor, setupPincode, paseVerifier);


### PR DESCRIPTION
#### Problem
The spec was updated to force PasscodeId to be always zero for v1.0, and this was updated in #15924. However, there still exists calls to outdated constructors which include the PasscodeId integer parameter, which causes crashing on execution. Additionally, #20017 enforces initialization of Controller::SetupParams::controllerVendorId, without which causes the CHIPTool android application to crash when commissioning devices. 

#### Change overview
- Removes PasscodeId field from the corresponding JNI constructor parameter which was missed in the original fix.
- Initializes SetupParams::controllerVendorId to be VendorId::NotSpecified
- Includes a new Android instrumentation test to the CHIPTool library for verifying the DeviceController path can successfully computePaseVerifier

#### Testing
Running CHIPTool android application and run `Provision CHIP device with WI-FI` and ensure it no longer crashes
Additionally, running the newly added instrumentation test to ensure the codepath modified in this PR doesn’t crash.