### PR TITLE
chip-tool: add more flexibility in PAA root folder selection

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -41,6 +41,7 @@ constexpr chip::FabricId kIdentityAlphaFabricId = 1;
 constexpr chip::FabricId kIdentityBetaFabricId  = 2;
 constexpr chip::FabricId kIdentityGammaFabricId = 3;
 constexpr chip::FabricId kIdentityOtherFabricId = 4;
+constexpr const char *kTrustStorePathVariable = "CHIPTOOL_PAA_TRUST_STORE_PATH";
 
 namespace {
 const chip::Credentials::AttestationTrustStore * GetTestFileAttestationTrustStore(const char * paaTrustStorePath)
@@ -99,6 +100,12 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     factoryInitParams.listenPort = port;
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
 
+    if (!mPaaTrustStorePath.HasValue()) {
+      char * const trust_store_path = getenv(kTrustStorePathVariable);
+      if (trust_store_path != nullptr) {
+        mPaaTrustStorePath.SetValue(trust_store_path);
+      }
+    }
     const chip::Credentials::AttestationTrustStore * trustStore = mPaaTrustStorePath.HasValue()
         ? GetTestFileAttestationTrustStore(mPaaTrustStorePath.Value())
         : chip::Credentials::GetTestAttestationTrustStore();
@@ -107,9 +114,9 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     {
         ChipLogError(chipTool, "No PAAs found in path: %s", mPaaTrustStorePath.Value());
         ChipLogError(chipTool,
-                     "Please specify a valid path containing trusted PAA certificates using [--paa-trust-store-path paa/file/path] "
-                     "argument");
-
+                     "Please specify a valid path containing trusted PAA certificates using"
+                     "the argument [--paa-trust-store-path paa/file/path]"
+                     "or environment variable [%s=paa/file/path]", kTrustStorePathVariable);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 

--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -41,7 +41,7 @@ constexpr chip::FabricId kIdentityAlphaFabricId = 1;
 constexpr chip::FabricId kIdentityBetaFabricId  = 2;
 constexpr chip::FabricId kIdentityGammaFabricId = 3;
 constexpr chip::FabricId kIdentityOtherFabricId = 4;
-constexpr const char *kTrustStorePathVariable = "CHIPTOOL_PAA_TRUST_STORE_PATH";
+constexpr const char * kTrustStorePathVariable  = "CHIPTOOL_PAA_TRUST_STORE_PATH";
 
 namespace {
 const chip::Credentials::AttestationTrustStore * GetTestFileAttestationTrustStore(const char * paaTrustStorePath)
@@ -100,11 +100,13 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
     factoryInitParams.listenPort = port;
     ReturnLogErrorOnFailure(DeviceControllerFactory::GetInstance().Init(factoryInitParams));
 
-    if (!mPaaTrustStorePath.HasValue()) {
-      char * const trust_store_path = getenv(kTrustStorePathVariable);
-      if (trust_store_path != nullptr) {
-        mPaaTrustStorePath.SetValue(trust_store_path);
-      }
+    if (!mPaaTrustStorePath.HasValue())
+    {
+        char * const trust_store_path = getenv(kTrustStorePathVariable);
+        if (trust_store_path != nullptr)
+        {
+            mPaaTrustStorePath.SetValue(trust_store_path);
+        }
     }
     const chip::Credentials::AttestationTrustStore * trustStore = mPaaTrustStorePath.HasValue()
         ? GetTestFileAttestationTrustStore(mPaaTrustStorePath.Value())
@@ -116,7 +118,8 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
         ChipLogError(chipTool,
                      "Please specify a valid path containing trusted PAA certificates using"
                      "the argument [--paa-trust-store-path paa/file/path]"
-                     "or environment variable [%s=paa/file/path]", kTrustStorePathVariable);
+                     "or environment variable [%s=paa/file/path]",
+                     kTrustStorePathVariable);
         return CHIP_ERROR_INVALID_ARGUMENT;
     }
 


### PR DESCRIPTION
#### Problem

Fixes #21681 chip-tool: add more flexibility in PAA root folder selection

#### Change overview

If `--paa-trust-store-path` is not given, and the environment variable
`CHIPTOOL_PAA_TRUST_STORE_PATH` exists, use its value.

#### Testing

Manual confirmation of the logged `mPaaTrustStorePath.Value()`.
