### PR TITLE
Fix a typo in examples/darwin-framework-tool/commands/provider/OTAPro…

### DIFF
--- a/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
+++ b/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
@@ -105,10 +105,10 @@ constexpr uint8_t kUpdateTokenLen = 32;
                completionHandler:(void (^_Nonnull)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
                                      NSError * _Nullable error))completionHandler
 {
-    MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * applyUpdateResponsePrams =
+    MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * applyUpdateResponseParams =
         [[MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams alloc] init];
-    applyUpdateResponsePrams.action = @(MTROtaSoftwareUpdateProviderOTAApplyUpdateActionProceed);
-    completionHandler(applyUpdateResponsePrams, nil);
+    applyUpdateResponseParams.action = @(MTROtaSoftwareUpdateProviderOTAApplyUpdateActionProceed);
+    completionHandler(applyUpdateResponseParams, nil);
 }
 
 - (void)handleNotifyUpdateApplied:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams * _Nonnull)params


### PR DESCRIPTION
…viderDelegate.mm (Prams -> Params)

#### Problem

This is just an annoying typo. "Prams" instead of "Params"...

#### Change overview
 * Change "Prams" to "Params".
