### PR TITLE
Fix the python output name

### DIFF
--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -358,7 +358,7 @@ chip_python_wheel_action("chip-clusters") {
   py_package_name = "chip-clusters"
   py_platform_tag = "any"
 
-  output_name = "chip_clusters-${chip_python_version}-py3-any.whl"
+  output_name = "chip_clusters-${chip_python_version}-py3-none-any.whl"
 }
 
 chip_python_wheel_action("chip-repl") {
@@ -406,5 +406,5 @@ chip_python_wheel_action("chip-repl") {
     ":chip-core",
   ]
 
-  output_name = "chip_repl-${chip_python_version}-py3-any.whl"
+  output_name = "chip_repl-${chip_python_version}-py3-none-any.whl"
 }


### PR DESCRIPTION
#### Problem

As of 61dd4d02047 ("[python] Split Python wheel in two separate wheels (#20054)")

ninja will forever try to regenerate this file because the filename is
specified incorrectly:

```
  ninja: Entering directory `out/debug'
  ninja explain: output linux_x64_gcc/controller/python/chip_repl-0.0-py3-any.whl doesn't exist
  ninja explain: linux_x64_gcc/controller/python/chip_repl-0.0-py3-any.whl is dirty
  ninja explain: output linux_x64_gcc/controller/python/chip_clusters-0.0-py3-any.whl doesn't exist
  ninja explain: linux_x64_gcc/controller/python/chip_clusters-0.0-py3-any.whl is dirty
  ninja explain: linux_x64_gcc/obj/src/controller/python/chip-repl.stamp is dirty
  ninja explain: linux_x64_gcc/obj/default.stamp is dirty
  ninja explain: obj/host_gcc.stamp is dirty
  ninja explain: obj/default.stamp is dirty
  [2/3] ACTION //src/controller/python:chip-clusters(//build/toolchain/host:linux_x64_gcc)
```

#### Change overview

Fix the output filename.

#### Testing

```
ninja -vC out/debug -d explain
```