### PR TITLE
[ESP32] Support log configuration in menuconfig

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -69,6 +69,12 @@ chip_gn_arg_append("esp32_cxx"             "\"${CMAKE_CXX_COMPILER}\"")
 chip_gn_arg_append("esp32_cpu"             "\"esp32\"")
 chip_gn_arg_bool("is_debug"                ${is_debug})
 
+# Config the chip log level by IDF menuconfig
+chip_gn_arg_bool  ("chip_error_logging"        CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 1)
+chip_gn_arg_bool  ("chip_progress_logging"     CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 3)
+chip_gn_arg_bool  ("chip_detail_logging"       CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 4)
+chip_gn_arg_bool  ("chip_automation_logging"   CONFIG_LOG_DEFAULT_LEVEL GREATER_EQUAL 5)
+
 if(CONFIG_ENABLE_CHIPOBLE)
 chip_gn_arg_append("chip_config_network_layer_ble"           "true")
 else()

--- a/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
+++ b/src/platform/ESP32/ConnectivityManagerImpl_WiFi.cpp
@@ -350,6 +350,8 @@ CHIP_ERROR ConnectivityManagerImpl::_GetAndLogWiFiStatsCounters(void)
     uint16_t freq;
     uint16_t bssid;
 
+    IgnoreUnusedVariable(freq);
+    IgnoreUnusedVariable(bssid);
     err = esp_wifi_get_config(WIFI_IF_STA, &wifiConfig);
     if (err != ESP_OK)
     {


### PR DESCRIPTION
#### Problem
For esp chip the uart log print level can be configured by menuconfig,like this
```
(Top) → Component config → Log output → Default log verbosity
( ) No output
( ) Error
( ) Warning
(X) Info
( ) Debug
( ) Verbose
```
this controls the log of all the components , except the CHIP log currently
#### Change overview
this pr make it avaliable that the CHIP log output can be configured through idf.py menuconfig for esp32 chip
