### PR TITLE
Remove TODO item which is no more valid

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -739,8 +739,6 @@ exit:
             (void) groupDataProvider->RemoveFabric(newFabricIndex);
         }
 
-        // TODO(#19898): All ACL work done within AddNOC does not trigger ACL cluster updates
-
         (void) Access::GetAccessControl().DeleteAllEntriesForFabric(newFabricIndex);
 
         MatterReportingAttributeChangeCallback(commandPath.mEndpointId, OperationalCredentials::Id,

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -438,9 +438,7 @@ private:
             // Remove access control entries in reverse order (it could be any order, but reverse order
             // will cause less churn in persistent storage).
 
-            // TODO(#19898): The fabric removal not trigger ACL cluster updates
             // TODO(#19899): The fabric removal not remove ACL extensions
-
             CHIP_ERROR aclErr = Access::GetAccessControl().DeleteAllEntriesForFabric(fabricIndex);
             if (aclErr != CHIP_NO_ERROR)
             {


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* From the log, I see when the AddNOC command is handled, ACL an AccessControlEntryChangeddo event get logged.
yufengwang@yufengwang:~/connectedhomeip/out/debug/standalone$ ./chip-all-clusters-app | grep aaaa
[1659461311.391696][161082:161082] CHIP:ZCL: aaaa: OpCreds: Received an AddNOC command
[1659461311.394670][161082:161082] CHIP:DMG: aaaa: OnEntryChanged
[1659461311.394682][161082:161082] CHIP:DMG: aaaa:OnEntryChanged:kAdded
[1659461311.394690][161082:161082] CHIP:DMG: aaaa:OnEntryChanged:AuthMode::kPase
[1659461311.394747][161082:161082] CHIP:DMG: aaaa:OnEntryChanged:LogEvent:1

AddNOC does the right thing, we need to update the TODOs

* Fixes #19898 

#### Change overview
Remove TODO item which is no more valid

#### Testing
How was this tested? (at least one bullet point required)
* no code change