### PR TITLE
[test] Add --dry-run option to run_test_suite.py

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -209,7 +209,7 @@ class TestDefinition:
     target: TestTarget
     is_manual: bool
 
-    def Run(self, runner, apps_register, paths: ApplicationPaths, pics_file: str, timeout_seconds: typing.Optional[int]):
+    def Run(self, runner, apps_register, paths: ApplicationPaths, pics_file: str, timeout_seconds: typing.Optional[int], dry_run=False):
         """
         Executes the given test case using the provided runner for execution.
         """
@@ -264,14 +264,20 @@ class TestDefinition:
             app = apps_register.get('default')
             app.start()
             pairing_cmd = tool_cmd + ['pairing', 'code', TEST_NODE_ID, app.setupCode]
-            runner.RunSubprocess(pairing_cmd,
-                                 name='PAIR', dependencies=[apps_register])
-
             test_cmd = tool_cmd + ['tests', self.run_name] + ['--PICS', pics_file]
-            runner.RunSubprocess(
-                test_cmd,
-                name='TEST', dependencies=[apps_register],
-                timeout_seconds=timeout_seconds)
+
+            if dry_run:
+                logging.info(" ".join(pairing_cmd))
+                logging.info(" ".join(test_cmd))
+
+            else:
+                runner.RunSubprocess(pairing_cmd,
+                                     name='PAIR', dependencies=[apps_register])
+
+                runner.RunSubprocess(
+                    test_cmd,
+                    name='TEST', dependencies=[apps_register],
+                    timeout_seconds=timeout_seconds)
 
         except Exception:
             logging.error("!!!!!!!!!!!!!!!!!!!! ERROR !!!!!!!!!!!!!!!!!!!!!!")

--- a/scripts/tests/run_test_suite.py
+++ b/scripts/tests/run_test_suite.py
@@ -62,6 +62,7 @@ class RunContext:
     tests: typing.List[chiptest.TestDefinition]
     in_unshare: bool
     chip_tool: str
+    dry_run: bool
 
 
 @click.group(chain=True)
@@ -70,6 +71,11 @@ class RunContext:
     default='info',
     type=click.Choice(__LOG_LEVELS__.keys(), case_sensitive=False),
     help='Determines the verbosity of script output.')
+@click.option(
+    '--dry-run',
+    default=False,
+    is_flag=True,
+    help='Only print out shell commands that would be executed')
 @click.option(
     '--target',
     default=['all'],
@@ -106,7 +112,7 @@ class RunContext:
     '--chip-tool',
     help='Binary path of chip tool app to use to run the test')
 @click.pass_context
-def main(context, log_level, target, target_glob, target_skip_glob,
+def main(context, dry_run, log_level, target, target_glob, target_skip_glob,
          no_log_timestamps, root, internal_inside_unshare, chip_tool):
     # Ensures somewhat pretty logging of what is going on
     log_fmt = '%(asctime)s.%(msecs)03d %(levelname)-7s %(message)s'
@@ -151,7 +157,7 @@ def main(context, log_level, target, target_glob, target_skip_glob,
 
     context.obj = RunContext(root=root, tests=tests,
                              in_unshare=internal_inside_unshare,
-                             chip_tool=chip_tool)
+                             chip_tool=chip_tool, dry_run=dry_run)
 
 
 @main.command(
@@ -245,7 +251,10 @@ def cmd_run(context, iterations, all_clusters_app, lock_app, ota_provider_app, o
         for test in context.obj.tests:
             test_start = time.monotonic()
             try:
-                test.Run(runner, apps_register, paths, pics_file, test_timeout_seconds)
+                if context.obj.dry_run:
+                    logging.info("Would run test %s:" % test.name)
+
+                test.Run(runner, apps_register, paths, pics_file, test_timeout_seconds, context.obj.dry_run)
                 test_end = time.monotonic()
                 logging.info('%-20s - Completed in %0.2f seconds' %
                              (test.name, (test_end - test_start)))


### PR DESCRIPTION
#### Problem
When debugging issues exposed by the test suite, it would be convenient to output the underlying commands that are being executed in order to run them manually with `gdb` and debug the problem.

#### Change overview
Adds a `--dry-run` flag to `./scripts/tests/run_test_suite.py` to display underlying commands that are run by each test.

Example:
```
$ ./scripts/tests/run_test_suite.py --dry-run --chip-tool ./out/debug/standalone/chip-tool run \
          --iterations 1 --test-timeout-seconds 120 \ 
          --all-clusters-app ./out/debug/standalone/chip-all-clusters-app \
          --lock-app ./out/debug/standalone/chip-lock-app  \
          --ota-provider-app ./out/linux-x64-ota-provider/chip-ota-provider-app    \
          --ota-requestor-app ./out/linux-x64-ota-requestor/chip-ota-requestor-app   \
          --tv-app ./out/debug/standalone/chip-tv-app

...

2022-07-22 23:01:06.174 INFO    Starting iteration 1
2022-07-22 23:01:06.174 INFO    Would run test DL_LockUnlock:
2022-07-22 23:01:06.278 INFO    ip netns exec tool ./out/debug/standalone/chip-tool pairing code 0x12344321 MT:-24J0YXE00KA0648G00
2022-07-22 23:01:06.278 INFO    ip netns exec tool ./out/debug/standalone/chip-tool tests DL_LockUnlock --PICS src/app/tests/suites/certification/ci-pics-values
2022-07-22 23:01:06.279 INFO    DL_LockUnlock        - Completed in 0.10 seconds
2022-07-22 23:01:06.279 INFO    Would run test DL_Schedules:
2022-07-22 23:01:06.384 INFO    ip netns exec tool ./out/debug/standalone/chip-tool pairing code 0x12344321 MT:-24J0YXE00KA0648G00
2022-07-22 23:01:06.384 INFO    ip netns exec tool ./out/debug/standalone/chip-tool tests DL_Schedules --PICS src/app/tests/suites/certification/ci-pics-values
2022-07-22 23:01:06.385 INFO    DL_Schedules         - Completed in 0.11 seconds
2022-07-22 23:01:06.385 INFO    Would run test DL_UsersAndCredentials:
2022-07-22 23:01:06.490 INFO    ip netns exec tool ./out/debug/standalone/chip-tool pairing code 0x12344321 MT:-24J0YXE00KA0648G00
2022-07-22 23:01:06.490 INFO    ip netns exec tool ./out/debug/standalone/chip-tool tests DL_UsersAndCredentials --PICS src/app/tests/suites/certification/ci-pics-values
2022-07-22 23:01:06.491 INFO    DL_UsersAndCredentials - Completed in 0.11 seconds
2022-07-22 23:01:06.491 INFO    Would run test OTA_SuccessfulTransfer:
2022-07-22 23:01:06.596 INFO    ip netns exec tool ./out/debug/standalone/chip-tool pairing code 0x12344321 MT:-24J029Q00KA0648G00
2022-07-22 23:01:06.596 INFO    ip netns exec tool ./out/debug/standalone/chip-tool tests OTA_SuccessfulTransfer --PICS src/app/tests/suites/certification/ci-pics-values
2022-07-22 23:01:06.597 INFO    OTA_SuccessfulTransfer - Completed in 0.11 seconds
2022-07-22 23:01:06.597 INFO    Would run test TV_AccountLoginCluster:
2022-07-22 23:01:06.702 INFO    ip netns exec tool ./out/debug/standalone/chip-tool pairing code 0x12344321 MT:-24J0YXE00KA0648G00
2022-07-22 23:01:06.702 INFO    ip netns exec tool ./out/debug/standalone/chip-tool tests TV_AccountLoginCluster --PICS src/app/tests/suites/certification/ci-pics-values
2022-07-22 23:01:06.703 INFO    TV_AccountLoginCluster - Completed in 0.11 seconds
```

#### Testing
How was this tested? (at least one bullet point required)
* The new feature was tested locally
* CI for regressions