### PR TITLE
[BL602]1.add bflb-iot-tool to chip-build-vscode;2.support build bl602-light in vscode

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -331,6 +331,7 @@
                 "android-arm64-chip-tvserver",
                 "android-x64-chip-tool",
                 "android-x86-chip-tool",
+                "bl602-light",
                 "efr32-brd4161a-light",
                 "efr32-brd4163a-light",
                 "efr32-brd4164a-light",

--- a/integrations/docker/images/chip-build-vscode/Dockerfile
+++ b/integrations/docker/images/chip-build-vscode/Dockerfile
@@ -66,6 +66,11 @@ RUN set -x \
     && rm -rf /var/lib/apt/lists/* \
     && : # last line
 
+# Required for the Bouffalolab platform
+RUN set -x \
+    && pip3 install bflb-iot-tool \
+    && : # last line
+
 ENV AMEBA_PATH=/opt/ameba/ambd_sdk_with_chip_non_NDA
 ENV ANDROID_HOME=/opt/android/sdk
 ENV ANDROID_NDK_HOME=/opt/android/android-ndk-r21b


### PR DESCRIPTION
#### Problem
1. need bflb-iot-tool in vscode docker image.
2. need add the support of vscode.

#### Change overview
1.add bflb-iot-tool to chip-build-vscode.
2.build bl602-light as run vscode task.

#### Testing
local build chip-build-vscode;build bl602-light in vscode.
