### PR TITLE
Fixed addGroups command failure

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -110,7 +110,7 @@ static EmberAfStatus GroupAdd(FabricIndex fabricIndex, EndpointId endpointId, Gr
 
     GroupDataProvider * provider = GetGroupDataProvider();
     VerifyOrReturnError(nullptr != provider, EMBER_ZCL_STATUS_NOT_FOUND);
-    VerifyOrReturnError(KeyExists(fabricIndex, groupId), EMBER_ZCL_STATUS_UNSUPPORTED_ACCESS);
+    VerifyOrReturnError(!KeyExists(fabricIndex, groupId), EMBER_ZCL_STATUS_UNSUPPORTED_ACCESS);
 
     // Add a new entry to the GroupTable
     CHIP_ERROR err = provider->SetGroupInfo(fabricIndex, GroupDataProvider::GroupInfo(groupId, groupName));


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #21157.

#### Change overview
see above

#### Testing
How was this tested? (at least one bullet point required)
* Tested add groups command ,
 `AddGroupResponse:` {

[1658742473334] [28062:2229447] CHIP: [TOO]     `status: 0`

[1658742473334] [28062:2229447] CHIP: [TOO]     groupId: 1

[1658742473334] [28062:2229447] CHIP: [TOO]    }

* Read group-table, 
[1658744862569] [34900:2269320] CHIP: [TOO]   GroupTable: 1 entries
[1658744862569] [34900:2269320] CHIP: [TOO]     [1]: {
[1658744862569] [34900:2269320] CHIP: [TOO]       GroupId: 1
[1658744862569] [34900:2269320] CHIP: [TOO]       Endpoints: 1 entries
[1658744862569] [34900:2269320] CHIP: [TOO]         [1]: 0
[1658744862569] [34900:2269320] CHIP: [TOO]       GroupName: grp1
[1658744862569] [34900:2269320] CHIP: [TOO]       FabricIndex: 1
[1658744862569] [34900:2269320] CHIP: [TOO]      }
