### PR TITLE
Make sure we don't crash when commissioning with no pairing delegate.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -888,7 +888,10 @@ void DeviceCommissioner::OnSessionEstablished(const SessionHandle & session)
 
     ChipLogDetail(Controller, "Remote device completed SPAKE2+ handshake");
 
-    mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR);
+    if (mPairingDelegate != nullptr)
+    {
+        mPairingDelegate->OnPairingComplete(CHIP_NO_ERROR);
+    }
 
     if (mRunCommissioningAfterConnection)
     {

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -436,7 +436,10 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
         mSystemLayer->CancelTimer(OnDeviceDiscoveredTimeoutCallback, this);
 
         ResetDiscoveryState();
-        pairingDelegate->OnPairingComplete(error);
+        if (pairingDelegate != nullptr)
+        {
+            pairingDelegate->OnPairingComplete(error);
+        }
         return;
     }
 
@@ -449,7 +452,10 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
         return;
     }
 
-    pairingDelegate->OnPairingComplete(error);
+    if (pairingDelegate != nullptr)
+    {
+        pairingDelegate->OnPairingComplete(error);
+    }
 }
 
 void SetUpCodePairer::OnPairingDeleted(CHIP_ERROR error)


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/21492

#### Problem
Missing null-checks.

#### Change overview
Add them.

