### PR TITLE
Replace `PeerId` -> `ScopedNodeId` where applicable.

### DIFF
--- a/examples/all-clusters-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-app/esp32/main/include/ShellCommands.h
@@ -140,7 +140,7 @@ private:
         GetInstance().SetOnConnecting(false);
     }
 
-    static void OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error)
+    static void OnConnectionFailure(void * context, const ScopedNodeId & peerId, CHIP_ERROR error)
     {
         streamer_printf(streamer_get(), "Establish CASESession Failure!\r\n");
         GetInstance().SetOnConnecting(false);
@@ -156,8 +156,9 @@ private:
             ChipLogError(SecureChannel, "Can't get the CASESessionManager");
             return;
         }
-        caseSessionManager->FindOrEstablishSession(caseCommand->GetFabricInfo()->GetPeerIdForNode(caseCommand->GetNodeId()),
-                                                   &sOnConnectedCallback, &sOnConnectionFailureCallback);
+        caseSessionManager->FindOrEstablishSession(
+            ScopedNodeId(caseCommand->GetNodeId(), caseCommand->GetFabricInfo()->GetFabricIndex()), &sOnConnectedCallback,
+            &sOnConnectionFailureCallback);
     }
 
     static CHIP_ERROR ConnectToNodeHandler(int argc, char ** argv)

--- a/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
+++ b/examples/all-clusters-minimal-app/esp32/main/include/ShellCommands.h
@@ -140,7 +140,7 @@ private:
         GetInstance().SetOnConnecting(false);
     }
 
-    static void OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error)
+    static void OnConnectionFailure(void * context, const ScopedNodeId & peerId, CHIP_ERROR error)
     {
         streamer_printf(streamer_get(), "Establish CASESession Failure!\r\n");
         GetInstance().SetOnConnecting(false);
@@ -156,8 +156,9 @@ private:
             ChipLogError(SecureChannel, "Can't get the CASESessionManager");
             return;
         }
-        caseSessionManager->FindOrEstablishSession(caseCommand->GetFabricInfo()->GetPeerIdForNode(caseCommand->GetNodeId()),
-                                                   &sOnConnectedCallback, &sOnConnectionFailureCallback);
+        caseSessionManager->FindOrEstablishSession(
+            ScopedNodeId(caseCommand->GetNodeId(), caseCommand->GetFabricInfo()->GetFabricIndex()), &sOnConnectedCallback,
+            &sOnConnectionFailureCallback);
     }
 
     static CHIP_ERROR ConnectToNodeHandler(int argc, char ** argv)

--- a/examples/chip-tool/commands/clusters/ModelCommand.cpp
+++ b/examples/chip-tool/commands/clusters/ModelCommand.cpp
@@ -55,7 +55,7 @@ void ModelCommand::OnDeviceConnectedFn(void * context, chip::OperationalDevicePr
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }
 
-void ModelCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR err)
+void ModelCommand::OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR err)
 {
     LogErrorOnFailure(err);
 

--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -70,7 +70,7 @@ private:
     std::vector<chip::EndpointId> mEndPointId;
 
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
-    static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
+    static void OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
@@ -78,7 +78,7 @@ void CloseSessionCommand::OnDeviceConnectedFn(void * context, OperationalDeviceP
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }
 
-void CloseSessionCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR err)
+void CloseSessionCommand::OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR err)
 {
     LogErrorOnFailure(err);
 

--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.h
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.h
@@ -47,7 +47,7 @@ private:
     chip::Optional<uint16_t> mTimeoutSecs;
 
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
-    static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
+    static void OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 
     // Try to send the action CloseSession status report.
     CHIP_ERROR CloseSession(chip::DeviceProxy * device);

--- a/examples/chip-tool/commands/tests/TestCommand.cpp
+++ b/examples/chip-tool/commands/tests/TestCommand.cpp
@@ -61,7 +61,7 @@ void TestCommand::OnDeviceConnectedFn(void * context, chip::OperationalDevicePro
     LogErrorOnFailure(command->ContinueOnChipMainThread(CHIP_NO_ERROR));
 }
 
-void TestCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error)
+void TestCommand::OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error)
 {
     ChipLogProgress(chipTool, " **** Test Setup: Device Connection Failure [deviceId=%" PRIu64 ". Error %" CHIP_ERROR_FORMAT "\n]",
                     peerId.GetNodeId(), error.Format());

--- a/examples/chip-tool/commands/tests/TestCommand.h
+++ b/examples/chip-tool/commands/tests/TestCommand.h
@@ -71,7 +71,7 @@ protected:
     void OnResponse(const chip::app::StatusIB & status, chip::TLV::TLVReader * data) override{};
 
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
-    static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
+    static void OnDeviceConnectionFailureFn(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 
     CHIP_ERROR ContinueOnChipMainThread(CHIP_ERROR err) override;
 

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -234,7 +234,7 @@ public:
 private:
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
     static void OnDeviceConnectedFn(void * context, chip::OperationalDeviceProxy * device);
-    static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
+    static void OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
 
     chip::Callback::Callback<chip::OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
@@ -333,7 +333,7 @@ void PairingCommand::OnDeviceConnectedFn(void * context, chip::OperationalDevice
     }
 }
 
-void PairingCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR err)
+void PairingCommand::OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR err)
 {
     ChipLogProgress(Controller, "OnDeviceConnectionFailureFn - attempt to get OperationalDeviceProxy failed");
     CommissionerDiscoveryController * cdc = GetCommissionerDiscoveryController();

--- a/examples/tv-casting-app/tv-casting-common/commands/clusters/ModelCommand.cpp
+++ b/examples/tv-casting-app/tv-casting-common/commands/clusters/ModelCommand.cpp
@@ -47,16 +47,8 @@ CHIP_ERROR ModelCommand::RunCommand()
         return SendGroupCommand(GroupIdFromNodeId(mDestinationId), fabricIndex);
     }
 
-    Server * server           = &(chip::Server::GetInstance());
-    const FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(fabricIndex);
-    if (fabric == nullptr)
-    {
-        ChipLogError(AppServer, "Did not find fabric for index %d", fabricIndex);
-        return CHIP_ERROR_INVALID_FABRIC_INDEX;
-    }
-
-    PeerId peerID = fabric->GetPeerIdForNode(mDestinationId);
-    server->GetCASESessionManager()->FindOrEstablishSession(peerID, &mOnDeviceConnectedCallback,
+    Server * server = &(chip::Server::GetInstance());
+    server->GetCASESessionManager()->FindOrEstablishSession(ScopedNodeId(mDestinationId, fabricIndex), &mOnDeviceConnectedCallback,
                                                             &mOnDeviceConnectionFailureCallback);
     return CHIP_NO_ERROR;
 }
@@ -71,7 +63,7 @@ void ModelCommand::OnDeviceConnectedFn(void * context, OperationalDeviceProxy * 
     VerifyOrReturn(CHIP_NO_ERROR == err, command->SetCommandExitStatus(err));
 }
 
-void ModelCommand::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR err)
+void ModelCommand::OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR err)
 {
     ChipLogProgress(chipTool, "ModelCommand::OnDeviceConnectionFailureFn");
     LogErrorOnFailure(err);

--- a/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
+++ b/examples/tv-casting-app/tv-casting-common/include/TargetVideoPlayerInfo.h
@@ -49,7 +49,7 @@ private:
         ChipLogProgress(AppServer, "HandleDeviceConnected created an instance of OperationalDeviceProxy");
     }
 
-    static void HandleDeviceConnectionFailure(void * context, chip::PeerId peerId, CHIP_ERROR error)
+    static void HandleDeviceConnectionFailure(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error)
     {
         TargetVideoPlayerInfo * _this  = static_cast<TargetVideoPlayerInfo *>(context);
         _this->mOperationalDeviceProxy = nullptr;

--- a/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/TargetVideoPlayerInfo.cpp
@@ -32,17 +32,9 @@ CHIP_ERROR TargetVideoPlayerInfo::Initialize(NodeId nodeId, FabricIndex fabricIn
         endpointInfo.Reset();
     }
 
-    Server * server           = &(chip::Server::GetInstance());
-    const FabricInfo * fabric = server->GetFabricTable().FindFabricWithIndex(fabricIndex);
-    if (fabric == nullptr)
-    {
-        ChipLogError(AppServer, "Did not find fabric for index %d", fabricIndex);
-        return CHIP_ERROR_INVALID_FABRIC_INDEX;
-    }
-
-    PeerId peerID = fabric->GetPeerIdForNode(nodeId);
-
-    server->GetCASESessionManager()->FindOrEstablishSession(peerID, &mOnConnectedCallback, &mOnConnectionFailureCallback);
+    Server * server = &(chip::Server::GetInstance());
+    server->GetCASESessionManager()->FindOrEstablishSession(ScopedNodeId(nodeId, fabricIndex), &mOnConnectedCallback,
+                                                            &mOnConnectionFailureCallback);
 
     if (mOperationalDeviceProxy == nullptr)
     {

--- a/src/app/CASEClient.cpp
+++ b/src/app/CASEClient.cpp
@@ -26,7 +26,7 @@ void CASEClient::SetRemoteMRPIntervals(const ReliableMessageProtocolConfig & rem
     mCASESession.SetRemoteMRPConfig(remoteMRPConfig);
 }
 
-CHIP_ERROR CASEClient::EstablishSession(PeerId peer, const Transport::PeerAddress & peerAddress,
+CHIP_ERROR CASEClient::EstablishSession(const ScopedNodeId & peer, const Transport::PeerAddress & peerAddress,
                                         const ReliableMessageProtocolConfig & remoteMRPConfig,
                                         SessionEstablishmentDelegate * delegate)
 {
@@ -46,9 +46,9 @@ CHIP_ERROR CASEClient::EstablishSession(PeerId peer, const Transport::PeerAddres
     VerifyOrReturnError(exchange != nullptr, CHIP_ERROR_INTERNAL);
 
     mCASESession.SetGroupDataProvider(mInitParams.groupDataProvider);
-    ReturnErrorOnFailure(mCASESession.EstablishSession(
-        *mInitParams.sessionManager, mInitParams.fabricTable, ScopedNodeId{ peer.GetNodeId(), mInitParams.fabricIndex }, exchange,
-        mInitParams.sessionResumptionStorage, mInitParams.certificateValidityPolicy, delegate, mInitParams.mrpLocalConfig));
+    ReturnErrorOnFailure(mCASESession.EstablishSession(*mInitParams.sessionManager, mInitParams.fabricTable, peer, exchange,
+                                                       mInitParams.sessionResumptionStorage, mInitParams.certificateValidityPolicy,
+                                                       delegate, mInitParams.mrpLocalConfig));
 
     return CHIP_NO_ERROR;
 }

--- a/src/app/CASEClient.h
+++ b/src/app/CASEClient.h
@@ -33,7 +33,6 @@ struct CASEClientInitParams
     Credentials::CertificateValidityPolicy * certificateValidityPolicy = nullptr;
     Messaging::ExchangeManager * exchangeMgr                           = nullptr;
     FabricTable * fabricTable                                          = nullptr;
-    FabricIndex fabricIndex                                            = kUndefinedFabricIndex;
     Credentials::GroupDataProvider * groupDataProvider                 = nullptr;
 
     Optional<ReliableMessageProtocolConfig> mrpLocalConfig = Optional<ReliableMessageProtocolConfig>::Missing();
@@ -46,7 +45,7 @@ public:
 
     void SetRemoteMRPIntervals(const ReliableMessageProtocolConfig & remoteMRPConfig);
 
-    CHIP_ERROR EstablishSession(PeerId peer, const Transport::PeerAddress & peerAddress,
+    CHIP_ERROR EstablishSession(const ScopedNodeId & peer, const Transport::PeerAddress & peerAddress,
                                 const ReliableMessageProtocolConfig & remoteMRPConfig, SessionEstablishmentDelegate * delegate);
 
 private:

--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -28,11 +28,11 @@ CHIP_ERROR CASESessionManager::Init(chip::System::Layer * systemLayer, const CAS
     return AddressResolve::Resolver::Instance().Init(systemLayer);
 }
 
-void CASESessionManager::FindOrEstablishSession(PeerId peerId, Callback::Callback<OnDeviceConnected> * onConnection,
+void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
                                                 Callback::Callback<OnDeviceConnectionFailure> * onFailure)
 {
-    ChipLogDetail(CASESessionManager, "FindOrEstablishSession: PeerId = " ChipLogFormatX64 ":" ChipLogFormatX64,
-                  ChipLogValueX64(peerId.GetCompressedFabricId()), ChipLogValueX64(peerId.GetNodeId()));
+    ChipLogDetail(CASESessionManager, "FindOrEstablishSession: PeerId = [%d:" ChipLogFormatX64 "]", peerId.GetFabricIndex(),
+                  ChipLogValueX64(peerId.GetNodeId()));
 
     OperationalDeviceProxy * session = FindExistingSession(peerId);
     if (session == nullptr)
@@ -64,7 +64,7 @@ void CASESessionManager::FindOrEstablishSession(PeerId peerId, Callback::Callbac
     }
 }
 
-void CASESessionManager::ReleaseSession(PeerId peerId)
+void CASESessionManager::ReleaseSession(const ScopedNodeId & peerId)
 {
     ReleaseSession(FindExistingSession(peerId));
 }
@@ -79,7 +79,7 @@ void CASESessionManager::ReleaseAllSessions()
     mConfig.devicePool->ReleaseAllDevices();
 }
 
-CHIP_ERROR CASESessionManager::GetPeerAddress(PeerId peerId, Transport::PeerAddress & addr)
+CHIP_ERROR CASESessionManager::GetPeerAddress(const ScopedNodeId & peerId, Transport::PeerAddress & addr)
 {
     OperationalDeviceProxy * session = FindExistingSession(peerId);
     VerifyOrReturnError(session != nullptr, CHIP_ERROR_NOT_CONNECTED);
@@ -87,7 +87,7 @@ CHIP_ERROR CASESessionManager::GetPeerAddress(PeerId peerId, Transport::PeerAddr
     return CHIP_NO_ERROR;
 }
 
-OperationalDeviceProxy * CASESessionManager::FindExistingSession(PeerId peerId) const
+OperationalDeviceProxy * CASESessionManager::FindExistingSession(const ScopedNodeId & peerId) const
 {
     return mConfig.devicePool->FindDevice(peerId);
 }

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -68,12 +68,12 @@ public:
      * The `onFailure` callback may be called before the FindOrEstablishSession
      * call returns, for error cases that are detected synchronously.
      */
-    void FindOrEstablishSession(PeerId peerId, Callback::Callback<OnDeviceConnected> * onConnection,
+    void FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
                                 Callback::Callback<OnDeviceConnectionFailure> * onFailure);
 
-    OperationalDeviceProxy * FindExistingSession(PeerId peerId) const;
+    OperationalDeviceProxy * FindExistingSession(const ScopedNodeId & peerId) const;
 
-    void ReleaseSession(PeerId peerId);
+    void ReleaseSession(const ScopedNodeId & peerId);
 
     void ReleaseSessionsForFabric(FabricIndex fabricIndex);
 
@@ -87,7 +87,7 @@ public:
      * an ongoing session with the peer node. If the session doesn't exist, the API will return
      * `CHIP_ERROR_NOT_CONNECTED` error.
      */
-    CHIP_ERROR GetPeerAddress(PeerId peerId, Transport::PeerAddress & addr);
+    CHIP_ERROR GetPeerAddress(const ScopedNodeId & peerId, Transport::PeerAddress & addr);
 
 private:
     void ReleaseSession(OperationalDeviceProxy * device) const;

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -50,8 +50,8 @@ void OperationalDeviceProxy::MoveToState(State aTargetState)
 {
     if (mState != aTargetState)
     {
-        ChipLogDetail(Controller, "OperationalDeviceProxy[" ChipLogFormatX64 ":" ChipLogFormatX64 "]: State change %d --> %d",
-                      ChipLogValueX64(mPeerId.GetCompressedFabricId()), ChipLogValueX64(mPeerId.GetNodeId()), to_underlying(mState),
+        ChipLogDetail(Controller, "OperationalDeviceProxy[%u:" ChipLogFormatX64 "]: State change %d --> %d",
+                      mPeerId.GetFabricIndex(), ChipLogValueX64(mPeerId.GetNodeId()), to_underlying(mState),
                       to_underlying(aTargetState));
         mState = aTargetState;
 
@@ -66,14 +66,14 @@ bool OperationalDeviceProxy::AttachToExistingSecureSession()
 {
     VerifyOrReturnError(mState == State::NeedsAddress || mState == State::ResolvingAddress || mState == State::HasAddress, false);
 
-    ScopedNodeId peerNodeId(mPeerId.GetNodeId(), mFabricIndex);
     auto sessionHandle =
-        mInitParams.sessionManager->FindSecureSessionForNode(peerNodeId, MakeOptional(Transport::SecureSession::Type::kCASE));
+        mInitParams.sessionManager->FindSecureSessionForNode(mPeerId, MakeOptional(Transport::SecureSession::Type::kCASE));
     if (!sessionHandle.HasValue())
         return false;
 
-    ChipLogProgress(Controller, "Found an existing secure session to [" ChipLogFormatX64 "-" ChipLogFormatX64 "]!",
-                    ChipLogValueX64(mPeerId.GetCompressedFabricId()), ChipLogValueX64(mPeerId.GetNodeId()));
+    ChipLogProgress(Controller, "Found an existing secure session to [%u:" ChipLogFormatX64 "]!", mPeerId.GetFabricIndex(),
+                    ChipLogValueX64(mPeerId.GetNodeId()));
+
     mDeviceAddress = sessionHandle.Value()->AsSecureSession()->GetPeerAddress();
     if (!mSecureSession.Grab(sessionHandle.Value()))
         return false;
@@ -169,7 +169,8 @@ void OperationalDeviceProxy::UpdateDeviceData(const Transport::PeerAddress & add
     char peerAddrBuff[Transport::PeerAddress::kMaxToStringSize];
     addr.ToString(peerAddrBuff);
 
-    ChipLogDetail(Controller, "Updating device address to %s while in state %d", peerAddrBuff, static_cast<int>(mState));
+    ChipLogDetail(Discovery, "OperationalDeviceProxy[%u:" ChipLogFormatX64 "]: Updating device address to %s while in state %d",
+                  mPeerId.GetFabricIndex(), ChipLogValueX64(mPeerId.GetNodeId()), peerAddrBuff, static_cast<int>(mState));
 #endif
 
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -212,7 +213,7 @@ CHIP_ERROR OperationalDeviceProxy::EstablishConnection()
 {
     mCASEClient = mInitParams.clientPool->Allocate(CASEClientInitParams{
         mInitParams.sessionManager, mInitParams.sessionResumptionStorage, mInitParams.certificateValidityPolicy,
-        mInitParams.exchangeMgr, mFabricTable, mFabricIndex, mInitParams.groupDataProvider, mInitParams.mrpLocalConfig });
+        mInitParams.exchangeMgr, mFabricTable, mInitParams.groupDataProvider, mInitParams.mrpLocalConfig });
     ReturnErrorCodeIf(mCASEClient == nullptr, CHIP_ERROR_NO_MEMORY);
 
     CHIP_ERROR err = mCASEClient->EstablishSession(mPeerId, mDeviceAddress, mRemoteMRPConfig, this);
@@ -359,14 +360,17 @@ void OperationalDeviceProxy::OnSessionHang()
 
 void OperationalDeviceProxy::ShutdownSubscriptions()
 {
-    app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mFabricIndex, GetDeviceId());
+    app::InteractionModelEngine::GetInstance()->ShutdownSubscriptions(mPeerId.GetFabricIndex(), GetDeviceId());
 }
 
 OperationalDeviceProxy::~OperationalDeviceProxy()
 {
     if (mAddressLookupHandle.IsActive())
     {
-        ChipLogProgress(Discovery, "Cancelling incomplete address resolution as device is being deleted.");
+        ChipLogDetail(Discovery,
+                      "OperationalDeviceProxy[%u:" ChipLogFormatX64
+                      "]: Cancelling incomplete address resolution as device is being deleted.",
+                      mPeerId.GetFabricIndex(), ChipLogValueX64(mPeerId.GetNodeId()));
 
         // Skip cancel callback since the destructor is being called, so we assume that this object is
         // obviously not used anymore
@@ -391,11 +395,19 @@ CHIP_ERROR OperationalDeviceProxy::LookupPeerAddress()
     // MoveToState calls in this method.
     if (mAddressLookupHandle.IsActive())
     {
-        ChipLogProgress(Discovery, "Operational node lookup already in progress. Will NOT start a new one.");
+        ChipLogProgress(Discovery,
+                        "OperationalDeviceProxy[%u:" ChipLogFormatX64
+                        "]: Operational node lookup already in progress. Will NOT start a new one.",
+                        mPeerId.GetFabricIndex(), ChipLogValueX64(mPeerId.GetNodeId()));
         return CHIP_NO_ERROR;
     }
 
-    NodeLookupRequest request(mPeerId);
+    auto const * fabricInfo = mFabricTable->FindFabricWithIndex(mPeerId.GetFabricIndex());
+    VerifyOrReturnError(fabricInfo != nullptr, CHIP_ERROR_INVALID_FABRIC_INDEX);
+
+    PeerId peerId(fabricInfo->GetCompressedFabricId(), mPeerId.GetNodeId());
+
+    NodeLookupRequest request(peerId);
 
     return Resolver::Instance().LookupNode(request, mAddressLookupHandle);
 }
@@ -407,8 +419,8 @@ void OperationalDeviceProxy::OnNodeAddressResolved(const PeerId & peerId, const 
 
 void OperationalDeviceProxy::OnNodeAddressResolutionFailed(const PeerId & peerId, CHIP_ERROR reason)
 {
-    ChipLogError(Discovery, "Operational discovery failed for 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
-                 ChipLogValueX64(peerId.GetNodeId()), reason.Format());
+    ChipLogError(Discovery, "OperationalDeviceProxy[%u:" ChipLogFormatX64 "]: operational discovery failed: %" CHIP_ERROR_FORMAT,
+                 mPeerId.GetFabricIndex(), ChipLogValueX64(mPeerId.GetNodeId()), reason.Format());
 
     if (IsResolvingAddress())
     {

--- a/src/app/OperationalDeviceProxyPool.h
+++ b/src/app/OperationalDeviceProxyPool.h
@@ -26,11 +26,11 @@ namespace chip {
 class OperationalDeviceProxyPoolDelegate
 {
 public:
-    virtual OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, PeerId peerId) = 0;
+    virtual OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, ScopedNodeId peerId) = 0;
 
     virtual void Release(OperationalDeviceProxy * device) = 0;
 
-    virtual OperationalDeviceProxy * FindDevice(PeerId peerId) = 0;
+    virtual OperationalDeviceProxy * FindDevice(ScopedNodeId peerId) = 0;
 
     virtual void ReleaseDevicesForFabric(FabricIndex fabricIndex) = 0;
 
@@ -45,14 +45,14 @@ class OperationalDeviceProxyPool : public OperationalDeviceProxyPoolDelegate
 public:
     ~OperationalDeviceProxyPool() override { mDevicePool.ReleaseAll(); }
 
-    OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, PeerId peerId) override
+    OperationalDeviceProxy * Allocate(DeviceProxyInitParams & params, ScopedNodeId peerId) override
     {
         return mDevicePool.CreateObject(params, peerId);
     }
 
     void Release(OperationalDeviceProxy * device) override { mDevicePool.ReleaseObject(device); }
 
-    OperationalDeviceProxy * FindDevice(PeerId peerId) override
+    OperationalDeviceProxy * FindDevice(ScopedNodeId peerId) override
     {
         OperationalDeviceProxy * foundDevice = nullptr;
         mDevicePool.ForEachActiveObject([&](auto * activeDevice) {

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -126,10 +126,10 @@ private:
     static void HandleDeviceConnected(void * context, OperationalDeviceProxy * device);
     void HandleDeviceConnected(OperationalDeviceProxy * device);
 
-    static void HandleDeviceConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error);
-    void HandleDeviceConnectionFailure(PeerId peerId, CHIP_ERROR error);
+    static void HandleDeviceConnectionFailure(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
+    void HandleDeviceConnectionFailure(const ScopedNodeId & peerId, CHIP_ERROR error);
 
-    CHIP_ERROR EstablishConnection(FabricIndex fabric, NodeId node);
+    CHIP_ERROR EstablishConnection(const ScopedNodeId & nodeId);
 
     PendingNotificationMap mPendingNotificationMap;
     BoundDeviceChangedHandler mBoundDeviceChangedHandler;

--- a/src/app/clusters/bindings/PendingNotificationMap.cpp
+++ b/src/app/clusters/bindings/PendingNotificationMap.cpp
@@ -22,7 +22,7 @@
 
 namespace chip {
 
-CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(FabricIndex * fabric, NodeId * node)
+CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(ScopedNodeId & nodeId)
 {
     // When entries are added to PendingNotificationMap, they are appended to the end.
     // To find the LRU peer, we need to find the peer whose last entry in the map is closer
@@ -72,8 +72,7 @@ CHIP_ERROR PendingNotificationMap::FindLRUConnectPeer(FabricIndex * fabric, Node
     if (minLastAppearValue < UINT16_MAX)
     {
         EmberBindingTableEntry entry = BindingTable::GetInstance().GetAt(static_cast<uint8_t>(lruBindingEntryIndex));
-        *fabric                      = entry.fabricIndex;
-        *node                        = entry.nodeId;
+        nodeId                       = ScopedNodeId(entry.nodeId, entry.fabricIndex);
         return CHIP_NO_ERROR;
     }
     return CHIP_ERROR_NOT_FOUND;
@@ -110,13 +109,13 @@ void PendingNotificationMap::RemoveEntry(uint8_t bindingEntryId)
     mNumEntries = newEntryCount;
 }
 
-void PendingNotificationMap::RemoveAllEntriesForNode(FabricIndex fabric, NodeId node)
+void PendingNotificationMap::RemoveAllEntriesForNode(const ScopedNodeId & nodeId)
 {
     uint8_t newEntryCount = 0;
     for (int i = 0; i < mNumEntries; i++)
     {
         EmberBindingTableEntry entry = BindingTable::GetInstance().GetAt(mPendingBindingEntries[i]);
-        if (entry.fabricIndex != fabric || entry.nodeId != node)
+        if (entry.fabricIndex != nodeId.GetFabricIndex() || entry.nodeId != nodeId.GetNodeId())
         {
             mPendingBindingEntries[newEntryCount] = mPendingBindingEntries[i];
             mPendingContexts[newEntryCount]       = mPendingContexts[i];

--- a/src/app/clusters/bindings/PendingNotificationMap.h
+++ b/src/app/clusters/bindings/PendingNotificationMap.h
@@ -100,15 +100,13 @@ public:
 
     Iterator end() { return Iterator(this, mNumEntries); }
 
-    CHIP_ERROR FindLRUConnectPeer(FabricIndex * fabric, NodeId * node);
+    CHIP_ERROR FindLRUConnectPeer(ScopedNodeId & nodeId);
 
     void AddPendingNotification(uint8_t bindingEntryId, PendingNotificationContext * context);
 
     void RemoveEntry(uint8_t bindingEntryId);
 
-    void RemoveAllEntriesForNode(FabricTable * fabricTable, PeerId peer);
-
-    void RemoveAllEntriesForNode(FabricIndex fabric, NodeId node);
+    void RemoveAllEntriesForNode(const ScopedNodeId & nodeId);
 
     void RemoveAllEntriesForFabric(FabricIndex fabric);
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -205,6 +205,12 @@ private:
      */
     IdleStateReason MapErrorToIdleStateReason(CHIP_ERROR error);
 
+    ScopedNodeId GetProviderScopedId() const
+    {
+        VerifyOrDie(mProviderLocation.HasValue());
+        return ScopedNodeId(mProviderLocation.Value().providerNodeID, mProviderLocation.Value().fabricIndex);
+    }
+
     /**
      * Record the new update state by updating the corresponding server attribute and logging a StateTransition event
      */
@@ -280,7 +286,7 @@ private:
      * Session connection callbacks
      */
     static void OnConnected(void * context, OperationalDeviceProxy * deviceProxy);
-    static void OnConnectionFailure(void * context, PeerId peerId, CHIP_ERROR error);
+    static void OnConnectionFailure(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
     Callback::Callback<OnDeviceConnected> mOnConnectedCallback;
     Callback::Callback<OnDeviceConnectionFailure> mOnConnectionFailureCallback;
 

--- a/src/app/tests/TestPendingNotificationMap.cpp
+++ b/src/app/tests/TestPendingNotificationMap.cpp
@@ -53,9 +53,8 @@ void TestEmptyMap(nlTestSuite * aSuite, void * aContext)
 {
     PendingNotificationMap pendingMap;
     NL_TEST_ASSERT(aSuite, pendingMap.begin() == pendingMap.end());
-    FabricIndex fabricIndex;
-    NodeId node;
-    NL_TEST_ASSERT(aSuite, pendingMap.FindLRUConnectPeer(&fabricIndex, &node) == CHIP_ERROR_NOT_FOUND);
+    chip::ScopedNodeId peer;
+    NL_TEST_ASSERT(aSuite, pendingMap.FindLRUConnectPeer(peer) == CHIP_ERROR_NOT_FOUND);
 }
 
 void TestAddRemove(nlTestSuite * aSuite, void * aContext)
@@ -75,7 +74,7 @@ void TestAddRemove(nlTestSuite * aSuite, void * aContext)
         ++iter;
     }
     NL_TEST_ASSERT(aSuite, iter == pendingMap.end());
-    pendingMap.RemoveAllEntriesForNode(0, 0);
+    pendingMap.RemoveAllEntriesForNode(chip::ScopedNodeId());
     uint8_t expectedEntryIndecies[] = { 1, 2, 3, 4, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19 };
     iter                            = pendingMap.begin();
     for (size_t i = 0; i < sizeof(expectedEntryIndecies); i++)
@@ -109,19 +108,18 @@ void TestLRUEntry(nlTestSuite * aSuite, void * aContext)
     pendingMap.AddPendingNotification(7, nullptr);
     pendingMap.AddPendingNotification(11, nullptr);
 
-    FabricIndex fabricIndex;
-    NodeId node;
+    chip::ScopedNodeId node;
 
-    NL_TEST_ASSERT(aSuite, pendingMap.FindLRUConnectPeer(&fabricIndex, &node) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(aSuite, fabricIndex == 0 && node == 1);
+    NL_TEST_ASSERT(aSuite, pendingMap.FindLRUConnectPeer(node) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, node.GetFabricIndex() == 0 && node.GetNodeId() == 1);
 
     pendingMap.RemoveEntry(1);
-    NL_TEST_ASSERT(aSuite, pendingMap.FindLRUConnectPeer(&fabricIndex, &node) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(aSuite, fabricIndex == 0 && node == 0);
+    NL_TEST_ASSERT(aSuite, pendingMap.FindLRUConnectPeer(node) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, node.GetFabricIndex() == 0 && node.GetNodeId() == 0);
 
     pendingMap.RemoveAllEntriesForFabric(0);
-    NL_TEST_ASSERT(aSuite, pendingMap.FindLRUConnectPeer(&fabricIndex, &node) == CHIP_NO_ERROR);
-    NL_TEST_ASSERT(aSuite, fabricIndex == 1 && node == 1);
+    NL_TEST_ASSERT(aSuite, pendingMap.FindLRUConnectPeer(node) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(aSuite, node.GetFabricIndex() == 1 && node.GetNodeId() == 1);
 }
 
 } // namespace

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -308,7 +308,7 @@ void CommissioningWindowOpener::OnDeviceConnectedCallback(void * context, Operat
     }
 }
 
-void CommissioningWindowOpener::OnDeviceConnectionFailureCallback(void * context, PeerId peerId, CHIP_ERROR error)
+void CommissioningWindowOpener::OnDeviceConnectionFailureCallback(void * context, const ScopedNodeId & peerId, CHIP_ERROR error)
 {
     OnOpenCommissioningWindowFailure(context, error);
 }

--- a/src/controller/CommissioningWindowOpener.h
+++ b/src/controller/CommissioningWindowOpener.h
@@ -127,7 +127,7 @@ private:
     static void OnOpenCommissioningWindowSuccess(void * context, const app::DataModel::NullObjectType &);
     static void OnOpenCommissioningWindowFailure(void * context, CHIP_ERROR error);
     static void OnDeviceConnectedCallback(void * context, OperationalDeviceProxy * device);
-    static void OnDeviceConnectionFailureCallback(void * context, PeerId peerId, CHIP_ERROR error);
+    static void OnDeviceConnectionFailureCallback(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
 
     DeviceController * const mController = nullptr;
     Step mNextStep                       = Step::kAcceptCommissioningStart;

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -82,7 +82,7 @@ void GetConnectedDeviceCallback::OnDeviceConnectedFn(void * context, Operational
     env->CallVoidMethod(javaCallback, successMethod, reinterpret_cast<jlong>(device));
 }
 
-void GetConnectedDeviceCallback::OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error)
+void GetConnectedDeviceCallback::OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error)
 {
     JNIEnv * env         = JniReferences::GetInstance().GetEnvForCurrentThread();
     auto * self          = static_cast<GetConnectedDeviceCallback *>(context);

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -34,7 +34,7 @@ struct GetConnectedDeviceCallback
     ~GetConnectedDeviceCallback();
 
     static void OnDeviceConnectedFn(void * context, OperationalDeviceProxy * device);
-    static void OnDeviceConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error);
+    static void OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
 
     Callback::Callback<OnDeviceConnected> mOnSuccess;
     Callback::Callback<OnDeviceConnectionFailure> mOnFailure;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -517,11 +517,7 @@ JNI_METHOD(jstring, getIpAddress)(JNIEnv * env, jobject self, jlong handle, jlon
     uint16_t port;
     char addrStr[50];
 
-    CHIP_ERROR err =
-        wrapper->Controller()->GetPeerAddressAndPort(PeerId()
-                                                         .SetCompressedFabricId(wrapper->Controller()->GetCompressedFabricId())
-                                                         .SetNodeId(static_cast<chip::NodeId>(deviceId)),
-                                                     addr, port);
+    CHIP_ERROR err = wrapper->Controller()->GetPeerAddressAndPort(deviceId, addr, port);
 
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -298,12 +298,9 @@ ChipError::StorageType pychip_DeviceController_GetAddressAndPort(chip::Controlle
                                                                  uint16_t * outPort)
 {
     Inet::IPAddress address;
-    ReturnErrorOnFailure(
-        devCtrl
-            ->GetPeerAddressAndPort(PeerId().SetCompressedFabricId(devCtrl->GetCompressedFabricId()).SetNodeId(nodeId), address,
-                                    *outPort)
-            .AsInteger());
-    VerifyOrReturnError(address.ToString(outAddress, maxAddressLen), CHIP_ERROR_BUFFER_TOO_SMALL.AsInteger());
+    ReturnErrorOnFailure(devCtrl->GetPeerAddressAndPort(nodeId, address, *outPort).AsInteger());
+    VerifyOrReturnError(address.ToString(outAddress, static_cast<uint32_t>(maxAddressLen)),
+                        CHIP_ERROR_BUFFER_TOO_SMALL.AsInteger());
 
     return CHIP_NO_ERROR.AsInteger();
 }
@@ -621,7 +618,7 @@ struct GetDeviceCallbacks
         delete self;
     }
 
-    static void OnConnectionFailureFn(void * context, PeerId peerId, CHIP_ERROR error)
+    static void OnConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error)
     {
         auto * self = static_cast<GetDeviceCallbacks *>(context);
         self->mCallback(nullptr, error.AsInteger());

--- a/src/darwin/Framework/CHIP/MTRDeviceConnectionBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectionBridge.h
@@ -50,7 +50,7 @@ private:
     chip::Callback::Callback<chip::OnDeviceConnectionFailure> mOnConnectFailed;
 
     static void OnConnected(void * context, chip::OperationalDeviceProxy * device);
-    static void OnConnectionFailure(void * context, chip::PeerId peerId, CHIP_ERROR error);
+    static void OnConnectionFailure(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error);
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceConnectionBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceConnectionBridge.mm
@@ -29,7 +29,7 @@ void MTRDeviceConnectionBridge::OnConnected(void * context, chip::OperationalDev
     });
 }
 
-void MTRDeviceConnectionBridge::OnConnectionFailure(void * context, chip::PeerId peerId, CHIP_ERROR error)
+void MTRDeviceConnectionBridge::OnConnectionFailure(void * context, const chip::ScopedNodeId & peerId, CHIP_ERROR error)
 {
     auto * object = static_cast<MTRDeviceConnectionBridge *>(context);
     dispatch_async(object->mQueue, ^{


### PR DESCRIPTION
Lots of places were still using `PeerId` when they should be using `ScopedNodeId`, since the former is really only meant to be used with mDNS, and nothing else.