### PR TITLE
Add auto-resubscribe support to chip-tool.

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -94,6 +94,11 @@ public:
         mError = error;
     }
 
+    void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
+    {
+        InteractionModelReports::OnDeallocatePaths(std::move(aReadPrepareParams));
+    }
+
     void Shutdown() override
     {
         // We don't shut down InteractionModelReports here; we leave it for
@@ -263,7 +268,7 @@ public:
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
         return SubscribeCommand::SubscribeAttribute(device, endpointIds, mClusterIds, mAttributeIds, mMinInterval, mMaxInterval,
-                                                    mFabricFiltered, mDataVersion, mKeepSubscriptions);
+                                                    mFabricFiltered, mDataVersion, mKeepSubscriptions, mAutoResubscribe);
     }
 
 private:
@@ -286,6 +291,8 @@ private:
                     "Comma-separated list of data versions for the clusters being subscribed to.");
         AddArgument("keepSubscriptions", 0, 1, &mKeepSubscriptions,
                     "Boolean indicating whether to keep existing subscriptions when creating the new one. Defaults to false.");
+        AddArgument("auto-resubscribe", 0, 1, &mAutoResubscribe,
+                    "Boolean indicating whether the subscription should auto-resubscribe.  Defaults to false.");
     }
 
     std::vector<chip::ClusterId> mClusterIds;
@@ -296,6 +303,7 @@ private:
     chip::Optional<bool> mFabricFiltered;
     chip::Optional<std::vector<chip::DataVersion>> mDataVersion;
     chip::Optional<bool> mKeepSubscriptions;
+    chip::Optional<bool> mAutoResubscribe;
 };
 
 class ReadEvent : public ReadCommand
@@ -391,6 +399,8 @@ public:
             "  This argument takes a comma separated list of true/false values.\n"
             "  If the number of paths exceeds the number of entries provided to is-urgent, then isUrgent will be false for the "
             "extra paths.");
+        AddArgument("auto-resubscribe", 0, 1, &mAutoResubscribe,
+                    "Boolean indicating whether the subscription should auto-resubscribe.  Defaults to false.");
     }
 
     ~SubscribeEvent() {}
@@ -398,7 +408,7 @@ public:
     CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
     {
         return SubscribeCommand::SubscribeEvent(device, endpointIds, mClusterIds, mEventIds, mMinInterval, mMaxInterval,
-                                                mFabricFiltered, mEventNumber, mKeepSubscriptions, mIsUrgents);
+                                                mFabricFiltered, mEventNumber, mKeepSubscriptions, mIsUrgents, mAutoResubscribe);
     }
 
 private:
@@ -411,6 +421,7 @@ private:
     chip::Optional<chip::EventNumber> mEventNumber;
     chip::Optional<bool> mKeepSubscriptions;
     chip::Optional<std::vector<bool>> mIsUrgents;
+    chip::Optional<bool> mAutoResubscribe;
 };
 
 class ReadAll : public ReadCommand

--- a/examples/chip-tool/templates/tests/partials/test_step.zapt
+++ b/examples/chip-tool/templates/tests/partials/test_step.zapt
@@ -106,11 +106,11 @@
 {{#if (isTestOnlyCluster cluster)}}{{>testOnlyClusterArguments}}, value
 {{else if isWait}}                 {{>waitArguments}}
 {{else if isReadAttribute}}        {{>attributeArguments}}{{>maybeFabricFiltered}}{{>maybeDataVersion~}}
-{{else if isSubscribeAttribute}}   {{>attributeArguments}}, {{minInterval}}, {{maxInterval}}{{>maybeFabricFiltered}}{{>maybeDataVersion}}{{>maybeKeepSubscriptions~}}
+{{else if isSubscribeAttribute}}   {{>attributeArguments}}, {{minInterval}}, {{maxInterval}}{{>maybeFabricFiltered}}{{>maybeDataVersion}}{{>maybeKeepSubscriptions~}}, /* autoResubscribe = */ chip::NullOptional
 {{else if isWriteGroupAttribute}}  {{>groupAttributeArguments}}, value{{>maybeDataVersion~}}
 {{else if isWriteAttribute}}       {{>attributeArguments}}, value{{>maybeTimedInteractionTimeoutMs}}{{>maybeSuppressResponse}}{{>maybeDataVersion~}}
 {{else if isReadEvent}}            {{>eventArguments}}{{>maybeFabricFiltered}}{{>maybeEventNumber~}}
-{{else if isSubscribeEvent}}       {{>eventArguments}}, {{minInterval}}, {{maxInterval}}{{>maybeFabricFiltered}}{{>maybeEventNumber}}{{>maybeKeepSubscriptions~}}
+{{else if isSubscribeEvent}}       {{>eventArguments}}, {{minInterval}}, {{maxInterval}}{{>maybeFabricFiltered}}{{>maybeEventNumber}}{{>maybeKeepSubscriptions~}}, /* autoResubscribe = */ chip::NullOptional
 {{else if isGroupCommand}}         {{>groupCommandArguments}}, value
 {{else if isCommand}}              {{>commandArguments}}, value{{>maybeTimedInteractionTimeoutMs}}{{>maybeSuppressResponse}}
 {{/if}}


### PR DESCRIPTION
#### Problem
chip-tool doesn't have a way to auto-resubscribe for subscriptions.

#### Change overview
Add auto-resubscribe support.

#### Testing
Set up a subscription in interactive mode with `--auto-resubsribe true`, after some reports restarted the server, observed the subscription getting re-established, over a new CASE session.