### PR TITLE
Software version string on efr32 chef build while doing automation testing

### DIFF
--- a/examples/chef/efr32/args.gni
+++ b/examples/chef/efr32/args.gni
@@ -20,6 +20,7 @@ efr32_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
 chip_enable_ota_requestor = true
 
+pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
 pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true

--- a/examples/chef/efr32/include/CHIPProjectConfig.h
+++ b/examples/chef/efr32/include/CHIPProjectConfig.h
@@ -70,17 +70,6 @@
 #define CHIP_DEVICE_CONFIG_DEVICE_HARDWARE_VERSION 1
 
 /**
- * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
- *
- * A string identifying the software version running on the device.
- * CHIP service currently expects the software version to be in the format
- * {MAJOR_VERSION}.0d{MINOR_VERSION}
- */
-#ifndef CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING
-#define CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING "0.1ALPHA"
-#endif
-
-/**
  * CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION
  *
  * A uint32_t identifying the software version running on the device.


### PR DESCRIPTION
Problem
The value of software version string is needed for test automation on efr32 platform.

Change overview
Put the software version string in the CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING by chef.py for efr32 sample app of chef build.
Add new config['silabs-thread']['EFR32_BOARD'] in config.yaml for specifying the board in use.

Testing
1. Set silabs-thread.EFR32_BOARD in config.yaml to 'BRD4161A'.
2. Set silabs-thread.GECKO_SDK in config.yaml to the path of git repo https://github.com/SiliconLabs/sdk_support.git(the commit I used is 175cbe761d2fab133725dab01abb1a149e23eb20).
3. Build the binary with command `/chef.py -zbra -d rootnode_dimmablelight_bCwGYSDpoe -t silabs-thread`.
4. Flash the image with command `/chef.py -f -d rootnode_dimmablelight_bCwGYSDpoe -t silabs-thread`.
5. Use RPC console to check the output is correct.

