### PR TITLE
[Tizen] Fix build when BLE support is disabled

### DIFF
--- a/config/tizen/chip-gn/platform/BUILD.gn
+++ b/config/tizen/chip-gn/platform/BUILD.gn
@@ -54,11 +54,11 @@ if (chip_enable_ble) {
   pkg_config("capi-network-bluetooth") {
     packages = [ "capi-network-bluetooth" ]
   }
+}
 
-  if (chip_enable_openthread) {
-    pkg_config("capi-network-thread") {
-      packages = [ "capi-network-thread" ]
-    }
+if (chip_enable_openthread) {
+  pkg_config("capi-network-thread") {
+    packages = [ "capi-network-thread" ]
   }
 }
 


### PR DESCRIPTION
#### Problem

Building examples for Tizen without BLE is currently broken.

#### Change overview

- fix Tizen BLE/OpenThread dependencies

#### Testing

Tested all build variants:

```sh
./scripts/build/build_examples.py --target tizen-arm-light build
./scripts/build/build_examples.py --target tizen-arm-light-no-ble build
./scripts/build/build_examples.py --target tizen-arm-light-no-wifi build
./scripts/build/build_examples.py --target tizen-arm-light-no-ble-no-wifi build
```