### PR TITLE
Clearly distinguish between unknown and all-0 discovery capabilities.

### DIFF
--- a/examples/all-clusters-app/nxp/mw320/main.cpp
+++ b/examples/all-clusters-app/nxp/mw320/main.cpp
@@ -775,7 +775,7 @@ std::string createSetupPayload()
     payload.version               = 0;
     payload.discriminator         = discriminator;
     payload.setUpPINCode          = setupPINCode;
-    payload.rendezvousInformation = RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE);
+    payload.rendezvousInformation.SetValue(chip::RendezvousInformationFlag::kBLE);
     payload.vendorID              = vendorId;
     payload.productID             = productId;
 

--- a/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadGenerateCommand.cpp
@@ -77,7 +77,12 @@ CHIP_ERROR SetupPayloadGenerateQRCodeCommand::Run()
 
     if (mRendezvous.HasValue())
     {
-        payload.rendezvousInformation.SetRaw(mRendezvous.Value());
+        payload.rendezvousInformation.Emplace().SetRaw(mRendezvous.Value());
+    }
+    else if (!payload.rendezvousInformation.HasValue())
+    {
+        // Default to not having anything in the discovery capabilities.
+        payload.rendezvousInformation.SetValue(RendezvousInformationFlag::kNone);
     }
 
     if (mTLVBytes.HasValue())

--- a/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
+++ b/examples/chip-tool/commands/payload/SetupPayloadParseCommand.cpp
@@ -78,35 +78,43 @@ CHIP_ERROR SetupPayloadParseCommand::Print(chip::SetupPayload payload)
     {
         StringBuilder<128> humanFlags;
 
-        if (payload.rendezvousInformation.HasAny())
+        if (!payload.rendezvousInformation.HasValue())
         {
-            if (payload.rendezvousInformation.Has(RendezvousInformationFlag::kSoftAP))
-            {
-                humanFlags.Add("Soft-AP");
-            }
-            if (payload.rendezvousInformation.Has(RendezvousInformationFlag::kBLE))
-            {
-                if (!humanFlags.Empty())
-                {
-                    humanFlags.Add(", ");
-                }
-                humanFlags.Add("BLE");
-            }
-            if (payload.rendezvousInformation.Has(RendezvousInformationFlag::kOnNetwork))
-            {
-                if (!humanFlags.Empty())
-                {
-                    humanFlags.Add(", ");
-                }
-                humanFlags.Add("On IP network");
-            }
+            ChipLogProgress(SetupPayload, "Discovery Bitmask:   UNKNOWN");
         }
         else
         {
-            humanFlags.Add("NONE");
-        }
+            if (payload.rendezvousInformation.Value().HasAny())
+            {
+                if (payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kSoftAP))
+                {
+                    humanFlags.Add("Soft-AP");
+                }
+                if (payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kBLE))
+                {
+                    if (!humanFlags.Empty())
+                    {
+                        humanFlags.Add(", ");
+                    }
+                    humanFlags.Add("BLE");
+                }
+                if (payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kOnNetwork))
+                {
+                    if (!humanFlags.Empty())
+                    {
+                        humanFlags.Add(", ");
+                    }
+                    humanFlags.Add("On IP network");
+                }
+            }
+            else
+            {
+                humanFlags.Add("NONE");
+            }
 
-        ChipLogProgress(SetupPayload, "Capabilities:        0x%02X (%s)", payload.rendezvousInformation.Raw(), humanFlags.c_str());
+            ChipLogProgress(SetupPayload, "Discovery Bitmask:   0x%02X (%s)", payload.rendezvousInformation.Value().Raw(),
+                            humanFlags.c_str());
+        }
     }
     if (payload.discriminator.IsShortDiscriminator())
     {

--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -84,33 +84,34 @@ CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
     NSLog(@"ProductID:     %@", payload.productID);
     NSLog(@"Custom flow:   %lu    (%@)", payload.commissioningFlow, CustomFlowString(payload.commissioningFlow));
     {
-        NSMutableString * humanFlags = [[NSMutableString alloc] init];
+        if (payload.rendezvousInformation == nil) {
+            NSLog(@"Capabilities:  UNKNOWN");
+        } else {
+            NSMutableString * humanFlags = [[NSMutableString alloc] init];
 
-        if (payload.rendezvousInformation) {
-            if (payload.rendezvousInformation & MTRRendezvousInformationNone) {
+            auto value = [payload.rendezvousInformation unsignedLongValue];
+            if (value == MTRDiscoveryCapabilitiesNone) {
                 [humanFlags appendString:@"NONE"];
             } else {
-                if (payload.rendezvousInformation & MTRRendezvousInformationSoftAP) {
+                if (value & MTRDiscoveryCapabilitiesSoftAP) {
                     [humanFlags appendString:@"SoftAP"];
                 }
-                if (payload.rendezvousInformation & MTRRendezvousInformationBLE) {
+                if (value & MTRDiscoveryCapabilitiesBLE) {
                     if (!humanFlags) {
                         [humanFlags appendString:@", "];
                     }
                     [humanFlags appendString:@"BLE"];
                 }
-                if (payload.rendezvousInformation & MTRRendezvousInformationOnNetwork) {
+                if (value & MTRDiscoveryCapabilitiesOnNetwork) {
                     if (!humanFlags) {
                         [humanFlags appendString:@", "];
                     }
                     [humanFlags appendString:@"ON NETWORK"];
                 }
             }
-        } else {
-            [humanFlags appendString:@"NONE"];
-        }
 
-        NSLog(@"Capabilities:  0x%02lX (%@)", payload.rendezvousInformation, humanFlags);
+            NSLog(@"Capabilities:  0x%02lX (%@)", value, humanFlags);
+        }
     }
     NSLog(@"Discriminator: %@", payload.discriminator);
     NSLog(@"Passcode:      %@", payload.setUpPINCode);

--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -186,9 +186,9 @@ int ChipLinuxAppInit(int argc, char * const argv[], OptionSet * customOptions)
                                                    LinuxDeviceOptions::GetInstance());
     SuccessOrExit(err);
 
-    if (LinuxDeviceOptions::GetInstance().payload.rendezvousInformation.HasAny())
+    if (LinuxDeviceOptions::GetInstance().payload.rendezvousInformation.HasValue())
     {
-        rendezvousFlags = LinuxDeviceOptions::GetInstance().payload.rendezvousInformation;
+        rendezvousFlags = LinuxDeviceOptions::GetInstance().payload.rendezvousInformation.Value();
     }
 
     err = GetPayloadContents(LinuxDeviceOptions::GetInstance().payload, rendezvousFlags);

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -283,7 +283,7 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
         break;
 
     case kDeviceOption_Capabilities:
-        LinuxDeviceOptions::GetInstance().payload.rendezvousInformation.SetRaw(static_cast<uint8_t>(atoi(aValue)));
+        LinuxDeviceOptions::GetInstance().payload.rendezvousInformation.Emplace().SetRaw(static_cast<uint8_t>(atoi(aValue)));
         break;
 
     case kDeviceOption_Discriminator: {

--- a/src/app/server/OnboardingCodesUtil.cpp
+++ b/src/app/server/OnboardingCodesUtil.cpp
@@ -98,9 +98,9 @@ void ShareQRCodeOverNFC(chip::RendezvousInformationFlags aRendezvousFlags)
 
 CHIP_ERROR GetPayloadContents(chip::PayloadContents & aPayload, chip::RendezvousInformationFlags aRendezvousFlags)
 {
-    CHIP_ERROR err                 = CHIP_NO_ERROR;
-    aPayload.version               = 0;
-    aPayload.rendezvousInformation = aRendezvousFlags;
+    CHIP_ERROR err   = CHIP_NO_ERROR;
+    aPayload.version = 0;
+    aPayload.rendezvousInformation.SetValue(aRendezvousFlags);
 
     err = GetCommissionableDataProvider()->GetSetupPasscode(aPayload.setUpPINCode);
     if (err != CHIP_NO_ERROR)

--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -98,7 +98,7 @@ CHIP_ERROR CommissioningWindowOpener::OpenCommissioningWindow(NodeId deviceId, S
 
     mSetupPayload.version = 0;
     mSetupPayload.discriminator.SetLongValue(discriminator);
-    mSetupPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kOnNetwork);
+    mSetupPayload.rendezvousInformation.SetValue(RendezvousInformationFlag::kOnNetwork);
 
     mCommissioningWindowCallback      = callback;
     mBasicCommissioningWindowCallback = nullptr;

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -71,8 +71,8 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
     CHIP_ERROR err = CHIP_NO_ERROR;
     bool isRunning = false;
 
-    bool searchOverAll = payload.rendezvousInformation == RendezvousInformationFlag::kNone;
-    if (searchOverAll || payload.rendezvousInformation == RendezvousInformationFlag::kBLE)
+    bool searchOverAll = !payload.rendezvousInformation.HasValue();
+    if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kBLE))
     {
         if (CHIP_NO_ERROR == (err = StartDiscoverOverBle(payload)))
         {
@@ -81,7 +81,7 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
         VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
     }
 
-    if (searchOverAll || payload.rendezvousInformation == RendezvousInformationFlag::kSoftAP)
+    if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kSoftAP))
     {
         if (CHIP_NO_ERROR == (err = StartDiscoverOverSoftAP(payload)))
         {

--- a/src/controller/python/chip/setup_payload/Generator.cpp
+++ b/src/controller/python/chip/setup_payload/Generator.cpp
@@ -40,7 +40,7 @@ extern "C" ChipError::StorageType pychip_SetupPayload_PrintOnboardingCodes(uint3
     payload.vendorID     = vendorId;
     payload.productID    = productId;
     payload.discriminator.SetLongValue(discriminator);
-    payload.rendezvousInformation = rendezvousFlags.SetRaw(capabilities);
+    payload.rendezvousInformation.SetValue(rendezvousFlags.SetRaw(capabilities));
 
     switch (customFlow)
     {

--- a/src/controller/python/chip/setup_payload/Parser.cpp
+++ b/src/controller/python/chip/setup_payload/Parser.cpp
@@ -38,7 +38,10 @@ void YieldSetupPayloadAttributes(const SetupPayload & payload, AttributeVisitor 
     attrVisitor("VendorID", std::to_string(payload.vendorID).c_str());
     attrVisitor("ProductID", std::to_string(payload.productID).c_str());
     attrVisitor("CommissioningFlow", std::to_string(static_cast<uint8_t>(payload.commissioningFlow)).c_str());
-    attrVisitor("RendezvousInformation", std::to_string(payload.rendezvousInformation.Raw()).c_str());
+    if (payload.rendezvousInformation.HasValue())
+    {
+        attrVisitor("RendezvousInformation", std::to_string(payload.rendezvousInformation.Value().Raw()).c_str());
+    }
     if (payload.discriminator.IsShortDiscriminator())
     {
         attrVisitor("Short discriminator", std::to_string(payload.discriminator.GetShortValue()).c_str());

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/QRCode/QRCodeViewController.m
@@ -706,7 +706,11 @@
     } else {
         _manualCodeLabel.hidden = YES;
         _versionLabel.text = [NSString stringWithFormat:@"%@", payload.version];
-        _rendezVousInformation.text = [NSString stringWithFormat:@"%lu", payload.rendezvousInformation];
+        if (payload.rendezvousInformation == nil) {
+            _rendezVousInformation.text = NOT_APPLICABLE_STRING;
+        } else {
+            _rendezVousInformation.text = [NSString stringWithFormat:@"%lu", [payload.rendezvousInformation unsignedLongValue]];
+        }
         if ([payload.serialNumber length] > 0) {
             self->_serialNumber.text = payload.serialNumber;
         } else {
@@ -763,15 +767,22 @@
 
 - (void)handleRendezVous:(MTRSetupPayload *)payload rawPayload:(NSString *)rawPayload
 {
-    switch (payload.rendezvousInformation) {
-    case MTRRendezvousInformationNone:
-    case MTRRendezvousInformationOnNetwork:
-    case MTRRendezvousInformationBLE:
-    case MTRRendezvousInformationAllMask:
+    if (payload.rendezvousInformation == nil) {
+        NSLog(@"Rendezvous Default");
+        [self handleRendezVousDefault:rawPayload];
+        return;
+    }
+
+    // TODO: This is a pretty broken way to handle a bitmask.
+    switch ([payload.rendezvousInformation unsignedLongValue]) {
+    case MTRDiscoveryCapabilitiesNone:
+    case MTRDiscoveryCapabilitiesOnNetwork:
+    case MTRDiscoveryCapabilitiesBLE:
+    case MTRDiscoveryCapabilitiesAllMask:
         NSLog(@"Rendezvous Default");
         [self handleRendezVousDefault:rawPayload];
         break;
-    case MTRRendezvousInformationSoftAP:
+    case MTRDiscoveryCapabilitiesSoftAP:
         NSLog(@"Rendezvous Wi-Fi");
         [self handleRendezVousWiFi:[self getNetworkName:payload.discriminator]];
         break;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -19,14 +19,14 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, MTRRendezvousInformationFlags) {
-    MTRRendezvousInformationNone = 0, // Device does not support any method for rendezvous
-    MTRRendezvousInformationSoftAP = 1 << 0, // Device supports WiFi softAP
-    MTRRendezvousInformationBLE = 1 << 1, // Device supports BLE
-    MTRRendezvousInformationOnNetwork = 1 << 2, // Device supports On Network setup
+typedef NS_ENUM(NSUInteger, MTRDiscoveryCapabilities) {
+    MTRDiscoveryCapabilitiesNone = 0, // Device does not support any method for rendezvous
+    MTRDiscoveryCapabilitiesSoftAP = 1 << 0, // Device supports WiFi softAP
+    MTRDiscoveryCapabilitiesBLE = 1 << 1, // Device supports BLE
+    MTRDiscoveryCapabilitiesOnNetwork = 1 << 2, // Device supports On Network setup
 
-    MTRRendezvousInformationAllMask
-    = MTRRendezvousInformationSoftAP | MTRRendezvousInformationBLE | MTRRendezvousInformationOnNetwork,
+    MTRDiscoveryCapabilitiesAllMask
+    = MTRDiscoveryCapabilitiesSoftAP | MTRDiscoveryCapabilitiesBLE | MTRDiscoveryCapabilitiesOnNetwork,
 };
 
 typedef NS_ENUM(NSUInteger, MTRCommissioningFlow) {
@@ -55,7 +55,13 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 @property (nonatomic, copy) NSNumber * vendorID;
 @property (nonatomic, copy) NSNumber * productID;
 @property (nonatomic, assign) MTRCommissioningFlow commissioningFlow;
-@property (nonatomic, assign) MTRRendezvousInformationFlags rendezvousInformation;
+/**
+ * rendezvousInformation is nil when the discovery capabilities bitmask is
+ * unknown.
+ *
+ * Otherwise its value is made up of the MTRDiscoveryCapabilities flags.
+ */
+@property (nonatomic, assign, nullable) NSNumber * rendezvousInformation;
 @property (nonatomic, copy) NSNumber * discriminator;
 @property (nonatomic, assign) BOOL hasShortDiscriminator;
 @property (nonatomic, copy) NSNumber * setUpPINCode;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -10,6 +10,7 @@
 #import "MTRSetupPayload.h"
 
 #ifdef __cplusplus
+#import <lib/core/Optional.h>
 #import <setup_payload/SetupPayload.h>
 #endif
 
@@ -17,7 +18,7 @@
 
 #ifdef __cplusplus
 - (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;
-- (MTRRendezvousInformationFlags)convertRendezvousFlags:(chip::RendezvousInformationFlags)value;
+- (NSNumber *)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value;
 - (MTRCommissioningFlow)convertCommissioningFlow:(chip::CommissioningFlow)value;
 #endif
 

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
@@ -52,7 +52,7 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertEqual(payload.rendezvousInformation, MTRRendezvousInformationNone);
+    XCTAssertNil(payload.rendezvousInformation);
 }
 
 - (void)testOnboardingPayloadParser_Manual_WrongType
@@ -83,7 +83,7 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertEqual(payload.rendezvousInformation, MTRRendezvousInformationNone);
+    XCTAssertNil(payload.rendezvousInformation);
 }
 
 - (void)testOnboardingPayloadParser_Admin_WrongType
@@ -114,7 +114,8 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertEqual(payload.rendezvousInformation, MTRRendezvousInformationSoftAP);
+    XCTAssertNotNil(payload.rendezvousInformation);
+    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
 }
 
 - (void)testOnboardingPayloadParser_QRCode_WrongType
@@ -146,7 +147,8 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertEqual(payload.rendezvousInformation, MTRRendezvousInformationSoftAP);
+    XCTAssertNotNil(payload.rendezvousInformation);
+    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
 }
 
 - (void)testOnboardingPayloadParser_NFC_WrongType
@@ -178,7 +180,7 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertEqual(payload.rendezvousInformation, MTRRendezvousInformationNone);
+    XCTAssertNil(payload.rendezvousInformation);
 }
 
 - (void)testManualParser_Error
@@ -219,7 +221,8 @@
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertEqual(payload.rendezvousInformation, MTRRendezvousInformationSoftAP);
+    XCTAssertNotNil(payload.rendezvousInformation);
+    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
 }
 
 - (void)testQRCodeParserWithOptionalData
@@ -239,7 +242,8 @@
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
-    XCTAssertEqual(payload.rendezvousInformation, MTRRendezvousInformationSoftAP);
+    XCTAssertNotNil(payload.rendezvousInformation);
+    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
     XCTAssertTrue([payload.serialNumber isEqualToString:@"123456789"]);
 
     NSArray<MTROptionalQRCodeInfo *> * vendorOptionalInfo = [payload getAllOptionalVendorData:&error];

--- a/src/setup_payload/ManualSetupPayloadParser.cpp
+++ b/src/setup_payload/ManualSetupPayloadParser.cpp
@@ -27,7 +27,6 @@
 #include <lib/support/logging/CHIPLogging.h>
 #include <lib/support/verhoeff/Verhoeff.h>
 
-#include <math.h>
 #include <string>
 #include <vector>
 

--- a/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadGenerator.cpp
@@ -168,8 +168,9 @@ static CHIP_ERROR generateBitSet(PayloadContents & payload, MutableByteSpan & bi
         populateBits(bits.data(), offset, payload.productID, kProductIDFieldLengthInBits, kTotalPayloadDataSizeInBits));
     ReturnErrorOnFailure(populateBits(bits.data(), offset, static_cast<uint64_t>(payload.commissioningFlow),
                                       kCommissioningFlowFieldLengthInBits, kTotalPayloadDataSizeInBits));
-    ReturnErrorOnFailure(populateBits(bits.data(), offset, payload.rendezvousInformation.Raw(), kRendezvousInfoFieldLengthInBits,
-                                      kTotalPayloadDataSizeInBits));
+    VerifyOrReturnError(payload.rendezvousInformation.HasValue(), CHIP_ERROR_INVALID_ARGUMENT);
+    ReturnErrorOnFailure(populateBits(bits.data(), offset, payload.rendezvousInformation.Value().Raw(),
+                                      kRendezvousInfoFieldLengthInBits, kTotalPayloadDataSizeInBits));
     ReturnErrorOnFailure(populateBits(bits.data(), offset, payload.discriminator.GetLongValue(),
                                       kPayloadDiscriminatorFieldLengthInBits, kTotalPayloadDataSizeInBits));
     ReturnErrorOnFailure(

--- a/src/setup_payload/QRCodeSetupPayloadParser.cpp
+++ b/src/setup_payload/QRCodeSetupPayloadParser.cpp
@@ -24,7 +24,6 @@
 #include "QRCodeSetupPayloadParser.h"
 #include "Base38Decode.h"
 
-#include <math.h>
 #include <memory>
 #include <string.h>
 #include <vector>
@@ -354,7 +353,8 @@ CHIP_ERROR QRCodeSetupPayloadParser::populatePayload(SetupPayload & outPayload)
     ReturnErrorOnFailure(readBits(buf, indexToReadFrom, dest, kRendezvousInfoFieldLengthInBits));
     static_assert(kRendezvousInfoFieldLengthInBits <= 8 * sizeof(RendezvousInformationFlag),
                   "Won't fit in RendezvousInformationFlags");
-    outPayload.rendezvousInformation = RendezvousInformationFlags(static_cast<RendezvousInformationFlag>(dest));
+    outPayload.rendezvousInformation.SetValue(
+        RendezvousInformationFlags().SetRaw(static_cast<std::underlying_type_t<RendezvousInformationFlag>>(dest)));
 
     ReturnErrorOnFailure(readBits(buf, indexToReadFrom, dest, kPayloadDiscriminatorFieldLengthInBits));
     static_assert(kPayloadDiscriminatorFieldLengthInBits <= 16, "Won't fit in uint16_t");

--- a/src/setup_payload/SetupPayload.cpp
+++ b/src/setup_payload/SetupPayload.cpp
@@ -74,7 +74,7 @@ bool PayloadContents::isValidQRCodePayload() const
 
     chip::RendezvousInformationFlags allvalid(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kOnNetwork,
                                               RendezvousInformationFlag::kSoftAP);
-    if (!rendezvousInformation.HasOnly(allvalid))
+    if (!rendezvousInformation.HasValue() || !rendezvousInformation.Value().HasOnly(allvalid))
     {
         return false;
     }

--- a/src/setup_payload/SetupPayload.h
+++ b/src/setup_payload/SetupPayload.h
@@ -29,6 +29,7 @@
 #include <vector>
 
 #include <lib/core/CHIPError.h>
+#include <lib/core/Optional.h>
 #include <lib/support/BitFlags.h>
 #include <lib/support/SetupDiscriminator.h>
 
@@ -115,11 +116,11 @@ enum class CommissioningFlow : uint8_t
  */
 struct PayloadContents
 {
-    uint8_t version                                  = 0;
-    uint16_t vendorID                                = 0;
-    uint16_t productID                               = 0;
-    CommissioningFlow commissioningFlow              = CommissioningFlow::kStandard;
-    RendezvousInformationFlags rendezvousInformation = RendezvousInformationFlag::kNone;
+    uint8_t version                     = 0;
+    uint16_t vendorID                   = 0;
+    uint16_t productID                  = 0;
+    CommissioningFlow commissioningFlow = CommissioningFlow::kStandard;
+    Optional<RendezvousInformationFlags> rendezvousInformation;
     SetupDiscriminator discriminator;
     uint32_t setUpPINCode = 0;
 

--- a/src/setup_payload/SetupPayloadHelper.cpp
+++ b/src/setup_payload/SetupPayloadHelper.cpp
@@ -124,8 +124,8 @@ static CHIP_ERROR addParameter(SetupPayload & setupPayload, const SetupPayloadPa
         break;
     case SetupPayloadKey_RendezVousInformation:
         ChipLogDetail(SetupPayload, "Loaded rendezvousInfo: %u", (uint16_t) parameter.uintValue);
-        setupPayload.rendezvousInformation =
-            RendezvousInformationFlags(static_cast<RendezvousInformationFlag>(parameter.uintValue));
+        setupPayload.rendezvousInformation.SetValue(RendezvousInformationFlags().SetRaw(
+            static_cast<std::underlying_type_t<RendezvousInformationFlag>>(parameter.uintValue)));
         break;
     case SetupPayloadKey_Discriminator:
         ChipLogDetail(SetupPayload, "Loaded discriminator: %u", (uint16_t) parameter.uintValue);

--- a/src/setup_payload/java/SetupPayloadParser-JNI.cpp
+++ b/src/setup_payload/java/SetupPayloadParser-JNI.cpp
@@ -122,7 +122,8 @@ jobject TransformSetupPayload(JNIEnv * env, SetupPayload & payload)
     env->SetIntField(setupPayload, discriminator, discriminatorValue);
     env->SetLongField(setupPayload, setUpPinCode, payload.setUpPINCode);
 
-    env->SetObjectField(setupPayload, discoveryCapabilities, CreateCapabilitiesHashSet(env, payload.rendezvousInformation));
+    env->SetObjectField(setupPayload, discoveryCapabilities,
+                        CreateCapabilitiesHashSet(env, payload.rendezvousInformation.ValueOr(RendezvousInformationFlag::kNone)));
 
     jmethodID addOptionalInfoMid =
         env->GetMethodID(setupPayloadClass, "addOptionalQRCodeInfo", "(Lchip/setuppayload/OptionalQRCodeInfo;)V");
@@ -274,7 +275,8 @@ void TransformSetupPayloadFromJobject(JNIEnv * env, jobject jPayload, SetupPaylo
     payload.setUpPINCode = env->GetLongField(jPayload, setUpPinCode);
 
     jobject discoveryCapabilitiesObj = env->GetObjectField(jPayload, discoveryCapabilities);
-    CreateCapabilitiesFromHashSet(env, discoveryCapabilitiesObj, payload.rendezvousInformation);
+    CreateCapabilitiesFromHashSet(env, discoveryCapabilitiesObj,
+                                  payload.rendezvousInformation.Emplace(RendezvousInformationFlag::kNone));
 }
 
 void CreateCapabilitiesFromHashSet(JNIEnv * env, jobject discoveryCapabilitiesObj, RendezvousInformationFlags & flags)

--- a/src/setup_payload/tests/TestHelpers.h
+++ b/src/setup_payload/tests/TestHelpers.h
@@ -45,11 +45,11 @@ inline SetupPayload GetDefaultPayload()
 {
     SetupPayload payload;
 
-    payload.version               = 0;
-    payload.vendorID              = 12;
-    payload.productID             = 1;
-    payload.commissioningFlow     = CommissioningFlow::kStandard;
-    payload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kSoftAP);
+    payload.version           = 0;
+    payload.vendorID          = 12;
+    payload.productID         = 1;
+    payload.commissioningFlow = CommissioningFlow::kStandard;
+    payload.rendezvousInformation.SetValue(RendezvousInformationFlag::kSoftAP);
     payload.discriminator.SetLongValue(128);
     payload.setUpPINCode = 2048;
 

--- a/src/setup_payload/tests/TestQRCode.cpp
+++ b/src/setup_payload/tests/TestQRCode.cpp
@@ -40,28 +40,29 @@ void TestRendezvousFlags(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload inPayload = GetDefaultPayload();
 
-    inPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kNone);
+    // Not having a value in rendezvousInformation is not allowed for a QR code.
+    inPayload.rendezvousInformation.SetValue(RendezvousInformationFlag::kNone);
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
-    inPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kSoftAP);
+    inPayload.rendezvousInformation.SetValue(RendezvousInformationFlag::kSoftAP);
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
-    inPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kBLE);
+    inPayload.rendezvousInformation.SetValue(RendezvousInformationFlag::kBLE);
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
-    inPayload.rendezvousInformation = RendezvousInformationFlags(RendezvousInformationFlag::kOnNetwork);
+    inPayload.rendezvousInformation.SetValue(RendezvousInformationFlag::kOnNetwork);
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
-    inPayload.rendezvousInformation =
-        RendezvousInformationFlags(RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork);
+    inPayload.rendezvousInformation.SetValue(
+        RendezvousInformationFlags(RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork));
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
-    inPayload.rendezvousInformation =
-        RendezvousInformationFlags(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kOnNetwork);
+    inPayload.rendezvousInformation.SetValue(
+        RendezvousInformationFlags(RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kOnNetwork));
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 
-    inPayload.rendezvousInformation = RendezvousInformationFlags(
-        RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork);
+    inPayload.rendezvousInformation.SetValue(RendezvousInformationFlags(
+        RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork));
     NL_TEST_ASSERT(inSuite, CheckWriteRead(inPayload));
 }
 
@@ -83,12 +84,12 @@ void TestMaximumValues(nlTestSuite * inSuite, void * inContext)
 {
     SetupPayload inPayload = GetDefaultPayload();
 
-    inPayload.version               = static_cast<uint8_t>((1 << kVersionFieldLengthInBits) - 1);
-    inPayload.vendorID              = 0xFFFF;
-    inPayload.productID             = 0xFFFF;
-    inPayload.commissioningFlow     = CommissioningFlow::kCustom;
-    inPayload.rendezvousInformation = RendezvousInformationFlags(
-        RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork);
+    inPayload.version           = static_cast<uint8_t>((1 << kVersionFieldLengthInBits) - 1);
+    inPayload.vendorID          = 0xFFFF;
+    inPayload.productID         = 0xFFFF;
+    inPayload.commissioningFlow = CommissioningFlow::kCustom;
+    inPayload.rendezvousInformation.SetValue(RendezvousInformationFlags(
+        RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork));
     inPayload.discriminator.SetLongValue(static_cast<uint16_t>((1 << kPayloadDiscriminatorFieldLengthInBits) - 1));
     inPayload.setUpPINCode = static_cast<uint32_t>((1 << kSetupPINCodeFieldLengthInBits) - 1);
 
@@ -306,7 +307,7 @@ void TestSetupPayloadVerify(nlTestSuite * inSuite, void * inContext)
     RendezvousInformationFlags invalid = RendezvousInformationFlags(
         RendezvousInformationFlag::kBLE, RendezvousInformationFlag::kSoftAP, RendezvousInformationFlag::kOnNetwork);
     invalid.SetRaw(static_cast<uint8_t>(invalid.Raw() + 1));
-    test_payload.rendezvousInformation = invalid;
+    test_payload.rendezvousInformation.SetValue(invalid);
     NL_TEST_ASSERT(inSuite, test_payload.isValidQRCodePayload() == false);
 
     // test invalid setup PIN


### PR DESCRIPTION
SetUpCodePairer was treating all-0 as unknown, which is not really right.

#### Problem
See above.

#### Change overview
Clearly track whether we know the discovery capabilities bitmask or not.

#### Testing
Should pass existing tests.  Verified that when using `MT:0000000000I.0648G00` as the pairing code we no longer do BLE discovery.