### PR TITLE
Remove ACL extension entry on RemoveFabric

### DIFF
--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -437,12 +437,21 @@ private:
 
             // Remove access control entries in reverse order (it could be any order, but reverse order
             // will cause less churn in persistent storage).
-
-            // TODO(#19899): The fabric removal not remove ACL extensions
             CHIP_ERROR aclErr = Access::GetAccessControl().DeleteAllEntriesForFabric(fabricIndex);
             if (aclErr != CHIP_NO_ERROR)
             {
                 ChipLogError(AppServer, "Warning, failed to delete access control state for fabric index 0x%x: %" CHIP_ERROR_FORMAT,
+                             static_cast<unsigned>(fabricIndex), aclErr.Format());
+            }
+
+            //  Remove ACL extension entry for the given fabricIndex.
+            auto & storage = mServer->GetPersistentStorage();
+            DefaultStorageKeyAllocator key;
+            aclErr = storage.SyncDeleteKeyValue(key.AccessControlExtensionEntry(fabricIndex));
+
+            if (aclErr != CHIP_NO_ERROR && aclErr != CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+            {
+                ChipLogError(AppServer, "Warning, failed to delete ACL extension entry for fabric index 0x%x: %" CHIP_ERROR_FORMAT,
                              static_cast<unsigned>(fabricIndex), aclErr.Format());
             }
 


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* RemoveFabric command does not remove ACL extensions from storage, only  remove all ACL entries for the given fabricIndex.

* Fixes #19899

#### Change overview
Remove ACL extension entry on RemoveFabric

#### Testing
How was this tested? (at least one bullet point required)
* Add a ACL extension and confirm it has been successfully added
```
./chip-tool accesscontrol read extension 12344321 0

[1659575074.180633][52365:52370] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_001F Attribute 0x0000_0001 DataVersion: 1301535624
[1659575074.180647][52365:52370] CHIP:TOO:   Extension: 1 entries
[1659575074.180654][52365:52370] CHIP:TOO:     [1]: {
[1659575074.180658][52365:52370] CHIP:TOO:       Data: 1718
[1659575074.180663][52365:52370] CHIP:TOO:       FabricIndex: 1
[1659575074.180666][52365:52370] CHIP:TOO:      }
```
* Remove the fabric with the index of 1 and confirm the ACL extension entry has been removed from the server log
`./chip-tool operationalcredentials remove-fabric 1 12344321 0`

