### PR TITLE
Fix some text entry leaks on Darwin.

### DIFF
--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -117,6 +117,13 @@ struct BrowseContext : public GenericContext
 
 struct InterfaceInfo
 {
+    InterfaceInfo();
+    InterfaceInfo(InterfaceInfo && other);
+    // Copying is not safe, because DnssdService bits need to be
+    // copied/deallocated properly.
+    InterfaceInfo(const InterfaceInfo & other) = delete;
+    ~InterfaceInfo();
+
     DnssdService service;
     std::vector<Inet::IPAddress> addresses;
     std::string fullyQualifiedDomainName;
@@ -141,7 +148,6 @@ struct ResolveContext : public GenericContext
     void OnNewInterface(uint32_t interfaceId, const char * fullname, const char * hostname, uint16_t port, uint16_t txtLen,
                         const unsigned char * txtRecord);
     bool HasInterface();
-    void RemoveInterfaces();
 };
 
 } // namespace Dnssd


### PR DESCRIPTION
We can get OnNewInterface twice for the same interface.  When the happens we
replace the old InterfaceInfo with a new one in the map.  Because our cleanup
was from ~ResolveContext, that meant we leaked any allocated memory the
InterfaceInfo was holding on to.

The fix is to make InterfaceInfo manage its own memory and make sure we transfer
the ownership properly via move constructors when inserting into the map.

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran `darwin-framework-tool pairing code` with LeakSanitizer and observed that the leak that had detected without these changes is gone.