### PR TITLE
Fix the ReadClient destructor to call OnDeallocatePaths.

### DIFF
--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -68,20 +68,29 @@ void ReadClient::ClearActiveSubscriptionState()
 
 void ReadClient::StopResubscription()
 {
-
     CancelLivenessCheckTimer();
     CancelResubscribeTimer();
-    mpCallback.OnDeallocatePaths(std::move(mReadPrepareParams));
+
+    // Only deallocate the paths if they are not already deallocated.
+    if (mReadPrepareParams.mpAttributePathParamsList != nullptr || mReadPrepareParams.mpEventPathParamsList != nullptr ||
+        mReadPrepareParams.mpDataVersionFilterList != nullptr)
+    {
+        mpCallback.OnDeallocatePaths(std::move(mReadPrepareParams));
+        // Make sure we will never try to free those pointers again.
+        mReadPrepareParams.mpAttributePathParamsList    = nullptr;
+        mReadPrepareParams.mAttributePathParamsListSize = 0;
+        mReadPrepareParams.mpEventPathParamsList        = nullptr;
+        mReadPrepareParams.mEventPathParamsListSize     = 0;
+        mReadPrepareParams.mpDataVersionFilterList      = nullptr;
+        mReadPrepareParams.mDataVersionFilterListSize   = 0;
+    }
 }
 
 ReadClient::~ReadClient()
 {
+    Close(CHIP_NO_ERROR, /* allowResubscription = */ false, /* allowOnDone = */ false);
     if (IsSubscriptionType())
     {
-        CancelLivenessCheckTimer();
-        CancelResubscribeTimer();
-
-        //
         // Only remove ourselves from the engine's tracker list if we still continue to have a valid pointer to it.
         // This won't be the case if the engine shut down before this destructor was called (in which case, mpImEngine
         // will point to null)
@@ -141,7 +150,7 @@ CHIP_ERROR ReadClient::ScheduleResubscription(uint32_t aTimeTillNextResubscripti
     return CHIP_NO_ERROR;
 }
 
-void ReadClient::Close(CHIP_ERROR aError, bool allowResubscription)
+void ReadClient::Close(CHIP_ERROR aError, bool allowResubscription, bool allowOnDone)
 {
     if (IsReadType())
     {
@@ -182,7 +191,10 @@ void ReadClient::Close(CHIP_ERROR aError, bool allowResubscription)
         StopResubscription();
     }
 
-    mpCallback.OnDone(this);
+    if (allowOnDone)
+    {
+        mpCallback.OnDone(this);
+    }
 }
 
 const char * ReadClient::GetStateStr() const

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -200,8 +200,9 @@ public:
          * This function is invoked when using SendAutoResubscribeRequest, where the ReadClient was configured to auto re-subscribe
          * and the ReadPrepareParams was moved into this client for management. This will have to be free'ed appropriately by the
          * application. If SendAutoResubscribeRequest fails, this function will be called before it returns the failure. If
-         * SendAutoResubscribeRequest succeeds, this function will be called immediately before calling OnDone. If
-         * SendAutoResubscribeRequest is not called, this function will not be called.
+         * SendAutoResubscribeRequest succeeds, this function will be called immediately before calling OnDone, or
+         * when the ReadClient is destroyed, if that happens before OnDone. If  SendAutoResubscribeRequest is not called,
+         * this function will not be called.
          */
         virtual void OnDeallocatePaths(ReadPrepareParams && aReadPrepareParams) {}
 
@@ -271,14 +272,6 @@ public:
      * OnDone() will not be called.
      */
     ~ReadClient() override;
-
-    /*
-     * This forcibly closes the exchange context if a valid one is pointed to. Such a situation does
-     * not arise during normal message processing flows that all normally call Close() above. This can only
-     * arise due to application-initiated destruction of the object when this object is handling receiving/sending
-     * message payloads. Abort() should be called first before the object is destroyed.
-     */
-    void Abort();
 
     /**
      *  Send a request.  There can be one request outstanding on a given ReadClient.
@@ -482,8 +475,9 @@ private:
      * AND if this ReadClient instance is tracking a subscription AND the applications decides to do so
      * in their implementation of Callback::OnResubscriptionNeeded().
      *
+     * If allowOnDone is false, will not call OnDone.
      */
-    void Close(CHIP_ERROR aError, bool allowResubscription = true);
+    void Close(CHIP_ERROR aError, bool allowResubscription = true, bool allowOnDone = true);
 
     void StopResubscription();
     void ClearActiveSubscriptionState();

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1761,6 +1761,7 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
 
         delegate.mGotReport = false;
 
+        attributePathParams.release();
         err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -1866,6 +1867,7 @@ void TestReadInteraction::TestSubscribePartialOverlap(nlTestSuite * apSuite, voi
 
         delegate.mGotReport = false;
 
+        attributePathParams.release();
         err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
@@ -1942,6 +1944,7 @@ void TestReadInteraction::TestSubscribeSetDirtyFullyOverlap(nlTestSuite * apSuit
 
         delegate.mGotReport = false;
 
+        attributePathParams.release();
         err = readClient.SendAutoResubscribeRequest(std::move(readPrepareParams));
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 

--- a/src/controller/TypedReadCallback.h
+++ b/src/controller/TypedReadCallback.h
@@ -65,6 +65,13 @@ public:
         mBufferedReadAdapter(*this)
     {}
 
+    ~TypedReadAttributeCallback()
+    {
+        // Ensure we release the ReadClient before we tear down anything else,
+        // so it can call our OnDeallocatePaths properly.
+        mReadClient = nullptr;
+    }
+
     app::BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }
 
     void AdoptReadClient(Platform::UniquePtr<app::ReadClient> aReadClient) { mReadClient = std::move(aReadClient); }
@@ -179,6 +186,13 @@ public:
         mOnError(aOnError), mOnDone(aOnDone), mOnSubscriptionEstablished(aOnSubscriptionEstablished),
         mOnResubscriptionAttempt(aOnResubscriptionAttempt)
     {}
+
+    ~TypedReadEventCallback()
+    {
+        // Ensure we release the ReadClient before we tear down anything else,
+        // so it can call our OnDeallocatePaths properly.
+        mReadClient = nullptr;
+    }
 
     void AdoptReadClient(Platform::UniquePtr<app::ReadClient> aReadClient) { mReadClient = std::move(aReadClient); }
 

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -299,6 +299,13 @@ public:
     {
     }
 
+    ~SubscriptionCallback()
+    {
+        // Ensure we release the ReadClient before we tear down anything else,
+        // so it can call our OnDeallocatePaths properly.
+        mReadClient = nullptr;
+    }
+
     BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }
 
     // We need to exist to get a ReadClient, so can't take this as a constructor argument.
@@ -765,6 +772,13 @@ public:
         , mOnSubscriptionEstablished(aOnSubscriptionEstablished)
         , mBufferedReadAdapter(*this)
     {
+    }
+
+    ~BufferedReadAttributeCallback()
+    {
+        // Ensure we release the ReadClient before we tear down anything else,
+        // so it can call our OnDeallocatePaths properly.
+        mReadClient = nullptr;
     }
 
     app::BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -127,6 +127,13 @@ public:
     {
     }
 
+    ~SubscriptionCallback()
+    {
+        // Ensure we release the ReadClient before we tear down anything else,
+        // so it can call our OnDeallocatePaths properly.
+        mReadClient = nullptr;
+    }
+
     BufferedReadCallback & GetBufferedCallback() { return mBufferedReadAdapter; }
 
     // We need to exist to get a ReadClient, so can't take this as a constructor argument.


### PR DESCRIPTION
This is actually somewhat dangerous, because there is a good chance ~ReadClient
is running from under the destructor of the ReadClient::Callback and we are
invoking a virtual method on the callback.  But this is the only way to ensure
we don't leak.  ReadClient::Callback implementations need to be able to handle
this.

Fixes https://github.com/project-chip/connectedhomeip/issues/21658

#### Problem
We never call OnDeallocatePaths if a ReadClient with auto-resubscribe is destroyed.

#### Change overview
Call it.

#### Testing
```
LSAN_OPTIONS="detect_leaks=1" chip-tool interactive start
```
and at the interactive prompt run:
```
basic subscribe data-model-revision 1 100 17 0 --auto-resubscribe true

quit()
```

Without this PR it shows path leaks.