### PR TITLE
Clean up the redundant user labels when the list becomes smaller than previous list for a given endpoint

### DIFF
--- a/examples/providers/DeviceInfoProviderImpl.cpp
+++ b/examples/providers/DeviceInfoProviderImpl.cpp
@@ -149,6 +149,13 @@ CHIP_ERROR DeviceInfoProviderImpl::SetUserLabelAt(EndpointId endpoint, size_t in
                                      static_cast<uint16_t>(writer.GetLengthWritten()));
 }
 
+CHIP_ERROR DeviceInfoProviderImpl::DeleteUserLabelAt(EndpointId endpoint, size_t index)
+{
+    DefaultStorageKeyAllocator keyAlloc;
+
+    return mStorage->SyncDeleteKeyValue(keyAlloc.UserLabelIndexKey(endpoint, index));
+}
+
 DeviceInfoProvider::UserLabelIterator * DeviceInfoProviderImpl::IterateUserLabel(EndpointId endpoint)
 {
     return chip::Platform::New<UserLabelIteratorImpl>(*this, endpoint);

--- a/examples/providers/DeviceInfoProviderImpl.h
+++ b/examples/providers/DeviceInfoProviderImpl.h
@@ -97,6 +97,7 @@ protected:
     CHIP_ERROR SetUserLabelLength(EndpointId endpoint, size_t val) override;
     CHIP_ERROR GetUserLabelLength(EndpointId endpoint, size_t & val) override;
     CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) override;
+    CHIP_ERROR DeleteUserLabelAt(EndpointId endpoint, size_t index) override;
 
 private:
     static constexpr size_t UserLabelTLVMaxSize() { return TLV::EstimateStructOverhead(kMaxLabelNameLength, kMaxLabelValueLength); }

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -48,6 +48,7 @@
 #include <lib/support/ScopedBuffer.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/CHIPDeviceLayer.h>
+#include <platform/DeviceInfoProvider.h>
 #include <string.h>
 #include <trace/trace.h>
 
@@ -269,9 +270,38 @@ const FabricInfo * RetrieveCurrentFabric(CommandHandler * aCommandHandler)
     return Server::GetInstance().GetFabricTable().FindFabricWithIndex(index);
 }
 
+void MatterRelatedDataCleanup()
+{
+    // Delete all user label data on the node which was added since it was commissioned.
+    DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
+
+    if (provider)
+    {
+        for (auto endpoint : EnabledEndpointsWithServerCluster(UserLabel::Id))
+        {
+            // If UserLabel cluster is implemented on this endpoint
+            if (CHIP_NO_ERROR != provider->ClearUserLabelList(endpoint))
+            {
+                ChipLogError(Zcl, "OperationalCredentials: Failed to clear UserLabelList for endpoint:%d", endpoint);
+            }
+        }
+    }
+
+    // TODO: The device SHALL delete all other Matter related data on the node which was created since it was commissioned.
+    // This includes all Fabric-Scoped data, including Access Control List, bindings, scenes, group keys, operational
+    // certificates, etc.
+}
+
 CHIP_ERROR DeleteFabricFromTable(FabricIndex fabricIndex)
 {
     ReturnErrorOnFailure(Server::GetInstance().GetFabricTable().Delete(fabricIndex));
+
+    // If the FabricIndex matches the last remaining entry in the Fabrics list, then the device SHALL delete all Matter
+    // related data on the node which was created since it was commissioned.
+    if (Server::GetInstance().GetFabricTable().FabricCount() == 0)
+    {
+        MatterRelatedDataCleanup();
+    }
 
     // We need to withdraw the advertisement for the now-removed fabric, so need
     // to restart advertising altogether.

--- a/src/app/clusters/user-label-server/user-label-server.cpp
+++ b/src/app/clusters/user-label-server/user-label-server.cpp
@@ -25,7 +25,9 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/AttributeAccessInterface.h>
+#include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
+#include <credentials/FabricTable.h>
 #include <lib/support/CodeUtils.h>
 #include <lib/support/logging/CHIPLogging.h>
 #include <platform/DeviceInfoProvider.h>
@@ -184,7 +186,39 @@ CHIP_ERROR UserLabelAttrAccess::Write(const ConcreteDataAttributePath & aPath, A
 
 } // anonymous namespace
 
+class UserLabelFabricTableDelegate : public chip::FabricTable::Delegate
+{
+public:
+    // Gets called when a fabric is deleted
+    void OnFabricRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override
+    {
+        // If the FabricIndex matches the last remaining entry in the Fabrics list, then the device SHALL delete all Matter
+        // related data on the node which was created since it was commissioned.
+        if (Server::GetInstance().GetFabricTable().FabricCount() == 0)
+        {
+            ChipLogProgress(Zcl, "UserLabel: Last Fabric index 0x%x was removed", static_cast<unsigned>(fabricIndex));
+
+            // Delete all user label data on the node which was added since it was commissioned.
+            DeviceLayer::DeviceInfoProvider * provider = DeviceLayer::GetDeviceInfoProvider();
+            if (provider)
+            {
+                for (auto endpoint : EnabledEndpointsWithServerCluster(UserLabel::Id))
+                {
+                    // If UserLabel cluster is implemented on this endpoint
+                    if (CHIP_NO_ERROR != provider->ClearUserLabelList(endpoint))
+                    {
+                        ChipLogError(Zcl, "UserLabel::Failed to clear UserLabelList for endpoint:%d", endpoint);
+                    }
+                }
+            }
+        }
+    }
+};
+
+UserLabelFabricTableDelegate gUserLabelFabricDelegate;
+
 void MatterUserLabelPluginServerInitCallback(void)
 {
     registerAttributeAccessOverride(&gAttrAccess);
+    Server::GetInstance().GetFabricTable().AddFabricDelegate(&gUserLabelFabricDelegate);
 }

--- a/src/app/tests/suites/TestUserLabelCluster.yaml
+++ b/src/app/tests/suites/TestUserLabelCluster.yaml
@@ -28,6 +28,30 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
+    - label: "Commit User Label List"
+      command: "writeAttribute"
+      attribute: "label list"
+      arguments:
+          value:
+              [
+                  { label: "room", value: "bedroom 1" },
+                  { label: "orientation", value: "South" },
+                  { label: "floor", value: "2" },
+                  { label: "direction", value: "down" },
+              ]
+
+    - label: "Verify committed User Label List"
+      command: "readAttribute"
+      attribute: "label list"
+      response:
+          value:
+              [
+                  { label: "room", value: "bedroom 1" },
+                  { label: "orientation", value: "South" },
+                  { label: "floor", value: "2" },
+                  { label: "direction", value: "down" },
+              ]
+
     - label: "Clear User Label List"
       command: "writeAttribute"
       attribute: "label list"
@@ -64,7 +88,7 @@ tests:
               - name: "nodeId"
                 value: nodeId
 
-    - label: "Verify"
+    - label: "Verify User Label List after reboot"
       command: "readAttribute"
       attribute: "label list"
       response:

--- a/src/include/platform/DeviceInfoProvider.h
+++ b/src/include/platform/DeviceInfoProvider.h
@@ -90,6 +90,7 @@ public:
     void SetStorageDelegate(PersistentStorageDelegate * storage);
 
     CHIP_ERROR SetUserLabelList(EndpointId endpoint, const AttributeList<UserLabelType, kMaxUserLabelListLength> & labelList);
+    CHIP_ERROR ClearUserLabelList(EndpointId endpoint);
     CHIP_ERROR AppendUserLabel(EndpointId endpoint, const UserLabelType & label);
 
     // Iterators
@@ -132,6 +133,16 @@ protected:
      *         or other CHIP_ERROR values from implementation on other errors.
      */
     virtual CHIP_ERROR SetUserLabelAt(EndpointId endpoint, size_t index, const UserLabelType & userLabel) = 0;
+
+    /**
+     * @brief Delete the UserLabel at the specified index of the UserLabelList on a given endpoint
+     *
+     * @param endpoint - id to UserLabelList on which to delete the UserLabel.
+     * @param index - index within the UserLabelList for which to remove the UserLabel.
+     * @return CHIP_NO_ERROR on success, CHIP_ERROR_INVALID_KEY_ID if index exceed the range (Total length - 1),
+     *         or other CHIP_ERROR values from implementation on other errors.
+     */
+    virtual CHIP_ERROR DeleteUserLabelAt(EndpointId endpoint, size_t index) = 0;
 
     /**
      * @brief Set the total length of the UserLabelList on a given endpoint

--- a/src/platform/DeviceInfoProvider.cpp
+++ b/src/platform/DeviceInfoProvider.cpp
@@ -66,8 +66,9 @@ CHIP_ERROR DeviceInfoProvider::ClearUserLabelList(EndpointId endpoint)
 {
     size_t length;
 
-    ReturnErrorOnFailure(GetUserLabelLength(endpoint, length));
-    ReturnErrorOnFailure(SetUserLabelLength(endpoint, 0));
+    CHIP_ERROR err = GetUserLabelLength(endpoint, length);
+    VerifyOrReturnError(err != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND, CHIP_NO_ERROR);
+    ReturnErrorOnFailure(err);
 
     for (size_t i = 0; i < length; i++)
     {

--- a/src/platform/DeviceInfoProvider.cpp
+++ b/src/platform/DeviceInfoProvider.cpp
@@ -38,13 +38,40 @@ DeviceInfoProvider * gDeviceInfoProvider = nullptr;
 CHIP_ERROR DeviceInfoProvider::SetUserLabelList(EndpointId endpoint,
                                                 const AttributeList<UserLabelType, kMaxUserLabelListLength> & labelList)
 {
-    size_t index = 0;
+    size_t index          = 0;
+    size_t previousLength = 0;
+    size_t currentLength  = labelList.size();
 
-    ReturnErrorOnFailure(SetUserLabelLength(endpoint, labelList.size()));
+    CHIP_ERROR err = GetUserLabelLength(endpoint, previousLength);
+    VerifyOrReturnError(err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND || err == CHIP_NO_ERROR, err);
+
+    ReturnErrorOnFailure(SetUserLabelLength(endpoint, currentLength));
 
     for (const UserLabelType & label : labelList)
     {
         ReturnErrorOnFailure(SetUserLabelAt(endpoint, index++, label));
+    }
+
+    // If the list becomes smaller than previous list for a given endpoint, all "over-size" keys
+    // (keys for [current_length..previous_length-1]) should be deleted, to recover space.
+    for (size_t i = currentLength; i < previousLength; i++)
+    {
+        ReturnErrorOnFailure(DeleteUserLabelAt(endpoint, i));
+    }
+
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DeviceInfoProvider::ClearUserLabelList(EndpointId endpoint)
+{
+    size_t length;
+
+    ReturnErrorOnFailure(GetUserLabelLength(endpoint, length));
+    ReturnErrorOnFailure(SetUserLabelLength(endpoint, 0));
+
+    for (size_t i = 0; i < length; i++)
+    {
+        ReturnErrorOnFailure(DeleteUserLabelAt(endpoint, i));
     }
 
     return CHIP_NO_ERROR;


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* DeviceInfoProvider allows the UserLabel list to be set per endpoint
  - Default impl in `examples/providers/DeviceInfoProviderImpl.cpp`  stores current list size as one key, and all the entries for that endpoint as separate keys
 
* The problems this causes are as follows:
- If the list is written with N entries, it takes N+1 PersistentStorageDelegate entries instead of possibly 1-2: 1 for the length, 1 for the list of entries, or better, 1 for the whole set of entries
- If the list is written with 0 entries, the size changes, but impl in `examples/providers/DeviceInfoProviderImpl.cpp` does not delete or move any of the storage: all the storage is left behind.
- If the RemoveFabric is done on the last fabric, all the data is left behind, which violates the following paragraph of spec: 

> 11.18.7.12. RemoveFabric Command
> ...
> - If the FabricIndex matches the last remaining entry in the Fabrics list, then the device SHALL delete all Matter related data on the node which was created since it was commissioned. This includes all Fabric-Scoped data, including Access Control List, bindings, scenes, group keys, operational certificates, etc.
> 

* There is no way to delete any of the data on any of the endpoints. As soon as a userlabel is written, the key is persisted until the platform removes all storage.

* Fixes #21131 
#### Change overview
* Add APIs to the interface to handle removal of last fabric
* When the list becomes smaller than previous list for a given endpoint, all "over-size" keys (keys for [current_length..previous_length-1]) should be deleted, to recover space.

#### Testing
How was this tested? (at least one bullet point required)
* Build chip_tool and all-clusters-app
`scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone chip_config_network_layer_ble=false && scripts/examples/gn_build_example.sh examples/chip-tool out/debug/standalone`

* Run TestUserLabelCluster yaml test
`scripts/run_in_build_env.sh "./scripts/tests/run_test_suite.py --chip-tool ./out/debug/standalone/chip-tool --log-level debug --target TestUserLabelCluster run --iterations 1 --all-clusters-app ./out/debug/standalone/chip-all-clusters-app"  `
