### PR TITLE
[nrfconnect] Update nRF Connect SDK to 2.0.2

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -2,7 +2,7 @@ ARG VERSION=latest
 FROM connectedhomeip/chip-build:${VERSION} as build
 
 # Compatible Nordic Connect SDK revision.
-ARG NCS_REVISION=fd5905aa6b04febd99d00dba6c482ac25eb15222
+ARG NCS_REVISION=v2.0.2
 
 RUN set -x \
     && apt-get update \
@@ -28,7 +28,7 @@ RUN set -x \
 WORKDIR /opt/NordicSemiconductor/nrfconnect
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
-    west==0.12.0 \
+    west==0.13.1 \
     && west init -m https://github.com/nrfconnect/sdk-nrf \
     && git -C nrf fetch origin "$NCS_REVISION" \
     && git -C nrf checkout FETCH_HEAD \
@@ -59,7 +59,7 @@ COPY --from=build /opt/NordicSemiconductor/nrfconnect/ /opt/NordicSemiconductor/
 RUN set -x \
     # python3-yaml package conflicts with nRF Python requirements
     && (apt-get remove -fy python3-yaml && apt-get autoremove || exit 0) \
-    && python3 -m pip install -U --no-cache-dir cmake==3.22.2 \
+    && python3 -m pip install -U --no-cache-dir cmake==3.22.5 \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/zephyr/scripts/requirements.txt \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/nrf/scripts/requirements.txt \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/bootloader/mcuboot/scripts/requirements.txt \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.90 Version bump reason: [Ameba] Add light-switch-app build option and enable matter_shell macro
+0.5.91 Version bump reason: [nRF Connect] Update nRF Connect SDK version


### PR DESCRIPTION
#### Problem
We need new SDK version to pull support for Thread 1.3

#### Change overview
Update nRF Connect SDK in Dockerfile.

#### Testing
Verified by CI.
