### PR TITLE
Use the new NSString-to-CharSpan conversions more.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCluster.mm
+++ b/src/darwin/Framework/CHIP/MTRCluster.mm
@@ -18,6 +18,7 @@
 #import "MTRBaseDevice.h"
 #import "MTRCluster_internal.h"
 #import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
 
 using namespace ::chip;
 
@@ -37,8 +38,7 @@ using namespace ::chip;
 
 - (chip::CharSpan)asCharSpan:(NSString *)value
 {
-    return chip::CharSpan(static_cast<const char *>([value dataUsingEncoding:NSUTF8StringEncoding].bytes),
-        [value lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
+    return AsCharSpan(value);
 }
 @end
 

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -17,6 +17,7 @@
 
 #import "MTROTAProviderDelegateBridge.h"
 #import "NSDataSpanConversion.h"
+#import "NSStringSpanConversion.h"
 
 #include <app/clusters/ota-provider/ota-provider.h>
 #include <lib/support/TypeTraits.h>
@@ -362,7 +363,7 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
 
                 char uriBuffer[kMaxBDXURILen];
                 MutableCharSpan uri(uriBuffer);
-                err = bdx::MakeURI(targetNodeId.GetNodeId(), CharSpan::fromCharString([data.imageURI UTF8String]), uri);
+                err = bdx::MakeURI(targetNodeId.GetNodeId(), AsCharSpan(data.imageURI), uri);
                 if (CHIP_NO_ERROR != err) {
                     LogErrorOnFailure(err);
                     handler->AddStatus(cachedCommandPath, Protocols::InteractionModel::Status::Failure);
@@ -462,9 +463,7 @@ CHIP_ERROR MTROTAProviderDelegateBridge::ConvertToQueryImageParams(
     }
 
     if (commandData.location.HasValue()) {
-        commandParams.location = [[NSString alloc] initWithBytes:commandData.location.Value().data()
-                                                          length:commandData.location.Value().size()
-                                                        encoding:NSUTF8StringEncoding];
+        commandParams.location = AsString(commandData.location.Value());
     }
 
     if (commandData.requestorCanConsent.HasValue()) {
@@ -488,7 +487,7 @@ void MTROTAProviderDelegateBridge::ConvertFromQueryImageResponseParms(
     }
 
     if (responseParams.imageURI) {
-        response.imageURI.SetValue(CharSpan([responseParams.imageURI UTF8String], responseParams.imageURI.length));
+        response.imageURI.SetValue(AsCharSpan(responseParams.imageURI));
     }
 
     if (responseParams.softwareVersion) {
@@ -496,8 +495,7 @@ void MTROTAProviderDelegateBridge::ConvertFromQueryImageResponseParms(
     }
 
     if (responseParams.softwareVersionString) {
-        response.softwareVersionString.SetValue(
-            CharSpan([responseParams.softwareVersionString UTF8String], responseParams.softwareVersionString.length));
+        response.softwareVersionString.SetValue(AsCharSpan(responseParams.softwareVersionString));
     }
 
     if (responseParams.updateToken) {

--- a/src/darwin/Framework/CHIP/NSStringSpanConversion.h
+++ b/src/darwin/Framework/CHIP/NSStringSpanConversion.h
@@ -26,7 +26,10 @@ NS_ASSUME_NONNULL_BEGIN
  * Utilities for converting between NSString and chip::CharSpan.
  */
 
-inline chip::CharSpan AsCharSpan(NSString * str) { return chip::CharSpan([str UTF8String], [str length]); }
+inline chip::CharSpan AsCharSpan(NSString * str)
+{
+    return chip::CharSpan([str UTF8String], [str lengthOfBytesUsingEncoding:NSUTF8StringEncoding]);
+}
 
 inline NSString * AsString(chip::CharSpan span)
 {


### PR DESCRIPTION
And fix the length for non-ASCII strings when converting to CharSpan.

#### Problem
Wrong conversion of NSString to CharSpan for non-ASCII strings.

#### Change overview
Fix the length computation, use the shared helpers in a few more places.

#### Testing
Nothing specific past CI. 