### PR TITLE
TV Android app - Enable shell commands and add basic support for some of them

### DIFF
--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/fragments/TerminalFragment.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/fragments/TerminalFragment.java
@@ -5,9 +5,11 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.EditText;
+import android.widget.TextView;
 import androidx.appcompat.app.AlertDialog;
 import androidx.fragment.app.Fragment;
 import com.matter.tv.server.R;
+import com.matter.tv.server.tvapp.AppPlatformShellCommands;
 
 /**
  * A simple {@link Fragment} subclass. Use the {@link TerminalFragment#newInstance} factory method
@@ -16,9 +18,23 @@ import com.matter.tv.server.R;
 public class TerminalFragment extends Fragment {
 
   private EditText terminalText;
+  private TextView terminalUsageDescription;
+  private AppPlatformShellCommands shellCommands;
+
+  private static String TERMINAL_INSTRUCTIONS =
+      "add <vid> [<pid>]    Add app with given vendor ID [1, 2, 9050]. Usage: app add 9050\r\n"
+          + "remove <endpoint>    Remove app at given endpoint [6, 7, etc]. Usage: app remove 6\r\n"
+          + "setpin <endpoint> <pincode>  Set pincode for app with given endpoint ID. Usage: app setpin 6 34567890\r\n"
+          + "commission <udc-entry>     Commission given udc-entry using given pincode from corresponding app. Usage:"
+          + "app commission 0\r\n"
+          + "add-admin-vendor <vid> Add vendor ID to list which will receive admin privileges. Usage: app "
+          + "add-admin-vendor 65521\r\n"
+          + "print-app-access     Print all ACLs for app platform fabric. Usage: app print-app-access\r\n"
+          + "remove-app-access    Remove all ACLs for app platform fabric. Usage: app remove-app-access\r\n";
 
   public TerminalFragment() {
     // Required empty public constructor
+    shellCommands = new AppPlatformShellCommands();
   }
 
   /**
@@ -51,6 +67,8 @@ public class TerminalFragment extends Fragment {
     super.onResume();
 
     terminalText = getView().findViewById(R.id.terminalTxt);
+    terminalUsageDescription = getView().findViewById(R.id.terminalDescriptionTxt);
+    terminalUsageDescription.setText(TERMINAL_INSTRUCTIONS);
 
     getView()
         .findViewById(R.id.OkBtn)
@@ -58,9 +76,11 @@ public class TerminalFragment extends Fragment {
             v -> {
               String message = terminalText.getText().toString();
 
+              String response = shellCommands.OnExecuteCommand(message.split(" "));
+
               AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 
-              builder.setMessage(message).setTitle("Response").create().show();
+              builder.setMessage(response).setTitle("Response").create().show();
             });
   }
 }

--- a/examples/tv-app/android/App/platform-app/src/main/res/layout/fragment_terminal.xml
+++ b/examples/tv-app/android/App/platform-app/src/main/res/layout/fragment_terminal.xml
@@ -24,6 +24,14 @@
         app:layout_constraintEnd_toEndOf="parent"
         app:layout_constraintStart_toStartOf="parent"/>
 
+    <TextView
+        android:id="@+id/terminalDescriptionTxt"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        app:layout_constraintTop_toBottomOf="@+id/OkBtn"
+        app:layout_constraintEnd_toEndOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        android:layout_marginTop="20dp" />
 
 
 </androidx.constraintlayout.widget.ConstraintLayout>

--- a/examples/tv-app/android/BUILD.gn
+++ b/examples/tv-app/android/BUILD.gn
@@ -41,6 +41,8 @@ shared_library("jni") {
     "include/target-navigator/TargetNavigatorManager.h",
     "java/AppImpl.cpp",
     "java/AppImpl.h",
+    "java/AppPlatformShellCommands-JNI.cpp",
+    "java/AppPlatformShellCommands-JNI.h",
     "java/ChannelManager.cpp",
     "java/ChannelManager.h",
     "java/ClusterChangeAttribute.cpp",
@@ -105,6 +107,7 @@ android_library("java") {
   ]
 
   sources = [
+    "java/src/com/matter/tv/server/tvapp/AppPlatformShellCommands.java",
     "java/src/com/matter/tv/server/tvapp/ChannelInfo.java",
     "java/src/com/matter/tv/server/tvapp/ChannelLineupInfo.java",
     "java/src/com/matter/tv/server/tvapp/ChannelManager.java",

--- a/examples/tv-app/android/java/AppImpl.cpp
+++ b/examples/tv-app/android/java/AppImpl.cpp
@@ -476,7 +476,6 @@ CHIP_ERROR InitVideoPlayerPlatform(JNIMyUserPrompter * userPrompter, jobject con
     // supported clusters so that ZAP will generated the requisite code.
     ChipLogDetail(DeviceLayer, "TV App: Disabling Fixed Content App Endpoints");
     emberAfEndpointEnableDisable(3, false);
-
     return CHIP_NO_ERROR;
 }
 

--- a/examples/tv-app/android/java/AppImpl.h
+++ b/examples/tv-app/android/java/AppImpl.h
@@ -153,7 +153,7 @@ public:
 protected:
     std::vector<ContentAppImpl *> mContentApps{
         new ContentAppImpl("Vendor1", 1, "exampleid", 11, "Version1", "20202021", nullptr),
-        new ContentAppImpl("Vendor2", 65520, "exampleString", 32768, "Version2", "20202021", nullptr),
+        new ContentAppImpl("Vendor2", 65521, "exampleString", 32768, "Version2", "20202021", nullptr),
         new ContentAppImpl("Vendor3", 9050, "App3", 22, "Version3", "20202021", nullptr),
         new ContentAppImpl("TestSuiteVendor", 1111, "applicationId", 22, "v2", "20202021", nullptr)
     };

--- a/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
@@ -1,0 +1,210 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "AppPlatformShellCommands-JNI.h"
+#include "AppImpl.h"
+#include "TvApp-JNI.h"
+#include <access/AccessControl.h>
+#include <jni.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+
+#if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+#include <app/app-platform/ContentAppPlatform.h>
+#endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+
+using namespace chip;
+
+char response[1024];
+
+using namespace ::chip::Controller;
+#if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+using namespace chip::AppPlatform;
+using namespace chip::Access;
+#endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+using namespace chip::app::Clusters;
+
+#if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+
+static CHIP_ERROR pairApp(bool printHeader, size_t index)
+{
+    // TODO: add pair app
+    return CHIP_NO_ERROR;
+}
+
+char * AppPlatformHandler(int argc, char ** argv)
+{
+    if (argc == 0 || strcmp(argv[0], "help") == 0)
+    {
+        strcpy(response, "check usage instructions on the UI");
+    }
+    else if (strcmp(argv[0], "add-admin-vendor") == 0)
+    {
+        if (argc < 2)
+        {
+            strcpy(response, "check usage instructions on the UI");
+        }
+        char * eptr;
+
+        uint16_t vid                    = (uint16_t) strtol(argv[1], &eptr, 10);
+        ContentAppFactoryImpl * factory = GetContentAppFactoryImpl();
+        factory->AddAdminVendorId(vid);
+
+        ChipLogProgress(DeviceLayer, "added admin-vendor");
+
+        strcpy(response, "added admin-vendor");
+
+        return response;
+    }
+    else if (strcmp(argv[0], "add") == 0)
+    {
+        if (argc < 2)
+        {
+            strcpy(response, "check usage instructions on the UI");
+        }
+        char * eptr;
+
+        uint16_t vid = (uint16_t) strtol(argv[1], &eptr, 10);
+        uint16_t pid = 0;
+        if (argc >= 3)
+        {
+            pid = (uint16_t) strtol(argv[2], &eptr, 10);
+        }
+        ContentAppPlatform::GetInstance().LoadContentAppByClient(vid, pid);
+
+        ChipLogProgress(DeviceLayer, "added app");
+
+        strcpy(response, "added app");
+
+        return response;
+    }
+    else if (strcmp(argv[0], "remove-app-access") == 0)
+    {
+        Access::GetAccessControl().DeleteAllEntriesForFabric(GetDeviceCommissioner()->GetFabricIndex());
+        strcpy(response, "removed app access");
+
+        return response;
+    }
+    else if (strcmp(argv[0], "remove") == 0)
+    {
+        if (argc < 2)
+        {
+            strcpy(response, "check usage instructions on the UI");
+        }
+        char * eptr;
+
+        uint16_t endpoint = (uint16_t) strtol(argv[1], &eptr, 10);
+        ContentApp * app  = ContentAppPlatform::GetInstance().GetContentApp(endpoint);
+        if (app == nullptr)
+        {
+            ChipLogProgress(DeviceLayer, "app not found");
+
+            strcpy(response, "app not found");
+            return response;
+        }
+        ContentAppPlatform::GetInstance().RemoveContentApp(app);
+
+        ChipLogProgress(DeviceLayer, "removed app");
+
+        strcpy(response, "removed app");
+
+        return response;
+    }
+    else if (strcmp(argv[0], "setpin") == 0)
+    {
+        if (argc < 3)
+        {
+            strcpy(response, "check usage instructions on the UI");
+        }
+        char * eptr;
+
+        uint16_t endpoint = (uint16_t) strtol(argv[1], &eptr, 10);
+        char * pincode    = argv[2];
+        ContentApp * app  = ContentAppPlatform::GetInstance().GetContentApp(endpoint);
+        if (app == nullptr)
+        {
+            ChipLogProgress(DeviceLayer, "app not found");
+            strcpy(response, "app not found");
+            return response;
+        }
+        if (app->GetAccountLoginDelegate() == nullptr)
+        {
+            ChipLogProgress(DeviceLayer, "no AccountLogin cluster for app with endpoint id=%d ", endpoint);
+
+            strcpy(response, "no AccountLogin cluster for app with endpoint");
+            return response;
+        }
+        app->GetAccountLoginDelegate()->SetSetupPin(pincode);
+
+        ChipLogProgress(DeviceLayer, "set pin success");
+
+        strcpy(response, "set pin success");
+
+        return response;
+    }
+    else if (strcmp(argv[0], "commission") == 0)
+    {
+        if (argc < 2)
+        {
+            strcpy(response, "check usage instructions on the UI");
+        }
+        char * eptr;
+        size_t index = (size_t) strtol(argv[1], &eptr, 10);
+        pairApp(true, index);
+        strcpy(response, "no supported atm");
+        return response;
+    }
+    else
+    {
+        strcpy(response, "invalid argument");
+        return response;
+    }
+    return response;
+}
+
+#endif // CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
+
+#define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
+    extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_tv_server_tvapp_AppPlatformShellCommands_##METHOD_NAME
+
+JNI_METHOD(jstring, OnExecuteCommand)(JNIEnv * env, jobject, jobjectArray stringArray)
+{
+    int argc     = env->GetArrayLength(stringArray);
+    char ** argv = new char *[(uint) argc];
+
+    // Fill in argv
+    for (int i = 0; i < argc; i++)
+    {
+        jstring string = (jstring)(env->GetObjectArrayElement(stringArray, i));
+        argv[i]        = (char *) env->GetStringUTFChars(string, 0);
+    }
+
+    // Store response to show it to the users
+    char * buf = AppPlatformHandler(argc, argv);
+
+    // Release UTF Chars
+    for (int i = 0; i < argc; i++)
+    {
+        ChipLogProgress(DeviceLayer, " Value=%s ", argv[i]);
+        jstring string = (jstring)(env->GetObjectArrayElement(stringArray, i));
+        env->ReleaseStringUTFChars(string, argv[i]);
+    }
+
+    return env->NewStringUTF(buf);
+}

--- a/examples/tv-app/android/java/AppPlatformShellCommands-JNI.h
+++ b/examples/tv-app/android/java/AppPlatformShellCommands-JNI.h
@@ -1,0 +1,25 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include "CommissionerMain.h"
+#include "lib/support/logging/CHIPLogging.h"
+#include <jni.h>
+
+class JNIAppPlatformShellCommands
+{
+};

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/AppPlatformShellCommands.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/AppPlatformShellCommands.java
@@ -1,0 +1,29 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.matter.tv.server.tvapp;
+
+public class AppPlatformShellCommands {
+
+  protected static final String TAG = "AppPlatformShellCommands";
+
+  public native String OnExecuteCommand(String[] argv);
+
+  static {
+    System.loadLibrary("TvApp");
+  }
+}


### PR DESCRIPTION
#### Problem
- TV Android app cannot execute shell commands, needed for Matter testing.
- TV casing app users cannot execute certain commands as they don't have access

#### Change overview
- Added JNI layer for Native C++ AppPlatfromShellCommand logic so that users can pass string and execute this code
- Added instructions on the UI how to use shell.

#### Testing
Manually tested the flow:
1) Run both TV Android app && TV casting app linux
2) On TV casting app, once TV Android app is discovered run `cast request 0`
3) On TV Android app, once you get a dialog popup select ok
4) On TV Android app go to -> Run Commands and select input text at the top
4) Enter add-admin-vendor 65521 and press ok
5) On TV casting app run command: `cast cluster channel read channel-list 0 1`