### PR TITLE
[Inet] Fix Get link local address for socket impl

### DIFF
--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -886,7 +886,8 @@ CHIP_ERROR InterfaceId::GetLinkLocalAddr(IPAddress * llAddr) const
                 if ((sin6_addr->s6_addr[0] == 0xfe) && ((sin6_addr->s6_addr[1] & 0xc0) == 0x80)) // Link Local Address
                 {
                     (*llAddr) = IPAddress((reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr);
-                    found     = true break;
+                    found     = true;
+                    break;
                 }
             }
         }

--- a/src/inet/InetInterface.cpp
+++ b/src/inet/InetInterface.cpp
@@ -868,6 +868,8 @@ CHIP_ERROR InterfaceId::GetLinkLocalAddr(IPAddress * llAddr) const
 
     struct ifaddrs * ifaddr;
     const int rv = getifaddrs(&ifaddr);
+    bool found   = false;
+
     if (rv == -1)
     {
         return INET_ERROR_ADDRESS_NOT_FOUND;
@@ -881,17 +883,17 @@ CHIP_ERROR InterfaceId::GetLinkLocalAddr(IPAddress * llAddr) const
                 ((mPlatformInterface == 0) || (mPlatformInterface == if_nametoindex(ifaddr_iter->ifa_name))))
             {
                 struct in6_addr * sin6_addr = &(reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr;
-                if (sin6_addr->s6_addr[0] == 0xfe && (sin6_addr->s6_addr[1] & 0xc0) == 0x80) // Link Local Address
+                if ((sin6_addr->s6_addr[0] == 0xfe) && ((sin6_addr->s6_addr[1] & 0xc0) == 0x80)) // Link Local Address
                 {
                     (*llAddr) = IPAddress((reinterpret_cast<struct sockaddr_in6 *>(ifaddr_iter->ifa_addr))->sin6_addr);
-                    break;
+                    found     = true break;
                 }
             }
         }
     }
     freeifaddrs(ifaddr);
 
-    return CHIP_NO_ERROR;
+    return (found) ? CHIP_NO_ERROR : INET_ERROR_ADDRESS_NOT_FOUND;
 }
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS && CHIP_SYSTEM_CONFIG_USE_BSD_IFADDRS

--- a/src/inet/InetInterface.h
+++ b/src/inet/InetInterface.h
@@ -185,7 +185,9 @@ public:
      *  @retval    #CHIP_ERROR_INVALID_ARGUMENT     If the link local address
      *                                              is nullptr.
      *  @retval    #INET_ERROR_ADDRESS_NOT_FOUND    If the link does not have
-     *                                              any address configured.
+     *                                              any address configured
+     *                                              or if no link local (fe80::)
+     *                                              address is present.
      *  @retval    #CHIP_NO_ERROR                   On success.
      */
     CHIP_ERROR GetLinkLocalAddr(IPAddress * llAddr) const;


### PR DESCRIPTION
#### Problem
Function return `CHIP_NO_ERROR` even if no link local address (fe80::) is present on the interface

#### Change overview
return `INET_ERROR_ADDRESS_NOT_FOUND` if no link local address is found

#### Testing
Manual test on Ubuntu 20.04. Moreover I didn't find any references to this method in the SDK.
