### PR TITLE
Improve discovery logging a bit.

### DIFF
--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -70,8 +70,11 @@ static void HandleNodeResolve(void * context, DnssdService * result, const Span<
 
     nodeData.resolutionData.port = result->mPort;
 
+    ChipLogDetail(Discovery, "Node with instance name %s discovered. TXT:", nodeData.commissionData.instanceName);
     for (size_t i = 0; i < result->mTextEntrySize; ++i)
     {
+        ChipLogDetail(Discovery, "  %s: %.*s", result->mTextEntries[i].mKey, static_cast<int>(result->mTextEntries[i].mDataSize),
+                      result->mTextEntries[i].mData);
         ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
         ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
         FillNodeDataFromTxt(key, val, nodeData.resolutionData);
@@ -134,8 +137,11 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, const Spa
     }
     nodeData.resolutionData.numIPs = addressesFound;
 
+    ChipLogDetail(Discovery, "Node with operational ID %s resolved. TXT:", result->mName);
     for (size_t i = 0; i < result->mTextEntrySize; ++i)
     {
+        ChipLogDetail(Discovery, "  %s: %.*s", result->mTextEntries[i].mKey, static_cast<int>(result->mTextEntries[i].mDataSize),
+                      result->mTextEntries[i].mData);
         ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
         ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
         FillNodeDataFromTxt(key, val, nodeData.resolutionData);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -70,17 +70,15 @@ static void HandleNodeResolve(void * context, DnssdService * result, const Span<
 
     nodeData.resolutionData.port = result->mPort;
 
-    ChipLogDetail(Discovery, "Node with instance name %s discovered. TXT:", nodeData.commissionData.instanceName);
     for (size_t i = 0; i < result->mTextEntrySize; ++i)
     {
-        ChipLogDetail(Discovery, "  %s: %.*s", result->mTextEntries[i].mKey, static_cast<int>(result->mTextEntries[i].mDataSize),
-                      result->mTextEntries[i].mData);
         ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
         ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
         FillNodeDataFromTxt(key, val, nodeData.resolutionData);
         FillNodeDataFromTxt(key, val, nodeData.commissionData);
     }
 
+    nodeData.LogDetail();
     proxy->OnNodeDiscovered(nodeData);
     proxy->Release();
 }
@@ -137,11 +135,8 @@ static void HandleNodeIdResolve(void * context, DnssdService * result, const Spa
     }
     nodeData.resolutionData.numIPs = addressesFound;
 
-    ChipLogDetail(Discovery, "Node with operational ID %s resolved. TXT:", result->mName);
     for (size_t i = 0; i < result->mTextEntrySize; ++i)
     {
-        ChipLogDetail(Discovery, "  %s: %.*s", result->mTextEntries[i].mKey, static_cast<int>(result->mTextEntries[i].mDataSize),
-                      result->mTextEntries[i].mData);
         ByteSpan key(reinterpret_cast<const uint8_t *>(result->mTextEntries[i].mKey), strlen(result->mTextEntries[i].mKey));
         ByteSpan val(result->mTextEntries[i].mData, result->mTextEntries[i].mDataSize);
         FillNodeDataFromTxt(key, val, nodeData.resolutionData);

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -125,6 +125,7 @@ struct CommonResolutionData
         {
             ChipLogDetail(Discovery, "\tMrp Interval active: not present");
         }
+        ChipLogDetail(Discovery, "\tTCP Supported: %d", supportsTcp);
     }
 };
 
@@ -243,6 +244,7 @@ struct DiscoveredNodeData
 
     void LogDetail() const
     {
+        ChipLogDetail(Discovery, "Discovered node:");
         resolutionData.LogDetail();
         commissionData.LogDetail();
     }

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -262,7 +262,7 @@ RegisterContext::RegisterContext(const char * sType, DnssdPublishCallback cb, vo
 
 void RegisterContext::DispatchFailure(DNSServiceErrorType err)
 {
-    ChipLogError(DeviceLayer, "Register (%s)", Error::ToString(err));
+    ChipLogError(Discovery, "Mdns: Register failure (%s)", Error::ToString(err));
     callback(context, nullptr, CHIP_ERROR_INTERNAL);
     MdnsContexts::GetInstance().Remove(this);
 }
@@ -283,7 +283,7 @@ BrowseContext::BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServ
 
 void BrowseContext::DispatchFailure(DNSServiceErrorType err)
 {
-    ChipLogError(DeviceLayer, "Browse (%s)", Error::ToString(err));
+    ChipLogError(Discovery, "Mdns: Browse failure (%s)", Error::ToString(err));
     callback(context, nullptr, 0, CHIP_ERROR_INTERNAL);
     MdnsContexts::GetInstance().Remove(this);
 }
@@ -309,7 +309,7 @@ ResolveContext::~ResolveContext()
 
 void ResolveContext::DispatchFailure(DNSServiceErrorType err)
 {
-    ChipLogError(DeviceLayer, "Resolve (%s)", Error::ToString(err));
+    ChipLogError(Discovery, "Mdns: Resolve failure (%s)", Error::ToString(err));
     callback(context, nullptr, Span<Inet::IPAddress>(), CHIP_ERROR_INTERNAL);
     MdnsContexts::GetInstance().Remove(this);
 }
@@ -326,6 +326,7 @@ void ResolveContext::DispatchSuccess()
             continue;
         }
 
+        ChipLogDetail(Discovery, "Mdns: Resolve success on interface %" PRIu32, interface.first);
         callback(context, &interface.second.service, Span<Inet::IPAddress>(ips.data(), ips.size()), CHIP_NO_ERROR);
         break;
     }
@@ -342,7 +343,7 @@ CHIP_ERROR ResolveContext::OnNewAddress(uint32_t interfaceId, const struct socka
 #ifdef CHIP_DETAIL_LOGGING
     char addrStr[INET6_ADDRSTRLEN];
     ip.ToString(addrStr, sizeof(addrStr));
-    ChipLogDetail(DeviceLayer, "Mdns: %s interface: %" PRIu32 " ip:%s", __func__, interfaceId, addrStr);
+    ChipLogDetail(Discovery, "Mdns: %s interface: %" PRIu32 " ip:%s", __func__, interfaceId, addrStr);
 #endif // CHIP_DETAIL_LOGGING
 
     return CHIP_NO_ERROR;
@@ -376,7 +377,7 @@ bool ResolveContext::HasAddress()
 void ResolveContext::OnNewInterface(uint32_t interfaceId, const char * fullname, const char * hostnameWithDomain, uint16_t port,
                                     uint16_t txtLen, const unsigned char * txtRecord)
 {
-    ChipLogDetail(DeviceLayer, "Mdns : %s hostname:%s fullname:%s interface: %" PRIu32, __func__, hostnameWithDomain, fullname,
+    ChipLogDetail(Discovery, "Mdns : %s hostname:%s fullname:%s interface: %" PRIu32, __func__, hostnameWithDomain, fullname,
                   interfaceId);
 
     InterfaceInfo interface;

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -100,7 +100,7 @@ void LogOnFailure(const char * name, DNSServiceErrorType err)
 {
     if (kDNSServiceErr_NoError != err)
     {
-        ChipLogError(DeviceLayer, "%s (%s)", name, Error::ToString(err));
+        ChipLogError(Discovery, "%s (%s)", name, Error::ToString(err));
     }
 }
 
@@ -165,7 +165,7 @@ namespace {
 static void OnRegister(DNSServiceRef sdRef, DNSServiceFlags flags, DNSServiceErrorType err, const char * name, const char * type,
                        const char * domain, void * context)
 {
-    ChipLogDetail(DeviceLayer, "Mdns: %s name: %s, type: %s, domain: %s, flags: %d", __func__, name, type, domain, flags);
+    ChipLogDetail(Discovery, "Mdns: %s name: %s, type: %s, domain: %s, flags: %d", __func__, name, type, domain, flags);
 
     auto sdCtx = reinterpret_cast<RegisterContext *>(context);
     sdCtx->Finalize(err);
@@ -174,7 +174,7 @@ static void OnRegister(DNSServiceRef sdRef, DNSServiceFlags flags, DNSServiceErr
 CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t interfaceId, const char * type, const char * name,
                     uint16_t port, ScopedTXTRecord & record)
 {
-    ChipLogProgress(DeviceLayer, "Publishing service %s on port %u with type: %s on interface id: %" PRIu32, name, port, type,
+    ChipLogProgress(Discovery, "Publishing service %s on port %u with type: %s on interface id: %" PRIu32, name, port, type,
                     interfaceId);
 
     RegisterContext * sdCtx = nullptr;
@@ -198,7 +198,7 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
 
 void OnBrowseAdd(BrowseContext * context, const char * name, const char * type, const char * domain, uint32_t interfaceId)
 {
-    ChipLogDetail(DeviceLayer, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, name, type, domain,
+    ChipLogDetail(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, name, type, domain,
                   interfaceId);
 
     VerifyOrReturn(strcmp(kLocalDot, domain) == 0);
@@ -225,7 +225,7 @@ void OnBrowseAdd(BrowseContext * context, const char * name, const char * type, 
 
 void OnBrowseRemove(BrowseContext * context, const char * name, const char * type, const char * domain, uint32_t interfaceId)
 {
-    ChipLogDetail(DeviceLayer, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, name, type, domain,
+    ChipLogDetail(Discovery, "Mdns: %s  name: %s, type: %s, domain: %s, interface: %" PRIu32, __func__, name, type, domain,
                   interfaceId);
 
     VerifyOrReturn(strcmp(kLocalDot, domain) == 0);
@@ -259,7 +259,7 @@ CHIP_ERROR Browse(void * context, DnssdBrowseCallback callback, uint32_t interfa
     auto sdCtx = chip::Platform::New<BrowseContext>(context, callback, protocol);
     VerifyOrReturnError(nullptr != sdCtx, CHIP_ERROR_NO_MEMORY);
 
-    ChipLogProgress(DeviceLayer, "Browsing for: %s", type);
+    ChipLogProgress(Discovery, "Browsing for: %s", type);
     DNSServiceRef sdRef;
     auto err = DNSServiceBrowse(&sdRef, kBrowseFlags, interfaceId, type, kLocalDot, OnBrowse, sdCtx);
     VerifyOrReturnError(kDNSServiceErr_NoError == err, sdCtx->Finalize(err));
@@ -329,7 +329,7 @@ static void OnResolve(DNSServiceRef sdRef, DNSServiceFlags flags, uint32_t inter
 static CHIP_ERROR Resolve(void * context, DnssdResolveCallback callback, uint32_t interfaceId,
                           chip::Inet::IPAddressType addressType, const char * type, const char * name)
 {
-    ChipLogDetail(DeviceLayer, "Resolve type=%s name=%s interface=%" PRIu32, type, name, interfaceId);
+    ChipLogDetail(Discovery, "Resolve type=%s name=%s interface=%" PRIu32, type, name, interfaceId);
 
     auto sdCtx = chip::Platform::New<ResolveContext>(context, callback, addressType);
     VerifyOrReturnError(nullptr != sdCtx, CHIP_ERROR_NO_MEMORY);


### PR DESCRIPTION
1) In shared "platform" discovery code, log when we discovered an operational id
   or a commissionable instance and what the TXT records were.
2) In Darwin code, do Discovery, not DeviceLayer logging and improve some of the
   log messages.

The intent is to make it a little clearer on failure where in the pipeline
things stop propagating information.

#### Problem
Can't tell whether we never got "all" addresses or whether consumer just ignored the result.

#### Change overview
Log when we plan to notify the consumer.

#### Testing
Ran chip-tool, saw the updated logs.