### PR TITLE
Add #if CHIP_HAVE_CONFIG around *BuildConfig headers

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -19,9 +19,7 @@
 // Included for the default AccessControlDelegate logging enables/disables.
 // See `chip_access_control_policy_logging_verbosity` in `src/app/BUILD.gn` for
 // the levels available.
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 #include "AccessControl.h"
 

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -19,7 +19,9 @@
 // Included for the default AccessControlDelegate logging enables/disables.
 // See `chip_access_control_policy_logging_verbosity` in `src/app/BUILD.gn` for
 // the levels available.
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 #include "AccessControl.h"
 

--- a/src/app/AppConfig.h
+++ b/src/app/AppConfig.h
@@ -1,0 +1,22 @@
+/*
+ *
+ *    Copyright (c) 2020-2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#if CHIP_HAVE_CONFIG_H
+#include <app/AppBuildConfig.h>
+#endif

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -53,6 +53,16 @@ buildconfig_header("app_buildconfig") {
   ]
 }
 
+source_set("app_config") {
+  sources = [
+    "AppConfig.h",
+  ]
+
+  public_deps = [
+    ":app_buildconfig",
+  ]
+}
+
 static_library("app") {
   output_name = "libCHIPDataModel"
 
@@ -179,7 +189,7 @@ static_library("app") {
   ]
 
   public_deps = [
-    ":app_buildconfig",
+    ":app_config",
     "${chip_root}/src/access",
     "${chip_root}/src/lib/address_resolve",
     "${chip_root}/src/lib/support",

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -54,13 +54,9 @@ buildconfig_header("app_buildconfig") {
 }
 
 source_set("app_config") {
-  sources = [
-    "AppConfig.h",
-  ]
+  sources = [ "AppConfig.h" ]
 
-  public_deps = [
-    ":app_buildconfig",
-  ]
+  public_deps = [ ":app_buildconfig" ]
 }
 
 static_library("app") {

--- a/src/app/MessageDef/AttributeDataIB.cpp
+++ b/src/app/MessageDef/AttributeDataIB.cpp
@@ -24,7 +24,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeDataIB.cpp
+++ b/src/app/MessageDef/AttributeDataIB.cpp
@@ -24,9 +24,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeDataIBs.cpp
+++ b/src/app/MessageDef/AttributeDataIBs.cpp
@@ -29,9 +29,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 using namespace chip;
 using namespace chip::TLV;

--- a/src/app/MessageDef/AttributeDataIBs.cpp
+++ b/src/app/MessageDef/AttributeDataIBs.cpp
@@ -29,7 +29,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 using namespace chip;
 using namespace chip::TLV;

--- a/src/app/MessageDef/AttributePathIB.cpp
+++ b/src/app/MessageDef/AttributePathIB.cpp
@@ -23,9 +23,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/data-model/Encode.h>
 #include <app/data-model/Nullable.h>
 

--- a/src/app/MessageDef/AttributePathIB.cpp
+++ b/src/app/MessageDef/AttributePathIB.cpp
@@ -23,7 +23,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/data-model/Encode.h>
 #include <app/data-model/Nullable.h>
 

--- a/src/app/MessageDef/AttributePathIBs.cpp
+++ b/src/app/MessageDef/AttributePathIBs.cpp
@@ -23,9 +23,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributePathIBs.cpp
+++ b/src/app/MessageDef/AttributePathIBs.cpp
@@ -23,7 +23,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeReportIB.cpp
+++ b/src/app/MessageDef/AttributeReportIB.cpp
@@ -24,7 +24,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeReportIB.cpp
+++ b/src/app/MessageDef/AttributeReportIB.cpp
@@ -24,9 +24,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeReportIBs.cpp
+++ b/src/app/MessageDef/AttributeReportIBs.cpp
@@ -28,9 +28,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeReportIBs.cpp
+++ b/src/app/MessageDef/AttributeReportIBs.cpp
@@ -28,7 +28,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeStatusIB.cpp
+++ b/src/app/MessageDef/AttributeStatusIB.cpp
@@ -23,9 +23,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeStatusIB.cpp
+++ b/src/app/MessageDef/AttributeStatusIB.cpp
@@ -23,7 +23,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeStatusIBs.cpp
+++ b/src/app/MessageDef/AttributeStatusIBs.cpp
@@ -25,7 +25,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/AttributeStatusIBs.cpp
+++ b/src/app/MessageDef/AttributeStatusIBs.cpp
@@ -25,9 +25,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/ClusterPathIB.cpp
+++ b/src/app/MessageDef/ClusterPathIB.cpp
@@ -21,7 +21,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/ClusterPathIB.cpp
+++ b/src/app/MessageDef/ClusterPathIB.cpp
@@ -21,9 +21,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/CommandDataIB.cpp
+++ b/src/app/MessageDef/CommandDataIB.cpp
@@ -24,7 +24,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/CommandDataIB.cpp
+++ b/src/app/MessageDef/CommandDataIB.cpp
@@ -24,9 +24,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/CommandPathIB.cpp
+++ b/src/app/MessageDef/CommandPathIB.cpp
@@ -24,9 +24,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 using namespace chip;
 using namespace chip::TLV;

--- a/src/app/MessageDef/CommandPathIB.cpp
+++ b/src/app/MessageDef/CommandPathIB.cpp
@@ -24,7 +24,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 using namespace chip;
 using namespace chip::TLV;

--- a/src/app/MessageDef/CommandStatusIB.cpp
+++ b/src/app/MessageDef/CommandStatusIB.cpp
@@ -23,9 +23,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/CommandStatusIB.cpp
+++ b/src/app/MessageDef/CommandStatusIB.cpp
@@ -23,7 +23,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/DataVersionFilterIB.cpp
+++ b/src/app/MessageDef/DataVersionFilterIB.cpp
@@ -27,7 +27,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/DataVersionFilterIB.cpp
+++ b/src/app/MessageDef/DataVersionFilterIB.cpp
@@ -27,9 +27,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/DataVersionFilterIBs.cpp
+++ b/src/app/MessageDef/DataVersionFilterIBs.cpp
@@ -22,9 +22,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/DataVersionFilterIBs.cpp
+++ b/src/app/MessageDef/DataVersionFilterIBs.cpp
@@ -22,7 +22,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventDataIB.cpp
+++ b/src/app/MessageDef/EventDataIB.cpp
@@ -29,7 +29,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventDataIB.cpp
+++ b/src/app/MessageDef/EventDataIB.cpp
@@ -29,9 +29,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventFilterIB.cpp
+++ b/src/app/MessageDef/EventFilterIB.cpp
@@ -27,7 +27,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventFilterIB.cpp
+++ b/src/app/MessageDef/EventFilterIB.cpp
@@ -27,9 +27,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventFilterIBs.cpp
+++ b/src/app/MessageDef/EventFilterIBs.cpp
@@ -22,9 +22,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventFilterIBs.cpp
+++ b/src/app/MessageDef/EventFilterIBs.cpp
@@ -22,7 +22,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -24,7 +24,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -24,9 +24,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventPathIBs.cpp
+++ b/src/app/MessageDef/EventPathIBs.cpp
@@ -24,7 +24,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventPathIBs.cpp
+++ b/src/app/MessageDef/EventPathIBs.cpp
@@ -24,9 +24,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventReportIB.cpp
+++ b/src/app/MessageDef/EventReportIB.cpp
@@ -24,7 +24,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventReportIB.cpp
+++ b/src/app/MessageDef/EventReportIB.cpp
@@ -24,9 +24,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventReportIBs.cpp
+++ b/src/app/MessageDef/EventReportIBs.cpp
@@ -28,9 +28,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventReportIBs.cpp
+++ b/src/app/MessageDef/EventReportIBs.cpp
@@ -28,7 +28,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventStatusIB.cpp
+++ b/src/app/MessageDef/EventStatusIB.cpp
@@ -23,9 +23,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/EventStatusIB.cpp
+++ b/src/app/MessageDef/EventStatusIB.cpp
@@ -23,7 +23,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -21,7 +21,9 @@
 #include "InvokeRequestMessage.h"
 #include "MessageDefHelper.h"
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -21,9 +21,7 @@
 #include "InvokeRequestMessage.h"
 #include "MessageDefHelper.h"
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -22,9 +22,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -22,7 +22,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeResponseIB.cpp
+++ b/src/app/MessageDef/InvokeResponseIB.cpp
@@ -21,7 +21,9 @@
 #include "InvokeResponseIB.h"
 #include "MessageDefHelper.h"
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeResponseIB.cpp
+++ b/src/app/MessageDef/InvokeResponseIB.cpp
@@ -21,9 +21,7 @@
 #include "InvokeResponseIB.h"
 #include "MessageDefHelper.h"
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -22,9 +22,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -22,7 +22,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeResponseMessage.cpp
+++ b/src/app/MessageDef/InvokeResponseMessage.cpp
@@ -21,9 +21,7 @@
 #include "InvokeResponseMessage.h"
 #include "MessageDefHelper.h"
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/InvokeResponseMessage.cpp
+++ b/src/app/MessageDef/InvokeResponseMessage.cpp
@@ -21,7 +21,9 @@
 #include "InvokeResponseMessage.h"
 #include "MessageDefHelper.h"
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -23,7 +23,9 @@
 
 #include "MessageDefHelper.h"
 #include <algorithm>
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/InteractionModelRevision.h>
 #include <app/util/basic-types.h>
 #include <inttypes.h>

--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -23,9 +23,7 @@
 
 #include "MessageDefHelper.h"
 #include <algorithm>
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/InteractionModelRevision.h>
 #include <app/util/basic-types.h>
 #include <inttypes.h>

--- a/src/app/MessageDef/ReadRequestMessage.cpp
+++ b/src/app/MessageDef/ReadRequestMessage.cpp
@@ -21,7 +21,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/ReadRequestMessage.cpp
+++ b/src/app/MessageDef/ReadRequestMessage.cpp
@@ -21,9 +21,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/ReportDataMessage.cpp
+++ b/src/app/MessageDef/ReportDataMessage.cpp
@@ -29,9 +29,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 using namespace chip;
 

--- a/src/app/MessageDef/ReportDataMessage.cpp
+++ b/src/app/MessageDef/ReportDataMessage.cpp
@@ -29,7 +29,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 using namespace chip;
 

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -29,7 +29,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <lib/core/CHIPCore.h>
 
 using namespace chip;

--- a/src/app/MessageDef/StatusIB.cpp
+++ b/src/app/MessageDef/StatusIB.cpp
@@ -29,9 +29,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <lib/core/CHIPCore.h>
 
 using namespace chip;

--- a/src/app/MessageDef/WriteRequestMessage.cpp
+++ b/src/app/MessageDef/WriteRequestMessage.cpp
@@ -26,7 +26,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/WriteRequestMessage.cpp
+++ b/src/app/MessageDef/WriteRequestMessage.cpp
@@ -26,9 +26,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/WriteResponseMessage.cpp
+++ b/src/app/MessageDef/WriteResponseMessage.cpp
@@ -21,7 +21,9 @@
 #include <stdarg.h>
 #include <stdio.h>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 
 namespace chip {
 namespace app {

--- a/src/app/MessageDef/WriteResponseMessage.cpp
+++ b/src/app/MessageDef/WriteResponseMessage.cpp
@@ -21,9 +21,7 @@
 #include <stdarg.h>
 #include <stdio.h>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 
 namespace chip {
 namespace app {

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -22,7 +22,9 @@
  *
  */
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/InteractionModelEngine.h>
 #include <app/InteractionModelHelper.h>
 #include <app/ReadClient.h>

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -22,9 +22,7 @@
  *
  */
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/InteractionModelHelper.h>
 #include <app/ReadClient.h>

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -22,7 +22,9 @@
  *
  */
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPathIB.h>
 #include <app/MessageDef/StatusResponseMessage.h>

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -22,9 +22,7 @@
  *
  */
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPathIB.h>
 #include <app/MessageDef/StatusResponseMessage.h>

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -23,9 +23,7 @@
  */
 
 #include "lib/core/CHIPError.h"
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/TimedRequest.h>
 #include <app/WriteClient.h>

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -23,7 +23,9 @@
  */
 
 #include "lib/core/CHIPError.h"
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/InteractionModelEngine.h>
 #include <app/TimedRequest.h>
 #include <app/WriteClient.h>

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -17,9 +17,7 @@
  */
 
 #include "messaging/ExchangeContext.h"
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPathIB.h>
 #include <app/StatusResponse.h>

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -17,7 +17,9 @@
  */
 
 #include "messaging/ExchangeContext.h"
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/EventPathIB.h>
 #include <app/StatusResponse.h>

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -23,9 +23,7 @@
  *
  */
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/Engine.h>
 #include <app/util/MatterCallbacks.h>

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -23,7 +23,9 @@
  *
  */
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/InteractionModelEngine.h>
 #include <app/reporting/Engine.h>
 #include <app/util/MatterCallbacks.h>

--- a/src/app/tests/TestBuilderParser.cpp
+++ b/src/app/tests/TestBuilderParser.cpp
@@ -16,9 +16,7 @@
  *    limitations under the License.
  */
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/MessageDef/ArrayBuilder.h>
 #include <app/MessageDef/ArrayParser.h>
 #include <app/MessageDef/ListBuilder.h>

--- a/src/app/tests/TestBuilderParser.cpp
+++ b/src/app/tests/TestBuilderParser.cpp
@@ -16,7 +16,9 @@
  *    limitations under the License.
  */
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/MessageDef/ArrayBuilder.h>
 #include <app/MessageDef/ArrayParser.h>
 #include <app/MessageDef/ListBuilder.h>

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -24,9 +24,7 @@
 
 #include <cinttypes>
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/data-model/Encode.h>
 #include <app/tests/AppTestContext.h>

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -24,7 +24,9 @@
 
 #include <cinttypes>
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/InteractionModelEngine.h>
 #include <app/data-model/Encode.h>
 #include <app/tests/AppTestContext.h>

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -22,9 +22,7 @@
  *
  */
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/MessageDef/EventFilterIBs.h>
 #include <app/MessageDef/EventStatusIB.h>
 #include <app/MessageDef/InvokeRequestMessage.h>

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -22,7 +22,9 @@
  *
  */
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/MessageDef/EventFilterIBs.h>
 #include <app/MessageDef/EventStatusIB.h>
 #include <app/MessageDef/InvokeRequestMessage.h>

--- a/src/app/tests/TestStatusIB.cpp
+++ b/src/app/tests/TestStatusIB.cpp
@@ -15,7 +15,9 @@
  *    limitations under the License.
  */
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/MessageDef/StatusIB.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>

--- a/src/app/tests/TestStatusIB.cpp
+++ b/src/app/tests/TestStatusIB.cpp
@@ -15,9 +15,7 @@
  *    limitations under the License.
  */
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/MessageDef/StatusIB.h>
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPError.h>

--- a/src/app/tests/TestStatusResponseMessage.cpp
+++ b/src/app/tests/TestStatusResponseMessage.cpp
@@ -22,9 +22,7 @@
  *
  */
 
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/MessageDef/StatusResponseMessage.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>

--- a/src/app/tests/TestStatusResponseMessage.cpp
+++ b/src/app/tests/TestStatusResponseMessage.cpp
@@ -22,7 +22,9 @@
  *
  */
 
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/MessageDef/StatusResponseMessage.h>
 #include <lib/core/CHIPError.h>
 #include <lib/support/CHIPMem.h>

--- a/src/controller/tests/TestEventCaching.cpp
+++ b/src/controller/tests/TestEventCaching.cpp
@@ -22,7 +22,9 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/AttributeAccessInterface.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>

--- a/src/controller/tests/TestEventCaching.cpp
+++ b/src/controller/tests/TestEventCaching.cpp
@@ -22,9 +22,7 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -21,9 +21,7 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -21,7 +21,9 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/AttributeAccessInterface.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -21,9 +21,7 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -21,7 +21,9 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/AttributeAccessInterface.h>
 #include <app/BufferedReadCallback.h>
 #include <app/CommandHandlerInterface.h>

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -26,7 +26,9 @@
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>
 #include <app/tests/AppTestContext.h>

--- a/src/controller/tests/TestServerCommandDispatch.cpp
+++ b/src/controller/tests/TestServerCommandDispatch.cpp
@@ -26,9 +26,7 @@
 #include "app-common/zap-generated/ids/Clusters.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>
 #include <app/tests/AppTestContext.h>

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -21,9 +21,7 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>

--- a/src/controller/tests/TestWriteChunking.cpp
+++ b/src/controller/tests/TestWriteChunking.cpp
@@ -21,7 +21,9 @@
 #include "app/ConcreteAttributePath.h"
 #include "protocols/interaction_model/Constants.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/AttributeAccessInterface.h>
 #include <app/CommandHandlerInterface.h>
 #include <app/InteractionModelEngine.h>

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -24,9 +24,7 @@
 
 #include "app/data-model/NullObject.h"
 #include <app-common/zap-generated/cluster-objects.h>
-#if CHIP_HAVE_CONFIG_H
-#include <app/AppBuildConfig.h>
-#endif
+#include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
 #include <app/tests/AppTestContext.h>
 #include <controller/InvokeInteraction.h>

--- a/src/controller/tests/data_model/TestCommands.cpp
+++ b/src/controller/tests/data_model/TestCommands.cpp
@@ -24,7 +24,9 @@
 
 #include "app/data-model/NullObject.h"
 #include <app-common/zap-generated/cluster-objects.h>
+#if CHIP_HAVE_CONFIG_H
 #include <app/AppBuildConfig.h>
+#endif
 #include <app/InteractionModelEngine.h>
 #include <app/tests/AppTestContext.h>
 #include <controller/InvokeInteraction.h>

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -26,12 +26,15 @@
 
 #include <cstdint>
 
+#if CHIP_HAVE_CONFIG_H
+#include <platform/CHIPDeviceBuildConfig.h>
+#include <setup_payload/CHIPAdditionalDataPayloadBuildConfig.h>
+#endif
+
 #include <app-common/zap-generated/cluster-objects.h>
 #include <lib/support/Span.h>
-#include <platform/CHIPDeviceBuildConfig.h>
 #include <platform/PersistedStorage.h>
 #include <platform/internal/CHIPDeviceLayerInternal.h>
-#include <setup_payload/CHIPAdditionalDataPayloadBuildConfig.h>
 
 namespace chip {
 namespace Ble {

--- a/src/platform/BUILD.gn
+++ b/src/platform/BUILD.gn
@@ -381,7 +381,7 @@ if (chip_device_platform != "none") {
 
     public_deps = [
       ":platform_base",
-      "${chip_root}/src/app:app_buildconfig",
+      "${chip_root}/src/app:app_config",
       "${chip_root}/src/app/common:cluster-objects",
       "${chip_root}/src/crypto",
       "${chip_root}/src/lib/support",

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -94,7 +94,7 @@ static_library("Darwin") {
   ]
 
   public_deps = [
-    "${chip_root}/src/app:app_buildconfig",
+    "${chip_root}/src/app:app_config",
     "${chip_root}/src/platform:platform_base",
   ]
 

--- a/src/setup_payload/AdditionalDataPayloadGenerator.h
+++ b/src/setup_payload/AdditionalDataPayloadGenerator.h
@@ -23,9 +23,13 @@
  */
 
 #pragma once
+
+#if CHIP_HAVE_CONFIG_H
+#include <setup_payload/CHIPAdditionalDataPayloadBuildConfig.h>
+#endif
+
 #include <lib/core/CHIPError.h>
 #include <lib/support/BitFlags.h>
-#include <setup_payload/CHIPAdditionalDataPayloadBuildConfig.h>
 #include <system/TLVPacketBufferBackingStore.h>
 
 namespace chip {


### PR DESCRIPTION
find ./ -name "*.h" -o -name "*.cpp" -exec sed -i "s/\(#include <app\/AppBuildConfig\.h>\)/#if CHIP_HAVE_CONFIG_H\n\1\n#endif/g" {} +

Manually for a few instances of CHIPDeviceBuildConfig.h and
CHIPAdditionalDataPayloadBuildConfig.h
