### PR TITLE
SystemLayerImplSelect: fix Request/ClearCallbackOnPendingXXX() for…

### DIFF
--- a/src/inet/TCPEndPointImplSockets.h
+++ b/src/inet/TCPEndPointImplSockets.h
@@ -25,10 +25,6 @@
 #include <inet/EndPointStateSockets.h>
 #include <inet/TCPEndPoint.h>
 
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-#include <dispatch/dispatch.h>
-#endif
-
 namespace chip {
 namespace Inet {
 
@@ -73,11 +69,6 @@ private:
     void HandleIncomingConnection();
     CHIP_ERROR BindSrcAddrFromIntf(IPAddressType addrType, InterfaceId intfId);
     static void HandlePendingIO(System::SocketEvents events, intptr_t data);
-
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    dispatch_source_t mReadableSource  = nullptr;
-    dispatch_source_t mWriteableSource = nullptr;
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
 #if INET_CONFIG_OVERRIDE_SYSTEM_TCP_USER_TIMEOUT
     /// This counts the number of bytes written on the TCP socket since thelast probe into the TCP outqueue was made.

--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -205,22 +205,6 @@ CHIP_ERROR UDPEndPointImplSockets::BindImpl(IPAddressType addressType, const IPA
         }
     }
 
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    dispatch_queue_t dispatchQueue = static_cast<System::LayerSocketsLoop *>(&GetSystemLayer())->GetDispatchQueue();
-    if (dispatchQueue != nullptr)
-    {
-        unsigned long fd = static_cast<unsigned long>(mSocket);
-
-        mReadableSource = dispatch_source_create(DISPATCH_SOURCE_TYPE_READ, fd, 0, dispatchQueue);
-        ReturnErrorCodeIf(mReadableSource == nullptr, CHIP_ERROR_NO_MEMORY);
-
-        dispatch_source_set_event_handler(mReadableSource, ^{
-            this->HandlePendingIO(System::SocketEventFlags::kRead);
-        });
-        dispatch_resume(mReadableSource);
-    }
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
-
     return CHIP_NO_ERROR;
 }
 
@@ -431,14 +415,6 @@ void UDPEndPointImplSockets::CloseImpl()
         close(mSocket);
         mSocket = kInvalidSocketFd;
     }
-
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    if (mReadableSource)
-    {
-        dispatch_source_cancel(mReadableSource);
-        dispatch_release(mReadableSource);
-    }
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 }
 
 void UDPEndPointImplSockets::Free()

--- a/src/inet/UDPEndPointImplSockets.h
+++ b/src/inet/UDPEndPointImplSockets.h
@@ -26,10 +26,6 @@
 #include <inet/EndPointStateSockets.h>
 #include <inet/UDPEndPoint.h>
 
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-#include <dispatch/dispatch.h>
-#endif
-
 namespace chip {
 namespace Inet {
 
@@ -64,10 +60,6 @@ private:
 
     InterfaceId mBoundIntfId;
     uint16_t mBoundPort;
-
-#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
-    dispatch_source_t mReadableSource = nullptr;
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
 #if CHIP_SYSTEM_CONFIG_USE_PLATFORM_MULTICAST_API
 public:

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -90,6 +90,10 @@ protected:
         int mFD;
         SocketEvents mPendingIO;
         SocketWatchCallback mCallback;
+#if CHIP_SYSTEM_CONFIG_USE_DISPATCH
+        dispatch_source_t mRdSource;
+        dispatch_source_t mWrSource;
+#endif
         intptr_t mCallbackData;
     };
     SocketWatch mSocketWatchPool[kSocketWatchMax];


### PR DESCRIPTION
…dispatch case, clean transport

#### Problem

For CHIP_SYSTEM_CONFIG_USE_DISPATCH (Darwin) case, Request/ClearCallbackOnPendingXXX() were not working (no loop calling select to evaluate watches).
But still, these methods were called in TCP and UDP endpoint implementations, despite dispatch-specific extra code for the same purpose in the endpoints.

#### Change overview

This changeset now moves all CHIP_SYSTEM_CONFIG_USE_DISPATCH specific socket watching code into SystemLayerImplSelect, by making Request/ClearCallbackOnPendingXXX() actually working with dispatch.

The issue surfaced in my (a bit exotic) use case when I needed to get callbacks for events on a plain socket not wrapped as TCPEndPoint.
Doing this, I realized Request/ClearCallbackOnPendingXXX() were non-functional due to the missing select main loop.
Fixing this revealed the similar dispatch code in the endpoints that was needed to get those events handled despite Request/ClearCallbackOnPendingXXX() not working. That dispatch specific endpoint code now became redundant (delivering events twice), so had to be removed.

#### Testing
* manually regression tested with bridge-example running on darwin (hence using dispatch), showing no difference when being run with and w/o these changes applied - except for Request/ClearCallbackOnPendingXXX() not working without the changes.

I am aware that this might be a too deep intervention and too limited testing for coming from a CHIP newbie like me (not newbie in code deep diving, though), but I think it cleans up an inconsistency in the IP endpoints, and maybe can be of use after review by CHIP experts...
