### PR TITLE
Allow Darwin frawework to commission onto a password-less WiFi network.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
+++ b/src/darwin/Framework/CHIP/MTRCommissioningParameters.h
@@ -36,15 +36,16 @@ NS_ASSUME_NONNULL_BEGIN
  */
 @property (nonatomic, copy, nullable) NSData * attestationNonce;
 /**
- *  The Wi-Fi SSID
+ *  The Wi-Fi SSID, if available.
  */
 @property (nonatomic, copy, nullable) NSData * wifiSSID;
 /**
- *  The Wi-Fi Credentials
+ *  The Wi-Fi Credentials.  Allowed to be nil or 0-length data for an open
+ *  network, as long as wifiSSID is not nil.
  */
 @property (nonatomic, copy, nullable) NSData * wifiCredentials;
 /**
- *  The Thread operational dataset
+ *  The Thread operational dataset, if available.
  */
 @property (nonatomic, copy, nullable) NSData * threadOperationalDataset;
 /**

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -405,20 +405,20 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
 
         chip::Controller::CommissioningParameters params;
         if (commissioningParams.CSRNonce) {
-            params.SetCSRNonce(chip::ByteSpan((uint8_t *) commissioningParams.CSRNonce.bytes, commissioningParams.CSRNonce.length));
+            params.SetCSRNonce(AsByteSpan(commissioningParams.CSRNonce));
         }
         if (commissioningParams.attestationNonce) {
-            params.SetAttestationNonce(chip::ByteSpan(
-                (uint8_t *) commissioningParams.attestationNonce.bytes, commissioningParams.attestationNonce.length));
+            params.SetAttestationNonce(AsByteSpan(commissioningParams.attestationNonce));
         }
         if (commissioningParams.threadOperationalDataset) {
-            params.SetThreadOperationalDataset(chip::ByteSpan((uint8_t *) commissioningParams.threadOperationalDataset.bytes,
-                commissioningParams.threadOperationalDataset.length));
+            params.SetThreadOperationalDataset(AsByteSpan(commissioningParams.threadOperationalDataset));
         }
-        if (commissioningParams.wifiSSID && commissioningParams.wifiCredentials) {
-            chip::ByteSpan ssid((uint8_t *) commissioningParams.wifiSSID.bytes, commissioningParams.wifiSSID.length);
-            chip::ByteSpan credentials(
-                (uint8_t *) commissioningParams.wifiCredentials.bytes, commissioningParams.wifiCredentials.length);
+        if (commissioningParams.wifiSSID) {
+            chip::ByteSpan ssid = AsByteSpan(commissioningParams.wifiSSID);
+            chip::ByteSpan credentials;
+            if (commissioningParams.wifiCredentials != nil) {
+                credentials = AsByteSpan(commissioningParams.wifiCredentials);
+            }
             chip::Controller::WiFiCredentials wifiCreds(ssid, credentials);
             params.SetWiFiCredentials(wifiCreds);
         }


### PR DESCRIPTION
We were requiring a WiFi password in order to provide the WiFi SSID to
the underlying SDK.  But not all networks have a password.

#### Problem
Can't commission a Matter device onto an open Wifi network.

#### Change overview
Fix things so it can be commissioned.

#### Testing
Needs to be tested by someone with an open network...