### PR TITLE
ExchangeHolder: A RAII'fied, safer, hands-free construct for EC clean-up management

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -664,7 +664,7 @@ bool InteractionModelEngine::TrimFabricForSubscriptions(FabricIndex aFabricIndex
          eventPathsSubscribedByCurrentFabric > perFabricPathCapacity ||
          subscriptionsEstablishedByCurrentFabric > perFabricSubscriptionCapacity))
     {
-        candidate->Abort();
+        candidate->Close();
         return true;
     }
     return false;
@@ -847,7 +847,7 @@ bool InteractionModelEngine::TrimFabricForRead(FabricIndex aFabricIndex)
          // Always evict the transactions on PASE sessions if the fabric table is full.
          (aFabricIndex == kUndefinedFabricIndex && mpFabricTable->FabricCount() == GetConfigMaxFabrics())))
     {
-        candidate->Abort();
+        candidate->Close();
         return true;
     }
     return false;

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -40,6 +40,7 @@
 #include <lib/support/DLLUtil.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeHolder.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
@@ -368,7 +369,6 @@ private:
     CHIP_ERROR ProcessAttributeReportIBs(TLV::TLVReader & aAttributeDataIBsReader);
     CHIP_ERROR ProcessEventReportIBs(TLV::TLVReader & aEventReportIBsReader);
 
-    void ClearExchangeContext() { mpExchangeCtx = nullptr; }
     static void OnLivenessTimeoutCallback(System::Layer * apSystemLayer, void * apAppState);
     CHIP_ERROR ProcessSubscribeResponse(System::PacketBufferHandle && aPayload);
     CHIP_ERROR RefreshLivenessCheckTimer();
@@ -415,7 +415,7 @@ private:
     CHIP_ERROR GetMinEventNumber(const ReadPrepareParams & aReadPrepareParams, Optional<EventNumber> & aEventMin);
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
-    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
+    Messaging::ExchangeHolder mExchange;
     Callback & mpCallback;
     ClientState mState                = ClientState::Idle;
     bool mIsReporting                 = false;

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -39,7 +39,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeHolder.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
@@ -354,20 +354,8 @@ private:
         AwaitingDestruction,    ///< The object has completed its work and is awaiting destruction by the application.
     };
 
-    /*
-     * This forcibly closes the exchange context if a valid one is pointed to. Such a situation does
-     * not arise during normal message processing flows that all normally call Close() above.
-     *
-     * This will eventually call Close() to drive the process of eventually releasing this object (unless called from the
-     * destructor).
-     *
-     * This is only called by a very narrow set of external objects as needed.
-     */
-    void Abort(bool aCalledFromDestructor = false);
-
     /**
-     * Called internally to signal the completion of all work on this object, gracefully close the
-     * exchange and finally, signal to a registerd callback that it's
+     * Called internally to signal the completion of all work on this objecta and signal to a registered callback that it's
      * safe to release this object.
      */
     void Close();
@@ -445,7 +433,7 @@ private:
     // TODO: We should shutdown the transaction when the session expires.
     SessionHolder mSessionHandle;
 
-    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
+    Messaging::ExchangeHolder mExchangeCtx;
 
     ObjectList<AttributePathParams> * mpAttributePathList   = nullptr;
     ObjectList<EventPathParams> * mpEventPathList           = nullptr;

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -515,15 +515,8 @@ CHIP_ERROR Engine::BuildAndSendSingleReportData(ReadHandler * apReadHandler)
                   mCurReadHandlerIdx, hasMoreChunks ? "more messages" : "no more messages");
 
 exit:
-    if (err != CHIP_NO_ERROR)
-    {
-        //
-        // WillSendMessage() was called on this EC well before it got here (since there was an intention to generate reports, which
-        // occurs asynchronously. Consequently, if any error occurs, it's on us to close down the exchange.
-        //
-        apReadHandler->Abort();
-    }
-    else if ((apReadHandler->IsType(ReadHandler::InteractionType::Read) && !hasMoreChunks) || needCloseReadHandler)
+    if (err != CHIP_NO_ERROR || (apReadHandler->IsType(ReadHandler::InteractionType::Read) && !hasMoreChunks) ||
+        needCloseReadHandler)
     {
         //
         // In the case of successful report generation and we're on the last chunk of a read, we don't expect

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -2045,9 +2045,6 @@ void TestReadInteraction::TestSubscribeEarlyShutdown(nlTestSuite * apSuite, void
         NL_TEST_ASSERT(apSuite, engine.ActiveHandlerAt(0) != nullptr);
         delegate.mpReadHandler = engine.ActiveHandlerAt(0);
         NL_TEST_ASSERT(apSuite, delegate.mpReadHandler != nullptr);
-
-        // Shutdown the subscription
-        readClient.Abort();
     }
 
     // Cleanup

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -43,6 +43,7 @@ static_library("messaging") {
     "ExchangeContext.cpp",
     "ExchangeContext.h",
     "ExchangeDelegate.h",
+    "ExchangeHolder.h",
     "ExchangeMessageDispatch.cpp",
     "ExchangeMessageDispatch.h",
     "ExchangeMgr.cpp",

--- a/src/messaging/ExchangeContext.cpp
+++ b/src/messaging/ExchangeContext.cpp
@@ -309,6 +309,19 @@ ExchangeContext::ExchangeContext(ExchangeManager * em, uint16_t ExchangeId, cons
     mFlags.Set(Flags::kFlagEphemeralExchange, isEphemeralExchange);
     mDelegate = delegate;
 
+    //
+    // If we're an initiator and we just created this exchange, we obviously did so to send a message. Let's go ahead and
+    // set the flag on this to correctly mark it as so.
+    //
+    // This only applies to non-ephemeral exchanges. Ephemeral exchanges do not have an intention of sending out a message
+    // since they're created expressly for the purposes of sending out a standalone ACK when the message could not be handled
+    // through normal means.
+    //
+    if (Initiator && !isEphemeralExchange)
+    {
+        WillSendMessage();
+    }
+
     SetAckPending(false);
 
     // Do not request Ack for multicast

--- a/src/messaging/ExchangeContext.h
+++ b/src/messaging/ExchangeContext.h
@@ -54,6 +54,7 @@ public:
  *    This class represents an ongoing conversation (ExchangeContext) between two or more nodes.
  *    It defines methods for encoding and communicating CHIP messages within an ExchangeContext
  *    over various transport mechanisms, for example, TCP, UDP, or CHIP Reliable Messaging.
+ *
  */
 class DLL_EXPORT ExchangeContext : public ReliableMessageContext,
                                    public ReferenceCounted<ExchangeContext, ExchangeContextDeletor>,
@@ -204,6 +205,13 @@ public:
      */
     bool IsResponseExpected() const;
 
+    /**
+     * Determine whether we are expecting our consumer to send a message on
+     * this exchange (i.e. WillSendMessage was called and the message has not
+     * yet been sent).
+     */
+    bool IsSendExpected() const { return mFlags.Has(Flags::kFlagWillSendMessage); }
+
 private:
     class ExchangeSessionHolder : public SessionHolderWithDelegate
     {
@@ -220,13 +228,6 @@ private:
 
     ExchangeSessionHolder mSession; // The connection state
     uint16_t mExchangeId;           // Assigned exchange ID.
-
-    /**
-     * Determine whether we are expecting our consumer to send a message on
-     * this exchange (i.e. WillSendMessage was called and the message has not
-     * yet been sent).
-     */
-    bool IsSendExpected() const { return mFlags.Has(Flags::kFlagWillSendMessage); }
 
     /**
      *  Track whether we are now expecting a response to a message sent via this exchange (because that

--- a/src/messaging/ExchangeHolder.h
+++ b/src/messaging/ExchangeHolder.h
@@ -1,0 +1,140 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <lib/core/Optional.h>
+#include <lib/support/IntrusiveList.h>
+#include <messaging/ExchangeContext.h>
+
+namespace chip {
+namespace Messaging {
+
+/**
+ * @brief
+ *   This provides a RAII'fied wrapper for an ExchangeContext that automatically manages
+ *   cleaning up the EC when the holder ceases to exist, or acquires a new exchange. This is
+ *   meant to be used by application and protocol logic code that would otherwise need to closely
+ *   manage their internal pointers to an ExchangeContext and correctly
+ *   null-it out/abort it depending on the circumstances. This relies on clear rules
+ *   established by ExchangeContext and the transfer of ownership at various points
+ *   in its lifetime.
+ *
+ *   It does this by intercepting OnExchangeClosing and looking at the various
+ *   states the exchange might be in to decide how best to correctly shutdown the exchange.
+ *   (see AbortIfNeeded()).
+ *
+ *   This is a delegate forwarder - consumers can still register to be an ExchangeDelegate
+ *   and get notified of all relevant happenings on that delegate interface.
+ *
+ */
+class ExchangeHolder : public ExchangeDelegate
+{
+public:
+    /**
+     * @brief
+     *    Constructor that takes an ExchangeDelegate that is forwarded all relevant
+     *    calls from the underlying exchange.
+     */
+    ExchangeHolder(ExchangeDelegate & delegate) : mpExchangeDelegate(delegate) {}
+
+    virtual ~ExchangeHolder() { Release(); }
+
+    bool Contains(const ExchangeContext * exchange) const { return mpExchangeCtx == exchange; }
+
+    /**
+     * @brief
+     *    Replaces the held exchange and associated delegate to instead track the given ExchangeContext, aborting
+     *    and dereferencing any previously held exchange as necessary. This method should be called whenever protocol logic
+     *    that is managing this holder is transitioning from an outdated Exchange to a new one, often during
+     *    the start of a new transaction.
+     */
+    void Grab(ExchangeContext * exchange)
+    {
+        Release();
+
+        mpExchangeCtx = exchange;
+        mpExchangeCtx->SetDelegate(this);
+    }
+
+    /*
+     * @brief
+     *    This shuts down the exchange (if a valid one is being tracked) and releases our reference to it.
+     */
+    void Release()
+    {
+        if (mpExchangeCtx)
+        {
+            mpExchangeCtx->SetDelegate(nullptr);
+
+            /**
+             * Shutting down the exchange requires calling Abort() on the exchange selectively in the following scenarios:
+             *      1. The exchange is currently awaiting a response. This would have happened if our consumer just sent a message
+             * on the exchange and is awaiting a response. Since we no longer care to wait for the response, we don't care about
+             * doing MRP retries for the send we just did, so abort the exchange.
+             *
+             *      2. Our consumer has signaled an interest in sending a message. This could have been signaled right at exchange
+             * creation time as the initiator, or when handling a message and the consumer intends to send a response, albeit,
+             * asynchronously. In both cases, the stack expects the exchange consumer to close/abort the EC if it no longer has
+             * interest in it. Since we don't have a pending message at this point, calling Abort is OK here as well.
+             *
+             */
+            if (mpExchangeCtx->IsResponseExpected() || mpExchangeCtx->IsSendExpected())
+            {
+                mpExchangeCtx->Abort();
+            }
+        }
+
+        mpExchangeCtx = nullptr;
+    }
+
+    explicit operator bool() const { return mpExchangeCtx != nullptr; }
+    ExchangeContext * Get() const { return mpExchangeCtx; }
+
+    ExchangeContext * operator->() const
+    {
+        VerifyOrDie(mpExchangeCtx != nullptr);
+        return mpExchangeCtx;
+    }
+
+private:
+    CHIP_ERROR OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                 System::PacketBufferHandle && payload) override
+    {
+        return mpExchangeDelegate.OnMessageReceived(ec, payloadHeader, std::move(payload));
+    }
+
+    void OnResponseTimeout(ExchangeContext * ec) override { return mpExchangeDelegate.OnResponseTimeout(ec); }
+
+    void OnExchangeClosing(ExchangeContext * ec) override
+    {
+        if (mpExchangeCtx)
+        {
+            mpExchangeCtx->SetDelegate(nullptr);
+            mpExchangeCtx = nullptr;
+        }
+
+        mpExchangeDelegate.OnExchangeClosing(ec);
+    }
+
+    ExchangeMessageDispatch & GetMessageDispatch() override { return mpExchangeDelegate.GetMessageDispatch(); }
+
+    ExchangeDelegate & mpExchangeDelegate;
+    ExchangeContext * mpExchangeCtx = nullptr;
+};
+
+} // namespace Messaging
+} // namespace chip

--- a/src/messaging/tests/BUILD.gn
+++ b/src/messaging/tests/BUILD.gn
@@ -50,6 +50,7 @@ chip_test_suite("tests") {
     # And TestAbortExchangesForFabric does not link on EFR32 for some reason.
     test_sources += [
       "TestAbortExchangesForFabric.cpp",
+      "TestExchangeHolder.cpp",
       "TestExchangeMgr.cpp",
       "TestReliableMessageProtocol.cpp",
     ]

--- a/src/messaging/tests/TestExchangeHolder.cpp
+++ b/src/messaging/tests/TestExchangeHolder.cpp
@@ -1,0 +1,441 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for aborting existing exchanges (except
+ *      one) for a fabric.
+ */
+
+#include "messaging/ExchangeDelegate.h"
+#include <lib/support/UnitTestContext.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <lib/support/UnitTestUtils.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeHolder.h>
+#include <messaging/ExchangeMgr.h>
+#include <messaging/tests/MessagingContext.h>
+#include <protocols/Protocols.h>
+#include <system/SystemPacketBuffer.h>
+#include <transport/SessionManager.h>
+
+namespace chip {
+namespace Protocols {
+
+//
+// Let's create a mock protocol that encapsulates a 3 message exchange to test out the ExchangeHolder
+// and the various states the underlying exchange might be set to, altering the clean-up behavior
+// the holder will execute depending on those states.
+//
+namespace MockProtocol {
+static constexpr Id Id(VendorId::TestVendor1, 1);
+
+enum class MessageType : uint8_t
+{
+    kMsg1 = 0x01,
+    kMsg2 = 0x02,
+    kMsg3 = 0x03
+};
+} // namespace MockProtocol
+
+template <>
+struct MessageTypeTraits<MockProtocol::MessageType>
+{
+    static constexpr const Protocols::Id & ProtocolId() { return MockProtocol::Id; }
+};
+
+} // namespace Protocols
+} // namespace chip
+
+namespace {
+
+using namespace chip;
+using namespace chip::Messaging;
+using namespace chip::System;
+using namespace chip::Protocols;
+
+using TestContext = Test::LoopbackMessagingContext;
+
+TestContext * gCtx = nullptr;
+
+class MockProtocolResponder : public ExchangeDelegate, public Messaging::UnsolicitedMessageHandler
+{
+public:
+    enum class BehaviorModifier
+    {
+        kNone,
+        kHoldMsg1,
+    };
+
+    MockProtocolResponder(BehaviorModifier modifier = BehaviorModifier::kNone) : mExchangeCtx(*this)
+    {
+        VerifyOrDie(gCtx != nullptr);
+        mBehaviorModifier = modifier;
+        gCtx->GetExchangeManager().RegisterUnsolicitedMessageHandlerForProtocol(chip::Protocols::MockProtocol::Id, this);
+    }
+
+    ~MockProtocolResponder()
+    {
+        gCtx->GetExchangeManager().UnregisterUnsolicitedMessageHandlerForProtocol(chip::Protocols::MockProtocol::Id);
+    }
+
+    bool DidInteractionSucceed() { return mInteractionSucceeded; }
+
+private:
+    CHIP_ERROR OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                 System::PacketBufferHandle && buffer) override;
+
+    CHIP_ERROR OnUnsolicitedMessageReceived(const PayloadHeader & payloadHeader, ExchangeDelegate *& newDelegate) override
+    {
+        newDelegate = this;
+        return CHIP_NO_ERROR;
+    }
+
+    void OnResponseTimeout(ExchangeContext * ec) override {}
+
+    ExchangeHolder mExchangeCtx;
+    BehaviorModifier mBehaviorModifier = BehaviorModifier::kNone;
+    bool mInteractionSucceeded         = false;
+};
+
+class MockProtocolInitiator : public ExchangeDelegate
+{
+public:
+    enum class BehaviorModifier
+    {
+        kNone,
+        kHoldMsg2,
+    };
+
+    MockProtocolInitiator(BehaviorModifier modifier = BehaviorModifier::kNone) : mExchangeCtx(*this)
+    {
+        mBehaviorModifier = modifier;
+    }
+
+    CHIP_ERROR StartInteraction(SessionHandle & sessionHandle);
+
+    bool DidInteractionSucceed() { return mInteractionSucceeded; }
+
+private:
+    CHIP_ERROR OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                 System::PacketBufferHandle && buffer) override;
+
+    void OnResponseTimeout(ExchangeContext * ec) override {}
+
+    ExchangeHolder mExchangeCtx;
+    BehaviorModifier mBehaviorModifier = BehaviorModifier::kNone;
+    bool mInteractionSucceeded         = false;
+};
+
+CHIP_ERROR MockProtocolResponder::OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                                    System::PacketBufferHandle && buffer)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (payloadHeader.HasMessageType(chip::Protocols::MockProtocol::MessageType::kMsg1))
+    {
+        //
+        // This is the first message in the exchange - let's have our holder start managing the exchange by grabbing it.
+        //
+        mExchangeCtx.Grab(ec);
+
+        if (mBehaviorModifier != BehaviorModifier::kHoldMsg1)
+        {
+            PacketBufferHandle respBuffer = MessagePacketBuffer::New(0);
+            VerifyOrReturnError(!buffer.IsNull(), CHIP_ERROR_NO_MEMORY);
+            ReturnErrorOnFailure(mExchangeCtx->SendMessage(chip::Protocols::MockProtocol::MessageType::kMsg2, std::move(respBuffer),
+                                                           SendMessageFlags::kExpectResponse));
+        }
+        else
+        {
+            mExchangeCtx->WillSendMessage();
+        }
+    }
+    else if (payloadHeader.HasMessageType(chip::Protocols::MockProtocol::MessageType::kMsg3))
+    {
+        mInteractionSucceeded = true;
+    }
+    else
+    {
+        err = CHIP_ERROR_INVALID_MESSAGE_TYPE;
+    }
+
+    return err;
+}
+
+CHIP_ERROR MockProtocolInitiator::StartInteraction(SessionHandle & sessionHandle)
+{
+    PacketBufferHandle buffer = MessagePacketBuffer::New(0);
+    VerifyOrReturnError(!buffer.IsNull(), CHIP_ERROR_NO_MEMORY);
+
+    auto exchange = gCtx->GetExchangeManager().NewContext(sessionHandle, this);
+    VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    //
+    // This is the first exchange in this interaction - let's have our holder start managing the exchange by grabbing it.
+    //
+    mExchangeCtx.Grab(exchange);
+
+    ReturnErrorOnFailure(mExchangeCtx->SendMessage(chip::Protocols::MockProtocol::MessageType::kMsg1, std::move(buffer),
+                                                   SendMessageFlags::kExpectResponse));
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR MockProtocolInitiator::OnMessageReceived(ExchangeContext * ec, const PayloadHeader & payloadHeader,
+                                                    System::PacketBufferHandle && buffer)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    if (payloadHeader.HasMessageType(chip::Protocols::MockProtocol::MessageType::kMsg2))
+    {
+        if (mBehaviorModifier != BehaviorModifier::kHoldMsg2)
+        {
+            PacketBufferHandle respBuffer = MessagePacketBuffer::New(0);
+            VerifyOrReturnError(!buffer.IsNull(), CHIP_ERROR_NO_MEMORY);
+            ReturnErrorOnFailure(mExchangeCtx->SendMessage(chip::Protocols::MockProtocol::MessageType::kMsg3, std::move(respBuffer),
+                                                           SendMessageFlags::kNone));
+
+            mInteractionSucceeded = true;
+        }
+        else
+        {
+            mExchangeCtx->WillSendMessage();
+        }
+    }
+    else
+    {
+        err = CHIP_ERROR_INVALID_MESSAGE_TYPE;
+    }
+
+    return err;
+}
+
+void TestExchangeHolder(nlTestSuite * inSuite, void * inContext)
+{
+    TestContext & ctx = *reinterpret_cast<TestContext *>(inContext);
+
+    gCtx = &ctx;
+
+    auto sessionHandle = ctx.GetSessionAliceToBob();
+
+    //
+    // #1: Initiator >--- Msg1 --X  Responder.
+    //
+    // Initiator sends Msg1 to Responder, but we set it up such that Responder doesn't actually
+    // receive the message.
+    //
+    // Then, destroy both objects. Initiator's holder should correctly abort the exchange since it's waiting for
+    // a response.
+    //
+    {
+        ChipLogProgress(ExchangeManager, "-------- #1: Initiator >-- Msg1 --X Responder ---------");
+
+        {
+            MockProtocolInitiator initiator;
+            MockProtocolResponder responder;
+
+            auto err = initiator.StartInteraction(sessionHandle);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+        }
+
+        //
+        // Service IO AFTER the objects above cease to exist to prevent Msg1 from getting to Responder. This also
+        // flush any pending messages in the queue.
+        //
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(inSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    }
+
+    //
+    // #2: Initiator --- Msg1 -->  Responder (WillSend)
+    //
+    // Initiator sends Msg1 to Responder, which is received successfully. However, Responder
+    // doesn't send a response right away (calls WillSendMessage() on the EC).
+    //
+    // Then, destroy both objects. Initiator's holder should correctly abort the exchange since it's waiting for
+    // a response, and so should the Responder's holder since it has yet to send a message.
+    //
+    {
+        {
+            ChipLogProgress(ExchangeManager, "-------- #2: Initiator >-- Msg1 --> Responder (WillSend) ---------");
+
+            MockProtocolInitiator initiator;
+            MockProtocolResponder responder(MockProtocolResponder::BehaviorModifier::kHoldMsg1);
+
+            auto err = initiator.StartInteraction(sessionHandle);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+        }
+
+        NL_TEST_ASSERT(inSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    }
+
+    //
+    // #3:            Initiator --- Msg1 -->  Responder
+    //     (WillSend) Initiator <-- Msg2 <--  Responder
+    //
+    // Initiator receives Msg2 back from Responder, but calls WillSend on that EC.
+    //
+    // Then, destroy both objects. Initiator's holder should correctly abort the exchange since it's waiting
+    // to send a response, and Responder's holder should abort as well since it's waiting for a response.
+    //
+    {
+        {
+            ChipLogProgress(ExchangeManager, "-------- #3: (WillSend) Initiator <-- Msg2 <-- Responder ---------");
+
+            MockProtocolInitiator initiator(MockProtocolInitiator::BehaviorModifier::kHoldMsg2);
+            MockProtocolResponder responder;
+
+            auto err = initiator.StartInteraction(sessionHandle);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+        }
+
+        NL_TEST_ASSERT(inSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    }
+
+    //
+    // #4:            Initiator --- Msg1 -->  Responder
+    //                Initiator <-- Msg2 <--  Responder
+    //                Initiator >-- Msg3 -->  Responder
+    //
+    // Initiator sends final message in exchange to Responder, which is received successfully.
+    //
+    // Then, destroy both objects. Initiator's holder should NOT abort the underlying exchange since
+    // it has sent the final message in the exchange, while responder's holder should NOT abor the underlying
+    // exchange either since it is not going to send any further messages on the exchange.
+    //
+    {
+        {
+            ChipLogProgress(ExchangeManager, "-------- #4: Initiator >-- Msg3 -->  Responder ---------");
+
+            MockProtocolInitiator initiator;
+            MockProtocolResponder responder;
+
+            auto err = initiator.StartInteraction(sessionHandle);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+        }
+
+        NL_TEST_ASSERT(inSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    }
+
+    //
+    // #5:            Initiator --- Msg1 -->  Responder (WillSend)
+    //                Initiator --- Msg1 -->  Responder (WillSend)
+    //
+    // Similar to #2, except we have Initiator start the interaction again. This validates
+    // ExchangeHolder::Grab in correctly aborting a previous exchange and acquiring a new one.
+    //
+    // Then, destroy both objects. Both holders should abort the exchange (see #2).
+    //
+    {
+        {
+            ChipLogProgress(ExchangeManager, "-------- #5: Initiator >-- Msg1 -->  Responder (WillSend) X2 ---------");
+
+            MockProtocolInitiator initiator;
+            MockProtocolResponder responder(MockProtocolResponder::BehaviorModifier::kHoldMsg1);
+
+            auto err = initiator.StartInteraction(sessionHandle);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+
+            err = initiator.StartInteraction(sessionHandle);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+        }
+
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(inSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    }
+
+    //
+    // #6:            Initiator --- Msg1 -->  Responder
+    //                Initiator <-- Msg2 <--  Responder
+    //                Initiator >-- Msg3 -->  Responder
+    //
+    //                X2
+    //
+    // Similar to #4, except we do the entire interaction twice. This validates
+    // ExchangeHolder::Grab in correctly releasing a reference to a previous exchange (but not aborting it)
+    // and acquiring a new one.
+    //
+    // Then, destroy both objects. Both holders should release their reference without aborting.
+    //
+    {
+        {
+            ChipLogProgress(ExchangeManager, "-------- #6: Initiator >-- Msg3 -->  Responder X2 ---------");
+
+            MockProtocolInitiator initiator;
+            MockProtocolResponder responder;
+
+            auto err = initiator.StartInteraction(sessionHandle);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+
+            err = initiator.StartInteraction(sessionHandle);
+            NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+            ctx.DrainAndServiceIO();
+        }
+
+        NL_TEST_ASSERT(inSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+    }
+}
+
+// Test Suite
+
+/**
+ *  Test Suite that lists all the test functions.
+ */
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestExchangeHolder", TestExchangeHolder),
+
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+// clang-format off
+nlTestSuite sSuite =
+{
+    "Test-TestExchangeHolder",
+    &sTests[0],
+    TestContext::Initialize,
+    TestContext::Finalize
+};
+// clang-format on
+
+} // anonymous namespace
+
+/**
+ *  Main
+ */
+int TestExchangeHolder()
+{
+    return chip::ExecuteTestsWithContext<TestContext>(&sSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestExchangeHolder);


### PR DESCRIPTION
#### Problem

Most protocol layer logic need to keep a pointer to the `ExchangeContext` around while they transition between states of sending out a message and waiting for responses. They carefully 'null out' this pointer once they have sent or received the last message in a given exchange. If they abruptly get shutdown, they look at this pointer to decide if they should abort it given the EC is still alive and well.

This results in bugs that PRs like #20141 need to fix.

#### Solution

Creation of a new RAII'fied `ExchangeHolder` that manages a pointer to an `ExchangeContext`, that automatically and safely, manages not just 'null'ing out the EC (i.e setting it's delegate pointer to null), but also calling `Abort()` as needed when it gets destroyed along with its consuming object.

It does so by implementing the contract that is codified in the ExchangeContext today in terms of when you're permitted to call Abort() on it as an application/protocol layer logic using an EC. It also utilizes `OnExchangeClosing` to safely know the exchange is being scheduled for closure to then correctly null out its delegate.

I've updated `ReadClient` to show-case it as a proof-of-concept.