### PR TITLE
Run crypto tests (only) under BoringSSL from unified build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -391,7 +391,7 @@ jobs:
                           #   use that on Darwin.
                           # * the "host clang" build, which uses the pigweed
                           #   clang.
-                          "default") GN_ARGS='target_os="all" is_asan=true enable_host_clang_build=false';;
+                          "default") GN_ARGS='target_os="all" is_asan=true enable_host_clang_build=false enable_host_clang_boringssl_crypto_tests=false';;
                           "python_lib") GN_ARGS='enable_rtti=true enable_pylib=true';;
                       esac
                       BUILD_TYPE=$BUILD_TYPE scripts/build/gn_gen.sh --args="$GN_ARGS" --export-compile-commands

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -241,6 +241,13 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     enable_host_gcc_mbedtls_crypto_tests =
         enable_default_builds && host_os != "win"
 
+    # Enable building chip with clang & boringssl
+    enable_host_clang_boringssl_build = false
+
+    # Enable limited testing with clang & boringssl
+    enable_host_clang_boringssl_crypto_tests =
+        enable_default_builds && host_os != "win"
+
     # Build the chip-cert tool.
     enable_standalone_chip_cert_build =
         enable_default_builds && host_os != "win" && chip_crypto == "openssl"
@@ -360,6 +367,23 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     }
 
     builds += [ ":host_gcc_mbedtls_crypto_tests" ]
+  }
+
+  if (enable_host_clang_boringssl_build) {
+    chip_build("host_clang_boringssl") {
+      toolchain = "${chip_root}/config/boringssl/toolchain:${host_os}_${host_cpu}_clang_boringssl"
+    }
+
+    builds += [ ":host_clang_boringssl" ]
+  }
+
+  if (enable_host_clang_boringssl_crypto_tests) {
+    chip_build("host_clang_boringssl_crypto_tests") {
+      test_group = "//src:crypto_tests"
+      toolchain = "${chip_root}/config/boringssl/toolchain:${host_os}_${host_cpu}_clang_boringssl"
+    }
+
+    builds += [ ":host_clang_boringssl_crypto_tests" ]
   }
 
   if (enable_android_builds) {

--- a/config/boringssl/toolchain/BUILD.gn
+++ b/config/boringssl/toolchain/BUILD.gn
@@ -1,0 +1,26 @@
+# Copyright (c) 2020 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+
+import("${build_root}/toolchain/gcc_toolchain.gni")
+
+gcc_toolchain("${host_os}_${host_cpu}_clang_boringssl") {
+  toolchain_args = {
+    current_os = host_os
+    current_cpu = host_cpu
+    is_clang = true
+    chip_crypto = "boringssl"
+  }
+}


### PR DESCRIPTION
#### Problem

There's no coverage of BoringSSL from unified build.

#### Change overview

Add a new default option enable_host_clang_boringssl_crypto_tests
to the unified build that runs the tests from src/crypto and
src/credentials only.

Also add an option enable_host_clang_boringssl_build that runs all of
the tests (and builds any tools), which is not enabled by default.

This gives some coverage to BoringSSL without costing a full build
(it would be even cheaper if we could swap out the CryptoPAL via
the command line..)

#### Testing

`gn_build.sh`