### PR TITLE
Fix ACL Check on IM event per path basis

### DIFF
--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -491,11 +491,6 @@ private:
     static CHIP_ERROR CopyEvent(const TLV::TLVReader & aReader, TLV::TLVWriter & aWriter, EventLoadOutContext * apContext);
 
     /**
-     * @brief construct EventStatusIB to target buffer for report
-     */
-    static CHIP_ERROR WriteEventStatusIB(TLV::TLVWriter & aWriter, const ConcreteEventPath & aEvent, StatusIB aStatus);
-
-    /**
      * @brief
      *   A function to get the circular buffer for particular priority
      *

--- a/src/app/MessageDef/EventReportIB.cpp
+++ b/src/app/MessageDef/EventReportIB.cpp
@@ -149,5 +149,27 @@ EventReportIB::Builder & EventReportIB::Builder::EndOfEventReportIB()
     EndOfContainer();
     return *this;
 }
+
+CHIP_ERROR EventReportIB::ConstructEventStatusIB(TLV::TLVWriter & aWriter, const ConcreteEventPath & aEvent, StatusIB aStatus)
+{
+    Builder eventReportIBBuilder;
+    ReturnErrorOnFailure(eventReportIBBuilder.Init(&aWriter));
+    EventStatusIB::Builder & eventStatusIBBuilder = eventReportIBBuilder.CreateEventStatus();
+    ReturnErrorOnFailure(eventReportIBBuilder.GetError());
+    EventPathIB::Builder & eventPathIBBuilder = eventStatusIBBuilder.CreatePath();
+    ReturnErrorOnFailure(eventStatusIBBuilder.GetError());
+    ReturnErrorOnFailure(eventPathIBBuilder.Endpoint(aEvent.mEndpointId)
+                             .Cluster(aEvent.mClusterId)
+                             .Event(aEvent.mEventId)
+                             .EndOfEventPathIB()
+                             .GetError());
+
+    ReturnErrorOnFailure(eventStatusIBBuilder.CreateErrorStatus().EncodeStatusIB(aStatus).GetError());
+
+    ReturnErrorOnFailure(eventStatusIBBuilder.EndOfEventStatusIB().GetError());
+    ReturnErrorOnFailure(eventReportIBBuilder.EndOfEventReportIB().GetError());
+    ReturnErrorOnFailure(aWriter.Finalize());
+    return CHIP_NO_ERROR;
+}
 } // namespace app
 } // namespace chip

--- a/src/app/MessageDef/EventReportIB.h
+++ b/src/app/MessageDef/EventReportIB.h
@@ -109,6 +109,11 @@ private:
     EventStatusIB::Builder mEventStatus;
     EventDataIB::Builder mEventData;
 };
+
+/**
+ * @brief construct EventStatusIB to target buffer for report
+ */
+CHIP_ERROR ConstructEventStatusIB(TLV::TLVWriter & aWriter, const ConcreteEventPath & aEvent, StatusIB aStatus);
 } // namespace EventReportIB
 } // namespace app
 } // namespace chip

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -25,6 +25,7 @@
 
 #include <app/AppConfig.h>
 #include <app/InteractionModelEngine.h>
+#include <app/RequiredPrivilege.h>
 #include <app/reporting/Engine.h>
 #include <app/util/MatterCallbacks.h>
 
@@ -290,21 +291,62 @@ exit:
     return err;
 }
 
+CHIP_ERROR Engine::CheckAccessDeniedEventPaths(TLV::TLVWriter & aWriter, bool & aHasEncodedData, ReadHandler * apReadHandler)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    for (auto current = apReadHandler->mpEventPathList; current != nullptr;)
+    {
+        if (current->mValue.HasEventWildcard())
+        {
+            current = current->mpNext;
+            continue;
+        }
+
+        Access::RequestPath requestPath{ .cluster = current->mValue.mClusterId, .endpoint = current->mValue.mEndpointId };
+        ConcreteEventPath path(current->mValue.mEndpointId, current->mValue.mClusterId, current->mValue.mEventId);
+        Access::Privilege requestPrivilege = RequiredPrivilege::ForReadEvent(path);
+
+        err = Access::GetAccessControl().Check(apReadHandler->GetSubjectDescriptor(), requestPath, requestPrivilege);
+        if (err != CHIP_ERROR_ACCESS_DENIED)
+        {
+            ReturnErrorOnFailure(err);
+        }
+        else
+        {
+            TLV::TLVWriter checkpoint = aWriter;
+            err                       = EventReportIB::ConstructEventStatusIB(aWriter, path,
+                                                        StatusIB(Protocols::InteractionModel::Status::UnsupportedAccess));
+            if (err != CHIP_NO_ERROR)
+            {
+                aWriter = checkpoint;
+                break;
+            }
+            aHasEncodedData = true;
+            ChipLogDetail(InteractionModel, "Acces to event (%u, " ChipLogFormatMEI ", " ChipLogFormatMEI ") denied by ACL",
+                          current->mValue.mEndpointId, ChipLogValueMEI(current->mValue.mClusterId),
+                          ChipLogValueMEI(current->mValue.mEventId));
+        }
+        current = current->mpNext;
+    }
+
+    return err;
+}
+
 CHIP_ERROR Engine::BuildSingleReportDataEventReports(ReportDataMessage::Builder & aReportDataBuilder, ReadHandler * apReadHandler,
                                                      bool aBufferIsUsed, bool * apHasMoreChunks, bool * apHasEncodedData)
 {
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-    size_t eventCount = 0;
+    CHIP_ERROR err        = CHIP_NO_ERROR;
+    size_t eventCount     = 0;
+    bool hasEncodedStatus = false;
     TLV::TLVWriter backup;
     bool eventClean                = true;
-    const auto * eventList         = apReadHandler->GetEventPathList();
     auto & eventMin                = apReadHandler->GetEventMin();
     EventManagement & eventManager = EventManagement::GetInstance();
     bool hasMoreChunks             = false;
 
     aReportDataBuilder.Checkpoint(backup);
 
-    VerifyOrExit(eventList != nullptr, );
+    VerifyOrExit(apReadHandler->GetEventPathList() != nullptr, );
 
     // If the eventManager is not valid or has not been initialized,
     // skip the rest of processing
@@ -326,7 +368,11 @@ CHIP_ERROR Engine::BuildSingleReportDataEventReports(ReportDataMessage::Builder 
         SuccessOrExit(err = aReportDataBuilder.GetError());
         VerifyOrExit(eventReportIBs.GetWriter() != nullptr, err = CHIP_ERROR_INCORRECT_STATE);
         SuccessOrExit(err = eventReportIBs.GetWriter()->ReserveBuffer(kReservedSizeEndOfReportIBs));
-        err = eventManager.FetchEventsSince(*(eventReportIBs.GetWriter()), eventList, eventMin, eventCount,
+
+        err = CheckAccessDeniedEventPaths(*(eventReportIBs.GetWriter()), hasEncodedStatus, apReadHandler);
+        SuccessOrExit(err);
+
+        err = eventManager.FetchEventsSince(*(eventReportIBs.GetWriter()), apReadHandler->GetEventPathList(), eventMin, eventCount,
                                             apReadHandler->GetSubjectDescriptor());
 
         if ((err == CHIP_END_OF_TLV) || (err == CHIP_ERROR_TLV_UNDERRUN) || (err == CHIP_NO_ERROR))
@@ -375,12 +421,12 @@ CHIP_ERROR Engine::BuildSingleReportDataEventReports(ReportDataMessage::Builder 
 exit:
     if (apHasEncodedData != nullptr)
     {
-        *apHasEncodedData = !(eventCount == 0 || eventClean);
+        *apHasEncodedData = hasEncodedStatus || (eventCount != 0);
     }
 
     // Maybe encoding the attributes has already used up all space.
     if ((err == CHIP_NO_ERROR || err == CHIP_ERROR_NO_MEMORY || err == CHIP_ERROR_BUFFER_TOO_SMALL) &&
-        (eventCount == 0 || eventClean))
+        !(hasEncodedStatus || (eventCount != 0)))
     {
         aReportDataBuilder.Rollback(backup);
         aReportDataBuilder.ResetError();

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -154,6 +154,7 @@ private:
                                    AttributeReportIBs::Builder & aAttributeReportIBs,
                                    const ConcreteReadAttributePath & aClusterInfo,
                                    AttributeValueEncoder::AttributeEncodeState * apEncoderState);
+    CHIP_ERROR CheckAccessDeniedEventPaths(TLV::TLVWriter & aWriter, bool & aHasEncodedData, ReadHandler * apReadHandler);
 
     // If version match, it means don't send, if version mismatch, it means send.
     // If client sends the same path with multiple data versions, client will get the data back per the spec, because at least one

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -71,6 +71,7 @@ chip_test_suite("tests") {
   output_name = "libAppTests"
 
   test_sources = [
+    "TestAclEvent.cpp",
     "TestAttributePathExpandIterator.cpp",
     "TestAttributeValueDecoder.cpp",
     "TestAttributeValueEncoder.cpp",

--- a/src/app/tests/TestAclEvent.cpp
+++ b/src/app/tests/TestAclEvent.cpp
@@ -1,0 +1,405 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      This file implements unit tests for CHIP Interaction Model Read Interaction
+ *
+ */
+
+#include "lib/support/CHIPMem.h"
+#include <access/AccessControl.h>
+#include <app/AttributeAccessInterface.h>
+#include <app/InteractionModelEngine.h>
+#include <app/MessageDef/AttributeReportIBs.h>
+#include <app/MessageDef/EventDataIB.h>
+#include <app/tests/AppTestContext.h>
+#include <app/util/basic-types.h>
+#include <app/util/mock/Constants.h>
+#include <app/util/mock/Functions.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/core/CHIPTLVDebug.hpp>
+#include <lib/core/CHIPTLVUtilities.hpp>
+#include <lib/support/CHIPCounter.h>
+#include <lib/support/ErrorStr.h>
+#include <lib/support/UnitTestContext.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/Flags.h>
+#include <nlunit-test.h>
+#include <protocols/interaction_model/Constants.h>
+
+#include <type_traits>
+
+namespace {
+using namespace chip;
+using namespace chip::Access;
+
+uint8_t gDebugEventBuffer[128];
+uint8_t gInfoEventBuffer[128];
+uint8_t gCritEventBuffer[128];
+chip::app::CircularEventBuffer gCircularEventBuffer[3];
+chip::ClusterId kTestClusterId1    = 6;
+chip::ClusterId kTestClusterId2    = 7;
+chip::EndpointId kTestEndpointId   = 1;
+chip::EventId kTestEventIdDebug    = 1;
+chip::EventId kTestEventIdCritical = 2;
+chip::TLV::Tag kTestEventTag       = chip::TLV::ContextTag(1);
+
+class TestAccessControlDelegate : public AccessControl::Delegate
+{
+public:
+    // Check
+    CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const chip::Access::RequestPath & requestPath,
+                     Privilege requestPrivilege) override
+    {
+        if (requestPath.cluster == kTestClusterId1)
+        {
+            return CHIP_ERROR_ACCESS_DENIED;
+        }
+        return CHIP_NO_ERROR;
+    }
+};
+
+AccessControl::Delegate * GetTestAccessControlDelegate()
+{
+    static TestAccessControlDelegate accessControlDelegate;
+    return &accessControlDelegate;
+}
+
+class TestDeviceTypeResolver : public AccessControl::DeviceTypeResolver
+{
+public:
+    bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) override { return false; }
+} gDeviceTypeResolver;
+
+class TestContext : public chip::Test::AppContext
+{
+public:
+    static int Initialize(void * context)
+    {
+        if (AppContext::Initialize(context) != SUCCESS)
+            return FAILURE;
+
+        auto * ctx = static_cast<TestContext *>(context);
+
+        if (ctx->mEventCounter.Init(0) != CHIP_NO_ERROR)
+        {
+            return FAILURE;
+        }
+
+        chip::app::LogStorageResources logStorageResources[] = {
+            { &gDebugEventBuffer[0], sizeof(gDebugEventBuffer), chip::app::PriorityLevel::Debug },
+            { &gInfoEventBuffer[0], sizeof(gInfoEventBuffer), chip::app::PriorityLevel::Info },
+            { &gCritEventBuffer[0], sizeof(gCritEventBuffer), chip::app::PriorityLevel::Critical },
+        };
+
+        chip::app::EventManagement::CreateEventManagement(&ctx->GetExchangeManager(), ArraySize(logStorageResources),
+                                                          gCircularEventBuffer, logStorageResources, &ctx->mEventCounter);
+        Access::GetAccessControl().Finish();
+        Access::GetAccessControl().Init(GetTestAccessControlDelegate(), gDeviceTypeResolver);
+        return SUCCESS;
+    }
+
+    static int Finalize(void * context)
+    {
+        chip::app::EventManagement::DestroyEventManagement();
+
+        if (AppContext::Finalize(context) != SUCCESS)
+            return FAILURE;
+
+        return SUCCESS;
+    }
+
+private:
+    chip::MonotonicallyIncreasingCounter<chip::EventNumber> mEventCounter;
+};
+
+class TestEventGenerator : public chip::app::EventLoggingDelegate
+{
+public:
+    CHIP_ERROR WriteEvent(chip::TLV::TLVWriter & aWriter)
+    {
+        chip::TLV::TLVType dataContainerType;
+        ReturnErrorOnFailure(aWriter.StartContainer(chip::TLV::ContextTag(chip::to_underlying(chip::app::EventDataIB::Tag::kData)),
+                                                    chip::TLV::kTLVType_Structure, dataContainerType));
+        ReturnErrorOnFailure(aWriter.Put(kTestEventTag, mStatus));
+        return aWriter.EndContainer(dataContainerType);
+    }
+
+    void SetStatus(int32_t aStatus) { mStatus = aStatus; }
+
+private:
+    int32_t mStatus;
+};
+
+void GenerateEvents(nlTestSuite * apSuite, void * apContext)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    chip::EventNumber eid1, eid2;
+    chip::app::EventOptions options1;
+    options1.mPath     = { kTestEndpointId, kTestClusterId1, kTestEventIdDebug };
+    options1.mPriority = chip::app::PriorityLevel::Info;
+
+    chip::app::EventOptions options2;
+    options2.mPath     = { kTestEndpointId, kTestClusterId2, kTestEventIdCritical };
+    options2.mPriority = chip::app::PriorityLevel::Critical;
+    TestEventGenerator testEventGenerator;
+    chip::app::EventManagement & logMgmt = chip::app::EventManagement::GetInstance();
+
+    ChipLogDetail(DataManagement, "Generating Events");
+    testEventGenerator.SetStatus(0);
+    err = logMgmt.LogEvent(&testEventGenerator, options1, eid1);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    testEventGenerator.SetStatus(1);
+    err = logMgmt.LogEvent(&testEventGenerator, options2, eid2);
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+}
+
+class MockInteractionModelApp : public chip::app::ReadClient::Callback
+{
+public:
+    void OnEventData(const chip::app::EventHeader & aEventHeader, chip::TLV::TLVReader * apData,
+                     const chip::app::StatusIB * apStatus) override
+    {
+        ++mNumDataElementIndex;
+        mGotEventResponse = true;
+        if (apStatus != nullptr && !apStatus->IsSuccess())
+        {
+            mNumReadEventFailureStatusReceived++;
+            mLastStatusReceived = *apStatus;
+        }
+        else
+        {
+            mLastStatusReceived = chip::app::StatusIB();
+        }
+    }
+
+    void OnError(CHIP_ERROR aError) override
+    {
+        mError     = aError;
+        mReadError = true;
+    }
+
+    void OnDone(chip::app::ReadClient *) override {}
+
+    void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
+    {
+        if (aReadPrepareParams.mpEventPathParamsList != nullptr)
+        {
+            delete[] aReadPrepareParams.mpEventPathParamsList;
+        }
+    }
+
+    int mNumDataElementIndex               = 0;
+    bool mGotEventResponse                 = false;
+    int mNumReadEventFailureStatusReceived = 0;
+    int mNumAttributeResponse              = 0;
+    bool mGotReport                        = false;
+    bool mReadError                        = false;
+    chip::app::ReadHandler * mpReadHandler = nullptr;
+    chip::app::StatusIB mLastStatusReceived;
+    CHIP_ERROR mError = CHIP_NO_ERROR;
+    std::vector<chip::app::ConcreteAttributePath> mReceivedAttributePaths;
+};
+
+} // namespace
+
+namespace chip {
+namespace app {
+class TestAclEvent
+{
+public:
+    static void TestReadRoundtripWithEventStatusIBInEventReport(nlTestSuite * apSuite, void * apContext);
+};
+
+void TestAclEvent::TestReadRoundtripWithEventStatusIBInEventReport(nlTestSuite * apSuite, void * apContext)
+{
+    TestContext & ctx = *static_cast<TestContext *>(apContext);
+    CHIP_ERROR err    = CHIP_NO_ERROR;
+
+    Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
+    // Shouldn't have anything in the retransmit table when starting the test.
+    NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);
+
+    GenerateEvents(apSuite, apContext);
+
+    auto * engine = chip::app::InteractionModelEngine::GetInstance();
+    err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable());
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    // A custom AccessControl::Delegate has been installed that grants privilege to any cluster except the test cluster.
+    // When reading events with concrete paths without enough privilege, we will get a EventStatusIB
+    {
+        chip::app::EventPathParams eventPathParams[1];
+        eventPathParams[0].mEndpointId = kTestEndpointId;
+        eventPathParams[0].mClusterId  = kTestClusterId1;
+        eventPathParams[0].mEventId    = kTestEventIdDebug;
+
+        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+        readPrepareParams.mpEventPathParamsList    = eventPathParams;
+        readPrepareParams.mEventPathParamsListSize = 1;
+        readPrepareParams.mEventNumber.SetValue(1);
+
+        MockInteractionModelApp delegate;
+        NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Read);
+
+        err = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+
+        NL_TEST_ASSERT(apSuite, delegate.mGotEventResponse);
+        NL_TEST_ASSERT(apSuite, delegate.mNumReadEventFailureStatusReceived == 1);
+        NL_TEST_ASSERT(apSuite, delegate.mLastStatusReceived.mStatus == Protocols::InteractionModel::Status::UnsupportedAccess);
+        NL_TEST_ASSERT(apSuite, !delegate.mReadError);
+    }
+
+    GenerateEvents(apSuite, apContext);
+
+    // When reading events with withcard paths without enough privilege for reading all events, we will exclude all events without
+    // enough priviledge when generating the report.
+    {
+        chip::app::EventPathParams eventPathParams[1];
+        eventPathParams[0].mEndpointId = kTestEndpointId;
+        eventPathParams[0].mClusterId  = kTestClusterId1;
+
+        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+        readPrepareParams.mpEventPathParamsList    = eventPathParams;
+        readPrepareParams.mEventPathParamsListSize = 1;
+        readPrepareParams.mEventNumber.SetValue(1);
+
+        MockInteractionModelApp delegate;
+        NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Read);
+
+        err = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+        NL_TEST_ASSERT(apSuite, delegate.mNumReadEventFailureStatusReceived == 0);
+        NL_TEST_ASSERT(apSuite, !delegate.mReadError);
+    }
+
+    GenerateEvents(apSuite, apContext);
+
+    // When reading events with withcard paths where the partial don't have enough privilege, we will exclude those partial
+    // when generating the report.
+    {
+        chip::app::EventPathParams eventPathParams[1];
+        eventPathParams[0].mEndpointId = kTestEndpointId;
+
+        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+        readPrepareParams.mpEventPathParamsList    = eventPathParams;
+        readPrepareParams.mEventPathParamsListSize = 1;
+        readPrepareParams.mEventNumber.SetValue(1);
+
+        MockInteractionModelApp delegate;
+        NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Read);
+
+        err = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, delegate.mGotEventResponse);
+        NL_TEST_ASSERT(apSuite, delegate.mNumReadEventFailureStatusReceived == 0);
+        NL_TEST_ASSERT(apSuite, !delegate.mReadError);
+    }
+
+    GenerateEvents(apSuite, apContext);
+
+    // When reading events with two concrete paths where one has enough priviledge, another don't have , we will get a EventStatusIB
+    // and eventDataIB
+    {
+        chip::app::EventPathParams eventPathParams[2];
+        eventPathParams[0].mEndpointId = kTestEndpointId;
+        eventPathParams[0].mClusterId  = kTestClusterId1;
+        eventPathParams[0].mEventId    = kTestEventIdDebug;
+        eventPathParams[1].mEndpointId = kTestEndpointId;
+        eventPathParams[1].mClusterId  = kTestClusterId2;
+        eventPathParams[1].mEventId    = kTestEventIdCritical;
+
+        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+        readPrepareParams.mpEventPathParamsList    = eventPathParams;
+        readPrepareParams.mEventPathParamsListSize = 1;
+        readPrepareParams.mEventNumber.SetValue(1);
+
+        MockInteractionModelApp delegate;
+        NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
+
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Read);
+
+        err = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, delegate.mGotEventResponse);
+        NL_TEST_ASSERT(apSuite, delegate.mNumReadEventFailureStatusReceived == 1);
+        NL_TEST_ASSERT(apSuite, !delegate.mReadError);
+    }
+    NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadClients() == 0);
+    engine->Shutdown();
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+
+} // namespace app
+} // namespace chip
+
+namespace {
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestReadRoundtripWithEventStatusIBInEventReport", chip::app::TestAclEvent::TestReadRoundtripWithEventStatusIBInEventReport),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+// clang-format off
+nlTestSuite sSuite =
+{
+    "TestAclEvent",
+    &sTests[0],
+    TestContext::Initialize,
+    TestContext::Finalize
+};
+// clang-format on
+
+} // namespace
+
+int TestAclEvent()
+{
+    return chip::ExecuteTestsWithContext<TestContext>(&sSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestAclEvent)

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -23,6 +23,7 @@
  */
 
 #include "lib/support/CHIPMem.h"
+#include <access/examples/PermissiveAccessControlDelegate.h>
 #include <app/AttributeAccessInterface.h>
 #include <app/InteractionModelEngine.h>
 #include <app/MessageDef/AttributeReportIBs.h>
@@ -41,9 +42,8 @@
 #include <lib/support/UnitTestRegistration.h>
 #include <messaging/ExchangeContext.h>
 #include <messaging/Flags.h>
-#include <protocols/interaction_model/Constants.h>
-
 #include <nlunit-test.h>
+#include <protocols/interaction_model/Constants.h>
 
 #include <type_traits>
 
@@ -299,7 +299,6 @@ public:
     static void TestReadRoundtripWithNoMatchPathDataVersionFilter(nlTestSuite * apSuite, void * apContext);
     static void TestReadRoundtripWithMultiSamePathDifferentDataVersionFilter(nlTestSuite * apSuite, void * apContext);
     static void TestReadRoundtripWithSameDifferentPathsDataVersionFilter(nlTestSuite * apSuite, void * apContext);
-    static void TestReadRoundtripWithEventStatusIBInEventReport(nlTestSuite * apSuite, void * apContext);
     static void TestReadWildcard(nlTestSuite * apSuite, void * apContext);
     static void TestReadChunking(nlTestSuite * apSuite, void * apContext);
     static void TestSetDirtyBetweenChunks(nlTestSuite * apSuite, void * apContext);
@@ -1043,84 +1042,6 @@ void TestReadInteraction::TestReadRoundtripWithSameDifferentPathsDataVersionFilt
         NL_TEST_ASSERT(apSuite, !delegate.mReadError);
 
         delegate.mNumAttributeResponse = 0;
-    }
-
-    NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadClients() == 0);
-    engine->Shutdown();
-    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
-}
-
-void TestReadInteraction::TestReadRoundtripWithEventStatusIBInEventReport(nlTestSuite * apSuite, void * apContext)
-{
-    TestContext & ctx = *static_cast<TestContext *>(apContext);
-    CHIP_ERROR err    = CHIP_NO_ERROR;
-
-    Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
-    // Shouldn't have anything in the retransmit table when starting the test.
-    NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);
-
-    GenerateEvents(apSuite, apContext);
-
-    auto * engine = chip::app::InteractionModelEngine::GetInstance();
-    err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable());
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-    // When reading events with concrete paths without enough privilege, we will get a EventStatusIB
-    {
-        chip::app::EventPathParams eventPathParams[1];
-        eventPathParams[0].mEndpointId = kTestEndpointId;
-        eventPathParams[0].mClusterId  = kTestClusterId;
-        eventPathParams[0].mEventId    = kTestEventIdDebug;
-
-        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
-        readPrepareParams.mpEventPathParamsList    = eventPathParams;
-        readPrepareParams.mEventPathParamsListSize = 1;
-        readPrepareParams.mEventNumber.SetValue(1);
-
-        MockInteractionModelApp delegate;
-        NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
-
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
-                                   chip::app::ReadClient::InteractionType::Read);
-
-        err = readClient.SendRequest(readPrepareParams);
-        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-        ctx.DrainAndServiceIO();
-
-        NL_TEST_ASSERT(apSuite, delegate.mGotEventResponse);
-        NL_TEST_ASSERT(apSuite, delegate.mNumReadEventFailureStatusReceived > 0);
-        NL_TEST_ASSERT(apSuite, delegate.mLastStatusReceived.mStatus == Protocols::InteractionModel::Status::UnsupportedAccess);
-        NL_TEST_ASSERT(apSuite, !delegate.mReadError);
-    }
-
-    GenerateEvents(apSuite, apContext);
-
-    // When reading events with withcard paths without enough privilege for reading one or more event, we will exclude the events
-    // when generating the report.
-    {
-        chip::app::EventPathParams eventPathParams[1];
-        eventPathParams[0].mEndpointId = kTestEndpointId;
-        eventPathParams[0].mClusterId  = kTestClusterId;
-
-        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
-        readPrepareParams.mpEventPathParamsList    = eventPathParams;
-        readPrepareParams.mEventPathParamsListSize = 1;
-        readPrepareParams.mEventNumber.SetValue(1);
-
-        MockInteractionModelApp delegate;
-        NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
-
-        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
-                                   chip::app::ReadClient::InteractionType::Read);
-
-        err = readClient.SendRequest(readPrepareParams);
-        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-
-        ctx.DrainAndServiceIO();
-        NL_TEST_ASSERT(apSuite, !delegate.mGotEventResponse);
-        NL_TEST_ASSERT(apSuite, delegate.mNumReadEventFailureStatusReceived == 0);
-        NL_TEST_ASSERT(apSuite, !delegate.mReadError);
     }
 
     NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadClients() == 0);
@@ -2736,9 +2657,6 @@ const nlTest sTests[] =
     NL_TEST_DEF("TestReadRoundtripWithNoMatchPathDataVersionFilter", chip::app::TestReadInteraction::TestReadRoundtripWithNoMatchPathDataVersionFilter),
     NL_TEST_DEF("TestReadRoundtripWithMultiSamePathDifferentDataVersionFilter", chip::app::TestReadInteraction::TestReadRoundtripWithMultiSamePathDifferentDataVersionFilter),
     NL_TEST_DEF("TestReadRoundtripWithSameDifferentPathsDataVersionFilter", chip::app::TestReadInteraction::TestReadRoundtripWithSameDifferentPathsDataVersionFilter),
-    // TODO(#10253): In unit tests, the access control delegate will always pass, in this case, we will never get a StatusIB for
-    // UnsupportedAccess status code, the test below can be re-enabled after we have a better access control function in unit tests.
-    // NL_TEST_DEF("TestReadRoundtripWithEventStatusIBInEventReport", chip::app::TestReadInteraction::TestReadRoundtripWithEventStatusIBInEventReport),
     NL_TEST_DEF("TestReadWildcard", chip::app::TestReadInteraction::TestReadWildcard),
     NL_TEST_DEF("TestReadChunking", chip::app::TestReadInteraction::TestReadChunking),
     NL_TEST_DEF("TestSetDirtyBetweenChunks", chip::app::TestReadInteraction::TestSetDirtyBetweenChunks),


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/20787

#### Change overview
we loops over paths, puts in errors for the concrete event paths that are not allowed. For ACL denied concrete ones from wildcard, we just silently do nothing

#### Testing
compilation and enable acl event tests where
1. Read events with concrete event path, reject that event path, we see event status with UnsupportedAccess in report.
2. Read events with wildcard path, reject that event path, we silently skip those ACL denied paths.
