### PR TITLE
[Tizen] Wait for mDNS on-browse events until timeout

### DIFF
--- a/src/platform/Tizen/DnssdImpl.h
+++ b/src/platform/Tizen/DnssdImpl.h
@@ -80,6 +80,9 @@ struct BrowseContext : public GenericContext
     void * mCbContext;
 
     dnssd_browser_h mBrowserHandle = 0;
+    // The timeout source used to stop browsing
+    GSource * mTimeoutSource = nullptr;
+
     std::vector<DnssdService> mServices;
     bool mIsBrowsing = false;
 


### PR DESCRIPTION
#### Problem

Tizen Native API dos not deliver all-for-now event (such event is delivered by e.g. Avahi), so it is impossible to tell when the mDNS browsing shall be considered finished. This commit adds timeout event which is delivered after 250ms from the last on-browse event. This allows Tizen platform to discover more than one mDNS service on local network.

#### Change overview

- added timeout event delivered when on-browse is idle for N miliseconds

#### Testing

Running two lighting app on local network (one on Tizen device and one on Linux) and then running `chip-tool` on Tizen to check whether it will discover more than one mDNS service.

```
root:~> /opt/usr/apps/chip-tool pairing onnetwork 1 1235
[...]
I/CHIP    ( 3276): DL: Thread platform event type [16385]
D/CHIP    ( 3276): DL: [PUSH] thread default context [0x72405150]
D/CHIP    ( 3276): DL: [RUN] glib main loop [0x724032d0]
D/CHIP    ( 3276): DL: DNSsd OnBrowse
D/CHIP    ( 3276): DL: DNSsd OnBrowseAdd: name: 61B9DC538F447661, type: _matterc._udp, interfaceId: 3
D/CHIP    ( 3276): DL: DNSsd OnBrowse
D/CHIP    ( 3276): DL: DNSsd OnBrowseAdd: name: 6084F5B7FE27BE6C, type: _matterc._udp, interfaceId: 3
D/CHIP    ( 3276): DL: DNSsd OnBrowseTimeout: all for now
D/CHIP    ( 3276): DL: DNSsd Resolve: name: 61B9DC538F447661, type: _matterc._udp, interfaceId: 3
D/CHIP    ( 3276): DL: [PUSH] thread default context [0x71a01ce0]
D/CHIP    ( 3276): DL: DNSsd ResolveAsync
D/CHIP    ( 3276): DL: [POP] thread default context [0x71a01ce0]
D/CHIP    ( 3276): DL: DNSsd Resolve: name: 6084F5B7FE27BE6C, type: _matterc._udp, interfaceId: 3
D/CHIP    ( 3276): DL: [PUSH] thread default context [0x71a01ce0]
D/CHIP    ( 3276): DL: [RUN] glib main loop [0x71a00da0]
D/CHIP    ( 3276): DL: DNSsd OnResolve
D/CHIP    ( 3276): DL: DNSsd OnResolve: IPv4: 192.168.88.230, IPv6: FE80:0000:0000:0000:BA27:EBFF:FE60:0E4D, ret: 0
D/CHIP    ( 3276): DIS: Discovered node:
D/CHIP    ( 3276): DIS:         IP Address #1: fe80::ba27:ebff:fe60:e4d
D/CHIP    ( 3276): DIS:         Port: 5540
[...]
```