### PR TITLE
Avoid extra copy constructors get called by passing by reference

### DIFF
--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -56,7 +56,7 @@ AllClustersAppCommandHandler * AllClustersAppCommandHandler::FromJSON(const char
         return nullptr;
     }
 
-    return Platform::New<AllClustersAppCommandHandler>(value);
+    return Platform::New<AllClustersAppCommandHandler>(std::move(value));
 }
 
 void AllClustersAppCommandHandler::HandleCommand(intptr_t context)

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
@@ -30,7 +30,7 @@ public:
 
     static void HandleCommand(intptr_t context);
 
-    AllClustersAppCommandHandler(Json::Value & jasonValue) : mJsonValue(std::move(jasonValue)) {}
+    AllClustersAppCommandHandler(Json::Value && jasonValue) : mJsonValue(std::move(jasonValue)) {}
 
 private:
     Json::Value mJsonValue;

--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.h
@@ -30,7 +30,7 @@ public:
 
     static void HandleCommand(intptr_t context);
 
-    AllClustersAppCommandHandler(Json::Value jasonValue) : mJsonValue(std::move(jasonValue)) {}
+    AllClustersAppCommandHandler(Json::Value & jasonValue) : mJsonValue(std::move(jasonValue)) {}
 
 private:
     Json::Value mJsonValue;

--- a/examples/lock-app/linux/src/LockAppCommandDelegate.cpp
+++ b/examples/lock-app/linux/src/LockAppCommandDelegate.cpp
@@ -31,7 +31,7 @@ public:
 
     static void HandleCommand(intptr_t context);
 
-    LockAppCommandHandler(std::string & cmd, Json::Value & params) :
+    LockAppCommandHandler(std::string && cmd, Json::Value && params) :
         mCommandName(std::move(cmd)), mCommandParameters(std::move(params))
     {}
 
@@ -75,7 +75,7 @@ LockAppCommandHandler * LockAppCommandHandler::FromJSON(const char * json)
         params = value["Params"];
     }
     auto commandName = value["Cmd"].asString();
-    return chip::Platform::New<LockAppCommandHandler>(commandName, params);
+    return chip::Platform::New<LockAppCommandHandler>(std::move(commandName), std::move(params));
 }
 
 void LockAppCommandHandler::HandleCommand(intptr_t context)

--- a/examples/lock-app/linux/src/LockAppCommandDelegate.cpp
+++ b/examples/lock-app/linux/src/LockAppCommandDelegate.cpp
@@ -31,7 +31,8 @@ public:
 
     static void HandleCommand(intptr_t context);
 
-    LockAppCommandHandler(std::string cmd, Json::Value params) : mCommandName(std::move(cmd)), mCommandParameters(std::move(params))
+    LockAppCommandHandler(std::string & cmd, Json::Value & params) :
+        mCommandName(std::move(cmd)), mCommandParameters(std::move(params))
     {}
 
 private:


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* 'Json::Value' is an expensive class, we should avoid any unnecessary copy constructors get called for temporary object

#### Change overview
Avoid extra copy constructors get called by passing by reference

#### Testing
How was this tested? (at least one bullet point required)
* Send the event command over named pipe
`echo '{"Name":"SoftwareFault"}' > /tmp/chip_all_clusters_fifo_1425416`

* Confirmed the event is correctly generated on the device 
```
[1659370004.896161][1425416:1425416] CHIP:EM: Received message of type 0x10 with protocolId (0, 0) and MessageCounter:46053166 on exchange 57411r
[1659370004.896170][1425416:1425416] CHIP:EM: Found matching exchange: 57411r, Delegate: (nil)
[1659370004.896178][1425416:1425416] CHIP:EM: Rxd Ack; Removing MessageCounter:28211151 from Retrans Table on exchange 57411r
[1659370004.896183][1425416:1425416] CHIP:EM: Removed CHIP MessageCounter:28211151 from RetransTable on exchange 57411r
[1659370019.360011][1425416:1425428] CHIP:-: Received payload: "{"Name":"SoftwareFault"}"
[1659370019.360421][1425416:1425416] CHIP:ZCL: SoftwareDiagnosticsDelegate: OnSoftwareFaultDetected
[1659370019.360502][1425416:1425416] CHIP:EVL: LogEvent event number: 0x0000000000000004 priority: 1, endpoint id:  0x0 cluster id: 0x0000_0034 event id: 0x0 Sys timestamp: 0x00000000244AB1D3
```
