### PR TITLE
Chef - Add automated_test_stamp to Chef CD builds

### DIFF
--- a/examples/chef/cicd_config.json
+++ b/examples/chef/cicd_config.json
@@ -2,14 +2,14 @@
     "ci_allow_list": ["rootnode_dimmablelight_bCwGYSDpoe"],
     "cd_platforms": {
         "linux": {
-            "linux_x86": ["--cpu_type", "x64"],
-            "linux_arm64_ipv6only": ["--cpu_type", "arm64", "--ipv6only"]
+            "linux_x86": ["--cpu_type", "x64", "-a"],
+            "linux_arm64_ipv6only": ["--cpu_type", "arm64", "--ipv6only", "-a"]
         },
         "esp32": {
-            "m5stack": []
+            "m5stack": ["-a"]
         },
         "nrfconnect": {
-            "nrf52840dk": []
+            "nrf52840dk": ["-a"]
         }
     }
 }


### PR DESCRIPTION
#### Problem
* Chef CD builds don't use the automated_test_stamp which is helpful to differentiate builds.

#### Change overview
* Add appropriate flag in Chef CD flow.

#### Testing
* Tested locally:
```
./chef.py -zcbra -d rootnode_dimmablelight_bCwGYSDpoe -t linux
./chef.py -zcbra -d rootnode_dimmablelight_bCwGYSDpoe -t esp32
./chef.py -zcbra -d rootnode_dimmablelight_bCwGYSDpoe -t nrfconnect
```