### PR TITLE
Ignore StartupMode when rebooting due to OTA.

### DIFF
--- a/examples/ota-requestor-app/linux/main.cpp
+++ b/examples/ota-requestor-app/linux/main.cpp
@@ -347,7 +347,7 @@ int main(int argc, char * argv[])
         argv[0] = kImageExecPath;
         execv(argv[0], argv);
 
-        // If successfully executing the new iamge, execv should not return
+        // If successfully executing the new image, execv should not return
         ChipLogError(SoftwareUpdate, "The OTA image is invalid");
     }
     return 0;

--- a/src/app/clusters/mode-select-server/mode-select-server.cpp
+++ b/src/app/clusters/mode-select-server/mode-select-server.cpp
@@ -33,6 +33,7 @@
 #include <app/util/odd-sized-integers.h>
 #include <app/util/util.h>
 #include <lib/support/CodeUtils.h>
+#include <platform/DiagnosticDataProvider.h>
 
 using namespace std;
 using namespace chip;
@@ -40,6 +41,8 @@ using namespace chip::app;
 using namespace chip::app::Clusters;
 using namespace chip::app::Clusters::ModeSelect;
 using namespace chip::Protocols;
+
+using BootReasonType = GeneralDiagnostics::BootReasonType;
 
 static InteractionModel::Status verifyModeValue(const EndpointId endpointId, const uint8_t newMode);
 
@@ -132,9 +135,6 @@ void emberAfModeSelectClusterServerInitCallback(EndpointId endpointId)
         EmberAfStatus status = Attributes::StartUpMode::Get(endpointId, startUpMode);
         if (status == EMBER_ZCL_STATUS_SUCCESS && !startUpMode.IsNull())
         {
-            // Initialise currentMode to 0
-            uint8_t currentMode = 0;
-            status              = Attributes::CurrentMode::Get(endpointId, &currentMode);
 #ifdef EMBER_AF_PLUGIN_ON_OFF
             // OnMode with Power Up
             // If the On/Off feature is supported and the On/Off cluster attribute StartUpOnOff is present, with a
@@ -158,7 +158,27 @@ void emberAfModeSelectClusterServerInitCallback(EndpointId endpointId)
                 }
             }
 #endif // EMBER_AF_PLUGIN_ON_OFF
-            if (status == EMBER_ZCL_STATUS_SUCCESS && startUpMode.Value() != currentMode)
+
+            BootReasonType bootReason = BootReasonType::kUnspecified;
+            CHIP_ERROR error          = DeviceLayer::GetDiagnosticDataProvider().GetBootReason(bootReason);
+
+            if (error != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Unable to retrieve boot reason: %" CHIP_ERROR_FORMAT, error.Format());
+                // We really only care whether the boot reason is OTA.  Assume it's not.
+                bootReason = BootReasonType::kUnspecified;
+            }
+            if (bootReason == BootReasonType::kSoftwareUpdateCompleted)
+            {
+                ChipLogDetail(Zcl, "ModeSelect: CurrentMode is ignored for OTA reboot");
+                return;
+            }
+
+            // Initialise currentMode to 0
+            uint8_t currentMode = 0;
+            status              = Attributes::CurrentMode::Get(endpointId, &currentMode);
+
+            if ((status == EMBER_ZCL_STATUS_SUCCESS) && (startUpMode.Value() != currentMode))
             {
                 status = Attributes::CurrentMode::Set(endpointId, startUpMode.Value());
                 if (status != EMBER_ZCL_STATUS_SUCCESS)

--- a/src/lib/support/SafeInt.h
+++ b/src/lib/support/SafeInt.h
@@ -34,14 +34,13 @@ namespace chip {
  * of type U to the given type T.  It does this by verifying that the value is
  * in the range of valid values for T.
  */
-template <typename T, typename U>
+template <typename T, typename U, std::enable_if_t<std::is_integral<T>::value, int> = 0>
 bool CanCastTo(U arg)
 {
     using namespace std;
     // U might be a reference to an integer type, if we're assigning from
     // something passed by reference.
     typedef typename remove_reference<U>::type V; // V for "value"
-    static_assert(is_integral<T>::value, "Must be assigning to an integral type");
     static_assert(is_integral<V>::value, "Must be assigning from an integral type");
 
     // We want to check that "arg" can fit inside T but without doing any tests
@@ -103,6 +102,12 @@ bool CanCastTo(U arg)
     }
 
     return 0 <= arg && static_cast<uintmax_t>(arg) <= static_cast<uintmax_t>(numeric_limits<T>::max());
+}
+
+template <typename T, typename U, std::enable_if_t<std::is_enum<T>::value, int> = 0>
+bool CanCastTo(U arg)
+{
+    return CanCastTo<std::underlying_type_t<T>>(arg);
 }
 
 /**

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
@@ -72,16 +72,12 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
 CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
 {
     uint32_t reason = 0;
+    ReturnErrorOnFailure(ConfigurationMgr().GetBootReason(reason));
 
-    CHIP_ERROR err = ConfigurationMgr().GetBootReason(reason);
+    VerifyOrReturnError(CanCastTo<BootReasonType>(reason), CHIP_ERROR_INVALID_INTEGER_VALUE);
+    bootReason = static_cast<BootReasonType>(reason);
 
-    if (err == CHIP_NO_ERROR)
-    {
-        VerifyOrReturnError(CanCastTo<BootReasonType>(reason), CHIP_ERROR_INVALID_INTEGER_VALUE);
-        bootReason = static_cast<BootReasonType>(reason);
-    }
-
-    return err;
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.cpp
@@ -23,6 +23,7 @@
 
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
+#include <lib/support/SafeInt.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/Darwin/DiagnosticDataProviderImpl.h>
 #include <platform/DiagnosticDataProvider.h>
@@ -66,6 +67,21 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetTotalOperationalHours(uint32_t & total
     }
 
     return CHIP_ERROR_INVALID_TIME;
+}
+
+CHIP_ERROR DiagnosticDataProviderImpl::GetBootReason(BootReasonType & bootReason)
+{
+    uint32_t reason = 0;
+
+    CHIP_ERROR err = ConfigurationMgr().GetBootReason(reason);
+
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(CanCastTo<BootReasonType>(reason), CHIP_ERROR_INVALID_INTEGER_VALUE);
+        bootReason = static_cast<BootReasonType>(reason);
+    }
+
+    return err;
 }
 
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWatermarks()

--- a/src/platform/Darwin/DiagnosticDataProviderImpl.h
+++ b/src/platform/Darwin/DiagnosticDataProviderImpl.h
@@ -38,6 +38,7 @@ public:
     // ===== Methods that implement the PlatformManager abstract interface.
     CHIP_ERROR GetUpTime(uint64_t & upTime) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
 
     // ===== Methods that implement the DiagnosticDataProvider abstract interface.
     bool SupportsWatermarks() override { return true; }


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/19272

This will only work on platforms that actually set boot reasons
properly (i.e. probably not Mac/Linux).

#### Problem
See #19272.

#### Change overview
Change StartupMode handling to ignore the attribute when rebooting for OTA.  This is extracted from https://github.com/project-chip/connectedhomeip/pull/20440

#### Testing
1. Made sure that normal restart of all-clusters-app on Mac picks up the StartupMode.
2. Hacked up the Darwin version of `DiagnosticDataProviderImpl::GetBootReason` to return `kSoftwareUpdateCompleted` and verified that in this case the pre-restart CurrentMode value sticks around instead of StartupMode overwriting it.