### PR TITLE
Empty out af-gen-event.h for thermostat sample

### DIFF
--- a/zzz_generated/thermostat/zap-generated/af-gen-event.h
+++ b/zzz_generated/thermostat/zap-generated/af-gen-event.h
@@ -39,39 +39,4 @@
 #ifndef __AF_GEN_EVENT__
 #define __AF_GEN_EVENT__
 
-// Code used to configure the cluster event mechanism
-#define EMBER_AF_GENERATED_EVENT_CODE                                                                                              \
-    EmberEventControl emberAfBarrierControlClusterServerTickCallbackControl1;                                                      \
-    extern void emberAfPluginColorControlServerTempTransitionEventHandler(void);                                                   \
-    extern void emberAfPluginColorControlServerXyTransitionEventHandler(void);                                                     \
-    extern void emberAfPluginDoorLockServerLockoutEventHandler(void);                                                              \
-    extern void emberAfPluginDoorLockServerRelockEventHandler(void);                                                               \
-    static void clusterTickWrapper(EmberEventControl * control, EmberAfTickFunction callback, chip::EndpointId endpoint)           \
-    {                                                                                                                              \
-        /* emberAfPushEndpointNetworkIndex(endpoint); */                                                                           \
-        emberEventControlSetInactive(control);                                                                                     \
-        (*callback)(endpoint);                                                                                                     \
-        /* emberAfPopNetworkIndex(); */                                                                                            \
-    }                                                                                                                              \
-    void emberAfBarrierControlClusterServerTickCallbackWrapperFunction1(void)                                                      \
-    {                                                                                                                              \
-        clusterTickWrapper(&emberAfBarrierControlClusterServerTickCallbackControl1,                                                \
-                           emberAfBarrierControlClusterServerTickCallback, 1);                                                     \
-    }
-
-// EmberEventData structs used to populate the EmberEventData table
-#define EMBER_AF_GENERATED_EVENTS                                                                                                  \
-    { &emberAfBarrierControlClusterServerTickCallbackControl1, emberAfBarrierControlClusterServerTickCallbackWrapperFunction1 },
-
-#define EMBER_AF_GENERATED_EVENT_STRINGS                                                                                           \
-    "Barrier Control Cluster Server EP 1", "Color Control Cluster Server Plugin HueSatTransition",                                 \
-        "Color Control Cluster Server Plugin TempTransition", "Color Control Cluster Server Plugin XyTransition",                  \
-        "Door Lock Server Cluster Plugin Lockout", "Door Lock Server Cluster Plugin Relock", "IAS Zone Server Plugin ManageQueue",
-
-// The length of the event context table used to track and retrieve cluster events
-#define EMBER_AF_EVENT_CONTEXT_LENGTH 2
-
-// EmberAfEventContext structs used to populate the EmberAfEventContext table
-#define EMBER_AF_GENERATED_EVENT_CONTEXT                                                                                           \
-    { 0x1, 0x103, false, EMBER_AF_LONG_POLL, EMBER_AF_OK_TO_SLEEP, &emberAfBarrierControlClusterServerTickCallbackControl1 },
 #endif // __AF_GEN_EVENT__


### PR DESCRIPTION
#### Problem

The thermostat sample does not link in some configurations (ASAN):

```
  g++ -O0 -fPIC -Werror -Wl,--fatal-warnings -fdiagnostics-color -fsanitize=address -fno-omit-frame-pointer -Wl,--gc-sections -pie -Wl,-Map,standalone/thermostat-app.map @standalone/thermostat-app.rsp -o standalone/thermostat-app
  /usr/bin/ld: standalone/obj/src/app/util/thermostat-common.af-event.cpp.o: in function `emberAfBarrierControlClusterServerTickCallbackWrapperFunction1()':
  /ssd/src/connectedhomeip/out/debug/../../src/app/util/af-event.cpp:69: undefined reference to `emberAfBarrierControlClusterServerTickCallback(unsigned short)'
```

#### Change overview

This application does not enable the door lock or barrier control
clusters. Remove the corresponding event code.

#### Testing

gn_build.sh is_asan=true
