### PR TITLE
Remove unused field from WiFi commissioning driver

### DIFF
--- a/src/include/platform/NetworkCommissioning.h
+++ b/src/include/platform/NetworkCommissioning.h
@@ -135,7 +135,7 @@ public:
     public:
         /**
          * @brief Callback for the network driver pushing the event of network status change to the network commissioning cluster.
-         * The platforms is explected to push the status from operations such as autonomous connection after loss of connectivity or
+         * The platforms is expected to push the status from operations such as autonomous connection after loss of connectivity or
          * during initial establishment.
          *
          * This function must be called in a thread-safe manner with CHIP stack.

--- a/src/platform/Ameba/NetworkCommissioningDriver.h
+++ b/src/platform/Ameba/NetworkCommissioningDriver.h
@@ -127,7 +127,6 @@ private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
     CHIP_ERROR StartScanWiFiNetworks(ByteSpan ssid);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
     ScanCallback * mpScanCallback;

--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.h
@@ -134,9 +134,8 @@ private:
     bool StartScanWiFiNetworks(ByteSpan ssid);
     static void OnScanWiFiNetworkDone(wfx_wifi_scan_result_t * aScanResult);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
-    WiFiNetwork mSavedNetwork         = {};
-    WiFiNetwork mStagingNetwork       = {};
+    WiFiNetwork mSavedNetwork   = {};
+    WiFiNetwork mStagingNetwork = {};
     ScanCallback * mpScanCallback;
     ConnectCallback * mpConnectCallback;
 };

--- a/src/platform/ESP32/NetworkCommissioningDriver.h
+++ b/src/platform/ESP32/NetworkCommissioningDriver.h
@@ -127,7 +127,6 @@ private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
     CHIP_ERROR StartScanWiFiNetworks(ByteSpan ssid);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
     ScanCallback * mpScanCallback;

--- a/src/platform/Linux/NetworkCommissioningDriver.h
+++ b/src/platform/Linux/NetworkCommissioningDriver.h
@@ -47,7 +47,7 @@ public:
 
 private:
     size_t currentIterating = 0;
-    // Note: We cannot post a event in ScheduleLambda since std::vector is not trivial copiable.
+    // Note: We cannot post a event in ScheduleLambda since std::vector is not trivial copyable.
     std::vector<T> * mpScanResponse;
 };
 
@@ -102,7 +102,6 @@ public:
 private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
     Optional<Status> mScanStatus;

--- a/src/platform/P6/NetworkCommissioningDriver.h
+++ b/src/platform/P6/NetworkCommissioningDriver.h
@@ -133,7 +133,6 @@ private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
     CHIP_ERROR StartScanWiFiNetworks(ByteSpan ssid);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
     ScanCallback * mpScanCallback;

--- a/src/platform/Tizen/NetworkCommissioningDriver.h
+++ b/src/platform/Tizen/NetworkCommissioningDriver.h
@@ -74,7 +74,6 @@ public:
 private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
 };

--- a/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.h
+++ b/src/platform/bouffalolab/BL602/NetworkCommissioningDriver.h
@@ -129,7 +129,6 @@ private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
     CHIP_ERROR StartScanWiFiNetworks(ByteSpan ssid);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
     ScanCallback * mpScanCallback;

--- a/src/platform/mbed/NetworkCommissioningDriver.h
+++ b/src/platform/mbed/NetworkCommissioningDriver.h
@@ -143,7 +143,6 @@ private:
 
     chip::DeviceLayer::Internal::WiFiAuthSecurityType NsapiToNetworkSecurity(nsapi_security_t nsapi_security);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
     ScanCallback * mScanCallback;

--- a/src/platform/webos/NetworkCommissioningDriver.h
+++ b/src/platform/webos/NetworkCommissioningDriver.h
@@ -47,7 +47,7 @@ public:
 
 private:
     size_t currentIterating = 0;
-    // Note: We cannot post a event in ScheduleLambda since std::vector is not trivial copiable.
+    // Note: We cannot post a event in ScheduleLambda since std::vector is not trivial copyable.
     std::vector<T> * mpScanResponse;
 };
 
@@ -102,7 +102,6 @@ public:
 private:
     bool NetworkMatch(const WiFiNetwork & network, ByteSpan networkId);
 
-    WiFiNetworkIterator mWiFiIterator = WiFiNetworkIterator(this);
     WiFiNetwork mSavedNetwork;
     WiFiNetwork mStagingNetwork;
     Optional<Status> mScanStatus;


### PR DESCRIPTION
#### Problem

It seems that WiFi commissioning driver class (for most platforms) has unused private field `mWiFiIterator`.

#### Change overview

- removed unused field
- small typo fixes

#### Testing

CI will test that.