### PR TITLE
[BDX][Darwin] Add basic BDX protocol supports for Matter.framework

### DIFF
--- a/examples/darwin-framework-tool/commands/provider/OTASoftwareUpdateInteractive.h
+++ b/examples/darwin-framework-tool/commands/provider/OTASoftwareUpdateInteractive.h
@@ -27,7 +27,7 @@ public:
         : CHIPCommandBridge(commandName)
     {
     }
-    void SetCandidatesFromFilePath(char * _Nonnull filePath);
+    CHIP_ERROR SetCandidatesFromFilePath(char * _Nonnull filePath);
     CHIP_ERROR SetUserConsentStatus(char * _Nonnull status);
     static constexpr size_t kFilepathBufLen = 256;
 

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
@@ -50,6 +50,28 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)handleNotifyUpdateApplied:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                 completionHandler:(StatusCompletion)completionHandler;
 
+/**
+ * Notify the delegate when a BDX Session starts
+ *
+ */
+- (void)handleBDXTransferSessionBegin:(NSString * _Nonnull)fileDesignator
+                               offset:(NSNumber * _Nonnull)offset
+                    completionHandler:(void (^)(NSError * error))completionHandler;
+
+/**
+ * Notify the delegate when a BDX Session ends
+ *
+ */
+- (void)handleBDXTransferSessionEnd:(NSError * _Nullable)error;
+
+/**
+ * Notify the delegate when a BDX Query message has been received
+ *
+ */
+- (void)handleBDXQuery:(NSNumber * _Nonnull)blockSize
+            blockIndex:(NSNumber * _Nonnull)blockIndex
+           bytesToSkip:(NSNumber * _Nonnull)bytesToSkip
+     completionHandler:(void (^)(NSData * _Nullable data, BOOL isEOF))completionHandler;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/protocols/bdx/BdxTransferSession.h
+++ b/src/protocols/bdx/BdxTransferSession.h
@@ -174,7 +174,6 @@ public:
      * @param initData  Data for initializing this object and for populating a TransferInit message
      *                  The role parameter will determine whether to populate a ReceiveInit or SendInit
      * @param timeout   The amount of time to wait for a response before considering the transfer failed
-     * @param curTime   The current time since epoch. Needed to set a start time for the transfer timeout.
      *
      * @return CHIP_ERROR Result of initialization and preparation of a TransferInit message. May also indicate if the
      *                    TransferSession object is unable to handle this request.

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -137,8 +137,8 @@ public:
      * @param[in] layer      A System::Layer pointer to use to start the polling timer
      * @param[in] role       The role of the Initiator: Sender or Receiver of BDX data
      * @param[in] initData   Data needed for preparing a transfer request BDX message
-     * @param[in] timeoutMs  The chosen timeout delay for the BDX transfer in milliseconds
-     * @param[in] pollFreqMs The period for the TransferSession poll timer in milliseconds
+     * @param[in] timeout    The chosen timeout delay for the BDX transfer in milliseconds
+     * @param[in] pollFreq   The period for the TransferSession poll timer in milliseconds
      */
     CHIP_ERROR InitiateTransfer(System::Layer * layer, TransferRole role, const TransferSession::TransferInitData & initData,
                                 System::Clock::Timeout timeout,


### PR DESCRIPTION
#### Problem

This PR add  an early BDX protocol support to Matter.framework.

It can be validated, with the pre condition that `chip-ota-requestor-app` has been commissioned onto the `darwin-framework-tool` fabric: 

``` 
# Shell 1
./out/debug/standalone/chip-ota-requestor-app --discriminator 3840 --secured-device-port 5560 --KVS /tmp/chip_kvs_requestor --otaDownloadPath /tmp/test.bin
```

``` 
#Shell 2
# Creates an OTA image file
echo "Test" > /tmp/my-fw.bin # Or any other biffer content that will fit onto multiple queries...
./src/app/ota_image_tool.py create -v 0xFFF1 -p 0x8001 -vn 10 -vs "1.0.0" -da sha256 "/tmp/my-fw.bin" "/tmp/my-fw.ota"

# Creates a json file listing all the available OTA image files
echo '{
    "deviceSoftwareVersionModel": [
        {
            "vendorId": 65521,
            "productId": 32769,
            "softwareVersion": 10,
            "softwareVersionString": "1.0.0",
            "cDVersionNumber": 18,
            "softwareVersionValid": true,
            "minApplicableSoftwareVersion": 0,
            "maxApplicableSoftwareVersion": 100,
            "otaURL": "/tmp/my-fw.ota"
        }
    ]
}' > /tmp/updates.json
 

$ ./out/debug/standalone/darwin-framework-tool interactive start
# Once in interactive mode
otasoftwareupdateapp candidate-file-path /tmp/updates.json
otasoftwareupdateapp set-consent-status granted
otasoftwareupdaterequestor announce-ota-provider 0x54FDA4CA5275DB40 0 0 0 0x12344321 0
```

Most of the BDX work is handle internally into the framework while only some methods to let the application returns the OTA image file, and the OTA image block are exposed.
```
/**
 * Notify the delegate when a BDX Session starts
 *
 */
- (void)handleBDXTransferSessionBegin:(NSString * _Nonnull)fileDesignator
                               offset:(NSNumber * _Nonnull)offset
                    completionHandler:(void (^)(NSError * error))completionHandler;

/**
 * Notify the delegate when a BDX Session ends
 *
 */
- (void)handleBDXTransferSessionEnd:(NSError * _Nullable)error;

/**
 * Notify the delegate when a BDX Query message has been received
 *
 */
- (void)handleBDXQuery:(NSNumber * _Nonnull)blockSize
            blockIndex:(NSNumber * _Nonnull)blockIndex
           bytesToSkip:(NSNumber * _Nonnull)bytesToSkip
     completionHandler:(void (^)(NSData * _Nullable data, BOOL isEOF))completionHandler;
```

There is still more work to do, such as handling `MaxLength`,  exposing some bdx configuration properties to the delegate, enhance the mechanism used to select if bdx protocol should be used or not, ...

#### Change overview
 * Register an handler for the BDX protocol for the Matter.framework
 * Add some delegate methods for this BDX protocol handler.
 * Fix some documentation typos

#### Testing
See description.