### PR TITLE
Fix MultiPressComplete event simulation.

### DIFF
--- a/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
+++ b/examples/all-clusters-app/linux/AllClustersCommandDelegate.cpp
@@ -117,7 +117,7 @@ void AllClustersAppCommandHandler::HandleCommand(intptr_t context)
     {
         uint8_t previousPosition = static_cast<uint8_t>(self->mJsonValue["PreviousPosition"].asUInt());
         uint8_t count            = static_cast<uint8_t>(self->mJsonValue["TotalNumberOfPressesCounted"].asUInt());
-        self->OnSwitchMultiPressOngoingHandler(previousPosition, count);
+        self->OnSwitchMultiPressCompleteHandler(previousPosition, count);
     }
     else if (name == "PowerOnReboot")
     {


### PR DESCRIPTION
Copy/paste caused the wrong function to be called.

Fixes https://github.com/project-chip/connectedhomeip/issues/21700

#### Problem
Wrong function being called.

#### Change overview
Call the right one.

