### PR TITLE
chip-cert: Fixed ReadKey() Implementation.

### DIFF
--- a/src/tools/chip-cert/Cmd_ConvertKey.cpp
+++ b/src/tools/chip-cert/Cmd_ConvertKey.cpp
@@ -228,7 +228,7 @@ bool Cmd_ConvertKey(int argc, char * argv[])
     res = InitOpenSSL();
     VerifyTrueOrExit(res);
 
-    res = ReadKey(gInFileName, key.get());
+    res = ReadKey(gInFileName, key);
     VerifyTrueOrExit(res);
 
     if (IsPrivateKeyFormat(gOutFormat) && EC_KEY_get0_private_key(EVP_PKEY_get1_EC_KEY(key.get())) == nullptr)

--- a/src/tools/chip-cert/Cmd_GenAttCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenAttCert.cpp
@@ -533,7 +533,7 @@ bool Cmd_GenAttCert(int argc, char * argv[])
 
     if (gInKeyFileName != nullptr)
     {
-        res = ReadKey(gInKeyFileName, newKey.get());
+        res = ReadKey(gInKeyFileName, newKey);
         VerifyTrueOrExit(res);
     }
     else
@@ -564,7 +564,7 @@ bool Cmd_GenAttCert(int argc, char * argv[])
         res = ReadCert(gCACertFileName, caCert.get());
         VerifyTrueOrExit(res);
 
-        res = ReadKey(gCAKeyFileName, caKey.get(), gCertConfig.IsErrorTestCaseEnabled());
+        res = ReadKey(gCAKeyFileName, caKey, gCertConfig.IsErrorTestCaseEnabled());
         VerifyTrueOrExit(res);
 
         res = MakeAttCert(gAttCertType, gSubjectCN, gSubjectVID, gSubjectPID, gEncodeVIDandPIDasCN, caCert.get(), caKey.get(),

--- a/src/tools/chip-cert/Cmd_GenCD.cpp
+++ b/src/tools/chip-cert/Cmd_GenCD.cpp
@@ -1147,7 +1147,7 @@ bool Cmd_GenCD(int argc, char * argv[])
         std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)> key(EVP_PKEY_new(), &EVP_PKEY_free);
 
         VerifyOrReturnError(ReadCert(gCertFileName, cert.get()), false);
-        VerifyOrReturnError(ReadKey(gKeyFileName, key.get()), false);
+        VerifyOrReturnError(ReadKey(gKeyFileName, key), false);
 
         // Extract the subject key id from the X509 certificate.
         ByteSpan signerKeyId;

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -812,7 +812,7 @@ bool Cmd_GenCert(int argc, char * argv[])
 
     if (gInKeyFileName != nullptr)
     {
-        res = ReadKey(gInKeyFileName, newKey.get());
+        res = ReadKey(gInKeyFileName, newKey);
         VerifyTrueOrExit(res);
     }
     else
@@ -839,7 +839,7 @@ bool Cmd_GenCert(int argc, char * argv[])
         res = ReadCert(gCACertFileName, caCert.get());
         VerifyTrueOrExit(res);
 
-        res = ReadKey(gCAKeyFileName, caKey.get());
+        res = ReadKey(gCAKeyFileName, caKey);
         VerifyTrueOrExit(res);
 
         caCertPtr = caCert.get();

--- a/src/tools/chip-cert/Cmd_ResignCert.cpp
+++ b/src/tools/chip-cert/Cmd_ResignCert.cpp
@@ -1,6 +1,6 @@
 /*
  *
- *    Copyright (c) 2021 Project CHIP Authors
+ *    Copyright (c) 2021-2022 Project CHIP Authors
  *    Copyright (c) 2013-2017 Nest Labs, Inc.
  *    All rights reserved.
  *
@@ -194,7 +194,7 @@ bool Cmd_ResignCert(int argc, char * argv[])
     res = ReadCert(gInCertFileName, cert.get(), inCertFmt);
     VerifyTrueOrExit(res);
 
-    res = ReadKey(gCAKeyFileName, caKey.get());
+    res = ReadKey(gCAKeyFileName, caKey);
     VerifyTrueOrExit(res);
 
     if (!gSelfSign)

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -423,7 +423,8 @@ extern bool MakeAttCert(AttCertType attCertType, const char * subjectCN, uint16_
                         X509 * newCert, EVP_PKEY * newKey, CertStructConfig & certConfig);
 extern bool GenerateKeyPair(EVP_PKEY * key);
 extern bool GenerateKeyPair_Secp256k1(EVP_PKEY * key);
-extern bool ReadKey(const char * fileName, EVP_PKEY * key, bool ignorErrorIfUnsupportedCurve = false);
+extern bool ReadKey(const char * fileName, std::unique_ptr<EVP_PKEY, void (*)(EVP_PKEY *)> & key,
+                    bool ignorErrorIfUnsupportedCurve = false);
 extern bool WriteKey(const char * fileName, EVP_PKEY * key, KeyFormat keyFmt);
 extern bool SerializeKeyPair(EVP_PKEY * key, chip::Crypto::P256SerializedKeypair & serializedKeypair);
 


### PR DESCRIPTION
#### Problem
In the latest OpenSSL implementation the PEM_read_bio_PrivateKey() method
releases and allocates new object for the private key.

#### Change overview
Updated the implementation accordingly

#### Testing
manual tested the chip-cert tool