### PR TITLE
Treat PICS as case-insensitive in YAML.

### DIFF
--- a/src/app/tests/suites/pics/BUILD.gn
+++ b/src/app/tests/suites/pics/BUILD.gn
@@ -23,6 +23,8 @@ static_library("pics") {
     "PICSBooleanExpressionParser.h",
     "PICSBooleanReader.cpp",
     "PICSBooleanReader.h",
+    "PICSNormalizer.cpp",
+    "PICSNormalizer.h",
   ]
 
   cflags = [ "-Wconversion" ]

--- a/src/app/tests/suites/pics/PICSBooleanExpressionParser.cpp
+++ b/src/app/tests/suites/pics/PICSBooleanExpressionParser.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "PICSBooleanExpressionParser.h"
+#include "PICSNormalizer.h"
 
 #include <lib/support/CodeUtils.h>
 
@@ -149,6 +150,8 @@ bool PICSBooleanExpressionParser::EvaluateSubExpression(std::vector<std::string>
         bool expr = EvaluateSubExpression(tokens, PICS, index);
         return !expr;
     }
+
+    token = PICSNormalizer::Normalize(token);
 
     index++;
 

--- a/src/app/tests/suites/pics/PICSBooleanReader.cpp
+++ b/src/app/tests/suites/pics/PICSBooleanReader.cpp
@@ -16,6 +16,7 @@
  */
 
 #include "PICSBooleanReader.h"
+#include "PICSNormalizer.h"
 
 #include <lib/support/CodeUtils.h>
 
@@ -43,6 +44,7 @@ std::map<std::string, bool> PICSBooleanReader::Read(std::string filepath)
 
         std::getline(ss, key, '=');
         VerifyOrDieWithMsg(!key.empty(), chipTool, "Missing PICS key at line %u", lineNumber + 1);
+        key = PICSNormalizer::Normalize(key);
 
         std::getline(ss, value);
         if (value == "0")

--- a/src/app/tests/suites/pics/PICSNormalizer.cpp
+++ b/src/app/tests/suites/pics/PICSNormalizer.cpp
@@ -1,0 +1,30 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "PICSNormalizer.h"
+
+#include <algorithm>
+#include <cctype>
+
+std::string PICSNormalizer::Normalize(std::string code)
+{
+    // Convert to all-lowercase so people who mess up cases don't have things
+    // break on them in subtle ways.
+    std::transform(code.begin(), code.end(), code.begin(), [](unsigned char c) { return std::tolower(c); });
+
+    // TODO strip off "(Additional Context)" bits from the end of the code.
+    return code;
+}

--- a/src/app/tests/suites/pics/PICSNormalizer.h
+++ b/src/app/tests/suites/pics/PICSNormalizer.h
@@ -1,0 +1,28 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * @file
+ * @brief Declaration of a method that normalizes a PICS code.
+ */
+
+#include <string>
+
+class PICSNormalizer
+{
+public:
+    static std::string Normalize(std::string code);
+};


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/21425

#### Problem
People have a hard time spelling PICS right wrt case.

#### Change overview
Treat PICS as case-insensitive in YAML tests.

#### Testing
Checked that if I use a case-mismatched PICS value it gets treated correctly.