### PR TITLE
Fix build of all-clusters-app to not build extraneous things.

### DIFF
--- a/examples/all-clusters-app/linux/BUILD.gn
+++ b/examples/all-clusters-app/linux/BUILD.gn
@@ -121,3 +121,7 @@ group("linux") {
     deps += [ ":chip-all-clusters-app" ]
   }
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}

--- a/examples/all-clusters-minimal-app/linux/BUILD.gn
+++ b/examples/all-clusters-minimal-app/linux/BUILD.gn
@@ -101,3 +101,7 @@ group("linux") {
   deps = []
   deps += [ ":chip-all-clusters-minimal-app" ]
 }
+
+group("default") {
+  deps = [ ":linux" ]
+}


### PR DESCRIPTION
The all-clusters-app .gn file did not say what the default thing to
build is, so we were defaulting to "all targets declared in any .gn
file we depend on".

This led to us compiling address-resolve-tool, for example, in
addition to all-clusters-app.

The fix is to explicitly say what the default thing to build is.

Fixes https://github.com/project-chip/connectedhomeip/issues/21221

#### Problem
See above.

#### Change overview
See above.

#### Testing
Built using `scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone` and verified that `address-resolve-tool` is not built anymore.

Verified that both `./gn_build.sh` and `./scripts/run_in_build_env.sh "./scripts/build/build_examples.py --target darwin-x64-address-resolve-tool build"` do in fact build `address-resolve-tool`.