### PR TITLE
Add crypto target to build examples

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -69,11 +69,11 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                      "./scripts/build/build_examples.py \
-                        --target linux-arm64-all-clusters \
-                        --target linux-arm64-chip-tool-ipv6only \
-                        --target linux-arm64-lock \
-                        --target linux-arm64-minmdns \
-                        --target linux-arm64-thermostat-no-ble \
+                        --target linux-arm64-clang-all-clusters \
+                        --target linux-arm64-clang-chip-tool-ipv6only \
+                        --target linux-arm64-clang-lock \
+                        --target linux-arm64-clang-minmdns \
+                        --target linux-arm64-clang-thermostat-no-ble \
                         build \
                      "
             - name: Bloat report - chip-tool
@@ -81,14 +81,14 @@ jobs:
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux arm64 chip-tool-ipv6only \
-                    out/linux-arm64-chip-tool-ipv6only/chip-tool \
+                    out/linux-arm64-clang-chip-tool-ipv6only/chip-tool \
                     /tmp/bloat_reports/
             - name: Bloat report - thermostat
               timeout-minutes: 5
               run: |
                   .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
                     linux arm64 thermostat-no-ble \
-                    out/linux-arm64-thermostat-no-ble/thermostat-app \
+                    out/linux-arm64-clang-thermostat-no-ble/thermostat-app \
                     /tmp/bloat_reports/
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -19,6 +19,22 @@ from platform import uname
 from .gn import GnBuilder
 
 
+class HostCryptoLibrary(Enum):
+    """Defines what cryptographic backend applications should use."""
+    OPENSSL = auto()
+    MBEDTLS = auto()
+    BORINGSSL = auto()
+
+    @property
+    def gn_argument(self):
+        if self == HostCryptoLibrary.OPENSSL:
+            return 'chip_crypto="openssl"'
+        elif self == HostCryptoLibrary.MBEDTLS:
+            return 'chip_crypto="mbedtls"'
+        elif self == HostCryptoLibrary.BORINGSSL:
+            return 'chip_crypto="boringssl"'
+
+
 class HostApp(Enum):
     ALL_CLUSTERS = auto()
     ALL_CLUSTERS_MINIMAL = auto()
@@ -198,7 +214,7 @@ class HostBuilder(GnBuilder):
                  separate_event_loop=True, use_libfuzzer=False, use_clang=False,
                  interactive_mode=True, extra_tests=False,
                  use_platform_mdns=False, enable_rpcs=False,
-                 use_coverage=False):
+                 use_coverage=False, crypto_library: HostCryptoLibrary = None):
         super(HostBuilder, self).__init__(
             root=os.path.join(root, 'examples', app.ExamplePath()),
             runner=runner)
@@ -264,14 +280,19 @@ class HostBuilder(GnBuilder):
         if app == HostApp.NL_TEST_RUNNER:
             self.build_command = 'runner'
 
+        # Crypto library has per-platform defaults (like openssl for linux/mac
+        # and mbedtls for android/freertos/zephyr/mbed/...)
+        if crypto_library:
+            self.extra_gn_options.append(crypto_library.gn_argument)
+
+        if self.board == HostBoard.ARM64:
+            if not use_clang:
+                raise Exception("Cross compile only supported using clang")
+
         if app == HostApp.CERT_TOOL:
             # Certification only built for openssl
-            if self.board == HostBoard.ARM64:
-                # OpenSSL and mbedTLS conflicts.
-                # We only cross compile with mbedTLS.
-                raise Exception(
-                    "Cannot cross compile CERT TOOL: ssl library conflict")
-            self.extra_gn_options.append('chip_crypto="openssl"')
+            if self.board == HostBoard.ARM64 and crypto_library == HostCryptoLibrary.MBEDTLS:
+                raise Exception("MbedTLS not supported for cross compiling cert tool")
             self.build_command = 'src/tools/chip-cert'
         elif app == HostApp.ADDRESS_RESOLVE:
             self.build_command = 'src/lib/address_resolve:address-resolve-tool'
@@ -287,8 +308,6 @@ class HostBuilder(GnBuilder):
             self.extra_gn_options.extend(
                 [
                     'target_cpu="arm64"',
-                    'is_clang=true',
-                    'chip_crypto="mbedtls"',
                     'sysroot="%s"' % self.SysRootPath('SYSROOT_AARCH64')
                 ]
             )

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -1,170 +1,170 @@
 # Commands will be run in CHIP project root.
 cd "{root}"
 
-# Generating linux-arm64-all-clusters
+# Generating linux-arm64-clang-all-clusters
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-all-clusters'
 
-# Generating linux-arm64-all-clusters-app-nodeps
+# Generating linux-arm64-clang-all-clusters-app-nodeps
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-app-nodeps'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-all-clusters-app-nodeps'
 
-# Generating linux-arm64-all-clusters-app-nodeps-ipv6only
+# Generating linux-arm64-clang-all-clusters-app-nodeps-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-app-nodeps-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-all-clusters-app-nodeps-ipv6only'
 
-# Generating linux-arm64-all-clusters-ipv6only
+# Generating linux-arm64-clang-all-clusters-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-all-clusters-ipv6only'
 
-# Generating linux-arm64-all-clusters-minimal
+# Generating linux-arm64-clang-all-clusters-minimal
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-minimal-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-minimal'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-minimal-app/linux '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-all-clusters-minimal'
 
-# Generating linux-arm64-all-clusters-minimal-ipv6only
+# Generating linux-arm64-clang-all-clusters-minimal-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-minimal-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-all-clusters-minimal-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/all-clusters-minimal-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-all-clusters-minimal-ipv6only'
 
-# Generating linux-arm64-bridge
+# Generating linux-arm64-clang-bridge
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/bridge-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-bridge'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/bridge-app/linux '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-bridge'
 
-# Generating linux-arm64-bridge-ipv6only
+# Generating linux-arm64-clang-bridge-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/bridge-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-bridge-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/bridge-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-bridge-ipv6only'
 
-# Generating linux-arm64-chip-tool
+# Generating linux-arm64-clang-chip-tool
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-chip-tool'
 
-# Generating linux-arm64-chip-tool-ipv6only
+# Generating linux-arm64-clang-chip-tool-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-chip-tool-ipv6only'
 
-# Generating linux-arm64-chip-tool-nodeps
+# Generating linux-arm64-clang-chip-tool-nodeps
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-nodeps'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-chip-tool-nodeps'
 
-# Generating linux-arm64-chip-tool-nodeps-ipv6only
+# Generating linux-arm64-clang-chip-tool-nodeps-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-chip-tool-nodeps-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false chip_enable_wifi=false chip_enable_openthread=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-chip-tool-nodeps-ipv6only'
 
-# Generating linux-arm64-light
+# Generating linux-arm64-clang-light
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-light'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-light'
 
-# Generating linux-arm64-light-ipv6only
+# Generating linux-arm64-clang-light-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-light-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-light-ipv6only'
 
-# Generating linux-arm64-light-rpc
+# Generating linux-arm64-clang-light-rpc
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=import("//with_pw_rpc.gni") target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-light-rpc'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=import("//with_pw_rpc.gni") is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-light-rpc'
 
-# Generating linux-arm64-light-rpc-ipv6only
+# Generating linux-arm64-clang-light-rpc-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=import("//with_pw_rpc.gni") chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-light-rpc-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lighting-app/linux '"'"'--args=import("//with_pw_rpc.gni") chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-light-rpc-ipv6only'
 
-# Generating linux-arm64-lock
+# Generating linux-arm64-clang-lock
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-lock'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/linux '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-lock'
 
-# Generating linux-arm64-lock-ipv6only
+# Generating linux-arm64-clang-lock-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-lock-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/lock-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-lock-ipv6only'
 
-# Generating linux-arm64-minmdns
+# Generating linux-arm64-clang-minmdns
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-minmdns'
 
-# Generating linux-arm64-minmdns-ipv6only
+# Generating linux-arm64-clang-minmdns-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-minmdns-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-minmdns-ipv6only'
 
-# Generating linux-arm64-ota-provider
+# Generating linux-arm64-clang-ota-provider
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_config_network_layer_ble=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-ota-provider'
 
-# Generating linux-arm64-ota-provider-ipv6only
+# Generating linux-arm64-clang-ota-provider-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-provider-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-ota-provider-ipv6only'
 
-# Generating linux-arm64-ota-requestor
+# Generating linux-arm64-clang-ota-requestor
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_config_network_layer_ble=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-ota-requestor'
 
-# Generating linux-arm64-ota-requestor-ipv6only
+# Generating linux-arm64-clang-ota-requestor-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-ota-requestor-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-requestor-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false chip_config_network_layer_ble=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-ota-requestor-ipv6only'
 
-# Generating linux-arm64-python-bindings
+# Generating linux-arm64-clang-python-bindings
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '"'"'--args=enable_rtti=false chip_project_config_include_dirs=["//config/python"] target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-python-bindings'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '"'"'--args=is_clang=true enable_rtti=false chip_project_config_include_dirs=["//config/python"] target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-python-bindings'
 
-# Generating linux-arm64-shell
+# Generating linux-arm64-clang-shell
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-shell'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-shell'
 
-# Generating linux-arm64-shell-ipv6only
+# Generating linux-arm64-clang-shell-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-shell-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/standalone '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-shell-ipv6only'
 
-# Generating linux-arm64-thermostat
+# Generating linux-arm64-clang-thermostat
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-thermostat'
 
-# Generating linux-arm64-thermostat-ipv6only
+# Generating linux-arm64-clang-thermostat-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-thermostat-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-thermostat-ipv6only'
 
-# Generating linux-arm64-tv-app
+# Generating linux-arm64-clang-tv-app
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-tv-app'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-tv-app'
 
-# Generating linux-arm64-tv-app-ipv6only
+# Generating linux-arm64-clang-tv-app-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-tv-app-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-tv-app-ipv6only'
 
-# Generating linux-arm64-tv-casting-app
+# Generating linux-arm64-clang-tv-casting-app
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux '"'"'--args=target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-tv-casting-app'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux '"'"'--args=is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-tv-casting-app'
 
-# Generating linux-arm64-tv-casting-app-ipv6only
+# Generating linux-arm64-clang-tv-casting-app-ipv6only
 bash -c '
 PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
- gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false target_cpu="arm64" is_clang=true chip_crypto="mbedtls" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-tv-casting-app-ipv6only'
+ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux '"'"'--args=chip_inet_config_enable_ipv4=false is_clang=true target_cpu="arm64" sysroot="SYSROOT_AARCH64"'"'"' {out}/linux-arm64-clang-tv-casting-app-ipv6only'
 
 # Generating linux-fake-tests
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_build_tests=true custom_toolchain="//build/toolchain/fake:fake_x64_gcc" chip_link_tests=true chip_device_platform="fake" chip_fake_platform=true' {out}/linux-fake-tests
@@ -200,7 +200,7 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/bridge-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-bridge-ipv6only
 
 # Generating linux-x64-chip-cert
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=chip_crypto="openssl"' {out}/linux-x64-chip-cert
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root} {out}/linux-x64-chip-cert
 
 # Generating linux-x64-chip-tool
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/chip-tool {out}/linux-x64-chip-tool
@@ -271,18 +271,6 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-tests
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root} --args=chip_build_tests=true {out}/linux-x64-tests
 
-# Generating linux-x64-tests-clang
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=is_clang=true chip_build_tests=true' {out}/linux-x64-tests-clang
-
-# Generating linux-x64-tests-coverage
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root} '--args=use_coverage=true chip_build_tests=true' {out}/linux-x64-tests-coverage
-
-# Create coverage output location
-mkdir -p {out}/linux-x64-tests-coverage/coverage
-
-# Initial coverage baseline
-lcov --initial --capture --directory {out}/linux-x64-tests-coverage/obj --output-file {out}/linux-x64-tests-coverage/coverage/lcov_base.info
-
 # Generating linux-x64-thermostat
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/thermostat/linux {out}/linux-x64-thermostat
 
@@ -301,104 +289,104 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 # Generating linux-x64-tv-casting-app-ipv6only
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-casting-app-ipv6only
 
-# Building linux-arm64-all-clusters
-ninja -C {out}/linux-arm64-all-clusters
+# Building linux-arm64-clang-all-clusters
+ninja -C {out}/linux-arm64-clang-all-clusters
 
-# Building linux-arm64-all-clusters-app-nodeps
-ninja -C {out}/linux-arm64-all-clusters-app-nodeps
+# Building linux-arm64-clang-all-clusters-app-nodeps
+ninja -C {out}/linux-arm64-clang-all-clusters-app-nodeps
 
-# Building linux-arm64-all-clusters-app-nodeps-ipv6only
-ninja -C {out}/linux-arm64-all-clusters-app-nodeps-ipv6only
+# Building linux-arm64-clang-all-clusters-app-nodeps-ipv6only
+ninja -C {out}/linux-arm64-clang-all-clusters-app-nodeps-ipv6only
 
-# Building linux-arm64-all-clusters-ipv6only
-ninja -C {out}/linux-arm64-all-clusters-ipv6only
+# Building linux-arm64-clang-all-clusters-ipv6only
+ninja -C {out}/linux-arm64-clang-all-clusters-ipv6only
 
-# Building linux-arm64-all-clusters-minimal
-ninja -C {out}/linux-arm64-all-clusters-minimal
+# Building linux-arm64-clang-all-clusters-minimal
+ninja -C {out}/linux-arm64-clang-all-clusters-minimal
 
-# Building linux-arm64-all-clusters-minimal-ipv6only
-ninja -C {out}/linux-arm64-all-clusters-minimal-ipv6only
+# Building linux-arm64-clang-all-clusters-minimal-ipv6only
+ninja -C {out}/linux-arm64-clang-all-clusters-minimal-ipv6only
 
-# Building linux-arm64-bridge
-ninja -C {out}/linux-arm64-bridge
+# Building linux-arm64-clang-bridge
+ninja -C {out}/linux-arm64-clang-bridge
 
-# Building linux-arm64-bridge-ipv6only
-ninja -C {out}/linux-arm64-bridge-ipv6only
+# Building linux-arm64-clang-bridge-ipv6only
+ninja -C {out}/linux-arm64-clang-bridge-ipv6only
 
-# Building linux-arm64-chip-tool
-ninja -C {out}/linux-arm64-chip-tool
+# Building linux-arm64-clang-chip-tool
+ninja -C {out}/linux-arm64-clang-chip-tool
 
-# Building linux-arm64-chip-tool-ipv6only
-ninja -C {out}/linux-arm64-chip-tool-ipv6only
+# Building linux-arm64-clang-chip-tool-ipv6only
+ninja -C {out}/linux-arm64-clang-chip-tool-ipv6only
 
-# Building linux-arm64-chip-tool-nodeps
-ninja -C {out}/linux-arm64-chip-tool-nodeps
+# Building linux-arm64-clang-chip-tool-nodeps
+ninja -C {out}/linux-arm64-clang-chip-tool-nodeps
 
-# Building linux-arm64-chip-tool-nodeps-ipv6only
-ninja -C {out}/linux-arm64-chip-tool-nodeps-ipv6only
+# Building linux-arm64-clang-chip-tool-nodeps-ipv6only
+ninja -C {out}/linux-arm64-clang-chip-tool-nodeps-ipv6only
 
-# Building linux-arm64-light
-ninja -C {out}/linux-arm64-light
+# Building linux-arm64-clang-light
+ninja -C {out}/linux-arm64-clang-light
 
-# Building linux-arm64-light-ipv6only
-ninja -C {out}/linux-arm64-light-ipv6only
+# Building linux-arm64-clang-light-ipv6only
+ninja -C {out}/linux-arm64-clang-light-ipv6only
 
-# Building linux-arm64-light-rpc
-ninja -C {out}/linux-arm64-light-rpc
+# Building linux-arm64-clang-light-rpc
+ninja -C {out}/linux-arm64-clang-light-rpc
 
-# Building linux-arm64-light-rpc-ipv6only
-ninja -C {out}/linux-arm64-light-rpc-ipv6only
+# Building linux-arm64-clang-light-rpc-ipv6only
+ninja -C {out}/linux-arm64-clang-light-rpc-ipv6only
 
-# Building linux-arm64-lock
-ninja -C {out}/linux-arm64-lock
+# Building linux-arm64-clang-lock
+ninja -C {out}/linux-arm64-clang-lock
 
-# Building linux-arm64-lock-ipv6only
-ninja -C {out}/linux-arm64-lock-ipv6only
+# Building linux-arm64-clang-lock-ipv6only
+ninja -C {out}/linux-arm64-clang-lock-ipv6only
 
-# Building linux-arm64-minmdns
-ninja -C {out}/linux-arm64-minmdns
+# Building linux-arm64-clang-minmdns
+ninja -C {out}/linux-arm64-clang-minmdns
 
-# Building linux-arm64-minmdns-ipv6only
-ninja -C {out}/linux-arm64-minmdns-ipv6only
+# Building linux-arm64-clang-minmdns-ipv6only
+ninja -C {out}/linux-arm64-clang-minmdns-ipv6only
 
-# Building linux-arm64-ota-provider
-ninja -C {out}/linux-arm64-ota-provider
+# Building linux-arm64-clang-ota-provider
+ninja -C {out}/linux-arm64-clang-ota-provider
 
-# Building linux-arm64-ota-provider-ipv6only
-ninja -C {out}/linux-arm64-ota-provider-ipv6only
+# Building linux-arm64-clang-ota-provider-ipv6only
+ninja -C {out}/linux-arm64-clang-ota-provider-ipv6only
 
-# Building linux-arm64-ota-requestor
-ninja -C {out}/linux-arm64-ota-requestor
+# Building linux-arm64-clang-ota-requestor
+ninja -C {out}/linux-arm64-clang-ota-requestor
 
-# Building linux-arm64-ota-requestor-ipv6only
-ninja -C {out}/linux-arm64-ota-requestor-ipv6only
+# Building linux-arm64-clang-ota-requestor-ipv6only
+ninja -C {out}/linux-arm64-clang-ota-requestor-ipv6only
 
-# Building linux-arm64-python-bindings
-ninja -C {out}/linux-arm64-python-bindings chip-repl
+# Building linux-arm64-clang-python-bindings
+ninja -C {out}/linux-arm64-clang-python-bindings chip-repl
 
-# Building linux-arm64-shell
-ninja -C {out}/linux-arm64-shell
+# Building linux-arm64-clang-shell
+ninja -C {out}/linux-arm64-clang-shell
 
-# Building linux-arm64-shell-ipv6only
-ninja -C {out}/linux-arm64-shell-ipv6only
+# Building linux-arm64-clang-shell-ipv6only
+ninja -C {out}/linux-arm64-clang-shell-ipv6only
 
-# Building linux-arm64-thermostat
-ninja -C {out}/linux-arm64-thermostat
+# Building linux-arm64-clang-thermostat
+ninja -C {out}/linux-arm64-clang-thermostat
 
-# Building linux-arm64-thermostat-ipv6only
-ninja -C {out}/linux-arm64-thermostat-ipv6only
+# Building linux-arm64-clang-thermostat-ipv6only
+ninja -C {out}/linux-arm64-clang-thermostat-ipv6only
 
-# Building linux-arm64-tv-app
-ninja -C {out}/linux-arm64-tv-app
+# Building linux-arm64-clang-tv-app
+ninja -C {out}/linux-arm64-clang-tv-app
 
-# Building linux-arm64-tv-app-ipv6only
-ninja -C {out}/linux-arm64-tv-app-ipv6only
+# Building linux-arm64-clang-tv-app-ipv6only
+ninja -C {out}/linux-arm64-clang-tv-app-ipv6only
 
-# Building linux-arm64-tv-casting-app
-ninja -C {out}/linux-arm64-tv-casting-app
+# Building linux-arm64-clang-tv-casting-app
+ninja -C {out}/linux-arm64-clang-tv-casting-app
 
-# Building linux-arm64-tv-casting-app-ipv6only
-ninja -C {out}/linux-arm64-tv-casting-app-ipv6only
+# Building linux-arm64-clang-tv-casting-app-ipv6only
+ninja -C {out}/linux-arm64-clang-tv-casting-app-ipv6only
 
 # Building linux-fake-tests
 ninja -C {out}/linux-fake-tests check
@@ -504,27 +492,6 @@ ninja -C {out}/linux-x64-shell-ipv6only
 
 # Building linux-x64-tests
 ninja -C {out}/linux-x64-tests check
-
-# Building linux-x64-tests-clang
-ninja -C {out}/linux-x64-tests-clang check
-
-# Build-only
-ninja -C {out}/linux-x64-tests-coverage default
-
-# Initial coverage baseline
-lcov --initial --capture --directory {out}/linux-x64-tests-coverage/obj --output-file {out}/linux-x64-tests-coverage/coverage/lcov_base.info
-
-# Building linux-x64-tests-coverage
-ninja -C {out}/linux-x64-tests-coverage check
-
-# Update coverage
-lcov --capture --directory {out}/linux-x64-tests-coverage/obj --output-file {out}/linux-x64-tests-coverage/coverage/lcov_test.info
-
-# Final coverage info
-lcov --add-tracefile {out}/linux-x64-tests-coverage/coverage/lcov_base.info --add-tracefile {out}/linux-x64-tests-coverage/coverage/lcov_test.info --output-file {out}/linux-x64-tests-coverage/coverage/lcov_final.info
-
-# HTML coverage
-genhtml {out}/linux-x64-tests-coverage/coverage/lcov_final.info --output-directory {out}/linux-x64-tests-coverage/coverage/html
 
 # Building linux-x64-thermostat
 ninja -C {out}/linux-x64-thermostat


### PR DESCRIPTION
#### Problem
Allow build_examples.py to control the crypto library target: pick one of openssl (typical default on host builds) or mbedtls or boringssl

#### Change overview
Add crypto library variant support
Enforce and show in the name that arm cross compiles are clang based
Moved coverage tests and clang tests to no-glob (as they overlap with regular tests, no reason to build all).

#### Testing
CI tests updated.