### PR TITLE
[Ameba] Attempt to reconnect to wifi after disconnection

### DIFF
--- a/src/platform/Ameba/ConnectivityManagerImpl.cpp
+++ b/src/platform/Ameba/ConnectivityManagerImpl.cpp
@@ -163,6 +163,7 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
         {
             ChangeWiFiStationState(kWiFiStationState_Connecting_Failed);
         }
+        DriveStationState();
     }
     if (event->Type == DeviceEventType::kRtkWiFiScanCompletedEvent)
     {


### PR DESCRIPTION
#### Problem
- After wifi is provisioned, ameba is not attempting to reconnect to wifi after disconnection and after the the reconnect interval has passed.
- Missing call to DriveStationState after wifi disconnection event.

#### Change overview
- Call DriveStationState after wifi disconnection event

#### Testing
- Provision ameba, let it connect to wifi, then disconnect it using "ATWD" at-command.
- Ameba will attempt to reconnect to wifi.