### PR TITLE
Make "./gn_build.sh is_asan=true" work by default on Mac.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -384,14 +384,10 @@ jobs:
                           # (similar to what examples-linux-standalone.yaml
                           # does), so use target_os="all" to get those picked
                           # up as part of the "unified" build.  But then to
-                          # save CI resources we want to exclude a few
-                          # redundant things:
-                          #
-                          # * the mbedtls build, since we don't really plan to
-                          #   use that on Darwin.
-                          # * the "host clang" build, which uses the pigweed
-                          #   clang.
-                          "default") GN_ARGS='target_os="all" is_asan=true enable_host_clang_build=false enable_host_gcc_mbedtls_build=false';;
+                          # save CI resources we want to exclude the
+                          # "host clang" build, which uses the pigweed
+                          # clang.
+                          "default") GN_ARGS='target_os="all" is_asan=true enable_host_clang_build=false';;
                           "python_lib") GN_ARGS='enable_rtti=true enable_pylib=true';;
                       esac
                       BUILD_TYPE=$BUILD_TYPE scripts/build/gn_gen.sh --args="$GN_ARGS" --export-compile-commands

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -235,7 +235,20 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     enable_host_gcc_build = enable_default_builds && host_os != "win"
 
     # Enable building chip with gcc & mbedtls.
-    enable_host_gcc_mbedtls_build = enable_default_builds && host_os != "win"
+    enable_host_gcc_mbedtls_build = false
+
+    # Enable limited testing with gcc & mbedtls.
+    enable_host_gcc_mbedtls_crypto_tests =
+        enable_default_builds && host_os != "win"
+
+    # Enable building chip with clang & boringssl
+    enable_host_clang_boringssl_build = false
+
+    # Enable limited testing with clang & boringssl.  On Mac, boringssl does
+    # not compile with ASAN enabled.
+    enable_host_clang_boringssl_crypto_tests =
+        enable_default_builds && host_os != "win" &&
+        !(is_asan == true && host_os == "mac")
 
     # Build the chip-cert tool.
     enable_standalone_chip_cert_build =

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -348,9 +348,6 @@ declare_args() {
   # Enable Thread sanitizer
   is_tsan = false
 
-  # Enable address sanitizer
-  is_asan = false
-
   # Enable memory sanitizer
   is_msan = false
 

--- a/build/config/compiler/compiler.gni
+++ b/build/config/compiler/compiler.gni
@@ -50,4 +50,7 @@ declare_args() {
 
   # Generate code coverage analysis artifacts when enabled.
   use_coverage = false
+
+  # Enable address sanitizer
+  is_asan = false
 }


### PR DESCRIPTION
The boringssl tests don't compile with asan on Mac.

#### Problem
See above.

#### Change overview
Only turn on the boringssl tests on mac when is_asan is false.

#### Testing
Compiled with both is_asan true and false on Mac.