### PR TITLE
Add full threading backtrace dumps in Cirque and REPL 

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -279,7 +279,7 @@ jobs:
             - name: Run Tests
               timeout-minutes: 40
               run: |
-                  scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --script-gdb --app out/linux-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factoryreset --script-args "--log-level INFO -t 10 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
+                  scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --app out/linux-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factoryreset --script-args "--log-level INFO -t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() && !env.ACT }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -279,7 +279,7 @@ jobs:
             - name: Run Tests
               timeout-minutes: 40
               run: |
-                  scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --app out/linux-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factoryreset --script-args "--log-level INFO -t 3600 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
+                  scripts/run_in_build_env.sh './scripts/tests/run_python_test.py --script-gdb --app out/linux-x64-all-clusters-no-ble-no-wifi-tsan-clang-test/chip-all-clusters-app --factoryreset --script-args "--log-level INFO -t 10 --disable-test ClusterObjectTests.TestTimedRequestTimeout"'
             - name: Uploading core files
               uses: actions/upload-artifact@v2
               if: ${{ failure() && !env.ACT }}

--- a/src/controller/python/chip/native/CommonStackInit.cpp
+++ b/src/controller/python/chip/native/CommonStackInit.cpp
@@ -49,6 +49,17 @@ struct __attribute__((packed)) PyCommonStackInitParams
     uint32_t mBluetoothAdapterId;
 };
 
+/**
+ * Function to artifically cause a crash to happen
+ * that can be used in place of os.exit() in Python so that
+ * when run through GDB, you'll get a backtrace of what happened.
+ */
+void pychip_CauseCrash()
+{
+    uint8_t * ptr = nullptr;
+    *ptr          = 0;
+}
+
 ChipError::StorageType pychip_CommonStackInit(const PyCommonStackInitParams * aParams)
 {
     ReturnErrorOnFailure(Platform::MemoryInit().AsInteger());

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -50,9 +50,15 @@ sh.setStream(sys.stdout)
 logger.addHandler(sh)
 
 
-def TestFail(message):
+def TestFail(message, doCrash=False):
     logger.fatal("Testfail: {}".format(message))
-    os._exit(1)
+
+    if (doCrash):
+        #
+        # Cause a crash to happen so that we can actually get a meaningful
+        # backtrace when run through GDB.
+        #
+        chip.native.GetLibraryHandle().pychip_CauseCrash()
 
 
 def FailIfNot(cond, message):
@@ -143,7 +149,7 @@ class TestTimeout(threading.Thread):
                 self._cv.wait(wait_time)
                 wait_time = stop_time - time.time()
         if time.time() > stop_time:
-            TestFail("Timeout")
+            TestFail("Timeout", doCrash=True)
 
 
 class TestResult:

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -38,6 +38,7 @@ import chip.native
 import chip.FabricAdmin
 import copy
 import secrets
+import faulthandler
 
 logger = logging.getLogger('PythonMatterControllerTEST')
 logger.setLevel(logging.INFO)
@@ -55,10 +56,18 @@ def TestFail(message, doCrash=False):
 
     if (doCrash):
         #
+        # Let's dump the Python backtrace for all threads, since the backtrace we'll
+        # get from gdb (if one is attached) won't give us good Python symbol information.
+        #
+        faulthandler.dump_traceback()
+
+        #
         # Cause a crash to happen so that we can actually get a meaningful
         # backtrace when run through GDB.
         #
         chip.native.GetLibraryHandle().pychip_CauseCrash()
+    else:
+        os._exit(1)
 
 
 def FailIfNot(cond, message):

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -55,6 +55,10 @@ def TestFail(message, doCrash=False):
     logger.fatal("Testfail: {}".format(message))
 
     if (doCrash):
+        logger.fatal("--------------------------------")
+        logger.fatal("Backtrace of all Python threads:")
+        logger.fatal("--------------------------------")
+
         #
         # Let's dump the Python backtrace for all threads, since the backtrace we'll
         # get from gdb (if one is attached) won't give us good Python symbol information.

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -83,7 +83,7 @@ class TestPythonController(CHIPVirtualHome):
                    if device['type'] == 'MobileDevice']
 
         for server in server_ids:
-            self.execute_device_cmd(server, "CHIPCirqueDaemon.py -- run gdb -return-child-result -q -ex \"set pagination off\" -ex run -ex \"bt 25\" --args {} --thread --discriminator {}".format(
+            self.execute_device_cmd(server, "CHIPCirqueDaemon.py -- run gdb -batch -return-child-result -q -ex \"set pagination off\" -ex run -ex \"thread apply all bt\" --args {} --thread --discriminator {}".format(
                 os.path.join(CHIP_REPO, "out/debug/standalone/chip-all-clusters-app"), TEST_DISCRIMINATOR))
 
         self.reset_thread_devices(server_ids)
@@ -97,7 +97,7 @@ class TestPythonController(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
-        command = "gdb -return-child-result -q -ex run -ex bt --args python3 {} -t 240 -a {} --paa-trust-store-path {}".format(
+        command = "gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" --args python3 {} -t 10 -a {} --paa-trust-store-path {}".format(
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/mobile-device-test.py"), ethernet_ip,
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))

--- a/src/test_driver/linux-cirque/MobileDeviceTest.py
+++ b/src/test_driver/linux-cirque/MobileDeviceTest.py
@@ -97,7 +97,7 @@ class TestPythonController(CHIPVirtualHome):
         self.execute_device_cmd(req_device_id, "pip3 install {}".format(os.path.join(
             CHIP_REPO, "out/debug/linux_x64_gcc/controller/python/chip_repl-0.0-py3-none-any.whl")))
 
-        command = "gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" --args python3 {} -t 10 -a {} --paa-trust-store-path {}".format(
+        command = "gdb -batch -return-child-result -q -ex run -ex \"thread apply all bt\" --args python3 {} -t 240 -a {} --paa-trust-store-path {}".format(
             os.path.join(
                 CHIP_REPO, "src/controller/python/test/test_scripts/mobile-device-test.py"), ethernet_ip,
             os.path.join(CHIP_REPO, MATTER_DEVELOPMENT_PAA_ROOT_CERTS))


### PR DESCRIPTION
### Problem

When Cirque or REPL tests fail due to a test timeout, it currently just calls `os.exit()`. When used with GDB, this prevents being able to retrieve meaningful back-traces.

### Solution

Trigger a crash instead. This will permit GDB to actually provide a meaningful backtrace.

Consequently, enable GDB-based execution in the REPL tests, as well as dumping out the backtraces for all threads in both the Cirque and REPL tests.

NOTE: In CI, we don't have gdb for the repl tests, so they won't dump out the GDB backtrace.

**This is going to be used to debug some other PR Cirque failures.** 