### PR TITLE
[EFR32]Correcting the pointer of matter_support and setting IPv4, WPA3 only for WiFi

### DIFF
--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -226,14 +226,6 @@ efr32_executable("light_switch_app") {
     sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
   }
 
-  if (chip_enable_wifi_ipv4) {
-    defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-  }
-
-  if (wifi_enable_security_wpa3) {
-    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-  }
-
   # WiFi Settings
   if (chip_enable_wifi) {
     if (use_rs911x) {
@@ -260,6 +252,14 @@ efr32_executable("light_switch_app") {
     } else if (use_wf200) {
       sources += wf200_plat_src
       include_dirs += wf200_plat_incs
+    }
+
+    if (chip_enable_wifi_ipv4) {
+      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+    }
+
+    if (wifi_enable_security_wpa3) {
+      defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
     }
   }
 

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -226,14 +226,6 @@ efr32_executable("lighting_app") {
     sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
   }
 
-  if (chip_enable_wifi_ipv4) {
-    defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-  }
-
-  if (wifi_enable_security_wpa3) {
-    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-  }
-
   # WiFi Settings
   if (chip_enable_wifi) {
     if (use_rs911x) {
@@ -260,6 +252,14 @@ efr32_executable("lighting_app") {
     } else if (use_wf200) {
       sources += wf200_plat_src
       include_dirs += wf200_plat_incs
+    }
+
+    if (chip_enable_wifi_ipv4) {
+      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+    }
+
+    if (wifi_enable_security_wpa3) {
+      defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
     }
   }
 

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -223,14 +223,6 @@ efr32_executable("lock_app") {
     sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
   }
 
-  if (chip_enable_wifi_ipv4) {
-    defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-  }
-
-  if (wifi_enable_security_wpa3) {
-    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-  }
-
   # WiFi Settings
   if (chip_enable_wifi) {
     if (use_rs911x) {
@@ -257,6 +249,14 @@ efr32_executable("lock_app") {
     } else if (use_wf200) {
       sources += wf200_plat_src
       include_dirs += wf200_plat_incs
+    }
+
+    if (chip_enable_wifi_ipv4) {
+      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+    }
+
+    if (wifi_enable_security_wpa3) {
+      defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
     }
   }
 

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -209,14 +209,6 @@ efr32_executable("window_app") {
     sources += [ "${examples_plat_dir}/OTAConfig.cpp" ]
   }
 
-  if (chip_enable_wifi_ipv4) {
-    defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
-  }
-
-  if (wifi_enable_security_wpa3) {
-    defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
-  }
-
   # WiFi Settings
   if (chip_enable_wifi) {
     if (use_rs911x) {
@@ -243,6 +235,14 @@ efr32_executable("window_app") {
     } else if (use_wf200) {
       sources += wf200_plat_src
       include_dirs += wf200_plat_incs
+    }
+
+    if (chip_enable_wifi_ipv4) {
+      defines += [ "CHIP_DEVICE_CONFIG_ENABLE_IPV4" ]
+    }
+
+    if (wifi_enable_security_wpa3) {
+      defines += [ "WIFI_ENABLE_SECURITY_WPA3=1" ]
     }
   }
 


### PR DESCRIPTION
#### Problem
third_party/silabs/matter_support was not pointing to correct pointer due to rebasing

#### Change overview
Correcting the pointer of third_party/silabs/matter_support repo to point to main head
setting the IPv4 and WPA3 functionality only for wifi 

#### Testing
Tested manually using EFR32+RS9116
