### PR TITLE
add ScanNetworks step to CHIPDeviceController

### DIFF
--- a/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/GenericChipDeviceListener.kt
+++ b/src/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/GenericChipDeviceListener.kt
@@ -23,6 +23,14 @@ open class GenericChipDeviceListener : ChipDeviceController.CompletionListener {
     // No op
   }
 
+  override fun onReadCommissioningInfo(vendorId: Int,productId: Int, wifiEndpointId: Int, threadEndpointId: Int) {
+    // No op
+  }
+
+  override fun onCommissioningStatusUpdate(nodeId: Long, stage: String, errorCode: Int) {
+    // No op
+  }
+
   override fun onNotifyChipConnectionClosed() {
     // No op
   }

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -38,11 +38,32 @@ public:
 
     CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningDelegate::CommissioningReport report) override;
 
+    /**
+     * @brief
+     *   This function puts the AutoCommissioner in a paused state to prevent advancing to the next stage.
+     * It is expected that a DevicePairingDelegate may call this method when processing the
+     * OnCommissioningStatusUpdate, for example, in order to obtain network credentials from the user based
+     * upon the results of the NetworkScan.
+     * Use ResumeCommissioning to continue the commissioning process.
+     *
+     */
+    void PauseCommissioning();
+
+    /**
+     * @brief
+     *   An error return value means resume failed, for example:
+     *   - AutoCommissioner was not in a paused state.
+     *   - AutoCommissioner was unable to continue (no DeviceProxy)
+     */
+    CHIP_ERROR ResumeCommissioning();
+
 protected:
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);
     DeviceCommissioner * GetCommissioner() { return mCommissioner; }
+    CHIP_ERROR PerformStep(CommissioningStage nextStage);
 
 private:
+    DeviceProxy * GetDeviceProxyForStep(CommissioningStage nextStage);
     void ReleaseDAC();
     void ReleasePAI();
 
@@ -74,6 +95,9 @@ private:
 
     bool mNeedsNetworkSetup = false;
     ReadCommissioningInfo mDeviceCommissioningInfo;
+
+    CommissioningStage mPausedStage = CommissioningStage::kError;
+    bool mCommissioningPaused       = false;
 
     // TODO: Why were the nonces statically allocated, but the certs dynamically allocated?
     uint8_t * mDAC   = nullptr;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1592,6 +1592,7 @@ void DeviceCommissioner::CommissioningStageComplete(CHIP_ERROR err, Commissionin
     {
         mPairingDelegate->OnCommissioningStatusUpdate(PeerId(GetCompressedFabricId(), nodeId), mCommissioningStage, err);
     }
+
     if (mCommissioningDelegate == nullptr)
     {
         return;
@@ -1747,20 +1748,27 @@ void DeviceCommissioner::OnDone(app::ReadClient *)
                 {
                     if (features.Has(app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kWiFiNetworkInterface))
                     {
+                        ChipLogProgress(Controller, "----- NetworkCommissioning Features: has WiFi. endpointid = %u",
+                                        path.mEndpointId);
                         info.network.wifi.endpoint = path.mEndpointId;
                     }
                     else if (features.Has(
                                  app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kThreadNetworkInterface))
                     {
+                        ChipLogProgress(Controller, "----- NetworkCommissioning Features: has Thread. endpointid = %u",
+                                        path.mEndpointId);
                         info.network.thread.endpoint = path.mEndpointId;
                     }
                     else if (features.Has(
                                  app::Clusters::NetworkCommissioning::NetworkCommissioningFeature::kEthernetNetworkInterface))
                     {
+                        ChipLogProgress(Controller, "----- NetworkCommissioning Features: has Ethernet. endpointid = %u",
+                                        path.mEndpointId);
                         info.network.eth.endpoint = path.mEndpointId;
                     }
                     else
                     {
+                        ChipLogProgress(Controller, "----- NetworkCommissioning Features: no features.");
                         // TODO: Gross workaround for the empty feature map on all clusters. Remove.
                         if (info.network.thread.endpoint == kInvalidEndpointId)
                         {
@@ -1809,6 +1817,12 @@ void DeviceCommissioner::OnDone(app::ReadClient *)
     }
     mAttributeCache = nullptr;
     mReadClient     = nullptr;
+
+    if (mPairingDelegate != nullptr)
+    {
+        mPairingDelegate->OnReadCommissioningInfo(info);
+    }
+
     CommissioningDelegate::CommissioningReport report;
     report.Set<ReadCommissioningInfo>(info);
     CommissioningStageComplete(return_err, report);
@@ -1845,6 +1859,39 @@ void DeviceCommissioner::OnSetRegulatoryConfigResponse(
     }
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
     commissioner->CommissioningStageComplete(err, report);
+}
+
+void DeviceCommissioner::OnScanNetworksFailure(void * context, CHIP_ERROR error)
+{
+    ChipLogProgress(Controller, "Received ScanNetworks failure response %" CHIP_ERROR_FORMAT, error.Format());
+
+    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
+    if (commissioner->GetPairingDelegate() != nullptr)
+    {
+        commissioner->GetPairingDelegate()->OnScanNetworksFailure(error);
+    }
+    // need to advance to next step
+    // clear error so that we don't abort the commissioning when ScanNetworks fails
+    commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
+}
+
+void DeviceCommissioner::OnScanNetworksResponse(void * context,
+                                                const NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & data)
+{
+    CommissioningDelegate::CommissioningReport report;
+
+    ChipLogProgress(Controller, "Received ScanNetwork response, networkingStatus=%u debugText=%s",
+                    to_underlying(data.networkingStatus),
+                    (data.debugText.HasValue() ? std::string(data.debugText.Value().data(), data.debugText.Value().size()).c_str()
+                                               : "none provided"));
+    DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
+
+    if (commissioner->GetPairingDelegate() != nullptr)
+    {
+        commissioner->GetPairingDelegate()->OnScanNetworksSuccess(data);
+    }
+    // need to advance to next step
+    commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
 }
 
 void DeviceCommissioner::OnNetworkConfigResponse(void * context,
@@ -1976,6 +2023,16 @@ void DeviceCommissioner::PerformCommissioningStep(DeviceProxy * proxy, Commissio
         mReadClient     = std::move(readClient);
     }
     break;
+    case CommissioningStage::kScanNetworks: {
+        NetworkCommissioning::Commands::ScanNetworks::Type request;
+        if (params.GetWiFiCredentials().HasValue())
+        {
+            request.ssid.Emplace(params.GetWiFiCredentials().Value().ssid);
+        }
+        request.breadcrumb.Emplace(breadcrumb);
+        SendCommand<NetworkCommissioningCluster>(proxy, request, OnScanNetworksResponse, OnScanNetworksFailure, endpoint, timeout);
+        break;
+    }
     case CommissioningStage::kConfigRegulatory: {
         // To set during config phase:
         // UTC time

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -773,8 +773,12 @@ private:
         void * context,
         const chip::app::Clusters::GeneralCommissioning::Commands::SetRegulatoryConfigResponse::DecodableType & data);
     static void
+    OnScanNetworksResponse(void * context,
+                           const app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & data);
+    static void OnScanNetworksFailure(void * context, CHIP_ERROR err);
+    static void
     OnNetworkConfigResponse(void * context,
-                            const chip::app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & data);
+                            const app::Clusters::NetworkCommissioning::Commands::NetworkConfigResponse::DecodableType & data);
     static void OnConnectNetworkResponse(
         void * context, const chip::app::Clusters::NetworkCommissioning::Commands::ConnectNetworkResponse::DecodableType & data);
     static void OnCommissioningCompleteResponse(

--- a/src/controller/CommissioningDelegate.cpp
+++ b/src/controller/CommissioningDelegate.cpp
@@ -41,6 +41,10 @@ const char * StageToString(CommissioningStage stage)
         return "ArmFailSafe";
         break;
 
+    case kScanNetworks:
+        return "ScanNetworks";
+        break;
+
     case kConfigRegulatory:
         return "ConfigRegulatory";
         break;

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -52,6 +52,9 @@ enum CommissioningStage : uint8_t
     kFindOperational,
     kSendComplete,
     kCleanup,
+    // ScanNetworks can happen anytime after kArmFailsafe.
+    // However, the circ tests fail if it is earlier in the list
+    kScanNetworks,
 };
 
 const char * StageToString(CommissioningStage stage);
@@ -261,10 +264,12 @@ public:
         return *this;
     }
 
+    // If a ThreadOperationalDataset is provided, then the ThreadNetworkScan will not be attempted
     CommissioningParameters & SetThreadOperationalDataset(ByteSpan threadOperationalDataset)
     {
 
         mThreadOperationalDataset.SetValue(threadOperationalDataset);
+        mAttemptThreadNetworkScan = MakeOptional(static_cast<bool>(false));
         return *this;
     }
     // This parameter should be set with the information returned from kSendOpCertSigningRequest. It must be set before calling
@@ -352,6 +357,26 @@ public:
 
     Credentials::DeviceAttestationDelegate * GetDeviceAttestationDelegate() const { return mDeviceAttestationDelegate; }
 
+    // If an SSID is provided, and AttemptWiFiNetworkScan is true,
+    // then a directed scan will be performed using the SSID provided in the WiFiCredentials object
+    Optional<bool> GetAttemptWiFiNetworkScan() const { return mAttemptWiFiNetworkScan; }
+    CommissioningParameters & SetAttemptWiFiNetworkScan(bool attemptWiFiNetworkScan)
+    {
+        mAttemptWiFiNetworkScan = MakeOptional(attemptWiFiNetworkScan);
+        return *this;
+    }
+
+    // If a ThreadOperationalDataset is provided, then the ThreadNetworkScan will not be attempted
+    Optional<bool> GetAttemptThreadNetworkScan() const { return mAttemptThreadNetworkScan; }
+    CommissioningParameters & SetAttemptThreadNetworkScan(bool attemptThreadNetworkScan)
+    {
+        if (!mThreadOperationalDataset.HasValue())
+        {
+            mAttemptThreadNetworkScan = MakeOptional(attemptThreadNetworkScan);
+        }
+        return *this;
+    }
+
 private:
     // Items that can be set by the commissioner
     Optional<uint16_t> mFailsafeTimerSeconds;
@@ -379,6 +404,8 @@ private:
     CompletionStatus completionStatus;
     Credentials::DeviceAttestationDelegate * mDeviceAttestationDelegate =
         nullptr; // Delegate to handle device attestation failures during commissioning
+    Optional<bool> mAttemptWiFiNetworkScan;
+    Optional<bool> mAttemptThreadNetworkScan; // This automatically gets set to false when a ThreadOperationalDataset is set
 };
 
 struct RequestedCertificate

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -17,6 +17,7 @@
 
 #pragma once
 
+#include <app-common/zap-generated/cluster-objects.h>
 #include <controller/CommissioningDelegate.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/NodeId.h>
@@ -75,6 +76,26 @@ public:
     {}
 
     virtual void OnCommissioningStatusUpdate(PeerId peerId, CommissioningStage stageCompleted, CHIP_ERROR error) {}
+
+    /**
+     * @brief
+     *  Called with the ReadCommissioningInfo returned from the target
+     */
+    virtual void OnReadCommissioningInfo(const ReadCommissioningInfo & info) {}
+
+    /**
+     * @brief
+     *  Called with the NetworkScanResponse returned from the target
+     */
+    virtual void
+    OnScanNetworksSuccess(const app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & dataResponse)
+    {}
+
+    /**
+     * @brief
+     *  Called when the NetworkScan request fails.
+     */
+    virtual void OnScanNetworksFailure(CHIP_ERROR error) {}
 };
 
 } // namespace Controller

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -74,7 +74,8 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     chip::Inet::EndPointManager<Inet::TCPEndPoint> * tcpEndPointManager,
     chip::Inet::EndPointManager<Inet::UDPEndPoint> * udpEndPointManager, AndroidOperationalCredentialsIssuerPtr opCredsIssuerPtr,
     jobject keypairDelegate, jbyteArray rootCertificate, jbyteArray intermediateCertificate, jbyteArray nodeOperationalCertificate,
-    jbyteArray ipkEpochKey, uint16_t listenPort, CHIP_ERROR * errInfoOnFailure)
+    jbyteArray ipkEpochKey, uint16_t listenPort, uint16_t controllerVendorId, uint16_t failsafeTimerSeconds,
+    bool attemptNetworkScanWiFi, bool attemptNetworkScanThread, CHIP_ERROR * errInfoOnFailure)
 {
     if (errInfoOnFailure == nullptr)
     {
@@ -146,9 +147,16 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     setupParams.controllerVendorId             = VendorId::NotSpecified;
     setupParams.pairingDelegate                = wrapper.get();
     setupParams.operationalCredentialsDelegate = opCredsIssuer;
+    setupParams.defaultCommissioner            = &wrapper->mAutoCommissioner;
     initParams.fabricIndependentStorage        = wrapperStorage;
 
     wrapper->mGroupDataProvider.SetStorageDelegate(wrapperStorage);
+
+    CommissioningParameters params = wrapper->mAutoCommissioner.GetCommissioningParameters();
+    params.SetFailsafeTimerSeconds(failsafeTimerSeconds);
+    params.SetAttemptWiFiNetworkScan(attemptNetworkScanWiFi);
+    params.SetAttemptThreadNetworkScan(attemptNetworkScanThread);
+    wrapper->UpdateCommissioningParameters(params);
 
     CHIP_ERROR err = wrapper->mGroupDataProvider.Init();
     if (err != CHIP_NO_ERROR)
@@ -358,6 +366,13 @@ CHIP_ERROR AndroidDeviceControllerWrapper::ApplyNetworkCredentials(chip::Control
     return err;
 }
 
+CHIP_ERROR AndroidDeviceControllerWrapper::UpdateCommissioningParameters(const chip::Controller::CommissioningParameters & params)
+{
+    // this will wipe out any custom attestationNonce and csrNonce that was being used.
+    // however, Android APIs don't allow these to be set to custom values today.
+    return mAutoCommissioner.SetCommissioningParameters(params);
+}
+
 void AndroidDeviceControllerWrapper::OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status)
 {
     chip::DeviceLayer::StackUnlock unlock;
@@ -401,6 +416,210 @@ void AndroidDeviceControllerWrapper::OnCommissioningComplete(NodeId deviceId, CH
         env->ReleaseByteArrayElements(operationalDatasetBytes, operationalDataset, 0);
         env->DeleteGlobalRef(operationalDatasetBytes);
     }
+}
+
+void AndroidDeviceControllerWrapper::OnCommissioningStatusUpdate(PeerId peerId, chip::Controller::CommissioningStage stageCompleted,
+                                                                 CHIP_ERROR error)
+{
+    chip::DeviceLayer::StackUnlock unlock;
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    jmethodID onCommissioningStatusUpdateMethod;
+    CHIP_ERROR err = JniReferences::GetInstance().FindMethod(env, mJavaObjectRef, "onCommissioningStatusUpdate",
+                                                             "(JLJAVA/LANG/STRING;I)V", &onCommissioningStatusUpdateMethod);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error finding Java method: %" CHIP_ERROR_FORMAT, err.Format()));
+
+    UtfString jStageCompleted(env, StageToString(stageCompleted));
+    env->CallVoidMethod(mJavaObjectRef, onCommissioningStatusUpdateMethod, static_cast<jlong>(peerId.GetNodeId()),
+                        jStageCompleted.jniValue(), error.AsInteger());
+}
+
+void AndroidDeviceControllerWrapper::OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info)
+{
+    // calls: onReadCommissioningInfo(int vendorId, int productId, int wifiEndpointId, int threadEndpointId)
+    chip::DeviceLayer::StackUnlock unlock;
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+    jmethodID onReadCommissioningInfoMethod;
+    CHIP_ERROR err = JniReferences::GetInstance().FindMethod(env, mJavaObjectRef, "onReadCommissioningInfo", "(IIII)V",
+                                                             &onReadCommissioningInfoMethod);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error finding Java method: %" CHIP_ERROR_FORMAT, err.Format()));
+
+    env->CallVoidMethod(mJavaObjectRef, onReadCommissioningInfoMethod, static_cast<jint>(info.basic.vendorId),
+                        static_cast<jint>(info.basic.productId), static_cast<jint>(info.network.wifi.endpoint),
+                        static_cast<jint>(info.network.thread.endpoint));
+}
+
+void AndroidDeviceControllerWrapper::OnScanNetworksSuccess(
+    const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & dataResponse)
+{
+    chip::DeviceLayer::StackUnlock unlock;
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
+    jmethodID javaMethod;
+
+    VerifyOrReturn(env != nullptr, ChipLogError(Zcl, "Error invoking Java callback: no JNIEnv"));
+
+    err = JniReferences::GetInstance().FindMethod(
+        env, mJavaObjectRef, "onScanNetworksSuccess",
+        "(Ljava/lang/Integer;Ljava/util/Optional;Ljava/util/Optional;Ljava/util/Optional;)V", &javaMethod);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Error invoking Java callback: %s", ErrorStr(err)));
+
+    jobject NetworkingStatus;
+    std::string NetworkingStatusClassName     = "java/lang/Integer";
+    std::string NetworkingStatusCtorSignature = "(I)V";
+    chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
+        NetworkingStatusClassName.c_str(), NetworkingStatusCtorSignature.c_str(),
+        static_cast<uint8_t>(dataResponse.networkingStatus), NetworkingStatus);
+    jobject DebugText;
+    if (!dataResponse.debugText.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, DebugText);
+    }
+    else
+    {
+        jobject DebugTextInsideOptional;
+        DebugTextInsideOptional =
+            env->NewStringUTF(std::string(dataResponse.debugText.Value().data(), dataResponse.debugText.Value().size()).c_str());
+        chip::JniReferences::GetInstance().CreateOptional(DebugTextInsideOptional, DebugText);
+    }
+    jobject WiFiScanResults;
+    if (!dataResponse.wiFiScanResults.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, WiFiScanResults);
+    }
+    else
+    {
+        // TODO: use this
+        jobject WiFiScanResultsInsideOptional;
+        chip::JniReferences::GetInstance().CreateArrayList(WiFiScanResultsInsideOptional);
+
+        auto iter_WiFiScanResultsInsideOptional = dataResponse.wiFiScanResults.Value().begin();
+        while (iter_WiFiScanResultsInsideOptional.Next())
+        {
+            auto & entry = iter_WiFiScanResultsInsideOptional.GetValue();
+            jobject newElement_security;
+            std::string newElement_securityClassName     = "java/lang/Integer";
+            std::string newElement_securityCtorSignature = "(I)V";
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(newElement_securityClassName.c_str(),
+                                                                          newElement_securityCtorSignature.c_str(),
+                                                                          entry.security.Raw(), newElement_security);
+            jobject newElement_ssid;
+            jbyteArray newElement_ssidByteArray = env->NewByteArray(static_cast<jsize>(entry.ssid.size()));
+            env->SetByteArrayRegion(newElement_ssidByteArray, 0, static_cast<jsize>(entry.ssid.size()),
+                                    reinterpret_cast<const jbyte *>(entry.ssid.data()));
+            newElement_ssid = newElement_ssidByteArray;
+            jobject newElement_bssid;
+            jbyteArray newElement_bssidByteArray = env->NewByteArray(static_cast<jsize>(entry.bssid.size()));
+            env->SetByteArrayRegion(newElement_bssidByteArray, 0, static_cast<jsize>(entry.bssid.size()),
+                                    reinterpret_cast<const jbyte *>(entry.bssid.data()));
+            newElement_bssid = newElement_bssidByteArray;
+            jobject newElement_channel;
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>("java/lang/Integer", "(I)V", entry.channel,
+                                                                           newElement_channel);
+            jobject newElement_wiFiBand;
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>(
+                "java/lang/Integer", "(I)V", static_cast<uint8_t>(entry.wiFiBand), newElement_wiFiBand);
+            jobject newElement_rssi;
+            chip::JniReferences::GetInstance().CreateBoxedObject<int8_t>("java/lang/Integer", "(I)V", entry.rssi, newElement_rssi);
+
+            jclass wiFiInterfaceScanResultStructClass;
+            err = chip::JniReferences::GetInstance().GetClassRef(
+                env, "chip/devicecontroller/ChipStructs$NetworkCommissioningClusterWiFiInterfaceScanResult",
+                wiFiInterfaceScanResultStructClass);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterWiFiInterfaceScanResult");
+                return;
+            }
+            jmethodID wiFiInterfaceScanResultStructCtor =
+                env->GetMethodID(wiFiInterfaceScanResultStructClass, "<init>",
+                                 "(Ljava/lang/Integer;[B[BLjava/lang/Integer;Ljava/lang/Integer;Ljava/lang/Integer;)V");
+            if (wiFiInterfaceScanResultStructCtor == nullptr)
+            {
+                ChipLogError(Zcl, "Could not find ChipStructs$NetworkCommissioningClusterWiFiInterfaceScanResult constructor");
+                return;
+            }
+
+            jobject newElement =
+                env->NewObject(wiFiInterfaceScanResultStructClass, wiFiInterfaceScanResultStructCtor, newElement_security,
+                               newElement_ssid, newElement_bssid, newElement_channel, newElement_wiFiBand, newElement_rssi);
+            chip::JniReferences::GetInstance().AddToList(WiFiScanResultsInsideOptional, newElement);
+        }
+        chip::JniReferences::GetInstance().CreateOptional(WiFiScanResultsInsideOptional, WiFiScanResults);
+    }
+    jobject ThreadScanResults;
+    if (!dataResponse.threadScanResults.HasValue())
+    {
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, ThreadScanResults);
+    }
+    else
+    {
+        jobject ThreadScanResultsInsideOptional;
+        chip::JniReferences::GetInstance().CreateArrayList(ThreadScanResultsInsideOptional);
+
+        auto iter_ThreadScanResultsInsideOptional = dataResponse.threadScanResults.Value().begin();
+        while (iter_ThreadScanResultsInsideOptional.Next())
+        {
+            auto & entry = iter_ThreadScanResultsInsideOptional.GetValue();
+            jobject newElement_panId;
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>("java/lang/Integer", "(I)V", entry.panId,
+                                                                           newElement_panId);
+            jobject newElement_extendedPanId;
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint64_t>("java/lang/Long", "(J)V", entry.extendedPanId,
+                                                                           newElement_extendedPanId);
+            jobject newElement_networkName;
+            newElement_networkName = env->NewStringUTF(std::string(entry.networkName.data(), entry.networkName.size()).c_str());
+            jobject newElement_channel;
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint16_t>("java/lang/Integer", "(I)V", entry.channel,
+                                                                           newElement_channel);
+            jobject newElement_version;
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>("java/lang/Integer", "(I)V", entry.version,
+                                                                          newElement_version);
+            jobject newElement_extendedAddress;
+            jbyteArray newElement_extendedAddressByteArray = env->NewByteArray(static_cast<jsize>(entry.extendedAddress.size()));
+            env->SetByteArrayRegion(newElement_extendedAddressByteArray, 0, static_cast<jsize>(entry.extendedAddress.size()),
+                                    reinterpret_cast<const jbyte *>(entry.extendedAddress.data()));
+            newElement_extendedAddress = newElement_extendedAddressByteArray;
+            jobject newElement_rssi;
+            chip::JniReferences::GetInstance().CreateBoxedObject<int8_t>("java/lang/Integer", "(I)V", entry.rssi, newElement_rssi);
+            jobject newElement_lqi;
+            chip::JniReferences::GetInstance().CreateBoxedObject<uint8_t>("java/lang/Integer", "(I)V", entry.lqi, newElement_lqi);
+
+            jclass threadInterfaceScanResultStructClass;
+            err = chip::JniReferences::GetInstance().GetClassRef(
+                env, "chip/devicecontroller/ChipStructs$NetworkCommissioningClusterThreadInterfaceScanResult",
+                threadInterfaceScanResultStructClass);
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(Zcl, "Could not find class ChipStructs$NetworkCommissioningClusterThreadInterfaceScanResult");
+                return;
+            }
+            jmethodID threadInterfaceScanResultStructCtor =
+                env->GetMethodID(threadInterfaceScanResultStructClass, "<init>",
+                                 "(Ljava/lang/Integer;Ljava/lang/Long;Ljava/lang/String;Ljava/lang/Integer;Ljava/lang/"
+                                 "Integer;[BLjava/lang/Integer;Ljava/lang/Integer;)V");
+            if (threadInterfaceScanResultStructCtor == nullptr)
+            {
+                ChipLogError(Zcl, "Could not find ChipStructs$NetworkCommissioningClusterThreadInterfaceScanResult constructor");
+                return;
+            }
+
+            jobject newElement =
+                env->NewObject(threadInterfaceScanResultStructClass, threadInterfaceScanResultStructCtor, newElement_panId,
+                               newElement_extendedPanId, newElement_networkName, newElement_channel, newElement_version,
+                               newElement_extendedAddress, newElement_rssi, newElement_lqi);
+            chip::JniReferences::GetInstance().AddToList(ThreadScanResultsInsideOptional, newElement);
+        }
+        chip::JniReferences::GetInstance().CreateOptional(ThreadScanResultsInsideOptional, ThreadScanResults);
+    }
+
+    env->CallVoidMethod(mJavaObjectRef, javaMethod, NetworkingStatus, DebugText, WiFiScanResults, ThreadScanResults);
+}
+
+void AndroidDeviceControllerWrapper::OnScanNetworksFailure(CHIP_ERROR error)
+{
+    chip::DeviceLayer::StackUnlock unlock;
+
+    CallJavaMethod("onScanNetworksFailure", static_cast<jint>(error.AsInteger()));
 }
 
 CHIP_ERROR AndroidDeviceControllerWrapper::SyncGetKeyValue(const char * key, void * value, uint16_t & size)

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -70,16 +70,34 @@ public:
      */
     CHIP_ERROR ApplyNetworkCredentials(chip::Controller::CommissioningParameters & params, jobject networkCredentials);
 
+    /**
+     * Update the CommissioningParameters used by the active device commissioner
+     */
+    CHIP_ERROR UpdateCommissioningParameters(const chip::Controller::CommissioningParameters & params);
+
     // DevicePairingDelegate implementation
     void OnStatusUpdate(chip::Controller::DevicePairingDelegate::Status status) override;
     void OnPairingComplete(CHIP_ERROR error) override;
     void OnPairingDeleted(CHIP_ERROR error) override;
     void OnCommissioningComplete(chip::NodeId deviceId, CHIP_ERROR error) override;
+    void OnCommissioningStatusUpdate(chip::PeerId peerId, chip::Controller::CommissioningStage stageCompleted,
+                                     CHIP_ERROR error) override;
+    void OnReadCommissioningInfo(const chip::Controller::ReadCommissioningInfo & info) override;
+    void OnScanNetworksSuccess(
+        const chip::app::Clusters::NetworkCommissioning::Commands::ScanNetworksResponse::DecodableType & dataResponse) override;
+    void OnScanNetworksFailure(CHIP_ERROR error) override;
 
     // PersistentStorageDelegate implementation
     CHIP_ERROR SyncSetKeyValue(const char * key, const void * value, uint16_t size) override;
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override;
     CHIP_ERROR SyncDeleteKeyValue(const char * key) override;
+
+    chip::Controller::AutoCommissioner * GetAutoCommissioner() { return &mAutoCommissioner; }
+
+    const chip::Controller::CommissioningParameters & GetCommissioningParameters() const
+    {
+        return mAutoCommissioner.GetCommissioningParameters();
+    }
 
     static AndroidDeviceControllerWrapper * FromJNIHandle(jlong handle)
     {
@@ -113,16 +131,20 @@ public:
      * @param[in] nodeOperationalCertificate an X.509 DER-encoded operational certificate for this node
      * @param[in] ipkEpochKey the IPK epoch key to use for this node
      * @param[in] listenPort the UDP port to listen on
+     * @param[in] controllerVendorId the vendor ID identifying the controller
+     * @param[in] failsafeTimerSeconds the failsafe timer in seconds
+     * @param[in] attemptNetworkScanWiFi whether to attempt a network scan when configuring the network for a WiFi device
+     * @param[in] attemptNetworkScanThread whether to attempt a network scan when configuring the network for a Thread device
      * @param[out] errInfoOnFailure a pointer to a CHIP_ERROR that will be populated if this method returns nullptr
      */
-    static AndroidDeviceControllerWrapper * AllocateNew(JavaVM * vm, jobject deviceControllerObj, chip::NodeId nodeId,
-                                                        const chip::CATValues & cats, chip::System::Layer * systemLayer,
-                                                        chip::Inet::EndPointManager<chip::Inet::TCPEndPoint> * tcpEndPointManager,
-                                                        chip::Inet::EndPointManager<chip::Inet::UDPEndPoint> * udpEndPointManager,
-                                                        AndroidOperationalCredentialsIssuerPtr opCredsIssuer,
-                                                        jobject keypairDelegate, jbyteArray rootCertificate,
-                                                        jbyteArray intermediateCertificate, jbyteArray nodeOperationalCertificate,
-                                                        jbyteArray ipkEpochKey, uint16_t listenPort, CHIP_ERROR * errInfoOnFailure);
+    static AndroidDeviceControllerWrapper *
+    AllocateNew(JavaVM * vm, jobject deviceControllerObj, chip::NodeId nodeId, const chip::CATValues & cats,
+                chip::System::Layer * systemLayer, chip::Inet::EndPointManager<chip::Inet::TCPEndPoint> * tcpEndPointManager,
+                chip::Inet::EndPointManager<chip::Inet::UDPEndPoint> * udpEndPointManager,
+                AndroidOperationalCredentialsIssuerPtr opCredsIssuer, jobject keypairDelegate, jbyteArray rootCertificate,
+                jbyteArray intermediateCertificate, jbyteArray nodeOperationalCertificate, jbyteArray ipkEpochKey,
+                uint16_t listenPort, uint16_t controllerVendorId, uint16_t failsafeTimerSeconds, bool attemptNetworkScanWiFi,
+                bool attemptNetworkScanThread, CHIP_ERROR * errInfoOnFailure);
 
 private:
     using ChipDeviceControllerPtr = std::unique_ptr<chip::Controller::DeviceCommissioner>;
@@ -145,6 +167,8 @@ private:
     const char * password              = nullptr;
     jbyteArray operationalDatasetBytes = nullptr;
     jbyte * operationalDataset         = nullptr;
+
+    chip::Controller::AutoCommissioner mAutoCommissioner;
 
     AndroidDeviceControllerWrapper(ChipDeviceControllerPtr controller, AndroidOperationalCredentialsIssuerPtr opCredsIssuer) :
         mController(std::move(controller)), mOpCredsIssuer(std::move(opCredsIssuer))

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -169,6 +169,25 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject contr
     err = chip::JniReferences::GetInstance().FindMethod(env, controllerParams, "getUdpListenPort", "()I", &getUdpListenPort);
     SuccessOrExit(err);
 
+    jmethodID getControllerVendorId;
+    err = chip::JniReferences::GetInstance().FindMethod(env, controllerParams, "getControllerVendorId", "()I",
+                                                        &getControllerVendorId);
+
+    jmethodID getFailsafeTimerSeconds;
+    err = chip::JniReferences::GetInstance().FindMethod(env, controllerParams, "getFailsafeTimerSeconds", "()I",
+                                                        &getFailsafeTimerSeconds);
+    SuccessOrExit(err);
+
+    jmethodID getAttemptNetworkScanWiFi;
+    err = chip::JniReferences::GetInstance().FindMethod(env, controllerParams, "getAttemptNetworkScanWiFi", "()Z",
+                                                        &getAttemptNetworkScanWiFi);
+    SuccessOrExit(err);
+
+    jmethodID getAttemptNetworkScanThread;
+    err = chip::JniReferences::GetInstance().FindMethod(env, controllerParams, "getAttemptNetworkScanThread", "()Z",
+                                                        &getAttemptNetworkScanThread);
+    SuccessOrExit(err);
+
     jmethodID getKeypairDelegate;
     err = chip::JniReferences::GetInstance().FindMethod(env, controllerParams, "getKeypairDelegate",
                                                         "()Lchip/devicecontroller/KeypairDelegate;", &getKeypairDelegate);
@@ -199,13 +218,17 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject contr
         jbyteArray intermediateCertificate = (jbyteArray) env->CallObjectMethod(controllerParams, getIntermediateCertificate);
         jbyteArray operationalCertificate  = (jbyteArray) env->CallObjectMethod(controllerParams, getOperationalCertificate);
         jbyteArray ipk                     = (jbyteArray) env->CallObjectMethod(controllerParams, getIpk);
+        uint16_t failsafeTimerSeconds      = env->CallIntMethod(controllerParams, getFailsafeTimerSeconds);
+        bool attemptNetworkScanWiFi        = env->CallIntMethod(controllerParams, getAttemptNetworkScanWiFi);
+        bool attemptNetworkScanThread      = env->CallIntMethod(controllerParams, getAttemptNetworkScanThread);
 
         std::unique_ptr<chip::Controller::AndroidOperationalCredentialsIssuer> opCredsIssuer(
             new chip::Controller::AndroidOperationalCredentialsIssuer());
         wrapper = AndroidDeviceControllerWrapper::AllocateNew(
             sJVM, self, kLocalDeviceId, chip::kUndefinedCATs, &DeviceLayer::SystemLayer(), DeviceLayer::TCPEndPointManager(),
             DeviceLayer::UDPEndPointManager(), std::move(opCredsIssuer), keypairDelegate, rootCertificate, intermediateCertificate,
-            operationalCertificate, ipk, listenPort, &err);
+            operationalCertificate, ipk, listenPort, controllerVendorId, failsafeTimerSeconds, attemptNetworkScanWiFi,
+            attemptNetworkScanThread, &err);
         SuccessOrExit(err);
     }
 
@@ -374,6 +397,48 @@ JNI_METHOD(void, establishPaseConnectionByAddress)
     if (err != CHIP_NO_ERROR)
     {
         ChipLogError(Controller, "Failed to establish PASE connection.");
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+    }
+}
+
+JNI_METHOD(void, pauseCommissioning)
+(JNIEnv * env, jobject self, jlong handle)
+{
+    ChipLogProgress(Controller, "pauseCommissioning() called");
+    chip::DeviceLayer::StackLock lock;
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+
+    wrapper->GetAutoCommissioner()->PauseCommissioning();
+}
+
+JNI_METHOD(void, resumeCommissioning)
+(JNIEnv * env, jobject self, jlong handle)
+{
+    ChipLogProgress(Controller, "resumeCommissioning() called");
+    chip::DeviceLayer::StackLock lock;
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+
+    wrapper->GetAutoCommissioner()->ResumeCommissioning();
+}
+
+JNI_METHOD(void, updateCommissioningNetworkCredentials)
+(JNIEnv * env, jobject self, jlong handle, jobject networkCredentials)
+{
+    ChipLogProgress(Controller, "updateCommissioningNetworkCredentials() called");
+    chip::DeviceLayer::StackLock lock;
+    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
+
+    CommissioningParameters commissioningParams = wrapper->GetCommissioningParameters();
+    CHIP_ERROR err                              = wrapper->ApplyNetworkCredentials(commissioningParams, networkCredentials);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "ApplyNetworkCredentials failed. Err = %" CHIP_ERROR_FORMAT, err.Format());
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
+    }
+    err = wrapper->UpdateCommissioningParameters(commissioningParams);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(Controller, "UpdateCommissioningParameters failed. Err = %" CHIP_ERROR_FORMAT, err.Format());
         JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
     }
 }

--- a/src/controller/java/src/chip/devicecontroller/ControllerParams.java
+++ b/src/controller/java/src/chip/devicecontroller/ControllerParams.java
@@ -11,6 +11,9 @@ public final class ControllerParams {
   @Nullable private final byte[] intermediateCertificate;
   @Nullable private final byte[] operationalCertificate;
   @Nullable private final byte[] ipk;
+  private final int failsafeTimerSeconds = 30;
+  private final boolean attemptNetworkScanWiFi = false;
+  private final boolean attemptNetworkScanThread = true;
 
   private static final int LEGACY_GLOBAL_CHIP_PORT = 5540;
 
@@ -49,6 +52,18 @@ public final class ControllerParams {
     return ipk;
   }
 
+  public int getFailsafeTimerSeconds() {
+    return failsafeTimerSeconds;
+  }
+
+  public boolean getAttemptNetworkScanWiFi() {
+    return attemptNetworkScanWiFi;
+  }
+
+  public boolean getAttemptNetworkScanThread() {
+    return attemptNetworkScanThread;
+  }
+
   /** Returns parameters with ephemerally generated operational credentials */
   public static Builder newBuilder() {
     return new Builder();
@@ -75,6 +90,9 @@ public final class ControllerParams {
     @Nullable private byte[] intermediateCertificate = null;
     @Nullable private byte[] operationalCertificate = null;
     @Nullable private byte[] ipk = null;
+    private int failsafeTimerSeconds = 30;
+    private boolean attemptNetworkScanWiFi = false;
+    private boolean attemptNetworkScanThread = true;
 
     private Builder() {}
 
@@ -83,6 +101,29 @@ public final class ControllerParams {
         throw new IllegalArgumentException("udpListenPort must be >= 0");
       }
       this.udpListenPort = udpListenPort;
+      return this;
+    }
+
+    public Builder setControllerVendorId(int controllerVendorId) {
+      this.controllerVendorId = controllerVendorId;
+      return this;
+    }
+
+    public Builder setFailsafeTimerSeconds(int failsafeTimerSeconds) {
+      if (failsafeTimerSeconds < 1 || failsafeTimerSeconds > 900) {
+        throw new IllegalArgumentException("failsafeTimerSeconds must be between 0 and 900");
+      }
+      this.failsafeTimerSeconds = failsafeTimerSeconds;
+      return this;
+    }
+
+    public Builder setAttemptNetworkScanWiFi(boolean attemptNetworkScanWiFi) {
+      this.attemptNetworkScanWiFi = attemptNetworkScanWiFi;
+      return this;
+    }
+
+    public Builder setAttemptNetworkScanThread(boolean attemptNetworkScanThread) {
+      this.attemptNetworkScanThread = attemptNetworkScanThread;
       return this;
     }
 


### PR DESCRIPTION
#### Problem
* There is no way to trigger a scanNetworks during commissioning
* There is no way for apps using the iOS/Android libraries to access the network type of the client (ReadCommissioningInfo data), or access the scan results in order to choose the best network credentials for the device.
* There is no way to pause the commissioning flow in the event that async processing (user or cloud) is needed to select and input the best network info.

#### Change overview
* Added an optional commissioning step for performing the ScanNetworks
* Added PairingDelegate callbacks for receiving the ReadCommissioningInfo and Scan results
* Added pauseCommissioning/resumeCommissioning commands to DeviceCommissioner
* Added glue to make this functionality available to Android
* TODO: glue to make this functionality available to iOS

#### Testing
* Tested using chip-tool and sample apps.
* Tested with efr32