### PR TITLE
[BDX][Darwin] Stop polling for messages when the BDX transfer has bee…

### DIFF
--- a/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
+++ b/examples/ota-provider-app/ota-provider-common/BdxOtaSender.cpp
@@ -180,7 +180,6 @@ void BdxOtaSender::HandleTransferSessionOutput(TransferSession::OutputEvent & ev
         break;
     case TransferSession::OutputEventType::kAckEOFReceived:
         ChipLogDetail(BDX, "Transfer completed, got AckEOF");
-        mStopPolling = true;
         Reset();
         break;
     case TransferSession::OutputEventType::kStatusReceived:
@@ -212,7 +211,7 @@ void BdxOtaSender::Reset()
 {
     mFabricIndex.ClearValue();
     mNodeId.ClearValue();
-    mTransfer.Reset();
+    Responder::ResetTransfer();
     if (mExchangeCtx != nullptr)
     {
         mExchangeCtx->Close();

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -276,9 +276,9 @@ private:
             return;
         }
 
+        Responder::ResetTransfer();
         mFabricIndex.ClearValue();
         mNodeId.ClearValue();
-        mTransfer.Reset();
 
         if (mExchangeCtx != nullptr) {
             mExchangeCtx->Close();

--- a/src/protocols/bdx/TransferFacilitator.cpp
+++ b/src/protocols/bdx/TransferFacilitator.cpp
@@ -109,6 +109,12 @@ CHIP_ERROR Responder::PrepareForTransfer(System::Layer * layer, TransferRole rol
     return CHIP_NO_ERROR;
 }
 
+void Responder::ResetTransfer()
+{
+    mTransfer.Reset();
+    mStopPolling = true;
+}
+
 CHIP_ERROR Initiator::InitiateTransfer(System::Layer * layer, TransferRole role, const TransferSession::TransferInitData & initData,
                                        System::Clock::Timeout timeout, System::Clock::Timeout pollFreq)
 {

--- a/src/protocols/bdx/TransferFacilitator.h
+++ b/src/protocols/bdx/TransferFacilitator.h
@@ -119,6 +119,8 @@ public:
     CHIP_ERROR PrepareForTransfer(System::Layer * layer, TransferRole role, BitFlags<TransferControlFlags> xferControlOpts,
                                   uint16_t maxBlockSize, System::Clock::Timeout timeout,
                                   System::Clock::Timeout pollFreq = TransferFacilitator::kDefaultPollFreq);
+
+    void ResetTransfer();
 };
 
 /**


### PR DESCRIPTION
…n finished

#### Problem

When the bdx transfer has been completed (because of a success or a failure), the darwin bdx sender keeps polling.

The same happens for the example provider if something goes wrong in the session.

Fix #21388

#### Change overview
 * Expose a `bdx::Responder::ResetTransfer` method that clears the transfer session and set the boolean to stop polling (sigh).

#### Testing
It was tested using `darwin-framework-tool interactive start` and following the steps from https://github.com/project-chip/connectedhomeip/pull/21161#issue-1316826938 with the addition of some logs into `HandleTransferSessionOutput`.