### PR TITLE
fix subscription id

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -57,12 +57,12 @@ ReadClient::ReadClient(InteractionModelEngine * apImEngine, Messaging::ExchangeM
 
 void ReadClient::ClearActiveSubscriptionState()
 {
-    mIsReporting             = false;
-    mIsPrimingReports        = true;
-    mPendingMoreChunks       = false;
-    mMinIntervalFloorSeconds = 0;
-    mMaxInterval             = 0;
-    mSubscriptionId          = 0;
+    mIsReporting                  = false;
+    mWaitingForFirstPrimingReport = true;
+    mPendingMoreChunks            = false;
+    mMinIntervalFloorSeconds      = 0;
+    mMaxInterval                  = 0;
+    mSubscriptionId               = 0;
     MoveToState(ClientState::Idle);
 }
 
@@ -504,7 +504,12 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
     err = report.GetSubscriptionId(&subscriptionId);
     if (CHIP_NO_ERROR == err)
     {
-        if (mIsPrimingReports)
+        if (!IsSubscriptionType())
+        {
+            err = CHIP_ERROR_INVALID_ARGUMENT;
+            goto exit;
+        }
+        if (mWaitingForFirstPrimingReport)
         {
             mSubscriptionId = subscriptionId;
         }
@@ -592,7 +597,7 @@ exit:
         err                     = StatusResponse::Send(Status::Success, mExchange.Get(), !noResponseExpected);
     }
 
-    mIsPrimingReports = false;
+    mWaitingForFirstPrimingReport = false;
     return err;
 }
 

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -504,11 +504,7 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
     err = report.GetSubscriptionId(&subscriptionId);
     if (CHIP_NO_ERROR == err)
     {
-        if (!IsSubscriptionType())
-        {
-            err = CHIP_ERROR_INVALID_ARGUMENT;
-            goto exit;
-        }
+        VerifyOrExit(IsSubscriptionType(), err = CHIP_ERROR_INVALID_ARGUMENT);
         if (mWaitingForFirstPrimingReport)
         {
             mSubscriptionId = subscriptionId;

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -496,14 +496,15 @@ private:
     Messaging::ExchangeManager * mpExchangeMgr = nullptr;
     Messaging::ExchangeHolder mExchange;
     Callback & mpCallback;
-    ClientState mState                = ClientState::Idle;
-    bool mIsReporting                 = false;
-    bool mIsInitialReport             = true;
-    bool mIsPrimingReports            = true;
-    bool mPendingMoreChunks           = false;
-    uint16_t mMinIntervalFloorSeconds = 0;
-    uint16_t mMaxInterval             = 0;
-    SubscriptionId mSubscriptionId    = 0;
+    ClientState mState    = ClientState::Idle;
+    bool mIsReporting     = false;
+    bool mIsInitialReport = true;
+    // boolean to check if client is waiting for the first priming report
+    bool mWaitingForFirstPrimingReport = true;
+    bool mPendingMoreChunks            = false;
+    uint16_t mMinIntervalFloorSeconds  = 0;
+    uint16_t mMaxInterval              = 0;
+    SubscriptionId mSubscriptionId     = 0;
     ScopedNodeId mPeer;
     InteractionType mInteractionType = InteractionType::Read;
     Timestamp mEventTimestamp;


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/21594

#### Change overview
ReadClient should return error when receiving report with subscription
Id and current action is read.
Rename mIsPrimingReports with comments.

#### Testing
Add test to validate the returned error when receiving report with subscription
Id and current action is read.
