### PR TITLE
[TC-SWTCH]: Add capability to adjust the state of the the switch position

### DIFF
--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
@@ -20,15 +20,16 @@
 
 #include "NamedPipeCommands.h"
 
+#include <json/json.h>
 #include <platform/DiagnosticDataProvider.h>
 
 class AllClustersCommandDelegate : public NamedPipeCommandDelegate
 {
 public:
-    void OnEventCommandReceived(const char * command) override;
+    void OnEventCommandReceived(const char * json) override;
 
 private:
-    std::string mCurrentCommand;
+    Json::Value mJsonValue;
 
     static void HandleEventCommand(intptr_t context);
 
@@ -50,7 +51,39 @@ private:
     void OnSoftwareFaultEventHandler(uint32_t eventId);
 
     /**
-     * Should be called when a switch operation takes place on the Node.
+     * Should be called when the latching switch is moved to a new position.
      */
-    void OnSwitchEventHandler(uint32_t eventId);
+    void OnSwitchLatchedHandler(uint8_t newPosition);
+
+    /**
+     * Should be called when the momentary switch starts to be pressed.
+     */
+    void OnSwitchInitialPressedHandler(uint8_t newPosition);
+
+    /**
+     * Should be called when the momentary switch has been pressed for a "long" time.
+     */
+    void OnSwitchLongPressedHandler(uint8_t newPosition);
+
+    /**
+     * Should be called when the momentary switch has been released.
+     */
+    void OnSwitchShortReleasedHandler(uint8_t previousPosition);
+
+    /**
+     * Should be called when the momentary switch has been released after having been pressed for a long time.
+     */
+    void OnSwitchLongReleasedHandler(uint8_t previousPosition);
+
+    /**
+     * Should be called to indicate how many times the momentary switch has been pressed in a multi-press
+     * sequence, during that sequence.
+     */
+    void OnSwitchMultiPressOngoingHandler(uint8_t newPosition, uint8_t count);
+
+    /**
+     * Should be called to indicate how many times the momentary switch has been pressed in a multi-press
+     * sequence, after it has been detected that the sequence has ended.
+     */
+    void OnSwitchMultiPressCompleteHandler(uint8_t previousPosition, uint8_t count);
 };

--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -36,6 +36,7 @@ source_set("chip-all-clusters-common") {
     "${chip_root}/examples/platform/linux:app-main",
     "${chip_root}/src/app/tests/suites/credentials:dac_provider",
     "${chip_root}/src/lib",
+    "${chip_root}/third_party/jsoncpp",
   ]
 
   include_dirs =

--- a/examples/all-clusters-app/linux/README.md
+++ b/examples/all-clusters-app/linux/README.md
@@ -81,7 +81,7 @@ all-cluster-app event named pipe /tmp/chip_all_clusters_fifo-<PID>.
 1. Generate event `SoftwareFault` when a software fault takes place on the Node.
 
 ```
-$ echo SoftwareFault > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"SoftwareFault"}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 #### Trigger `HardwareFault` events
@@ -90,21 +90,21 @@ $ echo SoftwareFault > /tmp/chip_all_clusters_fifo-<PID>
    hardware faults currently detected by the Node.
 
 ```
-$ echo HardwareFaultChange > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"HardwareFaultChange"}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 2. Generate event `RadioFaultChange` to indicate a change in the set of radio
    faults currently detected by the Node.
 
 ```
-$ echo RadioFaultChange > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"RadioFaultChange"}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 3. Generate event `NetworkFaultChange` to indicate a change in the set of
    network faults currently detected by the Node.
 
 ```
-$ echo NetworkFaultChange > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"NetworkFaultChange"}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 4. Generate event `BootReason` to indicate the reason that caused the device to
@@ -129,7 +129,7 @@ $ echo NetworkFaultChange > /tmp/chip_all_clusters_fifo-<PID>
     reboot.
 
 ```
-$ echo <BootReason> > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"<BootReason>"}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 #### Trigger Switch events
@@ -138,41 +138,41 @@ $ echo <BootReason> > /tmp/chip_all_clusters_fifo-<PID>
    position.
 
 ```
-$ echo SwitchLatched > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"SwitchLatched","NewPosition":3}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 2. Generate event `InitialPress`, when the momentary switch starts to be
    pressed.
 
 ```
-$ echo InitialPress > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"InitialPress","NewPosition":3}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 3. Generate event `LongPress`, when the momentary switch has been pressed for a
    "long" time.
 
 ```
-$ echo LongPress > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"LongPress","NewPosition":3}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 4. Generate event `ShortRelease`, when the momentary switch has been released.
 
 ```
-$ echo ShortRelease > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"ShortRelease","PreviousPosition":3}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 5. Generate event `LongRelease` when the momentary switch has been released and
    after having been pressed for a long time.
 
 ```
-$ echo LongRelease > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"LongRelease","PreviousPosition":3}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 6. Generate event `MultiPressOngoing` to indicate how many times the momentary
    switch has been pressed in a multi-press sequence, during that sequence.
 
 ```
-$ echo MultiPressOngoing > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"MultiPressOngoing","NewPosition":3,"CurrentNumberOfPressesCounted":4}' > /tmp/chip_all_clusters_fifo-<PID>
 ```
 
 7. Generate event `MultiPressComplete` to indicate how many times the momentary
@@ -180,5 +180,5 @@ $ echo MultiPressOngoing > /tmp/chip_all_clusters_fifo-<PID>
    that the sequence has ended.
 
 ```
-$ echo MultiPressComplete > /tmp/chip_all_clusters_fifo-<PID>
+$ echo '{"Name":"MultiPressComplete","PreviousPosition":3,"TotalNumberOfPressesCounted":2}' > /tmp/chip_all_clusters_fifo-<PID>
 ```

--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -55,7 +55,7 @@ using namespace chip::DeviceLayer;
 
 namespace {
 
-constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_all_cluster_fifo_";
+constexpr const char kChipEventFifoPathPrefix[] = "/tmp/chip_all_clusters_fifo_";
 LowPowerManager sLowPowerManager;
 NamedPipeCommands sChipNamedPipeCommands;
 AllClustersCommandDelegate sAllClustersCommandDelegate;

--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -24,7 +24,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 
-static constexpr const size_t kChipEventCmdBufSize = 80;
+static constexpr const size_t kChipEventCmdBufSize = 256;
 
 CHIP_ERROR NamedPipeCommands::Start(std::string & path, NamedPipeCommandDelegate * delegate)
 {

--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -24,8 +24,8 @@
 class NamedPipeCommandDelegate
 {
 public:
-    virtual ~NamedPipeCommandDelegate()                       = default;
-    virtual void OnEventCommandReceived(const char * payload) = 0;
+    virtual ~NamedPipeCommandDelegate()                    = default;
+    virtual void OnEventCommandReceived(const char * json) = 0;
 };
 
 class NamedPipeCommands


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* To verify the latching and Momentary switch state as explained in the test case TC-SWTCH-3.2, we need a way to modify the state of the switch will be helpful to verify this simulated functionality.

* currently test case expects to change the state of the switch from 0 to 1 and vice versa and expects to read the attribute. As of now there is no provision to change the change the state of the switch. Hence requesting for a way to verify this functionality.

* For test case TC-SWTCH-2.2 - Also needs a method change the switch position and returns to the existing position.
For ex: The test steps needs to operate the switch and release the switch by the operator.

Test plan link:
https://github.com/CHIP-Specifications/chip-test-plans/blob/master/src/cluster/switch.adoc

* Fixes #20384

#### Change overview
Add capability to adjust the state of the the switch position

#### Testing
How was this tested? (at least one bullet point required)
* On Server Side:
`./chip-lighting-app`

* On Client Side:
`$ echo '{"Name":"MultiPressComplete","PreviousPosition":3,"TotalNumberOfPressesCounted":2}' > /tmp/chip_all_clusters_fifo_300736`

* On Server Side:
```
[1658622864.847377][300736:300741] CHIP:-: Received payload: "{"Name":"MultiPressComplete","PreviousPosition":3,"TotalNumberOfPressesCounted":2}"
[1658622864.848002][300736:300736] CHIP:DMG: Endpoint 1, Cluster 0x0000_003B update version to 791f0732
[1658622864.848067][300736:300736] CHIP:-: The new position when the momentary switch has been pressed in a multi-press sequence:3
[1658622864.848103][300736:300736] CHIP:-: 2 times the momentary switch has been pressed
[1658622864.848135][300736:300736] CHIP:ZCL: SwitchServer: OnMultiPressOngoing
[1658622864.848229][300736:300736] CHIP:EVL: LogEvent event number: 0x0000000000050002 priority: 1, endpoint id:  0x1 cluster id: 0x0000_003B event id: 0x5 Sys timestamp: 0x0000000014C2BDD6
```

