### PR TITLE
Fix crash on fail-safe timeout due to closed exchange

### DIFF
--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -186,7 +186,7 @@ void CommandHandler::DecrementHoldOff()
         return;
     }
 
-    if (!mExchangeCtx->IsGroupExchangeContext() && !mSentStatusResponse)
+    if (mExchangeCtx.Get() != nullptr && !mExchangeCtx->IsGroupExchangeContext() && !mSentStatusResponse)
     {
         CHIP_ERROR err = SendCommandResponse();
         if (err != CHIP_NO_ERROR)

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -186,12 +186,19 @@ void CommandHandler::DecrementHoldOff()
         return;
     }
 
-    if (mExchangeCtx.Get() != nullptr && !mExchangeCtx->IsGroupExchangeContext() && !mSentStatusResponse)
+    if (!mSentStatusResponse)
     {
-        CHIP_ERROR err = SendCommandResponse();
-        if (err != CHIP_NO_ERROR)
+        if (!mExchangeCtx)
         {
-            ChipLogError(DataManagement, "Failed to send command response: %" CHIP_ERROR_FORMAT, err.Format());
+            ChipLogProgress(DataManagement, "Skipping command response: exchange context is null");
+        }
+        else if (!mExchangeCtx->IsGroupExchangeContext())
+        {
+            CHIP_ERROR err = SendCommandResponse();
+            if (err != CHIP_NO_ERROR)
+            {
+                ChipLogError(DataManagement, "Failed to send command response: %" CHIP_ERROR_FORMAT, err.Format());
+            }
         }
     }
 


### PR DESCRIPTION
#### Problem
When CommandHandler is released it dereferences an exchange holder to figure out if the status response can be sent.
The exchange holder, however, can be nulled-out at this point.

#### Change overview
Add a null check. 
Fixes #21586

#### Testing
Added a unit test that reproduces the crash scenario.
