### PR TITLE
[ble] Fix scanning with manual pairing code

### DIFF
--- a/src/ble/BleConnectionDelegate.h
+++ b/src/ble/BleConnectionDelegate.h
@@ -52,7 +52,7 @@ public:
 
     // Call this function to delegate the connection steps required to get a BLE_CONNECTION_OBJECT
     // out of a peripheral discriminator.
-    virtual void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) = 0;
+    virtual void NewConnection(BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator) = 0;
 
     // Call this function to stop the connection
     virtual CHIP_ERROR CancelConnection() = 0;

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -371,7 +371,7 @@ CHIP_ERROR BleLayer::CancelBleIncompleteConnection()
     return err;
 }
 
-CHIP_ERROR BleLayer::NewBleConnectionByDiscriminator(uint16_t connDiscriminator, void * appState,
+CHIP_ERROR BleLayer::NewBleConnectionByDiscriminator(uint16_t discriminator, bool shortDiscriminator, void * appState,
                                                      BleConnectionDelegate::OnConnectionCompleteFunct onSuccess,
                                                      BleConnectionDelegate::OnConnectionErrorFunct onError)
 {
@@ -382,7 +382,7 @@ CHIP_ERROR BleLayer::NewBleConnectionByDiscriminator(uint16_t connDiscriminator,
     mConnectionDelegate->OnConnectionComplete = onSuccess;
     mConnectionDelegate->OnConnectionError    = onError;
 
-    mConnectionDelegate->NewConnection(this, appState == nullptr ? this : appState, connDiscriminator);
+    mConnectionDelegate->NewConnection(this, appState == nullptr ? this : appState, discriminator, shortDiscriminator);
 
     return CHIP_NO_ERROR;
 }

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -245,7 +245,7 @@ public:
     void Shutdown();
 
     CHIP_ERROR CancelBleIncompleteConnection();
-    CHIP_ERROR NewBleConnectionByDiscriminator(uint16_t connDiscriminator, void * appState = nullptr,
+    CHIP_ERROR NewBleConnectionByDiscriminator(uint16_t discriminator, bool shortDiscriminator = false, void * appState = nullptr,
                                                BleConnectionDelegate::OnConnectionCompleteFunct onSuccess = OnConnectionComplete,
                                                BleConnectionDelegate::OnConnectionErrorFunct onError      = OnConnectionError);
     CHIP_ERROR NewBleConnectionByObject(BLE_CONNECTION_OBJECT connObj);

--- a/src/ble/CHIPBleServiceData.h
+++ b/src/ble/CHIPBleServiceData.h
@@ -46,6 +46,7 @@ enum chipBLEServiceDataType
 struct ChipBLEDeviceIdentificationInfo
 {
     constexpr static uint16_t kDiscriminatorMask            = 0xfff;
+    constexpr static uint16_t kShortDiscriminatorMask       = 0xf00;
     constexpr static uint8_t kAdditionalDataFlagMask        = 0x1;
     constexpr static uint8_t kAdvertisementVersionMask      = 0xf0;
     constexpr static uint8_t kAdvertisementVersionShiftBits = 4u;
@@ -90,6 +91,8 @@ struct ChipBLEDeviceIdentificationInfo
     {
         return chip::Encoding::LittleEndian::Get16(DeviceDiscriminatorAndAdvVersion) & kDiscriminatorMask;
     }
+
+    uint16_t GetShortDiscriminator() const { return GetDeviceDiscriminator() & kShortDiscriminatorMask; }
 
     void SetDeviceDiscriminator(uint16_t deviceDiscriminator)
     {

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -114,8 +114,8 @@ CHIP_ERROR SetUpCodePairer::StartDiscoverOverBle(SetupPayload & payload)
 
     // Handle possibly-sync callbacks.
     mWaitingForDiscovery[kBLETransport] = true;
-    CHIP_ERROR err = mBleLayer->NewBleConnectionByDiscriminator(payload.discriminator, this, OnDiscoveredDeviceOverBleSuccess,
-                                                                OnDiscoveredDeviceOverBleError);
+    CHIP_ERROR err = mBleLayer->NewBleConnectionByDiscriminator(payload.discriminator, payload.isShortDiscriminator, this,
+                                                                OnDiscoveredDeviceOverBleSuccess, OnDiscoveredDeviceOverBleError);
     if (err != CHIP_NO_ERROR)
     {
         mWaitingForDiscovery[kBLETransport] = false;

--- a/src/platform/Darwin/BleConnectionDelegate.h
+++ b/src/platform/Darwin/BleConnectionDelegate.h
@@ -26,7 +26,7 @@ namespace Internal {
 class BleConnectionDelegateImpl : public Ble::BleConnectionDelegate
 {
 public:
-    virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator);
+    virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator);
     virtual CHIP_ERROR CancelConnection();
 };
 

--- a/src/platform/Darwin/BleConnectionDelegateImpl.mm
+++ b/src/platform/Darwin/BleConnectionDelegateImpl.mm
@@ -67,11 +67,12 @@ namespace DeviceLayer {
     namespace Internal {
         BleConnection * ble;
 
-        void BleConnectionDelegateImpl::NewConnection(Ble::BleLayer * bleLayer, void * appState, const uint16_t deviceDiscriminator)
+        void BleConnectionDelegateImpl::NewConnection(
+            Ble::BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator)
         {
             ChipLogProgress(Ble, "%s", __FUNCTION__);
             CancelConnection();
-            ble = [[BleConnection alloc] initWithDiscriminator:deviceDiscriminator];
+            ble = [[BleConnection alloc] initWithDiscriminator:discriminator];
             [ble setBleLayer:bleLayer];
             ble.appState = appState;
             ble.onConnectionComplete = OnConnectionComplete;

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -68,6 +68,9 @@ struct BLEScanConfig
     // If scanning by discriminator, what are we scanning for
     uint16_t mDiscriminator = 0;
 
+    // Match only 4 most significant bits of the discriminator
+    bool mShortDiscriminator = false;
+
     // If scanning by address, what address are we searching for
     std::string mAddress;
 
@@ -148,7 +151,7 @@ private:
 
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
-    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator) override;
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -1290,7 +1290,7 @@ void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, uint16_
     mBLEScanConfig.mDiscriminator      = discriminator;
     mBLEScanConfig.mShortDiscriminator = shortDiscriminator;
     mBLEScanConfig.mAppState           = appState;
-    ChipLogProgress(DeviceLayer, "NewConnection: discriminator value [%u]", connDiscriminator);
+    ChipLogProgress(DeviceLayer, "NewConnection: discriminator value [%u]", discriminator);
 
     // Initiate Scan.
     PlatformMgr().ScheduleWork(InitiateScan, static_cast<intptr_t>(BleScanState::kScanForDiscriminator));

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -455,10 +455,8 @@ void BLEManagerImpl::OnChipDeviceScanned(void * device, const chip::Ble::ChipBLE
 
     if (mBLEScanConfig.mBleScanState == BleScanState::kScanForDiscriminator)
     {
-        if (info.GetDeviceDiscriminator() != mBLEScanConfig.mDiscriminator)
-        {
-            return;
-        }
+        const uint16_t discr = mBLEScanConfig.mShortDiscriminator ? info.GetShortDiscriminator() : info.GetDeviceDiscriminator();
+        VerifyOrReturn(discr == mBLEScanConfig.mDiscriminator);
         ChipLogProgress(DeviceLayer, "Device discriminator match. Attempting to connect.");
     }
     else if (mBLEScanConfig.mBleScanState == BleScanState::kScanForAddress)
@@ -1287,10 +1285,11 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) {}
 
-void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator)
+void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator)
 {
-    mBLEScanConfig.mDiscriminator = connDiscriminator;
-    mBLEScanConfig.mAppState      = appState;
+    mBLEScanConfig.mDiscriminator      = discriminator;
+    mBLEScanConfig.mShortDiscriminator = shortDiscriminator;
+    mBLEScanConfig.mAppState           = appState;
     ChipLogProgress(DeviceLayer, "NewConnection: discriminator value [%u]", connDiscriminator);
 
     // Initiate Scan.

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -59,6 +59,9 @@ struct BLEScanConfig
     // If scanning by discriminator, what are we scanning for
     uint16_t mDiscriminator = 0;
 
+    // Match only 4 most significant bits of the discriminator
+    bool mShortDiscriminator = false;
+
     // If scanning by address, what address are we searching for
     std::string mAddress;
 
@@ -122,7 +125,7 @@ private:
 
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
-    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator) override;
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/android/BLEManagerImpl.cpp
+++ b/src/platform/android/BLEManagerImpl.cpp
@@ -40,7 +40,8 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-namespace {} // namespace
+namespace {
+} // namespace
 
 BLEManagerImpl BLEManagerImpl::sInstance;
 
@@ -280,7 +281,7 @@ bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, cons
     env->ExceptionClear();
     tmpConnObj = reinterpret_cast<intptr_t>(conId);
     rc         = (bool) env->CallBooleanMethod(mBLEManagerObject, mOnUnsubscribeCharacteristicMethod, static_cast<jint>(tmpConnObj),
-                                               svcIdObj, charIdObj);
+                                       svcIdObj, charIdObj);
     VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
 exit:

--- a/src/platform/android/BLEManagerImpl.cpp
+++ b/src/platform/android/BLEManagerImpl.cpp
@@ -40,9 +40,7 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-namespace {
-
-} // namespace
+namespace {} // namespace
 
 BLEManagerImpl BLEManagerImpl::sInstance;
 
@@ -282,7 +280,7 @@ bool BLEManagerImpl::UnsubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, cons
     env->ExceptionClear();
     tmpConnObj = reinterpret_cast<intptr_t>(conId);
     rc         = (bool) env->CallBooleanMethod(mBLEManagerObject, mOnUnsubscribeCharacteristicMethod, static_cast<jint>(tmpConnObj),
-                                       svcIdObj, charIdObj);
+                                               svcIdObj, charIdObj);
     VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
 exit:
@@ -449,7 +447,7 @@ exit:
 
 // ===== start implement virtual methods on BleConnectionDelegate.
 
-void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator)
+void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator)
 {
     chip::DeviceLayer::StackUnlock unlock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -461,7 +459,7 @@ void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const u
     VerifyOrExit(env != NULL, err = CHIP_JNI_ERROR_NO_ENV);
 
     env->ExceptionClear();
-    env->CallVoidMethod(mBLEManagerObject, mOnNewConnectionMethod, static_cast<jint>(connDiscriminator));
+    env->CallVoidMethod(mBLEManagerObject, mOnNewConnectionMethod, static_cast<jint>(discriminator));
     VerifyOrExit(!env->ExceptionCheck(), err = CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
 exit:

--- a/src/platform/android/BLEManagerImpl.h
+++ b/src/platform/android/BLEManagerImpl.h
@@ -90,7 +90,7 @@ private:
 
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
-    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator) override;
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -511,7 +511,7 @@ bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const 
 {
     bool result = false;
     result      = SubscribeCharacteristicToWebOS(conId, static_cast<const uint8_t *>(svcId->bytes),
-                                            static_cast<const uint8_t *>(charId->bytes));
+                                                 static_cast<const uint8_t *>(charId->bytes));
     return result;
 }
 
@@ -609,8 +609,7 @@ bool BLEManagerImpl::SendWriteRequestToWebOS(void * bleConnObj, const uint8_t * 
         valueParam.put("string", value);
     }
     else
-    {
-    }
+    {}
     param.put("value", valueParam);
 
     ChipLogProgress(Ble, "SendWriteRequestToWebOS Param : param  %s", param.stringify().c_str());
@@ -888,10 +887,11 @@ void BLEManagerImpl::InitiateScan(intptr_t arg)
     sInstance.InitiateScan(static_cast<BleScanState>(arg));
 }
 
-void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator)
+void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator)
 {
-    mBLEScanConfig.mDiscriminator = connDiscriminator;
-    mBLEScanConfig.mAppState      = appState;
+    mBLEScanConfig.mDiscriminator      = discriminator;
+    mBLEScanConfig.mShortDiscriminator = shortDiscriminator;
+    mBLEScanConfig.mAppState           = appState;
 
     // Scan initiation performed async, to ensure that the BLE subsystem is initialized.
     PlatformMgr().ScheduleWork(InitiateScan, static_cast<intptr_t>(BleScanState::kScanForDiscriminator));

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -511,7 +511,7 @@ bool BLEManagerImpl::SubscribeCharacteristic(BLE_CONNECTION_OBJECT conId, const 
 {
     bool result = false;
     result      = SubscribeCharacteristicToWebOS(conId, static_cast<const uint8_t *>(svcId->bytes),
-                                                 static_cast<const uint8_t *>(charId->bytes));
+                                            static_cast<const uint8_t *>(charId->bytes));
     return result;
 }
 
@@ -609,7 +609,8 @@ bool BLEManagerImpl::SendWriteRequestToWebOS(void * bleConnObj, const uint8_t * 
         valueParam.put("string", value);
     }
     else
-    {}
+    {
+    }
     param.put("value", valueParam);
 
     ChipLogProgress(Ble, "SendWriteRequestToWebOS Param : param  %s", param.stringify().c_str());

--- a/src/platform/webos/BLEManagerImpl.h
+++ b/src/platform/webos/BLEManagerImpl.h
@@ -53,6 +53,9 @@ struct BLEScanConfig
     // If scanning by discriminator, what are we scanning for
     uint16_t mDiscriminator = 0;
 
+    // Match only 4 most significant bits of the discriminator
+    bool mShortDiscriminator = false;
+
     // If scanning by address, what address are we searching for
     std::string mAddress;
 
@@ -131,7 +134,7 @@ private:
 
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
-    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t discriminator, bool shortDiscriminator) override;
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate


### PR DESCRIPTION
#### Problem
Manual pairing code encodes only 4 most significant bits of the device discriminator, so special filtering mode is
needed to match desired devices. It turns out filtering by short discriminator was not implemented in the BLE layer.
It might have been overlooked because the test discriminator is 0xf00, so only the most significant bits are used.

#### Change overview
Extend BleConnectionDelegate interface and fill the gap for Linux and Tizen. Darwin has not fully compliant, but working solution, and Android and webos must be fixed someday, too.
Fixes #21160

#### Testing
Verified using chip-tool's `code-thread` command that now the device is correctly matched event if the discriminator is `0xF01`.