### PR TITLE
Do not setup ConfigurationMgr via PlatformMgr on each platform

### DIFF
--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -178,9 +178,18 @@ protected:
 /**
  * Returns a reference to a ConfigurationManager object.
  *
- * Applications should use this to access the features of the ConfigurationManager.
+ * Applications should use this to access features of the ConfigurationManager object
+ * that are common to all platforms.
  */
-extern ConfigurationManager & ConfigurationMgr();
+ConfigurationManager & ConfigurationMgr();
+
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+extern ConfigurationManager & ConfigurationMgrImpl();
 
 /**
  * Sets a reference to a ConfigurationManager object.
@@ -188,7 +197,7 @@ extern ConfigurationManager & ConfigurationMgr();
  * This must be called before any calls to ConfigurationMgr. If a nullptr is passed in,
  * no changes will be made.
  */
-extern void SetConfigurationMgr(ConfigurationManager * configurationManager);
+void SetConfigurationMgr(ConfigurationManager * configurationManager);
 
 inline CHIP_ERROR ConfigurationManager::GetLocationCapability(uint8_t & location)
 {

--- a/src/platform/Ameba/ConfigurationManagerImpl.cpp
+++ b/src/platform/Ameba/ConfigurationManagerImpl.cpp
@@ -284,5 +284,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     // sys_reset();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Ameba/ConfigurationManagerImpl.h
+++ b/src/platform/Ameba/ConfigurationManagerImpl.h
@@ -76,5 +76,13 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Ameba/PlatformManagerImpl.cpp
+++ b/src/platform/Ameba/PlatformManagerImpl.cpp
@@ -59,8 +59,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 
     CHIP_ERROR err;
 
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
     // Make sure the LwIP core lock has been initialized
     err = Internal::InitLwIPCoreLock();
 

--- a/src/platform/CYW30739/ConfigurationManagerImpl.cpp
+++ b/src/platform/CYW30739/ConfigurationManagerImpl.cpp
@@ -212,5 +212,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     wiced_hal_wdog_reset_system();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/CYW30739/ConfigurationManagerImpl.h
+++ b/src/platform/CYW30739/ConfigurationManagerImpl.h
@@ -74,5 +74,13 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/CYW30739/PlatformManagerImpl.cpp
+++ b/src/platform/CYW30739/PlatformManagerImpl.cpp
@@ -45,8 +45,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = PersistedStorage::KeyValueStoreMgrImpl().Init();
     SuccessOrExit(err);
 
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
     /* Create the thread object. */
     mThread = wiced_rtos_create_thread();
     VerifyOrExit(mThread != nullptr, err = CHIP_ERROR_NO_MEMORY);

--- a/src/platform/Darwin/ConfigurationManagerImpl.cpp
+++ b/src/platform/Darwin/ConfigurationManagerImpl.cpp
@@ -496,5 +496,10 @@ void ConfigurationManagerImpl::RunConfigUnitTest(void)
 #endif // CHIP_DISABLE_PLATFORM_KVS
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Darwin/ConfigurationManagerImpl.h
+++ b/src/platform/Darwin/ConfigurationManagerImpl.h
@@ -92,5 +92,13 @@ private:
     void RunConfigUnitTest(void) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -52,7 +52,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     SuccessOrExit(err);
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 #endif // CHIP_DISABLE_PLATFORM_KVS
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
 
     mRunLoopSem = dispatch_semaphore_create(0);
 

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -307,5 +307,10 @@ CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 }
 #endif
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/EFR32/ConfigurationManagerImpl.h
+++ b/src/platform/EFR32/ConfigurationManagerImpl.h
@@ -82,7 +82,15 @@ inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * b
 {
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
-
 #endif /* SL_WIFI */
+
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/EFR32/PlatformManagerImpl.cpp
+++ b/src/platform/EFR32/PlatformManagerImpl.cpp
@@ -50,8 +50,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = chip::DeviceLayer::PersistedStorage::KeyValueStoreMgrImpl().Init();
     SuccessOrExit(err);
 
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     // Initialize LwIP.
     tcpip_init(NULL, NULL);

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -337,5 +337,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     esp_restart();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -87,5 +87,13 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/ESP32/PlatformManagerImpl.cpp
+++ b/src/platform/ESP32/PlatformManagerImpl.cpp
@@ -59,8 +59,6 @@ static int app_entropy_source(void * data, unsigned char * output, size_t len, s
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
     esp_err_t err;
     // Arrange for CHIP-encapsulated ESP32 errors to be translated to text
     Internal::ESP32Utils::RegisterESP32ErrorFormatter();

--- a/src/platform/Linux/ConfigurationManagerImpl.cpp
+++ b/src/platform/Linux/ConfigurationManagerImpl.cpp
@@ -397,5 +397,10 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
     return err;
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/ConfigurationManagerImpl.h
+++ b/src/platform/Linux/ConfigurationManagerImpl.h
@@ -88,5 +88,13 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Linux/PlatformManagerImpl.cpp
+++ b/src/platform/Linux/PlatformManagerImpl.cpp
@@ -175,7 +175,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
     // Initialize the configuration system.
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     // Call _InitChipStack() on the generic implementation base class

--- a/src/platform/P6/ConfigurationManagerImpl.cpp
+++ b/src/platform/P6/ConfigurationManagerImpl.cpp
@@ -238,5 +238,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     NVIC_SystemReset();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/P6/ConfigurationManagerImpl.h
+++ b/src/platform/P6/ConfigurationManagerImpl.h
@@ -78,5 +78,13 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/P6/PlatformManagerImpl.cpp
+++ b/src/platform/P6/PlatformManagerImpl.cpp
@@ -43,8 +43,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
 
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
     // Make sure the LwIP core lock has been initialized
     err = Internal::InitLwIPCoreLock();
     SuccessOrExit(err);

--- a/src/platform/SingletonConfigurationManager.cpp
+++ b/src/platform/SingletonConfigurationManager.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <lib/support/CodeUtils.h>
+#include <platform/ConfigurationManager.h>
 
 namespace chip {
 namespace DeviceLayer {
@@ -37,8 +38,12 @@ ConfigurationManager * gInstance = nullptr;
 
 ConfigurationManager & ConfigurationMgr()
 {
-    VerifyOrDie(gInstance != nullptr);
-    return *gInstance;
+    if (gInstance != nullptr)
+    {
+        return *gInstance;
+    }
+
+    return ConfigurationMgrImpl();
 }
 
 void SetConfigurationMgr(ConfigurationManager * configurationManager)

--- a/src/platform/Tizen/ConfigurationManagerImpl.cpp
+++ b/src/platform/Tizen/ConfigurationManagerImpl.cpp
@@ -177,5 +177,10 @@ void ConfigurationManagerImpl::RunConfigUnitTest(void)
     PosixConfig::RunConfigUnitTest();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Tizen/ConfigurationManagerImpl.h
+++ b/src/platform/Tizen/ConfigurationManagerImpl.h
@@ -72,5 +72,13 @@ private:
     void RunConfigUnitTest(void) override;
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Tizen/PlatformManagerImpl.cpp
+++ b/src/platform/Tizen/PlatformManagerImpl.cpp
@@ -39,7 +39,6 @@ PlatformManagerImpl PlatformManagerImpl::sInstance;
 CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     return Internal::GenericPlatformManagerImpl_POSIX<PlatformManagerImpl>::_InitChipStack();

--- a/src/platform/Zephyr/ConfigurationManagerImpl.cpp
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.cpp
@@ -180,5 +180,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     PlatformMgr().Shutdown();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/ConfigurationManagerImpl.h
+++ b/src/platform/Zephyr/ConfigurationManagerImpl.h
@@ -99,5 +99,13 @@ inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * /
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/Zephyr/PlatformManagerImpl.cpp
+++ b/src/platform/Zephyr/PlatformManagerImpl.cpp
@@ -106,7 +106,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // Initialize the configuration system.
     err = Internal::ZephyrConfig::Init();
     SuccessOrExit(err);
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
 
 #if !CONFIG_NORDIC_SECURITY_BACKEND
     // Add entropy source based on Zephyr entropy driver

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -215,5 +215,10 @@ CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize)
     return ReadConfigValueStr(AndroidConfig::kConfigKey_UniqueId, buf, bufSize, dateLen);
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -83,5 +83,13 @@ private:
     jobject mConfigurationManagerObject = nullptr;
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/android/PlatformManagerImpl.cpp
+++ b/src/platform/android/PlatformManagerImpl.cpp
@@ -46,7 +46,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     // Initialize the configuration system.
     err = Internal::AndroidConfig::Init();
     SuccessOrExit(err);
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 
     // Call _InitChipStack() on the generic implementation base class

--- a/src/platform/bouffalolab/BL602/ConfigurationManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL602/ConfigurationManagerImpl.cpp
@@ -180,5 +180,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     hal_reboot();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/bouffalolab/BL602/ConfigurationManagerImpl.h
+++ b/src/platform/bouffalolab/BL602/ConfigurationManagerImpl.h
@@ -91,9 +91,6 @@ private:
     CHIP_ERROR WriteConfigValueBin(Key key, const uint8_t * data, size_t dataLen) override;
     void RunConfigUnitTest(void) override;
 
-    friend ConfigurationManager & ConfigurationMgr(void);
-    friend ConfigurationManagerImpl & ConfigurationMgrImpl(void);
-
     static ConfigurationManagerImpl sInstance;
 
     // ===== Private members reserved for use by this class only.
@@ -101,33 +98,19 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
-/**
- * Returns the public interface of the ConfigurationManager singleton object.
- *
- * Chip applications should use this to access features of the ConfigurationManager object
- * that are common to all platforms.
- */
-inline ConfigurationManager & ConfigurationMgr(void)
-{
-    return ConfigurationManagerImpl::sInstance;
-}
-
-/**
- * Returns the platform-specific implementation of the ConfigurationManager singleton object.
- *
- * Chip applications can use this to gain access to features of the ConfigurationManager
- * that are specific to the BL602 platform.
- */
-inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
-{
-    return ConfigurationManagerImpl::sInstance;
-}
-
 inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
     log_error("ConfigurationManagerImpl::_GetPrimaryWiFiMACAddress() is not supported now.\r\n");
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
+
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/bouffalolab/BL602/PlatformManagerImpl.cpp
+++ b/src/platform/bouffalolab/BL602/PlatformManagerImpl.cpp
@@ -188,8 +188,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
 {
     CHIP_ERROR err;
 
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
     // Initialize the configuration system.
     err = Internal::BL602Config::Init();
     log_error("err: %d\r\n", err);

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -184,5 +184,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     SysCtrlSystemReset();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.h
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.h
@@ -75,5 +75,13 @@ inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * b
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc13x2_26x2/PlatformManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/PlatformManagerImpl.cpp
@@ -107,7 +107,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // Initialize the configuration system.
     err = Internal::CC13X2_26X2Config::Init();
     SuccessOrExit(err);
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
 
     // DMM Addition
     DMMPolicy_Params dmmPolicyParams;

--- a/src/platform/cc32xx/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc32xx/ConfigurationManagerImpl.cpp
@@ -197,5 +197,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     MAP_PRCMHibernateCycleTrigger();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc32xx/ConfigurationManagerImpl.h
+++ b/src/platform/cc32xx/ConfigurationManagerImpl.h
@@ -69,5 +69,13 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc32xx/PlatformManagerImpl.cpp
+++ b/src/platform/cc32xx/PlatformManagerImpl.cpp
@@ -69,7 +69,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // Initialize the configuration system.
     err = Internal::CC32XXConfig::Init();
     SuccessOrExit(err);
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
 
     // Initialize LwIP.
     tcpip_init(NULL, NULL);

--- a/src/platform/fake/BUILD.gn
+++ b/src/platform/fake/BUILD.gn
@@ -20,6 +20,7 @@ assert(chip_device_platform == "fake")
 
 static_library("fake") {
   sources = [
+    "../SingletonConfigurationManager.cpp",
     "CHIPDevicePlatformEvent.h",
     "ConfigurationManagerImpl.cpp",
     "ConfigurationManagerImpl.h",

--- a/src/platform/fake/ConfigurationManagerImpl.cpp
+++ b/src/platform/fake/ConfigurationManagerImpl.cpp
@@ -19,12 +19,10 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
     return sInstance;
 }
 
-ConfigurationManager & ConfigurationMgr()
+ConfigurationManager & ConfigurationMgrImpl()
 {
     return ConfigurationManagerImpl::GetDefaultInstance();
 }
-
-void SetConfigurationMgr(ConfigurationManager * configurationManager) {}
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -108,5 +108,13 @@ private:
     System::Clock::Seconds32 mFirmwareBuildChipEpochTime = System::Clock::Seconds32(0);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/ConfigurationManagerImpl.cpp
+++ b/src/platform/mbed/ConfigurationManagerImpl.cpp
@@ -235,5 +235,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     system_reset();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/ConfigurationManagerImpl.h
+++ b/src/platform/mbed/ConfigurationManagerImpl.h
@@ -75,5 +75,13 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/mbed/PlatformManagerImpl.cpp
+++ b/src/platform/mbed/PlatformManagerImpl.cpp
@@ -92,8 +92,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     tcpip_init(NULL, NULL);
 #endif
 
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
     auto err = System::Clock::InitClock_RealTime();
     SuccessOrExit(err);
 

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.cpp
@@ -291,5 +291,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     RESET_SystemReset();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/k32w/k32w0/ConfigurationManagerImpl.h
@@ -84,5 +84,13 @@ inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * b
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/k32w/k32w0/PlatformManagerImpl.cpp
@@ -130,8 +130,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
         goto exit;
     }
 
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
     mStartTime = System::SystemClock().GetMonotonicTimestamp();
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/platform/nxp/mw320/BUILD.gn
+++ b/src/platform/nxp/mw320/BUILD.gn
@@ -25,6 +25,7 @@ if (chip_enable_openthread) {
 static_library("mw320") {
   sources = [
     "../../FreeRTOS/SystemTimeSupport.cpp",
+    "../../SingletonConfigurationManager.cpp",
     "BLEManagerImpl.cpp",
     "BLEManagerImpl.h",
     "CHIPDevicePlatformConfig.h",

--- a/src/platform/nxp/mw320/ConfigurationManagerImpl.cpp
+++ b/src/platform/nxp/mw320/ConfigurationManagerImpl.cpp
@@ -48,11 +48,6 @@ ConfigurationManagerImpl & ConfigurationManagerImpl::GetDefaultInstance()
     return sInstance;
 }
 
-ConfigurationManager & ConfigurationMgr()
-{
-    return ConfigurationManagerImpl::GetDefaultInstance();
-}
-
 CHIP_ERROR ConfigurationManagerImpl::Init()
 {
     CHIP_ERROR err;
@@ -198,6 +193,11 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     // Restart the system.
     ChipLogProgress(DeviceLayer, "System restarting");
     //__NVIC_SystemReset(void);
+}
+
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/nxp/mw320/ConfigurationManagerImpl.h
+++ b/src/platform/nxp/mw320/ConfigurationManagerImpl.h
@@ -94,8 +94,6 @@ private:
     // ===== Members for internal use by the following friends.
 
     friend class Internal::NetworkProvisioningServerImpl;
-    friend ConfigurationManager & ConfigurationMgr(void);
-    friend ConfigurationManagerImpl & ConfigurationMgrImpl(void);
 
     //    static ConfigurationManagerImpl sInstance;
 
@@ -103,30 +101,6 @@ private:
 
     static void DoFactoryReset(intptr_t arg);
 };
-
-#if 0
-/**
- * Returns the public interface of the ConfigurationManager singleton object.
- *
- * Chip applications should use this to access features of the ConfigurationManager object
- * that are common to all platforms.
- */
-inline ConfigurationManager & ConfigurationMgr(void)
-{
-    return ConfigurationManagerImpl::sInstance;
-}
-
-/**
- * Returns the platform-specific implementation of the ConfigurationManager singleton object.
- *
- * Chio applications can use this to gain access to features of the ConfigurationManager
- * that are specific to the MW320 platform.
- */
-inline ConfigurationManagerImpl & ConfigurationMgrImpl(void)
-{
-    return ConfigurationManagerImpl::sInstance;
-}
-#endif // 0
 
 inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * buf)
 {
@@ -138,6 +112,14 @@ inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * b
     // return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
     return CHIP_NO_ERROR;
 }
+
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
 
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/nxp/mw320/PlatformManagerImpl.cpp
+++ b/src/platform/nxp/mw320/PlatformManagerImpl.cpp
@@ -61,8 +61,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     err = Internal::MW320Config::Init();
     SuccessOrExit(err);
 
-    // SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
-
     // Initialize LwIP.
     // tcpip_init(NULL, NULL);
 

--- a/src/platform/qpg/ConfigurationManagerImpl.cpp
+++ b/src/platform/qpg/ConfigurationManagerImpl.cpp
@@ -190,5 +190,10 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
     qvCHIP_ResetSystem();
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/qpg/ConfigurationManagerImpl.h
+++ b/src/platform/qpg/ConfigurationManagerImpl.h
@@ -74,5 +74,13 @@ inline CHIP_ERROR ConfigurationManagerImpl::GetPrimaryWiFiMACAddress(uint8_t * b
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/qpg/PlatformManagerImpl.cpp
+++ b/src/platform/qpg/PlatformManagerImpl.cpp
@@ -44,7 +44,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack(void)
     // Initialize the configuration system.
     err = Internal::QPGConfig::Init();
     SuccessOrExit(err);
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
     // Initialize LwIP.

--- a/src/platform/webos/ConfigurationManagerImpl.cpp
+++ b/src/platform/webos/ConfigurationManagerImpl.cpp
@@ -390,5 +390,10 @@ CHIP_ERROR ConfigurationManagerImpl::GetLocationCapability(uint8_t & location)
     return err;
 }
 
+ConfigurationManager & ConfigurationMgrImpl()
+{
+    return ConfigurationManagerImpl::GetDefaultInstance();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/webos/ConfigurationManagerImpl.h
+++ b/src/platform/webos/ConfigurationManagerImpl.h
@@ -88,5 +88,13 @@ private:
     static void DoFactoryReset(intptr_t arg);
 };
 
+/**
+ * Returns the platform-specific implementation of the ConfigurationManager object.
+ *
+ * Applications can use this to gain access to features of the ConfigurationManager
+ * that are specific to the selected platform.
+ */
+ConfigurationManager & ConfigurationMgrImpl();
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/webos/PlatformManagerImpl.cpp
+++ b/src/platform/webos/PlatformManagerImpl.cpp
@@ -165,7 +165,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
     // Initialize the configuration system.
     ReturnErrorOnFailure(Internal::PosixConfig::Init());
-    SetConfigurationMgr(&ConfigurationManagerImpl::GetDefaultInstance());
     SetDeviceInfoProvider(&DeviceInfoProviderImpl::GetDefaultInstance());
     SetDeviceInstanceInfoProvider(&DeviceInstanceInfoProviderMgrImpl());
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We should not setup ConfigurationMgr via PlatformMgr separately on each platform. ConfigurationMgr lifecycle is independent of PlatformMgr, and this will cause call ConfigurationMgr get set up whenever PaltformMgr is initialized.

* Fixes #17400

#### Change overview
Do not setup ConfigurationMgr via PlatformMgr on each platform

#### Testing
How was this tested? (at least one bullet point required)
1. On Server Side:
sudo rm -rf /tmp/chip_*
./chip-lighting-app

2. On Client Side:
./chip-tool pairing onnetwork 12344321 20202021

3. Confirm we still able to readout the value from ConfigurationMgr 
