### PR TITLE
[Infineon] Support Identify cluster in lock-app for CYW30739

### DIFF
--- a/examples/lock-app/cyw30739/src/ZclCallbacks.cpp
+++ b/examples/lock-app/cyw30739/src/ZclCallbacks.cpp
@@ -56,6 +56,17 @@ void MatterPostAttributeChangeCallback(const app::ConcreteAttributePath & attrib
             return;
         }
         break;
+    case Identify::Id:
+        if (attributePath.mAttributeId == Identify::Attributes::IdentifyTime::Id)
+        {
+            uint16_t identifyTime;
+            if (EMBER_ZCL_STATUS_SUCCESS == Identify::Attributes::IdentifyTime::Get(attributePath.mEndpointId, &identifyTime))
+            {
+                ChipLogProgress(Zcl, "IdentifyTime %u", identifyTime);
+                return;
+            }
+        }
+        break;
     default:
         printf("Unhandled cluster ID: 0x%04lx\n", attributePath.mClusterId);
         return;

--- a/examples/lock-app/cyw30739/src/main.cpp
+++ b/examples/lock-app/cyw30739/src/main.cpp
@@ -29,6 +29,7 @@
 #include <OTAConfig.h>
 #endif
 #include <app/clusters/door-lock-server/door-lock-server.h>
+#include <app/clusters/identify-server/identify-server.h>
 #include <app/server/Server.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 #include <inet/EndPointStateOpenThread.h>
@@ -78,6 +79,13 @@ static wiced_led_config_t chip_lighting_led_config[2] = {
         .led    = PLATFORM_LED_2,
         .bright = 50,
     },
+};
+
+static Identify gIdentify = {
+    chip::EndpointId{ 1 },
+    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
+    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
+    EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
 };
 
 APPLICATION_START()


### PR DESCRIPTION
Problem
Infineon does not support Identify cluster in lock-app for CYW30739.

Change overview
Add Identify cluster support to the example.

Testing
Sent Identify command to the Infineon lock-app and verified it works.
