### PR TITLE
Fix comparison of a nullable value to a non-nullable saved value.

### DIFF
--- a/examples/chip-tool/templates/tests/partials/value_equals.zapt
+++ b/examples/chip-tool/templates/tests/partials/value_equals.zapt
@@ -6,6 +6,7 @@
     VerifyOrReturn(CheckValueNull("{{label}}", {{actual}}));
   {{else}}
     {{#if (chip_tests_variables_has expected)}}
+      {{#if (chip_tests_variables_is_nullable expected)}}
       {{! Expected value is also a nullable. }}
       if ({{expected}}.IsNull()) {
         VerifyOrReturn(CheckValueNull("{{label}}", {{actual}}));
@@ -15,6 +16,10 @@
         VerifyOrReturn(CheckValueNonNull("{{label}}", {{actual}}));
         {{>valueEquals label=(concat label ".Value()") actual=(concat actual ".Value()") expected=(concat expected ".Value()") isNullable=false keepAsExpected=true depth=(incrementDepth depth)}}
       }
+      {{else}}
+        VerifyOrReturn(CheckValueNonNull("{{label}}", {{actual}}));
+        {{>valueEquals label=(concat label ".Value()") actual=(concat actual ".Value()") expected=expected isNullable=false keepAsExpected=true depth=(incrementDepth depth)}}
+      {{/if}}
     {{else}}
       VerifyOrReturn(CheckValueNonNull("{{label}}", {{actual}}));
       {{>valueEquals label=(concat label ".Value()") actual=(concat actual ".Value()") expected=expected isNullable=false depth=(incrementDepth depth)}}


### PR DESCRIPTION
The code generated for the case when a non-nullable value was saved via saveAs
and then a nullable value was being compared to it did not compile, because we
would try to do .IsNull() and .Value() on the non-nullable saved value.

The changes here check whether the saved value is actually nullable and generate
code accordingly, instead of assuming that if we're comparing a nullable to
something the something must also be nullable.

#### Problem
See above.  This came up in https://github.com/project-chip/connectedhomeip/pull/21361

#### Change overview
See above.

#### Testing
Verified that regenerating https://github.com/project-chip/connectedhomeip/pull/21361 with this change makes it generate correct code.