### PR TITLE
[Darwin] Make MTRControllerFactory the OTA Provider Delegate

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -38,9 +38,6 @@ CHIP_ERROR CHIPCommandBridge::Run()
     ChipLogProgress(chipTool, "Running Command");
     ReturnErrorOnFailure(MaybeSetUpStack());
     SetIdentity(mCommissionerName.HasValue() ? mCommissionerName.Value() : kIdentityAlpha);
-    ChipLogDetail(chipTool, "Setting OTA Provider Delegate:");
-    mOTADelegate.nodeID = [CurrentCommissioner() controllerNodeId];
-    [CurrentCommissioner() setOTAProviderDelegate:mOTADelegate queue:mOTAProviderCallbackQueue];
     ReturnLogErrorOnFailure(RunCommand());
     ReturnLogErrorOnFailure(StartWaiting(GetWaitDuration()));
 
@@ -67,7 +64,6 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
     CHIPToolKeypair * nocSigner = [[CHIPToolKeypair alloc] init];
     storage = [[CHIPToolPersistentStorageDelegate alloc] init];
 
-    mOTAProviderCallbackQueue = dispatch_queue_create("com.darwin-framework-tool.command", DISPATCH_QUEUE_SERIAL);
     mOTADelegate = [[OTAProviderDelegate alloc] init];
 
     auto factory = [MTRControllerFactory sharedInstance];
@@ -79,6 +75,7 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
     auto params = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
     params.port = @(kListenPort);
     params.startServer = YES;
+    params.otaProviderDelegate = mOTADelegate;
 
     if ([factory startup:params] == NO) {
         ChipLogError(chipTool, "Controller factory startup failed");

--- a/src/darwin/Framework/CHIP/MTRControllerFactory.h
+++ b/src/darwin/Framework/CHIP/MTRControllerFactory.h
@@ -25,6 +25,7 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MTRPersistentStorageDelegate;
+@protocol MTROTAProviderDelegate;
 @protocol MTRKeypair;
 
 @class MTRDeviceController;
@@ -37,6 +38,13 @@ NS_ASSUME_NONNULL_BEGIN
  * controllers ends up interacting with.
  */
 @property (strong, nonatomic, readonly) id<MTRPersistentStorageDelegate> storageDelegate;
+
+/*
+ * OTA Provider delegate to be called when an OTA Requestor is requesting a software update.
+ * Defaults to nil.
+ */
+@property (strong, nonatomic, nullable) id<MTROTAProviderDelegate> otaProviderDelegate;
+
 /*
  * The Product Attestation Authority certificates that are trusted to sign
  * device attestation information.  Defaults to nil.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -27,7 +27,6 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 
 @class MTRCommissioningParameters;
 @protocol MTRDevicePairingDelegate;
-@protocol MTROTAProviderDelegate;
 
 @interface MTRDeviceController : NSObject
 
@@ -119,15 +118,6 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
  * @param[in] queue The queue on which the callbacks will be delivered
  */
 - (void)setPairingDelegate:(id<MTRDevicePairingDelegate>)delegate queue:(dispatch_queue_t)queue;
-
-/**
- * Set the Delegate for the OTA Provider as well as the Queue on which the Delegate callbacks will be triggered
- *
- * @param[in] delegate The delegate the OTA Provider should use
- *
- * @param[in] queue The queue on which the callbacks will be delivered
- */
-- (void)setOTAProviderDelegate:(id<MTROTAProviderDelegate>)delegate queue:(dispatch_queue_t)queue;
 
 /**
  * Shutdown the controller. Calls to shutdown after the first one are NO-OPs.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -25,7 +25,6 @@
 #import "MTRError_Internal.h"
 #import "MTRKeypair.h"
 #import "MTRLogging.h"
-#import "MTROTAProviderDelegateBridge.h"
 #import "MTROperationalCredentialsDelegate.h"
 #import "MTRP256KeypairBridge.h"
 #import "MTRPersistentStorageDelegateBridge.h"
@@ -57,7 +56,6 @@ static NSString * const kErrorSigningKeypairInit = @"Init failure while creating
 static NSString * const kErrorOperationalCredentialsInit = @"Init failure while creating operational credentials delegate";
 static NSString * const kErrorOperationalKeypairInit = @"Init failure while creating operational keypair bridge";
 static NSString * const kErrorPairingInit = @"Init failure while creating a pairing delegate";
-static NSString * const kErrorOtaProviderInit = @"Init failure while creating an OTA provider delegate";
 static NSString * const kErrorPairDevice = @"Failure while pairing the device";
 static NSString * const kErrorUnpairDevice = @"Failure while unpairing the device";
 static NSString * const kErrorStopPairing = @"Failure while trying to stop the pairing process";
@@ -77,7 +75,6 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
 
 @property (readonly) chip::Controller::DeviceCommissioner * cppCommissioner;
 @property (readonly) MTRDevicePairingDelegateBridge * pairingDelegateBridge;
-@property (readonly) MTROTAProviderDelegateBridge * otaProviderDelegateBridge;
 @property (readonly) MTROperationalCredentialsDelegate * operationalCredentialsDelegate;
 @property (readonly) MTRP256KeypairBridge signingKeypairBridge;
 @property (readonly) MTRP256KeypairBridge operationalKeypairBridge;
@@ -95,11 +92,6 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
 
         _pairingDelegateBridge = new MTRDevicePairingDelegateBridge();
         if ([self checkForInitError:(_pairingDelegateBridge != nullptr) logMsg:kErrorPairingInit]) {
-            return nil;
-        }
-
-        _otaProviderDelegateBridge = new MTROTAProviderDelegateBridge();
-        if ([self checkForInitError:(_otaProviderDelegateBridge != nullptr) logMsg:kErrorOtaProviderInit]) {
             return nil;
         }
 
@@ -154,11 +146,6 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
     if (_operationalCredentialsDelegate) {
         delete _operationalCredentialsDelegate;
         _operationalCredentialsDelegate = nullptr;
-    }
-
-    if (_otaProviderDelegateBridge) {
-        delete _otaProviderDelegateBridge;
-        _otaProviderDelegateBridge = nullptr;
     }
 
     if (_pairingDelegateBridge) {
@@ -626,13 +613,6 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
 {
     dispatch_async(_chipWorkQueue, ^{
         self->_pairingDelegateBridge->setDelegate(delegate, queue);
-    });
-}
-
-- (void)setOTAProviderDelegate:(id<MTROTAProviderDelegate>)delegate queue:(dispatch_queue_t)queue;
-{
-    dispatch_async(_chipWorkQueue, ^{
-        self->_otaProviderDelegateBridge->setDelegate(delegate, queue);
     });
 }
 

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
@@ -24,10 +24,11 @@ NS_ASSUME_NONNULL_BEGIN
 class MTROTAProviderDelegateBridge : public chip::app::Clusters::OTAProviderDelegate
 {
 public:
-    MTROTAProviderDelegateBridge();
+    MTROTAProviderDelegateBridge(id<MTROTAProviderDelegate> delegate);
     ~MTROTAProviderDelegateBridge();
 
-    void setDelegate(id<MTROTAProviderDelegate> delegate, dispatch_queue_t queue);
+    void Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeManager);
+    void Shutdown();
 
     void HandleQueryImage(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
@@ -59,7 +60,7 @@ private:
         MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams * commandParams);
 
     _Nullable id<MTROTAProviderDelegate> mDelegate;
-    _Nullable dispatch_queue_t mQueue;
+    dispatch_queue_t mWorkQueue;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -23,73 +23,85 @@
 #include <platform/PlatformManager.h>
 #include <protocols/interaction_model/Constants.h>
 
-// BDX
 #include <MTRError_Internal.h>
+#include <messaging/ExchangeMgr.h>
+#include <protocols/bdx/BdxUri.h>
 #include <protocols/bdx/TransferFacilitator.h>
-
-#include <app/InteractionModelEngine.h> // For InteractionModelEngine::GetInstance()->GetExchangeManager();
-#include <platform/CHIPDeviceLayer.h> // For &DeviceLayer::SystemLayer()
-// BDX
 
 using namespace chip;
 using namespace chip::app;
 using namespace chip::app::Clusters::OtaSoftwareUpdateProvider;
+using namespace chip::bdx;
 
 // TODO Expose a method onto the delegate to make that configurable.
 constexpr uint32_t kMaxBdxBlockSize = 1024;
+constexpr uint32_t kMaxBDXURILen = 256;
 constexpr System::Clock::Timeout kBdxTimeout = System::Clock::Seconds16(5 * 60); // OTA Spec mandates >= 5 minutes
 constexpr System::Clock::Timeout kBdxPollIntervalMs = System::Clock::Milliseconds32(50);
 constexpr bdx::TransferRole kBdxRole = bdx::TransferRole::kSender;
 
 class BdxOTASender : public bdx::Responder {
 public:
-    BdxOTASender() {}
+    BdxOTASender() {};
 
-    CHIP_ERROR Start(FabricIndex fabricIndex, NodeId nodeId)
+    CHIP_ERROR PrepareForTransfer(FabricIndex fabricIndex, NodeId nodeId)
     {
-        if (mInitialized) {
-            VerifyOrReturnError(mFabricIndex.HasValue() && mNodeId.HasValue(), CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(mDelegate != nil, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(mExchangeMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
-            // Prevent a new node connection since another is active
-            VerifyOrReturnError(mFabricIndex.Value() == fabricIndex && mNodeId.Value() == nodeId, CHIP_ERROR_BUSY);
-
-            // Reset stale connection from the Same Node if exists
-            Reset();
-        }
-        mInitialized = true;
-
-        mFabricIndex.SetValue(fabricIndex);
-        mNodeId.SetValue(nodeId);
+        ReturnErrorOnFailure(ConfigureState(fabricIndex, nodeId));
 
         BitFlags<bdx::TransferControlFlags> flags(bdx::TransferControlFlags::kReceiverDrive);
-        // TODO Have a better mechanism to remove the need from getting an instance of the system layer here.
-        return PrepareForTransfer(&DeviceLayer::SystemLayer(), kBdxRole, flags, kMaxBdxBlockSize, kBdxTimeout, kBdxPollIntervalMs);
+        return Responder::PrepareForTransfer(mSystemLayer, kBdxRole, flags, kMaxBdxBlockSize, kBdxTimeout, kBdxPollIntervalMs);
     }
 
-    void SetDelegate(id<MTROTAProviderDelegate> delegate, dispatch_queue_t queue)
+    CHIP_ERROR Init(System::Layer * systemLayer, Messaging::ExchangeManager * exchangeMgr)
     {
-        // TODO Have a better mechanism to retrieve the exchange manager instance
-        // In order to register ourself as a protocol handler for BDX, it needs to be a reference
-        // to the exchange manager instance. That's not ideal but the reference is retrieved
-        // from the interaction model engine instance.
-        auto exchangeMgr = InteractionModelEngine::GetInstance()->GetExchangeManager();
-        if (delegate && queue) {
+        VerifyOrReturnError(mSystemLayer == nullptr, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(mExchangeMgr == nullptr, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(systemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(exchangeMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        exchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::BDX::Id, this);
+
+        mSystemLayer = systemLayer;
+        mExchangeMgr = exchangeMgr;
+        mWorkQueue = DeviceLayer::PlatformMgrImpl().GetWorkQueue();
+
+        return CHIP_NO_ERROR;
+    }
+
+    CHIP_ERROR Shutdown()
+    {
+        VerifyOrReturnError(mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
+        VerifyOrReturnError(mExchangeMgr != nullptr, CHIP_ERROR_INCORRECT_STATE);
+
+        mExchangeMgr->UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::BDX::Id);
+
+        mExchangeMgr = nullptr;
+        mSystemLayer = nullptr;
+        mWorkQueue = nil;
+
+        ResetState();
+
+        return CHIP_NO_ERROR;
+    }
+
+    void SetDelegate(id<MTROTAProviderDelegate> delegate)
+    {
+        if (delegate) {
             mDelegate = delegate;
-            mDelegateQueue = queue;
-            mWorkQueue = DeviceLayer::PlatformMgrImpl().GetWorkQueue();
-            exchangeMgr->RegisterUnsolicitedMessageHandlerForProtocol(Protocols::BDX::Id, this);
         } else {
-            Reset();
-            exchangeMgr->UnregisterUnsolicitedMessageHandlerForProtocol(Protocols::BDX::Id);
+            ResetState();
         }
     }
 
 private:
-    CHIP_ERROR OnMessageToSend(bdx::TransferSession::OutputEvent & event)
+    CHIP_ERROR OnMessageToSend(TransferSession::OutputEvent & event)
     {
         VerifyOrReturnError(mExchangeCtx != nullptr, CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnError(mDelegate != nil, CHIP_ERROR_INCORRECT_STATE);
-        VerifyOrReturnError(mDelegateQueue != nil, CHIP_ERROR_INCORRECT_STATE);
 
         Messaging::SendFlags sendFlags;
 
@@ -103,7 +115,7 @@ private:
         return mExchangeCtx->SendMessage(msgTypeData.ProtocolId, msgTypeData.MessageType, std::move(event.MsgData), sendFlags);
     }
 
-    CHIP_ERROR OnTransferSessionBegin(bdx::TransferSession::OutputEvent & event)
+    CHIP_ERROR OnTransferSessionBegin(TransferSession::OutputEvent & event)
     {
         uint16_t fdl = 0;
         auto fd = mTransfer.GetFileDesignator(fdl);
@@ -122,7 +134,7 @@ private:
                 // bdx::TransferSession will automatically reject a transfer if there are no
                 // common supported control modes. It will also default to the smaller
                 // block size.
-                bdx::TransferSession::TransferAcceptData acceptData;
+                TransferSession::TransferAcceptData acceptData;
                 acceptData.ControlMode = bdx::TransferControlFlags::kReceiverDrive;
                 acceptData.MaxBlockSize = mTransfer.GetTransferBlockSize();
                 acceptData.StartOffset = mTransfer.GetStartOffset();
@@ -132,38 +144,39 @@ private:
             });
         };
 
-        dispatch_async(mDelegateQueue, ^{
-            [mDelegate handleBDXTransferSessionBegin:fileDesignator offset:offset completionHandler:completionHandler];
+        auto strongDelegate = mDelegate;
+        dispatch_async(mWorkQueue, ^{
+            [strongDelegate handleBDXTransferSessionBegin:fileDesignator offset:offset completionHandler:completionHandler];
         });
 
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR OnTransferSessionEnd(bdx::TransferSession::OutputEvent & event)
+    CHIP_ERROR OnTransferSessionEnd(TransferSession::OutputEvent & event)
     {
-        CHIP_ERROR error = CHIP_ERROR_INTERNAL;
-        if (event.EventType == bdx::TransferSession::OutputEventType::kAckEOFReceived) {
-            error = CHIP_NO_ERROR;
-        } else if (event.EventType == bdx::TransferSession::OutputEventType::kTransferTimeout) {
+        CHIP_ERROR error = CHIP_NO_ERROR;
+        if (event.EventType == TransferSession::OutputEventType::kTransferTimeout) {
             error = CHIP_ERROR_TIMEOUT;
+        } else if (event.EventType != TransferSession::OutputEventType::kAckEOFReceived) {
+            error = CHIP_ERROR_INTERNAL;
         }
 
-        auto delegate = mDelegate; // mDelegate will be set to nil by Reset, so get a strong ref to it.
-        dispatch_async(mDelegateQueue, ^{
-            [delegate handleBDXTransferSessionEnd:[MTRError errorForCHIPErrorCode:error]];
+        auto strongDelegate = mDelegate;
+        dispatch_async(mWorkQueue, ^{
+            [strongDelegate handleBDXTransferSessionEnd:[MTRError errorForCHIPErrorCode:error]];
         });
 
-        Reset();
+        ResetState();
         return CHIP_NO_ERROR;
     }
 
-    CHIP_ERROR OnBlockQuery(bdx::TransferSession::OutputEvent & event)
+    CHIP_ERROR OnBlockQuery(TransferSession::OutputEvent & event)
     {
         auto blockSize = @(mTransfer.GetTransferBlockSize());
         auto blockIndex = @(mTransfer.GetNextBlockNum());
 
         auto bytesToSkip = @(0);
-        if (event.EventType == bdx::TransferSession::OutputEventType::kQueryWithSkipReceived) {
+        if (event.EventType == TransferSession::OutputEventType::kQueryWithSkipReceived) {
             bytesToSkip = @(event.bytesToSkip.BytesToSkip);
         }
 
@@ -174,7 +187,7 @@ private:
                     return;
                 }
 
-                bdx::TransferSession::BlockData blockData;
+                TransferSession::BlockData blockData;
                 blockData.Data = static_cast<const uint8_t *>([data bytes]);
                 blockData.Length = static_cast<size_t>([data length]);
                 blockData.IsEof = isEOF;
@@ -189,44 +202,47 @@ private:
 
         // TODO Handle MaxLength
 
-        dispatch_async(mDelegateQueue, ^{
-            [mDelegate handleBDXQuery:blockSize blockIndex:blockIndex bytesToSkip:bytesToSkip completionHandler:completionHandler];
+        auto strongDelegate = mDelegate;
+        dispatch_async(mWorkQueue, ^{
+            [strongDelegate handleBDXQuery:blockSize
+                                blockIndex:blockIndex
+                               bytesToSkip:bytesToSkip
+                         completionHandler:completionHandler];
         });
 
         return CHIP_NO_ERROR;
     }
 
-    void HandleTransferSessionOutput(bdx::TransferSession::OutputEvent & event) override
+    void HandleTransferSessionOutput(TransferSession::OutputEvent & event) override
     {
         VerifyOrReturn(mDelegate != nil);
-        VerifyOrReturn(mDelegateQueue != nil);
 
         CHIP_ERROR err = CHIP_NO_ERROR;
         switch (event.EventType) {
-        case bdx::TransferSession::OutputEventType::kInitReceived:
+        case TransferSession::OutputEventType::kInitReceived:
             err = OnTransferSessionBegin(event);
             break;
-        case bdx::TransferSession::OutputEventType::kStatusReceived:
+        case TransferSession::OutputEventType::kStatusReceived:
             ChipLogError(BDX, "Got StatusReport %x", static_cast<uint16_t>(event.statusData.statusCode));
             [[fallthrough]];
-        case bdx::TransferSession::OutputEventType::kAckEOFReceived:
-        case bdx::TransferSession::OutputEventType::kInternalError:
-        case bdx::TransferSession::OutputEventType::kTransferTimeout:
+        case TransferSession::OutputEventType::kAckEOFReceived:
+        case TransferSession::OutputEventType::kInternalError:
+        case TransferSession::OutputEventType::kTransferTimeout:
             err = OnTransferSessionEnd(event);
             break;
-        case bdx::TransferSession::OutputEventType::kQueryWithSkipReceived:
-        case bdx::TransferSession::OutputEventType::kQueryReceived:
+        case TransferSession::OutputEventType::kQueryWithSkipReceived:
+        case TransferSession::OutputEventType::kQueryReceived:
             err = OnBlockQuery(event);
             break;
-        case bdx::TransferSession::OutputEventType::kMsgToSend:
+        case TransferSession::OutputEventType::kMsgToSend:
             err = OnMessageToSend(event);
             break;
-        case bdx::TransferSession::OutputEventType::kNone:
-        case bdx::TransferSession::OutputEventType::kAckReceived:
+        case TransferSession::OutputEventType::kNone:
+        case TransferSession::OutputEventType::kAckReceived:
             // Nothing to do.
             break;
-        case bdx::TransferSession::OutputEventType::kAcceptReceived:
-        case bdx::TransferSession::OutputEventType::kBlockReceived:
+        case TransferSession::OutputEventType::kAcceptReceived:
+        case TransferSession::OutputEventType::kBlockReceived:
         default:
             // Should never happens.
             chipDie();
@@ -235,19 +251,38 @@ private:
         LogErrorOnFailure(err);
     }
 
-    void Reset()
+    CHIP_ERROR ConfigureState(chip::FabricIndex fabricIndex, chip::NodeId nodeId)
     {
+        if (mInitialized) {
+            // Prevent a new node connection since another is active.
+            VerifyOrReturnError(mFabricIndex.Value() == fabricIndex && mNodeId.Value() == nodeId, CHIP_ERROR_BUSY);
+
+            // Reset stale connection from the same Node if exists.
+            ResetState();
+        }
+
+        mFabricIndex.SetValue(fabricIndex);
+        mNodeId.SetValue(nodeId);
+
+        mInitialized = true;
+
+        return CHIP_NO_ERROR;
+    }
+
+    void ResetState()
+    {
+        if (!mInitialized) {
+            return;
+        }
+
         mFabricIndex.ClearValue();
         mNodeId.ClearValue();
         mTransfer.Reset();
+
         if (mExchangeCtx != nullptr) {
             mExchangeCtx->Close();
             mExchangeCtx = nullptr;
         }
-
-        mDelegate = nil;
-        mDelegateQueue = nil;
-        mWorkQueue = nil;
 
         mInitialized = false;
     }
@@ -256,80 +291,100 @@ private:
     Optional<FabricIndex> mFabricIndex;
     Optional<NodeId> mNodeId;
     id<MTROTAProviderDelegate> mDelegate = nil;
-    dispatch_queue_t mDelegateQueue = nil;
     dispatch_queue_t mWorkQueue = nil;
+    Messaging::ExchangeManager * mExchangeMgr = nullptr;
 };
 
 BdxOTASender gOtaSender;
 
 static NSInteger const kOtaProviderEndpoint = 0;
 
-MTROTAProviderDelegateBridge::MTROTAProviderDelegateBridge(void)
-    : mDelegate(nil)
+MTROTAProviderDelegateBridge::MTROTAProviderDelegateBridge(id<MTROTAProviderDelegate> delegate)
+    : mDelegate(delegate)
+    , mWorkQueue(DeviceLayer::PlatformMgrImpl().GetWorkQueue())
 {
-}
-
-MTROTAProviderDelegateBridge::~MTROTAProviderDelegateBridge(void) {}
-
-void MTROTAProviderDelegateBridge::setDelegate(id<MTROTAProviderDelegate> delegate, dispatch_queue_t queue)
-{
-    mDelegate = delegate ?: nil;
-    mQueue = queue ?: nil;
-
-    gOtaSender.SetDelegate(delegate, queue);
+    gOtaSender.SetDelegate(delegate);
     Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, this);
 }
+
+MTROTAProviderDelegateBridge::~MTROTAProviderDelegateBridge()
+{
+    gOtaSender.SetDelegate(nil);
+    Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, nullptr);
+}
+
+void MTROTAProviderDelegateBridge::Init(System::Layer * systemLayer, Messaging::ExchangeManager * exchangeManager)
+{
+    gOtaSender.Init(systemLayer, exchangeManager);
+}
+
+void MTROTAProviderDelegateBridge::Shutdown() { gOtaSender.Shutdown(); }
 
 void MTROTAProviderDelegateBridge::HandleQueryImage(
     CommandHandler * commandObj, const ConcreteCommandPath & commandPath, const Commands::QueryImage::DecodableType & commandData)
 {
-    id<MTROTAProviderDelegate> strongDelegate = mDelegate;
-    if (strongDelegate && mQueue) {
-        auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterQueryImageParams alloc] init];
-        CHIP_ERROR err = ConvertToQueryImageParams(commandData, commandParams);
-        if (err != CHIP_NO_ERROR) {
-            commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::InvalidCommand);
-            return;
-        }
-
-        // Make sure to hold on to the command handler and command path to be used in the completion block
-        __block CommandHandler::Handle handle(commandObj);
-        __block ConcreteCommandPath cachedCommandPath(commandPath.mEndpointId, commandPath.mClusterId, commandPath.mCommandId);
-
-        dispatch_async(mQueue, ^{
-            [strongDelegate handleQueryImage:commandParams
-                           completionHandler:^(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
-                               NSError * _Nullable error) {
-                               dispatch_async(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
-                                   Commands::QueryImageResponse::Type response;
-                                   ConvertFromQueryImageResponseParms(data, response);
-
-                                   CommandHandler * handler = handle.Get();
-                                   if (handler) {
-                                       auto hasUpdate =
-                                           [data.status isEqual:@(MTROtaSoftwareUpdateProviderOTAQueryStatusUpdateAvailable)];
-                                       auto isBDXProtocolSupported = [commandParams.protocolsSupported
-                                           containsObject:@(MTROtaSoftwareUpdateProviderOTADownloadProtocolBDXSynchronous)];
-
-                                       if (hasUpdate && isBDXProtocolSupported) {
-                                           auto fabricIndex = handler->GetSubjectDescriptor().fabricIndex;
-                                           auto nodeId = handler->GetSubjectDescriptor().subject;
-                                           CHIP_ERROR err = gOtaSender.Start(fabricIndex, nodeId);
-                                           if (CHIP_NO_ERROR != err) {
-                                               LogErrorOnFailure(err);
-                                               handler->AddStatus(cachedCommandPath, Protocols::InteractionModel::Status::Failure);
-                                               handle.Release();
-                                               return;
-                                           }
-                                       }
-
-                                       handler->AddResponse(cachedCommandPath, response);
-                                       handle.Release();
-                                   }
-                               });
-                           }];
-        });
+    auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterQueryImageParams alloc] init];
+    CHIP_ERROR err = ConvertToQueryImageParams(commandData, commandParams);
+    if (err != CHIP_NO_ERROR) {
+        commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::InvalidCommand);
+        return;
     }
+
+    // Make sure to hold on to the command handler and command path to be used in the completion block
+    __block CommandHandler::Handle handle(commandObj);
+    __block ConcreteCommandPath cachedCommandPath(commandPath.mEndpointId, commandPath.mClusterId, commandPath.mCommandId);
+
+    auto completionHandler = ^(
+        MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error) {
+        dispatch_async(mWorkQueue, ^{
+            CommandHandler * handler = handle.Get();
+            VerifyOrReturn(handler != nullptr);
+
+            Commands::QueryImageResponse::Type response;
+            ConvertFromQueryImageResponseParms(data, response);
+
+            auto hasUpdate = [data.status isEqual:@(MTROtaSoftwareUpdateProviderOTAQueryStatusUpdateAvailable)];
+            auto isBDXProtocolSupported =
+                [commandParams.protocolsSupported containsObject:@(MTROtaSoftwareUpdateProviderOTADownloadProtocolBDXSynchronous)];
+
+            if (hasUpdate && isBDXProtocolSupported) {
+                auto fabricIndex = handler->GetSubjectDescriptor().fabricIndex;
+                auto nodeId = handler->GetSubjectDescriptor().subject;
+                CHIP_ERROR err = gOtaSender.PrepareForTransfer(fabricIndex, nodeId);
+                if (CHIP_NO_ERROR != err) {
+                    LogErrorOnFailure(err);
+                    handler->AddStatus(cachedCommandPath, Protocols::InteractionModel::Status::Failure);
+                    handle.Release();
+                    return;
+                }
+
+                auto targetNodeId = handler->GetExchangeContext()->GetSessionHandle()->AsSecureSession()->GetLocalScopedNodeId();
+
+                char uriBuffer[kMaxBDXURILen];
+                MutableCharSpan uri(uriBuffer);
+                err = bdx::MakeURI(targetNodeId.GetNodeId(), CharSpan::fromCharString([data.imageURI UTF8String]), uri);
+                if (CHIP_NO_ERROR != err) {
+                    LogErrorOnFailure(err);
+                    handler->AddStatus(cachedCommandPath, Protocols::InteractionModel::Status::Failure);
+                    handle.Release();
+                    return;
+                }
+
+                response.imageURI.SetValue(uri);
+                handler->AddResponse(cachedCommandPath, response);
+                handle.Release();
+                return;
+            }
+
+            handler->AddResponse(cachedCommandPath, response);
+            handle.Release();
+        });
+    };
+
+    auto strongDelegate = mDelegate;
+    dispatch_async(mWorkQueue, ^{
+        [strongDelegate handleQueryImage:commandParams completionHandler:completionHandler];
+    });
 }
 
 void MTROTAProviderDelegateBridge::HandleApplyUpdateRequest(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
@@ -339,29 +394,26 @@ void MTROTAProviderDelegateBridge::HandleApplyUpdateRequest(CommandHandler * com
     __block CommandHandler::Handle handle(commandObj);
     __block ConcreteCommandPath cachedCommandPath(commandPath.mEndpointId, commandPath.mClusterId, commandPath.mCommandId);
 
-    id<MTROTAProviderDelegate> strongDelegate = mDelegate;
-    if (strongDelegate && mQueue) {
-        auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
-        ConvertToApplyUpdateRequestParams(commandData, commandParams);
+    auto completionHandler
+        = ^(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error) {
+              dispatch_async(mWorkQueue, ^{
+                  CommandHandler * handler = handle.Get();
+                  VerifyOrReturn(handler != nullptr);
 
-        dispatch_async(mQueue, ^{
-            [strongDelegate
-                handleApplyUpdateRequest:commandParams
-                       completionHandler:^(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
-                           NSError * _Nullable error) {
-                           dispatch_async(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
-                               Commands::ApplyUpdateResponse::Type response;
-                               ConvertFromApplyUpdateRequestResponseParms(data, response);
+                  Commands::ApplyUpdateResponse::Type response;
+                  ConvertFromApplyUpdateRequestResponseParms(data, response);
+                  handler->AddResponse(cachedCommandPath, response);
+                  handle.Release();
+              });
+          };
 
-                               CommandHandler * handler = handle.Get();
-                               if (handler) {
-                                   handler->AddResponse(cachedCommandPath, response);
-                                   handle.Release();
-                               }
-                           });
-                       }];
-        });
-    }
+    auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
+    ConvertToApplyUpdateRequestParams(commandData, commandParams);
+
+    auto strongDelegate = mDelegate;
+    dispatch_async(mWorkQueue, ^{
+        [strongDelegate handleApplyUpdateRequest:commandParams completionHandler:completionHandler];
+    });
 }
 
 void MTROTAProviderDelegateBridge::HandleNotifyUpdateApplied(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
@@ -371,24 +423,23 @@ void MTROTAProviderDelegateBridge::HandleNotifyUpdateApplied(CommandHandler * co
     __block CommandHandler::Handle handle(commandObj);
     __block ConcreteCommandPath cachedCommandPath(commandPath.mEndpointId, commandPath.mClusterId, commandPath.mCommandId);
 
-    id<MTROTAProviderDelegate> strongDelegate = mDelegate;
-    if (strongDelegate && mQueue) {
-        auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
-        ConvertToNotifyUpdateAppliedParams(commandData, commandParams);
+    auto completionHandler = ^(NSError * _Nullable error) {
+        dispatch_async(mWorkQueue, ^{
+            CommandHandler * handler = handle.Get();
+            VerifyOrReturn(handler != nullptr);
 
-        dispatch_async(mQueue, ^{
-            [strongDelegate handleNotifyUpdateApplied:commandParams
-                                    completionHandler:^(NSError * _Nullable error) {
-                                        dispatch_async(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
-                                            CommandHandler * handler = handle.Get();
-                                            if (handler) {
-                                                handler->AddStatus(cachedCommandPath, Protocols::InteractionModel::Status::Success);
-                                                handle.Release();
-                                            }
-                                        });
-                                    }];
+            handler->AddStatus(cachedCommandPath, Protocols::InteractionModel::Status::Success);
+            handle.Release();
         });
-    }
+    };
+
+    auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
+    ConvertToNotifyUpdateAppliedParams(commandData, commandParams);
+
+    auto strongDelegate = mDelegate;
+    dispatch_async(mWorkQueue, ^{
+        [strongDelegate handleNotifyUpdateApplied:commandParams completionHandler:completionHandler];
+    });
 }
 
 CHIP_ERROR MTROTAProviderDelegateBridge::ConvertToQueryImageParams(


### PR DESCRIPTION
#### Problem

This PR moves the OTA Provider delegate from `MTRDeviceController` to `MTRControllerFactory`.
It also internalise the conversion from an ota URL to a proper BDX URI since the BDX uri is supposed to use the nodeId used for the CASE session where the `QueryImageResponse` is issued:
```
The Operational Node ID in the host field SHALL match the NodeID of the OTA Provider responding with the QueryImageResponse.
```

This PR also change onto which dispatch queue the method of the `MTROTAProviderDelegate` are processed. Everything happens onto the chip work dispatch queue. It should not change much of the behaviour since most of the delegates exposes a completion handler that can be called from a different queue, their internally ensure that the work is dispatched to the chip work dispatch queue.

#fix #20948

#### Change overview
 * Register the delegate as a startup parameter of the `MTRControllerFactory`.
 * update the dispatch queue used for the `MTROTAProviderDelegate` callback methods.
 
#### Testing

It has been tested using the same procedure than #21161 