### PR TITLE
Allocate a handler for each JSON command to process

### DIFF
--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
@@ -23,15 +23,17 @@
 #include <json/json.h>
 #include <platform/DiagnosticDataProvider.h>
 
-class AllClustersCommandDelegate : public NamedPipeCommandDelegate
+class AllClustersAppCommandHandler
 {
 public:
-    void OnEventCommandReceived(const char * json) override;
+    static AllClustersAppCommandHandler * FromJSON(const char * json);
+
+    static void HandleCommand(intptr_t context);
+
+    AllClustersAppCommandHandler(Json::Value jasonValue) : mJsonValue(std::move(jasonValue)) {}
 
 private:
     Json::Value mJsonValue;
-
-    static void HandleEventCommand(intptr_t context);
 
     bool IsClusterPresentOnAnyEndpoint(chip::ClusterId clusterId);
 
@@ -86,4 +88,10 @@ private:
      * sequence, after it has been detected that the sequence has ended.
      */
     void OnSwitchMultiPressCompleteHandler(uint8_t previousPosition, uint8_t count);
+};
+
+class AllClustersCommandDelegate : public NamedPipeCommandDelegate
+{
+public:
+    void OnEventCommandReceived(const char * json) override;
 };


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Currently, we only support process the json event command in sequence, if the previous one is still pending on processing, the new command will be lost,  we need to buffer the json command before processing to guarantee all incoming json command get processed.

#### Change overview
Allocate a handler for each JSON command to process

#### Testing
How was this tested? (at least one bullet point required)
* Write a program keep sending the event command over pipe
`echo '{"Name":"SoftwareFault"}' > /tmp/chip_all_clusters_fifo_974836`
* Confirm the event command is received and processed on the server w/o corruption
```
[1659120067.414462][974836:974841] CHIP:-: Received payload: "{"Name":"SoftwareFault"}"
[1659120067.414843][974836:974836] CHIP:ZCL: SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected
[1659120067.414919][974836:974836] CHIP:EVL: LogEvent event number: 0x0000000000000003 priority: 1, endpoint id:  0x0 cluster id: 0x0000_0034 event id: 0x0 Sys timestamp: 0x000000001564BB09
```

