### PR TITLE
Remove the weak MatterGetAccessPrivilegeForXX functions and add stubs

### DIFF
--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -26,6 +26,7 @@ static_library("helpers") {
   sources = [
     "AppTestContext.cpp",
     "AppTestContext.h",
+    "integration/RequiredPrivilegeStubs.cpp",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/app/tests/integration/BUILD.gn
+++ b/src/app/tests/integration/BUILD.gn
@@ -21,6 +21,7 @@ assert(chip_build_tools)
 
 executable("chip-im-initiator") {
   sources = [
+    "RequiredPrivilegeStubs.cpp",
     "chip_im_initiator.cpp",
     "common.cpp",
   ]
@@ -41,6 +42,7 @@ executable("chip-im-initiator") {
 executable("chip-im-responder") {
   sources = [
     "MockEvents.cpp",
+    "RequiredPrivilegeStubs.cpp",
     "chip_im_responder.cpp",
     "common.cpp",
   ]

--- a/src/app/tests/integration/RequiredPrivilegeStubs.cpp
+++ b/src/app/tests/integration/RequiredPrivilegeStubs.cpp
@@ -1,7 +1,6 @@
 /*
  *
  *    Copyright (c) 2022 Project CHIP Authors
- *    All rights reserved.
  *
  *    Licensed under the Apache License, Version 2.0 (the "License");
  *    you may not use this file except in compliance with the License.
@@ -16,12 +15,24 @@
  *    limitations under the License.
  */
 
-#include "RequiredPrivilege.h"
+#include <app/util/privilege-storage.h>
 
-namespace chip {
-namespace app {
+int MatterGetAccessPrivilegeForReadAttribute(chip::ClusterId cluster, chip::AttributeId attribute)
+{
+    return kMatterAccessPrivilegeAdminister;
+}
 
-constexpr Access::Privilege RequiredPrivilege::kPrivilegeMapper[];
+int MatterGetAccessPrivilegeForWriteAttribute(chip::ClusterId cluster, chip::AttributeId attribute)
+{
+    return kMatterAccessPrivilegeAdminister;
+}
 
-} // namespace app
-} // namespace chip
+int MatterGetAccessPrivilegeForInvokeCommand(chip::ClusterId cluster, chip::CommandId command)
+{
+    return kMatterAccessPrivilegeAdminister;
+}
+
+int MatterGetAccessPrivilegeForReadEvent(chip::ClusterId cluster, chip::EventId event)
+{
+    return kMatterAccessPrivilegeAdminister;
+}


### PR DESCRIPTION
#### Problem
#19706 
The `MatterGetAccessPrivilegeForXX` functions in `src/app/RequiredPrivilege.cpp` sometimes does not override the weak functions in `src/app/RequiredPrivilege.cpp`.

#### Change overview
Remove the weak functions and add stubs for `tests:helper` and `chip-im-responder/initiator`

#### Testing
CI