### PR TITLE
Use "copy" ownership for members of params structs on Darwin where possible.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCluster.h
+++ b/src/darwin/Framework/CHIP/MTRCluster.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @end
 
 /**
- * CHIPWriteParams
+ * MTRWriteParams
  *    This is used to control the behavior of cluster writes.
  *    If not provided (i.e. nil passed for the CHIPWriteParams argument), will be
  *    treated as if a default-initialized object was passed in.
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
  * This value is specified in milliseconds
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedWriteTimeout;
+@property (nonatomic, copy, nullable) NSNumber * timedWriteTimeout;
 
 /**
  * Sets the data version for the Write Request for the interaction.
@@ -62,7 +62,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If not nil, the write will only succeed if the current data version of
  * the cluster matches the provided data version.
  */
-@property (strong, nonatomic, nullable) NSNumber * dataVersion;
+@property (nonatomic, copy, nullable) NSNumber * dataVersion;
 
 - (instancetype)init;
 
@@ -86,7 +86,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If NO, the read/subscribe is not fabric-filtered and will see all
  * non-fabric-sensitive data for the given attribute path.
  */
-@property (strong, nonatomic, nullable) NSNumber * fabricFiltered;
+@property (nonatomic, copy, nullable) NSNumber * fabricFiltered;
 
 - (instancetype)init;
 
@@ -109,7 +109,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * If YES, the subscribe will allow any previous subscriptions to remain.
  */
-@property (strong, nonatomic, nullable) NSNumber * keepPreviousSubscriptions;
+@property (nonatomic, copy, nullable) NSNumber * keepPreviousSubscriptions;
 
 /**
  * Whether the subscription should automatically try to re-establish if it
@@ -123,7 +123,7 @@ NS_ASSUME_NONNULL_BEGIN
  * called again.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * autoResubscribe;
+@property (nonatomic, copy, nullable) NSNumber * autoResubscribe;
 
 - (instancetype)init;
 

--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -30,31 +30,31 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  *  The CSRNonce
  */
-@property (nonatomic, nullable, copy, readwrite) NSData * CSRNonce;
+@property (nonatomic, copy, nullable) NSData * CSRNonce;
 /**
  *  The AttestationNonce
  */
-@property (nonatomic, nullable, copy, readwrite) NSData * attestationNonce;
+@property (nonatomic, copy, nullable) NSData * attestationNonce;
 /**
  *  The Wi-Fi SSID
  */
-@property (nonatomic, nullable, copy, readwrite) NSData * wifiSSID;
+@property (nonatomic, copy, nullable) NSData * wifiSSID;
 /**
  *  The Wi-Fi Credentials
  */
-@property (nonatomic, nullable, copy, readwrite) NSData * wifiCredentials;
+@property (nonatomic, copy, nullable) NSData * wifiCredentials;
 /**
  *  The Thread operational dataset
  */
-@property (nonatomic, nullable, copy, readwrite) NSData * threadOperationalDataset;
+@property (nonatomic, copy, nullable) NSData * threadOperationalDataset;
 /**
  *  The Device Attestation status delegate
  */
-@property (nonatomic, nullable, strong, readwrite) id<MTRDeviceAttestationDelegate> deviceAttestationDelegate;
+@property (nonatomic, strong, nullable) id<MTRDeviceAttestationDelegate> deviceAttestationDelegate;
 /**
  *  The timeout in secs to set for fail-safe when attestation fails
  */
-@property (nonatomic, nullable, copy, readwrite) NSNumber * failSafeExpiryTimeoutSecs;
+@property (nonatomic, copy, nullable) NSNumber * failSafeExpiryTimeoutSecs;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRControllerFactory.h
+++ b/src/darwin/Framework/CHIP/MTRControllerFactory.h
@@ -37,30 +37,30 @@ NS_ASSUME_NONNULL_BEGIN
  * controllers.  It is used to store persistent information for the fabrics the
  * controllers ends up interacting with.
  */
-@property (strong, nonatomic, readonly) id<MTRPersistentStorageDelegate> storageDelegate;
+@property (nonatomic, strong, readonly) id<MTRPersistentStorageDelegate> storageDelegate;
 
 /*
  * OTA Provider delegate to be called when an OTA Requestor is requesting a software update.
  * Defaults to nil.
  */
-@property (strong, nonatomic, nullable) id<MTROTAProviderDelegate> otaProviderDelegate;
+@property (nonatomic, strong, nullable) id<MTROTAProviderDelegate> otaProviderDelegate;
 
 /*
  * The Product Attestation Authority certificates that are trusted to sign
  * device attestation information.  Defaults to nil.
  *
  */
-@property (strong, nonatomic, nullable) NSArray<NSData *> * paaCerts;
+@property (nonatomic, copy, nullable) NSArray<NSData *> * paaCerts;
 /*
  * The network port to bind to.  If not specified, an ephemeral port will be
  * used.
  */
-@property (strong, nonatomic, nullable) NSNumber * port;
+@property (nonatomic, copy, nullable) NSNumber * port;
 /*
  * Whether to run a server capable of accepting incoming CASE
  * connections.  Defaults to NO.
  */
-@property (nonatomic) BOOL startServer;
+@property (nonatomic, assign) BOOL startServer;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithStorage:(id<MTRPersistentStorageDelegate>)storageDelegate;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -30,7 +30,7 @@ NS_ASSUME_NONNULL_BEGIN
  * must be initialized using initWithOperationalKeypair (to provide the
  * operational credentials for the controller itself).
  */
-@property (strong, nonatomic, readonly, nullable) id<MTRKeypair> nocSigner;
+@property (nonatomic, copy, readonly, nullable) id<MTRKeypair> nocSigner;
 /**
  * Fabric id for the controller.  Must be set to a nonzero value.  This is
  * scoped by the root public key, which is determined as follows:
@@ -42,13 +42,13 @@ NS_ASSUME_NONNULL_BEGIN
  *   key of the nocSigner keypair, since in this case we are not using an
  *   intermediate certificate.
  */
-@property (nonatomic, readonly) uint64_t fabricId;
+@property (nonatomic, assign, readonly) uint64_t fabricId;
 /**
  * IPK to use for the controller's fabric.  Allowed to change from the last time
  * a controller was started on this fabric if a new IPK has been distributed to
  * all the devices the controller wants to interact with.
  */
-@property (strong, nonatomic, readonly) NSData * ipk;
+@property (nonatomic, copy, readonly) NSData * ipk;
 
 /**
  * Vendor ID (allocated by the Connectivity Standards Alliance) for
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  * * Will override existing value if not nil. Otherwise existing value will be
  *   used.
  */
-@property (strong, nonatomic, nullable) NSNumber * vendorId;
+@property (nonatomic, copy, nullable) NSNumber * vendorId;
 
 /**
  * Node id for this controller.
@@ -95,7 +95,7 @@ NS_ASSUME_NONNULL_BEGIN
  *    generated operational key.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * nodeId;
+@property (nonatomic, copy, nullable) NSNumber * nodeId;
 
 // TODO: Add something here for CATs?
 
@@ -130,7 +130,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   2) The subject DN must match the subject DN of the existing root
  *      certificate.
  */
-@property (strong, nonatomic, nullable) NSData * rootCertificate;
+@property (nonatomic, copy, nullable) NSData * rootCertificate;
 
 /**
  * Intermediate certificate, in X.509 DER form, to use.
@@ -162,7 +162,7 @@ NS_ASSUME_NONNULL_BEGIN
  *     allows switching from using an intermediate CA to not using one.
  *
  */
-@property (strong, nonatomic, nullable) NSData * intermediateCertificate;
+@property (nonatomic, copy, nullable) NSData * intermediateCertificate;
 
 /**
  * Operational certificate, in X.509 DER form, to use.
@@ -173,7 +173,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If nil, an operational certificate will be determined as described in the
  * documentation for nodeId.
  */
-@property (strong, nonatomic, nullable, readonly) NSData * operationalCertificate;
+@property (nonatomic, copy, readonly, nullable) NSData * operationalCertificate;
 
 /**
  * Operational keypair to use.  If operationalCertificate is not nil, the public
@@ -184,7 +184,7 @@ NS_ASSUME_NONNULL_BEGIN
  * will for that certificated will be determined as described in the
  * documentation for nodeId.
  */
-@property (strong, nonatomic, nullable) id<MTRKeypair> operationalKeypair;
+@property (nonatomic, strong, nullable) id<MTRKeypair> operationalKeypair;
 
 - (instancetype)init NS_UNAVAILABLE;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -36,7 +36,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceControllerStartupParams ()
 // We want to be able to write to operationalCertificate in
 // MTRDeviceControllerStartupParamsInternal.
-@property (strong, nonatomic, nullable) NSData * operationalCertificate;
+@property (nonatomic, copy, nullable) NSData * operationalCertificate;
 
 // Init method that just copies the values of all our ivars.
 - (instancetype)initWithParams:(MTRDeviceControllerStartupParams *)params;
@@ -45,14 +45,14 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceControllerStartupParamsInternal : MTRDeviceControllerStartupParams
 
 // Fabric table we can use to do things like allocate operational keys.
-@property (nonatomic, readonly) chip::FabricTable * fabricTable;
+@property (nonatomic, assign, readonly) chip::FabricTable * fabricTable;
 
 // Fabric index we're starting on.  Only has a value when starting on an
 // existing fabric.
-@property (nonatomic, readonly) chip::Optional<chip::FabricIndex> fabricIndex;
+@property (nonatomic, assign, readonly) chip::Optional<chip::FabricIndex> fabricIndex;
 
 // Key store we're using with our fabric table, for sanity checks.
-@property (nonatomic, readonly) chip::Crypto::OperationalKeystore * keystore;
+@property (nonatomic, assign, readonly) chip::Crypto::OperationalKeystore * keystore;
 
 /**
  * Helper method that checks that our keypairs match our certificates.

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -43,24 +43,24 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 };
 
 @interface MTROptionalQRCodeInfo : NSObject
-@property (nonatomic, strong) NSNumber * infoType;
-@property (nonatomic, strong) NSNumber * tag;
-@property (nonatomic, strong) NSNumber * integerValue;
-@property (nonatomic, strong) NSString * stringValue;
+@property (nonatomic, copy) NSNumber * infoType;
+@property (nonatomic, copy) NSNumber * tag;
+@property (nonatomic, copy) NSNumber * integerValue;
+@property (nonatomic, copy) NSString * stringValue;
 @end
 
 @interface MTRSetupPayload : NSObject
 
-@property (nonatomic, strong) NSNumber * version;
-@property (nonatomic, strong) NSNumber * vendorID;
-@property (nonatomic, strong) NSNumber * productID;
+@property (nonatomic, copy) NSNumber * version;
+@property (nonatomic, copy) NSNumber * vendorID;
+@property (nonatomic, copy) NSNumber * productID;
 @property (nonatomic, assign) MTRCommissioningFlow commissioningFlow;
 @property (nonatomic, assign) MTRRendezvousInformationFlags rendezvousInformation;
-@property (nonatomic, strong) NSNumber * discriminator;
-@property (nonatomic) BOOL hasShortDiscriminator;
-@property (nonatomic, strong) NSNumber * setUpPINCode;
+@property (nonatomic, copy) NSNumber * discriminator;
+@property (nonatomic, assign) BOOL hasShortDiscriminator;
+@property (nonatomic, copy) NSNumber * setUpPINCode;
 
-@property (nonatomic, strong) NSString * serialNumber;
+@property (nonatomic, copy) NSString * serialNumber;
 - (nullable NSArray<MTROptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error;
 
 /**

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -19,6 +19,18 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+  auto other = [[MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params alloc] init];
+
+  {{#zcl_command_arguments}}
+  other.{{asStructPropertyName label}} = self.{{asStructPropertyName label}};
+  {{/zcl_command_arguments}}
+  other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+  return other;
+}
+
 - (NSString *)description
 {
   NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_command_arguments}}{{asStructPropertyName label}}:%@; {{/zcl_command_arguments}}>", NSStringFromClass([self class]) {{#zcl_command_arguments}},{{#if isArray}}_{{asStructPropertyName label}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName label}}{{/if}}{{/zcl_command_arguments}}];

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -7,16 +7,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_commands}}
-@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params : NSObject
+@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params : NSObject <NSCopying>
 {{#zcl_command_arguments}}
 
 {{! Override the getter name because some of our properties start with things
     like "new" or "init" }}
-@property (strong, nonatomic{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
+@property (nonatomic, copy{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
 {{/zcl_command_arguments}}
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
- * 
+ *
  * If nil (the default value), a regular invoke is done for commands that do
  * not require a timed invoke and a timed invoke with some default timed request
  * timeout is done for commands that require a timed invoke.
@@ -26,12 +26,12 @@ NS_ASSUME_NONNULL_BEGIN
  * desired security properties but large enough that it will allow a round-trip
  * from the sever to the client (for the status response and actual invoke
  * request) within the timeout window.
-  *
-  */
- @property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+ *
+ */
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
- - (instancetype)init;
- 
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 {{/zcl_commands}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -17,6 +17,17 @@ NS_ASSUME_NONNULL_BEGIN
   return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+  auto other = [[MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}} alloc] init];
+
+  {{#zcl_struct_items}}
+  other.{{asStructPropertyName label}} = self.{{asStructPropertyName label}};
+  {{/zcl_struct_items}}
+
+  return other;
+}
+
 - (NSString *)description
 {
   NSString *descriptionString = [NSString stringWithFormat:@"<%@: {{#zcl_struct_items}}{{asStructPropertyName label}}:%@; {{/zcl_struct_items}}>", NSStringFromClass([self class]){{#zcl_struct_items}},{{#if isArray}}_{{asStructPropertyName label}}{{else if (isOctetString type)}}[_{{asStructPropertyName label}} base64EncodedStringWithOptions:0]{{else}}_{{asStructPropertyName label}}{{/if}}{{/zcl_struct_items}}];
@@ -37,6 +48,17 @@ NS_ASSUME_NONNULL_BEGIN
     {{/zcl_event_fields}}
   }
   return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+  auto other = [[MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event alloc] init];
+
+  {{#zcl_event_fields}}
+  other.{{asStructPropertyName name}} = self.{{asStructPropertyName name}};
+  {{/zcl_event_fields}}
+
+  return other;
 }
 
 - (NSString *)description

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -6,23 +6,27 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_structs}}
-@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}} : NSObject
+@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}} : NSObject <NSCopying>
 {{! Override the getter name because some of our properties start with things
     like "new" or "init" }}
 {{#zcl_struct_items}}
-@property (strong, nonatomic{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
+@property (nonatomic, copy{{#unless (isStrEqual (asGetterName label) (asStructPropertyName label))}}, getter={{asGetterName label}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName label}};
 {{/zcl_struct_items}}
-- (instancetype)init;
 
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
 {{/zcl_structs}}
 
 {{#zcl_events}}
-@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event : NSObject
+@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event : NSObject <NSCopying>
 {{#zcl_event_fields}}
-@property (strong, nonatomic{{#unless (isStrEqual (asGetterName name) (asStructPropertyName name))}}, getter={{asGetterName name}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName name}};
+@property (nonatomic, copy{{#unless (isStrEqual (asGetterName name) (asStructPropertyName name))}}, getter={{asGetterName name}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName name}};
 {{/zcl_event_fields}}
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
 {{/zcl_events}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -22,9 +22,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MTRIdentifyClusterIdentifyParams : NSObject
+@interface MTRIdentifyClusterIdentifyParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull identifyTime;
+@property (nonatomic, copy) NSNumber * _Nonnull identifyTime;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -39,16 +39,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRIdentifyClusterTriggerEffectParams : NSObject
+@interface MTRIdentifyClusterTriggerEffectParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull effectIdentifier;
+@property (nonatomic, copy) NSNumber * _Nonnull effectIdentifier;
 
-@property (strong, nonatomic) NSNumber * _Nonnull effectVariant;
+@property (nonatomic, copy) NSNumber * _Nonnull effectVariant;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -63,16 +63,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterAddGroupParams : NSObject
+@interface MTRGroupsClusterAddGroupParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSString * _Nonnull groupName;
+@property (nonatomic, copy) NSString * _Nonnull groupName;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -87,16 +87,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterAddGroupResponseParams : NSObject
+@interface MTRGroupsClusterAddGroupResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -111,14 +111,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterViewGroupParams : NSObject
+@interface MTRGroupsClusterViewGroupParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -133,18 +133,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterViewGroupResponseParams : NSObject
+@interface MTRGroupsClusterViewGroupResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSString * _Nonnull groupName;
+@property (nonatomic, copy) NSString * _Nonnull groupName;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -159,14 +159,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterGetGroupMembershipParams : NSObject
+@interface MTRGroupsClusterGetGroupMembershipParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull groupList;
+@property (nonatomic, copy) NSArray * _Nonnull groupList;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -181,16 +181,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterGetGroupMembershipResponseParams : NSObject
+@interface MTRGroupsClusterGetGroupMembershipResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nullable capacity;
+@property (nonatomic, copy) NSNumber * _Nullable capacity;
 
-@property (strong, nonatomic) NSArray * _Nonnull groupList;
+@property (nonatomic, copy) NSArray * _Nonnull groupList;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -205,14 +205,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterRemoveGroupParams : NSObject
+@interface MTRGroupsClusterRemoveGroupParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -227,16 +227,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterRemoveGroupResponseParams : NSObject
+@interface MTRGroupsClusterRemoveGroupResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -251,12 +251,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterRemoveAllGroupsParams : NSObject
+@interface MTRGroupsClusterRemoveAllGroupsParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -271,16 +271,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupsClusterAddGroupIfIdentifyingParams : NSObject
+@interface MTRGroupsClusterAddGroupIfIdentifyingParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSString * _Nonnull groupName;
+@property (nonatomic, copy) NSString * _Nonnull groupName;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -295,22 +295,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterAddSceneParams : NSObject
+@interface MTRScenesClusterAddSceneParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSString * _Nonnull sceneName;
+@property (nonatomic, copy) NSString * _Nonnull sceneName;
 
-@property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
+@property (nonatomic, copy) NSArray * _Nonnull extensionFieldSets;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -325,18 +325,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterAddSceneResponseParams : NSObject
+@interface MTRScenesClusterAddSceneResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -351,16 +351,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterViewSceneParams : NSObject
+@interface MTRScenesClusterViewSceneParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -375,24 +375,24 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterViewSceneResponseParams : NSObject
+@interface MTRScenesClusterViewSceneResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 
-@property (strong, nonatomic) NSNumber * _Nullable transitionTime;
+@property (nonatomic, copy) NSNumber * _Nullable transitionTime;
 
-@property (strong, nonatomic) NSString * _Nullable sceneName;
+@property (nonatomic, copy) NSString * _Nullable sceneName;
 
-@property (strong, nonatomic) NSArray * _Nullable extensionFieldSets;
+@property (nonatomic, copy) NSArray * _Nullable extensionFieldSets;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -407,16 +407,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterRemoveSceneParams : NSObject
+@interface MTRScenesClusterRemoveSceneParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -431,18 +431,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterRemoveSceneResponseParams : NSObject
+@interface MTRScenesClusterRemoveSceneResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -457,14 +457,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterRemoveAllScenesParams : NSObject
+@interface MTRScenesClusterRemoveAllScenesParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -479,16 +479,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterRemoveAllScenesResponseParams : NSObject
+@interface MTRScenesClusterRemoveAllScenesResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -503,16 +503,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterStoreSceneParams : NSObject
+@interface MTRScenesClusterStoreSceneParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -527,18 +527,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterStoreSceneResponseParams : NSObject
+@interface MTRScenesClusterStoreSceneResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -553,18 +553,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterRecallSceneParams : NSObject
+@interface MTRScenesClusterRecallSceneParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 
-@property (strong, nonatomic) NSNumber * _Nullable transitionTime;
+@property (nonatomic, copy) NSNumber * _Nullable transitionTime;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -579,14 +579,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterGetSceneMembershipParams : NSObject
+@interface MTRScenesClusterGetSceneMembershipParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -601,20 +601,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterGetSceneMembershipResponseParams : NSObject
+@interface MTRScenesClusterGetSceneMembershipResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nullable capacity;
+@property (nonatomic, copy) NSNumber * _Nullable capacity;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSArray * _Nullable sceneList;
+@property (nonatomic, copy) NSArray * _Nullable sceneList;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -629,22 +629,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterEnhancedAddSceneParams : NSObject
+@interface MTRScenesClusterEnhancedAddSceneParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSString * _Nonnull sceneName;
+@property (nonatomic, copy) NSString * _Nonnull sceneName;
 
-@property (strong, nonatomic) NSArray * _Nonnull extensionFieldSets;
+@property (nonatomic, copy) NSArray * _Nonnull extensionFieldSets;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -659,18 +659,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterEnhancedAddSceneResponseParams : NSObject
+@interface MTRScenesClusterEnhancedAddSceneResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -685,16 +685,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterEnhancedViewSceneParams : NSObject
+@interface MTRScenesClusterEnhancedViewSceneParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -709,24 +709,24 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterEnhancedViewSceneResponseParams : NSObject
+@interface MTRScenesClusterEnhancedViewSceneResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneId;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneId;
 
-@property (strong, nonatomic) NSNumber * _Nullable transitionTime;
+@property (nonatomic, copy) NSNumber * _Nullable transitionTime;
 
-@property (strong, nonatomic) NSString * _Nullable sceneName;
+@property (nonatomic, copy) NSString * _Nullable sceneName;
 
-@property (strong, nonatomic) NSArray * _Nullable extensionFieldSets;
+@property (nonatomic, copy) NSArray * _Nullable extensionFieldSets;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -741,22 +741,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterCopySceneParams : NSObject
+@interface MTRScenesClusterCopySceneParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull mode;
+@property (nonatomic, copy) NSNumber * _Nonnull mode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupIdFrom;
+@property (nonatomic, copy) NSNumber * _Nonnull groupIdFrom;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneIdFrom;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneIdFrom;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupIdTo;
+@property (nonatomic, copy) NSNumber * _Nonnull groupIdTo;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneIdTo;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneIdTo;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -771,18 +771,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRScenesClusterCopySceneResponseParams : NSObject
+@interface MTRScenesClusterCopySceneResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupIdFrom;
+@property (nonatomic, copy) NSNumber * _Nonnull groupIdFrom;
 
-@property (strong, nonatomic) NSNumber * _Nonnull sceneIdFrom;
+@property (nonatomic, copy) NSNumber * _Nonnull sceneIdFrom;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -797,12 +797,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROnOffClusterOffParams : NSObject
+@interface MTROnOffClusterOffParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -817,12 +817,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROnOffClusterOnParams : NSObject
+@interface MTROnOffClusterOnParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -837,12 +837,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROnOffClusterToggleParams : NSObject
+@interface MTROnOffClusterToggleParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -857,16 +857,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROnOffClusterOffWithEffectParams : NSObject
+@interface MTROnOffClusterOffWithEffectParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull effectId;
+@property (nonatomic, copy) NSNumber * _Nonnull effectId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull effectVariant;
+@property (nonatomic, copy) NSNumber * _Nonnull effectVariant;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -881,12 +881,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROnOffClusterOnWithRecallGlobalSceneParams : NSObject
+@interface MTROnOffClusterOnWithRecallGlobalSceneParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -901,18 +901,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROnOffClusterOnWithTimedOffParams : NSObject
+@interface MTROnOffClusterOnWithTimedOffParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull onOffControl;
+@property (nonatomic, copy) NSNumber * _Nonnull onOffControl;
 
-@property (strong, nonatomic) NSNumber * _Nonnull onTime;
+@property (nonatomic, copy) NSNumber * _Nonnull onTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull offWaitTime;
+@property (nonatomic, copy) NSNumber * _Nonnull offWaitTime;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -927,20 +927,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterMoveToLevelParams : NSObject
+@interface MTRLevelControlClusterMoveToLevelParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull level;
+@property (nonatomic, copy) NSNumber * _Nonnull level;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -955,20 +955,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterMoveParams : NSObject
+@interface MTRLevelControlClusterMoveParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (nonatomic, copy) NSNumber * _Nonnull moveMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (nonatomic, copy) NSNumber * _Nonnull rate;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -983,22 +983,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterStepParams : NSObject
+@interface MTRLevelControlClusterStepParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (nonatomic, copy) NSNumber * _Nonnull stepMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (nonatomic, copy) NSNumber * _Nonnull stepSize;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1013,16 +1013,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterStopParams : NSObject
+@interface MTRLevelControlClusterStopParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1037,20 +1037,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterMoveToLevelWithOnOffParams : NSObject
+@interface MTRLevelControlClusterMoveToLevelWithOnOffParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull level;
+@property (nonatomic, copy) NSNumber * _Nonnull level;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1065,20 +1065,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterMoveWithOnOffParams : NSObject
+@interface MTRLevelControlClusterMoveWithOnOffParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (nonatomic, copy) NSNumber * _Nonnull moveMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (nonatomic, copy) NSNumber * _Nonnull rate;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1093,22 +1093,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterStepWithOnOffParams : NSObject
+@interface MTRLevelControlClusterStepWithOnOffParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (nonatomic, copy) NSNumber * _Nonnull stepMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (nonatomic, copy) NSNumber * _Nonnull stepSize;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1123,16 +1123,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterStopWithOnOffParams : NSObject
+@interface MTRLevelControlClusterStopWithOnOffParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1147,14 +1147,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLevelControlClusterMoveToClosestFrequencyParams : NSObject
+@interface MTRLevelControlClusterMoveToClosestFrequencyParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull frequency;
+@property (nonatomic, copy) NSNumber * _Nonnull frequency;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1169,16 +1169,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterInstantActionParams : NSObject
+@interface MTRBridgedActionsClusterInstantActionParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1193,18 +1193,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterInstantActionWithTransitionParams : NSObject
+@interface MTRBridgedActionsClusterInstantActionWithTransitionParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1219,16 +1219,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterStartActionParams : NSObject
+@interface MTRBridgedActionsClusterStartActionParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1243,18 +1243,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterStartActionWithDurationParams : NSObject
+@interface MTRBridgedActionsClusterStartActionWithDurationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 
-@property (strong, nonatomic) NSNumber * _Nonnull duration;
+@property (nonatomic, copy) NSNumber * _Nonnull duration;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1269,16 +1269,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterStopActionParams : NSObject
+@interface MTRBridgedActionsClusterStopActionParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1293,16 +1293,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterPauseActionParams : NSObject
+@interface MTRBridgedActionsClusterPauseActionParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1317,18 +1317,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterPauseActionWithDurationParams : NSObject
+@interface MTRBridgedActionsClusterPauseActionWithDurationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 
-@property (strong, nonatomic) NSNumber * _Nonnull duration;
+@property (nonatomic, copy) NSNumber * _Nonnull duration;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1343,16 +1343,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterResumeActionParams : NSObject
+@interface MTRBridgedActionsClusterResumeActionParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1367,16 +1367,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterEnableActionParams : NSObject
+@interface MTRBridgedActionsClusterEnableActionParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1391,18 +1391,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterEnableActionWithDurationParams : NSObject
+@interface MTRBridgedActionsClusterEnableActionWithDurationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 
-@property (strong, nonatomic) NSNumber * _Nonnull duration;
+@property (nonatomic, copy) NSNumber * _Nonnull duration;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1417,16 +1417,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterDisableActionParams : NSObject
+@interface MTRBridgedActionsClusterDisableActionParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1441,18 +1441,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBridgedActionsClusterDisableActionWithDurationParams : NSObject
+@interface MTRBridgedActionsClusterDisableActionWithDurationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
 
-@property (strong, nonatomic) NSNumber * _Nullable invokeID;
+@property (nonatomic, copy) NSNumber * _Nullable invokeID;
 
-@property (strong, nonatomic) NSNumber * _Nonnull duration;
+@property (nonatomic, copy) NSNumber * _Nonnull duration;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1467,12 +1467,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBasicClusterMfgSpecificPingParams : NSObject
+@interface MTRBasicClusterMfgSpecificPingParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1487,28 +1487,28 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterQueryImageParams : NSObject
+@interface MTROtaSoftwareUpdateProviderClusterQueryImageParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull vendorId;
+@property (nonatomic, copy) NSNumber * _Nonnull vendorId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull productId;
+@property (nonatomic, copy) NSNumber * _Nonnull productId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
+@property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
 
-@property (strong, nonatomic) NSArray * _Nonnull protocolsSupported;
+@property (nonatomic, copy) NSArray * _Nonnull protocolsSupported;
 
-@property (strong, nonatomic) NSNumber * _Nullable hardwareVersion;
+@property (nonatomic, copy) NSNumber * _Nullable hardwareVersion;
 
-@property (strong, nonatomic) NSString * _Nullable location;
+@property (nonatomic, copy) NSString * _Nullable location;
 
-@property (strong, nonatomic) NSNumber * _Nullable requestorCanConsent;
+@property (nonatomic, copy) NSNumber * _Nullable requestorCanConsent;
 
-@property (strong, nonatomic) NSData * _Nullable metadataForProvider;
+@property (nonatomic, copy) NSData * _Nullable metadataForProvider;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1523,28 +1523,28 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams : NSObject
+@interface MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nullable delayedActionTime;
+@property (nonatomic, copy) NSNumber * _Nullable delayedActionTime;
 
-@property (strong, nonatomic) NSString * _Nullable imageURI;
+@property (nonatomic, copy) NSString * _Nullable imageURI;
 
-@property (strong, nonatomic) NSNumber * _Nullable softwareVersion;
+@property (nonatomic, copy) NSNumber * _Nullable softwareVersion;
 
-@property (strong, nonatomic) NSString * _Nullable softwareVersionString;
+@property (nonatomic, copy) NSString * _Nullable softwareVersionString;
 
-@property (strong, nonatomic) NSData * _Nullable updateToken;
+@property (nonatomic, copy) NSData * _Nullable updateToken;
 
-@property (strong, nonatomic) NSNumber * _Nullable userConsentNeeded;
+@property (nonatomic, copy) NSNumber * _Nullable userConsentNeeded;
 
-@property (strong, nonatomic) NSData * _Nullable metadataForRequestor;
+@property (nonatomic, copy) NSData * _Nullable metadataForRequestor;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1559,16 +1559,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams : NSObject
+@interface MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull updateToken;
+@property (nonatomic, copy) NSData * _Nonnull updateToken;
 
-@property (strong, nonatomic, getter=getNewVersion) NSNumber * _Nonnull newVersion;
+@property (nonatomic, copy, getter=getNewVersion) NSNumber * _Nonnull newVersion;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1583,16 +1583,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams : NSObject
+@interface MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull action;
+@property (nonatomic, copy) NSNumber * _Nonnull action;
 
-@property (strong, nonatomic) NSNumber * _Nonnull delayedActionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull delayedActionTime;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1607,16 +1607,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams : NSObject
+@interface MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull updateToken;
+@property (nonatomic, copy) NSData * _Nonnull updateToken;
 
-@property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
+@property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1631,22 +1631,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams : NSObject
+@interface MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull providerNodeId;
+@property (nonatomic, copy) NSNumber * _Nonnull providerNodeId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull vendorId;
+@property (nonatomic, copy) NSNumber * _Nonnull vendorId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull announcementReason;
+@property (nonatomic, copy) NSNumber * _Nonnull announcementReason;
 
-@property (strong, nonatomic) NSData * _Nullable metadataForNode;
+@property (nonatomic, copy) NSData * _Nullable metadataForNode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull endpoint;
+@property (nonatomic, copy) NSNumber * _Nonnull endpoint;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1661,16 +1661,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGeneralCommissioningClusterArmFailSafeParams : NSObject
+@interface MTRGeneralCommissioningClusterArmFailSafeParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull expiryLengthSeconds;
+@property (nonatomic, copy) NSNumber * _Nonnull expiryLengthSeconds;
 
-@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (nonatomic, copy) NSNumber * _Nonnull breadcrumb;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1685,16 +1685,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGeneralCommissioningClusterArmFailSafeResponseParams : NSObject
+@interface MTRGeneralCommissioningClusterArmFailSafeResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (nonatomic, copy) NSNumber * _Nonnull errorCode;
 
-@property (strong, nonatomic) NSString * _Nonnull debugText;
+@property (nonatomic, copy) NSString * _Nonnull debugText;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1709,18 +1709,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGeneralCommissioningClusterSetRegulatoryConfigParams : NSObject
+@interface MTRGeneralCommissioningClusterSetRegulatoryConfigParams : NSObject <NSCopying>
 
-@property (strong, nonatomic, getter=getNewRegulatoryConfig) NSNumber * _Nonnull newRegulatoryConfig;
+@property (nonatomic, copy, getter=getNewRegulatoryConfig) NSNumber * _Nonnull newRegulatoryConfig;
 
-@property (strong, nonatomic) NSString * _Nonnull countryCode;
+@property (nonatomic, copy) NSString * _Nonnull countryCode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull breadcrumb;
+@property (nonatomic, copy) NSNumber * _Nonnull breadcrumb;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1735,16 +1735,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams : NSObject
+@interface MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (nonatomic, copy) NSNumber * _Nonnull errorCode;
 
-@property (strong, nonatomic) NSString * _Nonnull debugText;
+@property (nonatomic, copy) NSString * _Nonnull debugText;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1759,12 +1759,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGeneralCommissioningClusterCommissioningCompleteParams : NSObject
+@interface MTRGeneralCommissioningClusterCommissioningCompleteParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1779,16 +1779,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGeneralCommissioningClusterCommissioningCompleteResponseParams : NSObject
+@interface MTRGeneralCommissioningClusterCommissioningCompleteResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull errorCode;
+@property (nonatomic, copy) NSNumber * _Nonnull errorCode;
 
-@property (strong, nonatomic) NSString * _Nonnull debugText;
+@property (nonatomic, copy) NSString * _Nonnull debugText;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1803,16 +1803,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterScanNetworksParams : NSObject
+@interface MTRNetworkCommissioningClusterScanNetworksParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nullable ssid;
+@property (nonatomic, copy) NSData * _Nullable ssid;
 
-@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
+@property (nonatomic, copy) NSNumber * _Nullable breadcrumb;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1827,20 +1827,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterScanNetworksResponseParams : NSObject
+@interface MTRNetworkCommissioningClusterScanNetworksResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull networkingStatus;
+@property (nonatomic, copy) NSNumber * _Nonnull networkingStatus;
 
-@property (strong, nonatomic) NSString * _Nullable debugText;
+@property (nonatomic, copy) NSString * _Nullable debugText;
 
-@property (strong, nonatomic) NSArray * _Nullable wiFiScanResults;
+@property (nonatomic, copy) NSArray * _Nullable wiFiScanResults;
 
-@property (strong, nonatomic) NSArray * _Nullable threadScanResults;
+@property (nonatomic, copy) NSArray * _Nullable threadScanResults;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1855,18 +1855,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams : NSObject
+@interface MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull ssid;
+@property (nonatomic, copy) NSData * _Nonnull ssid;
 
-@property (strong, nonatomic) NSData * _Nonnull credentials;
+@property (nonatomic, copy) NSData * _Nonnull credentials;
 
-@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
+@property (nonatomic, copy) NSNumber * _Nullable breadcrumb;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1881,16 +1881,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams : NSObject
+@interface MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull operationalDataset;
+@property (nonatomic, copy) NSData * _Nonnull operationalDataset;
 
-@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
+@property (nonatomic, copy) NSNumber * _Nullable breadcrumb;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1905,16 +1905,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterRemoveNetworkParams : NSObject
+@interface MTRNetworkCommissioningClusterRemoveNetworkParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull networkID;
+@property (nonatomic, copy) NSData * _Nonnull networkID;
 
-@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
+@property (nonatomic, copy) NSNumber * _Nullable breadcrumb;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1929,18 +1929,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterNetworkConfigResponseParams : NSObject
+@interface MTRNetworkCommissioningClusterNetworkConfigResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull networkingStatus;
+@property (nonatomic, copy) NSNumber * _Nonnull networkingStatus;
 
-@property (strong, nonatomic) NSString * _Nullable debugText;
+@property (nonatomic, copy) NSString * _Nullable debugText;
 
-@property (strong, nonatomic) NSNumber * _Nullable networkIndex;
+@property (nonatomic, copy) NSNumber * _Nullable networkIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1955,16 +1955,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterConnectNetworkParams : NSObject
+@interface MTRNetworkCommissioningClusterConnectNetworkParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull networkID;
+@property (nonatomic, copy) NSData * _Nonnull networkID;
 
-@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
+@property (nonatomic, copy) NSNumber * _Nullable breadcrumb;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -1979,18 +1979,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterConnectNetworkResponseParams : NSObject
+@interface MTRNetworkCommissioningClusterConnectNetworkResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull networkingStatus;
+@property (nonatomic, copy) NSNumber * _Nonnull networkingStatus;
 
-@property (strong, nonatomic) NSString * _Nullable debugText;
+@property (nonatomic, copy) NSString * _Nullable debugText;
 
-@property (strong, nonatomic) NSNumber * _Nullable errorValue;
+@property (nonatomic, copy) NSNumber * _Nullable errorValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2005,18 +2005,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRNetworkCommissioningClusterReorderNetworkParams : NSObject
+@interface MTRNetworkCommissioningClusterReorderNetworkParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull networkID;
+@property (nonatomic, copy) NSData * _Nonnull networkID;
 
-@property (strong, nonatomic) NSNumber * _Nonnull networkIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull networkIndex;
 
-@property (strong, nonatomic) NSNumber * _Nullable breadcrumb;
+@property (nonatomic, copy) NSNumber * _Nullable breadcrumb;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2031,18 +2031,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDiagnosticLogsClusterRetrieveLogsRequestParams : NSObject
+@interface MTRDiagnosticLogsClusterRetrieveLogsRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull intent;
+@property (nonatomic, copy) NSNumber * _Nonnull intent;
 
-@property (strong, nonatomic) NSNumber * _Nonnull requestedProtocol;
+@property (nonatomic, copy) NSNumber * _Nonnull requestedProtocol;
 
-@property (strong, nonatomic) NSData * _Nonnull transferFileDesignator;
+@property (nonatomic, copy) NSData * _Nonnull transferFileDesignator;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2057,20 +2057,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDiagnosticLogsClusterRetrieveLogsResponseParams : NSObject
+@interface MTRDiagnosticLogsClusterRetrieveLogsResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSData * _Nonnull content;
+@property (nonatomic, copy) NSData * _Nonnull content;
 
-@property (strong, nonatomic) NSNumber * _Nonnull timeStamp;
+@property (nonatomic, copy) NSNumber * _Nonnull timeStamp;
 
-@property (strong, nonatomic) NSNumber * _Nonnull timeSinceBoot;
+@property (nonatomic, copy) NSNumber * _Nonnull timeSinceBoot;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2085,16 +2085,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGeneralDiagnosticsClusterTestEventTriggerParams : NSObject
+@interface MTRGeneralDiagnosticsClusterTestEventTriggerParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull enableKey;
+@property (nonatomic, copy) NSData * _Nonnull enableKey;
 
-@property (strong, nonatomic) NSNumber * _Nonnull eventTrigger;
+@property (nonatomic, copy) NSNumber * _Nonnull eventTrigger;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2109,12 +2109,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRSoftwareDiagnosticsClusterResetWatermarksParams : NSObject
+@interface MTRSoftwareDiagnosticsClusterResetWatermarksParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2129,12 +2129,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRThreadNetworkDiagnosticsClusterResetCountsParams : NSObject
+@interface MTRThreadNetworkDiagnosticsClusterResetCountsParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2149,12 +2149,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRWiFiNetworkDiagnosticsClusterResetCountsParams : NSObject
+@interface MTRWiFiNetworkDiagnosticsClusterResetCountsParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2169,12 +2169,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTREthernetNetworkDiagnosticsClusterResetCountsParams : NSObject
+@interface MTREthernetNetworkDiagnosticsClusterResetCountsParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2189,22 +2189,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAdministratorCommissioningClusterOpenCommissioningWindowParams : NSObject
+@interface MTRAdministratorCommissioningClusterOpenCommissioningWindowParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull commissioningTimeout;
+@property (nonatomic, copy) NSNumber * _Nonnull commissioningTimeout;
 
-@property (strong, nonatomic) NSData * _Nonnull pakeVerifier;
+@property (nonatomic, copy) NSData * _Nonnull pakeVerifier;
 
-@property (strong, nonatomic) NSNumber * _Nonnull discriminator;
+@property (nonatomic, copy) NSNumber * _Nonnull discriminator;
 
-@property (strong, nonatomic) NSNumber * _Nonnull iterations;
+@property (nonatomic, copy) NSNumber * _Nonnull iterations;
 
-@property (strong, nonatomic) NSData * _Nonnull salt;
+@property (nonatomic, copy) NSData * _Nonnull salt;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2219,14 +2219,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams : NSObject
+@interface MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull commissioningTimeout;
+@property (nonatomic, copy) NSNumber * _Nonnull commissioningTimeout;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2241,12 +2241,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAdministratorCommissioningClusterRevokeCommissioningParams : NSObject
+@interface MTRAdministratorCommissioningClusterRevokeCommissioningParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2261,14 +2261,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterAttestationRequestParams : NSObject
+@interface MTROperationalCredentialsClusterAttestationRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull attestationNonce;
+@property (nonatomic, copy) NSData * _Nonnull attestationNonce;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2283,16 +2283,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterAttestationResponseParams : NSObject
+@interface MTROperationalCredentialsClusterAttestationResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull attestationElements;
+@property (nonatomic, copy) NSData * _Nonnull attestationElements;
 
-@property (strong, nonatomic) NSData * _Nonnull signature;
+@property (nonatomic, copy) NSData * _Nonnull signature;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2307,14 +2307,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterCertificateChainRequestParams : NSObject
+@interface MTROperationalCredentialsClusterCertificateChainRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull certificateType;
+@property (nonatomic, copy) NSNumber * _Nonnull certificateType;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2329,14 +2329,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterCertificateChainResponseParams : NSObject
+@interface MTROperationalCredentialsClusterCertificateChainResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull certificate;
+@property (nonatomic, copy) NSData * _Nonnull certificate;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2351,16 +2351,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterCSRRequestParams : NSObject
+@interface MTROperationalCredentialsClusterCSRRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull csrNonce;
+@property (nonatomic, copy) NSData * _Nonnull csrNonce;
 
-@property (strong, nonatomic) NSNumber * _Nullable isForUpdateNOC;
+@property (nonatomic, copy) NSNumber * _Nullable isForUpdateNOC;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2375,16 +2375,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterCSRResponseParams : NSObject
+@interface MTROperationalCredentialsClusterCSRResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull nocsrElements;
+@property (nonatomic, copy) NSData * _Nonnull nocsrElements;
 
-@property (strong, nonatomic) NSData * _Nonnull attestationSignature;
+@property (nonatomic, copy) NSData * _Nonnull attestationSignature;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2399,22 +2399,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterAddNOCParams : NSObject
+@interface MTROperationalCredentialsClusterAddNOCParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull nocValue;
+@property (nonatomic, copy) NSData * _Nonnull nocValue;
 
-@property (strong, nonatomic) NSData * _Nullable icacValue;
+@property (nonatomic, copy) NSData * _Nullable icacValue;
 
-@property (strong, nonatomic) NSData * _Nonnull ipkValue;
+@property (nonatomic, copy) NSData * _Nonnull ipkValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull caseAdminSubject;
+@property (nonatomic, copy) NSNumber * _Nonnull caseAdminSubject;
 
-@property (strong, nonatomic) NSNumber * _Nonnull adminVendorId;
+@property (nonatomic, copy) NSNumber * _Nonnull adminVendorId;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2429,16 +2429,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterUpdateNOCParams : NSObject
+@interface MTROperationalCredentialsClusterUpdateNOCParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull nocValue;
+@property (nonatomic, copy) NSData * _Nonnull nocValue;
 
-@property (strong, nonatomic) NSData * _Nullable icacValue;
+@property (nonatomic, copy) NSData * _Nullable icacValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2453,18 +2453,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterNOCResponseParams : NSObject
+@interface MTROperationalCredentialsClusterNOCResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull statusCode;
+@property (nonatomic, copy) NSNumber * _Nonnull statusCode;
 
-@property (strong, nonatomic) NSNumber * _Nullable fabricIndex;
+@property (nonatomic, copy) NSNumber * _Nullable fabricIndex;
 
-@property (strong, nonatomic) NSString * _Nullable debugText;
+@property (nonatomic, copy) NSString * _Nullable debugText;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2479,14 +2479,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterUpdateFabricLabelParams : NSObject
+@interface MTROperationalCredentialsClusterUpdateFabricLabelParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSString * _Nonnull label;
+@property (nonatomic, copy) NSString * _Nonnull label;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2501,14 +2501,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterRemoveFabricParams : NSObject
+@interface MTROperationalCredentialsClusterRemoveFabricParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2523,14 +2523,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTROperationalCredentialsClusterAddTrustedRootCertificateParams : NSObject
+@interface MTROperationalCredentialsClusterAddTrustedRootCertificateParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nonnull rootCertificate;
+@property (nonatomic, copy) NSData * _Nonnull rootCertificate;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2545,14 +2545,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupKeyManagementClusterKeySetWriteParams : NSObject
+@interface MTRGroupKeyManagementClusterKeySetWriteParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRGroupKeyManagementClusterGroupKeySetStruct * _Nonnull groupKeySet;
+@property (nonatomic, copy) MTRGroupKeyManagementClusterGroupKeySetStruct * _Nonnull groupKeySet;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2567,14 +2567,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupKeyManagementClusterKeySetReadParams : NSObject
+@interface MTRGroupKeyManagementClusterKeySetReadParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupKeySetID;
+@property (nonatomic, copy) NSNumber * _Nonnull groupKeySetID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2589,14 +2589,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupKeyManagementClusterKeySetReadResponseParams : NSObject
+@interface MTRGroupKeyManagementClusterKeySetReadResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRGroupKeyManagementClusterGroupKeySetStruct * _Nonnull groupKeySet;
+@property (nonatomic, copy) MTRGroupKeyManagementClusterGroupKeySetStruct * _Nonnull groupKeySet;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2611,14 +2611,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupKeyManagementClusterKeySetRemoveParams : NSObject
+@interface MTRGroupKeyManagementClusterKeySetRemoveParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull groupKeySetID;
+@property (nonatomic, copy) NSNumber * _Nonnull groupKeySetID;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2633,14 +2633,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupKeyManagementClusterKeySetReadAllIndicesParams : NSObject
+@interface MTRGroupKeyManagementClusterKeySetReadAllIndicesParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull groupKeySetIDs;
+@property (nonatomic, copy) NSArray * _Nonnull groupKeySetIDs;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2655,14 +2655,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams : NSObject
+@interface MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull groupKeySetIDs;
+@property (nonatomic, copy) NSArray * _Nonnull groupKeySetIDs;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2677,14 +2677,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRModeSelectClusterChangeToModeParams : NSObject
+@interface MTRModeSelectClusterChangeToModeParams : NSObject <NSCopying>
 
-@property (strong, nonatomic, getter=getNewMode) NSNumber * _Nonnull newMode;
+@property (nonatomic, copy, getter=getNewMode) NSNumber * _Nonnull newMode;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2699,14 +2699,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterLockDoorParams : NSObject
+@interface MTRDoorLockClusterLockDoorParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nullable pinCode;
+@property (nonatomic, copy) NSData * _Nullable pinCode;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2721,14 +2721,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterUnlockDoorParams : NSObject
+@interface MTRDoorLockClusterUnlockDoorParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSData * _Nullable pinCode;
+@property (nonatomic, copy) NSData * _Nullable pinCode;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2743,16 +2743,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterUnlockWithTimeoutParams : NSObject
+@interface MTRDoorLockClusterUnlockWithTimeoutParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull timeout;
+@property (nonatomic, copy) NSNumber * _Nonnull timeout;
 
-@property (strong, nonatomic) NSData * _Nullable pinCode;
+@property (nonatomic, copy) NSData * _Nullable pinCode;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2767,26 +2767,26 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterSetWeekDayScheduleParams : NSObject
+@interface MTRDoorLockClusterSetWeekDayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull weekDayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull weekDayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull daysMask;
+@property (nonatomic, copy) NSNumber * _Nonnull daysMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull startHour;
+@property (nonatomic, copy) NSNumber * _Nonnull startHour;
 
-@property (strong, nonatomic) NSNumber * _Nonnull startMinute;
+@property (nonatomic, copy) NSNumber * _Nonnull startMinute;
 
-@property (strong, nonatomic) NSNumber * _Nonnull endHour;
+@property (nonatomic, copy) NSNumber * _Nonnull endHour;
 
-@property (strong, nonatomic) NSNumber * _Nonnull endMinute;
+@property (nonatomic, copy) NSNumber * _Nonnull endMinute;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2801,16 +2801,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetWeekDayScheduleParams : NSObject
+@interface MTRDoorLockClusterGetWeekDayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull weekDayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull weekDayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2825,28 +2825,28 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetWeekDayScheduleResponseParams : NSObject
+@interface MTRDoorLockClusterGetWeekDayScheduleResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull weekDayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull weekDayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nullable daysMask;
+@property (nonatomic, copy) NSNumber * _Nullable daysMask;
 
-@property (strong, nonatomic) NSNumber * _Nullable startHour;
+@property (nonatomic, copy) NSNumber * _Nullable startHour;
 
-@property (strong, nonatomic) NSNumber * _Nullable startMinute;
+@property (nonatomic, copy) NSNumber * _Nullable startMinute;
 
-@property (strong, nonatomic) NSNumber * _Nullable endHour;
+@property (nonatomic, copy) NSNumber * _Nullable endHour;
 
-@property (strong, nonatomic) NSNumber * _Nullable endMinute;
+@property (nonatomic, copy) NSNumber * _Nullable endMinute;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2861,16 +2861,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterClearWeekDayScheduleParams : NSObject
+@interface MTRDoorLockClusterClearWeekDayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull weekDayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull weekDayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2885,20 +2885,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterSetYearDayScheduleParams : NSObject
+@interface MTRDoorLockClusterSetYearDayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull yearDayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull yearDayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
+@property (nonatomic, copy) NSNumber * _Nonnull localStartTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
+@property (nonatomic, copy) NSNumber * _Nonnull localEndTime;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2913,16 +2913,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetYearDayScheduleParams : NSObject
+@interface MTRDoorLockClusterGetYearDayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull yearDayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull yearDayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2937,22 +2937,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetYearDayScheduleResponseParams : NSObject
+@interface MTRDoorLockClusterGetYearDayScheduleResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull yearDayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull yearDayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nullable localStartTime;
+@property (nonatomic, copy) NSNumber * _Nullable localStartTime;
 
-@property (strong, nonatomic) NSNumber * _Nullable localEndTime;
+@property (nonatomic, copy) NSNumber * _Nullable localEndTime;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2967,16 +2967,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterClearYearDayScheduleParams : NSObject
+@interface MTRDoorLockClusterClearYearDayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull yearDayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull yearDayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -2991,20 +2991,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterSetHolidayScheduleParams : NSObject
+@interface MTRDoorLockClusterSetHolidayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull holidayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull holidayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull localStartTime;
+@property (nonatomic, copy) NSNumber * _Nonnull localStartTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull localEndTime;
+@property (nonatomic, copy) NSNumber * _Nonnull localEndTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull operatingMode;
+@property (nonatomic, copy) NSNumber * _Nonnull operatingMode;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3019,14 +3019,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetHolidayScheduleParams : NSObject
+@interface MTRDoorLockClusterGetHolidayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull holidayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull holidayIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3041,22 +3041,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetHolidayScheduleResponseParams : NSObject
+@interface MTRDoorLockClusterGetHolidayScheduleResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull holidayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull holidayIndex;
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nullable localStartTime;
+@property (nonatomic, copy) NSNumber * _Nullable localStartTime;
 
-@property (strong, nonatomic) NSNumber * _Nullable localEndTime;
+@property (nonatomic, copy) NSNumber * _Nullable localEndTime;
 
-@property (strong, nonatomic) NSNumber * _Nullable operatingMode;
+@property (nonatomic, copy) NSNumber * _Nullable operatingMode;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3071,14 +3071,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterClearHolidayScheduleParams : NSObject
+@interface MTRDoorLockClusterClearHolidayScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull holidayIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull holidayIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3093,26 +3093,26 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterSetUserParams : NSObject
+@interface MTRDoorLockClusterSetUserParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull operationType;
+@property (nonatomic, copy) NSNumber * _Nonnull operationType;
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 
-@property (strong, nonatomic) NSString * _Nullable userName;
+@property (nonatomic, copy) NSString * _Nullable userName;
 
-@property (strong, nonatomic) NSNumber * _Nullable userUniqueId;
+@property (nonatomic, copy) NSNumber * _Nullable userUniqueId;
 
-@property (strong, nonatomic) NSNumber * _Nullable userStatus;
+@property (nonatomic, copy) NSNumber * _Nullable userStatus;
 
-@property (strong, nonatomic) NSNumber * _Nullable userType;
+@property (nonatomic, copy) NSNumber * _Nullable userType;
 
-@property (strong, nonatomic) NSNumber * _Nullable credentialRule;
+@property (nonatomic, copy) NSNumber * _Nullable credentialRule;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3127,14 +3127,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetUserParams : NSObject
+@interface MTRDoorLockClusterGetUserParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3149,32 +3149,32 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetUserResponseParams : NSObject
+@interface MTRDoorLockClusterGetUserResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 
-@property (strong, nonatomic) NSString * _Nullable userName;
+@property (nonatomic, copy) NSString * _Nullable userName;
 
-@property (strong, nonatomic) NSNumber * _Nullable userUniqueId;
+@property (nonatomic, copy) NSNumber * _Nullable userUniqueId;
 
-@property (strong, nonatomic) NSNumber * _Nullable userStatus;
+@property (nonatomic, copy) NSNumber * _Nullable userStatus;
 
-@property (strong, nonatomic) NSNumber * _Nullable userType;
+@property (nonatomic, copy) NSNumber * _Nullable userType;
 
-@property (strong, nonatomic) NSNumber * _Nullable credentialRule;
+@property (nonatomic, copy) NSNumber * _Nullable credentialRule;
 
-@property (strong, nonatomic) NSArray * _Nullable credentials;
+@property (nonatomic, copy) NSArray * _Nullable credentials;
 
-@property (strong, nonatomic) NSNumber * _Nullable creatorFabricIndex;
+@property (nonatomic, copy) NSNumber * _Nullable creatorFabricIndex;
 
-@property (strong, nonatomic) NSNumber * _Nullable lastModifiedFabricIndex;
+@property (nonatomic, copy) NSNumber * _Nullable lastModifiedFabricIndex;
 
-@property (strong, nonatomic) NSNumber * _Nullable nextUserIndex;
+@property (nonatomic, copy) NSNumber * _Nullable nextUserIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3189,14 +3189,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterClearUserParams : NSObject
+@interface MTRDoorLockClusterClearUserParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull userIndex;
+@property (nonatomic, copy) NSNumber * _Nonnull userIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3211,24 +3211,24 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterSetCredentialParams : NSObject
+@interface MTRDoorLockClusterSetCredentialParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull operationType;
+@property (nonatomic, copy) NSNumber * _Nonnull operationType;
 
-@property (strong, nonatomic) MTRDoorLockClusterDlCredential * _Nonnull credential;
+@property (nonatomic, copy) MTRDoorLockClusterDlCredential * _Nonnull credential;
 
-@property (strong, nonatomic) NSData * _Nonnull credentialData;
+@property (nonatomic, copy) NSData * _Nonnull credentialData;
 
-@property (strong, nonatomic) NSNumber * _Nullable userIndex;
+@property (nonatomic, copy) NSNumber * _Nullable userIndex;
 
-@property (strong, nonatomic) NSNumber * _Nullable userStatus;
+@property (nonatomic, copy) NSNumber * _Nullable userStatus;
 
-@property (strong, nonatomic) NSNumber * _Nullable userType;
+@property (nonatomic, copy) NSNumber * _Nullable userType;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3243,18 +3243,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterSetCredentialResponseParams : NSObject
+@interface MTRDoorLockClusterSetCredentialResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nullable userIndex;
+@property (nonatomic, copy) NSNumber * _Nullable userIndex;
 
-@property (strong, nonatomic) NSNumber * _Nullable nextCredentialIndex;
+@property (nonatomic, copy) NSNumber * _Nullable nextCredentialIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3269,14 +3269,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetCredentialStatusParams : NSObject
+@interface MTRDoorLockClusterGetCredentialStatusParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRDoorLockClusterDlCredential * _Nonnull credential;
+@property (nonatomic, copy) MTRDoorLockClusterDlCredential * _Nonnull credential;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3291,22 +3291,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterGetCredentialStatusResponseParams : NSObject
+@interface MTRDoorLockClusterGetCredentialStatusResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull credentialExists;
+@property (nonatomic, copy) NSNumber * _Nonnull credentialExists;
 
-@property (strong, nonatomic) NSNumber * _Nullable userIndex;
+@property (nonatomic, copy) NSNumber * _Nullable userIndex;
 
-@property (strong, nonatomic) NSNumber * _Nullable creatorFabricIndex;
+@property (nonatomic, copy) NSNumber * _Nullable creatorFabricIndex;
 
-@property (strong, nonatomic) NSNumber * _Nullable lastModifiedFabricIndex;
+@property (nonatomic, copy) NSNumber * _Nullable lastModifiedFabricIndex;
 
-@property (strong, nonatomic) NSNumber * _Nullable nextCredentialIndex;
+@property (nonatomic, copy) NSNumber * _Nullable nextCredentialIndex;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3321,14 +3321,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRDoorLockClusterClearCredentialParams : NSObject
+@interface MTRDoorLockClusterClearCredentialParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRDoorLockClusterDlCredential * _Nullable credential;
+@property (nonatomic, copy) MTRDoorLockClusterDlCredential * _Nullable credential;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3343,12 +3343,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRWindowCoveringClusterUpOrOpenParams : NSObject
+@interface MTRWindowCoveringClusterUpOrOpenParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3363,12 +3363,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRWindowCoveringClusterDownOrCloseParams : NSObject
+@interface MTRWindowCoveringClusterDownOrCloseParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3383,12 +3383,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRWindowCoveringClusterStopMotionParams : NSObject
+@interface MTRWindowCoveringClusterStopMotionParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3403,14 +3403,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRWindowCoveringClusterGoToLiftValueParams : NSObject
+@interface MTRWindowCoveringClusterGoToLiftValueParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull liftValue;
+@property (nonatomic, copy) NSNumber * _Nonnull liftValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3425,14 +3425,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRWindowCoveringClusterGoToLiftPercentageParams : NSObject
+@interface MTRWindowCoveringClusterGoToLiftPercentageParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull liftPercent100thsValue;
+@property (nonatomic, copy) NSNumber * _Nonnull liftPercent100thsValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3447,14 +3447,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRWindowCoveringClusterGoToTiltValueParams : NSObject
+@interface MTRWindowCoveringClusterGoToTiltValueParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull tiltValue;
+@property (nonatomic, copy) NSNumber * _Nonnull tiltValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3469,14 +3469,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRWindowCoveringClusterGoToTiltPercentageParams : NSObject
+@interface MTRWindowCoveringClusterGoToTiltPercentageParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull tiltPercent100thsValue;
+@property (nonatomic, copy) NSNumber * _Nonnull tiltPercent100thsValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3491,14 +3491,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBarrierControlClusterBarrierControlGoToPercentParams : NSObject
+@interface MTRBarrierControlClusterBarrierControlGoToPercentParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull percentOpen;
+@property (nonatomic, copy) NSNumber * _Nonnull percentOpen;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3513,12 +3513,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRBarrierControlClusterBarrierControlStopParams : NSObject
+@interface MTRBarrierControlClusterBarrierControlStopParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3533,16 +3533,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRThermostatClusterSetpointRaiseLowerParams : NSObject
+@interface MTRThermostatClusterSetpointRaiseLowerParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull mode;
+@property (nonatomic, copy) NSNumber * _Nonnull mode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull amount;
+@property (nonatomic, copy) NSNumber * _Nonnull amount;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3557,20 +3557,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRThermostatClusterGetWeeklyScheduleResponseParams : NSObject
+@interface MTRThermostatClusterGetWeeklyScheduleResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull numberOfTransitionsForSequence;
+@property (nonatomic, copy) NSNumber * _Nonnull numberOfTransitionsForSequence;
 
-@property (strong, nonatomic) NSNumber * _Nonnull dayOfWeekForSequence;
+@property (nonatomic, copy) NSNumber * _Nonnull dayOfWeekForSequence;
 
-@property (strong, nonatomic) NSNumber * _Nonnull modeForSequence;
+@property (nonatomic, copy) NSNumber * _Nonnull modeForSequence;
 
-@property (strong, nonatomic) NSArray * _Nonnull transitions;
+@property (nonatomic, copy) NSArray * _Nonnull transitions;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3585,20 +3585,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRThermostatClusterSetWeeklyScheduleParams : NSObject
+@interface MTRThermostatClusterSetWeeklyScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull numberOfTransitionsForSequence;
+@property (nonatomic, copy) NSNumber * _Nonnull numberOfTransitionsForSequence;
 
-@property (strong, nonatomic) NSNumber * _Nonnull dayOfWeekForSequence;
+@property (nonatomic, copy) NSNumber * _Nonnull dayOfWeekForSequence;
 
-@property (strong, nonatomic) NSNumber * _Nonnull modeForSequence;
+@property (nonatomic, copy) NSNumber * _Nonnull modeForSequence;
 
-@property (strong, nonatomic) NSArray * _Nonnull transitions;
+@property (nonatomic, copy) NSArray * _Nonnull transitions;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3613,16 +3613,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRThermostatClusterGetWeeklyScheduleParams : NSObject
+@interface MTRThermostatClusterGetWeeklyScheduleParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull daysToReturn;
+@property (nonatomic, copy) NSNumber * _Nonnull daysToReturn;
 
-@property (strong, nonatomic) NSNumber * _Nonnull modeToReturn;
+@property (nonatomic, copy) NSNumber * _Nonnull modeToReturn;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3637,12 +3637,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRThermostatClusterClearWeeklyScheduleParams : NSObject
+@interface MTRThermostatClusterClearWeeklyScheduleParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3657,22 +3657,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveToHueParams : NSObject
+@interface MTRColorControlClusterMoveToHueParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull hue;
+@property (nonatomic, copy) NSNumber * _Nonnull hue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull direction;
+@property (nonatomic, copy) NSNumber * _Nonnull direction;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3687,20 +3687,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveHueParams : NSObject
+@interface MTRColorControlClusterMoveHueParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (nonatomic, copy) NSNumber * _Nonnull moveMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (nonatomic, copy) NSNumber * _Nonnull rate;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3715,22 +3715,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterStepHueParams : NSObject
+@interface MTRColorControlClusterStepHueParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (nonatomic, copy) NSNumber * _Nonnull stepMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (nonatomic, copy) NSNumber * _Nonnull stepSize;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3745,20 +3745,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveToSaturationParams : NSObject
+@interface MTRColorControlClusterMoveToSaturationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull saturation;
+@property (nonatomic, copy) NSNumber * _Nonnull saturation;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3773,20 +3773,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveSaturationParams : NSObject
+@interface MTRColorControlClusterMoveSaturationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (nonatomic, copy) NSNumber * _Nonnull moveMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (nonatomic, copy) NSNumber * _Nonnull rate;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3801,22 +3801,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterStepSaturationParams : NSObject
+@interface MTRColorControlClusterStepSaturationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (nonatomic, copy) NSNumber * _Nonnull stepMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (nonatomic, copy) NSNumber * _Nonnull stepSize;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3831,22 +3831,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveToHueAndSaturationParams : NSObject
+@interface MTRColorControlClusterMoveToHueAndSaturationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull hue;
+@property (nonatomic, copy) NSNumber * _Nonnull hue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull saturation;
+@property (nonatomic, copy) NSNumber * _Nonnull saturation;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3861,22 +3861,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveToColorParams : NSObject
+@interface MTRColorControlClusterMoveToColorParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull colorX;
+@property (nonatomic, copy) NSNumber * _Nonnull colorX;
 
-@property (strong, nonatomic) NSNumber * _Nonnull colorY;
+@property (nonatomic, copy) NSNumber * _Nonnull colorY;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3891,20 +3891,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveColorParams : NSObject
+@interface MTRColorControlClusterMoveColorParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull rateX;
+@property (nonatomic, copy) NSNumber * _Nonnull rateX;
 
-@property (strong, nonatomic) NSNumber * _Nonnull rateY;
+@property (nonatomic, copy) NSNumber * _Nonnull rateY;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3919,22 +3919,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterStepColorParams : NSObject
+@interface MTRColorControlClusterStepColorParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepX;
+@property (nonatomic, copy) NSNumber * _Nonnull stepX;
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepY;
+@property (nonatomic, copy) NSNumber * _Nonnull stepY;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3949,20 +3949,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveToColorTemperatureParams : NSObject
+@interface MTRColorControlClusterMoveToColorTemperatureParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull colorTemperature;
+@property (nonatomic, copy) NSNumber * _Nonnull colorTemperature;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -3977,22 +3977,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterEnhancedMoveToHueParams : NSObject
+@interface MTRColorControlClusterEnhancedMoveToHueParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull enhancedHue;
+@property (nonatomic, copy) NSNumber * _Nonnull enhancedHue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull direction;
+@property (nonatomic, copy) NSNumber * _Nonnull direction;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4007,20 +4007,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterEnhancedMoveHueParams : NSObject
+@interface MTRColorControlClusterEnhancedMoveHueParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (nonatomic, copy) NSNumber * _Nonnull moveMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (nonatomic, copy) NSNumber * _Nonnull rate;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4035,22 +4035,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterEnhancedStepHueParams : NSObject
+@interface MTRColorControlClusterEnhancedStepHueParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (nonatomic, copy) NSNumber * _Nonnull stepMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (nonatomic, copy) NSNumber * _Nonnull stepSize;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4065,22 +4065,22 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterEnhancedMoveToHueAndSaturationParams : NSObject
+@interface MTRColorControlClusterEnhancedMoveToHueAndSaturationParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull enhancedHue;
+@property (nonatomic, copy) NSNumber * _Nonnull enhancedHue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull saturation;
+@property (nonatomic, copy) NSNumber * _Nonnull saturation;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4095,26 +4095,26 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterColorLoopSetParams : NSObject
+@interface MTRColorControlClusterColorLoopSetParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull updateFlags;
+@property (nonatomic, copy) NSNumber * _Nonnull updateFlags;
 
-@property (strong, nonatomic) NSNumber * _Nonnull action;
+@property (nonatomic, copy) NSNumber * _Nonnull action;
 
-@property (strong, nonatomic) NSNumber * _Nonnull direction;
+@property (nonatomic, copy) NSNumber * _Nonnull direction;
 
-@property (strong, nonatomic) NSNumber * _Nonnull time;
+@property (nonatomic, copy) NSNumber * _Nonnull time;
 
-@property (strong, nonatomic) NSNumber * _Nonnull startHue;
+@property (nonatomic, copy) NSNumber * _Nonnull startHue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4129,16 +4129,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterStopMoveStepParams : NSObject
+@interface MTRColorControlClusterStopMoveStepParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4153,24 +4153,24 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterMoveColorTemperatureParams : NSObject
+@interface MTRColorControlClusterMoveColorTemperatureParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull moveMode;
+@property (nonatomic, copy) NSNumber * _Nonnull moveMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull rate;
+@property (nonatomic, copy) NSNumber * _Nonnull rate;
 
-@property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMinimumMireds;
+@property (nonatomic, copy) NSNumber * _Nonnull colorTemperatureMinimumMireds;
 
-@property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMaximumMireds;
+@property (nonatomic, copy) NSNumber * _Nonnull colorTemperatureMaximumMireds;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4185,26 +4185,26 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRColorControlClusterStepColorTemperatureParams : NSObject
+@interface MTRColorControlClusterStepColorTemperatureParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepMode;
+@property (nonatomic, copy) NSNumber * _Nonnull stepMode;
 
-@property (strong, nonatomic) NSNumber * _Nonnull stepSize;
+@property (nonatomic, copy) NSNumber * _Nonnull stepSize;
 
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMinimumMireds;
+@property (nonatomic, copy) NSNumber * _Nonnull colorTemperatureMinimumMireds;
 
-@property (strong, nonatomic) NSNumber * _Nonnull colorTemperatureMaximumMireds;
+@property (nonatomic, copy) NSNumber * _Nonnull colorTemperatureMaximumMireds;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsMask;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsMask;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionsOverride;
+@property (nonatomic, copy) NSNumber * _Nonnull optionsOverride;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4219,14 +4219,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRChannelClusterChangeChannelParams : NSObject
+@interface MTRChannelClusterChangeChannelParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSString * _Nonnull match;
+@property (nonatomic, copy) NSString * _Nonnull match;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4241,16 +4241,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRChannelClusterChangeChannelResponseParams : NSObject
+@interface MTRChannelClusterChangeChannelResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSString * _Nullable data;
+@property (nonatomic, copy) NSString * _Nullable data;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4265,16 +4265,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRChannelClusterChangeChannelByNumberParams : NSObject
+@interface MTRChannelClusterChangeChannelByNumberParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull majorNumber;
+@property (nonatomic, copy) NSNumber * _Nonnull majorNumber;
 
-@property (strong, nonatomic) NSNumber * _Nonnull minorNumber;
+@property (nonatomic, copy) NSNumber * _Nonnull minorNumber;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4289,14 +4289,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRChannelClusterSkipChannelParams : NSObject
+@interface MTRChannelClusterSkipChannelParams : NSObject <NSCopying>
 
-@property (strong, nonatomic, getter=getCount) NSNumber * _Nonnull count;
+@property (nonatomic, copy, getter=getCount) NSNumber * _Nonnull count;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4311,16 +4311,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTargetNavigatorClusterNavigateTargetParams : NSObject
+@interface MTRTargetNavigatorClusterNavigateTargetParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull target;
+@property (nonatomic, copy) NSNumber * _Nonnull target;
 
-@property (strong, nonatomic) NSString * _Nullable data;
+@property (nonatomic, copy) NSString * _Nullable data;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4335,16 +4335,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTargetNavigatorClusterNavigateTargetResponseParams : NSObject
+@interface MTRTargetNavigatorClusterNavigateTargetResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSString * _Nullable data;
+@property (nonatomic, copy) NSString * _Nullable data;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4359,12 +4359,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterPlayParams : NSObject
+@interface MTRMediaPlaybackClusterPlayParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4379,12 +4379,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterPauseParams : NSObject
+@interface MTRMediaPlaybackClusterPauseParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4399,12 +4399,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterStopPlaybackParams : NSObject
+@interface MTRMediaPlaybackClusterStopPlaybackParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4419,12 +4419,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterStartOverParams : NSObject
+@interface MTRMediaPlaybackClusterStartOverParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4439,12 +4439,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterPreviousParams : NSObject
+@interface MTRMediaPlaybackClusterPreviousParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4459,12 +4459,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterNextParams : NSObject
+@interface MTRMediaPlaybackClusterNextParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4479,12 +4479,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterRewindParams : NSObject
+@interface MTRMediaPlaybackClusterRewindParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4499,12 +4499,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterFastForwardParams : NSObject
+@interface MTRMediaPlaybackClusterFastForwardParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4519,14 +4519,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterSkipForwardParams : NSObject
+@interface MTRMediaPlaybackClusterSkipForwardParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull deltaPositionMilliseconds;
+@property (nonatomic, copy) NSNumber * _Nonnull deltaPositionMilliseconds;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4541,14 +4541,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterSkipBackwardParams : NSObject
+@interface MTRMediaPlaybackClusterSkipBackwardParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull deltaPositionMilliseconds;
+@property (nonatomic, copy) NSNumber * _Nonnull deltaPositionMilliseconds;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4563,16 +4563,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterPlaybackResponseParams : NSObject
+@interface MTRMediaPlaybackClusterPlaybackResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSString * _Nullable data;
+@property (nonatomic, copy) NSString * _Nullable data;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4587,14 +4587,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaPlaybackClusterSeekParams : NSObject
+@interface MTRMediaPlaybackClusterSeekParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull position;
+@property (nonatomic, copy) NSNumber * _Nonnull position;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4609,14 +4609,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaInputClusterSelectInputParams : NSObject
+@interface MTRMediaInputClusterSelectInputParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull index;
+@property (nonatomic, copy) NSNumber * _Nonnull index;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4631,12 +4631,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaInputClusterShowInputStatusParams : NSObject
+@interface MTRMediaInputClusterShowInputStatusParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4651,12 +4651,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaInputClusterHideInputStatusParams : NSObject
+@interface MTRMediaInputClusterHideInputStatusParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4671,16 +4671,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRMediaInputClusterRenameInputParams : NSObject
+@interface MTRMediaInputClusterRenameInputParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull index;
+@property (nonatomic, copy) NSNumber * _Nonnull index;
 
-@property (strong, nonatomic) NSString * _Nonnull name;
+@property (nonatomic, copy) NSString * _Nonnull name;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4695,12 +4695,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRLowPowerClusterSleepParams : NSObject
+@interface MTRLowPowerClusterSleepParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4715,14 +4715,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRKeypadInputClusterSendKeyParams : NSObject
+@interface MTRKeypadInputClusterSendKeyParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull keyCode;
+@property (nonatomic, copy) NSNumber * _Nonnull keyCode;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4737,14 +4737,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRKeypadInputClusterSendKeyResponseParams : NSObject
+@interface MTRKeypadInputClusterSendKeyResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4759,18 +4759,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRContentLauncherClusterLaunchContentParams : NSObject
+@interface MTRContentLauncherClusterLaunchContentParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRContentLauncherClusterContentSearch * _Nonnull search;
+@property (nonatomic, copy) MTRContentLauncherClusterContentSearch * _Nonnull search;
 
-@property (strong, nonatomic) NSNumber * _Nonnull autoPlay;
+@property (nonatomic, copy) NSNumber * _Nonnull autoPlay;
 
-@property (strong, nonatomic) NSString * _Nullable data;
+@property (nonatomic, copy) NSString * _Nullable data;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4785,18 +4785,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRContentLauncherClusterLaunchURLParams : NSObject
+@interface MTRContentLauncherClusterLaunchURLParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSString * _Nonnull contentURL;
+@property (nonatomic, copy) NSString * _Nonnull contentURL;
 
-@property (strong, nonatomic) NSString * _Nullable displayString;
+@property (nonatomic, copy) NSString * _Nullable displayString;
 
-@property (strong, nonatomic) MTRContentLauncherClusterBrandingInformation * _Nullable brandingInformation;
+@property (nonatomic, copy) MTRContentLauncherClusterBrandingInformation * _Nullable brandingInformation;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4811,16 +4811,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRContentLauncherClusterLaunchResponseParams : NSObject
+@interface MTRContentLauncherClusterLaunchResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSString * _Nullable data;
+@property (nonatomic, copy) NSString * _Nullable data;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4835,14 +4835,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAudioOutputClusterSelectOutputParams : NSObject
+@interface MTRAudioOutputClusterSelectOutputParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull index;
+@property (nonatomic, copy) NSNumber * _Nonnull index;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4857,16 +4857,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAudioOutputClusterRenameOutputParams : NSObject
+@interface MTRAudioOutputClusterRenameOutputParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull index;
+@property (nonatomic, copy) NSNumber * _Nonnull index;
 
-@property (strong, nonatomic) NSString * _Nonnull name;
+@property (nonatomic, copy) NSString * _Nonnull name;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4881,16 +4881,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRApplicationLauncherClusterLaunchAppParams : NSObject
+@interface MTRApplicationLauncherClusterLaunchAppParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRApplicationLauncherClusterApplication * _Nonnull application;
+@property (nonatomic, copy) MTRApplicationLauncherClusterApplication * _Nonnull application;
 
-@property (strong, nonatomic) NSData * _Nullable data;
+@property (nonatomic, copy) NSData * _Nullable data;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4905,14 +4905,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRApplicationLauncherClusterStopAppParams : NSObject
+@interface MTRApplicationLauncherClusterStopAppParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRApplicationLauncherClusterApplication * _Nonnull application;
+@property (nonatomic, copy) MTRApplicationLauncherClusterApplication * _Nonnull application;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4927,14 +4927,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRApplicationLauncherClusterHideAppParams : NSObject
+@interface MTRApplicationLauncherClusterHideAppParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRApplicationLauncherClusterApplication * _Nonnull application;
+@property (nonatomic, copy) MTRApplicationLauncherClusterApplication * _Nonnull application;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4949,16 +4949,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRApplicationLauncherClusterLauncherResponseParams : NSObject
+@interface MTRApplicationLauncherClusterLauncherResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSData * _Nonnull data;
+@property (nonatomic, copy) NSData * _Nonnull data;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4973,14 +4973,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAccountLoginClusterGetSetupPINParams : NSObject
+@interface MTRAccountLoginClusterGetSetupPINParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSString * _Nonnull tempAccountIdentifier;
+@property (nonatomic, copy) NSString * _Nonnull tempAccountIdentifier;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -4995,14 +4995,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAccountLoginClusterGetSetupPINResponseParams : NSObject
+@interface MTRAccountLoginClusterGetSetupPINResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSString * _Nonnull setupPIN;
+@property (nonatomic, copy) NSString * _Nonnull setupPIN;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5017,16 +5017,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAccountLoginClusterLoginParams : NSObject
+@interface MTRAccountLoginClusterLoginParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSString * _Nonnull tempAccountIdentifier;
+@property (nonatomic, copy) NSString * _Nonnull tempAccountIdentifier;
 
-@property (strong, nonatomic) NSString * _Nonnull setupPIN;
+@property (nonatomic, copy) NSString * _Nonnull setupPIN;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5041,12 +5041,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRAccountLoginClusterLogoutParams : NSObject
+@interface MTRAccountLoginClusterLogoutParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5061,20 +5061,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRElectricalMeasurementClusterGetProfileInfoResponseCommandParams : NSObject
+@interface MTRElectricalMeasurementClusterGetProfileInfoResponseCommandParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull profileCount;
+@property (nonatomic, copy) NSNumber * _Nonnull profileCount;
 
-@property (strong, nonatomic) NSNumber * _Nonnull profileIntervalPeriod;
+@property (nonatomic, copy) NSNumber * _Nonnull profileIntervalPeriod;
 
-@property (strong, nonatomic) NSNumber * _Nonnull maxNumberOfIntervals;
+@property (nonatomic, copy) NSNumber * _Nonnull maxNumberOfIntervals;
 
-@property (strong, nonatomic) NSArray * _Nonnull listOfAttributes;
+@property (nonatomic, copy) NSArray * _Nonnull listOfAttributes;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5089,12 +5089,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRElectricalMeasurementClusterGetProfileInfoCommandParams : NSObject
+@interface MTRElectricalMeasurementClusterGetProfileInfoCommandParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5109,24 +5109,24 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRElectricalMeasurementClusterGetMeasurementProfileResponseCommandParams : NSObject
+@interface MTRElectricalMeasurementClusterGetMeasurementProfileResponseCommandParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull startTime;
+@property (nonatomic, copy) NSNumber * _Nonnull startTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull status;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@property (strong, nonatomic) NSNumber * _Nonnull profileIntervalPeriod;
+@property (nonatomic, copy) NSNumber * _Nonnull profileIntervalPeriod;
 
-@property (strong, nonatomic) NSNumber * _Nonnull numberOfIntervalsDelivered;
+@property (nonatomic, copy) NSNumber * _Nonnull numberOfIntervalsDelivered;
 
-@property (strong, nonatomic) NSNumber * _Nonnull attributeId;
+@property (nonatomic, copy) NSNumber * _Nonnull attributeId;
 
-@property (strong, nonatomic) NSArray * _Nonnull intervals;
+@property (nonatomic, copy) NSArray * _Nonnull intervals;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5141,18 +5141,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams : NSObject
+@interface MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull attributeId;
+@property (nonatomic, copy) NSNumber * _Nonnull attributeId;
 
-@property (strong, nonatomic) NSNumber * _Nonnull startTime;
+@property (nonatomic, copy) NSNumber * _Nonnull startTime;
 
-@property (strong, nonatomic) NSNumber * _Nonnull numberOfIntervals;
+@property (nonatomic, copy) NSNumber * _Nonnull numberOfIntervals;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5167,12 +5167,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestParams : NSObject
+@interface MTRTestClusterClusterTestParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5187,14 +5187,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestSpecificResponseParams : NSObject
+@interface MTRTestClusterClusterTestSpecificResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull returnValue;
+@property (nonatomic, copy) NSNumber * _Nonnull returnValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5209,12 +5209,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestNotHandledParams : NSObject
+@interface MTRTestClusterClusterTestNotHandledParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5229,14 +5229,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestAddArgumentsResponseParams : NSObject
+@interface MTRTestClusterClusterTestAddArgumentsResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull returnValue;
+@property (nonatomic, copy) NSNumber * _Nonnull returnValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5251,12 +5251,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestSpecificParams : NSObject
+@interface MTRTestClusterClusterTestSpecificParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5271,14 +5271,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestSimpleArgumentResponseParams : NSObject
+@interface MTRTestClusterClusterTestSimpleArgumentResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull returnValue;
+@property (nonatomic, copy) NSNumber * _Nonnull returnValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5293,12 +5293,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestUnknownCommandParams : NSObject
+@interface MTRTestClusterClusterTestUnknownCommandParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5313,24 +5313,24 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestStructArrayArgumentResponseParams : NSObject
+@interface MTRTestClusterClusterTestStructArrayArgumentResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (nonatomic, copy) NSArray * _Nonnull arg1;
 
-@property (strong, nonatomic) NSArray * _Nonnull arg2;
+@property (nonatomic, copy) NSArray * _Nonnull arg2;
 
-@property (strong, nonatomic) NSArray * _Nonnull arg3;
+@property (nonatomic, copy) NSArray * _Nonnull arg3;
 
-@property (strong, nonatomic) NSArray * _Nonnull arg4;
+@property (nonatomic, copy) NSArray * _Nonnull arg4;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg5;
+@property (nonatomic, copy) NSNumber * _Nonnull arg5;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg6;
+@property (nonatomic, copy) NSNumber * _Nonnull arg6;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5345,16 +5345,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestAddArgumentsParams : NSObject
+@interface MTRTestClusterClusterTestAddArgumentsParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (nonatomic, copy) NSNumber * _Nonnull arg1;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg2;
+@property (nonatomic, copy) NSNumber * _Nonnull arg2;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5369,14 +5369,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestListInt8UReverseResponseParams : NSObject
+@interface MTRTestClusterClusterTestListInt8UReverseResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (nonatomic, copy) NSArray * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5391,14 +5391,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestSimpleArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestSimpleArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (nonatomic, copy) NSNumber * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5413,16 +5413,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestEnumsResponseParams : NSObject
+@interface MTRTestClusterClusterTestEnumsResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (nonatomic, copy) NSNumber * _Nonnull arg1;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg2;
+@property (nonatomic, copy) NSNumber * _Nonnull arg2;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5437,24 +5437,24 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestStructArrayArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestStructArrayArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (nonatomic, copy) NSArray * _Nonnull arg1;
 
-@property (strong, nonatomic) NSArray * _Nonnull arg2;
+@property (nonatomic, copy) NSArray * _Nonnull arg2;
 
-@property (strong, nonatomic) NSArray * _Nonnull arg3;
+@property (nonatomic, copy) NSArray * _Nonnull arg3;
 
-@property (strong, nonatomic) NSArray * _Nonnull arg4;
+@property (nonatomic, copy) NSArray * _Nonnull arg4;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg5;
+@property (nonatomic, copy) NSNumber * _Nonnull arg5;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg6;
+@property (nonatomic, copy) NSNumber * _Nonnull arg6;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5469,20 +5469,20 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestNullableOptionalResponseParams : NSObject
+@interface MTRTestClusterClusterTestNullableOptionalResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull wasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull wasPresent;
 
-@property (strong, nonatomic) NSNumber * _Nullable wasNull;
+@property (nonatomic, copy) NSNumber * _Nullable wasNull;
 
-@property (strong, nonatomic) NSNumber * _Nullable value;
+@property (nonatomic, copy) NSNumber * _Nullable value;
 
-@property (strong, nonatomic) NSNumber * _Nullable originalValue;
+@property (nonatomic, copy) NSNumber * _Nullable originalValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5497,14 +5497,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestStructArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestStructArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nonnull arg1;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5519,68 +5519,68 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestComplexNullableOptionalResponseParams : NSObject
+@interface MTRTestClusterClusterTestComplexNullableOptionalResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull nullableIntWasNull;
+@property (nonatomic, copy) NSNumber * _Nonnull nullableIntWasNull;
 
-@property (strong, nonatomic) NSNumber * _Nullable nullableIntValue;
+@property (nonatomic, copy) NSNumber * _Nullable nullableIntValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionalIntWasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull optionalIntWasPresent;
 
-@property (strong, nonatomic) NSNumber * _Nullable optionalIntValue;
+@property (nonatomic, copy) NSNumber * _Nullable optionalIntValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalIntWasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull nullableOptionalIntWasPresent;
 
-@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalIntWasNull;
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalIntWasNull;
 
-@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalIntValue;
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalIntValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull nullableStringWasNull;
+@property (nonatomic, copy) NSNumber * _Nonnull nullableStringWasNull;
 
-@property (strong, nonatomic) NSString * _Nullable nullableStringValue;
+@property (nonatomic, copy) NSString * _Nullable nullableStringValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionalStringWasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull optionalStringWasPresent;
 
-@property (strong, nonatomic) NSString * _Nullable optionalStringValue;
+@property (nonatomic, copy) NSString * _Nullable optionalStringValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalStringWasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull nullableOptionalStringWasPresent;
 
-@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalStringWasNull;
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalStringWasNull;
 
-@property (strong, nonatomic) NSString * _Nullable nullableOptionalStringValue;
+@property (nonatomic, copy) NSString * _Nullable nullableOptionalStringValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull nullableStructWasNull;
+@property (nonatomic, copy) NSNumber * _Nonnull nullableStructWasNull;
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable nullableStructValue;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable nullableStructValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionalStructWasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull optionalStructWasPresent;
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable optionalStructValue;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable optionalStructValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalStructWasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull nullableOptionalStructWasPresent;
 
-@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalStructWasNull;
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalStructWasNull;
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable nullableOptionalStructValue;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable nullableOptionalStructValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull nullableListWasNull;
+@property (nonatomic, copy) NSNumber * _Nonnull nullableListWasNull;
 
-@property (strong, nonatomic) NSArray * _Nullable nullableListValue;
+@property (nonatomic, copy) NSArray * _Nullable nullableListValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull optionalListWasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull optionalListWasPresent;
 
-@property (strong, nonatomic) NSArray * _Nullable optionalListValue;
+@property (nonatomic, copy) NSArray * _Nullable optionalListValue;
 
-@property (strong, nonatomic) NSNumber * _Nonnull nullableOptionalListWasPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull nullableOptionalListWasPresent;
 
-@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalListWasNull;
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalListWasNull;
 
-@property (strong, nonatomic) NSArray * _Nullable nullableOptionalListValue;
+@property (nonatomic, copy) NSArray * _Nullable nullableOptionalListValue;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5595,14 +5595,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestNestedStructArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestNestedStructArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRTestClusterClusterNestedStruct * _Nonnull arg1;
+@property (nonatomic, copy) MTRTestClusterClusterNestedStruct * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5617,14 +5617,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterBooleanResponseParams : NSObject
+@interface MTRTestClusterClusterBooleanResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull value;
+@property (nonatomic, copy) NSNumber * _Nonnull value;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5639,14 +5639,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestListStructArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestListStructArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (nonatomic, copy) NSArray * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5661,14 +5661,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterSimpleStructResponseParams : NSObject
+@interface MTRTestClusterClusterSimpleStructResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nonnull arg1;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5683,14 +5683,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestListInt8UArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestListInt8UArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (nonatomic, copy) NSArray * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5705,14 +5705,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestEmitTestEventResponseParams : NSObject
+@interface MTRTestClusterClusterTestEmitTestEventResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull value;
+@property (nonatomic, copy) NSNumber * _Nonnull value;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5727,14 +5727,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestNestedStructListArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestNestedStructListArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRTestClusterClusterNestedStructList * _Nonnull arg1;
+@property (nonatomic, copy) MTRTestClusterClusterNestedStructList * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5749,14 +5749,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams : NSObject
+@interface MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull value;
+@property (nonatomic, copy) NSNumber * _Nonnull value;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5771,14 +5771,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestListNestedStructListArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestListNestedStructListArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (nonatomic, copy) NSArray * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5793,14 +5793,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestListInt8UReverseRequestParams : NSObject
+@interface MTRTestClusterClusterTestListInt8UReverseRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSArray * _Nonnull arg1;
+@property (nonatomic, copy) NSArray * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5815,16 +5815,16 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestEnumsRequestParams : NSObject
+@interface MTRTestClusterClusterTestEnumsRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (nonatomic, copy) NSNumber * _Nonnull arg1;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg2;
+@property (nonatomic, copy) NSNumber * _Nonnull arg2;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5839,14 +5839,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestNullableOptionalRequestParams : NSObject
+@interface MTRTestClusterClusterTestNullableOptionalRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nullable arg1;
+@property (nonatomic, copy) NSNumber * _Nullable arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5861,36 +5861,36 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestComplexNullableOptionalRequestParams : NSObject
+@interface MTRTestClusterClusterTestComplexNullableOptionalRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nullable nullableInt;
+@property (nonatomic, copy) NSNumber * _Nullable nullableInt;
 
-@property (strong, nonatomic) NSNumber * _Nullable optionalInt;
+@property (nonatomic, copy) NSNumber * _Nullable optionalInt;
 
-@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalInt;
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalInt;
 
-@property (strong, nonatomic) NSString * _Nullable nullableString;
+@property (nonatomic, copy) NSString * _Nullable nullableString;
 
-@property (strong, nonatomic) NSString * _Nullable optionalString;
+@property (nonatomic, copy) NSString * _Nullable optionalString;
 
-@property (strong, nonatomic) NSString * _Nullable nullableOptionalString;
+@property (nonatomic, copy) NSString * _Nullable nullableOptionalString;
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable nullableStruct;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable nullableStruct;
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable optionalStruct;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable optionalStruct;
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable nullableOptionalStruct;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable nullableOptionalStruct;
 
-@property (strong, nonatomic) NSArray * _Nullable nullableList;
+@property (nonatomic, copy) NSArray * _Nullable nullableList;
 
-@property (strong, nonatomic) NSArray * _Nullable optionalList;
+@property (nonatomic, copy) NSArray * _Nullable optionalList;
 
-@property (strong, nonatomic) NSArray * _Nullable nullableOptionalList;
+@property (nonatomic, copy) NSArray * _Nullable nullableOptionalList;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5905,14 +5905,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterSimpleStructEchoRequestParams : NSObject
+@interface MTRTestClusterClusterSimpleStructEchoRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nonnull arg1;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5927,12 +5927,12 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTimedInvokeRequestParams : NSObject
+@interface MTRTestClusterClusterTimedInvokeRequestParams : NSObject <NSCopying>
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5947,14 +5947,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams : NSObject
+@interface MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nullable arg1;
+@property (nonatomic, copy) NSNumber * _Nullable arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5969,18 +5969,18 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestEmitTestEventRequestParams : NSObject
+@interface MTRTestClusterClusterTestEmitTestEventRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (nonatomic, copy) NSNumber * _Nonnull arg1;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg2;
+@property (nonatomic, copy) NSNumber * _Nonnull arg2;
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg3;
+@property (nonatomic, copy) NSNumber * _Nonnull arg3;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -5995,14 +5995,14 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
-@interface MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams : NSObject
+@interface MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams : NSObject <NSCopying>
 
-@property (strong, nonatomic) NSNumber * _Nonnull arg1;
+@property (nonatomic, copy) NSNumber * _Nonnull arg1;
 /**
  * Controls whether the command is a timed command (using Timed Invoke).
  *
@@ -6017,10 +6017,10 @@ NS_ASSUME_NONNULL_BEGIN
  * request) within the timeout window.
  *
  */
-@property (strong, nonatomic, nullable) NSNumber * timedInvokeTimeoutMs;
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
 
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -32,6 +32,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRIdentifyClusterIdentifyParams alloc] init];
+
+    other.identifyTime = self.identifyTime;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -51,6 +61,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRIdentifyClusterTriggerEffectParams alloc] init];
+
+    other.effectIdentifier = self.effectIdentifier;
+    other.effectVariant = self.effectVariant;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -74,6 +95,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterAddGroupParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.groupName = self.groupName;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -95,6 +127,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterAddGroupResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -112,6 +155,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterViewGroupParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -136,6 +189,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterViewGroupResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.groupName = self.groupName;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; groupName:%@; >",
@@ -153,6 +218,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterGetGroupMembershipParams alloc] init];
+
+    other.groupList = self.groupList;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -175,6 +250,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterGetGroupMembershipResponseParams alloc] init];
+
+    other.capacity = self.capacity;
+    other.groupList = self.groupList;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -192,6 +278,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterRemoveGroupParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -214,6 +310,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterRemoveGroupResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -229,6 +336,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterRemoveAllGroupsParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -249,6 +365,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupsClusterAddGroupIfIdentifyingParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.groupName = self.groupName;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -278,6 +405,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterAddSceneParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.transitionTime = self.transitionTime;
+    other.sceneName = self.sceneName;
+    other.extensionFieldSets = self.extensionFieldSets;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -302,6 +443,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterAddSceneResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; >",
@@ -321,6 +474,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterViewSceneParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -352,6 +516,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterViewSceneResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.transitionTime = self.transitionTime;
+    other.sceneName = self.sceneName;
+    other.extensionFieldSets = self.extensionFieldSets;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -372,6 +551,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterRemoveSceneParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -397,6 +587,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterRemoveSceneResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; >",
@@ -414,6 +616,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterRemoveAllScenesParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -436,6 +648,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterRemoveAllScenesResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -455,6 +678,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterStoreSceneParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -480,6 +714,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterStoreSceneResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; >",
@@ -503,6 +749,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterRecallSceneParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.transitionTime = self.transitionTime;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; sceneId:%@; transitionTime:%@; >",
@@ -520,6 +778,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterGetSceneMembershipParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -544,6 +812,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterGetSceneMembershipResponseParams alloc] init];
+
+    other.status = self.status;
+    other.capacity = self.capacity;
+    other.groupId = self.groupId;
+    other.sceneList = self.sceneList;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -573,6 +854,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterEnhancedAddSceneParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.transitionTime = self.transitionTime;
+    other.sceneName = self.sceneName;
+    other.extensionFieldSets = self.extensionFieldSets;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -597,6 +892,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterEnhancedAddSceneResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupId:%@; sceneId:%@; >",
@@ -616,6 +923,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterEnhancedViewSceneParams alloc] init];
+
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -647,6 +965,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterEnhancedViewSceneResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupId = self.groupId;
+    other.sceneId = self.sceneId;
+    other.transitionTime = self.transitionTime;
+    other.sceneName = self.sceneName;
+    other.extensionFieldSets = self.extensionFieldSets;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -675,6 +1008,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterCopySceneParams alloc] init];
+
+    other.mode = self.mode;
+    other.groupIdFrom = self.groupIdFrom;
+    other.sceneIdFrom = self.sceneIdFrom;
+    other.groupIdTo = self.groupIdTo;
+    other.sceneIdTo = self.sceneIdTo;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -699,6 +1046,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRScenesClusterCopySceneResponseParams alloc] init];
+
+    other.status = self.status;
+    other.groupIdFrom = self.groupIdFrom;
+    other.sceneIdFrom = self.sceneIdFrom;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; groupIdFrom:%@; sceneIdFrom:%@; >",
@@ -714,6 +1073,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROnOffClusterOffParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -732,6 +1100,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROnOffClusterOnParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -746,6 +1123,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROnOffClusterToggleParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -768,6 +1154,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROnOffClusterOffWithEffectParams alloc] init];
+
+    other.effectId = self.effectId;
+    other.effectVariant = self.effectVariant;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -783,6 +1180,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROnOffClusterOnWithRecallGlobalSceneParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -805,6 +1211,18 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROnOffClusterOnWithTimedOffParams alloc] init];
+
+    other.onOffControl = self.onOffControl;
+    other.onTime = self.onTime;
+    other.offWaitTime = self.offWaitTime;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -832,6 +1250,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterMoveToLevelParams alloc] init];
+
+    other.level = self.level;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -856,6 +1287,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterMoveParams alloc] init];
+
+    other.moveMode = self.moveMode;
+    other.rate = self.rate;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -885,6 +1329,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterStepParams alloc] init];
+
+    other.stepMode = self.stepMode;
+    other.stepSize = self.stepSize;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -905,6 +1363,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterStopParams alloc] init];
+
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -932,6 +1401,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterMoveToLevelWithOnOffParams alloc] init];
+
+    other.level = self.level;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -956,6 +1438,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterMoveWithOnOffParams alloc] init];
+
+    other.moveMode = self.moveMode;
+    other.rate = self.rate;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -985,6 +1480,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterStepWithOnOffParams alloc] init];
+
+    other.stepMode = self.stepMode;
+    other.stepSize = self.stepSize;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1007,6 +1516,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterStopWithOnOffParams alloc] init];
+
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: optionsMask:%@; optionsOverride:%@; >",
@@ -1024,6 +1544,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLevelControlClusterMoveToClosestFrequencyParams alloc] init];
+
+    other.frequency = self.frequency;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1044,6 +1574,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterInstantActionParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1069,6 +1610,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterInstantActionWithTransitionParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.transitionTime = self.transitionTime;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; transitionTime:%@; >",
@@ -1088,6 +1641,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterStartActionParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1113,6 +1677,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterStartActionWithDurationParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.duration = self.duration;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; duration:%@; >",
@@ -1134,6 +1710,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterStopActionParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1153,6 +1740,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterPauseActionParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1178,6 +1776,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterPauseActionWithDurationParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.duration = self.duration;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; duration:%@; >",
@@ -1199,6 +1809,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterResumeActionParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1218,6 +1839,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterEnableActionParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1243,6 +1875,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterEnableActionWithDurationParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.duration = self.duration;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; duration:%@; >",
@@ -1262,6 +1906,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterDisableActionParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1287,6 +1942,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBridgedActionsClusterDisableActionWithDurationParams alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.duration = self.duration;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; duration:%@; >",
@@ -1302,6 +1969,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBasicClusterMfgSpecificPingParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1334,6 +2010,23 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROtaSoftwareUpdateProviderClusterQueryImageParams alloc] init];
+
+    other.vendorId = self.vendorId;
+    other.productId = self.productId;
+    other.softwareVersion = self.softwareVersion;
+    other.protocolsSupported = self.protocolsSupported;
+    other.hardwareVersion = self.hardwareVersion;
+    other.location = self.location;
+    other.requestorCanConsent = self.requestorCanConsent;
+    other.metadataForProvider = self.metadataForProvider;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1372,6 +2065,23 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams alloc] init];
+
+    other.status = self.status;
+    other.delayedActionTime = self.delayedActionTime;
+    other.imageURI = self.imageURI;
+    other.softwareVersion = self.softwareVersion;
+    other.softwareVersionString = self.softwareVersionString;
+    other.updateToken = self.updateToken;
+    other.userConsentNeeded = self.userConsentNeeded;
+    other.metadataForRequestor = self.metadataForRequestor;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1397,6 +2107,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
+
+    other.updateToken = self.updateToken;
+    other.newVersion = self.newVersion;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1419,6 +2140,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams alloc] init];
+
+    other.action = self.action;
+    other.delayedActionTime = self.delayedActionTime;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -1438,6 +2170,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
+
+    other.updateToken = self.updateToken;
+    other.softwareVersion = self.softwareVersion;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1468,6 +2211,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams alloc] init];
+
+    other.providerNodeId = self.providerNodeId;
+    other.vendorId = self.vendorId;
+    other.announcementReason = self.announcementReason;
+    other.metadataForNode = self.metadataForNode;
+    other.endpoint = self.endpoint;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -1491,6 +2248,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGeneralCommissioningClusterArmFailSafeParams alloc] init];
+
+    other.expiryLengthSeconds = self.expiryLengthSeconds;
+    other.breadcrumb = self.breadcrumb;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: expiryLengthSeconds:%@; breadcrumb:%@; >",
@@ -1510,6 +2278,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGeneralCommissioningClusterArmFailSafeResponseParams alloc] init];
+
+    other.errorCode = self.errorCode;
+    other.debugText = self.debugText;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1535,6 +2314,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGeneralCommissioningClusterSetRegulatoryConfigParams alloc] init];
+
+    other.newRegulatoryConfig = self.newRegulatoryConfig;
+    other.countryCode = self.countryCode;
+    other.breadcrumb = self.breadcrumb;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: newRegulatoryConfig:%@; countryCode:%@; breadcrumb:%@; >",
@@ -1556,6 +2347,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams alloc] init];
+
+    other.errorCode = self.errorCode;
+    other.debugText = self.debugText;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1571,6 +2373,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGeneralCommissioningClusterCommissioningCompleteParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1593,6 +2404,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGeneralCommissioningClusterCommissioningCompleteResponseParams alloc] init];
+
+    other.errorCode = self.errorCode;
+    other.debugText = self.debugText;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1612,6 +2434,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterScanNetworksParams alloc] init];
+
+    other.ssid = self.ssid;
+    other.breadcrumb = self.breadcrumb;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1639,6 +2472,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterScanNetworksResponseParams alloc] init];
+
+    other.networkingStatus = self.networkingStatus;
+    other.debugText = self.debugText;
+    other.wiFiScanResults = self.wiFiScanResults;
+    other.threadScanResults = self.threadScanResults;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1663,6 +2509,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams alloc] init];
+
+    other.ssid = self.ssid;
+    other.credentials = self.credentials;
+    other.breadcrumb = self.breadcrumb;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1685,6 +2543,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams alloc] init];
+
+    other.operationalDataset = self.operationalDataset;
+    other.breadcrumb = self.breadcrumb;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1705,6 +2574,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterRemoveNetworkParams alloc] init];
+
+    other.networkID = self.networkID;
+    other.breadcrumb = self.breadcrumb;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1731,6 +2611,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterNetworkConfigResponseParams alloc] init];
+
+    other.networkingStatus = self.networkingStatus;
+    other.debugText = self.debugText;
+    other.networkIndex = self.networkIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: networkingStatus:%@; debugText:%@; networkIndex:%@; >",
@@ -1750,6 +2642,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterConnectNetworkParams alloc] init];
+
+    other.networkID = self.networkID;
+    other.breadcrumb = self.breadcrumb;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1776,6 +2679,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterConnectNetworkResponseParams alloc] init];
+
+    other.networkingStatus = self.networkingStatus;
+    other.debugText = self.debugText;
+    other.errorValue = self.errorValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: networkingStatus:%@; debugText:%@; errorValue:%@; >",
@@ -1797,6 +2712,18 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRNetworkCommissioningClusterReorderNetworkParams alloc] init];
+
+    other.networkID = self.networkID;
+    other.networkIndex = self.networkIndex;
+    other.breadcrumb = self.breadcrumb;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1821,6 +2748,18 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDiagnosticLogsClusterRetrieveLogsRequestParams alloc] init];
+
+    other.intent = self.intent;
+    other.requestedProtocol = self.requestedProtocol;
+    other.transferFileDesignator = self.transferFileDesignator;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1849,6 +2788,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDiagnosticLogsClusterRetrieveLogsResponseParams alloc] init];
+
+    other.status = self.status;
+    other.content = self.content;
+    other.timeStamp = self.timeStamp;
+    other.timeSinceBoot = self.timeSinceBoot;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; content:%@; timeStamp:%@; timeSinceBoot:%@; >",
@@ -1871,6 +2823,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGeneralDiagnosticsClusterTestEventTriggerParams alloc] init];
+
+    other.enableKey = self.enableKey;
+    other.eventTrigger = self.eventTrigger;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1889,6 +2852,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRSoftwareDiagnosticsClusterResetWatermarksParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1903,6 +2875,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRThreadNetworkDiagnosticsClusterResetCountsParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1921,6 +2902,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRWiFiNetworkDiagnosticsClusterResetCountsParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1935,6 +2925,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTREthernetNetworkDiagnosticsClusterResetCountsParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1963,6 +2962,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAdministratorCommissioningClusterOpenCommissioningWindowParams alloc] init];
+
+    other.commissioningTimeout = self.commissioningTimeout;
+    other.pakeVerifier = self.pakeVerifier;
+    other.discriminator = self.discriminator;
+    other.iterations = self.iterations;
+    other.salt = self.salt;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1984,6 +2997,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams alloc] init];
+
+    other.commissioningTimeout = self.commissioningTimeout;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1999,6 +3022,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAdministratorCommissioningClusterRevokeCommissioningParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2017,6 +3049,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterAttestationRequestParams alloc] init];
+
+    other.attestationNonce = self.attestationNonce;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2040,6 +3082,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterAttestationResponseParams alloc] init];
+
+    other.attestationElements = self.attestationElements;
+    other.signature = self.signature;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2060,6 +3113,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterCertificateChainRequestParams alloc] init];
+
+    other.certificateType = self.certificateType;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2077,6 +3140,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterCertificateChainResponseParams alloc] init];
+
+    other.certificate = self.certificate;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2100,6 +3173,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterCSRRequestParams alloc] init];
+
+    other.csrNonce = self.csrNonce;
+    other.isForUpdateNOC = self.isForUpdateNOC;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2120,6 +3204,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterCSRResponseParams alloc] init];
+
+    other.nocsrElements = self.nocsrElements;
+    other.attestationSignature = self.attestationSignature;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2150,6 +3245,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterAddNOCParams alloc] init];
+
+    other.nocValue = self.nocValue;
+    other.icacValue = self.icacValue;
+    other.ipkValue = self.ipkValue;
+    other.caseAdminSubject = self.caseAdminSubject;
+    other.adminVendorId = self.adminVendorId;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2172,6 +3281,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterUpdateNOCParams alloc] init];
+
+    other.nocValue = self.nocValue;
+    other.icacValue = self.icacValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2198,6 +3318,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterNOCResponseParams alloc] init];
+
+    other.statusCode = self.statusCode;
+    other.fabricIndex = self.fabricIndex;
+    other.debugText = self.debugText;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: statusCode:%@; fabricIndex:%@; debugText:%@; >",
@@ -2217,6 +3349,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterUpdateFabricLabelParams alloc] init];
+
+    other.label = self.label;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: label:%@; >", NSStringFromClass([self class]), _label];
@@ -2233,6 +3375,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterRemoveFabricParams alloc] init];
+
+    other.fabricIndex = self.fabricIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2254,6 +3406,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTROperationalCredentialsClusterAddTrustedRootCertificateParams alloc] init];
+
+    other.rootCertificate = self.rootCertificate;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: rootCertificate:%@; >", NSStringFromClass([self class]),
@@ -2271,6 +3433,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupKeyManagementClusterKeySetWriteParams alloc] init];
+
+    other.groupKeySet = self.groupKeySet;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2292,6 +3464,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupKeyManagementClusterKeySetReadParams alloc] init];
+
+    other.groupKeySetID = self.groupKeySetID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2309,6 +3491,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupKeyManagementClusterKeySetReadResponseParams alloc] init];
+
+    other.groupKeySet = self.groupKeySet;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2330,6 +3522,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupKeyManagementClusterKeySetRemoveParams alloc] init];
+
+    other.groupKeySetID = self.groupKeySetID;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2347,6 +3549,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupKeyManagementClusterKeySetReadAllIndicesParams alloc] init];
+
+    other.groupKeySetIDs = self.groupKeySetIDs;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2368,6 +3580,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams alloc] init];
+
+    other.groupKeySetIDs = self.groupKeySetIDs;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2387,6 +3609,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRModeSelectClusterChangeToModeParams alloc] init];
+
+    other.newMode = self.newMode;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: newMode:%@; >", NSStringFromClass([self class]), _newMode];
@@ -2403,6 +3635,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterLockDoorParams alloc] init];
+
+    other.pinCode = self.pinCode;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2424,6 +3666,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterUnlockDoorParams alloc] init];
+
+    other.pinCode = self.pinCode;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2443,6 +3695,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterUnlockWithTimeoutParams alloc] init];
+
+    other.timeout = self.timeout;
+    other.pinCode = self.pinCode;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2476,6 +3739,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterSetWeekDayScheduleParams alloc] init];
+
+    other.weekDayIndex = self.weekDayIndex;
+    other.userIndex = self.userIndex;
+    other.daysMask = self.daysMask;
+    other.startHour = self.startHour;
+    other.startMinute = self.startMinute;
+    other.endHour = self.endHour;
+    other.endMinute = self.endMinute;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2497,6 +3776,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetWeekDayScheduleParams alloc] init];
+
+    other.weekDayIndex = self.weekDayIndex;
+    other.userIndex = self.userIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2532,6 +3822,23 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetWeekDayScheduleResponseParams alloc] init];
+
+    other.weekDayIndex = self.weekDayIndex;
+    other.userIndex = self.userIndex;
+    other.status = self.status;
+    other.daysMask = self.daysMask;
+    other.startHour = self.startHour;
+    other.startMinute = self.startMinute;
+    other.endHour = self.endHour;
+    other.endMinute = self.endMinute;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: weekDayIndex:%@; userIndex:%@; status:%@; daysMask:%@; "
@@ -2553,6 +3860,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterClearWeekDayScheduleParams alloc] init];
+
+    other.weekDayIndex = self.weekDayIndex;
+    other.userIndex = self.userIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2580,6 +3898,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterSetYearDayScheduleParams alloc] init];
+
+    other.yearDayIndex = self.yearDayIndex;
+    other.userIndex = self.userIndex;
+    other.localStartTime = self.localStartTime;
+    other.localEndTime = self.localEndTime;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2600,6 +3931,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetYearDayScheduleParams alloc] init];
+
+    other.yearDayIndex = self.yearDayIndex;
+    other.userIndex = self.userIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2629,6 +3971,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetYearDayScheduleResponseParams alloc] init];
+
+    other.yearDayIndex = self.yearDayIndex;
+    other.userIndex = self.userIndex;
+    other.status = self.status;
+    other.localStartTime = self.localStartTime;
+    other.localEndTime = self.localEndTime;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2649,6 +4005,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterClearYearDayScheduleParams alloc] init];
+
+    other.yearDayIndex = self.yearDayIndex;
+    other.userIndex = self.userIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2676,6 +4043,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterSetHolidayScheduleParams alloc] init];
+
+    other.holidayIndex = self.holidayIndex;
+    other.localStartTime = self.localStartTime;
+    other.localEndTime = self.localEndTime;
+    other.operatingMode = self.operatingMode;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2694,6 +4074,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetHolidayScheduleParams alloc] init];
+
+    other.holidayIndex = self.holidayIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2723,6 +4113,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetHolidayScheduleResponseParams alloc] init];
+
+    other.holidayIndex = self.holidayIndex;
+    other.status = self.status;
+    other.localStartTime = self.localStartTime;
+    other.localEndTime = self.localEndTime;
+    other.operatingMode = self.operatingMode;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2741,6 +4145,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterClearHolidayScheduleParams alloc] init];
+
+    other.holidayIndex = self.holidayIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2774,6 +4188,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterSetUserParams alloc] init];
+
+    other.operationType = self.operationType;
+    other.userIndex = self.userIndex;
+    other.userName = self.userName;
+    other.userUniqueId = self.userUniqueId;
+    other.userStatus = self.userStatus;
+    other.userType = self.userType;
+    other.credentialRule = self.credentialRule;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2794,6 +4224,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetUserParams alloc] init];
+
+    other.userIndex = self.userIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2832,6 +4272,25 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetUserResponseParams alloc] init];
+
+    other.userIndex = self.userIndex;
+    other.userName = self.userName;
+    other.userUniqueId = self.userUniqueId;
+    other.userStatus = self.userStatus;
+    other.userType = self.userType;
+    other.credentialRule = self.credentialRule;
+    other.credentials = self.credentials;
+    other.creatorFabricIndex = self.creatorFabricIndex;
+    other.lastModifiedFabricIndex = self.lastModifiedFabricIndex;
+    other.nextUserIndex = self.nextUserIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2852,6 +4311,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterClearUserParams alloc] init];
+
+    other.userIndex = self.userIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2882,6 +4351,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterSetCredentialParams alloc] init];
+
+    other.operationType = self.operationType;
+    other.credential = self.credential;
+    other.credentialData = self.credentialData;
+    other.userIndex = self.userIndex;
+    other.userStatus = self.userStatus;
+    other.userType = self.userType;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2907,6 +4391,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterSetCredentialResponseParams alloc] init];
+
+    other.status = self.status;
+    other.userIndex = self.userIndex;
+    other.nextCredentialIndex = self.nextCredentialIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; userIndex:%@; nextCredentialIndex:%@; >",
@@ -2924,6 +4420,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetCredentialStatusParams alloc] init];
+
+    other.credential = self.credential;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2953,6 +4459,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterGetCredentialStatusResponseParams alloc] init];
+
+    other.credentialExists = self.credentialExists;
+    other.userIndex = self.userIndex;
+    other.creatorFabricIndex = self.creatorFabricIndex;
+    other.lastModifiedFabricIndex = self.lastModifiedFabricIndex;
+    other.nextCredentialIndex = self.nextCredentialIndex;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2975,6 +4495,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRDoorLockClusterClearCredentialParams alloc] init];
+
+    other.credential = self.credential;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2990,6 +4520,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRWindowCoveringClusterUpOrOpenParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3008,6 +4547,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRWindowCoveringClusterDownOrCloseParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -3022,6 +4570,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRWindowCoveringClusterStopMotionParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3042,6 +4599,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRWindowCoveringClusterGoToLiftValueParams alloc] init];
+
+    other.liftValue = self.liftValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: liftValue:%@; >", NSStringFromClass([self class]), _liftValue];
@@ -3058,6 +4625,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRWindowCoveringClusterGoToLiftPercentageParams alloc] init];
+
+    other.liftPercent100thsValue = self.liftPercent100thsValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3079,6 +4656,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRWindowCoveringClusterGoToTiltValueParams alloc] init];
+
+    other.tiltValue = self.tiltValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: tiltValue:%@; >", NSStringFromClass([self class]), _tiltValue];
@@ -3095,6 +4682,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRWindowCoveringClusterGoToTiltPercentageParams alloc] init];
+
+    other.tiltPercent100thsValue = self.tiltPercent100thsValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3116,6 +4713,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBarrierControlClusterBarrierControlGoToPercentParams alloc] init];
+
+    other.percentOpen = self.percentOpen;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3131,6 +4738,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRBarrierControlClusterBarrierControlStopParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3151,6 +4767,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRThermostatClusterSetpointRaiseLowerParams alloc] init];
+
+    other.mode = self.mode;
+    other.amount = self.amount;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3176,6 +4803,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRThermostatClusterGetWeeklyScheduleResponseParams alloc] init];
+
+    other.numberOfTransitionsForSequence = self.numberOfTransitionsForSequence;
+    other.dayOfWeekForSequence = self.dayOfWeekForSequence;
+    other.modeForSequence = self.modeForSequence;
+    other.transitions = self.transitions;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3204,6 +4844,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRThermostatClusterSetWeeklyScheduleParams alloc] init];
+
+    other.numberOfTransitionsForSequence = self.numberOfTransitionsForSequence;
+    other.dayOfWeekForSequence = self.dayOfWeekForSequence;
+    other.modeForSequence = self.modeForSequence;
+    other.transitions = self.transitions;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -3226,6 +4879,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRThermostatClusterGetWeeklyScheduleParams alloc] init];
+
+    other.daysToReturn = self.daysToReturn;
+    other.modeToReturn = self.modeToReturn;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: daysToReturn:%@; modeToReturn:%@; >",
@@ -3241,6 +4905,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRThermostatClusterClearWeeklyScheduleParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3269,6 +4942,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveToHueParams alloc] init];
+
+    other.hue = self.hue;
+    other.direction = self.direction;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3293,6 +4980,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveHueParams alloc] init];
+
+    other.moveMode = self.moveMode;
+    other.rate = self.rate;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3322,6 +5022,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterStepHueParams alloc] init];
+
+    other.stepMode = self.stepMode;
+    other.stepSize = self.stepSize;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3346,6 +5060,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveToSaturationParams alloc] init];
+
+    other.saturation = self.saturation;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3374,6 +5101,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveSaturationParams alloc] init];
+
+    other.moveMode = self.moveMode;
+    other.rate = self.rate;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: moveMode:%@; rate:%@; optionsMask:%@; optionsOverride:%@; >",
@@ -3399,6 +5139,20 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterStepSaturationParams alloc] init];
+
+    other.stepMode = self.stepMode;
+    other.stepSize = self.stepSize;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3429,6 +5183,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveToHueAndSaturationParams alloc] init];
+
+    other.hue = self.hue;
+    other.saturation = self.saturation;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3457,6 +5225,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveToColorParams alloc] init];
+
+    other.colorX = self.colorX;
+    other.colorY = self.colorY;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3481,6 +5263,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveColorParams alloc] init];
+
+    other.rateX = self.rateX;
+    other.rateY = self.rateY;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3510,6 +5305,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterStepColorParams alloc] init];
+
+    other.stepX = self.stepX;
+    other.stepY = self.stepY;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3534,6 +5343,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveToColorTemperatureParams alloc] init];
+
+    other.colorTemperature = self.colorTemperature;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3564,6 +5386,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterEnhancedMoveToHueParams alloc] init];
+
+    other.enhancedHue = self.enhancedHue;
+    other.direction = self.direction;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3588,6 +5424,19 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterEnhancedMoveHueParams alloc] init];
+
+    other.moveMode = self.moveMode;
+    other.rate = self.rate;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3617,6 +5466,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterEnhancedStepHueParams alloc] init];
+
+    other.stepMode = self.stepMode;
+    other.stepSize = self.stepSize;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3643,6 +5506,20 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterEnhancedMoveToHueAndSaturationParams alloc] init];
+
+    other.enhancedHue = self.enhancedHue;
+    other.saturation = self.saturation;
+    other.transitionTime = self.transitionTime;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3677,6 +5554,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterColorLoopSetParams alloc] init];
+
+    other.updateFlags = self.updateFlags;
+    other.action = self.action;
+    other.direction = self.direction;
+    other.time = self.time;
+    other.startHue = self.startHue;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -3698,6 +5591,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterStopMoveStepParams alloc] init];
+
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3727,6 +5631,21 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterMoveColorTemperatureParams alloc] init];
+
+    other.moveMode = self.moveMode;
+    other.rate = self.rate;
+    other.colorTemperatureMinimumMireds = self.colorTemperatureMinimumMireds;
+    other.colorTemperatureMaximumMireds = self.colorTemperatureMaximumMireds;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3763,6 +5682,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRColorControlClusterStepColorTemperatureParams alloc] init];
+
+    other.stepMode = self.stepMode;
+    other.stepSize = self.stepSize;
+    other.transitionTime = self.transitionTime;
+    other.colorTemperatureMinimumMireds = self.colorTemperatureMinimumMireds;
+    other.colorTemperatureMaximumMireds = self.colorTemperatureMaximumMireds;
+    other.optionsMask = self.optionsMask;
+    other.optionsOverride = self.optionsOverride;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3785,6 +5720,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRChannelClusterChangeChannelParams alloc] init];
+
+    other.match = self.match;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: match:%@; >", NSStringFromClass([self class]), _match];
@@ -3803,6 +5748,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRChannelClusterChangeChannelResponseParams alloc] init];
+
+    other.status = self.status;
+    other.data = self.data;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3826,6 +5782,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRChannelClusterChangeChannelByNumberParams alloc] init];
+
+    other.majorNumber = self.majorNumber;
+    other.minorNumber = self.minorNumber;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -3843,6 +5810,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRChannelClusterSkipChannelParams alloc] init];
+
+    other.count = self.count;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3863,6 +5840,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTargetNavigatorClusterNavigateTargetParams alloc] init];
+
+    other.target = self.target;
+    other.data = self.data;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3886,6 +5874,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTargetNavigatorClusterNavigateTargetResponseParams alloc] init];
+
+    other.status = self.status;
+    other.data = self.data;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -3901,6 +5900,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterPlayParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3919,6 +5927,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterPauseParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -3933,6 +5950,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterStopPlaybackParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3951,6 +5977,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterStartOverParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -3965,6 +6000,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterPreviousParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -3983,6 +6027,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterNextParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -3999,6 +6052,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterRewindParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -4013,6 +6075,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterFastForwardParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4033,6 +6104,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterSkipForwardParams alloc] init];
+
+    other.deltaPositionMilliseconds = self.deltaPositionMilliseconds;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -4050,6 +6131,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterSkipBackwardParams alloc] init];
+
+    other.deltaPositionMilliseconds = self.deltaPositionMilliseconds;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4073,6 +6164,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterPlaybackResponseParams alloc] init];
+
+    other.status = self.status;
+    other.data = self.data;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4090,6 +6192,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaPlaybackClusterSeekParams alloc] init];
+
+    other.position = self.position;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4110,6 +6222,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaInputClusterSelectInputParams alloc] init];
+
+    other.index = self.index;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: index:%@; >", NSStringFromClass([self class]), _index];
@@ -4126,6 +6248,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaInputClusterShowInputStatusParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -4140,6 +6271,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaInputClusterHideInputStatusParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4162,6 +6302,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRMediaInputClusterRenameInputParams alloc] init];
+
+    other.index = self.index;
+    other.name = self.name;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4177,6 +6328,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRLowPowerClusterSleepParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4197,6 +6357,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRKeypadInputClusterSendKeyParams alloc] init];
+
+    other.keyCode = self.keyCode;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: keyCode:%@; >", NSStringFromClass([self class]), _keyCode];
@@ -4213,6 +6383,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRKeypadInputClusterSendKeyResponseParams alloc] init];
+
+    other.status = self.status;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4235,6 +6415,18 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRContentLauncherClusterLaunchContentParams alloc] init];
+
+    other.search = self.search;
+    other.autoPlay = self.autoPlay;
+    other.data = self.data;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4260,6 +6452,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRContentLauncherClusterLaunchURLParams alloc] init];
+
+    other.contentURL = self.contentURL;
+    other.displayString = self.displayString;
+    other.brandingInformation = self.brandingInformation;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: contentURL:%@; displayString:%@; brandingInformation:%@; >",
@@ -4281,6 +6485,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRContentLauncherClusterLaunchResponseParams alloc] init];
+
+    other.status = self.status;
+    other.data = self.data;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4298,6 +6513,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAudioOutputClusterSelectOutputParams alloc] init];
+
+    other.index = self.index;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4318,6 +6543,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAudioOutputClusterRenameOutputParams alloc] init];
+
+    other.index = self.index;
+    other.name = self.name;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4341,6 +6577,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRApplicationLauncherClusterLaunchAppParams alloc] init];
+
+    other.application = self.application;
+    other.data = self.data;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: application:%@; data:%@; >", NSStringFromClass([self class]),
@@ -4360,6 +6607,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRApplicationLauncherClusterStopAppParams alloc] init];
+
+    other.application = self.application;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4377,6 +6634,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRApplicationLauncherClusterHideAppParams alloc] init];
+
+    other.application = self.application;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4400,6 +6667,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRApplicationLauncherClusterLauncherResponseParams alloc] init];
+
+    other.status = self.status;
+    other.data = self.data;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: status:%@; data:%@; >", NSStringFromClass([self class]),
@@ -4419,6 +6697,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAccountLoginClusterGetSetupPINParams alloc] init];
+
+    other.tempAccountIdentifier = self.tempAccountIdentifier;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4436,6 +6724,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAccountLoginClusterGetSetupPINResponseParams alloc] init];
+
+    other.setupPIN = self.setupPIN;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4458,6 +6756,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAccountLoginClusterLoginParams alloc] init];
+
+    other.tempAccountIdentifier = self.tempAccountIdentifier;
+    other.setupPIN = self.setupPIN;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: tempAccountIdentifier:%@; setupPIN:%@; >",
@@ -4473,6 +6782,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRAccountLoginClusterLogoutParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4499,6 +6817,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRElectricalMeasurementClusterGetProfileInfoResponseCommandParams alloc] init];
+
+    other.profileCount = self.profileCount;
+    other.profileIntervalPeriod = self.profileIntervalPeriod;
+    other.maxNumberOfIntervals = self.maxNumberOfIntervals;
+    other.listOfAttributes = self.listOfAttributes;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -4515,6 +6846,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRElectricalMeasurementClusterGetProfileInfoCommandParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4545,6 +6885,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRElectricalMeasurementClusterGetMeasurementProfileResponseCommandParams alloc] init];
+
+    other.startTime = self.startTime;
+    other.status = self.status;
+    other.profileIntervalPeriod = self.profileIntervalPeriod;
+    other.numberOfIntervalsDelivered = self.numberOfIntervalsDelivered;
+    other.attributeId = self.attributeId;
+    other.intervals = self.intervals;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: startTime:%@; status:%@; profileIntervalPeriod:%@; "
@@ -4570,6 +6925,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams alloc] init];
+
+    other.attributeId = self.attributeId;
+    other.startTime = self.startTime;
+    other.numberOfIntervals = self.numberOfIntervals;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: attributeId:%@; startTime:%@; numberOfIntervals:%@; >",
@@ -4585,6 +6952,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4605,6 +6981,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestSpecificResponseParams alloc] init];
+
+    other.returnValue = self.returnValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4620,6 +7006,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestNotHandledParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4640,6 +7035,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestAddArgumentsResponseParams alloc] init];
+
+    other.returnValue = self.returnValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4655,6 +7060,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestSpecificParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4675,6 +7089,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestSimpleArgumentResponseParams alloc] init];
+
+    other.returnValue = self.returnValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4690,6 +7114,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestUnknownCommandParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4720,6 +7153,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestStructArrayArgumentResponseParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.arg2 = self.arg2;
+    other.arg3 = self.arg3;
+    other.arg4 = self.arg4;
+    other.arg5 = self.arg5;
+    other.arg6 = self.arg6;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; arg3:%@; arg4:%@; arg5:%@; arg6:%@; >",
@@ -4741,6 +7189,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestAddArgumentsParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.arg2 = self.arg2;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -4758,6 +7217,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestListInt8UReverseResponseParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4778,6 +7247,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestSimpleArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
@@ -4796,6 +7275,17 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestEnumsResponseParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.arg2 = self.arg2;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4827,6 +7317,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestStructArrayArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.arg2 = self.arg2;
+    other.arg3 = self.arg3;
+    other.arg4 = self.arg4;
+    other.arg5 = self.arg5;
+    other.arg6 = self.arg6;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; arg3:%@; arg4:%@; arg5:%@; arg6:%@; >",
@@ -4852,6 +7357,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestNullableOptionalResponseParams alloc] init];
+
+    other.wasPresent = self.wasPresent;
+    other.wasNull = self.wasNull;
+    other.value = self.value;
+    other.originalValue = self.originalValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: wasPresent:%@; wasNull:%@; value:%@; originalValue:%@; >",
@@ -4869,6 +7387,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestStructArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -4943,6 +7471,43 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestComplexNullableOptionalResponseParams alloc] init];
+
+    other.nullableIntWasNull = self.nullableIntWasNull;
+    other.nullableIntValue = self.nullableIntValue;
+    other.optionalIntWasPresent = self.optionalIntWasPresent;
+    other.optionalIntValue = self.optionalIntValue;
+    other.nullableOptionalIntWasPresent = self.nullableOptionalIntWasPresent;
+    other.nullableOptionalIntWasNull = self.nullableOptionalIntWasNull;
+    other.nullableOptionalIntValue = self.nullableOptionalIntValue;
+    other.nullableStringWasNull = self.nullableStringWasNull;
+    other.nullableStringValue = self.nullableStringValue;
+    other.optionalStringWasPresent = self.optionalStringWasPresent;
+    other.optionalStringValue = self.optionalStringValue;
+    other.nullableOptionalStringWasPresent = self.nullableOptionalStringWasPresent;
+    other.nullableOptionalStringWasNull = self.nullableOptionalStringWasNull;
+    other.nullableOptionalStringValue = self.nullableOptionalStringValue;
+    other.nullableStructWasNull = self.nullableStructWasNull;
+    other.nullableStructValue = self.nullableStructValue;
+    other.optionalStructWasPresent = self.optionalStructWasPresent;
+    other.optionalStructValue = self.optionalStructValue;
+    other.nullableOptionalStructWasPresent = self.nullableOptionalStructWasPresent;
+    other.nullableOptionalStructWasNull = self.nullableOptionalStructWasNull;
+    other.nullableOptionalStructValue = self.nullableOptionalStructValue;
+    other.nullableListWasNull = self.nullableListWasNull;
+    other.nullableListValue = self.nullableListValue;
+    other.optionalListWasPresent = self.optionalListWasPresent;
+    other.optionalListValue = self.optionalListValue;
+    other.nullableOptionalListWasPresent = self.nullableOptionalListWasPresent;
+    other.nullableOptionalListWasNull = self.nullableOptionalListWasNull;
+    other.nullableOptionalListValue = self.nullableOptionalListValue;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -4976,6 +7541,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestNestedStructArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
@@ -4992,6 +7567,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterBooleanResponseParams alloc] init];
+
+    other.value = self.value;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -5012,6 +7597,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestListStructArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
@@ -5028,6 +7623,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterSimpleStructResponseParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -5048,6 +7653,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestListInt8UArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
@@ -5064,6 +7679,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestEmitTestEventResponseParams alloc] init];
+
+    other.value = self.value;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -5084,6 +7709,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestNestedStructListArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
@@ -5100,6 +7735,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams alloc] init];
+
+    other.value = self.value;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -5120,6 +7765,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestListNestedStructListArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
@@ -5136,6 +7791,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestListInt8UReverseRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -5158,6 +7823,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestEnumsRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.arg2 = self.arg2;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -5175,6 +7851,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestNullableOptionalRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -5217,6 +7903,27 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestComplexNullableOptionalRequestParams alloc] init];
+
+    other.nullableInt = self.nullableInt;
+    other.optionalInt = self.optionalInt;
+    other.nullableOptionalInt = self.nullableOptionalInt;
+    other.nullableString = self.nullableString;
+    other.optionalString = self.optionalString;
+    other.nullableOptionalString = self.nullableOptionalString;
+    other.nullableStruct = self.nullableStruct;
+    other.optionalStruct = self.optionalStruct;
+    other.nullableOptionalStruct = self.nullableOptionalStruct;
+    other.nullableList = self.nullableList;
+    other.optionalList = self.optionalList;
+    other.nullableOptionalList = self.nullableOptionalList;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -5241,6 +7948,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterSimpleStructEchoRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; >", NSStringFromClass([self class]), _arg1];
@@ -5255,6 +7972,15 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTimedInvokeRequestParams alloc] init];
+
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -5273,6 +7999,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description
@@ -5297,6 +8033,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestEmitTestEventRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.arg2 = self.arg2;
+    other.arg3 = self.arg3;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -5314,6 +8062,16 @@ NS_ASSUME_NONNULL_BEGIN
         _timedInvokeTimeoutMs = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams alloc] init];
+
+    other.arg1 = self.arg1;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
 }
 
 - (NSString *)description

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -21,777 +21,1002 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MTRScenesClusterAttributeValuePair : NSObject
-@property (strong, nonatomic) NSNumber * _Nullable attributeId;
-@property (strong, nonatomic) NSArray * _Nonnull attributeValue;
+@interface MTRScenesClusterAttributeValuePair : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nullable attributeId;
+@property (nonatomic, copy) NSArray * _Nonnull attributeValue;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRScenesClusterExtensionFieldSet : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull clusterId;
-@property (strong, nonatomic) NSArray * _Nonnull attributeValueList;
+@interface MTRScenesClusterExtensionFieldSet : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull clusterId;
+@property (nonatomic, copy) NSArray * _Nonnull attributeValueList;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRDescriptorClusterDeviceType : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull type;
-@property (strong, nonatomic) NSNumber * _Nonnull revision;
+@interface MTRDescriptorClusterDeviceType : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull type;
+@property (nonatomic, copy) NSNumber * _Nonnull revision;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRBindingClusterTargetStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nullable node;
-@property (strong, nonatomic) NSNumber * _Nullable group;
-@property (strong, nonatomic) NSNumber * _Nullable endpoint;
-@property (strong, nonatomic) NSNumber * _Nullable cluster;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@interface MTRBindingClusterTargetStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nullable node;
+@property (nonatomic, copy) NSNumber * _Nullable group;
+@property (nonatomic, copy) NSNumber * _Nullable endpoint;
+@property (nonatomic, copy) NSNumber * _Nullable cluster;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRAccessControlClusterTarget : NSObject
-@property (strong, nonatomic) NSNumber * _Nullable cluster;
-@property (strong, nonatomic) NSNumber * _Nullable endpoint;
-@property (strong, nonatomic) NSNumber * _Nullable deviceType;
+@interface MTRAccessControlClusterTarget : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nullable cluster;
+@property (nonatomic, copy) NSNumber * _Nullable endpoint;
+@property (nonatomic, copy) NSNumber * _Nullable deviceType;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRAccessControlClusterAccessControlEntry : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull privilege;
-@property (strong, nonatomic) NSNumber * _Nonnull authMode;
-@property (strong, nonatomic) NSArray * _Nullable subjects;
-@property (strong, nonatomic) NSArray * _Nullable targets;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@interface MTRAccessControlClusterAccessControlEntry : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull privilege;
+@property (nonatomic, copy) NSNumber * _Nonnull authMode;
+@property (nonatomic, copy) NSArray * _Nullable subjects;
+@property (nonatomic, copy) NSArray * _Nullable targets;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRAccessControlClusterExtensionEntry : NSObject
-@property (strong, nonatomic) NSData * _Nonnull data;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@interface MTRAccessControlClusterExtensionEntry : NSObject <NSCopying>
+@property (nonatomic, copy) NSData * _Nonnull data;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRAccessControlClusterAccessControlEntryChangedEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nullable adminNodeID;
-@property (strong, nonatomic) NSNumber * _Nullable adminPasscodeID;
-@property (strong, nonatomic) NSNumber * _Nonnull changeType;
-@property (strong, nonatomic) MTRAccessControlClusterAccessControlEntry * _Nullable latestValue;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
-@end
+@interface MTRAccessControlClusterAccessControlEntryChangedEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nullable adminNodeID;
+@property (nonatomic, copy) NSNumber * _Nullable adminPasscodeID;
+@property (nonatomic, copy) NSNumber * _Nonnull changeType;
+@property (nonatomic, copy) MTRAccessControlClusterAccessControlEntry * _Nullable latestValue;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
 
-@interface MTRAccessControlClusterAccessControlExtensionChangedEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nullable adminNodeID;
-@property (strong, nonatomic) NSNumber * _Nullable adminPasscodeID;
-@property (strong, nonatomic) NSNumber * _Nonnull changeType;
-@property (strong, nonatomic) MTRAccessControlClusterExtensionEntry * _Nullable latestValue;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
-@end
-
-@interface MTRBridgedActionsClusterActionStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
-@property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSNumber * _Nonnull type;
-@property (strong, nonatomic) NSNumber * _Nonnull endpointListID;
-@property (strong, nonatomic) NSNumber * _Nonnull supportedCommands;
-@property (strong, nonatomic) NSNumber * _Nonnull status;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRBridgedActionsClusterEndpointListStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull endpointListID;
-@property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSNumber * _Nonnull type;
-@property (strong, nonatomic) NSArray * _Nonnull endpoints;
+@interface MTRAccessControlClusterAccessControlExtensionChangedEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nullable adminNodeID;
+@property (nonatomic, copy) NSNumber * _Nullable adminPasscodeID;
+@property (nonatomic, copy) NSNumber * _Nonnull changeType;
+@property (nonatomic, copy) MTRAccessControlClusterExtensionEntry * _Nullable latestValue;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRBridgedActionsClusterStateChangedEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
-@property (strong, nonatomic) NSNumber * _Nonnull invokeID;
-@property (strong, nonatomic, getter=getNewState) NSNumber * _Nonnull newState;
-@end
+@interface MTRBridgedActionsClusterActionStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSString * _Nonnull name;
+@property (nonatomic, copy) NSNumber * _Nonnull type;
+@property (nonatomic, copy) NSNumber * _Nonnull endpointListID;
+@property (nonatomic, copy) NSNumber * _Nonnull supportedCommands;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
 
-@interface MTRBridgedActionsClusterActionFailedEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull actionID;
-@property (strong, nonatomic) NSNumber * _Nonnull invokeID;
-@property (strong, nonatomic, getter=getNewState) NSNumber * _Nonnull newState;
-@property (strong, nonatomic) NSNumber * _Nonnull error;
-@end
-
-@interface MTRBasicClusterCapabilityMinimaStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull caseSessionsPerFabric;
-@property (strong, nonatomic) NSNumber * _Nonnull subscriptionsPerFabric;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRBasicClusterStartUpEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
-@end
+@interface MTRBridgedActionsClusterEndpointListStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull endpointListID;
+@property (nonatomic, copy) NSString * _Nonnull name;
+@property (nonatomic, copy) NSNumber * _Nonnull type;
+@property (nonatomic, copy) NSArray * _Nonnull endpoints;
 
-@interface MTRBasicClusterShutDownEvent : NSObject
-@end
-
-@interface MTRBasicClusterLeaveEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
-@end
-
-@interface MTRBasicClusterReachableChangedEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull reachableNewValue;
-@end
-
-@interface MTROtaSoftwareUpdateRequestorClusterProviderLocation : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull providerNodeID;
-@property (strong, nonatomic) NSNumber * _Nonnull endpoint;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull previousState;
-@property (strong, nonatomic, getter=getNewState) NSNumber * _Nonnull newState;
-@property (strong, nonatomic) NSNumber * _Nonnull reason;
-@property (strong, nonatomic) NSNumber * _Nullable targetSoftwareVersion;
-@end
+@interface MTRBridgedActionsClusterStateChangedEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull invokeID;
+@property (nonatomic, copy, getter=getNewState) NSNumber * _Nonnull newState;
 
-@interface MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
-@property (strong, nonatomic) NSNumber * _Nonnull productID;
-@end
-
-@interface MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
-@property (strong, nonatomic) NSNumber * _Nonnull bytesDownloaded;
-@property (strong, nonatomic) NSNumber * _Nullable progressPercent;
-@property (strong, nonatomic) NSNumber * _Nullable platformCode;
-@end
-
-@interface MTRPowerSourceClusterBatChargeFaultChangeType : NSObject
-@property (strong, nonatomic) NSArray * _Nonnull current;
-@property (strong, nonatomic) NSArray * _Nonnull previous;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRPowerSourceClusterBatFaultChangeType : NSObject
-@property (strong, nonatomic) NSArray * _Nonnull current;
-@property (strong, nonatomic) NSArray * _Nonnull previous;
+@interface MTRBridgedActionsClusterActionFailedEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull actionID;
+@property (nonatomic, copy) NSNumber * _Nonnull invokeID;
+@property (nonatomic, copy, getter=getNewState) NSNumber * _Nonnull newState;
+@property (nonatomic, copy) NSNumber * _Nonnull error;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRPowerSourceClusterWiredFaultChangeType : NSObject
-@property (strong, nonatomic) NSArray * _Nonnull current;
-@property (strong, nonatomic) NSArray * _Nonnull previous;
+@interface MTRBasicClusterCapabilityMinimaStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull caseSessionsPerFabric;
+@property (nonatomic, copy) NSNumber * _Nonnull subscriptionsPerFabric;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRGeneralCommissioningClusterBasicCommissioningInfo : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull failSafeExpiryLengthSeconds;
-@property (strong, nonatomic) NSNumber * _Nonnull maxCumulativeFailsafeSeconds;
+@interface MTRBasicClusterStartUpEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRNetworkCommissioningClusterNetworkInfo : NSObject
-@property (strong, nonatomic) NSData * _Nonnull networkID;
-@property (strong, nonatomic) NSNumber * _Nonnull connected;
+@interface MTRBasicClusterShutDownEvent : NSObject <NSCopying>
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRNetworkCommissioningClusterThreadInterfaceScanResult : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull panId;
-@property (strong, nonatomic) NSNumber * _Nonnull extendedPanId;
-@property (strong, nonatomic) NSString * _Nonnull networkName;
-@property (strong, nonatomic) NSNumber * _Nonnull channel;
-@property (strong, nonatomic) NSNumber * _Nonnull version;
-@property (strong, nonatomic) NSData * _Nonnull extendedAddress;
-@property (strong, nonatomic) NSNumber * _Nonnull rssi;
-@property (strong, nonatomic) NSNumber * _Nonnull lqi;
+@interface MTRBasicClusterLeaveEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRNetworkCommissioningClusterWiFiInterfaceScanResult : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull security;
-@property (strong, nonatomic) NSData * _Nonnull ssid;
-@property (strong, nonatomic) NSData * _Nonnull bssid;
-@property (strong, nonatomic) NSNumber * _Nonnull channel;
-@property (strong, nonatomic) NSNumber * _Nonnull wiFiBand;
-@property (strong, nonatomic) NSNumber * _Nonnull rssi;
+@interface MTRBasicClusterReachableChangedEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull reachableNewValue;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRGeneralDiagnosticsClusterNetworkInterfaceType : NSObject
-@property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSNumber * _Nonnull isOperational;
-@property (strong, nonatomic) NSNumber * _Nullable offPremiseServicesReachableIPv4;
-@property (strong, nonatomic) NSNumber * _Nullable offPremiseServicesReachableIPv6;
-@property (strong, nonatomic) NSData * _Nonnull hardwareAddress;
-@property (strong, nonatomic) NSArray * _Nonnull iPv4Addresses;
-@property (strong, nonatomic) NSArray * _Nonnull iPv6Addresses;
-@property (strong, nonatomic) NSNumber * _Nonnull type;
+@interface MTROtaSoftwareUpdateRequestorClusterProviderLocation : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull providerNodeID;
+@property (nonatomic, copy) NSNumber * _Nonnull endpoint;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent : NSObject
-@property (strong, nonatomic) NSArray * _Nonnull current;
-@property (strong, nonatomic) NSArray * _Nonnull previous;
-@end
+@interface MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull previousState;
+@property (nonatomic, copy, getter=getNewState) NSNumber * _Nonnull newState;
+@property (nonatomic, copy) NSNumber * _Nonnull reason;
+@property (nonatomic, copy) NSNumber * _Nullable targetSoftwareVersion;
 
-@interface MTRGeneralDiagnosticsClusterRadioFaultChangeEvent : NSObject
-@property (strong, nonatomic) NSArray * _Nonnull current;
-@property (strong, nonatomic) NSArray * _Nonnull previous;
-@end
-
-@interface MTRGeneralDiagnosticsClusterNetworkFaultChangeEvent : NSObject
-@property (strong, nonatomic) NSArray * _Nonnull current;
-@property (strong, nonatomic) NSArray * _Nonnull previous;
-@end
-
-@interface MTRGeneralDiagnosticsClusterBootReasonEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull bootReason;
-@end
-
-@interface MTRSoftwareDiagnosticsClusterThreadMetrics : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull id;
-@property (strong, nonatomic) NSString * _Nullable name;
-@property (strong, nonatomic) NSNumber * _Nullable stackFreeCurrent;
-@property (strong, nonatomic) NSNumber * _Nullable stackFreeMinimum;
-@property (strong, nonatomic) NSNumber * _Nullable stackSize;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRSoftwareDiagnosticsClusterSoftwareFaultEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull id;
-@property (strong, nonatomic) NSString * _Nullable name;
-@property (strong, nonatomic) NSData * _Nullable faultRecording;
-@end
+@interface MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
+@property (nonatomic, copy) NSNumber * _Nonnull productID;
 
-@interface MTRThreadNetworkDiagnosticsClusterNeighborTable : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull extAddress;
-@property (strong, nonatomic) NSNumber * _Nonnull age;
-@property (strong, nonatomic) NSNumber * _Nonnull rloc16;
-@property (strong, nonatomic) NSNumber * _Nonnull linkFrameCounter;
-@property (strong, nonatomic) NSNumber * _Nonnull mleFrameCounter;
-@property (strong, nonatomic) NSNumber * _Nonnull lqi;
-@property (strong, nonatomic) NSNumber * _Nullable averageRssi;
-@property (strong, nonatomic) NSNumber * _Nullable lastRssi;
-@property (strong, nonatomic) NSNumber * _Nonnull frameErrorRate;
-@property (strong, nonatomic) NSNumber * _Nonnull messageErrorRate;
-@property (strong, nonatomic) NSNumber * _Nonnull rxOnWhenIdle;
-@property (strong, nonatomic) NSNumber * _Nonnull fullThreadDevice;
-@property (strong, nonatomic) NSNumber * _Nonnull fullNetworkData;
-@property (strong, nonatomic) NSNumber * _Nonnull isChild;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRThreadNetworkDiagnosticsClusterOperationalDatasetComponents : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull activeTimestampPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull pendingTimestampPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull masterKeyPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull networkNamePresent;
-@property (strong, nonatomic) NSNumber * _Nonnull extendedPanIdPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull meshLocalPrefixPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull delayPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull panIdPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull channelPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull pskcPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull securityPolicyPresent;
-@property (strong, nonatomic) NSNumber * _Nonnull channelMaskPresent;
+@interface MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
+@property (nonatomic, copy) NSNumber * _Nonnull bytesDownloaded;
+@property (nonatomic, copy) NSNumber * _Nullable progressPercent;
+@property (nonatomic, copy) NSNumber * _Nullable platformCode;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRThreadNetworkDiagnosticsClusterRouteTable : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull extAddress;
-@property (strong, nonatomic) NSNumber * _Nonnull rloc16;
-@property (strong, nonatomic) NSNumber * _Nonnull routerId;
-@property (strong, nonatomic) NSNumber * _Nonnull nextHop;
-@property (strong, nonatomic) NSNumber * _Nonnull pathCost;
-@property (strong, nonatomic) NSNumber * _Nonnull lqiIn;
-@property (strong, nonatomic) NSNumber * _Nonnull lqiOut;
-@property (strong, nonatomic) NSNumber * _Nonnull age;
-@property (strong, nonatomic) NSNumber * _Nonnull allocated;
-@property (strong, nonatomic) NSNumber * _Nonnull linkEstablished;
+@interface MTRPowerSourceClusterBatChargeFaultChangeType : NSObject <NSCopying>
+@property (nonatomic, copy) NSArray * _Nonnull current;
+@property (nonatomic, copy) NSArray * _Nonnull previous;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRThreadNetworkDiagnosticsClusterSecurityPolicy : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull rotationTime;
-@property (strong, nonatomic) NSNumber * _Nonnull flags;
+@interface MTRPowerSourceClusterBatFaultChangeType : NSObject <NSCopying>
+@property (nonatomic, copy) NSArray * _Nonnull current;
+@property (nonatomic, copy) NSArray * _Nonnull previous;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRThreadNetworkDiagnosticsClusterConnectionStatusEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull connectionStatus;
-@end
+@interface MTRPowerSourceClusterWiredFaultChangeType : NSObject <NSCopying>
+@property (nonatomic, copy) NSArray * _Nonnull current;
+@property (nonatomic, copy) NSArray * _Nonnull previous;
 
-@interface MTRWiFiNetworkDiagnosticsClusterDisconnectionEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull reasonCode;
-@end
-
-@interface MTRWiFiNetworkDiagnosticsClusterAssociationFailureEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull associationFailure;
-@property (strong, nonatomic) NSNumber * _Nonnull status;
-@end
-
-@interface MTRWiFiNetworkDiagnosticsClusterConnectionStatusEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull connectionStatus;
-@end
-
-@interface MTRBridgedDeviceBasicClusterStartUpEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull softwareVersion;
-@end
-
-@interface MTRBridgedDeviceBasicClusterShutDownEvent : NSObject
-@end
-
-@interface MTRBridgedDeviceBasicClusterLeaveEvent : NSObject
-@end
-
-@interface MTRBridgedDeviceBasicClusterReachableChangedEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull reachableNewValue;
-@end
-
-@interface MTRSwitchClusterSwitchLatchedEvent : NSObject
-@property (strong, nonatomic, getter=getNewPosition) NSNumber * _Nonnull newPosition;
-@end
-
-@interface MTRSwitchClusterInitialPressEvent : NSObject
-@property (strong, nonatomic, getter=getNewPosition) NSNumber * _Nonnull newPosition;
-@end
-
-@interface MTRSwitchClusterLongPressEvent : NSObject
-@property (strong, nonatomic, getter=getNewPosition) NSNumber * _Nonnull newPosition;
-@end
-
-@interface MTRSwitchClusterShortReleaseEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull previousPosition;
-@end
-
-@interface MTRSwitchClusterLongReleaseEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull previousPosition;
-@end
-
-@interface MTRSwitchClusterMultiPressOngoingEvent : NSObject
-@property (strong, nonatomic, getter=getNewPosition) NSNumber * _Nonnull newPosition;
-@property (strong, nonatomic) NSNumber * _Nonnull currentNumberOfPressesCounted;
-@end
-
-@interface MTRSwitchClusterMultiPressCompleteEvent : NSObject
-@property (strong, nonatomic, getter=getNewPosition) NSNumber * _Nonnull newPosition;
-@property (strong, nonatomic) NSNumber * _Nonnull totalNumberOfPressesCounted;
-@end
-
-@interface MTROperationalCredentialsClusterFabricDescriptor : NSObject
-@property (strong, nonatomic) NSData * _Nonnull rootPublicKey;
-@property (strong, nonatomic) NSNumber * _Nonnull vendorId;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricId;
-@property (strong, nonatomic) NSNumber * _Nonnull nodeId;
-@property (strong, nonatomic) NSString * _Nonnull label;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTROperationalCredentialsClusterNOCStruct : NSObject
-@property (strong, nonatomic) NSData * _Nonnull noc;
-@property (strong, nonatomic) NSData * _Nullable icac;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@interface MTRGeneralCommissioningClusterBasicCommissioningInfo : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull failSafeExpiryLengthSeconds;
+@property (nonatomic, copy) NSNumber * _Nonnull maxCumulativeFailsafeSeconds;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRGroupKeyManagementClusterGroupInfoMapStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
-@property (strong, nonatomic) NSArray * _Nonnull endpoints;
-@property (strong, nonatomic) NSString * _Nullable groupName;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@interface MTRNetworkCommissioningClusterNetworkInfo : NSObject <NSCopying>
+@property (nonatomic, copy) NSData * _Nonnull networkID;
+@property (nonatomic, copy) NSNumber * _Nonnull connected;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRGroupKeyManagementClusterGroupKeyMapStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull groupId;
-@property (strong, nonatomic) NSNumber * _Nonnull groupKeySetID;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@interface MTRNetworkCommissioningClusterThreadInterfaceScanResult : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull panId;
+@property (nonatomic, copy) NSNumber * _Nonnull extendedPanId;
+@property (nonatomic, copy) NSString * _Nonnull networkName;
+@property (nonatomic, copy) NSNumber * _Nonnull channel;
+@property (nonatomic, copy) NSNumber * _Nonnull version;
+@property (nonatomic, copy) NSData * _Nonnull extendedAddress;
+@property (nonatomic, copy) NSNumber * _Nonnull rssi;
+@property (nonatomic, copy) NSNumber * _Nonnull lqi;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRGroupKeyManagementClusterGroupKeySetStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull groupKeySetID;
-@property (strong, nonatomic) NSNumber * _Nonnull groupKeySecurityPolicy;
-@property (strong, nonatomic) NSData * _Nullable epochKey0;
-@property (strong, nonatomic) NSNumber * _Nullable epochStartTime0;
-@property (strong, nonatomic) NSData * _Nullable epochKey1;
-@property (strong, nonatomic) NSNumber * _Nullable epochStartTime1;
-@property (strong, nonatomic) NSData * _Nullable epochKey2;
-@property (strong, nonatomic) NSNumber * _Nullable epochStartTime2;
+@interface MTRNetworkCommissioningClusterWiFiInterfaceScanResult : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull security;
+@property (nonatomic, copy) NSData * _Nonnull ssid;
+@property (nonatomic, copy) NSData * _Nonnull bssid;
+@property (nonatomic, copy) NSNumber * _Nonnull channel;
+@property (nonatomic, copy) NSNumber * _Nonnull wiFiBand;
+@property (nonatomic, copy) NSNumber * _Nonnull rssi;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRFixedLabelClusterLabelStruct : NSObject
-@property (strong, nonatomic) NSString * _Nonnull label;
-@property (strong, nonatomic) NSString * _Nonnull value;
+@interface MTRGeneralDiagnosticsClusterNetworkInterfaceType : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nonnull name;
+@property (nonatomic, copy) NSNumber * _Nonnull isOperational;
+@property (nonatomic, copy) NSNumber * _Nullable offPremiseServicesReachableIPv4;
+@property (nonatomic, copy) NSNumber * _Nullable offPremiseServicesReachableIPv6;
+@property (nonatomic, copy) NSData * _Nonnull hardwareAddress;
+@property (nonatomic, copy) NSArray * _Nonnull iPv4Addresses;
+@property (nonatomic, copy) NSArray * _Nonnull iPv6Addresses;
+@property (nonatomic, copy) NSNumber * _Nonnull type;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRUserLabelClusterLabelStruct : NSObject
-@property (strong, nonatomic) NSString * _Nonnull label;
-@property (strong, nonatomic) NSString * _Nonnull value;
+@interface MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSArray * _Nonnull current;
+@property (nonatomic, copy) NSArray * _Nonnull previous;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRBooleanStateClusterStateChangeEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull stateValue;
-@end
+@interface MTRGeneralDiagnosticsClusterRadioFaultChangeEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSArray * _Nonnull current;
+@property (nonatomic, copy) NSArray * _Nonnull previous;
 
-@interface MTRModeSelectClusterSemanticTag : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull mfgCode;
-@property (strong, nonatomic) NSNumber * _Nonnull value;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRModeSelectClusterModeOptionStruct : NSObject
-@property (strong, nonatomic) NSString * _Nonnull label;
-@property (strong, nonatomic) NSNumber * _Nonnull mode;
-@property (strong, nonatomic) NSArray * _Nonnull semanticTags;
+@interface MTRGeneralDiagnosticsClusterNetworkFaultChangeEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSArray * _Nonnull current;
+@property (nonatomic, copy) NSArray * _Nonnull previous;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRDoorLockClusterDlCredential : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull credentialType;
-@property (strong, nonatomic) NSNumber * _Nonnull credentialIndex;
+@interface MTRGeneralDiagnosticsClusterBootReasonEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull bootReason;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRDoorLockClusterDoorLockAlarmEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull alarmCode;
-@end
+@interface MTRSoftwareDiagnosticsClusterThreadMetrics : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull id;
+@property (nonatomic, copy) NSString * _Nullable name;
+@property (nonatomic, copy) NSNumber * _Nullable stackFreeCurrent;
+@property (nonatomic, copy) NSNumber * _Nullable stackFreeMinimum;
+@property (nonatomic, copy) NSNumber * _Nullable stackSize;
 
-@interface MTRDoorLockClusterDoorStateChangeEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull doorState;
-@end
-
-@interface MTRDoorLockClusterLockOperationEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull lockOperationType;
-@property (strong, nonatomic) NSNumber * _Nonnull operationSource;
-@property (strong, nonatomic) NSNumber * _Nullable userIndex;
-@property (strong, nonatomic) NSNumber * _Nullable fabricIndex;
-@property (strong, nonatomic) NSNumber * _Nullable sourceNode;
-@property (strong, nonatomic) NSArray * _Nullable credentials;
-@end
-
-@interface MTRDoorLockClusterLockOperationErrorEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull lockOperationType;
-@property (strong, nonatomic) NSNumber * _Nonnull operationSource;
-@property (strong, nonatomic) NSNumber * _Nonnull operationError;
-@property (strong, nonatomic) NSNumber * _Nullable userIndex;
-@property (strong, nonatomic) NSNumber * _Nullable fabricIndex;
-@property (strong, nonatomic) NSNumber * _Nullable sourceNode;
-@property (strong, nonatomic) NSArray * _Nullable credentials;
-@end
-
-@interface MTRDoorLockClusterLockUserChangeEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull lockDataType;
-@property (strong, nonatomic) NSNumber * _Nonnull dataOperationType;
-@property (strong, nonatomic) NSNumber * _Nonnull operationSource;
-@property (strong, nonatomic) NSNumber * _Nullable userIndex;
-@property (strong, nonatomic) NSNumber * _Nullable fabricIndex;
-@property (strong, nonatomic) NSNumber * _Nullable sourceNode;
-@property (strong, nonatomic) NSNumber * _Nullable dataIndex;
-@end
-
-@interface MTRPumpConfigurationAndControlClusterSupplyVoltageLowEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterSupplyVoltageHighEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterPowerMissingPhaseEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterSystemPressureLowEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterSystemPressureHighEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterDryRunningEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterMotorTemperatureHighEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterElectronicTemperatureHighEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterPumpBlockedEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterSensorFailureEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterElectronicFatalFailureEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterGeneralFaultEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterLeakageEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterAirDetectionEvent : NSObject
-@end
-
-@interface MTRPumpConfigurationAndControlClusterTurbineOperationEvent : NSObject
-@end
-
-@interface MTRThermostatClusterThermostatScheduleTransition : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull transitionTime;
-@property (strong, nonatomic) NSNumber * _Nullable heatSetpoint;
-@property (strong, nonatomic) NSNumber * _Nullable coolSetpoint;
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRChannelClusterChannelInfo : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull majorNumber;
-@property (strong, nonatomic) NSNumber * _Nonnull minorNumber;
-@property (strong, nonatomic) NSString * _Nullable name;
-@property (strong, nonatomic) NSString * _Nullable callSign;
-@property (strong, nonatomic) NSString * _Nullable affiliateCallSign;
+@interface MTRSoftwareDiagnosticsClusterSoftwareFaultEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull id;
+@property (nonatomic, copy) NSString * _Nullable name;
+@property (nonatomic, copy) NSData * _Nullable faultRecording;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRChannelClusterLineupInfo : NSObject
-@property (strong, nonatomic) NSString * _Nonnull operatorName;
-@property (strong, nonatomic) NSString * _Nullable lineupName;
-@property (strong, nonatomic) NSString * _Nullable postalCode;
-@property (strong, nonatomic) NSNumber * _Nonnull lineupInfoType;
+@interface MTRThreadNetworkDiagnosticsClusterNeighborTable : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull extAddress;
+@property (nonatomic, copy) NSNumber * _Nonnull age;
+@property (nonatomic, copy) NSNumber * _Nonnull rloc16;
+@property (nonatomic, copy) NSNumber * _Nonnull linkFrameCounter;
+@property (nonatomic, copy) NSNumber * _Nonnull mleFrameCounter;
+@property (nonatomic, copy) NSNumber * _Nonnull lqi;
+@property (nonatomic, copy) NSNumber * _Nullable averageRssi;
+@property (nonatomic, copy) NSNumber * _Nullable lastRssi;
+@property (nonatomic, copy) NSNumber * _Nonnull frameErrorRate;
+@property (nonatomic, copy) NSNumber * _Nonnull messageErrorRate;
+@property (nonatomic, copy) NSNumber * _Nonnull rxOnWhenIdle;
+@property (nonatomic, copy) NSNumber * _Nonnull fullThreadDevice;
+@property (nonatomic, copy) NSNumber * _Nonnull fullNetworkData;
+@property (nonatomic, copy) NSNumber * _Nonnull isChild;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTargetNavigatorClusterTargetInfo : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull identifier;
-@property (strong, nonatomic) NSString * _Nonnull name;
+@interface MTRThreadNetworkDiagnosticsClusterOperationalDatasetComponents : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull activeTimestampPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull pendingTimestampPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull masterKeyPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull networkNamePresent;
+@property (nonatomic, copy) NSNumber * _Nonnull extendedPanIdPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull meshLocalPrefixPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull delayPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull panIdPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull channelPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull pskcPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull securityPolicyPresent;
+@property (nonatomic, copy) NSNumber * _Nonnull channelMaskPresent;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRMediaPlaybackClusterPlaybackPosition : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull updatedAt;
-@property (strong, nonatomic) NSNumber * _Nullable position;
+@interface MTRThreadNetworkDiagnosticsClusterRouteTable : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull extAddress;
+@property (nonatomic, copy) NSNumber * _Nonnull rloc16;
+@property (nonatomic, copy) NSNumber * _Nonnull routerId;
+@property (nonatomic, copy) NSNumber * _Nonnull nextHop;
+@property (nonatomic, copy) NSNumber * _Nonnull pathCost;
+@property (nonatomic, copy) NSNumber * _Nonnull lqiIn;
+@property (nonatomic, copy) NSNumber * _Nonnull lqiOut;
+@property (nonatomic, copy) NSNumber * _Nonnull age;
+@property (nonatomic, copy) NSNumber * _Nonnull allocated;
+@property (nonatomic, copy) NSNumber * _Nonnull linkEstablished;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRMediaInputClusterInputInfo : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull index;
-@property (strong, nonatomic) NSNumber * _Nonnull inputType;
-@property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSString * _Nonnull descriptionString;
+@interface MTRThreadNetworkDiagnosticsClusterSecurityPolicy : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull rotationTime;
+@property (nonatomic, copy) NSNumber * _Nonnull flags;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRContentLauncherClusterDimension : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull width;
-@property (strong, nonatomic) NSNumber * _Nonnull height;
-@property (strong, nonatomic) NSNumber * _Nonnull metric;
+@interface MTRThreadNetworkDiagnosticsClusterConnectionStatusEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull connectionStatus;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRContentLauncherClusterAdditionalInfo : NSObject
-@property (strong, nonatomic) NSString * _Nonnull name;
-@property (strong, nonatomic) NSString * _Nonnull value;
+@interface MTRWiFiNetworkDiagnosticsClusterDisconnectionEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull reasonCode;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRContentLauncherClusterParameter : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull type;
-@property (strong, nonatomic) NSString * _Nonnull value;
-@property (strong, nonatomic) NSArray * _Nullable externalIDList;
+@interface MTRWiFiNetworkDiagnosticsClusterAssociationFailureEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull associationFailure;
+@property (nonatomic, copy) NSNumber * _Nonnull status;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRContentLauncherClusterContentSearch : NSObject
-@property (strong, nonatomic) NSArray * _Nonnull parameterList;
+@interface MTRWiFiNetworkDiagnosticsClusterConnectionStatusEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull connectionStatus;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRContentLauncherClusterStyleInformation : NSObject
-@property (strong, nonatomic) NSString * _Nullable imageUrl;
-@property (strong, nonatomic) NSString * _Nullable color;
-@property (strong, nonatomic) MTRContentLauncherClusterDimension * _Nullable size;
+@interface MTRBridgedDeviceBasicClusterStartUpEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRContentLauncherClusterBrandingInformation : NSObject
-@property (strong, nonatomic) NSString * _Nonnull providerName;
-@property (strong, nonatomic) MTRContentLauncherClusterStyleInformation * _Nullable background;
-@property (strong, nonatomic) MTRContentLauncherClusterStyleInformation * _Nullable logo;
-@property (strong, nonatomic) MTRContentLauncherClusterStyleInformation * _Nullable progressBar;
-@property (strong, nonatomic) MTRContentLauncherClusterStyleInformation * _Nullable splash;
-@property (strong, nonatomic) MTRContentLauncherClusterStyleInformation * _Nullable waterMark;
+@interface MTRBridgedDeviceBasicClusterShutDownEvent : NSObject <NSCopying>
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRAudioOutputClusterOutputInfo : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull index;
-@property (strong, nonatomic) NSNumber * _Nonnull outputType;
-@property (strong, nonatomic) NSString * _Nonnull name;
+@interface MTRBridgedDeviceBasicClusterLeaveEvent : NSObject <NSCopying>
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRApplicationLauncherClusterApplication : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
-@property (strong, nonatomic) NSString * _Nonnull applicationId;
+@interface MTRBridgedDeviceBasicClusterReachableChangedEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull reachableNewValue;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRApplicationLauncherClusterApplicationEP : NSObject
-@property (strong, nonatomic) MTRApplicationLauncherClusterApplication * _Nonnull application;
-@property (strong, nonatomic) NSNumber * _Nullable endpoint;
+@interface MTRSwitchClusterSwitchLatchedEvent : NSObject <NSCopying>
+@property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRApplicationBasicClusterApplicationBasicApplication : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull catalogVendorId;
-@property (strong, nonatomic) NSString * _Nonnull applicationId;
+@interface MTRSwitchClusterInitialPressEvent : NSObject <NSCopying>
+@property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterSimpleStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull a;
-@property (strong, nonatomic) NSNumber * _Nonnull b;
-@property (strong, nonatomic) NSNumber * _Nonnull c;
-@property (strong, nonatomic) NSData * _Nonnull d;
-@property (strong, nonatomic) NSString * _Nonnull e;
-@property (strong, nonatomic) NSNumber * _Nonnull f;
-@property (strong, nonatomic) NSNumber * _Nonnull g;
-@property (strong, nonatomic) NSNumber * _Nonnull h;
+@interface MTRSwitchClusterLongPressEvent : NSObject <NSCopying>
+@property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterTestFabricScoped : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull fabricSensitiveInt8u;
-@property (strong, nonatomic) NSNumber * _Nullable optionalFabricSensitiveInt8u;
-@property (strong, nonatomic) NSNumber * _Nullable nullableFabricSensitiveInt8u;
-@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalFabricSensitiveInt8u;
-@property (strong, nonatomic) NSString * _Nonnull fabricSensitiveCharString;
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nonnull fabricSensitiveStruct;
-@property (strong, nonatomic) NSArray * _Nonnull fabricSensitiveInt8uList;
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@interface MTRSwitchClusterShortReleaseEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull previousPosition;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterNullablesAndOptionalsStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nullable nullableInt;
-@property (strong, nonatomic) NSNumber * _Nullable optionalInt;
-@property (strong, nonatomic) NSNumber * _Nullable nullableOptionalInt;
-@property (strong, nonatomic) NSString * _Nullable nullableString;
-@property (strong, nonatomic) NSString * _Nullable optionalString;
-@property (strong, nonatomic) NSString * _Nullable nullableOptionalString;
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable nullableStruct;
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable optionalStruct;
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nullable nullableOptionalStruct;
-@property (strong, nonatomic) NSArray * _Nullable nullableList;
-@property (strong, nonatomic) NSArray * _Nullable optionalList;
-@property (strong, nonatomic) NSArray * _Nullable nullableOptionalList;
+@interface MTRSwitchClusterLongReleaseEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull previousPosition;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterNestedStruct : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull a;
-@property (strong, nonatomic) NSNumber * _Nonnull b;
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nonnull c;
+@interface MTRSwitchClusterMultiPressOngoingEvent : NSObject <NSCopying>
+@property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition;
+@property (nonatomic, copy) NSNumber * _Nonnull currentNumberOfPressesCounted;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterNestedStructList : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull a;
-@property (strong, nonatomic) NSNumber * _Nonnull b;
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nonnull c;
-@property (strong, nonatomic) NSArray * _Nonnull d;
-@property (strong, nonatomic) NSArray * _Nonnull e;
-@property (strong, nonatomic) NSArray * _Nonnull f;
-@property (strong, nonatomic) NSArray * _Nonnull g;
+@interface MTRSwitchClusterMultiPressCompleteEvent : NSObject <NSCopying>
+@property (nonatomic, copy, getter=getNewPosition) NSNumber * _Nonnull newPosition;
+@property (nonatomic, copy) NSNumber * _Nonnull totalNumberOfPressesCounted;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterDoubleNestedStructList : NSObject
-@property (strong, nonatomic) NSArray * _Nonnull a;
+@interface MTROperationalCredentialsClusterFabricDescriptor : NSObject <NSCopying>
+@property (nonatomic, copy) NSData * _Nonnull rootPublicKey;
+@property (nonatomic, copy) NSNumber * _Nonnull vendorId;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricId;
+@property (nonatomic, copy) NSNumber * _Nonnull nodeId;
+@property (nonatomic, copy) NSString * _Nonnull label;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterTestListStructOctet : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull member1;
-@property (strong, nonatomic) NSData * _Nonnull member2;
+@interface MTROperationalCredentialsClusterNOCStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSData * _Nonnull noc;
+@property (nonatomic, copy) NSData * _Nullable icac;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
 - (instancetype)init;
-
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterTestEventEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull arg1;
-@property (strong, nonatomic) NSNumber * _Nonnull arg2;
-@property (strong, nonatomic) NSNumber * _Nonnull arg3;
-@property (strong, nonatomic) MTRTestClusterClusterSimpleStruct * _Nonnull arg4;
-@property (strong, nonatomic) NSArray * _Nonnull arg5;
-@property (strong, nonatomic) NSArray * _Nonnull arg6;
+@interface MTRGroupKeyManagementClusterGroupInfoMapStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSArray * _Nonnull endpoints;
+@property (nonatomic, copy) NSString * _Nullable groupName;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
-@interface MTRTestClusterClusterTestFabricScopedEventEvent : NSObject
-@property (strong, nonatomic) NSNumber * _Nonnull fabricIndex;
+@interface MTRGroupKeyManagementClusterGroupKeyMapStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull groupId;
+@property (nonatomic, copy) NSNumber * _Nonnull groupKeySetID;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRGroupKeyManagementClusterGroupKeySetStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull groupKeySetID;
+@property (nonatomic, copy) NSNumber * _Nonnull groupKeySecurityPolicy;
+@property (nonatomic, copy) NSData * _Nullable epochKey0;
+@property (nonatomic, copy) NSNumber * _Nullable epochStartTime0;
+@property (nonatomic, copy) NSData * _Nullable epochKey1;
+@property (nonatomic, copy) NSNumber * _Nullable epochStartTime1;
+@property (nonatomic, copy) NSData * _Nullable epochKey2;
+@property (nonatomic, copy) NSNumber * _Nullable epochStartTime2;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRFixedLabelClusterLabelStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nonnull label;
+@property (nonatomic, copy) NSString * _Nonnull value;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRUserLabelClusterLabelStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nonnull label;
+@property (nonatomic, copy) NSString * _Nonnull value;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRBooleanStateClusterStateChangeEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull stateValue;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRModeSelectClusterSemanticTag : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull mfgCode;
+@property (nonatomic, copy) NSNumber * _Nonnull value;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRModeSelectClusterModeOptionStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nonnull label;
+@property (nonatomic, copy) NSNumber * _Nonnull mode;
+@property (nonatomic, copy) NSArray * _Nonnull semanticTags;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRDoorLockClusterDlCredential : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull credentialType;
+@property (nonatomic, copy) NSNumber * _Nonnull credentialIndex;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRDoorLockClusterDoorLockAlarmEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull alarmCode;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRDoorLockClusterDoorStateChangeEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull doorState;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRDoorLockClusterLockOperationEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull lockOperationType;
+@property (nonatomic, copy) NSNumber * _Nonnull operationSource;
+@property (nonatomic, copy) NSNumber * _Nullable userIndex;
+@property (nonatomic, copy) NSNumber * _Nullable fabricIndex;
+@property (nonatomic, copy) NSNumber * _Nullable sourceNode;
+@property (nonatomic, copy) NSArray * _Nullable credentials;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRDoorLockClusterLockOperationErrorEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull lockOperationType;
+@property (nonatomic, copy) NSNumber * _Nonnull operationSource;
+@property (nonatomic, copy) NSNumber * _Nonnull operationError;
+@property (nonatomic, copy) NSNumber * _Nullable userIndex;
+@property (nonatomic, copy) NSNumber * _Nullable fabricIndex;
+@property (nonatomic, copy) NSNumber * _Nullable sourceNode;
+@property (nonatomic, copy) NSArray * _Nullable credentials;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRDoorLockClusterLockUserChangeEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull lockDataType;
+@property (nonatomic, copy) NSNumber * _Nonnull dataOperationType;
+@property (nonatomic, copy) NSNumber * _Nonnull operationSource;
+@property (nonatomic, copy) NSNumber * _Nullable userIndex;
+@property (nonatomic, copy) NSNumber * _Nullable fabricIndex;
+@property (nonatomic, copy) NSNumber * _Nullable sourceNode;
+@property (nonatomic, copy) NSNumber * _Nullable dataIndex;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterSupplyVoltageLowEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterSupplyVoltageHighEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterPowerMissingPhaseEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterSystemPressureLowEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterSystemPressureHighEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterDryRunningEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterMotorTemperatureHighEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterElectronicTemperatureHighEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterPumpBlockedEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterSensorFailureEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterElectronicFatalFailureEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterGeneralFaultEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterLeakageEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterAirDetectionEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRPumpConfigurationAndControlClusterTurbineOperationEvent : NSObject <NSCopying>
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRThermostatClusterThermostatScheduleTransition : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull transitionTime;
+@property (nonatomic, copy) NSNumber * _Nullable heatSetpoint;
+@property (nonatomic, copy) NSNumber * _Nullable coolSetpoint;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRChannelClusterChannelInfo : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull majorNumber;
+@property (nonatomic, copy) NSNumber * _Nonnull minorNumber;
+@property (nonatomic, copy) NSString * _Nullable name;
+@property (nonatomic, copy) NSString * _Nullable callSign;
+@property (nonatomic, copy) NSString * _Nullable affiliateCallSign;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRChannelClusterLineupInfo : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nonnull operatorName;
+@property (nonatomic, copy) NSString * _Nullable lineupName;
+@property (nonatomic, copy) NSString * _Nullable postalCode;
+@property (nonatomic, copy) NSNumber * _Nonnull lineupInfoType;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTargetNavigatorClusterTargetInfo : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull identifier;
+@property (nonatomic, copy) NSString * _Nonnull name;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRMediaPlaybackClusterPlaybackPosition : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull updatedAt;
+@property (nonatomic, copy) NSNumber * _Nullable position;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRMediaInputClusterInputInfo : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull index;
+@property (nonatomic, copy) NSNumber * _Nonnull inputType;
+@property (nonatomic, copy) NSString * _Nonnull name;
+@property (nonatomic, copy) NSString * _Nonnull descriptionString;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRContentLauncherClusterDimension : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull width;
+@property (nonatomic, copy) NSNumber * _Nonnull height;
+@property (nonatomic, copy) NSNumber * _Nonnull metric;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRContentLauncherClusterAdditionalInfo : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nonnull name;
+@property (nonatomic, copy) NSString * _Nonnull value;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRContentLauncherClusterParameter : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull type;
+@property (nonatomic, copy) NSString * _Nonnull value;
+@property (nonatomic, copy) NSArray * _Nullable externalIDList;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRContentLauncherClusterContentSearch : NSObject <NSCopying>
+@property (nonatomic, copy) NSArray * _Nonnull parameterList;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRContentLauncherClusterStyleInformation : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nullable imageUrl;
+@property (nonatomic, copy) NSString * _Nullable color;
+@property (nonatomic, copy) MTRContentLauncherClusterDimension * _Nullable size;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRContentLauncherClusterBrandingInformation : NSObject <NSCopying>
+@property (nonatomic, copy) NSString * _Nonnull providerName;
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformation * _Nullable background;
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformation * _Nullable logo;
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformation * _Nullable progressBar;
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformation * _Nullable splash;
+@property (nonatomic, copy) MTRContentLauncherClusterStyleInformation * _Nullable waterMark;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRAudioOutputClusterOutputInfo : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull index;
+@property (nonatomic, copy) NSNumber * _Nonnull outputType;
+@property (nonatomic, copy) NSString * _Nonnull name;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRApplicationLauncherClusterApplication : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull catalogVendorId;
+@property (nonatomic, copy) NSString * _Nonnull applicationId;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRApplicationLauncherClusterApplicationEP : NSObject <NSCopying>
+@property (nonatomic, copy) MTRApplicationLauncherClusterApplication * _Nonnull application;
+@property (nonatomic, copy) NSNumber * _Nullable endpoint;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRApplicationBasicClusterApplicationBasicApplication : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull catalogVendorId;
+@property (nonatomic, copy) NSString * _Nonnull applicationId;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterSimpleStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull a;
+@property (nonatomic, copy) NSNumber * _Nonnull b;
+@property (nonatomic, copy) NSNumber * _Nonnull c;
+@property (nonatomic, copy) NSData * _Nonnull d;
+@property (nonatomic, copy) NSString * _Nonnull e;
+@property (nonatomic, copy) NSNumber * _Nonnull f;
+@property (nonatomic, copy) NSNumber * _Nonnull g;
+@property (nonatomic, copy) NSNumber * _Nonnull h;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterTestFabricScoped : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull fabricSensitiveInt8u;
+@property (nonatomic, copy) NSNumber * _Nullable optionalFabricSensitiveInt8u;
+@property (nonatomic, copy) NSNumber * _Nullable nullableFabricSensitiveInt8u;
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalFabricSensitiveInt8u;
+@property (nonatomic, copy) NSString * _Nonnull fabricSensitiveCharString;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull fabricSensitiveStruct;
+@property (nonatomic, copy) NSArray * _Nonnull fabricSensitiveInt8uList;
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterNullablesAndOptionalsStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nullable nullableInt;
+@property (nonatomic, copy) NSNumber * _Nullable optionalInt;
+@property (nonatomic, copy) NSNumber * _Nullable nullableOptionalInt;
+@property (nonatomic, copy) NSString * _Nullable nullableString;
+@property (nonatomic, copy) NSString * _Nullable optionalString;
+@property (nonatomic, copy) NSString * _Nullable nullableOptionalString;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable nullableStruct;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable optionalStruct;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nullable nullableOptionalStruct;
+@property (nonatomic, copy) NSArray * _Nullable nullableList;
+@property (nonatomic, copy) NSArray * _Nullable optionalList;
+@property (nonatomic, copy) NSArray * _Nullable nullableOptionalList;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterNestedStruct : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull a;
+@property (nonatomic, copy) NSNumber * _Nonnull b;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull c;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterNestedStructList : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull a;
+@property (nonatomic, copy) NSNumber * _Nonnull b;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull c;
+@property (nonatomic, copy) NSArray * _Nonnull d;
+@property (nonatomic, copy) NSArray * _Nonnull e;
+@property (nonatomic, copy) NSArray * _Nonnull f;
+@property (nonatomic, copy) NSArray * _Nonnull g;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterDoubleNestedStructList : NSObject <NSCopying>
+@property (nonatomic, copy) NSArray * _Nonnull a;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterTestListStructOctet : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull member1;
+@property (nonatomic, copy) NSData * _Nonnull member2;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterTestEventEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull arg1;
+@property (nonatomic, copy) NSNumber * _Nonnull arg2;
+@property (nonatomic, copy) NSNumber * _Nonnull arg3;
+@property (nonatomic, copy) MTRTestClusterClusterSimpleStruct * _Nonnull arg4;
+@property (nonatomic, copy) NSArray * _Nonnull arg5;
+@property (nonatomic, copy) NSArray * _Nonnull arg6;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
+
+@interface MTRTestClusterClusterTestFabricScopedEventEvent : NSObject <NSCopying>
+@property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -33,6 +33,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRScenesClusterAttributeValuePair alloc] init];
+
+    other.attributeId = self.attributeId;
+    other.attributeValue = self.attributeValue;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: attributeId:%@; attributeValue:%@; >",
@@ -54,6 +64,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRScenesClusterExtensionFieldSet alloc] init];
+
+    other.clusterId = self.clusterId;
+    other.attributeValueList = self.attributeValueList;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: clusterId:%@; attributeValueList:%@; >",
@@ -73,6 +93,16 @@ NS_ASSUME_NONNULL_BEGIN
         _revision = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRDescriptorClusterDeviceType alloc] init];
+
+    other.type = self.type;
+    other.revision = self.revision;
+
+    return other;
 }
 
 - (NSString *)description
@@ -102,6 +132,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBindingClusterTargetStruct alloc] init];
+
+    other.node = self.node;
+    other.group = self.group;
+    other.endpoint = self.endpoint;
+    other.cluster = self.cluster;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: node:%@; group:%@; endpoint:%@; cluster:%@; fabricIndex:%@; >",
@@ -123,6 +166,17 @@ NS_ASSUME_NONNULL_BEGIN
         _deviceType = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRAccessControlClusterTarget alloc] init];
+
+    other.cluster = self.cluster;
+    other.endpoint = self.endpoint;
+    other.deviceType = self.deviceType;
+
+    return other;
 }
 
 - (NSString *)description
@@ -152,6 +206,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRAccessControlClusterAccessControlEntry alloc] init];
+
+    other.privilege = self.privilege;
+    other.authMode = self.authMode;
+    other.subjects = self.subjects;
+    other.targets = self.targets;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -172,6 +239,16 @@ NS_ASSUME_NONNULL_BEGIN
         _fabricIndex = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRAccessControlClusterExtensionEntry alloc] init];
+
+    other.data = self.data;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
 }
 
 - (NSString *)description
@@ -201,6 +278,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRAccessControlClusterAccessControlEntryChangedEvent alloc] init];
+
+    other.adminNodeID = self.adminNodeID;
+    other.adminPasscodeID = self.adminPasscodeID;
+    other.changeType = self.changeType;
+    other.latestValue = self.latestValue;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -227,6 +317,19 @@ NS_ASSUME_NONNULL_BEGIN
         _fabricIndex = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRAccessControlClusterAccessControlExtensionChangedEvent alloc] init];
+
+    other.adminNodeID = self.adminNodeID;
+    other.adminPasscodeID = self.adminPasscodeID;
+    other.changeType = self.changeType;
+    other.latestValue = self.latestValue;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
 }
 
 - (NSString *)description
@@ -259,6 +362,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBridgedActionsClusterActionStruct alloc] init];
+
+    other.actionID = self.actionID;
+    other.name = self.name;
+    other.type = self.type;
+    other.endpointListID = self.endpointListID;
+    other.supportedCommands = self.supportedCommands;
+    other.status = self.status;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -285,6 +402,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBridgedActionsClusterEndpointListStruct alloc] init];
+
+    other.endpointListID = self.endpointListID;
+    other.name = self.name;
+    other.type = self.type;
+    other.endpoints = self.endpoints;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: endpointListID:%@; name:%@; type:%@; endpoints:%@; >",
@@ -306,6 +435,17 @@ NS_ASSUME_NONNULL_BEGIN
         _newState = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBridgedActionsClusterStateChangedEvent alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.newState = self.newState;
+
+    return other;
 }
 
 - (NSString *)description
@@ -333,6 +473,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBridgedActionsClusterActionFailedEvent alloc] init];
+
+    other.actionID = self.actionID;
+    other.invokeID = self.invokeID;
+    other.newState = self.newState;
+    other.error = self.error;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: actionID:%@; invokeID:%@; newState:%@; error:%@; >",
@@ -354,6 +506,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBasicClusterCapabilityMinimaStruct alloc] init];
+
+    other.caseSessionsPerFabric = self.caseSessionsPerFabric;
+    other.subscriptionsPerFabric = self.subscriptionsPerFabric;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: caseSessionsPerFabric:%@; subscriptionsPerFabric:%@; >",
@@ -373,6 +535,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBasicClusterStartUpEvent alloc] init];
+
+    other.softwareVersion = self.softwareVersion;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -388,6 +559,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBasicClusterShutDownEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -408,6 +586,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBasicClusterLeaveEvent alloc] init];
+
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -425,6 +612,15 @@ NS_ASSUME_NONNULL_BEGIN
         _reachableNewValue = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBasicClusterReachableChangedEvent alloc] init];
+
+    other.reachableNewValue = self.reachableNewValue;
+
+    return other;
 }
 
 - (NSString *)description
@@ -448,6 +644,17 @@ NS_ASSUME_NONNULL_BEGIN
         _fabricIndex = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTROtaSoftwareUpdateRequestorClusterProviderLocation alloc] init];
+
+    other.providerNodeID = self.providerNodeID;
+    other.endpoint = self.endpoint;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
 }
 
 - (NSString *)description
@@ -475,6 +682,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent alloc] init];
+
+    other.previousState = self.previousState;
+    other.newState = self.newState;
+    other.reason = self.reason;
+    other.targetSoftwareVersion = self.targetSoftwareVersion;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -495,6 +714,16 @@ NS_ASSUME_NONNULL_BEGIN
         _productID = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent alloc] init];
+
+    other.softwareVersion = self.softwareVersion;
+    other.productID = self.productID;
+
+    return other;
 }
 
 - (NSString *)description
@@ -522,6 +751,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent alloc] init];
+
+    other.softwareVersion = self.softwareVersion;
+    other.bytesDownloaded = self.bytesDownloaded;
+    other.progressPercent = self.progressPercent;
+    other.platformCode = self.platformCode;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -542,6 +783,16 @@ NS_ASSUME_NONNULL_BEGIN
         _previous = [NSArray array];
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPowerSourceClusterBatChargeFaultChangeType alloc] init];
+
+    other.current = self.current;
+    other.previous = self.previous;
+
+    return other;
 }
 
 - (NSString *)description
@@ -565,6 +816,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPowerSourceClusterBatFaultChangeType alloc] init];
+
+    other.current = self.current;
+    other.previous = self.previous;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -584,6 +845,16 @@ NS_ASSUME_NONNULL_BEGIN
         _previous = [NSArray array];
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPowerSourceClusterWiredFaultChangeType alloc] init];
+
+    other.current = self.current;
+    other.previous = self.previous;
+
+    return other;
 }
 
 - (NSString *)description
@@ -607,6 +878,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGeneralCommissioningClusterBasicCommissioningInfo alloc] init];
+
+    other.failSafeExpiryLengthSeconds = self.failSafeExpiryLengthSeconds;
+    other.maxCumulativeFailsafeSeconds = self.maxCumulativeFailsafeSeconds;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -627,6 +908,16 @@ NS_ASSUME_NONNULL_BEGIN
         _connected = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRNetworkCommissioningClusterNetworkInfo alloc] init];
+
+    other.networkID = self.networkID;
+    other.connected = self.connected;
+
+    return other;
 }
 
 - (NSString *)description
@@ -663,6 +954,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRNetworkCommissioningClusterThreadInterfaceScanResult alloc] init];
+
+    other.panId = self.panId;
+    other.extendedPanId = self.extendedPanId;
+    other.networkName = self.networkName;
+    other.channel = self.channel;
+    other.version = self.version;
+    other.extendedAddress = self.extendedAddress;
+    other.rssi = self.rssi;
+    other.lqi = self.lqi;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -693,6 +1000,20 @@ NS_ASSUME_NONNULL_BEGIN
         _rssi = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRNetworkCommissioningClusterWiFiInterfaceScanResult alloc] init];
+
+    other.security = self.security;
+    other.ssid = self.ssid;
+    other.bssid = self.bssid;
+    other.channel = self.channel;
+    other.wiFiBand = self.wiFiBand;
+    other.rssi = self.rssi;
+
+    return other;
 }
 
 - (NSString *)description
@@ -730,6 +1051,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGeneralDiagnosticsClusterNetworkInterfaceType alloc] init];
+
+    other.name = self.name;
+    other.isOperational = self.isOperational;
+    other.offPremiseServicesReachableIPv4 = self.offPremiseServicesReachableIPv4;
+    other.offPremiseServicesReachableIPv6 = self.offPremiseServicesReachableIPv6;
+    other.hardwareAddress = self.hardwareAddress;
+    other.iPv4Addresses = self.iPv4Addresses;
+    other.iPv6Addresses = self.iPv6Addresses;
+    other.type = self.type;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -754,6 +1091,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent alloc] init];
+
+    other.current = self.current;
+    other.previous = self.previous;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -773,6 +1120,16 @@ NS_ASSUME_NONNULL_BEGIN
         _previous = [NSArray array];
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGeneralDiagnosticsClusterRadioFaultChangeEvent alloc] init];
+
+    other.current = self.current;
+    other.previous = self.previous;
+
+    return other;
 }
 
 - (NSString *)description
@@ -796,6 +1153,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGeneralDiagnosticsClusterNetworkFaultChangeEvent alloc] init];
+
+    other.current = self.current;
+    other.previous = self.previous;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -813,6 +1180,15 @@ NS_ASSUME_NONNULL_BEGIN
         _bootReason = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGeneralDiagnosticsClusterBootReasonEvent alloc] init];
+
+    other.bootReason = self.bootReason;
+
+    return other;
 }
 
 - (NSString *)description
@@ -842,6 +1218,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSoftwareDiagnosticsClusterThreadMetrics alloc] init];
+
+    other.id = self.id;
+    other.name = self.name;
+    other.stackFreeCurrent = self.stackFreeCurrent;
+    other.stackFreeMinimum = self.stackFreeMinimum;
+    other.stackSize = self.stackSize;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -864,6 +1253,17 @@ NS_ASSUME_NONNULL_BEGIN
         _faultRecording = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSoftwareDiagnosticsClusterSoftwareFaultEvent alloc] init];
+
+    other.id = self.id;
+    other.name = self.name;
+    other.faultRecording = self.faultRecording;
+
+    return other;
 }
 
 - (NSString *)description
@@ -912,6 +1312,28 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRThreadNetworkDiagnosticsClusterNeighborTable alloc] init];
+
+    other.extAddress = self.extAddress;
+    other.age = self.age;
+    other.rloc16 = self.rloc16;
+    other.linkFrameCounter = self.linkFrameCounter;
+    other.mleFrameCounter = self.mleFrameCounter;
+    other.lqi = self.lqi;
+    other.averageRssi = self.averageRssi;
+    other.lastRssi = self.lastRssi;
+    other.frameErrorRate = self.frameErrorRate;
+    other.messageErrorRate = self.messageErrorRate;
+    other.rxOnWhenIdle = self.rxOnWhenIdle;
+    other.fullThreadDevice = self.fullThreadDevice;
+    other.fullNetworkData = self.fullNetworkData;
+    other.isChild = self.isChild;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -957,6 +1379,26 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRThreadNetworkDiagnosticsClusterOperationalDatasetComponents alloc] init];
+
+    other.activeTimestampPresent = self.activeTimestampPresent;
+    other.pendingTimestampPresent = self.pendingTimestampPresent;
+    other.masterKeyPresent = self.masterKeyPresent;
+    other.networkNamePresent = self.networkNamePresent;
+    other.extendedPanIdPresent = self.extendedPanIdPresent;
+    other.meshLocalPrefixPresent = self.meshLocalPrefixPresent;
+    other.delayPresent = self.delayPresent;
+    other.panIdPresent = self.panIdPresent;
+    other.channelPresent = self.channelPresent;
+    other.pskcPresent = self.pskcPresent;
+    other.securityPolicyPresent = self.securityPolicyPresent;
+    other.channelMaskPresent = self.channelMaskPresent;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -999,6 +1441,24 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRThreadNetworkDiagnosticsClusterRouteTable alloc] init];
+
+    other.extAddress = self.extAddress;
+    other.rloc16 = self.rloc16;
+    other.routerId = self.routerId;
+    other.nextHop = self.nextHop;
+    other.pathCost = self.pathCost;
+    other.lqiIn = self.lqiIn;
+    other.lqiOut = self.lqiOut;
+    other.age = self.age;
+    other.allocated = self.allocated;
+    other.linkEstablished = self.linkEstablished;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1023,6 +1483,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRThreadNetworkDiagnosticsClusterSecurityPolicy alloc] init];
+
+    other.rotationTime = self.rotationTime;
+    other.flags = self.flags;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1042,6 +1512,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRThreadNetworkDiagnosticsClusterConnectionStatusEvent alloc] init];
+
+    other.connectionStatus = self.connectionStatus;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1059,6 +1538,15 @@ NS_ASSUME_NONNULL_BEGIN
         _reasonCode = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRWiFiNetworkDiagnosticsClusterDisconnectionEvent alloc] init];
+
+    other.reasonCode = self.reasonCode;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1082,6 +1570,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRWiFiNetworkDiagnosticsClusterAssociationFailureEvent alloc] init];
+
+    other.associationFailure = self.associationFailure;
+    other.status = self.status;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: associationFailure:%@; status:%@; >",
@@ -1099,6 +1597,15 @@ NS_ASSUME_NONNULL_BEGIN
         _connectionStatus = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRWiFiNetworkDiagnosticsClusterConnectionStatusEvent alloc] init];
+
+    other.connectionStatus = self.connectionStatus;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1120,6 +1627,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBridgedDeviceBasicClusterStartUpEvent alloc] init];
+
+    other.softwareVersion = self.softwareVersion;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1135,6 +1651,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBridgedDeviceBasicClusterShutDownEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -1153,6 +1676,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBridgedDeviceBasicClusterLeaveEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1169,6 +1699,15 @@ NS_ASSUME_NONNULL_BEGIN
         _reachableNewValue = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBridgedDeviceBasicClusterReachableChangedEvent alloc] init];
+
+    other.reachableNewValue = self.reachableNewValue;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1190,6 +1729,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSwitchClusterSwitchLatchedEvent alloc] init];
+
+    other.newPosition = self.newPosition;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1207,6 +1755,15 @@ NS_ASSUME_NONNULL_BEGIN
         _newPosition = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSwitchClusterInitialPressEvent alloc] init];
+
+    other.newPosition = self.newPosition;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1228,6 +1785,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSwitchClusterLongPressEvent alloc] init];
+
+    other.newPosition = self.newPosition;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1247,6 +1813,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSwitchClusterShortReleaseEvent alloc] init];
+
+    other.previousPosition = self.previousPosition;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1264,6 +1839,15 @@ NS_ASSUME_NONNULL_BEGIN
         _previousPosition = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSwitchClusterLongReleaseEvent alloc] init];
+
+    other.previousPosition = self.previousPosition;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1287,6 +1871,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSwitchClusterMultiPressOngoingEvent alloc] init];
+
+    other.newPosition = self.newPosition;
+    other.currentNumberOfPressesCounted = self.currentNumberOfPressesCounted;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: newPosition:%@; currentNumberOfPressesCounted:%@; >",
@@ -1306,6 +1900,16 @@ NS_ASSUME_NONNULL_BEGIN
         _totalNumberOfPressesCounted = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRSwitchClusterMultiPressCompleteEvent alloc] init];
+
+    other.newPosition = self.newPosition;
+    other.totalNumberOfPressesCounted = self.totalNumberOfPressesCounted;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1337,6 +1941,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTROperationalCredentialsClusterFabricDescriptor alloc] init];
+
+    other.rootPublicKey = self.rootPublicKey;
+    other.vendorId = self.vendorId;
+    other.fabricId = self.fabricId;
+    other.nodeId = self.nodeId;
+    other.label = self.label;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1360,6 +1978,17 @@ NS_ASSUME_NONNULL_BEGIN
         _fabricIndex = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTROperationalCredentialsClusterNOCStruct alloc] init];
+
+    other.noc = self.noc;
+    other.icac = self.icac;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1388,6 +2017,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGroupKeyManagementClusterGroupInfoMapStruct alloc] init];
+
+    other.groupId = self.groupId;
+    other.endpoints = self.endpoints;
+    other.groupName = self.groupName;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: groupId:%@; endpoints:%@; groupName:%@; fabricIndex:%@; >",
@@ -1409,6 +2050,17 @@ NS_ASSUME_NONNULL_BEGIN
         _fabricIndex = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGroupKeyManagementClusterGroupKeyMapStruct alloc] init];
+
+    other.groupId = self.groupId;
+    other.groupKeySetID = self.groupKeySetID;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1444,6 +2096,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRGroupKeyManagementClusterGroupKeySetStruct alloc] init];
+
+    other.groupKeySetID = self.groupKeySetID;
+    other.groupKeySecurityPolicy = self.groupKeySecurityPolicy;
+    other.epochKey0 = self.epochKey0;
+    other.epochStartTime0 = self.epochStartTime0;
+    other.epochKey1 = self.epochKey1;
+    other.epochStartTime1 = self.epochStartTime1;
+    other.epochKey2 = self.epochKey2;
+    other.epochStartTime2 = self.epochStartTime2;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1469,6 +2137,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRFixedLabelClusterLabelStruct alloc] init];
+
+    other.label = self.label;
+    other.value = self.value;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1490,6 +2168,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRUserLabelClusterLabelStruct alloc] init];
+
+    other.label = self.label;
+    other.value = self.value;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -1507,6 +2195,15 @@ NS_ASSUME_NONNULL_BEGIN
         _stateValue = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRBooleanStateClusterStateChangeEvent alloc] init];
+
+    other.stateValue = self.stateValue;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1528,6 +2225,16 @@ NS_ASSUME_NONNULL_BEGIN
         _value = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRModeSelectClusterSemanticTag alloc] init];
+
+    other.mfgCode = self.mfgCode;
+    other.value = self.value;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1553,6 +2260,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRModeSelectClusterModeOptionStruct alloc] init];
+
+    other.label = self.label;
+    other.mode = self.mode;
+    other.semanticTags = self.semanticTags;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: label:%@; mode:%@; semanticTags:%@; >",
@@ -1574,6 +2292,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRDoorLockClusterDlCredential alloc] init];
+
+    other.credentialType = self.credentialType;
+    other.credentialIndex = self.credentialIndex;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: credentialType:%@; credentialIndex:%@; >",
@@ -1593,6 +2321,15 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRDoorLockClusterDoorLockAlarmEvent alloc] init];
+
+    other.alarmCode = self.alarmCode;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: alarmCode:%@; >", NSStringFromClass([self class]), _alarmCode];
@@ -1609,6 +2346,15 @@ NS_ASSUME_NONNULL_BEGIN
         _doorState = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRDoorLockClusterDoorStateChangeEvent alloc] init];
+
+    other.doorState = self.doorState;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1637,6 +2383,20 @@ NS_ASSUME_NONNULL_BEGIN
         _credentials = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRDoorLockClusterLockOperationEvent alloc] init];
+
+    other.lockOperationType = self.lockOperationType;
+    other.operationSource = self.operationSource;
+    other.userIndex = self.userIndex;
+    other.fabricIndex = self.fabricIndex;
+    other.sourceNode = self.sourceNode;
+    other.credentials = self.credentials;
+
+    return other;
 }
 
 - (NSString *)description
@@ -1672,6 +2432,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRDoorLockClusterLockOperationErrorEvent alloc] init];
+
+    other.lockOperationType = self.lockOperationType;
+    other.operationSource = self.operationSource;
+    other.operationError = self.operationError;
+    other.userIndex = self.userIndex;
+    other.fabricIndex = self.fabricIndex;
+    other.sourceNode = self.sourceNode;
+    other.credentials = self.credentials;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: lockOperationType:%@; operationSource:%@; operationError:%@; "
@@ -1705,6 +2480,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRDoorLockClusterLockUserChangeEvent alloc] init];
+
+    other.lockDataType = self.lockDataType;
+    other.dataOperationType = self.dataOperationType;
+    other.operationSource = self.operationSource;
+    other.userIndex = self.userIndex;
+    other.fabricIndex = self.fabricIndex;
+    other.sourceNode = self.sourceNode;
+    other.dataIndex = self.dataIndex;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: lockDataType:%@; dataOperationType:%@; operationSource:%@; "
@@ -1724,6 +2514,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterSupplyVoltageLowEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1738,6 +2535,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterSupplyVoltageHighEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -1756,6 +2560,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterPowerMissingPhaseEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1770,6 +2581,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterSystemPressureLowEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -1788,6 +2606,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterSystemPressureHighEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1802,6 +2627,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterDryRunningEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -1820,6 +2652,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterMotorTemperatureHighEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1834,6 +2673,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -1852,6 +2698,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterElectronicTemperatureHighEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1866,6 +2719,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterPumpBlockedEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -1884,6 +2744,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterSensorFailureEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1898,6 +2765,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -1916,6 +2790,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterElectronicFatalFailureEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1930,6 +2811,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterGeneralFaultEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -1948,6 +2836,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterLeakageEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1964,6 +2859,13 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterAirDetectionEvent alloc] init];
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: >", NSStringFromClass([self class])];
@@ -1978,6 +2880,13 @@ NS_ASSUME_NONNULL_BEGIN
     if (self = [super init]) {
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRPumpConfigurationAndControlClusterTurbineOperationEvent alloc] init];
+
+    return other;
 }
 
 - (NSString *)description
@@ -2000,6 +2909,17 @@ NS_ASSUME_NONNULL_BEGIN
         _coolSetpoint = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRThermostatClusterThermostatScheduleTransition alloc] init];
+
+    other.transitionTime = self.transitionTime;
+    other.heatSetpoint = self.heatSetpoint;
+    other.coolSetpoint = self.coolSetpoint;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2029,6 +2949,19 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRChannelClusterChannelInfo alloc] init];
+
+    other.majorNumber = self.majorNumber;
+    other.minorNumber = self.minorNumber;
+    other.name = self.name;
+    other.callSign = self.callSign;
+    other.affiliateCallSign = self.affiliateCallSign;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2055,6 +2988,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRChannelClusterLineupInfo alloc] init];
+
+    other.operatorName = self.operatorName;
+    other.lineupName = self.lineupName;
+    other.postalCode = self.postalCode;
+    other.lineupInfoType = self.lineupInfoType;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2077,6 +3022,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTargetNavigatorClusterTargetInfo alloc] init];
+
+    other.identifier = self.identifier;
+    other.name = self.name;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2096,6 +3051,16 @@ NS_ASSUME_NONNULL_BEGIN
         _position = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRMediaPlaybackClusterPlaybackPosition alloc] init];
+
+    other.updatedAt = self.updatedAt;
+    other.position = self.position;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2123,6 +3088,18 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRMediaInputClusterInputInfo alloc] init];
+
+    other.index = self.index;
+    other.inputType = self.inputType;
+    other.name = self.name;
+    other.descriptionString = self.descriptionString;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: index:%@; inputType:%@; name:%@; descriptionString:%@; >",
@@ -2146,6 +3123,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRContentLauncherClusterDimension alloc] init];
+
+    other.width = self.width;
+    other.height = self.height;
+    other.metric = self.metric;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2165,6 +3153,16 @@ NS_ASSUME_NONNULL_BEGIN
         _value = @"";
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRContentLauncherClusterAdditionalInfo alloc] init];
+
+    other.name = self.name;
+    other.value = self.value;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2190,6 +3188,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRContentLauncherClusterParameter alloc] init];
+
+    other.type = self.type;
+    other.value = self.value;
+    other.externalIDList = self.externalIDList;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: type:%@; value:%@; externalIDList:%@; >",
@@ -2207,6 +3216,15 @@ NS_ASSUME_NONNULL_BEGIN
         _parameterList = [NSArray array];
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRContentLauncherClusterContentSearch alloc] init];
+
+    other.parameterList = self.parameterList;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2230,6 +3248,17 @@ NS_ASSUME_NONNULL_BEGIN
         _size = nil;
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRContentLauncherClusterStyleInformation alloc] init];
+
+    other.imageUrl = self.imageUrl;
+    other.color = self.color;
+    other.size = self.size;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2261,6 +3290,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRContentLauncherClusterBrandingInformation alloc] init];
+
+    other.providerName = self.providerName;
+    other.background = self.background;
+    other.logo = self.logo;
+    other.progressBar = self.progressBar;
+    other.splash = self.splash;
+    other.waterMark = self.waterMark;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2285,6 +3328,17 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRAudioOutputClusterOutputInfo alloc] init];
+
+    other.index = self.index;
+    other.outputType = self.outputType;
+    other.name = self.name;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2304,6 +3358,16 @@ NS_ASSUME_NONNULL_BEGIN
         _applicationId = @"";
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRApplicationLauncherClusterApplication alloc] init];
+
+    other.catalogVendorId = self.catalogVendorId;
+    other.applicationId = self.applicationId;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2327,6 +3391,16 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRApplicationLauncherClusterApplicationEP alloc] init];
+
+    other.application = self.application;
+    other.endpoint = self.endpoint;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString
@@ -2346,6 +3420,16 @@ NS_ASSUME_NONNULL_BEGIN
         _applicationId = @"";
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRApplicationBasicClusterApplicationBasicApplication alloc] init];
+
+    other.catalogVendorId = self.catalogVendorId;
+    other.applicationId = self.applicationId;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2381,6 +3465,22 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterSimpleStruct alloc] init];
+
+    other.a = self.a;
+    other.b = self.b;
+    other.c = self.c;
+    other.d = self.d;
+    other.e = self.e;
+    other.f = self.f;
+    other.g = self.g;
+    other.h = self.h;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2413,6 +3513,22 @@ NS_ASSUME_NONNULL_BEGIN
         _fabricIndex = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterTestFabricScoped alloc] init];
+
+    other.fabricSensitiveInt8u = self.fabricSensitiveInt8u;
+    other.optionalFabricSensitiveInt8u = self.optionalFabricSensitiveInt8u;
+    other.nullableFabricSensitiveInt8u = self.nullableFabricSensitiveInt8u;
+    other.nullableOptionalFabricSensitiveInt8u = self.nullableOptionalFabricSensitiveInt8u;
+    other.fabricSensitiveCharString = self.fabricSensitiveCharString;
+    other.fabricSensitiveStruct = self.fabricSensitiveStruct;
+    other.fabricSensitiveInt8uList = self.fabricSensitiveInt8uList;
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2461,6 +3577,26 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterNullablesAndOptionalsStruct alloc] init];
+
+    other.nullableInt = self.nullableInt;
+    other.optionalInt = self.optionalInt;
+    other.nullableOptionalInt = self.nullableOptionalInt;
+    other.nullableString = self.nullableString;
+    other.optionalString = self.optionalString;
+    other.nullableOptionalString = self.nullableOptionalString;
+    other.nullableStruct = self.nullableStruct;
+    other.optionalStruct = self.optionalStruct;
+    other.nullableOptionalStruct = self.nullableOptionalStruct;
+    other.nullableList = self.nullableList;
+    other.optionalList = self.optionalList;
+    other.nullableOptionalList = self.nullableOptionalList;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString =
@@ -2487,6 +3623,17 @@ NS_ASSUME_NONNULL_BEGIN
         _c = [MTRTestClusterClusterSimpleStruct new];
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterNestedStruct alloc] init];
+
+    other.a = self.a;
+    other.b = self.b;
+    other.c = self.c;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2520,6 +3667,21 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterNestedStructList alloc] init];
+
+    other.a = self.a;
+    other.b = self.b;
+    other.c = self.c;
+    other.d = self.d;
+    other.e = self.e;
+    other.f = self.f;
+    other.g = self.g;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: a:%@; b:%@; c:%@; d:%@; e:%@; f:%@; g:%@; >",
@@ -2537,6 +3699,15 @@ NS_ASSUME_NONNULL_BEGIN
         _a = [NSArray array];
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterDoubleNestedStructList alloc] init];
+
+    other.a = self.a;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2557,6 +3728,16 @@ NS_ASSUME_NONNULL_BEGIN
         _member2 = [NSData data];
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterTestListStructOctet alloc] init];
+
+    other.member1 = self.member1;
+    other.member2 = self.member2;
+
+    return other;
 }
 
 - (NSString *)description
@@ -2588,6 +3769,20 @@ NS_ASSUME_NONNULL_BEGIN
     return self;
 }
 
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterTestEventEvent alloc] init];
+
+    other.arg1 = self.arg1;
+    other.arg2 = self.arg2;
+    other.arg3 = self.arg3;
+    other.arg4 = self.arg4;
+    other.arg5 = self.arg5;
+    other.arg6 = self.arg6;
+
+    return other;
+}
+
 - (NSString *)description
 {
     NSString * descriptionString = [NSString stringWithFormat:@"<%@: arg1:%@; arg2:%@; arg3:%@; arg4:%@; arg5:%@; arg6:%@; >",
@@ -2605,6 +3800,15 @@ NS_ASSUME_NONNULL_BEGIN
         _fabricIndex = @(0);
     }
     return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone
+{
+    auto other = [[MTRTestClusterClusterTestFabricScopedEventEvent alloc] init];
+
+    other.fabricIndex = self.fabricIndex;
+
+    return other;
 }
 
 - (NSString *)description


### PR DESCRIPTION
Changes:

1. Makes all the Matter payload/struct/event structs implement NSCopying.
2. Uses "copy" for members of various params structs that are objects and not
   instances of some protocol, and "assign" for ones that are non-ARC types.
3. Somewhat aligns properties in params structs to list nonatomic first, then
   ownership, then readonly if the property is readonly, then nullable as
   needed.

#### Problem
Using "strong" ownership for params, which would ideally not mutate while we use them.

#### Change overview
Use "copy" ownership instead.

#### Testing
Should still pass CI.