### PR TITLE
[ESP32] Return the required length if buf is NULL when reading string/blob from NVS

### DIFF
--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -92,8 +92,11 @@ public:
     static CHIP_ERROR ReadConfigValue(Key key, bool & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint32_t & val);
     static CHIP_ERROR ReadConfigValue(Key key, uint64_t & val);
+
+    // If buf is NULL then outLen is set to the required length to fit the string/blob
     static CHIP_ERROR ReadConfigValueStr(Key key, char * buf, size_t bufSize, size_t & outLen);
     static CHIP_ERROR ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSize, size_t & outLen);
+
     static CHIP_ERROR WriteConfigValue(Key key, bool val);
     static CHIP_ERROR WriteConfigValue(Key key, uint32_t val);
     static CHIP_ERROR WriteConfigValue(Key key, uint64_t val);


### PR DESCRIPTION
#### Problem
* ReadConfigValueStr crashes if `buf` is NULL

#### Change overview
* Handle the NULL `buf` case and return the required size to fit string/blob in `ReadConfigValueStr` and `ReadConfigValueBin`

#### Testing
* Manually tested by calling these APIs in all-clusters-app