### PR TITLE
Fix status reponse in command sender

### DIFF
--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -127,16 +127,25 @@ CHIP_ERROR CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExcha
         MoveToState(State::ResponseReceived);
     }
 
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+    bool sendStatusResponse = false;
     VerifyOrExit(apExchangeContext == mExchangeCtx.Get(), err = CHIP_ERROR_INCORRECT_STATE);
+    sendStatusResponse = true;
 
     if (mState == State::AwaitingTimedStatus)
     {
-        VerifyOrExit(aPayloadHeader.HasMessageType(MsgType::StatusResponse), err = CHIP_ERROR_INVALID_MESSAGE_TYPE);
-        CHIP_ERROR statusError = CHIP_NO_ERROR;
-        SuccessOrExit(err = StatusResponse::ProcessStatusResponse(std::move(aPayload), statusError));
-        SuccessOrExit(err = statusError);
-        err = SendInvokeRequest();
+        if (aPayloadHeader.HasMessageType(Protocols::InteractionModel::MsgType::StatusResponse))
+        {
+            CHIP_ERROR statusError = CHIP_NO_ERROR;
+            SuccessOrExit(err = StatusResponse::ProcessStatusResponse(std::move(aPayload), statusError));
+            sendStatusResponse = false;
+            SuccessOrExit(err = statusError);
+            err = SendInvokeRequest();
+        }
+        else
+        {
+            err = CHIP_ERROR_INVALID_MESSAGE_TYPE;
+        }
         // Skip all other processing here (which is for the response to the
         // invoke request), no matter whether err is success or not.
         goto exit;
@@ -146,6 +155,7 @@ CHIP_ERROR CommandSender::OnMessageReceived(Messaging::ExchangeContext * apExcha
     {
         err = ProcessInvokeResponse(std::move(aPayload));
         SuccessOrExit(err);
+        sendStatusResponse = false;
     }
     else if (aPayloadHeader.HasMessageType(MsgType::StatusResponse))
     {
@@ -166,6 +176,11 @@ exit:
         {
             mpCallback->OnError(this, err);
         }
+    }
+
+    if (sendStatusResponse)
+    {
+        StatusResponse::Send(Status::InvalidAction, apExchangeContext, false /*aExpectResponse*/);
     }
 
     if (mState != State::CommandSent)


### PR DESCRIPTION
#### Problem
Fix status response in command sender
This PR is cut from https://github.com/project-chip/connectedhomeip/pull/19356

#### Change overview
Then onMessageReceived in CommandSender would send status response message with invalid action when there is error happening in incoming message.

#### Testing
CommandSender sends invoke requests, and Injects malformed invoke response, status response, unknown message in client side, and client would send status response message with invalid action.
