### PR TITLE
Added commands to bridge-app to control the reachable attribute

### DIFF
--- a/examples/bridge-app/linux/main.cpp
+++ b/examples/bridge-app/linux/main.cpp
@@ -855,6 +855,18 @@ void * bridge_polling_thread(void * context)
                 // TC-ACT-2.2 step 3i, add "Turn off Room 1 renamed lights"
                 action3.setIsVisible(true);
             }
+
+            // Commands used for the Bridged Device Basic Information test plan
+            if (ch == 'u')
+            {
+                // TC-BRBINFO-2.2 step 2 "Set reachable to false"
+                TempSensor1.SetReachable(false);
+            }
+            if (ch == 'v')
+            {
+                // TC-BRBINFO-2.2 step 2 "Set reachable to true"
+                TempSensor1.SetReachable(true);
+            }
             continue;
         }
 


### PR DESCRIPTION
#### Problem
The bridge-app did not have a way to test if the ReachableChanged event is sent. (for TC-BRBINFO-2.2 step 2)

#### Change overview
The following commands were added to bridge-app to support testing the ReachableChanged event.
  'u' - Was added to change reachable to false for endpoint 4 (TempSensor1)
  'v' - Was added to change reachable to true for endpoint 4 (Temp Sensor1)

#### Testing
1. Start bridge-app and wait for initialization to complete
2. Run chip-tool in interactive mode
    chip-tool interactive start
3. Run pairing in chip-tool (if it has not been done already)
    pairing ethernet 12344321 20202021 3840 localhost 5540    
4. Subscribe to the reachable attribute for endpoint 4
    bridgeddevicebasic subscribe reachable 1 60 12344321 4
5. Press 'u' in the bridge-app to change reachable to false for endpoint 4
6. Verify that the ReachableChanged event is seen in chip-tool.
7. Press 'v' in the bridge-app to change reachable to true for endpoint 4
8. Verify that the ReachableChanged event is seen in chip-tool.