### PR TITLE
Also run unit tests with chip_enable_schema_check=false.

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -81,6 +81,11 @@ jobs:
             - name: Run Tests
               timeout-minutes: 30
               run: scripts/tests/gn_tests.sh
+            - name: Setup Build without schema check
+              run: scripts/build/gn_gen.sh --args="chip_config_memory_debug_checks=true chip_config_memory_debug_dmalloc=true chip_enable_schema_check=false"
+            - name: Run Tests without schema check
+              timeout-minutes: 20
+              run: scripts/tests/gn_tests.sh
             # TODO Log Upload https://github.com/project-chip/connectedhomeip/issues/2227
             # TODO https://github.com/project-chip/connectedhomeip/issues/1512
             # - name: Run Code Coverage


### PR DESCRIPTION
Some IM code takes quite different codepaths depending on the value of
chip_enable_schema_check, so we should really be testing both configurations.

#### Problem
Not testing the code we are likely to actually ship on devices.

#### Change overview
Test it.
