### PR TITLE
[Darwin][BDX] Do not load all the rest of the file in memory to check  if the end of file has been reached during a BDX Query Block request

### DIFF
--- a/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
+++ b/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
@@ -25,6 +25,7 @@ constexpr uint8_t kUpdateTokenLen = 32;
 @property NSString * mOTAFilePath;
 @property NSFileHandle * mFileHandle;
 @property NSNumber * mFileOffset;
+@property NSNumber * mFileEndOffset;
 @property DeviceSoftwareVersionModel * candidate;
 @end
 
@@ -145,8 +146,19 @@ constexpr uint8_t kUpdateTokenLen = 32;
         return;
     }
 
+    uint64_t endOffset;
+    if (![handle seekToEndReturningOffset:&endOffset error:&seekError]) {
+        auto errorString = [NSString stringWithFormat:@"Error seeking file (%@) to end offset", fileDesignator];
+        auto error = [[NSError alloc] initWithDomain:@"OTAProviderDomain"
+                                                code:MTRErrorCodeGeneralError
+                                            userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(errorString, nil) }];
+        completionHandler(error);
+        return;
+    }
+
     _mFileHandle = handle;
     _mFileOffset = offset;
+    _mFileEndOffset = @(endOffset);
     completionHandler(nil);
 }
 
@@ -155,6 +167,7 @@ constexpr uint8_t kUpdateTokenLen = 32;
     NSLog(@"BDX TransferSession end with error: %@", error);
     _mFileHandle = nil;
     _mFileOffset = nil;
+    _mFileEndOffset = nil;
 }
 
 - (void)handleBDXQuery:(NSNumber * _Nonnull)blockSize
@@ -174,8 +187,15 @@ constexpr uint8_t kUpdateTokenLen = 32;
         return;
     }
 
-    NSData * data = [_mFileHandle readDataOfLength:[blockSize unsignedLongValue]];
-    completionHandler(data, [[_mFileHandle availableData] length] == 0);
+    NSData * data = [_mFileHandle readDataUpToLength:[blockSize unsignedLongValue] error:&error];
+    if (error != nil) {
+        NSLog(@"Error reading file %@", _mFileHandle);
+        completionHandler(nil, NO);
+        return;
+    }
+
+    BOOL isEOF = offset + [blockSize unsignedLongValue] >= [_mFileEndOffset unsignedLongLongValue];
+    completionHandler(data, isEOF);
 }
 
 - (void)SetOTAFilePath:(const char *)path


### PR DESCRIPTION
… if the end of file has been reached during a BDX Query Block request

#### Problem
The current code in `handleBDXQuery` loads all the file in memory in order to check if the end of file has been reached.

#### Change overview
* Seek to the end to get the end offset instead of loading everything in memory.
