### PR TITLE
Update python requirements

### DIFF
--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -10,10 +10,11 @@ appdirs==1.4.4
     # via
     #   -r requirements.txt
     #   mbed-os-tools
-    #   virtualenv
-appnope==0.1.2
+appnope==0.1.3
     # via -r requirements.txt
-attrs==21.2.0
+asttokens==2.0.5
+    # via stack-data
+attrs==22.1.0
     # via
     #   jsonschema
     #   pytest
@@ -21,19 +22,21 @@ backcall==0.2.0
     # via ipython
 beautifulsoup4==4.11.1
     # via mbed-os-tools
-bitstring==3.1.7
+bitstring==3.1.9
     # via -r requirements.esp32.txt
 brotli==1.0.9
     # via flask-compress
+build==0.8.0
+    # via pip-tools
 cbor==1.0.0
     # via -r requirements.txt
-cbor2==5.4.0
+cbor2==5.4.3
     # via -r requirements.txt
-certifi==2021.5.30
+certifi==2022.6.15
     # via requests
-cffi==1.14.5
+cffi==1.15.1
     # via cryptography
-chardet==4.0.0
+charset-normalizer==2.1.0
     # via requests
 click==8.1.3
     # via
@@ -42,7 +45,7 @@ click==8.1.3
     #   flask
     #   idf-component-manager
     #   pip-tools
-colorama==0.4.4
+colorama==0.4.5
     # via
     #   -r requirements.txt
     #   idf-component-manager
@@ -56,34 +59,36 @@ contextlib2==21.6.0
     # via
     #   idf-component-manager
     #   schema
-cryptography==3.4.7
+cryptography==37.0.4
     # via
     #   -r requirements.esp32.txt
     #   -r requirements.txt
-cxxfilt==0.2.2
+cxxfilt==0.3.0
     # via -r requirements.txt
-dbus-python==1.2.16 ; sys_platform == "linux"
+dbus-python==1.2.18 ; sys_platform == "linux"
     # via -r requirements.txt
-decorator==5.0.9
+decorator==5.1.1
     # via ipython
-distlib==0.3.2
+distlib==0.3.5
     # via virtualenv
 docopt==0.6.2
     # via pykwalify
-ecdsa==0.17.0
+ecdsa==0.18.0
     # via -r requirements.esp32.txt
-fastcore==1.3.26
+executing==0.9.1
+    # via stack-data
+fastcore==1.5.11
     # via ghapi
 fasteners==0.17.3
     # via mbed-os-tools
-filelock==3.0.12
+filelock==3.7.1
     # via virtualenv
 flask==0.12.5
     # via
     #   flask-compress
     #   flask-socketio
     #   gdbgui
-flask-compress==1.10.0
+flask-compress==1.12
     # via gdbgui
 flask-socketio==2.9.6
     # via gdbgui
@@ -92,24 +97,23 @@ future==0.18.2
     #   -r requirements.esp32.txt
     #   idf-component-manager
     #   mbed-os-tools
-    #   mobly
 gdbgui==0.13.2.0
     # via -r requirements.esp32.txt
 gevent==1.5.0
     # via gdbgui
-ghapi==0.1.19
+ghapi==1.0.0
     # via -r requirements.txt
 gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via -r requirements.mbed.txt
-greenlet==1.1.0
+greenlet==1.1.2
     # via gevent
-humanfriendly==9.2
+humanfriendly==10.0
     # via coloredlogs
 idf-component-manager==1.1.4
     # via -r requirements.esp32.txt
-idna==2.10
+idna==3.3
     # via requests
 iniconfig==1.1.1
     # via pytest
@@ -117,17 +121,15 @@ intelhex==2.3.0
     # via
     #   -r requirements.txt
     #   mbed-os-tools
-ipython==7.24.1
+ipython==8.4.0
     # via -r requirements.txt
-ipython-genutils==0.2.0
-    # via traitlets
-itsdangerous==2.0.1
+itsdangerous==2.1.2
     # via flask
-jedi==0.18.0
+jedi==0.18.1
     # via ipython
-jinja2==3.0.1
+jinja2==3.1.2
     # via flask
-jsonschema==4.4.0
+jsonschema==4.8.0
     # via -r requirements.txt
 junit-xml==1.9
     # via mbed-os-tools
@@ -141,47 +143,50 @@ lockfile==0.12.2
     #   mbed-os-tools
 mako==1.2.1
     # via pdoc3
-markdown==3.3.7
+markdown==3.4.1
     # via pdoc3
-markupsafe==2.0.1
+markupsafe==2.1.1
     # via
     #   jinja2
     #   mako
-matplotlib-inline==0.1.2
+matplotlib-inline==0.1.3
     # via ipython
 mbed-ls==1.8.11 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via -r requirements.mbed.txt
-mbed-os-tools==1.8.13
+mbed-os-tools==1.8.14
     # via mbed-ls
-mobly==1.10.1
+mobly==1.11.1
     # via -r requirements.txt
-numpy==1.23.0
+numpy==1.23.1
     # via pandas
-packaging==20.9
+packaging==21.3
     # via
+    #   build
     #   fastcore
     #   ghapi
     #   pytest
     #   west
 pandas==1.4.3 ; platform_machine != "aarch64" and platform_machine != "arm64"
     # via -r requirements.txt
-parso==0.8.2
+parso==0.8.3
     # via jedi
 pdoc3==0.10.0 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via -r requirements.mbed.txt
-pep517==0.10.0
-    # via pip-tools
+pep517==0.12.0
+    # via build
 pexpect==4.8.0
     # via ipython
 pgi==0.0.11.2 ; sys_platform == "linux"
     # via -r requirements.txt
 pickleshare==0.7.5
     # via ipython
-pip-tools==6.1.0
+pip-tools==6.8.0
     # via -r requirements.txt
+platformdirs==2.5.2
+    # via virtualenv
 pluggy==1.0.0
     # via pytest
-portpicker==1.4.0
+portpicker==1.5.2
     # via
     #   -r requirements.txt
     #   mobly
@@ -189,27 +194,29 @@ prettytable==2.5.0
     # via
     #   mbed-ls
     #   mbed-os-tools
-prompt-toolkit==3.0.26
+prompt-toolkit==3.0.30
     # via ipython
-protobuf==3.17.3
+protobuf==4.21.4
     # via -r requirements.txt
-psutil==5.8.0
+psutil==5.9.1
     # via
     #   -r requirements.txt
-    #   mobly
+    #   portpicker
 ptyprocess==0.7.0
     # via pexpect
+pure-eval==0.2.2
+    # via stack-data
 py==1.11.0
     # via pytest
-pycparser==2.20
+pycparser==2.21
     # via cffi
-pyelftools==0.27
+pyelftools==0.28
     # via -r requirements.esp32.txt
 pygdbmi==0.9.0.2
     # via
     #   -r requirements.esp32.txt
     #   gdbgui
-pygments==2.9.0
+pygments==2.12.0
     # via
     #   gdbgui
     #   ipython
@@ -228,7 +235,7 @@ pyserial==3.5
     #   mobly
 pytest==6.2.5 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via -r requirements.mbed.txt
-python-dateutil==2.8.1
+python-dateutil==2.8.2
     # via
     #   pandas
     #   pykwalify
@@ -240,18 +247,18 @@ python-socketio==4.6.1
     # via
     #   -r requirements.esp32.txt
     #   flask-socketio
-pytz==2021.1
+pytz==2022.1
     # via pandas
 pyudev==0.23.2 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via -r requirements.mbed.txt
-pyyaml==5.4.1
+pyyaml==6.0
     # via
     #   idf-component-manager
     #   mobly
     #   west
 reedsolo==1.5.4
     # via -r requirements.esp32.txt
-requests==2.25.1
+requests==2.28.1
     # via
     #   -r requirements.txt
     #   idf-component-manager
@@ -259,27 +266,30 @@ requests==2.25.1
     #   requests-toolbelt
 requests-toolbelt==0.9.1
     # via idf-component-manager
-ruamel-yaml==0.17.9
+ruamel-yaml==0.17.21
     # via pykwalify
+ruamel-yaml-clib==0.2.6
+    # via ruamel-yaml
 schema==0.7.5
     # via idf-component-manager
 six==1.16.0
     # via
     #   anytree
+    #   asttokens
     #   ecdsa
     #   idf-component-manager
     #   junit-xml
     #   mbed-os-tools
-    #   protobuf
     #   python-dateutil
     #   python-engineio
     #   python-socketio
     #   pyudev
-    #   virtualenv
 smmap==5.0.0
     # via gitdb
 soupsieve==2.3.2.post1
     # via beautifulsoup4
+stack-data==0.3.0
+    # via ipython
 stringcase==1.2.0
     # via -r requirements.txt
 tabulate==0.8.10
@@ -287,24 +297,28 @@ tabulate==0.8.10
 timeout-decorator==0.5.0
     # via mobly
 toml==0.10.2
+    # via pytest
+tomli==2.0.1
     # via
+    #   build
     #   pep517
-    #   pytest
-tornado==6.1
+tornado==6.2
     # via -r requirements.txt
-tqdm==4.61.1
+tqdm==4.64.0
     # via idf-component-manager
-traitlets==5.0.5
+traitlets==5.3.0
     # via
     #   ipython
     #   matplotlib-inline
 typing-extensions==4.3.0 ; platform_machine != "aarch64" and sys_platform == "linux"
-    # via -r requirements.mbed.txt
-urllib3==1.26.5
+    # via
+    #   -r requirements.mbed.txt
+    #   mobly
+urllib3==1.26.11
     # via requests
-virtualenv==20.4.7
+virtualenv==20.16.2
     # via -r requirements.txt
-watchdog==2.1.2
+watchdog==2.1.9
     # via -r requirements.txt
 wcwidth==0.2.5
     # via
@@ -312,10 +326,12 @@ wcwidth==0.2.5
     #   prompt-toolkit
 werkzeug==0.16.1
     # via flask
-west==0.12.0
+west==0.13.1
     # via -r requirements.txt
-wheel==0.36.2
-    # via -r requirements.txt
+wheel==0.37.1
+    # via
+    #   -r requirements.txt
+    #   pip-tools
 
 # The following packages are considered to be unsafe in a requirements file:
 # pip


### PR DESCRIPTION
#### Problem

Python requirements are out of date. Some versions do not have binary wheels for python 3.10,
which affects bootstrap performance.

#### Change overview

Regenerate python constraints via pip-compile requirements.txt -o constraints.txt

#### Testing

source scripts/bootstrap.sh