### PR TITLE
Mark fabric-scoped commands in the XML and use that in codegen.

### DIFF
--- a/src/app/zap-templates/templates/app/cluster-objects-src.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects-src.zapt
@@ -173,66 +173,32 @@ bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand)
     return false;
 }
 
-// TODO(#20811): Actually generate the following based on ZAP metadata
-// See https://github.com/project-chip/zap/issues/609
 bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)
 {
     // Maybe it would be smaller code to codegen a table and walk over it?
     // Not sure.
     switch (aCluster)
     {
-    case Clusters::Groups::Id: {
-        switch (aCommand)
-        {
-        case Clusters::Groups::Commands::AddGroup::Id:
-        case Clusters::Groups::Commands::ViewGroup::Id:
-        case Clusters::Groups::Commands::GetGroupMembership::Id:
-        case Clusters::Groups::Commands::RemoveGroup::Id:
-        case Clusters::Groups::Commands::RemoveAllGroups::Id:
-            return true;
-        default:
-            return false;
-        }
+    {{#zcl_clusters}}
+      {{#zcl_commands}}
+      {{#first}}
+      case Clusters::{{asUpperCamelCase parent.name}}::Id:
+      {
+          switch (aCommand) {
+      {{/first}}
+          {{#if isFabricScoped}}
+          case Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::Id:
+              return true;
+          {{/if}}
+      {{#last}}
+          default:
+              return false;
+          }
+      }
+      {{/last}}
+      {{/zcl_commands}}
+    {{/zcl_clusters}}
     }
-    case Clusters::GroupKeyManagement::Id: {
-        switch (aCommand)
-        {
-        case Clusters::GroupKeyManagement::Commands::KeySetWrite::Id:
-        case Clusters::GroupKeyManagement::Commands::KeySetRead::Id:
-        case Clusters::GroupKeyManagement::Commands::KeySetRemove::Id:
-        case Clusters::GroupKeyManagement::Commands::KeySetReadAllIndices::Id:
-            return true;
-        default:
-            return false;
-        }
-    }
-    case Clusters::GeneralCommissioning::Id: {
-        switch (aCommand)
-        {
-        case Clusters::GeneralCommissioning::Commands::CommissioningComplete::Id:
-            return true;
-        default:
-            return false;
-        }
-    }
-    case Clusters::Scenes::Id: {
-        // Entire cluster is fabric-scoped.
-        return true;
-    }
-    case Clusters::OperationalCredentials::Id: {
-        switch (aCommand)
-        {
-        case Clusters::OperationalCredentials::Commands::UpdateNOC::Id:
-        case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id:
-            return true;
-        default:
-            return false;
-        }
-    }
-    default:
-        break;
-    }
-
     return false;
 }
 

--- a/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/general-commissioning-cluster.xml
@@ -74,7 +74,7 @@ limitations under the License.
       <arg name="errorCode" type="CommissioningError"/>
       <arg name="debugText" type="CHAR_STRING"/>
     </command>
-    <command source="client" code="0x04" name="CommissioningComplete" response="CommissioningCompleteResponse" optional="false" cli="chip fabric_commissioning commissioningcomplete">
+    <command source="client" code="0x04" name="CommissioningComplete" response="CommissioningCompleteResponse" isFabricScoped="true" optional="false" cli="chip fabric_commissioning commissioningcomplete">
       <description>Signals the Server that the Client has successfully completed all steps of Commissioning/Recofiguration needed during fail-safe period.</description>
       <access op="invoke" privilege="administer"/>
     </command>

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -65,13 +65,13 @@ limitations under the License.
     <attribute side="server" code="0x0002" define="MAX_GROUPS_PER_FABRIC" type="INT16U" writable="false" optional="false">MaxGroupsPerFabric</attribute>
     <attribute side="server" code="0x0003" define="MAX_GROUP_KEYS_PER_FABRIC" type="INT16U" writable="false" optional="false">MaxGroupKeysPerFabric</attribute>
 
-    <command source="client" code="0x00" name="KeySetWrite" optional="false" cli="zcl GroupKeyManagement KeySetWrite">
+    <command source="client" code="0x00" name="KeySetWrite" isFabricScoped="true" optional="false" cli="zcl GroupKeyManagement KeySetWrite">
       <description>Revoke a Root Key from a Group</description>
       <arg name="GroupKeySet" type="GroupKeySetStruct"/>
       <access op="invoke" privilege="administer"/>
     </command>
 
-    <command source="client" code="0x01" name="KeySetRead" response="KeySetReadResponse" optional="false" cli="zcl GroupKeyManagement KeySetRead">
+    <command source="client" code="0x01" name="KeySetRead" isFabricScoped="true" response="KeySetReadResponse" optional="false" cli="zcl GroupKeyManagement KeySetRead">
       <description>Revoke a Root Key from a Group</description>
       <arg name="GroupKeySetID" type="INT16U"/>
       <access op="invoke" privilege="administer"/>
@@ -84,13 +84,13 @@ limitations under the License.
       <arg name="GroupKeySet" type="GroupKeySetStruct"/>
     </command>
 
-    <command source="client" code="0x03" name="KeySetRemove" optional="false" cli="zcl GroupKeyManagement KeySetRemove">
+    <command source="client" code="0x03" name="KeySetRemove" isFabricScoped="true" optional="false" cli="zcl GroupKeyManagement KeySetRemove">
       <description>Revoke a Root Key from a Group</description>
       <arg name="GroupKeySetID" type="INT16U"/>
       <access op="invoke" privilege="administer"/>
     </command>
 
-    <command source="client" code="0x04" name="KeySetReadAllIndices" response="KeySetReadAllIndicesResponse" optional="false" cli="zcl GroupKeyManagement KeySetReadAllIndices">
+    <command source="client" code="0x04" name="KeySetReadAllIndices" response="KeySetReadAllIndicesResponse" isFabricScoped="true" optional="false" cli="zcl GroupKeyManagement KeySetReadAllIndices">
       <description>Return the list of Group Key Sets associated with the accessing fabric</description>
       <arg name="GroupKeySetIDs" type="INT16U" array="true"/>
       <access op="invoke" privilege="administer"/>

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -113,7 +113,7 @@ limitations under the License.
       <access op="invoke" privilege="administer"/>
     </command>
 
-    <command source="client" code="0x07" name="UpdateNOC" response="NOCResponse" optional="false">
+    <command source="client" code="0x07" name="UpdateNOC" response="NOCResponse" isFabricScoped="true" optional="false">
       <description>Sender is requesting to update the node operational certificates.</description>
       <arg name="NOCValue" type="OCTET_STRING"/>
       <arg name="ICACValue" type="OCTET_STRING" optional="true"/>
@@ -127,7 +127,7 @@ limitations under the License.
       <arg name="DebugText" type="CHAR_STRING" optional="true"/>
     </command>
 
-    <command source="client" code="0x09" name="UpdateFabricLabel" response="NOCResponse" optional="false">
+    <command source="client" code="0x09" name="UpdateFabricLabel" response="NOCResponse" isFabricScoped="true" optional="false">
       <description>This command SHALL be used by an Administrative Node to set the user-visible Label field for a given Fabric, as reflected by entries in the Fabrics attribute.</description>
       <arg name="Label" type="CHAR_STRING" length="32"/>
       <access op="invoke" privilege="administer"/>

--- a/src/app/zap-templates/zcl/data-model/chip/scene.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/scene.xml
@@ -52,7 +52,7 @@ limitations under the License.
     <attribute side="server" code="0x0004" define="SCENE_NAME_SUPPORT" type="BITMAP8" min="0x00" max="0x80" writable="false" default="0x00" optional="false">NameSupport</attribute>
     <attribute side="server" code="0x0005" define="LAST_CONFIGURED_BY" type="node_id" writable="false" isNullable="true" optional="true">LastConfiguredBy</attribute>
    
-    <command source="client" code="0x00" name="AddScene" response="AddSceneResponse" optional="false" cli="chip scenes add">
+    <command source="client" code="0x00" name="AddScene" response="AddSceneResponse" isFabricScoped="true" optional="false" cli="chip scenes add">
       <description>
         Add a scene to the scene table. Extension field sets are supported, and are inputed as '{"ClusterID": VALUE, "AttributeValueList":[{"AttributeId": VALUE, "AttributeValue": VALUE}]}'
       </description>
@@ -64,7 +64,7 @@ limitations under the License.
       <access op="invoke" role="manage"/>
     </command>
    
-    <command source="client" code="0x01" name="ViewScene" response="ViewSceneResponse" optional="false" cli="chip scenes view">
+    <command source="client" code="0x01" name="ViewScene" response="ViewSceneResponse" isFabricScoped="true" optional="false" cli="chip scenes view">
       <description>
         Retrieves the requested scene entry from its Scene table.
       </description>
@@ -72,7 +72,7 @@ limitations under the License.
       <arg name="SceneId" type="INT8U"/>
     </command>
    
-    <command source="client" code="0x02" name="RemoveScene" response="RemoveSceneResponse" optional="false" cli="chip scenes remove">
+    <command source="client" code="0x02" name="RemoveScene" response="RemoveSceneResponse" isFabricScoped="true" optional="false" cli="chip scenes remove">
       <description>
         Removes the requested scene entry, corresponding to the value of the GroupID field, from its Scene Table
       </description>
@@ -81,7 +81,7 @@ limitations under the License.
       <access op="invoke" role="manage"/>
     </command>
     
-    <command source="client" code="0x03" name="RemoveAllScenes" response="RemoveAllScenesResponse" optional="false" cli="chip scenes rmall">
+    <command source="client" code="0x03" name="RemoveAllScenes" response="RemoveAllScenesResponse" isFabricScoped="true" optional="false" cli="chip scenes rmall">
       <description>
         Remove all scenes, corresponding to the value of the GroupID field, from its Scene Table
       </description>
@@ -89,7 +89,7 @@ limitations under the License.
       <access op="invoke" role="manage"/>
     </command>
     
-    <command source="client" code="0x04" name="StoreScene" response="StoreSceneResponse" optional="false" cli="chip scenes store">
+    <command source="client" code="0x04" name="StoreScene" response="StoreSceneResponse" isFabricScoped="true" optional="false" cli="chip scenes store">
       <description>
         Adds the scene entry into its Scene Table along with all extension field sets corresponding to the current state of other clusters on the same endpoint
       </description>
@@ -98,7 +98,7 @@ limitations under the License.
       <access op="invoke" role="manage"/>
     </command>
     
-    <command source="client" code="0x05" name="RecallScene" optional="false" cli="chip scenes recall">
+    <command source="client" code="0x05" name="RecallScene" isFabricScoped="true" optional="false" cli="chip scenes recall">
       <description>
         Set the attributes and corresponding state for each other cluster implemented on the endpoint accordingly to the resquested scene entry in the Scene Table
       </description>
@@ -107,14 +107,14 @@ limitations under the License.
       <arg name="TransitionTime" type="INT16U" optional="true" isNullable="true"/>
     </command>
    
-    <command source="client" code="0x06" name="GetSceneMembership" response="GetSceneMembershipResponse" optional="false" cli="chip scenes get">
+    <command source="client" code="0x06" name="GetSceneMembership" response="GetSceneMembershipResponse" isFabricScoped="true" optional="false" cli="chip scenes get">
       <description>
         Get an unused scene identifier when no commissioning tool is in the network, or for a commissioning tool to get the used scene identifiers within a certain group 
       </description>
       <arg name="GroupId" type="group_id"/>
     </command>
 
-    <command source="client" code="0x40" name="EnhancedAddScene" response="EnhancedAddSceneResponse" optional="true" cli="chip scenes eadd">
+    <command source="client" code="0x40" name="EnhancedAddScene" response="EnhancedAddSceneResponse" isFabricScoped="true" optional="true" cli="chip scenes eadd">
       <description>
         Allows a scene to be added using a finer scene transition time than the AddScene command.
       </description>
@@ -124,14 +124,14 @@ limitations under the License.
       <arg name="SceneName" type="CHAR_STRING"/>
       <arg name="ExtensionFieldSets" type="ExtensionFieldSet" array="true"/>
     </command>
-    <command source="client" code="0x41" name="EnhancedViewScene" response="EnhancedViewSceneResponse" optional="true" noDefaultImplementation="true" cli="chip scenes eview">
+    <command source="client" code="0x41" name="EnhancedViewScene" response="EnhancedViewSceneResponse" isFabricScoped="true" optional="true" noDefaultImplementation="true" cli="chip scenes eview">
       <description>
         Allows a scene to be retrieved using a finer scene transition time than the ViewScene command
       </description>
       <arg name="GroupId" type="group_id"/>
       <arg name="SceneId" type="INT8U"/>
     </command>
-    <command source="client" code="0x42" name="CopyScene" response="CopySceneResponse" optional="true" cli="chip scenes copy">
+    <command source="client" code="0x42" name="CopyScene" response="CopySceneResponse" isFabricScoped="true" optional="true" cli="chip scenes copy">
       <description>
         Allows a client to efficiently copy scenes from one group/scene identifier pair to another group/scene identifier pair.
       </description>

--- a/src/app/zap-templates/zcl/data-model/silabs/general.xml
+++ b/src/app/zap-templates/zcl/data-model/silabs/general.xml
@@ -100,7 +100,7 @@ limitations under the License.
     <globalAttribute side="either" code="0xFFFD" value="3"/>
     <attribute side="server" code="0x0000" define="GROUP_NAME_SUPPORT" type="BITMAP8" min="0x00" max="0x80" writable="false" optional="false">name support</attribute>
     <!-- NAME_SUPPORT -->
-    <command source="client" code="0x00" name="AddGroup" response="AddGroupResponse" optional="false" cli="zcl groups add">
+    <command source="client" code="0x00" name="AddGroup" response="AddGroupResponse" isFabricScoped="true" optional="false" cli="zcl groups add">
       <description>
         Command description for AddGroup
       </description>
@@ -108,32 +108,32 @@ limitations under the License.
       <arg name="groupName" type="CHAR_STRING"/>
       <access op="invoke" role="manage"/>
     </command>
-    <command source="client" code="0x01" name="ViewGroup" response="ViewGroupResponse" optional="false" cli="zcl groups view">
+    <command source="client" code="0x01" name="ViewGroup" response="ViewGroupResponse" isFabricScoped="true" optional="false" cli="zcl groups view">
       <description>
         Command description for ViewGroup
       </description>
       <arg name="groupId" type="group_id"/>
     </command>
-    <command source="client" code="0x02" name="GetGroupMembership" response="GetGroupMembershipResponse" cliFunctionName="zclGroupsGetCommand" optional="false" cli="zcl groups get">
+    <command source="client" code="0x02" name="GetGroupMembership" response="GetGroupMembershipResponse" cliFunctionName="zclGroupsGetCommand" isFabricScoped="true" optional="false" cli="zcl groups get">
       <description>
         Command description for GetGroupMembership
       </description>
       <arg name="groupList" type="group_id" array="true"/>
     </command>
-    <command source="client" code="0x03" name="RemoveGroup" response="RemoveGroupResponse" optional="false" cli="zcl groups remove">
+    <command source="client" code="0x03" name="RemoveGroup" response="RemoveGroupResponse" isFabricScoped="true" optional="false" cli="zcl groups remove">
       <description>
         Command description for RemoveGroup
       </description>
       <arg name="groupId" type="group_id"/>
       <access op="invoke" role="manage"/>
     </command>
-    <command source="client" code="0x04" name="RemoveAllGroups" optional="false" cli="zcl groups rmall">
+    <command source="client" code="0x04" name="RemoveAllGroups" isFabricScoped="true" optional="false" cli="zcl groups rmall">
       <description>
         Command description for RemoveAllGroups
       </description>
       <access op="invoke" role="manage"/>
     </command>
-    <command source="client" code="0x05" name="AddGroupIfIdentifying" optional="false" cli="zcl groups add-if-id">
+    <command source="client" code="0x05" name="AddGroupIfIdentifying" isFabricScoped="true" optional="false" cli="zcl groups add-if-id">
       <description>
         Command description for AddGroupIfIdentifying
       </description>

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -20695,35 +20695,103 @@ bool CommandNeedsTimedInvoke(ClusterId aCluster, CommandId aCommand)
     return false;
 }
 
-// TODO(#20811): Actually generate the following based on ZAP metadata
-// See https://github.com/project-chip/zap/issues/609
 bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)
 {
     // Maybe it would be smaller code to codegen a table and walk over it?
     // Not sure.
     switch (aCluster)
     {
+    case Clusters::Identify::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
     case Clusters::Groups::Id: {
         switch (aCommand)
         {
         case Clusters::Groups::Commands::AddGroup::Id:
+            return true;
         case Clusters::Groups::Commands::ViewGroup::Id:
+            return true;
         case Clusters::Groups::Commands::GetGroupMembership::Id:
+            return true;
         case Clusters::Groups::Commands::RemoveGroup::Id:
+            return true;
         case Clusters::Groups::Commands::RemoveAllGroups::Id:
+            return true;
+        case Clusters::Groups::Commands::AddGroupIfIdentifying::Id:
             return true;
         default:
             return false;
         }
     }
-    case Clusters::GroupKeyManagement::Id: {
+    case Clusters::Scenes::Id: {
         switch (aCommand)
         {
-        case Clusters::GroupKeyManagement::Commands::KeySetWrite::Id:
-        case Clusters::GroupKeyManagement::Commands::KeySetRead::Id:
-        case Clusters::GroupKeyManagement::Commands::KeySetRemove::Id:
-        case Clusters::GroupKeyManagement::Commands::KeySetReadAllIndices::Id:
+        case Clusters::Scenes::Commands::AddScene::Id:
             return true;
+        case Clusters::Scenes::Commands::ViewScene::Id:
+            return true;
+        case Clusters::Scenes::Commands::RemoveScene::Id:
+            return true;
+        case Clusters::Scenes::Commands::RemoveAllScenes::Id:
+            return true;
+        case Clusters::Scenes::Commands::StoreScene::Id:
+            return true;
+        case Clusters::Scenes::Commands::RecallScene::Id:
+            return true;
+        case Clusters::Scenes::Commands::GetSceneMembership::Id:
+            return true;
+        case Clusters::Scenes::Commands::EnhancedAddScene::Id:
+            return true;
+        case Clusters::Scenes::Commands::EnhancedViewScene::Id:
+            return true;
+        case Clusters::Scenes::Commands::CopyScene::Id:
+            return true;
+        default:
+            return false;
+        }
+    }
+    case Clusters::OnOff::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::LevelControl::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::BridgedActions::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::Basic::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::OtaSoftwareUpdateProvider::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::OtaSoftwareUpdateRequestor::Id: {
+        switch (aCommand)
+        {
         default:
             return false;
         }
@@ -20737,24 +20805,215 @@ bool CommandIsFabricScoped(ClusterId aCluster, CommandId aCommand)
             return false;
         }
     }
-    case Clusters::Scenes::Id: {
-        // Entire cluster is fabric-scoped.
-        return true;
+    case Clusters::NetworkCommissioning::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::DiagnosticLogs::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::GeneralDiagnostics::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::SoftwareDiagnostics::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::ThreadNetworkDiagnostics::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::WiFiNetworkDiagnostics::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::EthernetNetworkDiagnostics::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::AdministratorCommissioning::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
     }
     case Clusters::OperationalCredentials::Id: {
         switch (aCommand)
         {
         case Clusters::OperationalCredentials::Commands::UpdateNOC::Id:
+            return true;
         case Clusters::OperationalCredentials::Commands::UpdateFabricLabel::Id:
             return true;
         default:
             return false;
         }
     }
-    default:
-        break;
+    case Clusters::GroupKeyManagement::Id: {
+        switch (aCommand)
+        {
+        case Clusters::GroupKeyManagement::Commands::KeySetWrite::Id:
+            return true;
+        case Clusters::GroupKeyManagement::Commands::KeySetRead::Id:
+            return true;
+        case Clusters::GroupKeyManagement::Commands::KeySetRemove::Id:
+            return true;
+        case Clusters::GroupKeyManagement::Commands::KeySetReadAllIndices::Id:
+            return true;
+        default:
+            return false;
+        }
     }
-
+    case Clusters::ModeSelect::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::DoorLock::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::WindowCovering::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::BarrierControl::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::Thermostat::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::ColorControl::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::Channel::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::TargetNavigator::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::MediaPlayback::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::MediaInput::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::LowPower::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::KeypadInput::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::ContentLauncher::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::AudioOutput::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::ApplicationLauncher::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::AccountLogin::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::ElectricalMeasurement::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    case Clusters::TestCluster::Id: {
+        switch (aCommand)
+        {
+        default:
+            return false;
+        }
+    }
+    }
     return false;
 }
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/20811

#### Problem
Hardcoding which commands are fabric-scoped.  This does not allow non-standard things to be fabric-scoped.

#### Change overview
Use XML data for this instead.

#### Testing
Looked at generated code.