### PR TITLE
Move CommandSender/Handler and WriteClient/Handler over to `ExchangeHolder`

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -33,7 +33,8 @@ namespace chip {
 namespace app {
 
 CommandSender::CommandSender(Callback * apCallback, Messaging::ExchangeManager * apExchangeMgr, bool aIsTimedRequest) :
-    mpCallback(apCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(false), mTimedRequest(aIsTimedRequest)
+    mExchangeCtx(*this), mpCallback(apCallback), mpExchangeMgr(apExchangeMgr), mSuppressResponse(false),
+    mTimedRequest(aIsTimedRequest)
 {}
 
 CHIP_ERROR CommandSender::AllocateBuffer()
@@ -67,15 +68,17 @@ CHIP_ERROR CommandSender::SendCommandRequest(const SessionHandle & session, Opti
     ReturnErrorOnFailure(Finalize(mPendingInvokeData));
 
     // Create a new exchange context.
-    mpExchangeCtx = mpExchangeMgr->NewContext(session, this);
-    VerifyOrReturnError(mpExchangeCtx != nullptr, CHIP_ERROR_NO_MEMORY);
-    VerifyOrReturnError(!mpExchangeCtx->IsGroupExchangeContext(), CHIP_ERROR_INVALID_MESSAGE_TYPE);
+    auto exchange = mpExchangeMgr->NewContext(session, this);
+    VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_NO_MEMORY);
 
-    mpExchangeCtx->SetResponseTimeout(timeout.ValueOr(session->ComputeRoundTripTimeout(app::kExpectedIMProcessingTime)));
+    mExchangeCtx.Grab(exchange);
+    VerifyOrReturnError(!mExchangeCtx->IsGroupExchangeContext(), CHIP_ERROR_INVALID_MESSAGE_TYPE);
+
+    mExchangeCtx->SetResponseTimeout(timeout.ValueOr(session->ComputeRoundTripTimeout(app::kExpectedIMProcessingTime)));
 
     if (mTimedInvokeTimeoutMs.HasValue())
     {
-        ReturnErrorOnFailure(TimedRequest::Send(mpExchangeCtx, mTimedInvokeTimeoutMs.Value()));
+        ReturnErrorOnFailure(TimedRequest::Send(mExchangeCtx.Get(), mTimedInvokeTimeoutMs.Value()));
         MoveToState(State::AwaitingTimedStatus);
         return CHIP_NO_ERROR;
     }
@@ -90,14 +93,13 @@ CHIP_ERROR CommandSender::SendGroupCommandRequest(const SessionHandle & session)
     ReturnErrorOnFailure(Finalize(mPendingInvokeData));
 
     // Create a new exchange context.
-    mpExchangeCtx = mpExchangeMgr->NewContext(session, this);
-    VerifyOrReturnError(mpExchangeCtx != nullptr, CHIP_ERROR_NO_MEMORY);
-    VerifyOrReturnError(mpExchangeCtx->IsGroupExchangeContext(), CHIP_ERROR_INVALID_MESSAGE_TYPE);
+    auto exchange = mpExchangeMgr->NewContext(session, this);
+    VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_NO_MEMORY);
+
+    mExchangeCtx.Grab(exchange);
+    VerifyOrReturnError(mExchangeCtx->IsGroupExchangeContext(), CHIP_ERROR_INVALID_MESSAGE_TYPE);
 
     ReturnErrorOnFailure(SendInvokeRequest());
-
-    // Exchange is gone now, since it closed itself on successful send.
-    mpExchangeCtx = nullptr;
 
     Close();
     return CHIP_NO_ERROR;
@@ -108,8 +110,8 @@ CHIP_ERROR CommandSender::SendInvokeRequest()
     using namespace Protocols::InteractionModel;
     using namespace Messaging;
 
-    ReturnErrorOnFailure(mpExchangeCtx->SendMessage(MsgType::InvokeCommandRequest, std::move(mPendingInvokeData),
-                                                    SendMessageFlags::kExpectResponse));
+    ReturnErrorOnFailure(
+        mExchangeCtx->SendMessage(MsgType::InvokeCommandRequest, std::move(mPendingInvokeData), SendMessageFlags::kExpectResponse));
     MoveToState(State::CommandSent);
 
     return CHIP_NO_ERROR;
@@ -124,7 +126,7 @@ CHIP_ERROR CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExcha
     }
 
     CHIP_ERROR err = CHIP_NO_ERROR;
-    VerifyOrExit(apExchangeContext == mpExchangeCtx, err = CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrExit(apExchangeContext == mExchangeCtx.Get(), err = CHIP_ERROR_INCORRECT_STATE);
 
     if (mState == State::AwaitingTimedStatus)
     {
@@ -222,18 +224,6 @@ void CommandSender::Close()
     mSuppressResponse = false;
     mTimedRequest     = false;
     MoveToState(State::AwaitingDestruction);
-
-    // OnDone below can destroy us before we unwind all the way back into the
-    // exchange code and it tries to close itself.  Make sure that it doesn't
-    // try to notify us that it's closing, since we will be dead.
-    //
-    // For more details, see #10344.
-    if (mpExchangeCtx != nullptr)
-    {
-        mpExchangeCtx->SetDelegate(nullptr);
-    }
-
-    mpExchangeCtx = nullptr;
 
     if (mpCallback)
     {
@@ -441,28 +431,6 @@ void CommandSender::MoveToState(const State aTargetState)
 {
     mState = aTargetState;
     ChipLogDetail(DataManagement, "ICR moving to [%10.10s]", GetStateStr());
-}
-
-void CommandSender::Abort()
-{
-    //
-    // If the exchange context hasn't already been gracefully closed
-    // (signaled by setting it to null), then we need to forcibly
-    // tear it down.
-    //
-    if (mpExchangeCtx != nullptr)
-    {
-        // We might be a delegate for this exchange, and we don't want the
-        // OnExchangeClosing notification in that case.  Null out the delegate
-        // to avoid that.
-        //
-        // TODO: This makes all sorts of assumptions about what the delegate is
-        // (notice the "might" above!) that might not hold in practice.  We
-        // really need a better solution here....
-        mpExchangeCtx->SetDelegate(nullptr);
-        mpExchangeCtx->Abort();
-        mpExchangeCtx = nullptr;
-    }
 }
 
 } // namespace app

--- a/src/app/CommandSender.h
+++ b/src/app/CommandSender.h
@@ -38,7 +38,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeHolder.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
@@ -53,23 +53,6 @@ namespace app {
 class CommandSender final : public Messaging::ExchangeDelegate
 {
 public:
-    /*
-     * Destructor - as part of destruction, it will abort the exchange context
-     * if a valid one still exists.
-     *
-     * See Abort() for details on when that might occur.
-     */
-    ~CommandSender() override { Abort(); }
-
-    /**
-     * Gets the inner exchange context object, without ownership.
-     *
-     * @return The inner exchange context, might be nullptr if no
-     *         exchange context has been assigned or the context
-     *         has been released.
-     */
-    Messaging::ExchangeContext * GetExchangeContext() const { return mpExchangeCtx; }
-
     class Callback
     {
     public:
@@ -290,7 +273,7 @@ private:
 
     CHIP_ERROR Finalize(System::PacketBufferHandle & commandPacket);
 
-    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
+    Messaging::ExchangeHolder mExchangeCtx;
     Callback * mpCallback                      = nullptr;
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     InvokeRequestMessage::Builder mInvokeRequestBuilder;

--- a/src/app/WriteClient.h
+++ b/src/app/WriteClient.h
@@ -33,7 +33,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeHolder.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
@@ -125,14 +125,15 @@ public:
     WriteClient(Messaging::ExchangeManager * apExchangeMgr, Callback * apCallback, const Optional<uint16_t> & aTimedWriteTimeoutMs,
                 bool aSuppressResponse = false) :
         mpExchangeMgr(apExchangeMgr),
-        mpCallback(apCallback), mTimedWriteTimeoutMs(aTimedWriteTimeoutMs), mSuppressResponse(aSuppressResponse)
+        mExchangeCtx(*this), mpCallback(apCallback), mTimedWriteTimeoutMs(aTimedWriteTimeoutMs),
+        mSuppressResponse(aSuppressResponse)
     {}
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     WriteClient(Messaging::ExchangeManager * apExchangeMgr, Callback * apCallback, const Optional<uint16_t> & aTimedWriteTimeoutMs,
                 uint16_t aReservedSize) :
         mpExchangeMgr(apExchangeMgr),
-        mpCallback(apCallback), mTimedWriteTimeoutMs(aTimedWriteTimeoutMs), mReservedSize(aReservedSize)
+        mExchangeCtx(*this), mpCallback(apCallback), mTimedWriteTimeoutMs(aTimedWriteTimeoutMs), mReservedSize(aReservedSize)
     {}
 #endif
 
@@ -225,14 +226,6 @@ public:
      *  of the object and releases all held resources.
      */
     void Shutdown();
-
-    /*
-     * Destructor - as part of destruction, it will abort the exchange context
-     * if a valid one still exists.
-     *
-     * See Abort() for details on when that might occur.
-     */
-    ~WriteClient() override { Abort(); }
 
 private:
     friend class TestWriteInteraction;
@@ -378,9 +371,9 @@ private:
     CHIP_ERROR FinalizeMessage(bool aHasMoreChunks);
 
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
-    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
-    Callback * mpCallback                      = nullptr;
-    State mState                               = State::Initialized;
+    Messaging::ExchangeHolder mExchangeCtx;
+    Callback * mpCallback = nullptr;
+    State mState          = State::Initialized;
     System::PacketBufferTLVWriter mMessageWriter;
     WriteRequestMessage::Builder mWriteRequestBuilder;
     // TODO Maybe we should change PacketBufferTLVWriter so we can finalize it

--- a/src/app/WriteHandler.h
+++ b/src/app/WriteHandler.h
@@ -25,7 +25,7 @@
 #include <lib/support/CodeUtils.h>
 #include <lib/support/DLLUtil.h>
 #include <lib/support/logging/CHIPLogging.h>
-#include <messaging/ExchangeContext.h>
+#include <messaging/ExchangeHolder.h>
 #include <messaging/ExchangeMgr.h>
 #include <messaging/Flags.h>
 #include <protocols/Protocols.h>
@@ -41,6 +41,8 @@ namespace app {
 class WriteHandler : public Messaging::ExchangeDelegate
 {
 public:
+    WriteHandler() : mExchangeCtx(*this) {}
+
     /**
      *  Initialize the WriteHandler. Within the lifetime
      *  of this instance, this method is invoked once after object
@@ -96,7 +98,7 @@ public:
 
     bool MatchesExchangeContext(Messaging::ExchangeContext * apExchangeContext) const
     {
-        return !IsFree() && mpExchangeCtx == apExchangeContext;
+        return !IsFree() && mExchangeCtx.Get() == apExchangeContext;
     }
 
     void CacheACLCheckResult(const AttributeAccessToken & aToken) { mACLCheckCache.SetValue(aToken); }
@@ -158,7 +160,7 @@ private:
                                  System::PacketBufferHandle && aPayload) override;
     void OnResponseTimeout(Messaging::ExchangeContext * apExchangeContext) override;
 
-    Messaging::ExchangeContext * mpExchangeCtx = nullptr;
+    Messaging::ExchangeHolder mExchangeCtx;
     WriteResponseMessage::Builder mWriteResponseBuilder;
     State mState           = State::Uninitialized;
     bool mIsTimedRequest   = false;

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -452,8 +452,8 @@ void TestCommandInteraction::TestCommandHandlerWithWrongState(nlTestSuite * apSu
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
     TestExchangeDelegate delegate;
-    commandHandler.mpExchangeCtx = ctx.NewExchangeToAlice(&delegate);
-    err                          = commandHandler.SendCommandResponse();
+    commandHandler.mExchangeCtx.Grab(ctx.NewExchangeToAlice(&delegate));
+    err = commandHandler.SendCommandResponse();
 
     NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_INCORRECT_STATE);
 }
@@ -488,7 +488,7 @@ void TestCommandInteraction::TestCommandHandlerWithSendEmptyCommand(nlTestSuite 
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
 
     TestExchangeDelegate delegate;
-    commandHandler.mpExchangeCtx = ctx.NewExchangeToAlice(&delegate);
+    commandHandler.mExchangeCtx.Grab(ctx.NewExchangeToAlice(&delegate));
 
     err = commandHandler.PrepareCommand(path);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -521,7 +521,7 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
     System::PacketBufferHandle commandPacket;
 
     TestExchangeDelegate delegate;
-    commandHandler.mpExchangeCtx = ctx.NewExchangeToAlice(&delegate);
+    commandHandler.mExchangeCtx.Grab(ctx.NewExchangeToAlice(&delegate));
 
     AddInvokeResponseData(apSuite, apContext, &commandHandler, aNeedStatusCode);
     err = commandHandler.Finalize(commandPacket);
@@ -581,7 +581,7 @@ void TestCommandInteraction::TestCommandHandlerCommandDataEncoding(nlTestSuite *
     System::PacketBufferHandle commandPacket;
 
     TestExchangeDelegate delegate;
-    commandHandler.mpExchangeCtx = ctx.NewExchangeToAlice(&delegate);
+    commandHandler.mExchangeCtx.Grab(ctx.NewExchangeToAlice(&delegate));
 
     auto path = MakeTestCommandPath();
 
@@ -608,7 +608,7 @@ void TestCommandInteraction::TestCommandHandlerCommandEncodeFailure(nlTestSuite 
     System::PacketBufferHandle commandPacket;
 
     TestExchangeDelegate delegate;
-    commandHandler.mpExchangeCtx = ctx.NewExchangeToAlice(&delegate);
+    commandHandler.mExchangeCtx.Grab(ctx.NewExchangeToAlice(&delegate));
 
     auto path = MakeTestCommandPath();
 
@@ -635,7 +635,7 @@ void TestCommandInteraction::TestCommandHandlerCommandEncodeExternalFailure(nlTe
     System::PacketBufferHandle commandPacket;
 
     TestExchangeDelegate delegate;
-    commandHandler.mpExchangeCtx = ctx.NewExchangeToAlice(&delegate);
+    commandHandler.mExchangeCtx.Grab(ctx.NewExchangeToAlice(&delegate));
 
     auto path = MakeTestCommandPath();
 
@@ -672,7 +672,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedMsg(nlTestSuit
     System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
 
     TestExchangeDelegate delegate;
-    commandHandler.mpExchangeCtx = ctx.NewExchangeToAlice(&delegate);
+    commandHandler.mExchangeCtx.Grab(ctx.NewExchangeToAlice(&delegate));
 
     GenerateInvokeRequest(apSuite, apContext, commandDatabuf, /* aIsTimedRequest = */ false, kTestCommandIdWithData);
     err = commandHandler.ProcessInvokeRequest(std::move(commandDatabuf), false);
@@ -711,7 +711,7 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg(n
             System::PacketBufferHandle commandDatabuf = System::PacketBufferHandle::New(System::PacketBuffer::kMaxSize);
 
             TestExchangeDelegate delegate;
-            commandHandler.mpExchangeCtx = ctx.NewExchangeToAlice(&delegate);
+            commandHandler.mExchangeCtx.Grab(ctx.NewExchangeToAlice(&delegate));
 
             chip::isCommandDispatched = false;
             GenerateInvokeRequest(apSuite, apContext, commandDatabuf, messageIsTimed, kTestCommandIdNoData);

--- a/src/app/tests/TestWriteInteraction.cpp
+++ b/src/app/tests/TestWriteInteraction.cpp
@@ -306,15 +306,6 @@ void TestWriteInteraction::TestWriteHandler(nlTestSuite * apSuite, void * apCont
             }
             else
             {
-                //
-                // In a normal execution flow, the exchange manager would have closed out the exchange after the
-                // message dispatch call path had unwound. In this test however, we've manually allocated the exchange
-                // ourselves (as opposed to the exchange manager), so we need to take ownership of closing out the exchange.
-                //
-                // Note that this doesn't happen in the success case above, since that results in a call to send a message through
-                // the exchange context, which results in the exchange manager correctly closing it.
-                //
-                exchange->Close();
                 NL_TEST_ASSERT(apSuite, status == Status::UnsupportedAccess);
             }
 

--- a/src/messaging/ExchangeHolder.h
+++ b/src/messaging/ExchangeHolder.h
@@ -64,6 +64,8 @@ public:
      */
     void Grab(ExchangeContext * exchange)
     {
+        VerifyOrDie(exchange != nullptr);
+
         Release();
 
         mpExchangeCtx = exchange;


### PR DESCRIPTION
This moves the last 4 objects in the IM space over to the new but safer `ExchangeHolder` way of EC management. This removes a fair bit of the custom EC logic that existed and cleans up the state in the file.

Testing:

Ran the existing unit tests as well as relying on CI to run a bunch of Python and YAML tests to validate behavior.