### PR TITLE
mdns: set authoritative bit for mDNS replies

### DIFF
--- a/src/lib/dnssd/minimal_mdns/ResponseBuilder.h
+++ b/src/lib/dnssd/minimal_mdns/ResponseBuilder.h
@@ -52,7 +52,7 @@ public:
             mBuildOk = false;
         }
 
-        mHeader.SetFlags(mHeader.GetFlags().SetResponse());
+        mHeader.SetFlags(mHeader.GetFlags().SetResponse().SetAuthoritative());
 
         mEndianOutput =
             chip::Encoding::BigEndian::BufferWriter(mPacket->Start(), mPacket->DataLength() + mPacket->AvailableDataLength());

--- a/src/lib/dnssd/minimal_mdns/core/DnsHeader.h
+++ b/src/lib/dnssd/minimal_mdns/core/DnsHeader.h
@@ -53,6 +53,9 @@ public:
     bool IsResponse() const { return (mValue & kIsResponseMask) == kIsResponseMask; }
     BitPackedFlags & SetResponse() { return SetMask(kIsResponseMask); }
 
+    bool IsAuthoritative() const { return (mValue & kAuthoritativeMask) == kAuthoritativeMask; }
+    BitPackedFlags & SetAuthoritative() { return SetMask(kAuthoritativeMask); }
+
     bool IsTruncated() const { return (mValue & kTruncationMask) != 0; }
     BitPackedFlags & SetTruncated(bool value) { return value ? SetMask(kTruncationMask) : ClearMask(kTruncationMask); }
 
@@ -79,11 +82,11 @@ private:
     // 1111 1110 0000 0000 = FE0F
     // TODO(cecille): need to better document this value. Why is the comment different than the value?
     static constexpr uint16_t kMdnsNonIgnoredMask = 0x8E08;
-
-    static constexpr uint16_t kIsResponseMask = 0x8000;
-    static constexpr uint16_t kOpcodeMask     = 0x7000;
-    static constexpr uint16_t kTruncationMask = 0x0400;
-    static constexpr uint16_t kReturnCodeMask = 0x000F;
+    static constexpr uint16_t kAuthoritativeMask  = 0x0400;
+    static constexpr uint16_t kIsResponseMask     = 0x8000;
+    static constexpr uint16_t kOpcodeMask         = 0x7000;
+    static constexpr uint16_t kTruncationMask     = 0x0200;
+    static constexpr uint16_t kReturnCodeMask     = 0x000F;
 };
 
 /**


### PR DESCRIPTION

#### Problem

According to [RFC 6762](https://datatracker.ietf.org/doc/html/rfc6762#section-18.4) the AA bit must be set in multicast messages. The minimal mDNS implementation does not follow the spec.

#### Change overview

Always set the AA flags in minimal mDNS. This bit is harmless and is also always set in avahi.

The PR also fixes the wrong truncated flag value.

#### Testing

Manually tested with wireshark sniffing.
