### PR TITLE
[Darwin] Fix OTAProviderDelegate init after all controllers has been turned off and a new controller is started

### DIFF
--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
@@ -27,7 +27,7 @@ public:
     MTROTAProviderDelegateBridge(id<MTROTAProviderDelegate> delegate);
     ~MTROTAProviderDelegateBridge();
 
-    void Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeManager);
+    CHIP_ERROR Init(chip::System::Layer * systemLayer, chip::Messaging::ExchangeManager * exchangeManager);
     void Shutdown();
 
     void HandleQueryImage(

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -314,9 +314,9 @@ MTROTAProviderDelegateBridge::~MTROTAProviderDelegateBridge()
     Clusters::OTAProvider::SetDelegate(kOtaProviderEndpoint, nullptr);
 }
 
-void MTROTAProviderDelegateBridge::Init(System::Layer * systemLayer, Messaging::ExchangeManager * exchangeManager)
+CHIP_ERROR MTROTAProviderDelegateBridge::Init(System::Layer * systemLayer, Messaging::ExchangeManager * exchangeManager)
 {
-    gOtaSender.Init(systemLayer, exchangeManager);
+    return gOtaSender.Init(systemLayer, exchangeManager);
 }
 
 void MTROTAProviderDelegateBridge::Shutdown() { gOtaSender.Shutdown(); }

--- a/src/darwin/Framework/CHIPTests/MTRTestOTAProvider.h
+++ b/src/darwin/Framework/CHIPTests/MTRTestOTAProvider.h
@@ -1,0 +1,25 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <Matter/Matter.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MTRTestOTAProvider : NSObject <MTROTAProviderDelegate>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIPTests/MTRTestOTAProvider.m
+++ b/src/darwin/Framework/CHIPTests/MTRTestOTAProvider.m
@@ -1,0 +1,57 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import "MTRTestOTAProvider.h"
+
+@interface MTRTestOTAProvider ()
+@end
+
+@implementation MTRTestOTAProvider
+- (void)handleQueryImage:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
+       completionHandler:(void (^)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
+                             NSError * _Nullable error))completionHandler
+{
+}
+
+- (void)handleApplyUpdateRequest:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
+               completionHandler:(void (^)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                                     NSError * _Nullable error))completionHandler
+{
+}
+
+- (void)handleNotifyUpdateApplied:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
+                completionHandler:(StatusCompletion)completionHandler
+{
+}
+
+- (void)handleBDXTransferSessionBegin:(NSString * _Nonnull)fileDesignator
+                               offset:(NSNumber * _Nonnull)offset
+                    completionHandler:(void (^)(NSError * error))completionHandler
+{
+}
+
+- (void)handleBDXTransferSessionEnd:(NSError * _Nullable)error
+{
+}
+
+- (void)handleBDXQuery:(NSNumber * _Nonnull)blockSize
+            blockIndex:(NSNumber * _Nonnull)blockIndex
+           bytesToSkip:(NSNumber * _Nonnull)bytesToSkip
+     completionHandler:(void (^)(NSData * _Nullable data, BOOL isEOF))completionHandler
+{
+}
+
+@end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1E5801C328941C050033A199 /* MTRTestOTAProvider.m in Sources */ = {isa = PBXBuildFile; fileRef = 1E748B3828941A44008A1BE8 /* MTRTestOTAProvider.m */; };
 		1E85730C265519AE0050A4D9 /* callback-stub.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1E857307265519AE0050A4D9 /* callback-stub.cpp */; };
 		1EB41B7B263C4CC60048E4C1 /* MTRClustersTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EB41B7A263C4CC60048E4C1 /* MTRClustersTests.m */; };
 		1EC3238D271999E2002A8BF0 /* cluster-objects.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 1EC3238C271999E2002A8BF0 /* cluster-objects.cpp */; };
@@ -127,6 +128,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1E748B3828941A44008A1BE8 /* MTRTestOTAProvider.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRTestOTAProvider.m; sourceTree = "<group>"; };
+		1E748B3928941A45008A1BE8 /* MTRTestOTAProvider.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRTestOTAProvider.h; sourceTree = "<group>"; };
 		1E857307265519AE0050A4D9 /* callback-stub.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "callback-stub.cpp"; path = "../../../../zzz_generated/controller-clusters/zap-generated/callback-stub.cpp"; sourceTree = "<group>"; };
 		1EB41B7A263C4CC60048E4C1 /* MTRClustersTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRClustersTests.m; sourceTree = "<group>"; };
 		1EC3238C271999E2002A8BF0 /* cluster-objects.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "cluster-objects.cpp"; path = "../../../../zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp"; sourceTree = "<group>"; };
@@ -404,6 +407,8 @@
 		B202529A2459E34F00F97062 /* CHIPTests */ = {
 			isa = PBXGroup;
 			children = (
+				1E748B3928941A45008A1BE8 /* MTRTestOTAProvider.h */,
+				1E748B3828941A44008A1BE8 /* MTRTestOTAProvider.m */,
 				D437613E285BDC0D0051FEA2 /* MTRErrorTestUtils.h */,
 				D437613F285BDC0D0051FEA2 /* MTRTestKeys.h */,
 				D4376140285BDC0D0051FEA2 /* MTRTestStorage.h */,
@@ -667,6 +672,7 @@
 				997DED1A26955D0200975E97 /* MTRThreadOperationalDatasetTests.mm in Sources */,
 				51C8E3F82825CDB600D47D00 /* MTRTestKeys.m in Sources */,
 				99C65E10267282F1003402F6 /* MTRControllerTests.m in Sources */,
+				1E5801C328941C050033A199 /* MTRTestOTAProvider.m in Sources */,
 				5A6FEC9D27B5E48900F25F42 /* MTRXPCProtocolTests.m in Sources */,
 				5AE6D4E427A99041001F2493 /* MTRDeviceTests.m in Sources */,
 				5A7947DE27BEC3F500434CF2 /* MTRXPCListenerSampleTests.m in Sources */,


### PR DESCRIPTION
#### Problem

Fix #21306

#### Change overview
* Update `MTROTAProviderDelegateBridge::Init` so it returns an error if init fails
* Shuffle the code so `MTROTAProviderDelegateBridge::Init` happens when the system state has been initialised with proper values
* Add a test to make sure a new controller can be created after a proper cleanup of the system state

#### Testing
`xcodebuild test -target "Matter" -scheme "Matter Framework Tests" -sdk macosx -only-testing:MatterTests/MTRControllerTests/testControllerWithOTAProviderDelegate`