### PR TITLE
[Darwin] Add MTROTAHeaderParser and use it in darwin-framework-tool

### DIFF
--- a/src/darwin/Framework/CHIP/MTRError.h
+++ b/src/darwin/Framework/CHIP/MTRError.h
@@ -50,6 +50,7 @@ typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
     MTRErrorCodeWrongAddressType     = 7,
     MTRErrorCodeIntegrityCheckFailed = 8,
     MTRErrorCodeTimeout              = 9,
+    MTRErrorCodeBufferTooSmall       = 10,
 };
 // clang-format on
 

--- a/src/darwin/Framework/CHIP/MTRError.mm
+++ b/src/darwin/Framework/CHIP/MTRError.mm
@@ -77,6 +77,9 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
     } else if (errorCode == CHIP_ERROR_TIMEOUT) {
         code = MTRErrorCodeTimeout;
         [userInfo addEntriesFromDictionary:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Transaction timed out.", nil) }];
+    } else if (errorCode == CHIP_ERROR_BUFFER_TOO_SMALL) {
+        code = MTRErrorCodeBufferTooSmall;
+        [userInfo addEntriesFromDictionary:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"A buffer is too small.", nil) }];
     } else {
         code = MTRErrorCodeGeneralError;
         [userInfo addEntriesFromDictionary:@{
@@ -258,6 +261,9 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
         break;
     case MTRErrorCodeTimeout:
         code = CHIP_ERROR_TIMEOUT.AsInteger();
+        break;
+    case MTRErrorCodeBufferTooSmall:
+        code = CHIP_ERROR_BUFFER_TOO_SMALL.AsInteger();
         break;
     case MTRErrorCodeGeneralError: {
         if (error.userInfo != nil && error.userInfo[@"errorCode"] != nil) {

--- a/src/darwin/Framework/CHIP/MTROTAHeaderParser.h
+++ b/src/darwin/Framework/CHIP/MTROTAHeaderParser.h
@@ -1,0 +1,56 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+typedef NS_ENUM(NSUInteger, MTROTAImageDigestType) {
+    MTROTAImageDigestTypeSha256 = 1,
+    MTROTAImageDigestTypeSha256_128,
+    MTROTAImageDigestTypeSha256_120,
+    MTROTAImageDigestTypeSha256_96,
+    MTROTAImageDigestTypeSha256_64,
+    MTROTAImageDigestTypeSha256_32,
+    MTROTAImageDigestTypeSha384,
+    MTROTAImageDigestTypeSha512,
+    MTROTAImageDigestTypeSha3_224,
+    MTROTAImageDigestTypeSha3_256,
+    MTROTAImageDigestTypeSha3_384,
+    MTROTAImageDigestTypeSha3_512,
+};
+
+@interface MTROTAHeader : NSObject
+
+@property (nonatomic, strong) NSNumber * vendorID;
+@property (nonatomic, strong) NSNumber * productID;
+@property (nonatomic, strong) NSNumber * payloadSize;
+@property (nonatomic, strong) NSNumber * softwareVersion;
+@property (nonatomic, strong) NSString * softwareVersionString;
+@property (nonatomic, strong) NSString * releaseNotesURL;
+@property (nonatomic, strong) NSData * imageDigest;
+@property (nonatomic, assign) MTROTAImageDigestType imageDigestType;
+@property (nonatomic, strong) NSNumber * minApplicableVersion;
+@property (nonatomic, strong) NSNumber * maxApplicableVersion;
+
+@end
+
+@interface MTROTAHeaderParser : NSObject
++ (nullable MTROTAHeader *)headerFromData:(NSData *)data error:(NSError * __autoreleasing *)error;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTROTAHeaderParser.mm
+++ b/src/darwin/Framework/CHIP/MTROTAHeaderParser.mm
@@ -1,0 +1,72 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTROTAHeaderParser.h"
+
+#import "MTRError.h"
+#import "MTRError_Internal.h"
+#import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
+
+#include <lib/core/OTAImageHeader.h>
+
+@implementation MTROTAHeader
+@end
+
+@implementation MTROTAHeaderParser
++ (nullable MTROTAHeader *)headerFromData:(NSData *)data error:(NSError * __autoreleasing *)error
+{
+    chip::OTAImageHeaderParser parser;
+
+    parser.Init();
+
+    if (!parser.IsInitialized()) {
+        *error = [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil];
+        return nil;
+    }
+
+    chip::ByteSpan buffer = AsByteSpan(data);
+    chip::OTAImageHeader header;
+    CHIP_ERROR err = parser.AccumulateAndDecode(buffer, header);
+    if (err != CHIP_NO_ERROR) {
+        *error = [MTRError errorForCHIPErrorCode:err];
+        parser.Clear();
+        return nil;
+    }
+
+    auto headerObj = [MTROTAHeader new];
+    headerObj.vendorID = @(header.mVendorId);
+    headerObj.productID = @(header.mProductId);
+    headerObj.payloadSize = @(header.mPayloadSize);
+    headerObj.softwareVersion = @(header.mSoftwareVersion);
+    headerObj.softwareVersionString = AsString(header.mSoftwareVersionString);
+    headerObj.releaseNotesURL = AsString(header.mReleaseNotesURL);
+    headerObj.imageDigest = AsData(header.mImageDigest);
+    headerObj.imageDigestType = static_cast<MTROTAImageDigestType>(chip::to_underlying(header.mImageDigestType));
+
+    if (header.mMinApplicableVersion.HasValue()) {
+        headerObj.minApplicableVersion = @(header.mMinApplicableVersion.Value());
+    }
+
+    if (header.mMaxApplicableVersion.HasValue()) {
+        headerObj.maxApplicableVersion = @(header.mMaxApplicableVersion.Value());
+    }
+
+    parser.Clear();
+    return headerObj;
+}
+@end

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -34,6 +34,7 @@
 #import <Matter/MTRError.h>
 #import <Matter/MTRKeypair.h>
 #import <Matter/MTRManualSetupPayloadParser.h>
+#import <Matter/MTROTAHeaderParser.h>
 #import <Matter/MTROTAProviderDelegate.h>
 #import <Matter/MTRPersistentStorageDelegate.h>
 #import <Matter/MTRQRCodeSetupPayloadParser.h>

--- a/src/darwin/Framework/CHIP/NSStringSpanConversion.h
+++ b/src/darwin/Framework/CHIP/NSStringSpanConversion.h
@@ -1,0 +1,36 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#import "Foundation/Foundation.h"
+
+#include <lib/support/Span.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+/**
+ * Utilities for converting between NSString and chip::CharSpan.
+ */
+
+inline chip::CharSpan AsCharSpan(NSString * str) { return chip::CharSpan([str UTF8String], [str length]); }
+
+inline NSString * AsString(chip::CharSpan span)
+{
+    return [[NSString alloc] initWithBytes:span.data() length:span.size() encoding:NSUTF8StringEncoding];
+}
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -15,6 +15,8 @@
 		1ED276E026C57CF000547A89 /* MTRCallbackBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ED276DF26C57CF000547A89 /* MTRCallbackBridge.mm */; };
 		1ED276E226C5812A00547A89 /* MTRCluster.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1ED276E126C5812A00547A89 /* MTRCluster.mm */; };
 		1ED276E426C5832500547A89 /* MTRCluster.h in Headers */ = {isa = PBXBuildFile; fileRef = 1ED276E326C5832500547A89 /* MTRCluster.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EDCE545289049A100E41EC9 /* MTROTAHeaderParser.h in Headers */ = {isa = PBXBuildFile; fileRef = 1EDCE543289049A100E41EC9 /* MTROTAHeaderParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1EDCE546289049A100E41EC9 /* MTROTAHeaderParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = 1EDCE544289049A100E41EC9 /* MTROTAHeaderParser.mm */; };
 		27A53C1727FBC6920053F131 /* MTRAttestationTrustStoreBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 27A53C1527FBC6920053F131 /* MTRAttestationTrustStoreBridge.h */; };
 		27A53C1827FBC6920053F131 /* MTRAttestationTrustStoreBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 27A53C1627FBC6920053F131 /* MTRAttestationTrustStoreBridge.mm */; };
 		2C1B027A2641DB4E00780EF1 /* MTROperationalCredentialsDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2C1B02782641DB4E00780EF1 /* MTROperationalCredentialsDelegate.mm */; };
@@ -133,6 +135,8 @@
 		1ED276DF26C57CF000547A89 /* MTRCallbackBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MTRCallbackBridge.mm; path = "zap-generated/MTRCallbackBridge.mm"; sourceTree = "<group>"; };
 		1ED276E126C5812A00547A89 /* MTRCluster.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCluster.mm; sourceTree = "<group>"; };
 		1ED276E326C5832500547A89 /* MTRCluster.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCluster.h; sourceTree = "<group>"; };
+		1EDCE543289049A100E41EC9 /* MTROTAHeaderParser.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTROTAHeaderParser.h; sourceTree = "<group>"; };
+		1EDCE544289049A100E41EC9 /* MTROTAHeaderParser.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTROTAHeaderParser.mm; sourceTree = "<group>"; };
 		27A53C1527FBC6920053F131 /* MTRAttestationTrustStoreBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRAttestationTrustStoreBridge.h; sourceTree = "<group>"; };
 		27A53C1627FBC6920053F131 /* MTRAttestationTrustStoreBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRAttestationTrustStoreBridge.mm; sourceTree = "<group>"; };
 		2C1B02782641DB4E00780EF1 /* MTROperationalCredentialsDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTROperationalCredentialsDelegate.mm; sourceTree = "<group>"; };
@@ -313,6 +317,8 @@
 		B202528F2459E34F00F97062 /* CHIP */ = {
 			isa = PBXGroup;
 			children = (
+				1EDCE543289049A100E41EC9 /* MTROTAHeaderParser.h */,
+				1EDCE544289049A100E41EC9 /* MTROTAHeaderParser.mm */,
 				27A53C1527FBC6920053F131 /* MTRAttestationTrustStoreBridge.h */,
 				27A53C1627FBC6920053F131 /* MTRAttestationTrustStoreBridge.mm */,
 				88EBF8CB27FABDD500686BC1 /* MTRDeviceAttestationDelegate.h */,
@@ -484,6 +490,7 @@
 				991DC08B247704DC00C13860 /* MTRLogging.h in Headers */,
 				5A7947E527C0129F00434CF2 /* MTRDeviceController+XPC.h in Headers */,
 				B2E0D7B4245B0B5C003C5B48 /* MTRError_Internal.h in Headers */,
+				1EDCE545289049A100E41EC9 /* MTROTAHeaderParser.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -623,6 +630,7 @@
 				1EC3238D271999E2002A8BF0 /* cluster-objects.cpp in Sources */,
 				991DC0892475F47D00C13860 /* MTRDeviceController.mm in Sources */,
 				B2E0D7B7245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.mm in Sources */,
+				1EDCE546289049A100E41EC9 /* MTROTAHeaderParser.mm in Sources */,
 				1EC4CE5D25CC26E900D7304F /* MTRBaseClusters.mm in Sources */,
 				51E0310127EA20D20083DC9C /* MTRControllerAccessControl.mm in Sources */,
 				1ED276E226C5812A00547A89 /* MTRCluster.mm in Sources */,


### PR DESCRIPTION
#### Problem

`darwin-framework-tool` is currently using the SDK directly, aka the C++ version.

#fix #20804

#### Change overview
 * Expose a header parser for OTA image file.

#### Testing
I have tested that it moving the code from `darwin-framework-tool` to `src/darwin/Frameworl/CHIP/` does work.