### PR TITLE
[nrfconnect] Disable SHA512 to save flash

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -289,6 +289,10 @@ config MBEDTLS_SHA512_C
     bool
     default n
 
+config PSA_WANT_ALG_SHA_512
+    bool
+    default n
+
 config MBEDTLS_CIPHER_MODE_XTS
     bool
     default n


### PR DESCRIPTION
#### Problem
I noticed SHA-512 is by default compiled when building nRF Connect firmware although it is not required by Matter nor Thread.

#### Change overview
Disable SHA-512 to save some flash.

#### Testing
CI should catch missing function definitions, but also did smoke tests to verify the commissioning still works after this change.
