### PR TITLE
Fix chip-tool cleanup of subscription clients.

### DIFF
--- a/examples/chip-tool/commands/clusters/ReportCommand.h
+++ b/examples/chip-tool/commands/clusters/ReportCommand.h
@@ -144,15 +144,14 @@ protected:
 
     void OnDone(chip::app::ReadClient * aReadClient) override
     {
+        InteractionModelReports::CleanupReadClient(aReadClient);
+
         if (!mSubscriptionEstablished)
         {
-            InteractionModelReports::CleanupReadClient(aReadClient);
             SetCommandExitStatus(mError);
         }
-
         // else we must be getting here from Cleanup(), which means we have
-        // already done our exit status thing, and have done the ReadClient
-        // cleanup.
+        // already done our exit status thing.
     }
 
     void Shutdown() override
@@ -161,7 +160,10 @@ protected:
         ReportCommand::Shutdown();
     }
 
-    bool DeferInteractiveCleanup() override { return mSubscriptionEstablished; }
+    // For subscriptions we always defer interactive cleanup.  Either our
+    // ReadClients will terminate themselves (in which case they will be removed
+    // from our list anyway), or they should hang around until shutdown.
+    bool DeferInteractiveCleanup() override { return true; }
 
 private:
     bool mSubscriptionEstablished = false;


### PR DESCRIPTION
We were doing it from the wrong thread in some cases.

Fixes https://github.com/project-chip/connectedhomeip/issues/21599

#### Problem
See issue.

#### Change overview
Always defer cleanup of subscription commands, and ensure their ReadClients are properly destroyed OnDone.

#### Testing
Tested steps from issue above; no more asserts.