### PR TITLE
[telink] Downgrade Docker image to 0.5.84

### DIFF
--- a/.github/workflows/examples-telink.yaml
+++ b/.github/workflows/examples-telink.yaml
@@ -32,7 +32,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-telink:0.5.91
+            image: connectedhomeip/chip-build-telink:0.5.84
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/commit/3c1cabff487a39dc5f4290f77cbe631afe621712 bumped all the Docker image versions in CI, but apparently, Telink code on the sve branch was not prepared for that.

#### Change overview
Downgrade Docker image to 0.5.84

#### Testing
CI-tested.
