### PR TITLE
Chef - Increase cloudbuild size limit

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -54,4 +54,4 @@ artifacts:
 # slow.
 options:
     machineType: "E2_HIGHCPU_32"
-    diskSizeGb: 200
+    diskSizeGb: 500


### PR DESCRIPTION
#### Problem
* Chef cloudbuild is nearing the limit of size usage.

#### Change overview
* Increase cloud build size limit to 500gb.
