### PR TITLE
[BL602] Fix wifi dhcp failed

### DIFF
--- a/examples/lighting-app/bouffalolab/bl602/include/AppTask.h
+++ b/examples/lighting-app/bouffalolab/bl602/include/AppTask.h
@@ -71,7 +71,6 @@ private:
     static void FactoryResetButtonEventHandler(void);
     static void LightingActionButtonEventHandler(void);
     static void InitButtons(void);
-    static void StoreWifiConfig();
     void StartTimer(uint32_t aTimeoutMs);
 
     enum Function_t

--- a/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
+++ b/examples/lighting-app/bouffalolab/bl602/src/AppTask.cpp
@@ -152,7 +152,6 @@ CHIP_ERROR AppTask::Init()
     PrintOnboardingCodes(chip::RendezvousInformationFlag(chip::RendezvousInformationFlag::kBLE));
 
     InitButtons();
-    StoreWifiConfig();
 
 #if PW_RPC_ENABLED
     chip::rpc::Init();
@@ -554,11 +553,6 @@ void AppTask::InitButtons(void)
 {
     Button_Configure_FactoryResetEventHandler(&FactoryResetButtonEventHandler);
     Button_Configure_LightingActionEventHandler(&LightingActionButtonEventHandler);
-}
-
-void AppTask::StoreWifiConfig(void)
-{
-    wifi_mgmr_scan(NULL, NULL);
 }
 
 void AppTask::LightStateUpdateEventHandler(void)


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fix wifi dhcp failed. Wifi scan affects wifi DHCP and causes DHCP failure.

#### Change overview
Fix wifi dhcp failed.

#### Testing
How was this tested? (at least one bullet point required)
* When chip tool tool commission successfully with bl602, reset the bl602, and bl602 can get ip successfully.
