### PR TITLE
RPC: Fix NRF Attributes service

### DIFF
--- a/examples/platform/nrfconnect/Rpc.cpp
+++ b/examples/platform/nrfconnect/Rpc.cpp
@@ -117,7 +117,7 @@ public:
 
 namespace {
 
-constexpr size_t kRpcTaskSize = 4096;
+constexpr size_t kRpcTaskSize = 5120;
 constexpr int kRpcPriority    = 5;
 
 K_THREAD_STACK_DEFINE(rpc_stack_area, kRpcTaskSize);


### PR DESCRIPTION
#### Problem
Device was crashing while reading attricutes using the RPC attribute service.

#### Change overview
Increase stack for RPC thread (only included in RPC variants of the example apps)

#### Testing
Built RPC variant of nrf lighting app, and verified Attribute read works:
```
>>> rpcs.chip.rpc.Attributes.Read(endpoint=1,cluster=0x0006,attribute_id=0,type=protos.chip.rpc.AttributeType.ZCL_BOOLEAN_ATTRIBUTE_TYPE)
(Status.OK, chip.rpc.AttributeData(
    data_bool=False,
    tlv_data=
    b'\x15\x36\x01\x15\x35\x01\x26\x00\x6A\x14\xA9\x62\x37\x01\x24\x02\x01\x24\x03\x06\x24\x04\x00\x18\x28\x02\x18\x18\x18\x18'
))
```