### PR TITLE
Don't touch member variables from async dispatch.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1384,16 +1384,20 @@ void SubscriptionCallback::ReportData()
 {
     __block NSArray * attributeReports = mAttributeReports;
     mAttributeReports = nil;
+    __block auto attributeCallback = mAttributeReportCallback;
+
     __block NSArray * eventReports = mEventReports;
     mEventReports = nil;
-    if (mAttributeReportCallback && attributeReports.count) {
+    __block auto eventCallback = mEventReportCallback;
+
+    if (attributeCallback != nil && attributeReports.count) {
         dispatch_async(mQueue, ^{
-            mAttributeReportCallback(attributeReports);
+            attributeCallback(attributeReports);
         });
     }
-    if (mEventReportCallback && eventReports.count) {
+    if (eventCallback != nil && eventReports.count) {
         dispatch_async(mQueue, ^{
-            mEventReportCallback(eventReports);
+            eventCallback(eventReports);
         });
     }
 }


### PR DESCRIPTION
We were null-checking members, then calling them from an async block,
by which point they might be null.

Fixes https://github.com/project-chip/connectedhomeip/issues/21453

#### Problem
Crashes.

#### Change overview
See above.

#### Testing
Need to do stress-testing to see how this does on the crash stacks we are seeing...