### PR TITLE
[BL602]add configuration to change ota periodic query timeout value

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/BUILD.gn
+++ b/examples/lighting-app/bouffalolab/bl602/BUILD.gn
@@ -40,6 +40,9 @@ declare_args() {
 
   # Monitor & log memory usage at runtime.
   enable_heap_monitoring = false
+
+  # OTA periodic query timeout in seconds
+  ota_periodic_query_timeout = 86400
 }
 
 show_qr_code = false
@@ -64,6 +67,7 @@ bl602_sdk("sdk") {
   defines = [
     "CONFIG_PSM_EASYFLASH_SIZE=16384",
     "CHIP_DEVICE_CONFIG_USE_TEST_SETUP_PIN_CODE=${setupPinCode}",
+    "OTA_PERIODIC_QUERY_TIMEOUT=${ota_periodic_query_timeout}",
   ]
 
   if (chip_enable_pw_rpc) {

--- a/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
@@ -145,6 +145,7 @@ CHIP_ERROR AppTask::Init()
     gRequestorCore.Init(chip::Server::GetInstance(), gRequestorStorage, gRequestorUser, gDownloader);
     gImageProcessor.SetOTADownloader(&gDownloader);
     gDownloader.SetImageProcessorDelegate(&gImageProcessor);
+    gRequestorUser.SetPeriodicQueryTimeout(OTA_PERIODIC_QUERY_TIMEOUT);
     gRequestorUser.Init(&gRequestorCore, &gImageProcessor);
 
     ConfigurationMgr().LogDeviceConfig();


### PR DESCRIPTION
#### Problem
* Test case [TC-SU-2.8] requires a lower value of OTA periodic query timeout, default value is 24 hours, so add a configuration to change it.

#### Change overview
add configuration to change ota periodic query timeout value

#### Testing
test TC-SU-2.8 passed