### PR TITLE
[EFR32]Added connectivity for RS9116 when AP has WPA3 security mode

### DIFF
--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -63,6 +63,9 @@ declare_args() {
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
+
+  # Argument to force enable WPA3 security
+  wifi_enable_security_wpa3 = false
 }
 
 declare_args() {
@@ -225,6 +228,10 @@ efr32_executable("light_switch_app") {
 
   if (chip_enable_wifi_ipv4) {
     defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+  }
+
+  if (wifi_enable_security_wpa3) {
+    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
   }
 
   # WiFi Settings

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -63,6 +63,9 @@ declare_args() {
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
+
+  # Argument to force enable WPA3 security
+  wifi_enable_security_wpa3 = false
 }
 
 declare_args() {
@@ -225,6 +228,10 @@ efr32_executable("lighting_app") {
 
   if (chip_enable_wifi_ipv4) {
     defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+  }
+
+  if (wifi_enable_security_wpa3) {
+    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
   }
 
   # WiFi Settings

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -63,6 +63,9 @@ declare_args() {
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
+
+  # Argument to force enable WPA3 security
+  wifi_enable_security_wpa3 = false
 }
 
 declare_args() {
@@ -222,6 +225,10 @@ efr32_executable("lock_app") {
 
   if (chip_enable_wifi_ipv4) {
     defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+  }
+
+  if (wifi_enable_security_wpa3) {
+    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
   }
 
   # WiFi Settings

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -56,6 +56,9 @@ declare_args() {
 
   # Argument to Disable IPv4 for wifi(rs911)
   chip_enable_wifi_ipv4 = false
+
+  # Argument to force enable WPA3 security
+  wifi_enable_security_wpa3 = false
 }
 
 declare_args() {
@@ -208,6 +211,10 @@ efr32_executable("window_app") {
 
   if (chip_enable_wifi_ipv4) {
     defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+  }
+
+  if (wifi_enable_security_wpa3) {
+    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
   }
 
   # WiFi Settings

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -143,6 +143,22 @@ else
                 optArgs+="chip_enable_wifi_ipv4=true "
                 shift
                 ;;
+            --rs91x_setSecurityType)
+                if [ -z "$2" ]; then
+                    echo "--rs911x_setSecurityType requires WPA_WPA2 or WPA3_ONLY"
+                    exit 1
+                fi
+                if [ "$2" = "WPA_WPA2" ]; then
+                    optArgs+="wifi_enable_security_wpa3=false "
+                elif [ "$2" = "WPA3_ONLY" ]; then
+				    optArgs+="wifi_enable_security_wpa3=true "
+                else
+                    echo "Set security usage: --rs911x_setSecurityType WPA_WPA2|WPA3_ONLY"
+                    exit 1
+                fi
+                shift
+                shift
+                ;;
             --additional_data_advertising)
                 optArgs+="chip_enable_additional_data_advertising=true chip_enable_rotating_device_id=true "
                 shift

--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -151,7 +151,7 @@ else
                 if [ "$2" = "WPA_WPA2" ]; then
                     optArgs+="wifi_enable_security_wpa3=false "
                 elif [ "$2" = "WPA3_ONLY" ]; then
-				    optArgs+="wifi_enable_security_wpa3=true "
+                    optArgs+="wifi_enable_security_wpa3=true "
                 else
                     echo "Set security usage: --rs911x_setSecurityType WPA_WPA2|WPA3_ONLY"
                     exit 1


### PR DESCRIPTION
#### Problem
The DUT does not gets connected to AP which is in WPA3 security mode.

#### Change overview
Added the functionality to connect RS9116 to support WPA3 functionality. 
Added a flag --rs91x_setSecurityType to set the security mode to WPA_WPA2 and WPA3_ONLY mode which can be set during the build

#### Testing
Tested manually using EFR32+RS9116
