### PR TITLE
Update ZAP to tip.

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -451,7 +451,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -459,7 +459,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;
@@ -3606,7 +3606,7 @@ server cluster TestCluster = 4294048773 {
   }
 
   info event TestFabricScopedEvent = 2 {
-    fabric_idx arg1 = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute boolean boolean = 0;

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -396,7 +396,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -404,7 +404,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;
@@ -3032,7 +3032,7 @@ server cluster TestCluster = 4294048773 {
   }
 
   info event TestFabricScopedEvent = 2 {
-    fabric_idx arg1 = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute boolean boolean = 0;

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -254,7 +254,7 @@ client cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -262,7 +262,7 @@ client cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;
@@ -322,7 +322,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -330,7 +330,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -429,7 +429,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -437,7 +437,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
@@ -185,7 +185,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -193,7 +193,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -429,7 +429,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -437,7 +437,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
@@ -198,7 +198,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -206,7 +206,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -422,7 +422,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -430,7 +430,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
@@ -198,7 +198,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -206,7 +206,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -198,7 +198,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -206,7 +206,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
@@ -198,7 +198,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -206,7 +206,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -429,7 +429,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -437,7 +437,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
@@ -499,7 +499,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -507,7 +507,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
@@ -346,7 +346,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -354,7 +354,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -198,7 +198,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -206,7 +206,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
@@ -309,7 +309,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -317,7 +317,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
@@ -198,7 +198,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -206,7 +206,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -296,7 +296,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -304,7 +304,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -296,7 +296,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -304,7 +304,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/chip-tool/templates/ComplexArgumentParser-src.zapt
+++ b/examples/chip-tool/templates/ComplexArgumentParser-src.zapt
@@ -11,7 +11,7 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label, {{zapTypeToEncodable
     {{#unless isOptional}}
     {{~! Fabric index fields are not sent on writes, so don't force people to
       provide them. ~}}
-    {{#unless (isStrEqual label ../struct_fabric_idx_field)}}
+    {{#unless (is_num_equal fieldIdentifier 254)}}
     ReturnErrorOnFailure(ComplexArgumentParser::EnsureMemberExist("{{parent.name}}.{{asLowerCamelCase label}}", "{{asLowerCamelCase label}}", value.isMember("{{asLowerCamelCase label}}")));
     {{/unless}}
     {{/unless}}
@@ -22,7 +22,7 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label, {{zapTypeToEncodable
     {{#if isOptional}}
     if (value.isMember("{{asLowerCamelCase label}}"))
     {
-    {{else if (isStrEqual label ../struct_fabric_idx_field)}}
+    {{else if (is_num_equal fieldIdentifier 254)}}
     if (value.isMember("{{asLowerCamelCase label}}"))
     {
     {{/if}}
@@ -30,7 +30,7 @@ CHIP_ERROR ComplexArgumentParser::Setup(const char * label, {{zapTypeToEncodable
     ReturnErrorOnFailure(ComplexArgumentParser::Setup(labelWithMember, request.{{asLowerCamelCase label}}, value["{{asLowerCamelCase label}}"]));
     {{#if isOptional}}
     }
-    {{else if (isStrEqual label ../struct_fabric_idx_field)}}
+    {{else if (is_num_equal fieldIdentifier 254)}}
     }
     {{/if}}
 

--- a/examples/chip-tool/templates/helper.js
+++ b/examples/chip-tool/templates/helper.js
@@ -116,14 +116,7 @@ async function structs_with_cluster_name(options)
       continue;
     }
 
-    s.items.forEach(i => {
-      if (i.type.toLowerCase() == "fabric_idx") {
-        s.struct_fabric_idx_field = i.label;
-      }
-    })
-
-    if (s.struct_cluster_count == 1)
-    {
+    if (s.struct_cluster_count == 1) {
       const clusters = await zclQuery.selectStructClusters(this.global.db, s.id);
       blocks.push(
           { id : s.id, name : s.name, struct_fabric_idx_field : s.struct_fabric_idx_field, clusterName : clusters[0].name });

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -374,7 +374,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -382,7 +382,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -314,7 +314,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -322,7 +322,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -207,7 +207,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -215,7 +215,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/log-source-app/log-source-common/log-source-app.matter
+++ b/examples/log-source-app/log-source-common/log-source-app.matter
@@ -46,7 +46,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -54,7 +54,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -51,7 +51,7 @@ client cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -59,7 +59,7 @@ client cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;
@@ -117,7 +117,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -125,7 +125,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -51,7 +51,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -59,7 +59,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -245,7 +245,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -253,7 +253,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -160,7 +160,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -168,7 +168,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -65,7 +65,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -73,7 +73,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -317,7 +317,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -325,7 +325,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -223,7 +223,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -231,7 +231,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -572,7 +572,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -580,7 +580,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -286,7 +286,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -294,7 +294,7 @@ server cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;

--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -86,7 +86,7 @@ CHIP_ERROR LogExtensionChangedEvent(const AccessControlCluster::Structs::Extensi
                                     const Access::SubjectDescriptor & subjectDescriptor,
                                     AccessControlCluster::ChangeTypeEnum changeType)
 {
-    ExtensionEvent event{ .changeType = changeType, .adminFabricIndex = subjectDescriptor.fabricIndex };
+    ExtensionEvent event{ .changeType = changeType, .fabricIndex = subjectDescriptor.fabricIndex };
 
     if (subjectDescriptor.authMode == Access::AuthMode::kCase)
     {
@@ -387,7 +387,7 @@ void AccessControlAttribute::OnEntryChanged(const SubjectDescriptor * subjectDes
     }
 
     CHIP_ERROR err;
-    AclEvent event{ .changeType = ChangeTypeEnum::kChanged, .adminFabricIndex = subjectDescriptor->fabricIndex };
+    AclEvent event{ .changeType = ChangeTypeEnum::kChanged, .fabricIndex = subjectDescriptor->fabricIndex };
 
     if (changeType == ChangeType::kAdded)
     {

--- a/src/app/zap-templates/partials/cluster-objects-struct.zapt
+++ b/src/app/zap-templates/partials/cluster-objects-struct.zapt
@@ -16,15 +16,15 @@ namespace {{asUpperCamelCase name}} {
         CHIP_ERROR Decode(TLV::TLVReader &reader);
         {{/unless}}
 
-        static constexpr bool kIsFabricScoped = {{struct_is_fabric_scoped}};
+        static constexpr bool kIsFabricScoped = {{isFabricScoped}};
 
-        {{#if struct_is_fabric_scoped}}
+        {{#if isFabricScoped}}
         auto GetFabricIndex() const {
-            return {{ asLowerCamelCase struct_fabric_idx_field }};
+            return fabricIndex;
         }
 
         void SetFabricIndex(chip::FabricIndex fabricIndex_) {
-            {{ asLowerCamelCase struct_fabric_idx_field }} = fabricIndex_;
+            fabricIndex = fabricIndex_;
         }
 
         CHIP_ERROR EncodeForWrite(TLV::TLVWriter &writer, TLV::Tag tag) const;
@@ -46,15 +46,15 @@ namespace {{asUpperCamelCase name}} {
 
         CHIP_ERROR Decode(TLV::TLVReader &reader);
 
-        static constexpr bool kIsFabricScoped = {{struct_is_fabric_scoped}};
+        static constexpr bool kIsFabricScoped = {{isFabricScoped}};
 
-        {{#if struct_is_fabric_scoped}}
+        {{#if isFabricScoped}}
         auto GetFabricIndex() const {
-            return {{ asLowerCamelCase struct_fabric_idx_field }};
+            return fabricIndex;
         }
 
         void SetFabricIndex(chip::FabricIndex fabricIndex_) {
-            {{ asLowerCamelCase struct_fabric_idx_field }} = fabricIndex_;
+            fabricIndex = fabricIndex_;
         }
         {{/if}}
     };
@@ -65,7 +65,7 @@ namespace {{asUpperCamelCase name}} {
 } // namespace {{asUpperCamelCase name}}
 {{else}}
 namespace {{asUpperCamelCase name}} {
-{{#if struct_is_fabric_scoped}}
+{{#if isFabricScoped}}
 CHIP_ERROR Type::EncodeForWrite(TLV::TLVWriter &writer, TLV::Tag tag) const
 {
     return DoEncode(writer, tag, NullOptional);
@@ -79,12 +79,12 @@ CHIP_ERROR Type::EncodeForRead(TLV::TLVWriter &writer, TLV::Tag tag, FabricIndex
 CHIP_ERROR Type::DoEncode(TLV::TLVWriter &writer, TLV::Tag tag, const Optional<FabricIndex> & accessingFabricIndex) const
 {
     {{#if struct_has_fabric_sensitive_fields}}
-    bool includeSensitive = !accessingFabricIndex.HasValue() || (accessingFabricIndex.Value() == {{ asLowerCamelCase struct_fabric_idx_field }});
+    bool includeSensitive = !accessingFabricIndex.HasValue() || (accessingFabricIndex.Value() == fabricIndex);
     {{/if}}
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
     {{#zcl_struct_items}}
-    {{#if (isStrEqual label ../struct_fabric_idx_field)}}
+    {{#if (is_num_equal fieldIdentifier 254)}}
     if (accessingFabricIndex.HasValue()) {
       ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::k{{asUpperCamelCase label}})), {{asLowerCamelCase label}}));
     }

--- a/src/app/zap-templates/partials/idl/structure_definition.zapt
+++ b/src/app/zap-templates/partials/idl/structure_definition.zapt
@@ -1,5 +1,6 @@
-{{#if struct_is_fabric_scoped}}
-{{indent extraIndent~}} [fabric_scoped_by={{asUpperCamelCase struct_fabric_idx_field}}]
+{{! TODO: IDL consumers can't parse the square bracket syntax }}
+{{#if isFabricScoped_DISABLED_FOR_NOW}}
+{{indent extraIndent~}} [fabric_scoped_by=FabricIndex]
 {{/if}}
 {{indent extraIndent~}} struct {{name}} {
 {{#zcl_struct_items}}

--- a/src/app/zap-templates/templates/app/cluster-objects.zapt
+++ b/src/app/zap-templates/templates/app/cluster-objects.zapt
@@ -177,15 +177,15 @@ public:
     static constexpr PriorityLevel GetPriorityLevel() { return kPriorityLevel; }
     static constexpr EventId GetEventId() { return Events::{{asUpperCamelCase name}}::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::{{asUpperCamelCase parent.name}}::Id; }
-    static constexpr bool kIsFabricScoped = {{event_is_fabric_scoped}};
+    static constexpr bool kIsFabricScoped = {{isFabricSensitive}};
 
     {{#zcl_event_fields}}
     {{zapTypeToEncodableClusterObjectType type}} {{asLowerCamelCase name}}{{> cluster_objects_field_init}};
     {{/zcl_event_fields}}
 
-    {{#if event_is_fabric_scoped}}
+    {{#if isFabricSensitive}}
     auto GetFabricIndex() const {
-        return {{ asLowerCamelCase event_fabric_idx_field }};
+        return fabricIndex;
     }
     {{/if}}
 

--- a/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/access-control-cluster.xml
@@ -47,19 +47,17 @@ limitations under the License.
     <item fieldId="2" name="DeviceType" type="devtype_id" isNullable="true"/>
   </struct>
 
-  <struct name="AccessControlEntry">
+  <struct name="AccessControlEntry" isFabricScoped="true">
     <cluster code="0x001F"/>
     <item fieldId="1" name="Privilege" type="Privilege" isFabricSensitive="true"/>
     <item fieldId="2" name="AuthMode" type="AuthMode" isFabricSensitive="true"/>
     <item fieldId="3" name="Subjects" type="INT64U" isNullable="true" array="true" isFabricSensitive="true"/>
     <item fieldId="4" name="Targets" type="Target" isNullable="true" array="true" isFabricSensitive="true"/>
-    <item fieldId="0xFE" name="FabricIndex" type="fabric_idx" isFabricSensitive="true"/>
   </struct>
 
-  <struct name="ExtensionEntry">
+  <struct name="ExtensionEntry" isFabricScoped="true">
     <cluster code="0x001F"/>
     <item fieldId="1" name="Data" type="OCTET_STRING" length="128" isFabricSensitive="true"/>
-    <item fieldId="0xFE" name="FabricIndex" type="fabric_idx" isFabricSensitive="true"/>
   </struct>
 
   <cluster>
@@ -103,22 +101,20 @@ limitations under the License.
       <access op="read" privilege="view"/>
     </attribute>
 
-    <event side="server" code="0x0000" name="AccessControlEntryChanged" priority="info" optional="false">
+    <event side="server" code="0x0000" name="AccessControlEntryChanged" priority="info" isFabricSensitive="true" optional="false">
       <description>The cluster SHALL send AccessControlEntryChanged events whenever its ACL attribute data is changed by an Administrator.</description>
       <field id="1" name="AdminNodeID" type="node_id" isNullable="true"/>
       <field id="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
       <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
       <field id="4" name="LatestValue" type="AccessControlEntry" isNullable="true"/>
-      <field id="0xFE" name="AdminFabricIndex" type="fabric_idx"/>
       <access op="read" privilege="administer"/>
     </event>
-    <event side="server" code="0x0001" name="AccessControlExtensionChanged" priority="info" optional="false">
+    <event side="server" code="0x0001" name="AccessControlExtensionChanged" priority="info" isFabricSensitive="true" optional="false">
       <description>The cluster SHALL send AccessControlExtensionChanged events whenever its extension attribute data is changed by an Administrator.</description>
       <field id="1" name="AdminNodeID" type="node_id" isNullable="true"/>
       <field id="2" name="AdminPasscodeID" type="INT16U" isNullable="true"/>
       <field id="3" name="ChangeType" type="ChangeTypeEnum"/>
       <field id="4" name="LatestValue" type="ExtensionEntry" isNullable="true"/>
-      <field id="0xFE" name="AdminFabricIndex" type="fabric_idx"/>
       <access op="read" privilege="administer"/>
     </event>
   </cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/binding-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/binding-cluster.xml
@@ -17,13 +17,12 @@ limitations under the License.
 <configurator>
   <domain name="CHIP" />
 
-  <struct name="TargetStruct">
+  <struct name="TargetStruct" isFabricScoped="true">
     <cluster code="0x001e"/>
     <item fieldId="1" name="Node" type="NODE_ID" optional="true"/>
     <item fieldId="2" name="Group" type="GROUP_ID" optional="true"/>
     <item fieldId="3" name="Endpoint" type="ENDPOINT_NO" optional="true"/>
     <item fieldId="4" name="Cluster" type="CLUSTER_ID" optional="true"/>
-    <item fieldId="0xFE" name="FabricIndex" type="FABRIC_IDX"/>
   </struct>
 
   <cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/chip-ota.xml
@@ -108,11 +108,10 @@ limitations under the License.
         <item name="TimeOut" value="0x3"/>
         <item name="DelayByProvider" value="0x4"/>
     </enum>
-    <struct name="ProviderLocation">
+    <struct name="ProviderLocation" isFabricScoped="true">
         <cluster code="0x002a"/>
         <item fieldId="1" name="ProviderNodeID" type="node_id"/>
         <item fieldId="2" name="Endpoint" type="endpoint_no"/>
-        <item fieldId="0xFE" name="FabricIndex" type="fabric_idx"/>
     </struct>
     <cluster>
         <name>OTA Software Update Requestor</name>

--- a/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/group-key-mgmt-cluster.xml
@@ -17,19 +17,17 @@ limitations under the License.
 <configurator>
   <domain name="CHIP" />
 
-  <struct name="GroupKeyMapStruct">
+  <struct name="GroupKeyMapStruct" isFabricScoped="true">
     <cluster code="0x003F"/>
     <item fieldId="1" name="GroupId" type="group_id"/>
     <item fieldId="2" name="GroupKeySetID" type="INT16U"/>
-    <item fieldId="0xFE" name="FabricIndex" type="fabric_idx"/>
   </struct>
 
-  <struct name="GroupInfoMapStruct">
+  <struct name="GroupInfoMapStruct" isFabricScoped="true">
     <cluster code="0x003F"/>
     <item fieldId="1" name="GroupId" type="group_id"/>
     <item fieldId="2" name="Endpoints" type="endpoint_no" array="true"/>
     <item fieldId="3" name="GroupName" type="CHAR_STRING" length="16" optional="true"/>
-    <item fieldId="0xFE" name="FabricIndex" type="fabric_idx"/>
   </struct>
 
   <struct name="GroupKeySetStruct">

--- a/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/operational-credentials-cluster.xml
@@ -17,14 +17,13 @@ limitations under the License.
 <configurator>
   <domain name="CHIP"/>
 
-  <struct name="FabricDescriptor">
+  <struct name="FabricDescriptor" isFabricScoped="true">
     <cluster code="0x003E"/>
     <item fieldId="1" name="RootPublicKey" type="OCTET_STRING" length="65"/>
     <item fieldId="2" name="VendorId" type="VENDOR_ID"/>
     <item fieldId="3" name="FabricId" type="FABRIC_ID"/>
     <item fieldId="4" name="NodeId" type="NODE_ID"/>
     <item fieldId="5" name="Label" type="CHAR_STRING" length="32"/>
-    <item fieldId="0xFE" name="FabricIndex" type="fabric_idx"/>
   </struct>
 
   <enum name="OperationalCertStatus" type="ENUM8">
@@ -41,11 +40,10 @@ limitations under the License.
     <item name="InvalidFabricIndex" value="0x0b"/>
   </enum>
 
-  <struct name="NOCStruct">
+  <struct name="NOCStruct" isFabricScoped="true">
     <cluster code="0x003E"/>
     <item fieldId="1" name="NOC" type="OCTET_STRING" isFabricSensitive="true"/>
     <item fieldId="2" name="ICAC" type="OCTET_STRING" isNullable="true" isFabricSensitive="true"/>
-    <item fieldId="0xFE" name="FabricIndex" type="fabric_idx"/>
   </struct>
 
   <cluster>

--- a/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/test-cluster.xml
@@ -22,7 +22,7 @@ limitations under the License.
     <item name="member2" type="OCTET_STRING" length="32"/>
   </struct>
 
-  <struct name="TestFabricScoped">
+  <struct name="TestFabricScoped" isFabricScoped="true">
     <cluster code="0xFFF1FC05"/>
     <item fieldId="1" name="fabricSensitiveInt8u" type="INT8U" isFabricSensitive="true"/>
     <item fieldId="2" name="optionalFabricSensitiveInt8u" type="INT8U" optional="true" isFabricSensitive="true"/>
@@ -31,7 +31,6 @@ limitations under the License.
     <item fieldId="5" name="fabricSensitiveCharString" type="CHAR_STRING" isFabricSensitive="true"/>
     <item fieldId="6" name="fabricSensitiveStruct" type="SimpleStruct" isFabricSensitive="true"/>
     <item fieldId="7" name="fabricSensitiveInt8uList" type="INT8U" array="true" isFabricSensitive="true"/>
-    <item fieldId="0xFE" name="fabricIndex" type="fabric_idx"/>
   </struct>
 
   <enum name="SimpleEnum" type="ENUM8">
@@ -575,9 +574,8 @@ limitations under the License.
       <field id="6" name="arg6" type="SimpleEnum" array="true"/>
     </event>
 
-    <event code="0x0002" name="TestFabricScopedEvent" priority="info" side="server">
+    <event code="0x0002" name="TestFabricScopedEvent" priority="info" side="server" isFabricSensitive="true">
       <description>Example test event</description>
-      <field id="0xFE" name="arg1" type="fabric_idx"/>
     </event>
 
   </cluster>

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -478,7 +478,7 @@ client cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable AccessControlEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   info event access(read: administer) AccessControlExtensionChanged = 1 {
@@ -486,7 +486,7 @@ client cluster AccessControl = 31 {
     nullable INT16U adminPasscodeID = 2;
     ChangeTypeEnum changeType = 3;
     nullable ExtensionEntry latestValue = 4;
-    fabric_idx adminFabricIndex = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute access(read: administer, write: administer) AccessControlEntry acl[] = 0;
@@ -4168,7 +4168,7 @@ client cluster TestCluster = 4294048773 {
   }
 
   info event TestFabricScopedEvent = 2 {
-    fabric_idx arg1 = 254;
+    fabric_idx fabricIndex = 254;
   }
 
   attribute boolean boolean = 0;

--- a/src/controller/java/zap-generated/CHIPEventTLVValueDecoder.cpp
+++ b/src/controller/java/zap-generated/CHIPEventTLVValueDecoder.cpp
@@ -319,12 +319,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                    value_latestValue_fabricIndex);
             }
 
-            jobject value_adminFabricIndex;
-            std::string value_adminFabricIndexClassName     = "java/lang/Integer";
-            std::string value_adminFabricIndexCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(value_adminFabricIndexClassName.c_str(),
-                                                                          value_adminFabricIndexCtorSignature.c_str(),
-                                                                          cppValue.adminFabricIndex, value_adminFabricIndex);
+            jobject value_fabricIndex;
+            std::string value_fabricIndexClassName     = "java/lang/Integer";
+            std::string value_fabricIndexCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(value_fabricIndexClassName.c_str(),
+                                                                          value_fabricIndexCtorSignature.c_str(),
+                                                                          cppValue.fabricIndex, value_fabricIndex);
 
             jclass accessControlEntryChangedStructClass;
             err = chip::JniReferences::GetInstance().GetClassRef(
@@ -347,7 +347,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
 
             jobject value =
                 env->NewObject(accessControlEntryChangedStructClass, accessControlEntryChangedStructCtor, value_adminNodeID,
-                               value_adminPasscodeID, value_changeType, value_latestValue, value_adminFabricIndex);
+                               value_adminPasscodeID, value_changeType, value_latestValue, value_fabricIndex);
 
             return value;
         }
@@ -434,12 +434,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                                                    value_latestValue_fabricIndex);
             }
 
-            jobject value_adminFabricIndex;
-            std::string value_adminFabricIndexClassName     = "java/lang/Integer";
-            std::string value_adminFabricIndexCtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(value_adminFabricIndexClassName.c_str(),
-                                                                          value_adminFabricIndexCtorSignature.c_str(),
-                                                                          cppValue.adminFabricIndex, value_adminFabricIndex);
+            jobject value_fabricIndex;
+            std::string value_fabricIndexClassName     = "java/lang/Integer";
+            std::string value_fabricIndexCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(value_fabricIndexClassName.c_str(),
+                                                                          value_fabricIndexCtorSignature.c_str(),
+                                                                          cppValue.fabricIndex, value_fabricIndex);
 
             jclass accessControlExtensionChangedStructClass;
             err = chip::JniReferences::GetInstance().GetClassRef(
@@ -463,7 +463,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
 
             jobject value =
                 env->NewObject(accessControlExtensionChangedStructClass, accessControlExtensionChangedStructCtor, value_adminNodeID,
-                               value_adminPasscodeID, value_changeType, value_latestValue, value_adminFabricIndex);
+                               value_adminPasscodeID, value_changeType, value_latestValue, value_fabricIndex);
 
             return value;
         }
@@ -3394,11 +3394,12 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
             {
                 return nullptr;
             }
-            jobject value_arg1;
-            std::string value_arg1ClassName     = "java/lang/Integer";
-            std::string value_arg1CtorSignature = "(I)V";
-            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
-                value_arg1ClassName.c_str(), value_arg1CtorSignature.c_str(), cppValue.arg1, value_arg1);
+            jobject value_fabricIndex;
+            std::string value_fabricIndexClassName     = "java/lang/Integer";
+            std::string value_fabricIndexCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(value_fabricIndexClassName.c_str(),
+                                                                          value_fabricIndexCtorSignature.c_str(),
+                                                                          cppValue.fabricIndex, value_fabricIndex);
 
             jclass testFabricScopedEventStructClass;
             err = chip::JniReferences::GetInstance().GetClassRef(
@@ -3417,7 +3418,7 @@ jobject DecodeEventValue(const app::ConcreteEventPath & aPath, TLV::TLVReader & 
                 return nullptr;
             }
 
-            jobject value = env->NewObject(testFabricScopedEventStructClass, testFabricScopedEventStructCtor, value_arg1);
+            jobject value = env->NewObject(testFabricScopedEventStructClass, testFabricScopedEventStructCtor, value_fabricIndex);
 
             return value;
         }

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipEventStructs.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipEventStructs.java
@@ -29,19 +29,19 @@ public class ChipEventStructs {
     public @Nullable Integer adminPasscodeID;
     public Integer changeType;
     public @Nullable ChipStructs.AccessControlClusterAccessControlEntry latestValue;
-    public Integer adminFabricIndex;
+    public Integer fabricIndex;
 
     public AccessControlClusterAccessControlEntryChangedEvent(
         @Nullable Long adminNodeID,
         @Nullable Integer adminPasscodeID,
         Integer changeType,
         @Nullable ChipStructs.AccessControlClusterAccessControlEntry latestValue,
-        Integer adminFabricIndex) {
+        Integer fabricIndex) {
       this.adminNodeID = adminNodeID;
       this.adminPasscodeID = adminPasscodeID;
       this.changeType = changeType;
       this.latestValue = latestValue;
-      this.adminFabricIndex = adminFabricIndex;
+      this.fabricIndex = fabricIndex;
     }
 
     @Override
@@ -60,8 +60,8 @@ public class ChipEventStructs {
       output.append("\tlatestValue: ");
       output.append(latestValue);
       output.append("\n");
-      output.append("\tadminFabricIndex: ");
-      output.append(adminFabricIndex);
+      output.append("\tfabricIndex: ");
+      output.append(fabricIndex);
       output.append("\n");
       output.append("}\n");
       return output.toString();
@@ -73,19 +73,19 @@ public class ChipEventStructs {
     public @Nullable Integer adminPasscodeID;
     public Integer changeType;
     public @Nullable ChipStructs.AccessControlClusterExtensionEntry latestValue;
-    public Integer adminFabricIndex;
+    public Integer fabricIndex;
 
     public AccessControlClusterAccessControlExtensionChangedEvent(
         @Nullable Long adminNodeID,
         @Nullable Integer adminPasscodeID,
         Integer changeType,
         @Nullable ChipStructs.AccessControlClusterExtensionEntry latestValue,
-        Integer adminFabricIndex) {
+        Integer fabricIndex) {
       this.adminNodeID = adminNodeID;
       this.adminPasscodeID = adminPasscodeID;
       this.changeType = changeType;
       this.latestValue = latestValue;
-      this.adminFabricIndex = adminFabricIndex;
+      this.fabricIndex = fabricIndex;
     }
 
     @Override
@@ -104,8 +104,8 @@ public class ChipEventStructs {
       output.append("\tlatestValue: ");
       output.append(latestValue);
       output.append("\n");
-      output.append("\tadminFabricIndex: ");
-      output.append(adminFabricIndex);
+      output.append("\tfabricIndex: ");
+      output.append(fabricIndex);
       output.append("\n");
       output.append("}\n");
       return output.toString();
@@ -1248,18 +1248,18 @@ public class ChipEventStructs {
   }
 
   public static class TestClusterClusterTestFabricScopedEventEvent {
-    public Integer arg1;
+    public Integer fabricIndex;
 
-    public TestClusterClusterTestFabricScopedEventEvent(Integer arg1) {
-      this.arg1 = arg1;
+    public TestClusterClusterTestFabricScopedEventEvent(Integer fabricIndex) {
+      this.fabricIndex = fabricIndex;
     }
 
     @Override
     public String toString() {
       StringBuilder output = new StringBuilder();
       output.append("TestClusterClusterTestFabricScopedEventEvent {\n");
-      output.append("\targ1: ");
-      output.append(arg1);
+      output.append("\tfabricIndex: ");
+      output.append(fabricIndex);
       output.append("\n");
       output.append("}\n");
       return output.toString();

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -3106,14 +3106,14 @@ class AccessControl(Cluster):
                             ClusterObjectFieldDescriptor(Label="adminPasscodeID", Tag=2, Type=typing.Union[Nullable, uint]),
                             ClusterObjectFieldDescriptor(Label="changeType", Tag=3, Type=AccessControl.Enums.ChangeTypeEnum),
                             ClusterObjectFieldDescriptor(Label="latestValue", Tag=4, Type=typing.Union[Nullable, AccessControl.Structs.AccessControlEntry]),
-                            ClusterObjectFieldDescriptor(Label="adminFabricIndex", Tag=254, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=254, Type=uint),
                     ])
 
             adminNodeID: 'typing.Union[Nullable, uint]' = NullValue
             adminPasscodeID: 'typing.Union[Nullable, uint]' = NullValue
             changeType: 'AccessControl.Enums.ChangeTypeEnum' = 0
             latestValue: 'typing.Union[Nullable, AccessControl.Structs.AccessControlEntry]' = NullValue
-            adminFabricIndex: 'uint' = 0
+            fabricIndex: 'uint' = 0
 
         @dataclass
         class AccessControlExtensionChanged(ClusterEvent):
@@ -3133,14 +3133,14 @@ class AccessControl(Cluster):
                             ClusterObjectFieldDescriptor(Label="adminPasscodeID", Tag=2, Type=typing.Union[Nullable, uint]),
                             ClusterObjectFieldDescriptor(Label="changeType", Tag=3, Type=AccessControl.Enums.ChangeTypeEnum),
                             ClusterObjectFieldDescriptor(Label="latestValue", Tag=4, Type=typing.Union[Nullable, AccessControl.Structs.ExtensionEntry]),
-                            ClusterObjectFieldDescriptor(Label="adminFabricIndex", Tag=254, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=254, Type=uint),
                     ])
 
             adminNodeID: 'typing.Union[Nullable, uint]' = NullValue
             adminPasscodeID: 'typing.Union[Nullable, uint]' = NullValue
             changeType: 'AccessControl.Enums.ChangeTypeEnum' = 0
             latestValue: 'typing.Union[Nullable, AccessControl.Structs.ExtensionEntry]' = NullValue
-            adminFabricIndex: 'uint' = 0
+            fabricIndex: 'uint' = 0
 
 
 @dataclass
@@ -28681,9 +28681,9 @@ class TestCluster(Cluster):
             def descriptor(cls) -> ClusterObjectDescriptor:
                 return ClusterObjectDescriptor(
                     Fields = [
-                            ClusterObjectFieldDescriptor(Label="arg1", Tag=254, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="fabricIndex", Tag=254, Type=uint),
                     ])
 
-            arg1: 'uint' = 0
+            fabricIndex: 'uint' = 0
 
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
@@ -235,8 +235,8 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
             } while (0);
             do {
                 NSNumber * _Nonnull memberValue;
-                memberValue = [NSNumber numberWithUnsignedChar:cppValue.adminFabricIndex];
-                value.adminFabricIndex = memberValue;
+                memberValue = [NSNumber numberWithUnsignedChar:cppValue.fabricIndex];
+                value.fabricIndex = memberValue;
             } while (0);
 
             return value;
@@ -289,8 +289,8 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
             } while (0);
             do {
                 NSNumber * _Nonnull memberValue;
-                memberValue = [NSNumber numberWithUnsignedChar:cppValue.adminFabricIndex];
-                value.adminFabricIndex = memberValue;
+                memberValue = [NSNumber numberWithUnsignedChar:cppValue.fabricIndex];
+                value.fabricIndex = memberValue;
             } while (0);
 
             return value;
@@ -2173,8 +2173,8 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
 
             do {
                 NSNumber * _Nonnull memberValue;
-                memberValue = [NSNumber numberWithUnsignedChar:cppValue.arg1];
-                value.arg1 = memberValue;
+                memberValue = [NSNumber numberWithUnsignedChar:cppValue.fabricIndex];
+                value.fabricIndex = memberValue;
             } while (0);
 
             return value;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) NSNumber * _Nullable adminPasscodeID;
 @property (strong, nonatomic) NSNumber * _Nonnull changeType;
 @property (strong, nonatomic) MTRAccessControlClusterAccessControlEntry * _Nullable latestValue;
-@property (strong, nonatomic) NSNumber * _Nonnull adminFabricIndex;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @end
 
 @interface MTRAccessControlClusterAccessControlExtensionChangedEvent : NSObject
@@ -90,7 +90,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (strong, nonatomic) NSNumber * _Nullable adminPasscodeID;
 @property (strong, nonatomic) NSNumber * _Nonnull changeType;
 @property (strong, nonatomic) MTRAccessControlClusterExtensionEntry * _Nullable latestValue;
-@property (strong, nonatomic) NSNumber * _Nonnull adminFabricIndex;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @end
 
 @interface MTRBridgedActionsClusterActionStruct : NSObject
@@ -790,7 +790,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 @interface MTRTestClusterClusterTestFabricScopedEventEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -196,16 +196,16 @@ NS_ASSUME_NONNULL_BEGIN
 
         _latestValue = nil;
 
-        _adminFabricIndex = @(0);
+        _fabricIndex = @(0);
     }
     return self;
 }
 
 - (NSString *)description
 {
-    NSString * descriptionString = [NSString
-        stringWithFormat:@"<%@: adminNodeID:%@; adminPasscodeID:%@; changeType:%@; latestValue:%@; adminFabricIndex:%@; >",
-        NSStringFromClass([self class]), _adminNodeID, _adminPasscodeID, _changeType, _latestValue, _adminFabricIndex];
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: adminNodeID:%@; adminPasscodeID:%@; changeType:%@; latestValue:%@; fabricIndex:%@; >",
+                  NSStringFromClass([self class]), _adminNodeID, _adminPasscodeID, _changeType, _latestValue, _fabricIndex];
     return descriptionString;
 }
 
@@ -224,16 +224,16 @@ NS_ASSUME_NONNULL_BEGIN
 
         _latestValue = nil;
 
-        _adminFabricIndex = @(0);
+        _fabricIndex = @(0);
     }
     return self;
 }
 
 - (NSString *)description
 {
-    NSString * descriptionString = [NSString
-        stringWithFormat:@"<%@: adminNodeID:%@; adminPasscodeID:%@; changeType:%@; latestValue:%@; adminFabricIndex:%@; >",
-        NSStringFromClass([self class]), _adminNodeID, _adminPasscodeID, _changeType, _latestValue, _adminFabricIndex];
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: adminNodeID:%@; adminPasscodeID:%@; changeType:%@; latestValue:%@; fabricIndex:%@; >",
+                  NSStringFromClass([self class]), _adminNodeID, _adminPasscodeID, _changeType, _latestValue, _fabricIndex];
     return descriptionString;
 }
 
@@ -2599,14 +2599,15 @@ NS_ASSUME_NONNULL_BEGIN
 {
     if (self = [super init]) {
 
-        _arg1 = @(0);
+        _fabricIndex = @(0);
     }
     return self;
 }
 
 - (NSString *)description
 {
-    NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
+    NSString * descriptionString =
+        [NSString stringWithFormat:@"<%@: fabricIndex:%@; >", NSStringFromClass([self class]), _fabricIndex];
     return descriptionString;
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/af-structs.h
+++ b/zzz_generated/app-common/app-common/zap-generated/af-structs.h
@@ -53,7 +53,7 @@ typedef struct _TestFabricScoped
     chip::CharSpan fabricSensitiveCharString;
     SimpleStruct fabricSensitiveStruct;
     /* TYPE WARNING: array array defaults to */ uint8_t * fabricSensitiveInt8uList;
-    chip::FabricIndex fabricIndex;
+    chip::FabricIndex FabricIndex;
 } TestFabricScoped;
 
 // Struct for Dimension

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -2989,7 +2989,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kChangeType)), changeType));
     ReturnErrorOnFailure(
         DataModel::EncodeForRead(writer, TLV::ContextTag(to_underlying(Fields::kLatestValue)), GetFabricIndex(), latestValue));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminFabricIndex)), adminFabricIndex));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -3020,8 +3020,8 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         case to_underlying(Fields::kLatestValue):
             ReturnErrorOnFailure(DataModel::Decode(reader, latestValue));
             break;
-        case to_underlying(Fields::kAdminFabricIndex):
-            ReturnErrorOnFailure(DataModel::Decode(reader, adminFabricIndex));
+        case to_underlying(Fields::kFabricIndex):
+            ReturnErrorOnFailure(DataModel::Decode(reader, fabricIndex));
             break;
         default:
             break;
@@ -3043,7 +3043,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
     ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kChangeType)), changeType));
     ReturnErrorOnFailure(
         DataModel::EncodeForRead(writer, TLV::ContextTag(to_underlying(Fields::kLatestValue)), GetFabricIndex(), latestValue));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kAdminFabricIndex)), adminFabricIndex));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -3074,8 +3074,8 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         case to_underlying(Fields::kLatestValue):
             ReturnErrorOnFailure(DataModel::Decode(reader, latestValue));
             break;
-        case to_underlying(Fields::kAdminFabricIndex):
-            ReturnErrorOnFailure(DataModel::Decode(reader, adminFabricIndex));
+        case to_underlying(Fields::kFabricIndex):
+            ReturnErrorOnFailure(DataModel::Decode(reader, fabricIndex));
             break;
         default:
             break;
@@ -20598,7 +20598,7 @@ CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
 {
     TLV::TLVType outer;
     ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
-    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kArg1)), arg1));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kFabricIndex)), fabricIndex));
     ReturnErrorOnFailure(writer.EndContainer(outer));
     return CHIP_NO_ERROR;
 }
@@ -20617,8 +20617,8 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
         }
         switch (TLV::TagNumFromTag(reader.GetTag()))
         {
-        case to_underlying(Fields::kArg1):
-            ReturnErrorOnFailure(DataModel::Decode(reader, arg1));
+        case to_underlying(Fields::kFabricIndex):
+            ReturnErrorOnFailure(DataModel::Decode(reader, fabricIndex));
             break;
         default:
             break;

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -3514,11 +3514,11 @@ static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
 
 enum class Fields
 {
-    kAdminNodeID      = 1,
-    kAdminPasscodeID  = 2,
-    kChangeType       = 3,
-    kLatestValue      = 4,
-    kAdminFabricIndex = 254,
+    kAdminNodeID     = 1,
+    kAdminPasscodeID = 2,
+    kChangeType      = 3,
+    kLatestValue     = 4,
+    kFabricIndex     = 254,
 };
 
 struct Type
@@ -3533,9 +3533,9 @@ public:
     DataModel::Nullable<uint16_t> adminPasscodeID;
     ChangeTypeEnum changeType = static_cast<ChangeTypeEnum>(0);
     DataModel::Nullable<Structs::AccessControlEntry::Type> latestValue;
-    chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
+    chip::FabricIndex fabricIndex = static_cast<chip::FabricIndex>(0);
 
-    auto GetFabricIndex() const { return adminFabricIndex; }
+    auto GetFabricIndex() const { return fabricIndex; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3551,7 +3551,7 @@ public:
     DataModel::Nullable<uint16_t> adminPasscodeID;
     ChangeTypeEnum changeType = static_cast<ChangeTypeEnum>(0);
     DataModel::Nullable<Structs::AccessControlEntry::DecodableType> latestValue;
-    chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
+    chip::FabricIndex fabricIndex = static_cast<chip::FabricIndex>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -3561,11 +3561,11 @@ static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
 
 enum class Fields
 {
-    kAdminNodeID      = 1,
-    kAdminPasscodeID  = 2,
-    kChangeType       = 3,
-    kLatestValue      = 4,
-    kAdminFabricIndex = 254,
+    kAdminNodeID     = 1,
+    kAdminPasscodeID = 2,
+    kChangeType      = 3,
+    kLatestValue     = 4,
+    kFabricIndex     = 254,
 };
 
 struct Type
@@ -3580,9 +3580,9 @@ public:
     DataModel::Nullable<uint16_t> adminPasscodeID;
     ChangeTypeEnum changeType = static_cast<ChangeTypeEnum>(0);
     DataModel::Nullable<Structs::ExtensionEntry::Type> latestValue;
-    chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
+    chip::FabricIndex fabricIndex = static_cast<chip::FabricIndex>(0);
 
-    auto GetFabricIndex() const { return adminFabricIndex; }
+    auto GetFabricIndex() const { return fabricIndex; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -3598,7 +3598,7 @@ public:
     DataModel::Nullable<uint16_t> adminPasscodeID;
     ChangeTypeEnum changeType = static_cast<ChangeTypeEnum>(0);
     DataModel::Nullable<Structs::ExtensionEntry::DecodableType> latestValue;
-    chip::FabricIndex adminFabricIndex = static_cast<chip::FabricIndex>(0);
+    chip::FabricIndex fabricIndex = static_cast<chip::FabricIndex>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
@@ -27747,7 +27747,7 @@ static constexpr PriorityLevel kPriorityLevel = PriorityLevel::Info;
 
 enum class Fields
 {
-    kArg1 = 254,
+    kFabricIndex = 254,
 };
 
 struct Type
@@ -27758,9 +27758,9 @@ public:
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
     static constexpr bool kIsFabricScoped = true;
 
-    chip::FabricIndex arg1 = static_cast<chip::FabricIndex>(0);
+    chip::FabricIndex fabricIndex = static_cast<chip::FabricIndex>(0);
 
-    auto GetFabricIndex() const { return arg1; }
+    auto GetFabricIndex() const { return fabricIndex; }
 
     CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
 };
@@ -27772,7 +27772,7 @@ public:
     static constexpr EventId GetEventId() { return Events::TestFabricScopedEvent::Id; }
     static constexpr ClusterId GetClusterId() { return Clusters::TestCluster::Id; }
 
-    chip::FabricIndex arg1 = static_cast<chip::FabricIndex>(0);
+    chip::FabricIndex fabricIndex = static_cast<chip::FabricIndex>(0);
 
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };

--- a/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
+++ b/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp
@@ -2382,10 +2382,10 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
         }
     }
     {
-        CHIP_ERROR err = DataModelLogger::LogValue("AdminFabricIndex", indent + 1, value.adminFabricIndex);
+        CHIP_ERROR err = DataModelLogger::LogValue("FabricIndex", indent + 1, value.fabricIndex);
         if (err != CHIP_NO_ERROR)
         {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'AdminFabricIndex'");
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'FabricIndex'");
             return err;
         }
     }
@@ -2430,10 +2430,10 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
         }
     }
     {
-        CHIP_ERROR err = DataModelLogger::LogValue("AdminFabricIndex", indent + 1, value.adminFabricIndex);
+        CHIP_ERROR err = DataModelLogger::LogValue("FabricIndex", indent + 1, value.fabricIndex);
         if (err != CHIP_NO_ERROR)
         {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'AdminFabricIndex'");
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'FabricIndex'");
             return err;
         }
     }
@@ -3454,10 +3454,10 @@ CHIP_ERROR DataModelLogger::LogValue(const char * label, size_t indent,
 {
     DataModelLogger::LogString(label, indent, "{");
     {
-        CHIP_ERROR err = DataModelLogger::LogValue("Arg1", indent + 1, value.arg1);
+        CHIP_ERROR err = DataModelLogger::LogValue("FabricIndex", indent + 1, value.fabricIndex);
         if (err != CHIP_NO_ERROR)
         {
-            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'Arg1'");
+            DataModelLogger::LogString(indent + 1, "Event truncated due to invalid value for 'FabricIndex'");
             return err;
         }
     }


### PR DESCRIPTION
This update stops guessing at fabric-scoping based on the types of struct/event
fields and instead explicitly says which structs are fabric-scoped and which
events are fabric-sensitive in the XML.

The required FabricIndex field is then synthesized by ZAP, so we don't want it
in the XML anymore.

This fixes the naming of the FabricIndex field for some of the structs involved
and lays the groundwork for a per-spec implementation of LeaveEvent (which is
not fabric-sensitive but has a fabric-idx-typed field).

#### Problem
See above.  Need this to fix https://github.com/project-chip/connectedhomeip/issues/21192

#### Change overview
See above.

#### Testing
Looked at the generated code.  There should be no behavior changes apart from better name alignment with the spec.