### PR TITLE
Make sure chip-tool interactive cleanup happens on the Matter thread.

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -443,7 +443,7 @@ void CHIPCommand::StopWaiting()
 #endif // CONFIG_USE_SEPARATE_EVENTLOOP
 }
 
-void CHIPCommand::ExecuteDeferredCleanups()
+void CHIPCommand::ExecuteDeferredCleanups(intptr_t ignored)
 {
     for (auto * cmd : sDeferredCleanups)
     {

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -115,7 +115,7 @@ protected:
     virtual bool DeferInteractiveCleanup() { return false; }
 
     // Execute any deferred cleanups.  Used when exiting interactive mode.
-    void ExecuteDeferredCleanups();
+    static void ExecuteDeferredCleanups(intptr_t ignored);
 
 #ifdef CONFIG_USE_LOCAL_STORAGE
     PersistentStorage mDefaultStorage;

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -89,7 +89,7 @@ bool InteractiveStartCommand::ParseCommand(char * command)
 {
     if (strcmp(command, kInteractiveModeStopCommand) == 0)
     {
-        ExecuteDeferredCleanups();
+        chip::DeviceLayer::PlatformMgr().ScheduleWork(ExecuteDeferredCleanups, 0);
         return false;
     }
 


### PR DESCRIPTION
The interactive cleanup happens while the event loop is still running
(during the execution of the "interactive" command), so queuing the
cleanup on the event loop is reasonable.  And this ensures cleanups
don't run into MAtter locking assertions.

#### Problem
Fatal assertions if quitting while there is a live subscription with re-subscription enabled.

#### Change overview
Fix assertions.

#### Testing
Tried quitting, no more asserts.