### PR TITLE
Establish CASE on re-subscription

### DIFF
--- a/examples/bridge-app/esp32/main/main.cpp
+++ b/examples/bridge-app/esp32/main/main.cpp
@@ -32,6 +32,7 @@
 #include <lib/support/CHIPMemString.h>
 #include <lib/support/ErrorStr.h>
 
+#include <app/InteractionModelEngine.h>
 #include <app/server/Server.h>
 
 #if CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER

--- a/src/app/BufferedReadCallback.h
+++ b/src/app/BufferedReadCallback.h
@@ -86,9 +86,9 @@ private:
         mCallback.OnSubscriptionEstablished(aSubscriptionId);
     }
 
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override
+    CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override
     {
-        mCallback.OnResubscriptionAttempt(aTerminationCause, aNextResubscribeIntervalMsec);
+        return mCallback.OnResubscriptionNeeded(apReadClient, aTerminationCause);
     }
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -576,9 +576,9 @@ private:
         mCallback.OnSubscriptionEstablished(aSubscriptionId);
     }
 
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override
+    CHIP_ERROR OnResubscriptionNeeded(ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override
     {
-        mCallback.OnResubscriptionAttempt(aTerminationCause, aNextResubscribeIntervalMsec);
+        return mCallback.OnResubscriptionNeeded(apReadClient, aTerminationCause);
     }
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override

--- a/src/app/DeviceProxy.h
+++ b/src/app/DeviceProxy.h
@@ -27,7 +27,6 @@
 #pragma once
 
 #include <app/CommandSender.h>
-#include <app/InteractionModelEngine.h>
 #include <lib/core/CHIPCallback.h>
 #include <lib/core/CHIPCore.h>
 #include <lib/support/DLLUtil.h>

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -59,6 +59,8 @@
 #include <app/util/attribute-metadata.h>
 #include <app/util/basic-types.h>
 
+#include <app/CASESessionManager.h>
+
 namespace chip {
 namespace app {
 
@@ -102,17 +104,26 @@ public:
      *  Initialize the InteractionModel Engine.
      *
      *  @param[in]    apExchangeMgr    A pointer to the ExchangeManager object.
+     *  @param[in]    apFabricTable    A pointer to the FabricTable object.
+     *  @param[in]    apCASESessionMgr An optional pointer to a CASESessionManager (used for re-subscriptions).
      *
      *  @retval #CHIP_ERROR_INCORRECT_STATE If the state is not equal to
      *          kState_NotInitialized.
      *  @retval #CHIP_NO_ERROR On success.
      *
      */
-    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable);
+    CHIP_ERROR Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable,
+                    CASESessionManager * apCASESessionMgr = nullptr);
 
     void Shutdown();
 
-    Messaging::ExchangeManager * GetExchangeManager(void) const { return mpExchangeMgr; };
+    Messaging::ExchangeManager * GetExchangeManager(void) const { return mpExchangeMgr; }
+
+    /**
+     * Returns a pointer to the CASESessionManager. This can return nullptr if one wasn't
+     * provided in the call to Init().
+     */
+    CASESessionManager * GetCASESessionManager() const { return mpCASESessionMgr; }
 
     /**
      * Tears down an active subscription.
@@ -550,6 +561,8 @@ private:
 #endif
 
     FabricTable * mpFabricTable;
+
+    CASESessionManager * mpCASESessionMgr = nullptr;
 
     // A magic number for tracking values between stack Shutdown()-s and Init()-s.
     // An ObjectHandle is valid iff. its magic equals to this one.

--- a/src/app/OperationalDeviceProxy.cpp
+++ b/src/app/OperationalDeviceProxy.cpp
@@ -24,12 +24,11 @@
  *    messages to and from the corresponding CHIP devices.
  */
 
-#include "OperationalDeviceProxy.h"
+#include <app/OperationalDeviceProxy.h>
 
-#include "CASEClient.h"
-#include "CommandSender.h"
-#include "ReadPrepareParams.h"
-#include "transport/SecureSession.h"
+#include <app/CASEClient.h>
+#include <app/InteractionModelEngine.h>
+#include <transport/SecureSession.h>
 
 #include <lib/address_resolve/AddressResolve.h>
 #include <lib/core/CHIPCore.h>

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -181,6 +181,7 @@ CHIP_ERROR ReadHandler::SendStatusReport(Protocols::InteractionModel::Status aSt
         VerifyOrReturnLogError(!mExchangeCtx, CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnLogError(mSessionHandle, CHIP_ERROR_INCORRECT_STATE);
         auto exchange = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(mSessionHandle.Get().Value(), this);
+        VerifyOrReturnLogError(exchange != nullptr, CHIP_ERROR_INCORRECT_STATE);
         mExchangeCtx.Grab(exchange);
     }
 
@@ -200,10 +201,12 @@ CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload, b
         VerifyOrReturnLogError(!mExchangeCtx, CHIP_ERROR_INCORRECT_STATE);
         VerifyOrReturnLogError(mSessionHandle, CHIP_ERROR_INCORRECT_STATE);
         auto exchange = InteractionModelEngine::GetInstance()->GetExchangeManager()->NewContext(mSessionHandle.Get().Value(), this);
+        VerifyOrReturnLogError(exchange != nullptr, CHIP_ERROR_INCORRECT_STATE);
         mExchangeCtx.Grab(exchange);
     }
 
     VerifyOrReturnLogError(mExchangeCtx, CHIP_ERROR_INCORRECT_STATE);
+
     if (!IsReporting())
     {
         mCurrentReportsBeginGeneration = InteractionModelEngine::GetInstance()->GetReportingEngine().GetDirtySetGeneration();

--- a/src/app/ReadPrepareParams.h
+++ b/src/app/ReadPrepareParams.h
@@ -29,15 +29,6 @@
 
 namespace chip {
 namespace app {
-/**
- * @brief Used to specify the re-subscription policy. Namely, the method is invoked and provided the number of
- * retries that have occurred so far.
- *
- * aShouldResubscribe and aNextSubscriptionIntervalMsec are outparams indicating whether and how long into
- * the future a re-subscription should happen.
- */
-typedef void (*OnResubscribePolicyCB)(uint32_t aNumCumulativeRetries, uint32_t & aNextSubscriptionIntervalMsec,
-                                      bool & aShouldResubscribe);
 
 struct ReadPrepareParams
 {
@@ -51,12 +42,11 @@ struct ReadPrepareParams
     Optional<EventNumber> mEventNumber;
     // The timeout for waiting for the response or System::Clock::kZero to let the interaction model decide the timeout based on the
     // MRP timeouts of the session.
-    System::Clock::Timeout mTimeout          = System::Clock::kZero;
-    uint16_t mMinIntervalFloorSeconds        = 0;
-    uint16_t mMaxIntervalCeilingSeconds      = 0;
-    bool mKeepSubscriptions                  = false;
-    bool mIsFabricFiltered                   = true;
-    OnResubscribePolicyCB mResubscribePolicy = nullptr;
+    System::Clock::Timeout mTimeout     = System::Clock::kZero;
+    uint16_t mMinIntervalFloorSeconds   = 0;
+    uint16_t mMaxIntervalCeilingSeconds = 0;
+    bool mKeepSubscriptions             = false;
+    bool mIsFabricFiltered              = true;
 
     ReadPrepareParams() {}
     ReadPrepareParams(const SessionHandle & sessionHandle) { mSessionHolder.Grab(sessionHandle); }
@@ -78,7 +68,6 @@ struct ReadPrepareParams
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;
         other.mAttributePathParamsListSize = 0;
-        mResubscribePolicy                 = other.mResubscribePolicy;
     }
 
     ReadPrepareParams & operator=(ReadPrepareParams && other)
@@ -103,7 +92,6 @@ struct ReadPrepareParams
         other.mEventPathParamsListSize     = 0;
         other.mpAttributePathParamsList    = nullptr;
         other.mAttributePathParamsListSize = 0;
-        mResubscribePolicy                 = other.mResubscribePolicy;
         return *this;
     }
 };

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -30,6 +30,7 @@
 #include <app/CommandHandler.h>
 #include <app/ConcreteCommandPath.h>
 #include <app/EventLogging.h>
+#include <app/InteractionModelEngine.h>
 #include <app/reporting/reporting.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -221,9 +221,6 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
     app::DnssdServer::Instance().SetFabricTable(&mFabrics);
     app::DnssdServer::Instance().SetCommissioningModeProvider(&mCommissioningWindowManager);
 
-    err = chip::app::InteractionModelEngine::GetInstance()->Init(&mExchangeMgr, &GetFabricTable());
-    SuccessOrExit(err);
-
     chip::Dnssd::Resolver::Instance().Init(DeviceLayer::UDPEndPointManager());
 
 #if CHIP_CONFIG_ENABLE_SERVER_IM_EVENT
@@ -305,6 +302,9 @@ CHIP_ERROR Server::Init(const ServerInitParams & initParams)
 
     err = mCASEServer.ListenForSessionEstablishment(&mExchangeMgr, &mSessions, &mFabrics, mSessionResumptionStorage,
                                                     mCertificateValidityPolicy, mGroupsProvider);
+    SuccessOrExit(err);
+
+    err = chip::app::InteractionModelEngine::GetInstance()->Init(&mExchangeMgr, &GetFabricTable(), &mCASESessionManager);
     SuccessOrExit(err);
 
     // This code is necessary to restart listening to existing groups after a reboot

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -32,6 +32,7 @@ static_library("helpers") {
 
   deps = [
     "${chip_root}/src/access",
+    "${chip_root}/src/app",
     "${chip_root}/src/lib/support",
     "${chip_root}/src/messaging/tests:helpers",
     "${chip_root}/src/transport/raw/tests:helpers",

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -146,7 +146,6 @@ public:
         }
     }
 
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override {}
     void OnAttributeData(const chip::app::ConcreteDataAttributePath & aPath, chip::TLV::TLVReader * aData,
                          const chip::app::StatusIB & status) override
     {}

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.cpp
@@ -125,8 +125,6 @@ void InteractionModel::OnSubscriptionEstablished(SubscriptionId subscriptionId)
     ContinueOnChipMainThread(CHIP_NO_ERROR);
 }
 
-void InteractionModel::OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) {}
-
 /////////// WriteClient Callback Interface /////////
 void InteractionModel::OnResponse(const WriteClient * client, const ConcreteDataAttributePath & path, StatusIB status)
 {

--- a/src/app/tests/suites/commands/interaction_model/InteractionModel.h
+++ b/src/app/tests/suites/commands/interaction_model/InteractionModel.h
@@ -22,6 +22,7 @@
 #include <app/ChunkedWriteCallback.h>
 #include <app/CommandSender.h>
 #include <app/DeviceProxy.h>
+#include <app/InteractionModelEngine.h>
 #include <app/ReadClient.h>
 #include <app/WriteClient.h>
 #include <lib/support/CodeUtils.h>
@@ -436,7 +437,6 @@ public:
     void OnError(CHIP_ERROR error) override;
     void OnDone(chip::app::ReadClient * aReadClient) override;
     void OnSubscriptionEstablished(chip::SubscriptionId subscriptionId) override;
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override;
     /////////// WriteClient Callback Interface /////////
     void OnResponse(const chip::app::WriteClient * client, const chip::app::ConcreteDataAttributePath & path,
                     chip::app::StatusIB status) override;

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -205,8 +205,6 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
 
     InitDataModelHandler(stateParams.exchangeMgr);
 
-    ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->Init(stateParams.exchangeMgr, stateParams.fabricTable));
-
     ReturnErrorOnFailure(Dnssd::Resolver::Instance().Init(stateParams.udpEndPointManager));
 
     if (params.enableServerInteractions)
@@ -265,6 +263,9 @@ CHIP_ERROR DeviceControllerFactory::InitSystemState(FactoryInitParams params)
     // TODO: Need to be able to create a CASESessionManagerConfig here!
     stateParams.caseSessionManager = Platform::New<CASESessionManager>();
     ReturnErrorOnFailure(stateParams.caseSessionManager->Init(stateParams.systemLayer, sessionManagerConfig));
+
+    ReturnErrorOnFailure(chip::app::InteractionModelEngine::GetInstance()->Init(stateParams.exchangeMgr, stateParams.fabricTable,
+                                                                                stateParams.caseSessionManager));
 
     // store the system state
     mSystemState = chip::Platform::New<DeviceControllerSystemState>(std::move(stateParams));

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -124,12 +124,16 @@ private:
         }
     }
 
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override
+    CHIP_ERROR OnResubscriptionNeeded(chip::app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override
     {
+        ReturnErrorOnFailure(app::ReadClient::Callback::OnResubscriptionNeeded(apReadClient, aTerminationCause));
+
         if (mOnResubscriptionAttempt)
         {
-            mOnResubscriptionAttempt(*mReadClient.get(), aTerminationCause, aNextResubscribeIntervalMsec);
+            mOnResubscriptionAttempt(*mReadClient.get(), aTerminationCause, apReadClient->ComputeTimeTillNextSubscription());
         }
+
+        return CHIP_NO_ERROR;
     }
 
     void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
@@ -246,12 +250,16 @@ private:
         }
     }
 
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override
+    CHIP_ERROR OnResubscriptionNeeded(chip::app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override
     {
+        ReturnErrorOnFailure(app::ReadClient::Callback::OnResubscriptionNeeded(apReadClient, aTerminationCause));
+
         if (mOnResubscriptionAttempt)
         {
-            mOnResubscriptionAttempt(*mReadClient.get(), aTerminationCause, aNextResubscribeIntervalMsec);
+            mOnResubscriptionAttempt(*mReadClient.get(), aTerminationCause, apReadClient->ComputeTimeTillNextSubscription());
         }
+
+        return CHIP_NO_ERROR;
     }
 
     OnSuccessCallbackType mOnSuccess;

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -98,7 +98,7 @@ struct ReportEventCallback : public app::ReadClient::Callback
 
     void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override;
 
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override;
+    CHIP_ERROR OnResubscriptionNeeded(app::ReadClient * apReadClient, CHIP_ERROR aTerminationCause) override;
 
     /** Report errors back to Java layer. attributePath may be nullptr for general errors. */
     void ReportError(jobject eventPath, CHIP_ERROR err);

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -140,6 +140,10 @@ def TestDatamodel(test: BaseTestHelper, device_nodeid: int):
     FailIfNot(test.TestSubscription(nodeid=device_nodeid, endpoint=LIGHTING_ENDPOINT_ID),
               "Failed to subscribe attributes.")
 
+    logger.info("Testing re-subscription")
+    FailIfNot(asyncio.run(test.TestResubscription(nodeid=device_nodeid)),
+              "Failed to validated re-subscription")
+
     logger.info("Testing on off cluster over resolved connection")
     FailIfNot(test.TestOnOffCluster(nodeid=device_nodeid,
                                     endpoint=LIGHTING_ENDPOINT_ID,

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -157,8 +157,6 @@ public:
 
     void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablished = true; }
 
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override {}
-
     uint32_t mAttributeCount        = 0;
     uint32_t mEventCount            = 0;
     bool mOnReportEnd               = false;

--- a/src/controller/tests/TestReadChunking.cpp
+++ b/src/controller/tests/TestReadChunking.cpp
@@ -136,8 +136,6 @@ public:
 
     void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablished = true; }
 
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override {}
-
     uint32_t mAttributeCount        = 0;
     bool mOnReportEnd               = false;
     bool mOnSubscriptionEstablished = false;
@@ -306,7 +304,6 @@ public:
     void OnReportEnd() override { mOnReportEnd = true; }
 
     void OnSubscriptionEstablished(SubscriptionId aSubscriptionId) override { mOnSubscriptionEstablished = true; }
-    void OnResubscriptionAttempt(CHIP_ERROR aTerminationCause, uint32_t aNextResubscribeIntervalMsec) override {}
 
     uint32_t mAttributeCount = 0;
     // We record every dataversion field from every attribute IB.


### PR DESCRIPTION
This adds support for re-establishing CASE on re-subscription if a `CHIP_ERROR_TIMEOUT` was encountered as a default policy implementation, with the application having the ability to over-ride that if needed.

Fixes #16202 

This works out-of-the-box if you call `SendAutoResubscribeRequest`.

This deletes the function-callback approach in `ReadPrepareParams::mResubscribePolicy` and uses instead the re-named, `ReadClient::Callback::OnResubscriptionNeeded` callback to effect the right re-subscription policy.

That callback now pivots from being just an informational callback to one that places the onus on the application (if it over-rides the default impl) to schedule the ensuing re-subscription by calling back into `ReadClient::ScheduleResubscription`.

Helper methods are provided to help applications pick and select elements of the default re-sub implementation as they desire.

Other notables:
* Fixes missing clean-up of timers on ReadClient destruction initiated by the application.
* Fixes missing error-handling of calls made during re-subscription to ensure they trigger further re-subscription.


#### Testing

1. Added a new `TestSubscribeAttributeTimeout` in `TestRead.cpp` that validates re-subscription sans CASE.
2. Added a new `TestResubscription` in the Python test suite that validates re-subscription with CASE.
