### PR TITLE
[binding] Support binding to self

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
+++ b/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp
@@ -79,6 +79,12 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
         return;
     }
 
+    if (binding.type == EMBER_UNICAST_BINDING && peer_device == nullptr)
+    {
+        ChipLogProgress(NotSpecified, "Binding to self");
+        return;
+    }
+
     if (binding.type == EMBER_UNICAST_BINDING && binding.local == 1 &&
         (!binding.clusterId.HasValue() || binding.clusterId.Value() == Clusters::OnOff::Id))
     {

--- a/examples/all-clusters-app/ameba/main/BindingHandler.cpp
+++ b/examples/all-clusters-app/ameba/main/BindingHandler.cpp
@@ -122,7 +122,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             break;
         }
     }
-    else if (binding.type == EMBER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == EMBER_UNICAST_BINDING && !data->isGroup && peer_device != nullptr)
     {
         switch (data->clusterId)
         {
@@ -130,6 +130,10 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device);
             break;
         }
+    }
+    else if (binding.type == EMBER_UNICAST_BINDING && peer_device == nullptr)
+    {
+        ChipLogProgress(NotSpecified, "Binding to self");
     }
 }
 

--- a/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
+++ b/examples/all-clusters-app/nxp/mw320/binding-handler.cpp
@@ -80,6 +80,12 @@ static void BoundDeviceChangedHandler(const EmberBindingTableEntry & binding, ch
         return;
     }
 
+    if (binding.type == EMBER_UNICAST_BINDING && peer_device == nullptr)
+    {
+        ChipLogProgress(NotSpecified, "Binding to self");
+        return;
+    }
+
     if (binding.type == EMBER_UNICAST_BINDING && binding.local == 1 &&
         (!binding.clusterId.HasValue() || binding.clusterId.Value() == Clusters::OnOff::Id))
     {

--- a/examples/light-switch-app/ameba/main/BindingHandler.cpp
+++ b/examples/light-switch-app/ameba/main/BindingHandler.cpp
@@ -122,7 +122,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             break;
         }
     }
-    else if (binding.type == EMBER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == EMBER_UNICAST_BINDING && !data->isGroup && peer_device != nullptr)
     {
         switch (data->clusterId)
         {
@@ -130,6 +130,10 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device);
             break;
         }
+    }
+    else if (binding.type == EMBER_UNICAST_BINDING && peer_device == nullptr)
+    {
+        ChipLogProgress(NotSpecified, "Binding to self");
     }
 }
 

--- a/examples/light-switch-app/efr32/src/binding-handler.cpp
+++ b/examples/light-switch-app/efr32/src/binding-handler.cpp
@@ -124,9 +124,16 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:
-            VerifyOrDie(peer_device != nullptr && peer_device->ConnectionReady());
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device->GetExchangeManager(),
-                                              peer_device->GetSecureSession().Value());
+            if (peer_device != nullptr)
+            {
+                VerifyOrDie(peer_device->ConnectionReady());
+                ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device->GetExchangeManager(),
+                                                  peer_device->GetSecureSession().Value());
+            }
+            else
+            {
+                ChipLogProgress(NotSpecified, "Binding to self");
+            }
             break;
         }
     }

--- a/examples/light-switch-app/esp32/main/BindingHandler.cpp
+++ b/examples/light-switch-app/esp32/main/BindingHandler.cpp
@@ -118,7 +118,7 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
             break;
         }
     }
-    else if (binding.type == EMBER_UNICAST_BINDING && !data->isGroup)
+    else if (binding.type == EMBER_UNICAST_BINDING && !data->isGroup && peer_device != nullptr)
     {
         switch (data->clusterId)
         {
@@ -128,6 +128,10 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
                                               peer_device->GetSecureSession().Value());
             break;
         }
+    }
+    else if (binding.type == EMBER_UNICAST_BINDING && peer_device == nullptr)
+    {
+        ChipLogProgress(NotSpecified, "Binding to self");
     }
 }
 

--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -222,7 +222,7 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
             break;
         }
     }
-    else if (binding.type == EMBER_UNICAST_BINDING && !data->IsGroup)
+    else if (binding.type == EMBER_UNICAST_BINDING && !data->IsGroup && deviceProxy != nullptr)
     {
         switch (data->ClusterId)
         {
@@ -236,6 +236,10 @@ void BindingHandler::LightSwitchChangedHandler(const EmberBindingTableEntry & bi
             ChipLogError(NotSpecified, "Invalid binding unicast command data");
             break;
         }
+    }
+    else if (binding.type == EMBER_UNICAST_BINDING && deviceProxy == nullptr)
+    {
+        ChipLogProgress(NotSpecified, "Binding to self");
     }
 }
 

--- a/examples/light-switch-app/telink/src/binding-handler.cpp
+++ b/examples/light-switch-app/telink/src/binding-handler.cpp
@@ -125,9 +125,16 @@ void LightSwitchChangedHandler(const EmberBindingTableEntry & binding, Operation
         switch (data->clusterId)
         {
         case Clusters::OnOff::Id:
-            VerifyOrDie(peer_device != nullptr && peer_device->ConnectionReady());
-            ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device->GetExchangeManager(),
-                                              peer_device->GetSecureSession().Value());
+            if (peer_device != nullptr)
+            {
+                VerifyOrDie(peer_device->ConnectionReady());
+                ProcessOnOffUnicastBindingCommand(data->commandId, binding, peer_device->GetExchangeManager(),
+                                                  peer_device->GetSecureSession().Value());
+            }
+            else
+            {
+                ChipLogProgress(NotSpecified, "Binding to self");
+            }
             break;
         }
     }

--- a/src/app/clusters/bindings/BindingManager.h
+++ b/src/app/clusters/bindings/BindingManager.h
@@ -32,7 +32,8 @@ namespace chip {
  * The connection is managed by the stack and peer_device is guaranteed to be available.
  * The application shall decide the content to be sent to the peer.
  *
- * For unicast bindings peer_device will be a connected peer and group will be empty.
+ * For unicast bindings to self, peer_device and group will be nullptr.
+ * For unicast bindings to other devices, peer_device will be a connected peer and group will be nullptr.
  * For multicast bindings peer_device will be nullptr.
  *
  * E.g. The application will send on/off commands to peer for the OnOff cluster.
@@ -130,6 +131,8 @@ private:
 
     static void HandleDeviceConnectionFailure(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
     void HandleDeviceConnectionFailure(const ScopedNodeId & peerId, CHIP_ERROR error);
+
+    bool IsSelf(const ScopedNodeId & nodeId);
 
     CHIP_ERROR EstablishConnection(const ScopedNodeId & nodeId);
 


### PR DESCRIPTION
#### Problem

If a device receives a binding entry pointing to it self, it will initiate a connection to self which will not succeed.


#### Change overview

The PR filters out the binding entries to self and directly forwards then to the user provided callback.


#### Testing
How was this tested? (at least one bullet point required)
* Manually tested on Linux `all-cluster-app`.

```
chip-tool airing onnetwork 1 20202021
chip-tool binding write binding '[{"fabricIndex": 1, "node":1, "endpoint":1, "cluster":6}]' 1 0x1
```

After typing the `switch on` command we will see the `Binding to self` output. The users are expected to implement their own application logic for self bindings.