### PR TITLE
change for on off transitiontime feature

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1070,14 +1070,14 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
         if (useOnLevel)
         {
             // If OnLevel is defined, don't revert to stored level.
-            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice,
-                               currentOnOffTransitionTime, 0xFF, 0xFF, INVALID_STORED_LEVEL);
+            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, transitionTime,
+                              0xFF, 0xFF, INVALID_STORED_LEVEL);
         }
         else
         {
             // If OnLevel is not defined, set the CurrentLevel to the stored level.
-            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice,
-                               currentOnOffTransitionTime, 0xFF, 0xFF, temporaryCurrentLevelCache);
+            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, transitionTime,
+                              0xFF, 0xFF, temporaryCurrentLevelCache.Value());
         }
     }
 }

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -227,22 +227,21 @@ void emberAfLevelControlClusterServerTickCallback(EndpointId endpoint)
         {
             setOnOffValue(endpoint, (currentLevel.Value() != state->minLevel));
         }
-        else
+
+        if (state->storedLevel != INVALID_STORED_LEVEL)
         {
-            if (state->storedLevel != INVALID_STORED_LEVEL)
+            uint8_t storedLevel8u = (uint8_t) state->storedLevel;
+            status                = Attributes::CurrentLevel::Set(endpoint, storedLevel8u);
+            if (status != EMBER_ZCL_STATUS_SUCCESS)
             {
-                uint8_t storedLevel8u = (uint8_t) state->storedLevel;
-                status                = Attributes::CurrentLevel::Set(endpoint, storedLevel8u);
-                if (status != EMBER_ZCL_STATUS_SUCCESS)
-                {
-                    emberAfLevelControlClusterPrintln("ERR: writing current level %x", status);
-                }
-                else
-                {
-                    updateCoupledColorTemp(endpoint);
-                }
+                emberAfLevelControlClusterPrintln("ERR: writing current level %x", status);
+            }
+            else
+            {
+                updateCoupledColorTemp(endpoint);
             }
         }
+
         writeRemainingTime(endpoint, 0);
     }
     else
@@ -1070,16 +1069,15 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
         // time period OnOffTransitionTime."
         if (useOnLevel)
         {
-
             // If OnLevel is defined, don't revert to stored level.
-            moveToLevelHandler(endpoint, Commands::MoveToLevel::Id, minimumLevelAllowedForTheDevice, transitionTime, 0xFF, 0xFF,
-                               INVALID_STORED_LEVEL);
+            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, currentOnOffTransitionTime,
+                               0xFF, 0xFF, INVALID_STORED_LEVEL);
         }
         else
         {
             // If OnLevel is not defined, set the CurrentLevel to the stored level.
-            moveToLevelHandler(endpoint, Commands::MoveToLevel::Id, minimumLevelAllowedForTheDevice, transitionTime, 0xFF, 0xFF,
-                               temporaryCurrentLevelCache.Value());
+            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, currentOnOffTransitionTime,
+                               0xFF, 0xFF, temporaryCurrentLevelCache);
         }
     }
 }

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1070,14 +1070,14 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
         if (useOnLevel)
         {
             // If OnLevel is defined, don't revert to stored level.
-            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, transitionTime,
-                              0xFF, 0xFF, INVALID_STORED_LEVEL);
+            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, transitionTime, 0xFF,
+                               0xFF, INVALID_STORED_LEVEL);
         }
         else
         {
             // If OnLevel is not defined, set the CurrentLevel to the stored level.
-            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, transitionTime,
-                              0xFF, 0xFF, temporaryCurrentLevelCache.Value());
+            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, transitionTime, 0xFF,
+                               0xFF, temporaryCurrentLevelCache.Value());
         }
     }
 }

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -1070,14 +1070,14 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
         if (useOnLevel)
         {
             // If OnLevel is defined, don't revert to stored level.
-            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, currentOnOffTransitionTime,
-                               0xFF, 0xFF, INVALID_STORED_LEVEL);
+            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice,
+                               currentOnOffTransitionTime, 0xFF, 0xFF, INVALID_STORED_LEVEL);
         }
         else
         {
             // If OnLevel is not defined, set the CurrentLevel to the stored level.
-            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice, currentOnOffTransitionTime,
-                               0xFF, 0xFF, temporaryCurrentLevelCache);
+            moveToLevelHandler(endpoint, Commands::MoveToLevelWithOnOff::Id, minimumLevelAllowedForTheDevice,
+                               currentOnOffTransitionTime, 0xFF, 0xFF, temporaryCurrentLevelCache);
         }
     }
 }

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -190,13 +190,13 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::Comman
         else
         {
 #endif
-        // write the new on/off value
-        status = Attributes::OnOff::Set(endpoint, newValue);
-        if (status != EMBER_ZCL_STATUS_SUCCESS)
-        {
-            emberAfOnOffClusterPrintln("ERR: writing on/off %x", status);
-            return status;
-        }
+            // write the new on/off value
+            status = Attributes::OnOff::Set(endpoint, newValue);
+            if (status != EMBER_ZCL_STATUS_SUCCESS)
+            {
+                emberAfOnOffClusterPrintln("ERR: writing on/off %x", status);
+                return status;
+            }
 #ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
         }
 #endif
@@ -245,7 +245,7 @@ void OnOffServer::initOnOffServer(chip::EndpointId endpoint)
         EmberAfStatus status      = getOnOffValueForStartUp(endpoint, onOffValueForStartUp);
         if (status == EMBER_ZCL_STATUS_SUCCESS)
         {
-            status = setOnOffValue(endpoint, onOffValueForStartUp, false);
+            status = setOnOffValue(endpoint, onOffValueForStartUp, true);
         }
 
 #ifdef EMBER_AF_PLUGIN_MODE_SELECT

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -187,8 +187,9 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::Comman
         {
             emberAfOnOffClusterLevelControlEffectCallback(endpoint, newValue);
         }
+        else
+        {
 #endif
-
         // write the new on/off value
         status = Attributes::OnOff::Set(endpoint, newValue);
         if (status != EMBER_ZCL_STATUS_SUCCESS)
@@ -196,6 +197,9 @@ EmberAfStatus OnOffServer::setOnOffValue(chip::EndpointId endpoint, chip::Comman
             emberAfOnOffClusterPrintln("ERR: writing on/off %x", status);
             return status;
         }
+#ifdef EMBER_AF_PLUGIN_LEVEL_CONTROL
+        }
+#endif
     }
 
 #ifdef EMBER_AF_PLUGIN_SCENES

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -751,7 +751,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"Subscription complete"];
 
     NSLog(@"Subscribing...");
-    __block void (^reportHandler)(NSArray * _Nullable value, NSError * _Nullable error);
+    // reportHandler returns TRUE if it got the things it was looking for or if there's an error.
+    __block BOOL (^reportHandler)(NSArray * _Nullable value, NSError * _Nullable error);
     __auto_type * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(2) maxInterval:@(60)];
     [device subscribeWithQueue:queue
         params:params
@@ -761,7 +762,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
             if (reportHandler) {
                 __auto_type handler = reportHandler;
                 reportHandler = nil;
-                handler(value, nil);
+                BOOL done = handler(value, nil);
+                if (done == NO) {
+                    // Keep waiting.
+                    reportHandler = handler;
+                }
             }
         }
         eventReportHandler:nil
@@ -827,6 +832,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type reportExpectation = [self expectationWithDescription:@"Report handler called"];
     reportHandler = ^(NSArray * _Nullable value, NSError * _Nullable error) {
+        if (error != nil) {
+            return YES;
+        }
         NSLog(@"Report received: %@, error: %@", value, error);
         for (MTRAttributeReport * report in value) {
             if ([report.path.endpoint isEqualToNumber:@1] && [report.path.cluster isEqualToNumber:@6] &&
@@ -836,9 +844,11 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                 XCTAssertTrue([report.value isKindOfClass:[NSNumber class]]);
                 XCTAssertEqual([report.value boolValue], NO);
                 [reportExpectation fulfill];
-                break;
+                return YES;
             }
         }
+
+        return NO;
     };
 
     NSLog(@"Invoking another command...");


### PR DESCRIPTION
#### Problem
Fixes #22750 
Fixed the OnOffTransition feature when receiving an off command and OnOffTransitionTime is non-zero.
Testing OnOffTransitionTime feature, when receiving off command, the previous order: onoff attribute change to off, then execute move-to-level,  
The phenomenon of light is off immediately, no fade out.
The correct order should be : when receiving off command ,if defined  EMBER_AF_PLUGIN_LEVEL_CONTROL,  should execute move-to-level-with-on-off, adjust level first, when the level move to min-level, change the onoff attribute to off, if not define on-level, set current level to stored level.

#### Change overview
1. In on-off-server.cpp file, in the setOnOffValue() function, add a #else condition after the macro EMBER_AF_PLUGIN_LEVEL_CONTROL when set off.
2. In level-control.cpp file, at the emberAfOnOffClusterLevelControlEffectCallback() function, change the MoveToLevel::Id to MoveToLevelWithOnOff::Id to set on-off attribute after level adjustment when execute off effect.
3. In the emberAfLevelControlClusterServerTickCallback(), replace the setOnOffValue() with the OnOff::Attributes::OnOff::Set() function to avoid calling the setOnOffValue() in on-off-server.cpp
4. In the emberAfLevelControlClusterServerTickCallback(), add the storedLevel condition when deal with the level control with on off commands.

#### Testing
test using esp32 lighting-app example 
1. write a non-zero value to the OnOffTransitionTime attribute
2. send on/off command to the lighting-app, the light can fade in and out normally depend on the above time.