### PR TITLE
Move the configuration for fabric handling into Matter's zcl.json

### DIFF
--- a/src/app/zap-templates/zcl/zcl-with-test-extensions.json
+++ b/src/app/zap-templates/zcl/zcl-with-test-extensions.json
@@ -259,5 +259,11 @@
         ]
     },
     "defaultReportingPolicy": "mandatory",
-    "ZCLDataTypes": ["ARRAY", "BITMAP", "ENUM", "NUMBER", "STRING", "STRUCT"]
+    "ZCLDataTypes": ["ARRAY", "BITMAP", "ENUM", "NUMBER", "STRING", "STRUCT"],
+    "fabricHandling": {
+        "automaticallyCreateFields": true,
+        "indexFieldId": 254,
+        "indexFieldName": "FabricIndex",
+        "indexType": "fabric_idx"
+    }
 }

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -253,5 +253,11 @@
         ]
     },
     "defaultReportingPolicy": "mandatory",
-    "ZCLDataTypes": ["ARRAY", "BITMAP", "ENUM", "NUMBER", "STRING", "STRUCT"]
+    "ZCLDataTypes": ["ARRAY", "BITMAP", "ENUM", "NUMBER", "STRING", "STRUCT"],
+    "fabricHandling": {
+        "automaticallyCreateFields": true,
+        "indexFieldId": 254,
+        "indexFieldName": "FabricIndex",
+        "indexType": "fabric_idx"
+      }
 }

--- a/src/app/zap-templates/zcl/zcl.json
+++ b/src/app/zap-templates/zcl/zcl.json
@@ -259,5 +259,5 @@
         "indexFieldId": 254,
         "indexFieldName": "FabricIndex",
         "indexType": "fabric_idx"
-      }
+    }
 }


### PR DESCRIPTION
#### Problem

This logic was earlier hard-coded inside zap, so all zap users picked up the Matter-only logic.

#### Change overview
This commit moves the control and configuration of the logic to the zcl.json. Note that this commit can be merged regardless of zap version. If zap doesn't get updated yet.
