### PR TITLE
[BL602] Update button, not use dts to init

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/src/LEDWidget.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/LEDWidget.cpp
@@ -141,7 +141,7 @@ bool LEDWidget::IsTurnedOn()
 void LEDWidget::SetColor(uint8_t Hue, uint8_t Saturation)
 {
     uint8_t red, green, blue;
-    uint8_t brightness = mState ? mDefaultOnBrightness : 0;
+    uint8_t brightness = mDefaultOnBrightness;
     mHue               = static_cast<uint16_t>(Hue) * 360 / 254;        // mHue [0, 360]
     mSaturation        = static_cast<uint16_t>(Saturation) * 100 / 254; // mSaturation [0 , 100]
 

--- a/examples/lighting-app/bouffalolab/bl602/src/LEDWidget.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/LEDWidget.cpp
@@ -65,7 +65,6 @@ void LEDWidget::Set(bool state)
 void LEDWidget::SetBrightness(uint8_t brightness)
 {
     uint8_t red, green, blue;
-    log_info("mDefaultOnBrightness: %d, brightness: %d\r\n", mDefaultOnBrightness, brightness);
     HSB2rgb(mHue, mSaturation, brightness, red, green, blue);
     log_info("brightness: %d, mHue: %d, mSaturation: %d, red: %d, green: %d, blue: %d\r\n", brightness, mHue, mSaturation, red,
              green, blue);

--- a/examples/lighting-app/bouffalolab/bl602/src/LEDWidget.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/LEDWidget.cpp
@@ -99,7 +99,6 @@ void LEDWidget::Animate()
 
         if (nextChangeTimeMS < nowMS)
         {
-            // DoSet(!mState);
             mLastChangeTimeMS = nowMS;
         }
     }

--- a/examples/platform/bouffalolab/bl602/InitPlatform.cpp
+++ b/examples/platform/bouffalolab/bl602/InitPlatform.cpp
@@ -282,12 +282,7 @@ void InitPlatform(void)
 {
     bl_sys_init();
 
-    uint32_t fdt = 0, offset = 0;
-    if (0 == get_dts_addr("gpio", &fdt, &offset))
-    {
-        hal_gpio_init_from_dts(fdt, offset);
-        fdt_button_module_init((const void *) fdt, (int) offset);
-    }
+    hal_button_module_init(8, 1000, 4800, 5000);
     Platform_Light_Init();
     aos_register_event_filter(EV_KEY, event_cb_key_event, NULL);
 }

--- a/examples/platform/bouffalolab/bl602/InitPlatform.cpp
+++ b/examples/platform/bouffalolab/bl602/InitPlatform.cpp
@@ -246,8 +246,7 @@ static void event_cb_key_event(input_event_t * event, void * private_data)
     switch (event->code)
     {
     case KEY_1: {
-        log_info("[KEY_1] [EVT] INIT DONE %lld\r\n", aos_now_ms());
-        log_info("short press \r\n");
+        log_info("Short press \r\n");
 
         if (Button_LightingActionEventHandler != nullptr)
         {
@@ -256,13 +255,11 @@ static void event_cb_key_event(input_event_t * event, void * private_data)
     }
     break;
     case KEY_2: {
-        log_info("[KEY_2] [EVT] INIT DONE %lld\r\n", aos_now_ms());
-        log_info("long press \r\n");
+        log_info("Long press \r\n");
     }
     break;
     case KEY_3: {
-        log_info("[KEY_3] [EVT] INIT DONE %lld\r\n", aos_now_ms());
-        log_info("longlong press \r\n");
+        log_info("LongLong press \r\n");
         if (Button_FactoryResetEventHandler != nullptr)
         {
             (*Button_FactoryResetEventHandler)();


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Update button to support factory reset.

#### Change overview
Update button to support factory reset.


#### Testing
How was this tested? (at least one bullet point required)
* Long press the reset button for at least 5s, the light will blink.
