### PR TITLE
Fix storage location of Docker images and containers for Mac or linux

### DIFF
--- a/integrations/docker/build.sh
+++ b/integrations/docker/build.sh
@@ -33,6 +33,12 @@ IMAGE=${DOCKER_BUILD_IMAGE:-$(basename "$(pwd)")}
 # version
 VERSION=${DOCKER_BUILD_VERSION:-$(sed 's/ .*//' version)}
 
+if [[ $OSTYPE == 'darwin'* ]]; then
+    DOCKER_VOLUME_PATH=~/Library/Containers/com.docker.docker/Data/vms/0/
+else
+    DOCKER_VOLUME_PATH=/var/lib/docker/
+fi
+
 [[ ${*/--help//} != "${*}" ]] && {
     set +x
     echo "Usage: $me <OPTIONS>
@@ -59,7 +65,7 @@ set -ex
 
 [[ -n $VERSION ]] || die "version cannot be empty"
 
-mb_space_before=$(df -m /var/lib/docker/ | awk 'FNR==2{print $3}')
+mb_space_before=$(df -m "$DOCKER_VOLUME_PATH" | awk 'FNR==2{print $3}')
 
 # go find and build any CHIP images this image is "FROM"
 awk -F/ '/^FROM connectedhomeip/ {print $2}' Dockerfile | while read -r dep; do
@@ -92,8 +98,9 @@ docker image prune --force
 }
 
 docker images --filter=reference="$ORG/*"
-df -h /var/lib/docker/
-mb_space_after=$(df -m /var/lib/docker/ | awk 'FNR==2{print $3}')
+df -h "$DOCKER_VOLUME_PATH"
+mb_space_after=$(df -m "$DOCKER_VOLUME_PATH" | awk 'FNR==2{print $3}')
+
 printf "%'.f MB total used\n" "$((mb_space_before - mb_space_after))"
 
 exit 0


### PR DESCRIPTION
Problem
Information about used memory space when build image of docker on osx not working

Change overview

For linux  docker volume dir is /var/lib/docker/
For Mac docker volume dir is ~/Library/Containers/com.docker.docker/Data/vms/0/
A conditional statement has been added to check the system type.

Testing
Run ./integrations/docker/images/chip-build-tizen/build.sh
or other images