### PR TITLE
[QPG] Update flow for Server init in example apps

### DIFF
--- a/examples/lighting-app/qpg/include/AppTask.h
+++ b/examples/lighting-app/qpg/include/AppTask.h
@@ -48,11 +48,11 @@ private:
     friend AppTask & GetAppTask(void);
 
     CHIP_ERROR Init();
+    static void InitServer(intptr_t arg);
+    static void OpenCommissioning(intptr_t arg);
 
     static void ActionInitiated(LightingManager::Action_t aAction);
     static void ActionCompleted(LightingManager::Action_t aAction);
-
-    void CancelTimer(void);
 
     void DispatchEvent(AppEvent * event);
 
@@ -63,6 +63,7 @@ private:
     static void TimerEventHandler(chip::System::Layer * aLayer, void * aAppState);
 
     void StartTimer(uint32_t aTimeoutMs);
+    void CancelTimer(void);
 
     enum Function_t
     {

--- a/examples/lock-app/qpg/include/AppTask.h
+++ b/examples/lock-app/qpg/include/AppTask.h
@@ -52,6 +52,7 @@ private:
     friend AppTask & GetAppTask(void);
 
     CHIP_ERROR Init();
+    static void InitServer(intptr_t arg);
 
     static void ActionInitiated(BoltLockManager::Action_t aAction, int32_t aActor);
     static void ActionCompleted(BoltLockManager::Action_t aAction);

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -108,30 +108,8 @@ CHIP_ERROR AppTask::StartAppTask()
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR AppTask::Init()
+void AppTask::InitServer(intptr_t arg)
 {
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    ChipLogProgress(NotSpecified, "Current Software Version: %s", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
-
-    err = BoltLockMgr().Init();
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(NotSpecified, "BoltLockMgr().Init() failed");
-        return err;
-    }
-    BoltLockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
-
-    // Subscribe with our button callback to the qvCHIP button handler.
-    qvIO_SetBtnCallback(ButtonEventHandler);
-
-    qvIO_LedSet(LOCK_STATE_LED, !BoltLockMgr().IsUnlocked());
-
-#if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
-    chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
-#endif
-
-    // Init ZCL Data Model
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
 
@@ -145,8 +123,35 @@ CHIP_ERROR AppTask::Init()
     initParams.endpointNativeParams    = static_cast<void *>(&nativeParams);
     chip::Server::GetInstance().Init(initParams);
 
+#if CHIP_DEVICE_CONFIG_ENABLE_EXTENDED_DISCOVERY
+    chip::app::DnssdServer::Instance().SetExtendedDiscoveryTimeoutSecs(extDiscTimeoutSecs);
+#endif
+}
+CHIP_ERROR AppTask::Init()
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    ChipLogProgress(NotSpecified, "Current Software Version: %s", CHIP_DEVICE_CONFIG_DEVICE_SOFTWARE_VERSION_STRING);
+
+    // Init ZCL Data Model and start server
+    PlatformMgr().ScheduleWork(InitServer, 0);
+
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+
+    // Setup Bolt
+    err = BoltLockMgr().Init();
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(NotSpecified, "BoltLockMgr().Init() failed");
+        return err;
+    }
+    BoltLockMgr().SetCallbacks(ActionInitiated, ActionCompleted);
+
+    // Setup button handler
+    qvIO_SetBtnCallback(ButtonEventHandler);
+
+    qvIO_LedSet(LOCK_STATE_LED, !BoltLockMgr().IsUnlocked());
 
     UpdateClusterState();
 
@@ -164,7 +169,6 @@ void AppTask::AppTaskMain(void * pvParameter)
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(NotSpecified, "AppTask.Init() failed: %" CHIP_ERROR_FORMAT, err.Format());
-        return;
     }
 
     ChipLogProgress(NotSpecified, "App Task started");


### PR DESCRIPTION
#### Problem
* Server was initialized in the APP task while other Platform actions were running from the 'CHIP'/platform task.
* This created threading issues specifically for `RejoinExistingMulticastGroups()`, called from the Thread manager's `_OnPlatformEvent()` handling (CHIP task) as it could be called before the server intialized the Fabric list.

#### Change overview
* Moving init of Server to a Platform scheduled work. This will put both execution on the same task.
* Remains to be checked if `RejoinExistingMulticastGroups()` is actually functional.
* Updated opening of first advertising for lighting app to not open when part of a fabric.

#### Testing
* QPG Lighting app commissioned
* Application resetted
** Possibility for crash before the fix
** After fix, no crash seen - init flow runs from same task context (checked with debugger/logging)