### PR TITLE
[TI] updating ConnectivityManagerImpl CC32xx files to reflect updates in PR 19784

### DIFF
--- a/src/platform/cc32xx/ConnectivityManagerImpl.cpp
+++ b/src/platform/cc32xx/ConnectivityManagerImpl.cpp
@@ -19,6 +19,12 @@
 #include <platform/internal/CHIPDeviceLayerInternal.h>
 
 #include <platform/ConnectivityManager.h>
+#include <platform/internal/GenericConnectivityManagerImpl_UDP.ipp>
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+#include <platform/internal/GenericConnectivityManagerImpl_TCP.ipp>
+#endif
+
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.ipp>
 #endif

--- a/src/platform/cc32xx/ConnectivityManagerImpl.h
+++ b/src/platform/cc32xx/ConnectivityManagerImpl.h
@@ -26,6 +26,11 @@
 
 #include <platform/ConnectivityManager.h>
 #include <platform/internal/GenericConnectivityManagerImpl.h>
+#include <platform/internal/GenericConnectivityManagerImpl_UDP.h>
+
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+#include <platform/internal/GenericConnectivityManagerImpl_TCP.h>
+#endif
 #include <platform/internal/GenericConnectivityManagerImpl_WiFi.h>
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
 #include <platform/internal/GenericConnectivityManagerImpl_BLE.h>
@@ -50,6 +55,10 @@ namespace DeviceLayer {
  */
 class ConnectivityManagerImpl final : public ConnectivityManager,
                                       public Internal::GenericConnectivityManagerImpl<ConnectivityManagerImpl>,
+                                      public Internal::GenericConnectivityManagerImpl_UDP<ConnectivityManagerImpl>,
+#if INET_CONFIG_ENABLE_TCP_ENDPOINT
+                                      public Internal::GenericConnectivityManagerImpl_TCP<ConnectivityManagerImpl>,
+#endif
                                       public Internal::GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>,
 #if CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
                                       public Internal::GenericConnectivityManagerImpl_BLE<ConnectivityManagerImpl>,


### PR DESCRIPTION
#### Problem
What is being fixed?  
CC32xx ConnectivityManagerImpl files needed include statements added in PR 19784

#### Change overview
Include statements needed in CC32xx ConnectivityManagerImpl.cpp and ConnectivityManagerImpl.h 

#### Testing
How was this tested? (at least one bullet point required)
*Build example after adding include statements in source and header file
