### PR TITLE
[K32W0] Update VS Docker image to accomodate SDK 2.6.6

### DIFF
--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -41,6 +41,8 @@ COPY --from=crosscompile /opt/ubuntu-21.04-aarch64-sysroot /opt/ubuntu-21.04-aar
 
 COPY --from=ameba /opt/ameba /opt/ameba
 
+COPY --from=k32w /opt/sdk /opt/k32w_sdk
+
 COPY --from=imx /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
 
 COPY --from=ti /opt/ti/sysconfig_1.11.0 /opt/ti/sysconfig_1.11.0
@@ -73,7 +75,7 @@ ENV IDF_PATH=/opt/espressif/esp-idf/
 ENV IDF_TOOLS_PATH=/opt/espressif/tools
 ENV IMX_SDK_ROOT=/opt/fsl-imx-xwayland/5.10-hardknott/
 ENV NRF5_TOOLS_ROOT=/opt/NordicSemiconductor/nRF5_tools
-ENV NXP_K32W061_SDK_ROOT=/opt/sdk/sdks
+ENV NXP_K32W0_SDK_ROOT=/opt/k32w_sdk
 ENV OPENOCD_PATH=/opt/openocd/
 ENV PW_ENVIRONMENT_ROOT=/home/vscode/pigweed/env
 ENV QEMU_ESP32=/opt/espressif/qemu/xtensa-softmmu/qemu-system-xtensa

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.87 Version bump reason: K32W0-SDK 2.6.6 update
+0.5.88 Version bump reason: K32W0-SDK 2.6.6 update


### PR DESCRIPTION
Update VS Docker image to accomodate SDK 2.6.6
