### PR TITLE
[Ameba] Add light-switch-app build option and enable matter_shell macro

### DIFF
--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -3,7 +3,7 @@ FROM connectedhomeip/chip-build:${VERSION}
 
 # Setup Ameba
 ARG AMEBA_DIR=/opt/ameba
-ARG TAG_NAME=ameba_update_2022_07_15
+ARG TAG_NAME=ameba_update_2022_07_25
 RUN set -x \
     && apt-get update \
     && mkdir ${AMEBA_DIR} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.86 Version bump reason: [Ameba] Set matter_enable_persistentstorage_audit as disabled by default
+0.5.90 Version bump reason: [Ameba] Add light-switch-app build option and enable matter_shell macro


### PR DESCRIPTION
#### Problem
* Add light-switch-app build option
* Enable matter_shell macro

#### Change overview

* Update chip-build-ameba/Dockerfile
* Update version

#### Testing
Tested docker build
