### PR TITLE
Fix status report in ReadClient

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -397,8 +397,8 @@ private:
     /**This function handles processing of un-solicited ReportData messages on the client, which can
      * only occur post subscription establishment
      */
-    CHIP_ERROR OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
-                                       System::PacketBufferHandle && aPayload);
+    Status OnUnsolicitedReportData(Messaging::ExchangeContext * apExchangeContext, const PayloadHeader & aPayloadHeader,
+                                   System::PacketBufferHandle && aPayload);
 
     void DispatchCommand(CommandHandler & apCommandObj, const ConcreteCommandPath & aCommandPath,
                          TLV::TLVReader & apPayload) override;


### PR DESCRIPTION
#### Problem
Fix status report in ReadClient
This PR is cut from https://github.com/project-chip/connectedhomeip/pull/19356

#### Change overview
ProcessStatusReport would send status report with Success when the processing is successful, otherwise, the status report with invalid action would be sent by the caller. 

Then onMessageReceived in ReadClient would send status report with invalid action when there is error happening in incoming message.

Fix InteractionModelEngine::OnUnsolicitedReportData, when error happens, we should send status report with invalid action.

#### Testing
Add tests to test how readClient for read/subscribe handle problematic message.

