### PR TITLE
[EFR32] Switch support from BLE Notification to Indication

### DIFF
--- a/src/platform/EFR32/BLEManagerImpl.cpp
+++ b/src/platform/EFR32/BLEManagerImpl.cpp
@@ -423,12 +423,6 @@ void BLEManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
     }
     break;
 
-    case DeviceEventType::kCHIPoBLENotifyConfirm: {
-        ChipLogProgress(DeviceLayer, "_OnPlatformEvent kCHIPoBLENotifyConfirm");
-        HandleTxConfirmationEvent(event->CHIPoBLENotifyConfirm.ConId);
-    }
-    break;
-
     default:
         ChipLogProgress(DeviceLayer, "_OnPlatformEvent default:  event->Type = %d", event->Type);
         break;
@@ -479,23 +473,15 @@ bool BLEManagerImpl::SendIndication(BLE_CONNECTION_OBJECT conId, const ChipBleUU
     sl_status_t ret;
     uint16_t cId        = (UUIDsMatch(&ChipUUID_CHIPoBLEChar_RX, charId) ? gattdb_CHIPoBLEChar_Rx : gattdb_CHIPoBLEChar_Tx);
     uint8_t timerHandle = GetTimerHandle(conId, true);
-    ChipDeviceEvent event;
 
     VerifyOrExit(((conState != NULL) && (conState->subscribed != 0)), err = CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrExit(timerHandle != kMaxConnections, err = CHIP_ERROR_NO_MEMORY);
 
-    // start timer for light notification confirmation. Long delay for spake2 indication
+    // start timer for light indication confirmation. Long delay for spake2 indication
     sl_bt_system_set_lazy_soft_timer(TIMER_S_2_TIMERTICK(6), 0, timerHandle, true);
 
-    ret = sl_bt_gatt_server_send_notification(conId, cId, (data->DataLength()), data->Start());
+    ret = sl_bt_gatt_server_send_indication(conId, cId, (data->DataLength()), data->Start());
     err = MapBLEError(ret);
-
-    if (err == CHIP_NO_ERROR)
-    {
-        event.Type                        = DeviceEventType::kCHIPoBLENotifyConfirm;
-        event.CHIPoBLENotifyConfirm.ConId = conId;
-        err                               = PlatformMgr().PostEvent(&event);
-    }
 
 exit:
     if (err != CHIP_NO_ERROR)
@@ -873,20 +859,20 @@ void BLEManagerImpl::HandleTXCharCCCDWrite(volatile sl_bt_msg_t * evt)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     CHIPoBLEConState * bleConnState;
-    bool isDisabled;
+    bool isIndicationEnabled = false;
     ChipDeviceEvent event;
 
     bleConnState = GetConnectionState(evt->data.evt_gatt_server_user_write_request.connection);
     VerifyOrExit(bleConnState != NULL, err = CHIP_ERROR_NO_MEMORY);
 
     // Determine if the client is enabling or disabling notification/indication.
-    isDisabled = (evt->data.evt_gatt_server_characteristic_status.client_config_flags == sl_bt_gatt_disable);
+    isIndicationEnabled = (evt->data.evt_gatt_server_characteristic_status.client_config_flags == sl_bt_gatt_indication);
 
     ChipLogProgress(DeviceLayer, "HandleTXcharCCCDWrite - Config Flags value : %d",
                     evt->data.evt_gatt_server_characteristic_status.client_config_flags);
-    ChipLogProgress(DeviceLayer, "CHIPoBLE %s received", isDisabled ? "unsubscribe" : "subscribe");
+    ChipLogProgress(DeviceLayer, "CHIPoBLE %s received", isIndicationEnabled ? "subscribe" : "unsubscribe");
 
-    if (!isDisabled)
+    if (isIndicationEnabled)
     {
         // If indications are not already enabled for the connection...
         if (!bleConnState->subscribed)

--- a/src/platform/EFR32/btconf/gatt_configuration.btconf
+++ b/src/platform/EFR32/btconf/gatt_configuration.btconf
@@ -81,7 +81,6 @@
         <write authenticated="false" bonded="false" encrypted="false"/>
         <write_no_response authenticated="false" bonded="false" encrypted="false"/>
         <indicate authenticated="false" bonded="false" encrypted="false"/>
-        <notify authenticated="false" bonded="false" encrypted="false"/>
       </properties>
     </characteristic>
     

--- a/src/platform/EFR32/btconf/in_place_ota_dfu.xml
+++ b/src/platform/EFR32/btconf/in_place_ota_dfu.xml
@@ -1,0 +1,12 @@
+<gatt>
+  <service advertise="false" id="ota" name="Silicon Labs OTA" requirement="mandatory" sourceId="com.silabs.service.ota" type="primary" uuid="1D14D6EE-FD63-4FA1-BFA4-8F47B42119F0">
+    <informativeText>Abstract: The Silicon Labs OTA Service enables in-place over-the-air firmware update of the device. </informativeText>
+    <characteristic const="false" id="ota_control" name="Silicon Labs OTA Control" sourceId="com.silabs.characteristic.ota_control" uuid="F7BF3564-FB6D-4E53-88A4-5E37E0326063">
+      <informativeText>Abstract: Silicon Labs OTA Control. </informativeText>
+      <value length="1" type="user" variable_length="false"/>
+      <properties write="true">
+        <write authenticated="false" bonded="false" encrypted="false"/>
+      </properties>
+    </characteristic>
+  </service>
+</gatt>

--- a/src/platform/EFR32/gatt_db.c
+++ b/src/platform/EFR32/gatt_db.c
@@ -55,7 +55,7 @@ GATT_DATA(const sli_bt_gattdb_value_t gattdb_attribute_field_28) = { .len  = 16,
                                                                          0x1d,
                                                                      } };
 GATT_DATA(sli_bt_gattdb_attribute_chrvalue_t
-              gattdb_attribute_field_24)                         = { .properties = 0x3e,
+              gattdb_attribute_field_24)                         = { .properties = 0x2e,
                                              .max_len    = 247,
                                              .len        = 1,
                                              .data       = {
@@ -353,7 +353,7 @@ GATT_DATA(const sli_bt_gattdb_attribute_t gattdb_attributes_map[]) = {
       .caps           = 0xffff,
       .state          = 0x00,
       .datatype       = 0x05,
-      .characteristic = { .properties = 0x3e, .char_uuid = 0x8001 } },
+      .characteristic = { .properties = 0x2e, .char_uuid = 0x8001 } },
     { .handle      = 0x19,
       .uuid        = 0x8001,
       .permissions = 0x807,
@@ -367,7 +367,7 @@ GATT_DATA(const sli_bt_gattdb_attribute_t gattdb_attributes_map[]) = {
       .caps        = 0xffff,
       .state       = 0x00,
       .datatype    = 0x03,
-      .configdata  = { .flags = 0x03, .clientconfig_index = 0x01 } },
+      .configdata  = { .flags = 0x02, .clientconfig_index = 0x01 } },
     { .handle         = 0x1b,
       .uuid           = 0x0002,
       .permissions    = 0x801,


### PR DESCRIPTION
#### Problem
Matter Spec reverted back from requiring notification to requiring indications.

#### Change overview
* Modify BLE manager to support indication
* Modify Gatt Server configs to only support indications.

#### Testing
* Manual commissioning tests to validate ble is still functionnatal with indications