### PR TITLE
Fix TC_CADMIN_1_9 and TC_CADMIN_1_10 tests to not be broken.

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_10.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_10.yaml
@@ -32,12 +32,12 @@ config:
     discriminator:
         type: int16u
         defaultValue: 3840
-    payload:
+    correctPayload:
         type: char_string
-        defaultValue: "MT:0000000000I31506010"
-    payload2:
+        defaultValue: "MT:-24J0AFN00KA0648G00"
+    incorrectSetupCodePayload:
         type: char_string
-        defaultValue: "MT:0000000000I.0648G00"
+        defaultValue: "MT:-24J0AFN00I.0648G00"
 
 tests:
     - label: "TH_CR1 starts a commissioning process with DUT_CE"
@@ -48,6 +48,63 @@ tests:
           values:
               - name: "nodeId"
                 value: nodeId
+
+    - label:
+          "Open commissioning window exactly like we plan to later to verify
+          that `correctPayload` can in fact commision the device."
+      cluster: "AdministratorCommissioning"
+      command: "OpenBasicCommissioningWindow"
+      PICS: CADMIN.S.C01.Rsp
+      timedInteractionTimeoutMs: 10000
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 900
+
+    - label:
+          "Temporarily commission device with `correctPayload` just like we will
+          try to later"
+      identity: "beta"
+      cluster: "CommissionerCommands"
+      command: "PairWithCode"
+      # Only run this if we ran the previous step.
+      PICS: CADMIN.S && CADMIN.S.C01.Rsp
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId2
+              - name: "payload"
+                value: correctPayload
+
+    - label: "Wait for a CASE session"
+      identity: "beta"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      PICS: CADMIN.S
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId2
+
+    - label: "Read FabricIndex of beta so we can delete the temp fabric"
+      identity: "beta"
+      cluster: "Operational Credentials"
+      command: "readAttribute"
+      attribute: "CurrentFabricIndex"
+      # Only run this if we commissioned the device.
+      PICS: CADMIN.S.C01.Rsp
+      response:
+          saveAs: tempFabricIndex
+
+    - label: "Remove the temp fabric"
+      cluster: "Operational Credentials"
+      command: "RemoveFabric"
+      # Only run this if we commissioned the device.
+      PICS: CADMIN.S.C01.Rsp
+      arguments:
+          values:
+              - name: "FabricIndex"
+                value: tempFabricIndex
 
     - label: "TH_CR1 opens a commissioning window on DUT_CE"
       cluster: "AdministratorCommissioning"
@@ -71,7 +128,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -87,7 +144,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -103,7 +160,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -119,7 +176,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -135,7 +192,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -151,7 +208,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -167,7 +224,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -183,7 +240,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -199,7 +256,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -214,23 +271,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
-      response:
-          error: FAILURE
-
-    - label:
-          "TH_CR2 starts a commissioning process with DUT_CE using Invalid setup
-          code"
-      identity: "beta"
-      cluster: "CommissionerCommands"
-      command: "PairWithCode"
-      PICS: CADMIN.S
-      arguments:
-          values:
-              - name: "nodeId"
-                value: nodeId2
-              - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -246,7 +287,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -262,7 +303,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -278,7 +319,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -294,7 +335,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -310,7 +351,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -326,7 +367,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -342,7 +383,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -358,7 +399,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -374,10 +415,27 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
+    - label:
+          "TH_CR2 starts a commissioning process with DUT_CE using Invalid setup
+          code"
+      identity: "beta"
+      cluster: "CommissionerCommands"
+      command: "PairWithCode"
+      PICS: CADMIN.S
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId2
+              - name: "payload"
+                value: incorrectSetupCodePayload
+      response:
+          error: FAILURE
+
+    # This step must match the verification step above where we checked `correctPayload`
     - label:
           "TH_CR2 attempts to do PASE to DUT_CE using the correct onboarding
           payload"
@@ -390,6 +448,6 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload
+                value: correctPayload
       response:
           error: FAILURE

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_9.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_9.yaml
@@ -32,12 +32,12 @@ config:
     discriminator:
         type: int16u
         defaultValue: 3840
-    payload:
+    correctPayload:
         type: char_string
-        defaultValue: "MT:-24J0AFN00KA0648G00"
-    payload2:
+        defaultValue: "MT:-24J0AFN00I31506010"
+    incorrectSetupCodePayload:
         type: char_string
-        defaultValue: "MT:0000000000I.0648G00"
+        defaultValue: "MT:-24J0AFN00I.0648G00"
 
 tests:
     - label: "TH_CR1 starts a commissioning process with DUT_CE"
@@ -48,6 +48,71 @@ tests:
           values:
               - name: "nodeId"
                 value: nodeId
+
+    - label:
+          "Open commissioning window exactly like we plan to later to verify
+          that `correctPayload` can in fact commision the device."
+      cluster: "AdministratorCommissioning"
+      command: "OpenCommissioningWindow"
+      timedInteractionTimeoutMs: 10000
+      PICS: CADMIN.S.C00.Rsp
+      arguments:
+          values:
+              - name: "CommissioningTimeout"
+                value: 900
+              - name: "PAKEVerifier"
+                value: "\x06\xc7\x56\xdf\xfc\xd7\x22\x65\x34\x52\xa1\x2d\xcd\x94\x5d\x8c\x54\xda\x2b\x0f\x3c\xbd\x1b\x4d\xc3\xf1\xad\xb2\x23\xae\xb2\x6b\x04\x7c\xd2\x4c\x96\x86\x6f\x97\x9b\x1d\x83\xec\x50\xe2\xb4\xae\x30\xcd\xf2\xfd\xb3\x2b\xd8\xa2\x11\xb8\x37\xdc\x94\xed\xcd\x56\xf4\xd1\x43\x77\x19\x10\x76\xbf\xc5\x9d\x99\xb7\xdd\x30\x53\xef\xd6\xf0\x2c\x44\x34\xf2\xbd\xd2\x7a\xa4\xf9\xce\xa7\x0d\x73\x8e\x4c"
+              - name: "discriminator"
+                value: discriminator
+              - name: "iterations"
+                value: 1000
+              - name: "salt"
+                value: "SPAKE2P Key Salt"
+
+    - label:
+          "Temporarily commission device with `correctPayload` just like we will
+          try to later"
+      identity: "beta"
+      cluster: "CommissionerCommands"
+      command: "PairWithCode"
+      # Only run this if we ran the previous step.
+      PICS: CADMIN.S && CADMIN.S.C00.Rsp
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId2
+              - name: "payload"
+                value: correctPayload
+
+    - label: "Wait for a CASE session"
+      identity: "beta"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      PICS: CADMIN.S
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId2
+
+    - label: "Read FabricIndex of beta so we can delete the temp fabric"
+      identity: "beta"
+      cluster: "Operational Credentials"
+      command: "readAttribute"
+      attribute: "CurrentFabricIndex"
+      # Only run this if we commissioned the device.
+      PICS: CADMIN.S.C00.Rsp
+      response:
+          saveAs: tempFabricIndex
+
+    - label: "Remove the temp fabric"
+      cluster: "Operational Credentials"
+      command: "RemoveFabric"
+      # Only run this if we commissioned the device.
+      PICS: CADMIN.S.C00.Rsp
+      arguments:
+          values:
+              - name: "FabricIndex"
+                value: tempFabricIndex
 
     - label: "TH_CR1 opens a new commissioning window on DUT_CE"
       cluster: "AdministratorCommissioning"
@@ -79,7 +144,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -95,7 +160,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -111,7 +176,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -127,7 +192,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -143,7 +208,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -159,7 +224,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -175,7 +240,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -191,7 +256,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -207,7 +272,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -223,7 +288,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -239,7 +304,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -255,7 +320,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -271,7 +336,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -287,7 +352,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -303,7 +368,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -319,7 +384,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -335,7 +400,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -351,7 +416,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -367,7 +432,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
@@ -383,10 +448,11 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload2
+                value: incorrectSetupCodePayload
       response:
           error: FAILURE
 
+    # This step must match the verification step above where we checked `payload`
     - label:
           "TH_CR2 starts a commissioning process with DUT_CE using valid setup
           code"
@@ -399,7 +465,7 @@ tests:
               - name: "nodeId"
                 value: nodeId2
               - name: "payload"
-                value: payload
+                value: correctPayload
       response:
           error: FAILURE
 
@@ -413,6 +479,6 @@ tests:
               - name: "nodeId"
                 value: nodeId3
               - name: "payload"
-                value: payload
+                value: correctPayload
       response:
           error: FAILURE


### PR DESCRIPTION
There were several issues:

* The values of the "payload" variable were mixed up between the two tests.  as
  a result, "payload" actually had an incorrect setup code in both tests, and
  the tests testing that commissioning fails actually tested nothing at all,
  because it was guaranteed to fail.

* Some of the setup payloads involved claimed a zero discovery capability
  bitmask, instead of the expected "bit 2 is set to indicate on-network
  commissioning".  This led to a lot of BLE traffic when these tests run.

The specific fixes here are:

1) In TC_CADMIN_1_9, regenerate the "payload" value by running:

        chip-tool payload generate-qrcode --vendor-id 65521 --product-id 32769 --discriminator 3840 --rendezvous 4 --setup-pin-code 47514138

   and regenerate "payload2" by running:

        chip-tool payload generate-qrcode --vendor-id 65521 --product-id 32769 --discriminator 3840 --rendezvous 4 --setup-pin-code 20202023

   This ensures that the only difference between "payload" and "payload2" is the
   setup code, and sets the setup code for "payload" to match the verifier we
   are using.

2) In TC_CADMIN_1_10, regenerate the "payload" value by running:

         chip-tool payload generate-qrcode --vendor-id 65521 --product-id 32769 --discriminator 3840 --rendezvous 4 --setup-pin-code 20202021

   and regenerate "payload2" by running:

        chip-tool payload generate-qrcode --vendor-id 65521 --product-id 32769 --discriminator 3840 --rendezvous 4 --setup-pin-code 20202023

3) In both tests, add verification that the "payload" value can in fact
   commission the device properly when a commissioning window is opened the way
   the test opens it, so the rest of the test is meaningful.

4) Rename "payload" and "payload2" to more meaningful names.

