### PR TITLE
Move UseECM check for StartAdvertisement

### DIFF
--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -28,6 +28,13 @@ public:
     virtual ~AppDelegate() {}
     virtual void OnCommissioningSessionStarted() {}
     virtual void OnCommissioningSessionStopped() {}
+
+    /*
+    * This is called anytime a basic or enhanced commissioning window is opened.
+    *
+    * The type of the window can be retrieved by calling
+    * CommissioningWindowManager::CommissioningWindowStatus()
+    */
     virtual void OnCommissioningWindowOpened() {}
     virtual void OnCommissioningWindowClosed() {}
 };

--- a/src/app/server/AppDelegate.h
+++ b/src/app/server/AppDelegate.h
@@ -30,11 +30,11 @@ public:
     virtual void OnCommissioningSessionStopped() {}
 
     /*
-    * This is called anytime a basic or enhanced commissioning window is opened.
-    *
-    * The type of the window can be retrieved by calling
-    * CommissioningWindowManager::CommissioningWindowStatus()
-    */
+     * This is called anytime a basic or enhanced commissioning window is opened.
+     *
+     * The type of the window can be retrieved by calling
+     * CommissioningWindowManager::CommissioningWindowStatus()
+     */
     virtual void OnCommissioningWindowOpened() {}
     virtual void OnCommissioningWindowClosed() {}
 };

--- a/src/app/server/CommissioningWindowManager.cpp
+++ b/src/app/server/CommissioningWindowManager.cpp
@@ -374,11 +374,6 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
     }
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-    if (mAppDelegate != nullptr)
-    {
-        mAppDelegate->OnCommissioningWindowOpened();
-    }
-
     if (mUseECM)
     {
         mWindowStatus = AdministratorCommissioning::CommissioningWindowStatus::kEnhancedWindowOpen;
@@ -386,6 +381,11 @@ CHIP_ERROR CommissioningWindowManager::StartAdvertisement()
     else
     {
         mWindowStatus = AdministratorCommissioning::CommissioningWindowStatus::kBasicWindowOpen;
+    }
+
+    if (mAppDelegate != nullptr)
+    {
+        mAppDelegate->OnCommissioningWindowOpened();
     }
 
     // reset all advertising, switching to our new commissioning mode.


### PR DESCRIPTION
Moved UseECM check above AppDelegate to ensure CommissioningWindowStatus is set before Commissioning Window is activated.

#### Problem
* OnCommissioningWindowOpened runs before a window status is set. This may cause confusion as to which chip command triggered the commissioning window.

#### Change overview
* Moved the UseECM check above OnCommissioningWindowOpened check.

#### Testing
* No tests were conducted. Only a minor change to functions that are not dependent of each other.
