### PR TITLE
[Docs] Update building guide for Ubuntu 22.04

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -8,7 +8,7 @@ Tested on:
 
 -   macOS 10.15
 -   Debian 11
--   Ubuntu 20.04 LTS
+-   Ubuntu 22.04 LTS
 
 Build system features:
 
@@ -81,9 +81,8 @@ dependency.
 
 ### Installing prerequisites on Raspberry Pi 4
 
-Using `rpi-imager`, install the Ubuntu _21.04_ 64-bit _server_ OS for arm64
-architectures on a micro SD card. This release will have bluez 5.55 or newer
-which is required for BLE functionality.
+Using `rpi-imager`, install the Ubuntu _22.04_ 64-bit _server_ OS for arm64
+architectures on a micro SD card.
 
 Boot the SD card, login with the default user account "ubuntu" and password
 "ubuntu", then proceed with


### PR DESCRIPTION
#### Problem
Build documentation was previously using Ubuntu Server 20.04, now that https://github.com/project-chip/connectedhomeip/issues/16664 has been addressed, Ubuntu Server 22.04 can now be used.

More changes may be needed, this is to start the discussion.

#### Change overview
Documentation updates in `docs/guides/BUILDING.md`.

#### Testing
How was this tested? (at least one bullet point required)
* If manually tested, what platforms controller and device platforms were manually tested, and how?
  * I manually tested using Ubuntu 22.04 on a Raspberry Pi 4, built the `chip-tool` example and used it setup and control a Realtek Ameba board that was running the `lighting app` example
