### PR TITLE
Fix handling of short discriminator in Linux BLE scan.

### DIFF
--- a/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
@@ -30,7 +30,7 @@ void SetupPayloadGenerateCommand::ConfigurePayload(SetupPayload & payload)
 {
     if (mDiscriminator.HasValue())
     {
-        payload.discriminator = mDiscriminator.Value();
+        payload.discriminator.SetLongValue(mDiscriminator.Value());
     }
 
     if (mSetUpPINCode.HasValue())

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -70,10 +70,10 @@ CHIP_ERROR SetupPayloadParseCommand::Parse(std::string codeString, chip::SetupPa
 
 CHIP_ERROR SetupPayloadParseCommand::Print(chip::SetupPayload payload)
 {
-    ChipLogProgress(SetupPayload, "Version:       %u", payload.version);
-    ChipLogProgress(SetupPayload, "VendorID:      %u", payload.vendorID);
-    ChipLogProgress(SetupPayload, "ProductID:     %u", payload.productID);
-    ChipLogProgress(SetupPayload, "Custom flow:   %u    (%s)", to_underlying(payload.commissioningFlow),
+    ChipLogProgress(SetupPayload, "Version:             %u", payload.version);
+    ChipLogProgress(SetupPayload, "VendorID:            %u", payload.vendorID);
+    ChipLogProgress(SetupPayload, "ProductID:           %u", payload.productID);
+    ChipLogProgress(SetupPayload, "Custom flow:         %u    (%s)", to_underlying(payload.commissioningFlow),
                     CustomFlowString(payload.commissioningFlow));
     {
         StringBuilder<128> humanFlags;
@@ -106,15 +106,24 @@ CHIP_ERROR SetupPayloadParseCommand::Print(chip::SetupPayload payload)
             humanFlags.Add("NONE");
         }
 
-        ChipLogProgress(SetupPayload, "Capabilities:  0x%02X (%s)", payload.rendezvousInformation.Raw(), humanFlags.c_str());
+        ChipLogProgress(SetupPayload, "Capabilities:        0x%02X (%s)", payload.rendezvousInformation.Raw(), humanFlags.c_str());
     }
-    ChipLogProgress(SetupPayload, "Discriminator: %u", payload.discriminator);
-    ChipLogProgress(SetupPayload, "Passcode:      %u", payload.setUpPINCode);
+    if (payload.discriminator.IsShortDiscriminator())
+    {
+        ChipLogProgress(SetupPayload, "Short discriminator: %u   (0x%x)", payload.discriminator.GetShortValue(),
+                        payload.discriminator.GetShortValue());
+    }
+    else
+    {
+        ChipLogProgress(SetupPayload, "Long discriminator:  %u   (0x%x)", payload.discriminator.GetLongValue(),
+                        payload.discriminator.GetLongValue());
+    }
+    ChipLogProgress(SetupPayload, "Passcode:            %u", payload.setUpPINCode);
 
     std::string serialNumber;
     if (payload.getSerialNumber(serialNumber) == CHIP_NO_ERROR)
     {
-        ChipLogProgress(SetupPayload, "SerialNumber: %s", serialNumber.c_str());
+        ChipLogProgress(SetupPayload, "SerialNumber:        %s", serialNumber.c_str());
     }
 
     std::vector<OptionalQRCodeInfo> optionalVendorData = payload.getAllOptionalVendorData();
@@ -126,11 +135,11 @@ CHIP_ERROR SetupPayloadParseCommand::Print(chip::SetupPayload payload)
 
         if (isTypeString)
         {
-            ChipLogProgress(SetupPayload, "OptionalQRCodeInfo: tag=%u,string value=%s", info.tag, info.data.c_str());
+            ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,string value=%s", info.tag, info.data.c_str());
         }
         else
         {
-            ChipLogProgress(SetupPayload, "OptionalQRCodeInfo: tag=%u,int value=%u", info.tag, info.int32);
+            ChipLogProgress(SetupPayload, "OptionalQRCodeInfo:  tag=%u,int value=%u", info.tag, info.int32);
         }
     }
 

--- a/examples/platform/linux/CommissionableInit.cpp
+++ b/examples/platform/linux/CommissionableInit.cpp
@@ -59,7 +59,7 @@ CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & prov
 
     if (options.discriminator.HasValue())
     {
-        options.payload.discriminator = options.discriminator.Value();
+        options.payload.discriminator.SetLongValue(options.discriminator.Value());
     }
     else
     {
@@ -72,7 +72,7 @@ CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & prov
                      "given on command line. This is temporary and will disappear. Please update your scripts "
                      "to explicitly configure discriminator. ***",
                      static_cast<unsigned>(defaultTestDiscriminator));
-        options.payload.discriminator = defaultTestDiscriminator;
+        options.payload.discriminator.SetLongValue(defaultTestDiscriminator);
     }
 
     // Default to minimum PBKDF iterations
@@ -84,7 +84,7 @@ CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & prov
     ChipLogError(Support, "PASE PBKDF iterations set to %u", static_cast<unsigned>(spake2pIterationCount));
 
     return provider.Init(options.spake2pVerifier, options.spake2pSalt, spake2pIterationCount, setupPasscode,
-                         options.payload.discriminator);
+                         options.payload.discriminator.GetLongValue());
 }
 
 CHIP_ERROR InitConfigurationManager(ConfigurationManagerImpl & configManager, LinuxDeviceOptions & options)

--- a/examples/tv-casting-app/linux/main.cpp
+++ b/examples/tv-casting-app/linux/main.cpp
@@ -85,7 +85,7 @@ CHIP_ERROR InitCommissionableDataProvider(LinuxCommissionableDataProvider & prov
     ChipLogError(Support, "PASE PBKDF iterations set to %u", static_cast<unsigned>(spake2pIterationCount));
 
     return provider.Init(options.spake2pVerifier, options.spake2pSalt, spake2pIterationCount, setupPasscode,
-                         options.payload.discriminator);
+                         options.payload.discriminator.GetLongValue());
 }
 
 // To hold SPAKE2+ verifier, discriminator, passcode

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -115,13 +115,15 @@ CHIP_ERROR GetPayloadContents(chip::PayloadContents & aPayload, chip::Rendezvous
 #endif
     }
 
-    err = GetCommissionableDataProvider()->GetSetupDiscriminator(aPayload.discriminator);
+    uint16_t discriminator = 0;
+    err                    = GetCommissionableDataProvider()->GetSetupDiscriminator(discriminator);
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(AppServer, "GetCommissionableDataProvider()->GetSetupDiscriminator() failed: %" CHIP_ERROR_FORMAT,
                      err.Format());
         return err;
     }
+    aPayload.discriminator.SetLongValue(discriminator);
 
     err = chip::DeviceLayer::GetDeviceInstanceInfoProvider()->GetVendorId(aPayload.vendorID);
     if (err != CHIP_NO_ERROR)

--- a/src/ble/BleConnectionDelegate.h
+++ b/src/ble/BleConnectionDelegate.h
@@ -27,6 +27,7 @@
 #include <ble/BleError.h>
 
 #include <lib/support/DLLUtil.h>
+#include <lib/support/SetupDiscriminator.h>
 
 namespace chip {
 namespace Ble {
@@ -51,8 +52,8 @@ public:
     OnConnectionErrorFunct OnConnectionError;
 
     // Call this function to delegate the connection steps required to get a BLE_CONNECTION_OBJECT
-    // out of a peripheral discriminator.
-    virtual void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) = 0;
+    // out of a peripheral that matches the given discriminator.
+    virtual void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) = 0;
 
     // Call this function to stop the connection
     virtual CHIP_ERROR CancelConnection() = 0;

--- a/src/ble/BleLayer.cpp
+++ b/src/ble/BleLayer.cpp
@@ -371,7 +371,7 @@ CHIP_ERROR BleLayer::CancelBleIncompleteConnection()
     return err;
 }
 
-CHIP_ERROR BleLayer::NewBleConnectionByDiscriminator(uint16_t connDiscriminator, void * appState,
+CHIP_ERROR BleLayer::NewBleConnectionByDiscriminator(const SetupDiscriminator & connDiscriminator, void * appState,
                                                      BleConnectionDelegate::OnConnectionCompleteFunct onSuccess,
                                                      BleConnectionDelegate::OnConnectionErrorFunct onError)
 {

--- a/src/ble/BleLayer.h
+++ b/src/ble/BleLayer.h
@@ -54,6 +54,7 @@
 
 #include <ble/BleConfig.h>
 
+#include <lib/support/SetupDiscriminator.h>
 #include <system/SystemLayer.h>
 #include <system/SystemPacketBuffer.h>
 
@@ -245,7 +246,7 @@ public:
     void Shutdown();
 
     CHIP_ERROR CancelBleIncompleteConnection();
-    CHIP_ERROR NewBleConnectionByDiscriminator(uint16_t connDiscriminator, void * appState = nullptr,
+    CHIP_ERROR NewBleConnectionByDiscriminator(const SetupDiscriminator & connDiscriminator, void * appState = nullptr,
                                                BleConnectionDelegate::OnConnectionCompleteFunct onSuccess = OnConnectionComplete,
                                                BleConnectionDelegate::OnConnectionErrorFunct onError      = OnConnectionError);
     CHIP_ERROR NewBleConnectionByObject(BLE_CONNECTION_OBJECT connObj);

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -684,7 +684,9 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
         }
         else if (params.HasDiscriminator())
         {
-            SuccessOrExit(err = mSystemState->BleLayer()->NewBleConnectionByDiscriminator(params.GetDiscriminator()));
+            SetupDiscriminator discriminator;
+            discriminator.SetLongValue(params.GetDiscriminator());
+            SuccessOrExit(err = mSystemState->BleLayer()->NewBleConnectionByDiscriminator(discriminator));
         }
         else
         {

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -96,8 +96,8 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
         mPBKDFSalt = ByteSpan(mPBKDFSaltBuffer);
     }
 
-    mSetupPayload.version               = 0;
-    mSetupPayload.discriminator         = discriminator;
+    mSetupPayload.version = 0;
+    mSetupPayload.discriminator.SetLongValue(discriminator);
     mSetupPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kOnNetwork);
 
     mCommissioningWindowCallback      = callback;
@@ -142,7 +142,7 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindowInternal(Operationa
         AdministratorCommissioning::Commands::OpenCommissioningWindow::Type request;
         request.commissioningTimeout = mCommissioningWindowTimeout.count();
         request.PAKEVerifier         = serializedVerifierSpan;
-        request.discriminator        = mSetupPayload.discriminator;
+        request.discriminator        = mSetupPayload.discriminator.GetLongValue();
         request.iterations           = mPBKDFIterations;
         request.salt                 = mPBKDFSalt;
 

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -154,10 +154,17 @@ CHIP_ERROR SetUpCodePairer::StartDiscoverOverIP(SetupPayload & payload)
 {
     ChipLogProgress(Controller, "Starting commissioning discovery over DNS-SD");
 
-    currentFilter.type = payload.isShortDiscriminator ? Dnssd::DiscoveryFilterType::kShortDiscriminator
-                                                      : Dnssd::DiscoveryFilterType::kLongDiscriminator;
-    currentFilter.code =
-        payload.isShortDiscriminator ? static_cast<uint16_t>((payload.discriminator >> 8) & 0x0F) : payload.discriminator;
+    auto & discriminator = payload.discriminator;
+    if (discriminator.IsShortDiscriminator())
+    {
+        currentFilter.type = Dnssd::DiscoveryFilterType::kShortDiscriminator;
+        currentFilter.code = discriminator.GetShortValue();
+    }
+    else
+    {
+        currentFilter.type = Dnssd::DiscoveryFilterType::kLongDiscriminator;
+        currentFilter.code = discriminator.GetLongValue();
+    }
     // Handle possibly-sync callbacks.
     mWaitingForDiscovery[kIPTransport] = true;
     CHIP_ERROR err                     = mCommissioner->DiscoverCommissionableNodes(currentFilter);

--- a/src/controller/python/chip/setup_payload/Generator.cpp
+++ b/src/controller/python/chip/setup_payload/Generator.cpp
@@ -35,11 +35,11 @@ extern "C" ChipError::StorageType pychip_SetupPayload_PrintOnboardingCodes(uint3
     SetupPayload payload;
     RendezvousInformationFlags rendezvousFlags = RendezvousInformationFlag::kNone;
 
-    payload.version               = version;
-    payload.setUpPINCode          = passcode;
-    payload.vendorID              = vendorId;
-    payload.productID             = productId;
-    payload.discriminator         = discriminator;
+    payload.version      = version;
+    payload.setUpPINCode = passcode;
+    payload.vendorID     = vendorId;
+    payload.productID    = productId;
+    payload.discriminator.SetLongValue(discriminator);
     payload.rendezvousInformation = rendezvousFlags.SetRaw(capabilities);
 
     switch (customFlow)

--- a/src/controller/python/chip/setup_payload/Parser.cpp
+++ b/src/controller/python/chip/setup_payload/Parser.cpp
@@ -39,7 +39,14 @@ void YieldSetupPayloadAttributes(const SetupPayload & payload, AttributeVisitor 
     attrVisitor("ProductID", std::to_string(payload.productID).c_str());
     attrVisitor("CommissioningFlow", std::to_string(static_cast<uint8_t>(payload.commissioningFlow)).c_str());
     attrVisitor("RendezvousInformation", std::to_string(payload.rendezvousInformation.Raw()).c_str());
-    attrVisitor("Discriminator", std::to_string(payload.discriminator).c_str());
+    if (payload.discriminator.IsShortDiscriminator())
+    {
+        attrVisitor("Short discriminator", std::to_string(payload.discriminator.GetShortValue()).c_str());
+    }
+    else
+    {
+        attrVisitor("Long discriminator", std::to_string(payload.discriminator.GetLongValue()).c_str());
+    }
     attrVisitor("SetUpPINCode", std::to_string(payload.setUpPINCode).c_str());
 
     std::string serialNumber;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -350,7 +350,7 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
 
         std::string manualPairingCode;
         chip::SetupPayload payload;
-        payload.discriminator = discriminator;
+        payload.discriminator.SetLongValue(discriminator);
         payload.setUpPINCode = setupPINCode;
 
         auto errorCode = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(manualPairingCode);

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -57,6 +57,7 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 @property (nonatomic, assign) MTRCommissioningFlow commissioningFlow;
 @property (nonatomic, assign) MTRRendezvousInformationFlags rendezvousInformation;
 @property (nonatomic, strong) NSNumber * discriminator;
+@property (nonatomic) BOOL hasShortDiscriminator;
 @property (nonatomic, strong) NSNumber * setUpPINCode;
 
 @property (nonatomic, strong) NSString * serialNumber;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -64,7 +64,12 @@
         _productID = [NSNumber numberWithUnsignedShort:setupPayload.productID];
         _commissioningFlow = [self convertCommissioningFlow:setupPayload.commissioningFlow];
         _rendezvousInformation = [self convertRendezvousFlags:setupPayload.rendezvousInformation];
-        _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator];
+        _hasShortDiscriminator = setupPayload.discriminator.IsShortDiscriminator();
+        if (_hasShortDiscriminator) {
+            _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator.GetShortValue()];
+        } else {
+            _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator.GetLongValue()];
+        }
         _setUpPINCode = [NSNumber numberWithUnsignedInt:setupPayload.setUpPINCode];
 
         [self getSerialNumber:setupPayload];
@@ -134,6 +139,7 @@ static NSString * const MTRSetupPayloadCodingKeyVendorID = @"MTRSP.ck.vendorID";
 static NSString * const MTRSetupPayloadCodingKeyProductID = @"MTRSP.ck.productID";
 static NSString * const MTRSetupPayloadCodingKeyCommissioningFlow = @"MTRSP.ck.commissioningFlow";
 static NSString * const MTRSetupPayloadCodingKeyRendezvousFlags = @"MTRSP.ck.rendezvousFlags";
+static NSString * const MTRSetupPayloadCodingKeyHasShortDiscriminator = @"MTRSP.ck.hasShortDiscriminator";
 static NSString * const MTRSetupPayloadCodingKeyDiscriminator = @"MTRSP.ck.discriminator";
 static NSString * const MTRSetupPayloadCodingKeySetupPINCode = @"MTRSP.ck.setupPINCode";
 static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serialNumber";
@@ -148,10 +154,11 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     [coder encodeObject:self.version forKey:MTRSetupPayloadCodingKeyVersion];
     [coder encodeObject:self.vendorID forKey:MTRSetupPayloadCodingKeyVendorID];
     [coder encodeObject:self.productID forKey:MTRSetupPayloadCodingKeyProductID];
-    // Casts are safe because commissioning flow and rendezvous information
-    // values are all pretty small and non-negative.
+    // Casts are safe because commissioning flow, rendezvous information, and
+    // hasShortDiscriminator values are all pretty small and non-negative.
     [coder encodeInteger:static_cast<NSInteger>(self.commissioningFlow) forKey:MTRSetupPayloadCodingKeyCommissioningFlow];
     [coder encodeInteger:static_cast<NSInteger>(self.rendezvousInformation) forKey:MTRSetupPayloadCodingKeyRendezvousFlags];
+    [coder encodeInteger:static_cast<NSInteger>(self.hasShortDiscriminator) forKey:MTRSetupPayloadCodingKeyHasShortDiscriminator];
     [coder encodeObject:self.discriminator forKey:MTRSetupPayloadCodingKeyDiscriminator];
     [coder encodeObject:self.setUpPINCode forKey:MTRSetupPayloadCodingKeySetupPINCode];
     [coder encodeObject:self.serialNumber forKey:MTRSetupPayloadCodingKeySerialNumber];
@@ -164,6 +171,7 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     NSNumber * productID = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyProductID];
     NSInteger commissioningFlow = [decoder decodeIntegerForKey:MTRSetupPayloadCodingKeyCommissioningFlow];
     NSInteger rendezvousInformation = [decoder decodeIntegerForKey:MTRSetupPayloadCodingKeyRendezvousFlags];
+    NSInteger hasShortDiscriminator = [decoder decodeIntegerForKey:MTRSetupPayloadCodingKeyHasShortDiscriminator];
     NSNumber * discriminator = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyDiscriminator];
     NSNumber * setUpPINCode = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeySetupPINCode];
     NSString * serialNumber = [decoder decodeObjectOfClass:[NSString class] forKey:MTRSetupPayloadCodingKeySerialNumber];
@@ -174,6 +182,7 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     payload.productID = productID;
     payload.commissioningFlow = static_cast<MTRCommissioningFlow>(commissioningFlow);
     payload.rendezvousInformation = static_cast<MTRRendezvousInformationFlags>(rendezvousInformation);
+    payload.hasShortDiscriminator = static_cast<BOOL>(hasShortDiscriminator);
     payload.discriminator = discriminator;
     payload.setUpPINCode = setUpPINCode;
     payload.serialNumber = serialNumber;

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
@@ -45,7 +45,8 @@
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
-    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 2560);
+    XCTAssertTrue(payload.hasShortDiscriminator);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
     XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
@@ -75,7 +76,8 @@
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
-    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 2560);
+    XCTAssertTrue(payload.hasShortDiscriminator);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
     XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
@@ -105,6 +107,7 @@
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
+    XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
     XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
@@ -136,6 +139,7 @@
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
+    XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
     XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
@@ -167,7 +171,8 @@
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
-    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 2560);
+    XCTAssertTrue(payload.hasShortDiscriminator);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
     XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
@@ -207,6 +212,7 @@
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
+    XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
     XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
@@ -227,6 +233,7 @@
     XCTAssertNil(error);
 
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
+    XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
     XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);

--- a/src/lib/support/BUILD.gn
+++ b/src/lib/support/BUILD.gn
@@ -124,6 +124,7 @@ static_library("support") {
     "SafeInt.h",
     "SerializableIntegerSet.cpp",
     "SerializableIntegerSet.h",
+    "SetupDiscriminator.h",
     "SortUtils.h",
     "StateMachine.h",
     "ThreadOperationalDataset.cpp",

--- a/src/lib/support/SetupDiscriminator.h
+++ b/src/lib/support/SetupDiscriminator.h
@@ -88,8 +88,6 @@ public:
     }
 
 private:
-    static_assert(kLongBits == 12, "Unexpected field length");
-
     static constexpr uint16_t kLongMask = (1 << kLongBits) - 1;
     static constexpr uint8_t kShortMask = (1 << kShortBits) - 1;
 
@@ -101,9 +99,11 @@ private:
     }
 
     // If long discriminator, all 12 bits are used.  If short discriminator,
-    // only the low kManualSetupDiscriminatorFieldLengthInBits bits are used, to
-    // store the value of the short discriminator (which contains only the high
-    // bits of the complete 12-bit discriminator).
+    // only the low kShortBits bits are used, to store the value of the short
+    // discriminator (which contains only the high bits of the complete 12-bit
+    // discriminator).
+    static_assert(kLongBits == 12, "Unexpected field length");
+    static_assert(kShortBits <= kLongBits, "Unexpected field length");
     uint16_t mDiscriminator : 12;
     uint16_t mIsShortDiscriminator : 1;
 };

--- a/src/lib/support/SetupDiscriminator.h
+++ b/src/lib/support/SetupDiscriminator.h
@@ -1,0 +1,111 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file defines the SetupDiscriminator type, which is used by
+ *      low-level code (e.g. BLE) in addition to setup payload code.
+ */
+
+#pragma once
+
+#include <lib/support/CodeUtils.h>
+
+#include <cstdint>
+
+namespace chip {
+
+class SetupDiscriminator
+{
+public:
+    constexpr SetupDiscriminator() : mDiscriminator(0), mIsShortDiscriminator(0) {}
+
+    // See section 5.1.2. QR Code in the Matter specification
+    static constexpr int kLongBits = 12;
+
+    // See section 5.1.3. Manual Pairing Code in the Matter specification
+    static constexpr int kShortBits = 4;
+
+    void SetShortValue(uint8_t discriminator)
+    {
+        VerifyOrDie(discriminator == (discriminator & kShortMask));
+        mDiscriminator        = (discriminator & kShortMask);
+        mIsShortDiscriminator = true;
+    }
+
+    void SetLongValue(uint16_t discriminator)
+    {
+        VerifyOrDie(discriminator == (discriminator & kLongMask));
+        mDiscriminator        = (discriminator & kLongMask);
+        mIsShortDiscriminator = false;
+    }
+
+    bool IsShortDiscriminator() const { return mIsShortDiscriminator; }
+
+    uint8_t GetShortValue() const
+    {
+        if (IsShortDiscriminator())
+        {
+            return static_cast<uint8_t>(mDiscriminator);
+        }
+
+        return LongToShortValue(mDiscriminator);
+    }
+
+    uint16_t GetLongValue() const
+    {
+        VerifyOrDie(!IsShortDiscriminator());
+        return mDiscriminator;
+    }
+
+    bool MatchesLongDiscriminator(uint16_t discriminator) const
+    {
+        if (!IsShortDiscriminator())
+        {
+            return mDiscriminator == discriminator;
+        }
+
+        return mDiscriminator == LongToShortValue(discriminator);
+    }
+
+    bool operator==(const SetupDiscriminator & other) const
+    {
+        return mIsShortDiscriminator == other.mIsShortDiscriminator && mDiscriminator == other.mDiscriminator;
+    }
+
+private:
+    static_assert(kLongBits == 12, "Unexpected field length");
+
+    static constexpr uint16_t kLongMask = (1 << kLongBits) - 1;
+    static constexpr uint8_t kShortMask = (1 << kShortBits) - 1;
+
+    static uint8_t LongToShortValue(uint16_t longValue)
+    {
+        // Short value consists of the high bits of the long value.
+        constexpr int kLongToShortShift = kLongBits - kShortBits;
+        return static_cast<uint8_t>(longValue >> kLongToShortShift);
+    }
+
+    // If long discriminator, all 12 bits are used.  If short discriminator,
+    // only the low kManualSetupDiscriminatorFieldLengthInBits bits are used, to
+    // store the value of the short discriminator (which contains only the high
+    // bits of the complete 12-bit discriminator).
+    uint16_t mDiscriminator : 12;
+    uint16_t mIsShortDiscriminator : 1;
+};
+
+} // namespace chip

--- a/src/platform/Darwin/BleConnectionDelegate.h
+++ b/src/platform/Darwin/BleConnectionDelegate.h
@@ -26,7 +26,7 @@ namespace Internal {
 class BleConnectionDelegateImpl : public Ble::BleConnectionDelegate
 {
 public:
-    virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator);
+    virtual void NewConnection(Ble::BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator);
     virtual CHIP_ERROR CancelConnection();
 };
 

--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -712,7 +712,7 @@ void BLEManagerImpl::InitiateScan(intptr_t arg)
     sInstance.InitiateScan(static_cast<BleScanState>(arg));
 }
 
-void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator)
+void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator)
 {
     mBLEScanConfig.mDiscriminator = connDiscriminator;
     mBLEScanConfig.mAppState      = appState;
@@ -768,7 +768,7 @@ void BLEManagerImpl::OnDeviceScanned(BluezDevice1 * device, const chip::Ble::Chi
 
     if (mBLEScanConfig.mBleScanState == BleScanState::kScanForDiscriminator)
     {
-        if (info.GetDeviceDiscriminator() != mBLEScanConfig.mDiscriminator)
+        if (!mBLEScanConfig.mDiscriminator.MatchesLongDiscriminator(info.GetDeviceDiscriminator()))
         {
             return;
         }

--- a/src/platform/Linux/BLEManagerImpl.h
+++ b/src/platform/Linux/BLEManagerImpl.h
@@ -66,7 +66,7 @@ struct BLEScanConfig
     BleScanState mBleScanState = BleScanState::kNotScanning;
 
     // If scanning by discriminator, what are we scanning for
-    uint16_t mDiscriminator = 0;
+    SetupDiscriminator mDiscriminator;
 
     // If scanning by address, what address are we searching for
     std::string mAddress;
@@ -148,7 +148,7 @@ private:
 
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
-    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -455,7 +455,7 @@ void BLEManagerImpl::OnChipDeviceScanned(void * device, const chip::Ble::ChipBLE
 
     if (mBLEScanConfig.mBleScanState == BleScanState::kScanForDiscriminator)
     {
-        if (info.GetDeviceDiscriminator() != mBLEScanConfig.mDiscriminator)
+        if (!mBLEScanConfig.mDiscriminator.MatchesLongDiscriminator(info.GetDeviceDiscriminator()))
         {
             return;
         }
@@ -1287,11 +1287,18 @@ bool BLEManagerImpl::SendReadResponse(BLE_CONNECTION_OBJECT conId, BLE_READ_REQU
 
 void BLEManagerImpl::NotifyChipConnectionClosed(BLE_CONNECTION_OBJECT conId) {}
 
-void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator)
+void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator)
 {
     mBLEScanConfig.mDiscriminator = connDiscriminator;
     mBLEScanConfig.mAppState      = appState;
-    ChipLogProgress(DeviceLayer, "NewConnection: discriminator value [%u]", connDiscriminator);
+    if (connDiscriminator.IsShortDiscriminator())
+    {
+        ChipLogProgress(DeviceLayer, "NewConnection: short discriminator value [%u]", connDiscriminator.GetShortValue());
+    }
+    else
+    {
+        ChipLogProgress(DeviceLayer, "NewConnection: long discriminator value [%u]", connDiscriminator.GetLongValue());
+    }
 
     // Initiate Scan.
     PlatformMgr().ScheduleWork(InitiateScan, static_cast<intptr_t>(BleScanState::kScanForDiscriminator));

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -57,7 +57,7 @@ struct BLEScanConfig
     BleScanState mBleScanState = BleScanState::kNotScanning;
 
     // If scanning by discriminator, what are we scanning for
-    uint16_t mDiscriminator = 0;
+    SetupDiscriminator mDiscriminator;
 
     // If scanning by address, what address are we searching for
     std::string mAddress;
@@ -122,7 +122,7 @@ private:
 
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
-    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
     CHIP_ERROR CancelConnection() override;
 
     //  ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/platform/android/BLEManagerImpl.h
+++ b/src/platform/android/BLEManagerImpl.h
@@ -90,7 +90,7 @@ private:
 
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
-    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members for internal use by the following friends.

--- a/src/platform/webos/BLEManagerImpl.cpp
+++ b/src/platform/webos/BLEManagerImpl.cpp
@@ -888,7 +888,7 @@ void BLEManagerImpl::InitiateScan(intptr_t arg)
     sInstance.InitiateScan(static_cast<BleScanState>(arg));
 }
 
-void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const uint16_t connDiscriminator)
+void BLEManagerImpl::NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator)
 {
     mBLEScanConfig.mDiscriminator = connDiscriminator;
     mBLEScanConfig.mAppState      = appState;

--- a/src/platform/webos/BLEManagerImpl.h
+++ b/src/platform/webos/BLEManagerImpl.h
@@ -51,7 +51,7 @@ struct BLEScanConfig
     BleScanState mBleScanState = BleScanState::kNotScanning;
 
     // If scanning by discriminator, what are we scanning for
-    uint16_t mDiscriminator = 0;
+    SetupDiscriminator mDiscriminator;
 
     // If scanning by address, what address are we searching for
     std::string mAddress;
@@ -131,7 +131,7 @@ private:
 
     // ===== Members that implement virtual methods on BleConnectionDelegate.
 
-    void NewConnection(BleLayer * bleLayer, void * appState, uint16_t connDiscriminator) override;
+    void NewConnection(BleLayer * bleLayer, void * appState, const SetupDiscriminator & connDiscriminator) override;
     CHIP_ERROR CancelConnection() override;
 
     // ===== Members that implement virtual methods on ChipDeviceScannerDelegate

--- a/src/protocols/secure_channel/RendezvousParameters.h
+++ b/src/protocols/secure_channel/RendezvousParameters.h
@@ -54,6 +54,8 @@ public:
         return *this;
     }
 
+    // Discriminators in RendezvousParameters are always long (12-bit)
+    // discriminators.
     bool HasDiscriminator() const { return mDiscriminator <= kMaxRendezvousDiscriminatorValue; }
     uint16_t GetDiscriminator() const { return mDiscriminator; }
     RendezvousParameters & SetDiscriminator(uint16_t discriminator)

--- a/src/setup_payload/ManualSetupPayloadGenerator.cpp
+++ b/src/setup_payload/ManualSetupPayloadGenerator.cpp
@@ -38,14 +38,14 @@ static uint32_t chunk1PayloadRepresentation(const PayloadContents & payload)
      *     - <bit 2> VID/PID present flag
      */
 
-    constexpr int kDiscriminatorShift     = (kPayloadDiscriminatorFieldLengthInBits - kManualSetupChunk1DiscriminatorMsbitsLength);
+    constexpr int kDiscriminatorShift = (kManualSetupDiscriminatorFieldLengthInBits - kManualSetupChunk1DiscriminatorMsbitsLength);
     constexpr uint32_t kDiscriminatorMask = (1 << kManualSetupChunk1DiscriminatorMsbitsLength) - 1;
 
     static_assert(kManualSetupChunk1VidPidPresentBitPos >=
                       kManualSetupChunk1DiscriminatorMsbitsPos + kManualSetupChunk1DiscriminatorMsbitsLength,
                   "Discriminator won't fit");
 
-    uint32_t discriminatorChunk = (payload.discriminator >> kDiscriminatorShift) & kDiscriminatorMask;
+    uint32_t discriminatorChunk = (payload.discriminator.GetShortValue() >> kDiscriminatorShift) & kDiscriminatorMask;
     uint32_t vidPidPresentFlag  = payload.commissioningFlow != CommissioningFlow::kStandard ? 1 : 0;
 
     uint32_t result = (discriminatorChunk << kManualSetupChunk1DiscriminatorMsbitsPos) |
@@ -61,11 +61,10 @@ static uint32_t chunk2PayloadRepresentation(const PayloadContents & payload)
      *     - <bits 15..14> Discriminator <bits 9..8>
      */
 
-    constexpr int kDiscriminatorShift     = (kPayloadDiscriminatorFieldLengthInBits - kManualSetupDiscriminatorFieldLengthInBits);
     constexpr uint32_t kDiscriminatorMask = (1 << kManualSetupChunk2DiscriminatorLsbitsLength) - 1;
     constexpr uint32_t kPincodeMask       = (1 << kManualSetupChunk2PINCodeLsbitsLength) - 1;
 
-    uint32_t discriminatorChunk = (payload.discriminator >> kDiscriminatorShift) & kDiscriminatorMask;
+    uint32_t discriminatorChunk = payload.discriminator.GetShortValue() & kDiscriminatorMask;
 
     uint32_t result = ((payload.setUpPINCode & kPincodeMask) << kManualSetupChunk2PINCodeLsbitsPos) |
         (discriminatorChunk << kManualSetupChunk2DiscriminatorLsbitsPos);

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -151,10 +151,6 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     discriminator |= ((chunk1 >> kManualSetupChunk1DiscriminatorMsbitsPos) & kDiscriminatorMsbitsMask)
         << kManualSetupChunk2DiscriminatorLsbitsLength;
 
-    // Since manual code only contains upper msbits of discriminator, re-align
-    constexpr int kDiscriminatorShift = (kPayloadDiscriminatorFieldLengthInBits - kManualSetupDiscriminatorFieldLengthInBits);
-    discriminator <<= kDiscriminatorShift;
-
     constexpr uint32_t kPincodeMsbitsMask = (1 << kManualSetupChunk3PINCodeMsbitsLength) - 1;
     constexpr uint32_t kPincodeLsbitsMask = (1 << kManualSetupChunk2PINCodeLsbitsLength) - 1;
 
@@ -200,9 +196,8 @@ CHIP_ERROR ManualSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     outPayload.commissioningFlow = isLongCode ? CommissioningFlow::kCustom : CommissioningFlow::kStandard;
     static_assert(kSetupPINCodeFieldLengthInBits <= 32, "Won't fit in uint32_t");
     outPayload.setUpPINCode = static_cast<uint32_t>(setUpPINCode);
-    static_assert(kManualSetupDiscriminatorFieldLengthInBits <= 16, "Won't fit in uint16_t");
-    outPayload.discriminator        = static_cast<uint16_t>(discriminator);
-    outPayload.isShortDiscriminator = true;
+    static_assert(kManualSetupDiscriminatorFieldLengthInBits <= 8, "Won't fit in uint8_t");
+    outPayload.discriminator.SetShortValue(static_cast<uint8_t>(discriminator));
 
     return result;
 }

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -170,8 +170,8 @@ static CHIP_ERROR generateBitSet(PayloadContents & payload, MutableByteSpan & bi
                                       kCommissioningFlowFieldLengthInBits, kTotalPayloadDataSizeInBits));
     ReturnErrorOnFailure(populateBits(bits.data(), offset, payload.rendezvousInformation.Raw(), kRendezvousInfoFieldLengthInBits,
                                       kTotalPayloadDataSizeInBits));
-    ReturnErrorOnFailure(populateBits(bits.data(), offset, payload.discriminator, kPayloadDiscriminatorFieldLengthInBits,
-                                      kTotalPayloadDataSizeInBits));
+    ReturnErrorOnFailure(populateBits(bits.data(), offset, payload.discriminator.GetLongValue(),
+                                      kPayloadDiscriminatorFieldLengthInBits, kTotalPayloadDataSizeInBits));
     ReturnErrorOnFailure(
         populateBits(bits.data(), offset, payload.setUpPINCode, kSetupPINCodeFieldLengthInBits, kTotalPayloadDataSizeInBits));
     ReturnErrorOnFailure(populateBits(bits.data(), offset, 0, kPaddingFieldLengthInBits, kTotalPayloadDataSizeInBits));

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -358,7 +358,7 @@ CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)
 
     ReturnErrorOnFailure(readBits(buf, indexToReadFrom, dest, kPayloadDiscriminatorFieldLengthInBits));
     static_assert(kPayloadDiscriminatorFieldLengthInBits <= 16, "Won't fit in uint16_t");
-    outPayload.discriminator = static_cast<uint16_t>(dest);
+    outPayload.discriminator.SetLongValue(static_cast<uint16_t>(dest));
 
     ReturnErrorOnFailure(readBits(buf, indexToReadFrom, dest, kSetupPINCodeFieldLengthInBits));
     static_assert(kSetupPINCodeFieldLengthInBits <= 32, "Won't fit in uint32_t");

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -79,10 +79,7 @@ bool PayloadContents::isValidQRCodePayload() const
         return false;
     }
 
-    if (discriminator >= 1 << kPayloadDiscriminatorFieldLengthInBits)
-    {
-        return false;
-    }
+    // Discriminator validity is enforced by the SetupDiscriminator class.
 
     if (setUpPINCode >= 1 << kSetupPINCodeFieldLengthInBits)
     {
@@ -94,15 +91,8 @@ bool PayloadContents::isValidQRCodePayload() const
 
 bool PayloadContents::isValidManualCode() const
 {
-    // The discriminator for manual setup code is 4 most significant bits
-    // in a regular 12 bit discriminator. Let's make sure that the provided
-    // discriminator fits within 12 bits (kPayloadDiscriminatorFieldLengthInBits).
-    // The manual setup code generator will only use 4 most significant bits from
-    // it.
-    if (discriminator >= 1 << kPayloadDiscriminatorFieldLengthInBits)
-    {
-        return false;
-    }
+    // Discriminator validity is enforced by the SetupDiscriminator class.
+
     if (setUpPINCode >= 1 << kSetupPINCodeFieldLengthInBits)
     {
         return false;

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -30,6 +30,7 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/BitFlags.h>
+#include <lib/support/SetupDiscriminator.h>
 
 namespace chip {
 
@@ -39,13 +40,13 @@ const int kVendorIDFieldLengthInBits             = 16;
 const int kProductIDFieldLengthInBits            = 16;
 const int kCommissioningFlowFieldLengthInBits    = 2;
 const int kRendezvousInfoFieldLengthInBits       = 8;
-const int kPayloadDiscriminatorFieldLengthInBits = 12;
+const int kPayloadDiscriminatorFieldLengthInBits = SetupDiscriminator::kLongBits;
 const int kSetupPINCodeFieldLengthInBits         = 27;
 const int kPaddingFieldLengthInBits              = 4;
 const int kRawVendorTagLengthInBits              = 7;
 
 // See section 5.1.3. Manual Pairing Code in the Matter specification
-const int kManualSetupDiscriminatorFieldLengthInBits  = 4;
+const int kManualSetupDiscriminatorFieldLengthInBits  = SetupDiscriminator::kShortBits;
 const int kManualSetupChunk1DiscriminatorMsbitsPos    = 0;
 const int kManualSetupChunk1DiscriminatorMsbitsLength = 2;
 const int kManualSetupChunk1VidPidPresentBitPos =
@@ -119,12 +120,11 @@ struct PayloadContents
     uint16_t productID                               = 0;
     CommissioningFlow commissioningFlow              = CommissioningFlow::kStandard;
     RendezvousInformationFlags rendezvousInformation = RendezvousInformationFlag::kNone;
-    uint16_t discriminator                           = 0;
-    uint32_t setUpPINCode                            = 0;
+    SetupDiscriminator discriminator;
+    uint32_t setUpPINCode = 0;
 
     bool isValidQRCodePayload() const;
     bool isValidManualCode() const;
-    bool isShortDiscriminator = false;
     bool operator==(PayloadContents & input) const;
 
     static bool IsValidSetupPIN(uint32_t setupPIN);

--- a/src/setup_payload/SetupPayloadHelper.cpp
+++ b/src/setup_payload/SetupPayloadHelper.cpp
@@ -129,7 +129,7 @@ static CHIP_ERROR addParameter(SetupPayload & setupPayload, const SetupPayloadPa
         break;
     case SetupPayloadKey_Discriminator:
         ChipLogDetail(SetupPayload, "Loaded discriminator: %u", (uint16_t) parameter.uintValue);
-        setupPayload.discriminator = static_cast<uint16_t>(parameter.uintValue);
+        setupPayload.discriminator.SetLongValue(static_cast<uint16_t>(parameter.uintValue));
         break;
     case SetupPayloadKey_SetupPINCode:
         ChipLogDetail(SetupPayload, "Loaded setupPinCode: %lu", (unsigned long) parameter.uintValue);

--- a/src/setup_payload/java/SetupPayloadParser-JNI.cpp
+++ b/src/setup_payload/java/SetupPayloadParser-JNI.cpp
@@ -106,7 +106,20 @@ jobject TransformSetupPayload(JNIEnv * env, SetupPayload & payload)
     env->SetIntField(setupPayload, vendorId, payload.vendorID);
     env->SetIntField(setupPayload, productId, payload.productID);
     env->SetIntField(setupPayload, commissioningFlow, static_cast<int>(payload.commissioningFlow));
-    env->SetIntField(setupPayload, discriminator, payload.discriminator);
+    // TODO: The API we have here does not handle short discriminators in any
+    // sane way.  Just do what we used to do, which is pretend that a short
+    // discriminator is actually a long discriminator with the low bits all 0.
+    uint16_t discriminatorValue;
+    if (payload.discriminator.IsShortDiscriminator())
+    {
+        discriminatorValue = static_cast<uint16_t>(payload.discriminator.GetShortValue())
+            << (SetupDiscriminator::kLongBits - SetupDiscriminator::kShortBits);
+    }
+    else
+    {
+        discriminatorValue = payload.discriminator.GetLongValue();
+    }
+    env->SetIntField(setupPayload, discriminator, discriminatorValue);
     env->SetLongField(setupPayload, setUpPinCode, payload.setUpPINCode);
 
     env->SetObjectField(setupPayload, discoveryCapabilities, CreateCapabilitiesHashSet(env, payload.rendezvousInformation));
@@ -257,8 +270,8 @@ void TransformSetupPayloadFromJobject(JNIEnv * env, jobject jPayload, SetupPaylo
     payload.vendorID          = env->GetIntField(jPayload, vendorId);
     payload.productID         = env->GetIntField(jPayload, productId);
     payload.commissioningFlow = static_cast<CommissioningFlow>(env->GetIntField(jPayload, commissioningFlow));
-    payload.discriminator     = env->GetIntField(jPayload, discriminator);
-    payload.setUpPINCode      = env->GetLongField(jPayload, setUpPinCode);
+    payload.discriminator.SetLongValue(env->GetIntField(jPayload, discriminator));
+    payload.setUpPINCode = env->GetLongField(jPayload, setUpPinCode);
 
     jobject discoveryCapabilitiesObj = env->GetObjectField(jPayload, discoveryCapabilities);
     CreateCapabilitiesFromHashSet(env, discoveryCapabilitiesObj, payload.rendezvousInformation);

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -50,8 +50,8 @@ inline SetupPayload GetDefaultPayload()
     payload.productID             = 1;
     payload.commissioningFlow     = CommissioningFlow::kStandard;
     payload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kSoftAP);
-    payload.discriminator         = 128;
-    payload.setUpPINCode          = 2048;
+    payload.discriminator.SetLongValue(128);
+    payload.setUpPINCode = 2048;
 
     return payload;
 }

--- a/src/setup_payload/tests/TestManualCode.cpp
+++ b/src/setup_payload/tests/TestManualCode.cpp
@@ -64,8 +64,8 @@ bool CheckGenerator(const PayloadContents & payload, std::string expectedResult,
 PayloadContents GetDefaultPayload()
 {
     PayloadContents payload;
-    payload.setUpPINCode  = 12345679;
-    payload.discriminator = 2560;
+    payload.setUpPINCode = 12345679;
+    payload.discriminator.SetLongValue(2560);
 
     return payload;
 }
@@ -127,8 +127,8 @@ void TestDecimalRepresentation_FullPayloadWithoutZeros_DoesNotRequireCustomFlow(
 void TestDecimalRepresentation_AllZeros(nlTestSuite * inSuite, void * inContext)
 {
     PayloadContents payload;
-    payload.setUpPINCode  = 0;
-    payload.discriminator = 0;
+    payload.setUpPINCode = 0;
+    payload.discriminator.SetLongValue(0);
 
     std::string expectedResult;
 
@@ -138,8 +138,8 @@ void TestDecimalRepresentation_AllZeros(nlTestSuite * inSuite, void * inContext)
 void TestDecimalRepresentation_AllOnes(nlTestSuite * inSuite, void * inContext)
 {
     PayloadContents payload;
-    payload.setUpPINCode      = 0x7FFFFFF;
-    payload.discriminator     = 0xFFF;
+    payload.setUpPINCode = 0x7FFFFFF;
+    payload.discriminator.SetLongValue(0xFFF);
     payload.commissioningFlow = CommissioningFlow::kCustom;
     payload.vendorID          = 65535;
     payload.productID         = 65535;
@@ -149,18 +149,8 @@ void TestDecimalRepresentation_AllOnes(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, CheckGenerator(payload, expectedResult, /*allowInvalidPayload*/ true));
 }
 
-void TestDecimalRepresentation_InvalidPayload(nlTestSuite * inSuite, void * inContext)
-{
-    PayloadContents payload = GetDefaultPayload();
-    payload.discriminator   = 0x1f00;
-
-    ManualSetupPayloadGenerator generator(payload);
-    std::string result;
-    NL_TEST_ASSERT(inSuite, generator.payloadDecimalStringRepresentation(result) == CHIP_ERROR_INVALID_ARGUMENT);
-}
-
 void assertPayloadValues(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERROR expectedError, const PayloadContents & payload,
-                         uint32_t pinCode, uint16_t discriminator, uint16_t vendorID, uint16_t productID)
+                         uint32_t pinCode, const SetupDiscriminator & discriminator, uint16_t vendorID, uint16_t productID)
 {
     NL_TEST_ASSERT(inSuite, actualError == expectedError);
     NL_TEST_ASSERT(inSuite, payload.setUpPINCode == pinCode);
@@ -172,7 +162,7 @@ void assertPayloadValues(nlTestSuite * inSuite, CHIP_ERROR actualError, CHIP_ERR
 void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * inSuite, void * inContext)
 {
     PayloadContents payload = GetDefaultPayload();
-    payload.discriminator   = 0xa1f;
+    payload.discriminator.SetLongValue(0xa1f);
 
     {
         // Test short 11 digit code
@@ -182,14 +172,18 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 
         SetupPayload outPayload;
         CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 0xa00, payload.vendorID,
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        SetupDiscriminator discriminator;
+        discriminator.SetShortValue(0xa);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, discriminator, payload.vendorID,
                             payload.productID);
     }
 
     payload.vendorID          = 1;
     payload.productID         = 1;
     payload.commissioningFlow = CommissioningFlow::kCustom;
-    payload.discriminator     = 0xb1f;
+    payload.discriminator.SetLongValue(0xb1f);
 
     {
         // Test long 21 digit code
@@ -199,7 +193,11 @@ void TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator(nlTestSuite * in
 
         SetupPayload outPayload;
         CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, 0xb00, payload.vendorID,
+        NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+        SetupDiscriminator discriminator;
+        discriminator.SetShortValue(0xb);
+        assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, discriminator, payload.vendorID,
                             payload.productID);
     }
 }
@@ -212,17 +210,27 @@ void TestPayloadParser_FullPayload(nlTestSuite * inSuite, void * inContext)
     decimalString = "63610875354536714526";
     decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
     CHIP_ERROR err = ManualSetupPayloadParser(decimalString).populatePayload(payload);
-    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 123456780, 2560, 45367, 14526);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SetupDiscriminator discriminator;
+    discriminator.SetShortValue(0xa);
+    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 123456780, discriminator, 45367, 14526);
 
     decimalString = "52927623630456200032";
     decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
     err = ManualSetupPayloadParser(decimalString).populatePayload(payload);
-    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 38728284, 1280, 4562, 32);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    discriminator.SetShortValue(0x5);
+    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 38728284, discriminator, 4562, 32);
 
     decimalString = "40000100000000100001";
     decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
     err = ManualSetupPayloadParser(decimalString).populatePayload(payload);
-    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 1, 0, 1, 1);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    discriminator.SetShortValue(0);
+    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 1, discriminator, 1, 1);
 }
 
 void TestGenerateAndParser_FullPayload(nlTestSuite * inSuite, void * inContext)
@@ -238,7 +246,11 @@ void TestGenerateAndParser_FullPayload(nlTestSuite * inSuite, void * inContext)
 
     SetupPayload outPayload;
     CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, payload.discriminator, payload.vendorID,
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SetupDiscriminator discriminator;
+    discriminator.SetShortValue(payload.discriminator.GetShortValue());
+    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, discriminator, payload.vendorID,
                         payload.productID);
 }
 
@@ -252,7 +264,11 @@ void TestGenerateAndParser_PartialPayload(nlTestSuite * inSuite, void * inContex
 
     SetupPayload outPayload;
     CHIP_ERROR err = ManualSetupPayloadParser(result).populatePayload(outPayload);
-    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, payload.discriminator, payload.vendorID,
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SetupDiscriminator discriminator;
+    discriminator.SetShortValue(payload.discriminator.GetShortValue());
+    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, outPayload, payload.setUpPINCode, discriminator, payload.vendorID,
                         payload.productID);
 }
 
@@ -266,19 +282,29 @@ void TestPayloadParser_PartialPayload(nlTestSuite * inSuite, void * inContext)
     decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
     NL_TEST_ASSERT(inSuite, decimalString.length() == 11);
     err = ManualSetupPayloadParser(decimalString).populatePayload(payload);
-    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 123456780, 2560, 0, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    SetupDiscriminator discriminator;
+    discriminator.SetShortValue(0xa);
+    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 123456780, discriminator, 0, 0);
 
     decimalString = "0000010000";
     decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
     NL_TEST_ASSERT(inSuite, decimalString.length() == 11);
     err = ManualSetupPayloadParser(decimalString).populatePayload(payload);
-    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 1, 0, 0, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    discriminator.SetShortValue(0);
+    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 1, discriminator, 0, 0);
 
     decimalString = "63610875350000000000";
     decimalString += Verhoeff10::ComputeCheckChar(decimalString.c_str());
     NL_TEST_ASSERT(inSuite, decimalString.length() == 21);
     err = ManualSetupPayloadParser(decimalString).populatePayload(payload);
-    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 123456780, 2560, 0, 0);
+    NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
+
+    discriminator.SetShortValue(0xa);
+    assertPayloadValues(inSuite, err, CHIP_NO_ERROR, payload, 123456780, discriminator, 0, 0);
 
     // no discriminator (= 0)
     decimalString = "0033407535";
@@ -305,6 +331,7 @@ void TestPayloadParser_PartialPayload(nlTestSuite * inSuite, void * inContext)
 void TestShortCodeReadWrite(nlTestSuite * inSuite, void * context)
 {
     PayloadContents inPayload = GetDefaultPayload();
+
     SetupPayload outPayload;
 
     std::string result;
@@ -312,6 +339,9 @@ void TestShortCodeReadWrite(nlTestSuite * inSuite, void * context)
     generator.payloadDecimalStringRepresentation(result);
     ManualSetupPayloadParser(result).populatePayload(outPayload);
 
+    // Override the discriminator in the input payload with the short version,
+    // since that's what we will produce.
+    inPayload.discriminator.SetShortValue(inPayload.discriminator.GetShortValue());
     NL_TEST_ASSERT(inSuite, inPayload == outPayload);
 }
 
@@ -321,6 +351,7 @@ void TestLongCodeReadWrite(nlTestSuite * inSuite, void * context)
     inPayload.commissioningFlow = CommissioningFlow::kCustom;
     inPayload.vendorID          = 1;
     inPayload.productID         = 1;
+
     SetupPayload outPayload;
 
     std::string result;
@@ -328,6 +359,9 @@ void TestLongCodeReadWrite(nlTestSuite * inSuite, void * context)
     generator.payloadDecimalStringRepresentation(result);
     ManualSetupPayloadParser(result).populatePayload(outPayload);
 
+    // Override the discriminator in the input payload with the short version,
+    // since that's what we will produce.
+    inPayload.discriminator.SetShortValue(inPayload.discriminator.GetShortValue());
     NL_TEST_ASSERT(inSuite, inPayload == outPayload);
 }
 
@@ -336,7 +370,8 @@ void assertEmptyPayloadWithError(nlTestSuite * inSuite, CHIP_ERROR actualError, 
 {
     NL_TEST_ASSERT(inSuite, actualError == expectedError);
     NL_TEST_ASSERT(inSuite,
-                   payload.setUpPINCode == 0 && payload.discriminator == 0 && payload.productID == 0 && payload.vendorID == 0);
+                   payload.setUpPINCode == 0 && payload.discriminator.GetLongValue() == 0 && payload.productID == 0 &&
+                       payload.vendorID == 0);
 }
 
 void TestPayloadParser_InvalidEntry(nlTestSuite * inSuite, void * inContext)
@@ -524,7 +559,6 @@ const nlTest sTests[] =
     NL_TEST_DEF("Generate Decimal Representation from Full Payload with Zeros",         TestDecimalRepresentation_FullPayloadWithZeros),
     NL_TEST_DEF("Decimal Representation from Full Payload without Zeros",               TestDecimalRepresentation_FullPayloadWithoutZeros_DoesNotRequireCustomFlow),
     NL_TEST_DEF("Decimal Representation from Full Payload without Zeros (Custom Flow)", TestDecimalRepresentation_FullPayloadWithoutZeros),
-    NL_TEST_DEF("Test Decimal Representation - Invalid Payload",                        TestDecimalRepresentation_InvalidPayload),
     NL_TEST_DEF("Test 12 bit discriminator for manual setup code",                      TestGenerateAndParser_ManualSetupCodeWithLongDiscriminator),
     NL_TEST_DEF("Test Decimal Representation - All Zeros",                              TestDecimalRepresentation_AllZeros),
     NL_TEST_DEF("Test Decimal Representation - All Ones",                               TestDecimalRepresentation_AllOnes),

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -89,8 +89,8 @@ void TestMaximumValues(nlTestSuite * inSuite, void * inContext)
     inPayload.commissioningFlow     = CommissioningFlow::kCustom;
     inPayload.rendezvousInformation = RendezvousInformationFlags(
         RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork);
-    inPayload.discriminator = static_cast<uint16_t>((1 << kPayloadDiscriminatorFieldLengthInBits) - 1);
-    inPayload.setUpPINCode  = static_cast<uint32_t>((1 << kSetupPINCodeFieldLengthInBits) - 1);
+    inPayload.discriminator.SetLongValue(static_cast<uint16_t>((1 << kPayloadDiscriminatorFieldLengthInBits) - 1));
+    inPayload.setUpPINCode = static_cast<uint32_t>((1 << kSetupPINCodeFieldLengthInBits) - 1);
 
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload, /* allowInvalidPayload */ true));
 }
@@ -309,12 +309,7 @@ void TestSetupPayloadVerify(nlTestSuite * inSuite, void * inContext)
     test_payload.rendezvousInformation = invalid;
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
-    // test invalid discriminator
-    test_payload               = payload;
-    test_payload.discriminator = 1 << kPayloadDiscriminatorFieldLengthInBits;
-    NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
-
-    // test invalid stetup PIN
+    // test invalid setup PIN
     test_payload              = payload;
     test_payload.setUpPINCode = 1 << kSetupPINCodeFieldLengthInBits;
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
@@ -358,9 +353,9 @@ void TestPayloadInEquality(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload payload = GetDefaultPayload();
 
-    SetupPayload unequalPayload  = GetDefaultPayload();
-    unequalPayload.discriminator = 28;
-    unequalPayload.setUpPINCode  = 121233;
+    SetupPayload unequalPayload = GetDefaultPayload();
+    unequalPayload.discriminator.SetLongValue(28);
+    unequalPayload.setUpPINCode = 121233;
 
     NL_TEST_ASSERT(inSuite, !(payload == unequalPayload));
 }


### PR DESCRIPTION
A few changes here:

1. Implement a SetupDiscriminator class that commons up logic like "does this
   discriminator, which might be short or long, match the given long
   discriminator?" and "extract short discriminator from long discriminator".
2. Change SetupPayload to more clearly indicate whether it's storing a short or
   long discriminator, instead of storing a short discriminator the same way as
   a long discriminator with the low bits all 0 and hoping consumers check
   isShortDiscriminator.
3. Update BLE scanning APIs to take SetupDiscriminator.
4. Fix the Linux and Tizen BLE code to properly handle short discriminators
   (which used to not match if the long discriminator happened to have the low 8
   bits nonzero).
5. Fix the Darwin BLE code to properly handle long discriminators that have 0
   low bits.  Before this change they used to incorrectly match a long
   discriminator which had the same 4 high bits but different 8 low bits.

Fixes https://github.com/project-chip/connectedhomeip/issues/21160

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ensured that BLE commissioning still works on Darwin (which is where I can test) and that chip-tool payload parsing commands work right.