### PR TITLE
[ESP32] Details for using ccache for idf builds

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -182,6 +182,7 @@ CatalogVendorId
 CBB
 cbd
 CBOR
+Ccache
 ccf
 CCMP
 CCS

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -113,6 +113,14 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
         $ source ./scripts/activate.sh
         ```
 
+-   Enable Ccache for faster IDF builds
+
+    It is recommended to have Ccache installed for faster builds
+
+    ```
+    $ export IDF_CCACHE_ENABLE=1
+    ```
+
 -   Target Set
 
 To set IDF target, first:

--- a/examples/all-clusters-app/esp32/README.md
+++ b/examples/all-clusters-app/esp32/README.md
@@ -286,8 +286,8 @@ the ESP32 all-clusters-app to commission it onto a Wi-Fi network:
 
 Parameters:
 
-1. Discriminator: 3840 (configurable through menuconfig)
-2. Setup-pin-code: 20202021 (configurable through menuconfig)
+1. Discriminator: 3840
+2. Setup-pin-code: 20202021
 3. Node-id: 12344321 (you can assign any node id)
 
 ### Cluster control

--- a/examples/all-clusters-minimal-app/esp32/README.md
+++ b/examples/all-clusters-minimal-app/esp32/README.md
@@ -286,8 +286,8 @@ the ESP32 all-clusters-minimal-app to commission it onto a Wi-Fi network:
 
 Parameters:
 
-1. Discriminator: 3840 (configurable through menuconfig)
-2. Setup-pin-code: 20202021 (configurable through menuconfig)
+1. Discriminator: 3840
+2. Setup-pin-code: 20202021
 3. Node-id: 12344321 (you can assign any node id)
 
 ### Cluster control

--- a/examples/all-clusters-minimal-app/esp32/README.md
+++ b/examples/all-clusters-minimal-app/esp32/README.md
@@ -113,6 +113,14 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
         $ source ./scripts/activate.sh
         ```
 
+-   Enable Ccache for faster IDF builds
+
+    It is recommended to have Ccache installed for faster builds
+
+    ```
+    $ export IDF_CCACHE_ENABLE=1
+    ```
+
 -   Target Set
 
 To set IDF target, first:

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -263,8 +263,8 @@ the ESP32 all-clusters-app to commission it onto a Wi-Fi network:
 
 Parameters:
 
-1. Discriminator: 3840 (configurable through menuconfig)
-2. Setup-pin-code: 20202021 (configurable through menuconfig)
+1. Discriminator: 3840
+2. Setup-pin-code: 20202021
 3. Node-id: 12344321 (you can assign any node id)
 
 ### Cluster control

--- a/examples/bridge-app/esp32/README.md
+++ b/examples/bridge-app/esp32/README.md
@@ -135,6 +135,14 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
     ESP32 based device types, please refer
     [examples/all-clusters-app/esp32](https://github.com/project-chip/connectedhomeip/tree/master/examples/all-clusters-app/esp32)
 
+-   Enable Ccache for faster IDF builds
+
+    It is recommended to have Ccache installed for faster builds
+
+    ```
+    $ export IDF_CCACHE_ENABLE=1
+    ```
+
 -   To build the demo application.
 
           ```

--- a/examples/light-switch-app/esp32/README.md
+++ b/examples/light-switch-app/esp32/README.md
@@ -65,6 +65,14 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
         $ source ./scripts/activate.sh
 
+-   Enable Ccache for faster IDF builds
+
+    It is recommended to have Ccache installed for faster builds
+
+    ```
+    $ export IDF_CCACHE_ENABLE=1
+    ```
+
 -   Target Set
 
         $ idf.py set-target esp32

--- a/examples/lighting-app/esp32/README.md
+++ b/examples/lighting-app/esp32/README.md
@@ -75,6 +75,14 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
         $ source ./scripts/activate.sh
 
+-   Enable Ccache for faster IDF builds
+
+    It is recommended to have Ccache installed for faster builds
+
+    ```
+    $ export IDF_CCACHE_ENABLE=1
+    ```
+
 -   Target Set
 
         $ idf.py set-target esp32

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -179,8 +179,8 @@ the ESP32 all-clusters-app to commission it onto a Wi-Fi network:
 
 Parameters:
 
-1. Discriminator: 3840 (configurable through menuconfig)
-2. Setup-pin-code: 20202021 (configurable through menuconfig)
+1. Discriminator: 3840
+2. Setup-pin-code: 20202021
 3. Node-id: 12344321 (you can assign any node id)
 
 ### Cluster control

--- a/examples/lock-app/esp32/README.md
+++ b/examples/lock-app/esp32/README.md
@@ -57,6 +57,14 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
         $ source ./scripts/activate.sh
 
+-   Enable Ccache for faster IDF builds
+
+    It is recommended to have Ccache installed for faster builds
+
+    ```
+    $ export IDF_CCACHE_ENABLE=1
+    ```
+
 -   Target Set
 
         $ idf.py set-target esp32(or esp32c3)

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -57,6 +57,14 @@ make sure the IDF_PATH has been exported(See the manual setup steps above).
 
         $ source ./scripts/activate.sh
 
+-   Enable Ccache for faster IDF builds
+
+    It is recommended to have Ccache installed for faster builds
+
+    ```
+    $ export IDF_CCACHE_ENABLE=1
+    ```
+
 -   Target Select
 
         $ idf.py set-target esp32(or esp32c3)

--- a/examples/temperature-measurement-app/esp32/README.md
+++ b/examples/temperature-measurement-app/esp32/README.md
@@ -179,8 +179,8 @@ the ESP32 all-clusters-app to commission it onto a Wi-Fi network:
 
 Parameters:
 
-1. Discriminator: 3840 (configurable through menuconfig)
-2. Setup-pin-code: 20202021 (configurable through menuconfig)
+1. Discriminator: 3840
+2. Setup-pin-code: 20202021
 3. Node-id: 12344321 (you can assign any node id)
 
 ### Cluster control


### PR DESCRIPTION
#### Problem
* Building matter examples for ESP32 takes a lot of time

#### Change overview
* Details for using ccache with IDF builds
* Removed the stale menuconfig option details

#### Testing
- First local build took around ~6min and subsequent build was just ~2min