### PR TITLE
[EFR32]Added fix for scan filtering and temp fix for reset count on RS9116

### DIFF
--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -477,7 +477,11 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCou
 
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
 {
-    return CHIP_NO_ERROR;
+    int32_t err = wfx_reset_counts();
+    if(err == 0){
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
 }
 #endif // SL_WIFI
 

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -478,7 +478,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetWiFiOverrunCount(uint64_t & overrunCou
 CHIP_ERROR DiagnosticDataProviderImpl::ResetWiFiNetworkDiagnosticsCounts()
 {
     int32_t err = wfx_reset_counts();
-    if(err == 0){
+    if (err == 0)
+    {
         return CHIP_NO_ERROR;
     }
     return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;


### PR DESCRIPTION
#### Problem
Scan filtering if a user wants to scan a particular SSID
./chip-tool networkcommissioning scan-networks 1 0 --Ssid <SSID>

Reset counts fix for wifinetworkdiagnostics

DUT: EFR32+RS9116

#### Change overview
SDK related fixes to get the required outcome for scanning network and wifinetworkdiagnostics

#### Testing
Tested manually with EFR32+RS9116