### PR TITLE
Increase log message sizes on iOS.

### DIFF
--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -96,6 +96,7 @@ declare -a args=(
     'chip_crypto="mbedtls"'
     'chip_build_tools=false'
     'chip_build_tests=false'
+    'chip_log_message_max_size=4096' # might as well allow nice long log messages
     'chip_disable_platform_kvs=true'
     'target_cpu="'"$target_cpu"'"'
     'target_defines='"$target_defines"

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -34,7 +34,7 @@ declare_args() {
   chip_automation_logging = chip_logging
 
   # Configure the maximum size for logged messages
-  if (current_os == "linux" || current_os == "mac") {
+  if (current_os == "linux" || current_os == "mac" || current_os == "ios") {
     # Allow base64 encoding of 1 MTU (4 * (1280 / 3) + padding
     chip_log_message_max_size = 1708
   } else {


### PR DESCRIPTION
Default to the same 1 MTU in base64 as linux/mac, but also in the
XCode config just set a fairly generous 4KB limit.

#### Problem
Log messages on iOS getting truncated.

#### Change overview
Give ourselves more than the 256 chars of buffer we default to.

#### Testing
Need to figure out a good way to test.