### PR TITLE
Add support for octet-string-typed config variables in YAML.

### DIFF
--- a/examples/chip-tool/templates/tests/partials/command_value.zapt
+++ b/examples/chip-tool/templates/tests/partials/command_value.zapt
@@ -46,7 +46,7 @@
       {{else if (isCharString type)}}
         chip::Span<const char>("{{chip_tests_config_get_default_value definedValue}}", {{utf8StringLength (chip_tests_config_get_default_value definedValue)}});
       {{else if (isOctetString type)}}
-        {{!-- TODO Extract the length of the default value for ByteSpan--}}
+        {{> octetStringValue value=(chip_tests_config_get_default_value definedValue)}};
       {{else}}
         {{#if_is_strongly_typed_bitmap type}}
           static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>({{asTypedLiteral (chip_tests_config_get_default_value definedValue) type}});
@@ -60,11 +60,7 @@
       {{else if (isCharString type)}}
         chip::Span<const char>("{{definedValue}}garbage: not in length on purpose", {{utf8StringLength definedValue}});
       {{else if (isOctetString type)}}
-        {{~#if (isHexString definedValue)}}
-          chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringFromHexString definedValue}}garbage: not in length on purpose"), {{octetStringLengthFromHexString definedValue}});
-        {{else}}
-          chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral definedValue}}garbage: not in length on purpose"), {{definedValue.length}});
-        {{/if}}
+        {{> octetStringValue value=definedValue extraGarbage="garbage: not in length on purpose"}};
       {{else}}
         {{#if_is_strongly_typed_bitmap type}}
           static_cast<{{zapTypeToEncodableClusterObjectType type ns=ns}}>({{asTypedLiteral definedValue type}});

--- a/examples/chip-tool/templates/tests/partials/octet_string_value.zapt
+++ b/examples/chip-tool/templates/tests/partials/octet_string_value.zapt
@@ -1,0 +1,5 @@
+{{#if (isHexString value)}}
+  chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringFromHexString value}}{{extraGarbage}}"), {{octetStringLengthFromHexString value}})
+{{else}}
+  chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral value}}{{extraGarbage}}"), {{value.length}})
+{{/if}}

--- a/examples/chip-tool/templates/tests/partials/value_equals.zapt
+++ b/examples/chip-tool/templates/tests/partials/value_equals.zapt
@@ -58,11 +58,7 @@
       {{~#if (chip_tests_variables_has expected)}}{{expected}}
       {{else if keepAsExpected}}{{expected}}
       {{else if (isOctetString type)}}
-        {{~#if (isHexString expected)}}
-          chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringFromHexString expected}}"), {{octetStringLengthFromHexString expected}})
-        {{else}}
-          chip::ByteSpan(chip::Uint8::from_const_char("{{octetStringEscapedForCLiteral expected}}"), {{expected.length}})
-        {{/if}}
+        {{> octetStringValue value=expected}}
       {{else if (isCharString type)}}chip::CharSpan("{{expected}}", {{utf8StringLength expected}})
       {{else if (chip_tests_config_has expected)}}m{{asUpperCamelCase expected}}.HasValue() ? m{{asUpperCamelCase expected}}.Value() : {{asTypedLiteral (chip_tests_config_get_default_value expected) (chip_tests_config_get_type expected)}}
       {{else}}{{asTypedExpression expected type}}

--- a/examples/chip-tool/templates/tests/templates.json
+++ b/examples/chip-tool/templates/tests/templates.json
@@ -56,6 +56,10 @@
         {
             "name": "valueEquals",
             "path": "partials/value_equals.zapt"
+        },
+        {
+            "name": "octetStringValue",
+            "path": "partials/octet_string_value.zapt"
         }
     ],
     "templates": [

--- a/examples/darwin-framework-tool/templates/tests/partials/check_test_value.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/check_test_value.zapt
@@ -39,11 +39,7 @@
     VerifyOrReturn(CheckValue{{#if (isString type)}}AsString{{/if}}("{{label}}", {{actual}}, 
       {{~#if (chip_tests_variables_has expected)}}{{expected}}
       {{~else if (isOctetString type)}}
-        {{~#if (isHexString expected)}}
-        [[NSData alloc] initWithBytes:"{{octetStringFromHexString expected}}" length:{{octetStringLengthFromHexString expected}}]
-        {{else}}
-        [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral expected}}" length:{{expected.length}}]
-        {{/if}}
+        {{> octetStringValue value=expected}}
       {{~else if (isCharString type)}}@"{{expected}}"
       {{else if (chip_tests_config_has expected)}}m{{asUpperCamelCase expected}}.HasValue() ? m{{asUpperCamelCase expected}}.Value() : {{asTypedLiteral (chip_tests_config_get_default_value expected) (chip_tests_config_get_type expected)}}
       {{~else}}{{asTypedExpressionFromObjectiveC expected type}}

--- a/examples/darwin-framework-tool/templates/tests/partials/octet_string_value.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/octet_string_value.zapt
@@ -1,0 +1,5 @@
+{{~#if (isHexString value)}}
+[[NSData alloc] initWithBytes:"{{octetStringFromHexString value}}" length:{{octetStringLengthFromHexString value}}]
+{{else}}
+[[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral value}}" length:{{value.length}}]
+{{/if}}

--- a/examples/darwin-framework-tool/templates/tests/partials/test_value.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/test_value.zapt
@@ -37,7 +37,7 @@
       {{#if (isCharString type)}}
         m{{asUpperCamelCase definedValue}}.Value() : @"{{chip_tests_config_get_default_value definedValue}}";
       {{else if (isOctetString type)}}
-        {{!-- TODO Extract the length of the default value for ByteSpan--}}
+        {{> octetStringValue value=(chip_tests_config_get_default_value definedValue)}};
       {{else}}
         [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:m{{asUpperCamelCase definedValue}}.Value()] :
         [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{asTypedExpressionFromObjectiveC (chip_tests_config_get_default_value definedValue) type}}];
@@ -46,11 +46,7 @@
       {{#if (isCharString type)}}
         @"{{definedValue}}";
       {{else if (isOctetString type)}}
-        {{~#if (isHexString definedValue)}}
-        [[NSData alloc] initWithBytes:"{{octetStringFromHexString definedValue}}" length:{{octetStringLengthFromHexString definedValue}}];
-        {{else}}
-        [[NSData alloc] initWithBytes:"{{octetStringEscapedForCLiteral definedValue}}" length:{{definedValue.length}}];
-        {{/if}}
+        {{> octetStringValue value=definedValue}};
       {{else}}
         [NSNumber numberWith{{asObjectiveCNumberType definedValue type false}}:{{asTypedExpressionFromObjectiveC definedValue type}}];
       {{/if}}

--- a/examples/darwin-framework-tool/templates/tests/templates.json
+++ b/examples/darwin-framework-tool/templates/tests/templates.json
@@ -40,6 +40,10 @@
             "path": "partials/check_test_value.zapt"
         },
         {
+            "name": "octetStringValue",
+            "path": "partials/octet_string_value.zapt"
+        },
+        {
             "name": "maybeCheckExpectedConstraints",
             "path": "partials/checks/maybeCheckExpectedConstraints.zapt"
         }


### PR DESCRIPTION
#### Problem
Using a config variable of type `octet_string` in YAML generates incorrect code.

#### Change overview
Make it work.

#### Testing
Tried defining some variables in YAMLs and verified that the right code is generated.  Verified that for existing bits nothing changes.