### PR TITLE
[Telink]: Update to Zephyr v3.1.99 and removed hal deviation

### DIFF
--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -17,21 +17,17 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=95b54c90b1b7fb2626a9af3a5b7bd16459f35b45
+ARG ZEPHYR_REVISION=8cf9cc52e4de98d0303d8fed6a57ae956954986d
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
     west==0.12.0 \
-    && git clone https://github.com/rikorsev/zephyr \
+    && git clone https://github.com/telink-semi/zephyr \
     && cd zephyr \
     && git reset ${ZEPHYR_REVISION} --hard \
     && west init -l \
     && cd .. \
     && west update -o=--depth=1 -n -f smart \
-    && cd modules/hal/telink \
-    && git remote add telink https://github.com/rikorsev/hal_telink \
-    && git fetch telink telink_crypto \
-    && git checkout telink_crypto \
     && west zephyr-export \
     && : # last line
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.87 Version bump reason: K32W0-SDK 2.6.6 update
+0.5.88 Version bump reason: Update Telink Docker


### PR DESCRIPTION
**Problem**

To develop Matter OTA needs latest Zephyr version with Telink DFU support.

**Change overview**

Updated Telink Zephyr version and removed HAL deviation.
Switched to Telink Github account.

**Testing**

Tested manually.
Steps:

- Build image
- Run docker
- Check if Telink lighting-app example able to be built successfully