### PR TITLE
Disable -Wl,-z,defs in ASAN build

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -262,7 +262,7 @@ config("strict_warnings") {
     ]
   }
 
-  if (current_os == "linux" || current_os == "android") {
+  if (!is_asan && (current_os == "linux" || current_os == "android")) {
     ldflags += [ "-Wl,-z,defs" ]
   }
 }


### PR DESCRIPTION




#### Problem

Shared libraries built with address sanitizer have some unresolved
symbols created by the instrumentation. These will be provided by
the executable. This is by design but trips an unresolved symbol diagnostic.

#### Change overview

Disable strictures when ASAN is enabled.

#### Testing

gn_build.sh is_asan=true