### PR TITLE
[chip-tool] Add option 'discover-once' for chip-tool.

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.cpp
+++ b/examples/chip-tool/commands/pairing/PairingCommand.cpp
@@ -150,6 +150,17 @@ void PairingCommand::OnStatusUpdate(DevicePairingDelegate::Status status)
         ChipLogError(chipTool, "Secure Pairing Failed");
         SetCommandExitStatus(CHIP_ERROR_INCORRECT_STATE);
         break;
+    case DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices:
+        if (IsDiscoverOnce())
+        {
+            ChipLogError(chipTool, "Secure Pairing Failed");
+            SetCommandExitStatus(CHIP_ERROR_INCORRECT_STATE);
+        }
+        else
+        {
+            ChipLogProgress(chipTool, "Secure Pairing Discovering More Devices");
+        }
+        break;
     }
 }
 

--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -80,6 +80,7 @@ public:
         case PairingMode::Code:
         case PairingMode::CodePaseOnly:
             AddArgument("payload", &mOnboardingPayload);
+            AddArgument("discover-once", 0, 1, &mDiscoverOnce);
             break;
         case PairingMode::Ble:
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
@@ -144,6 +145,7 @@ public:
 
     /////////// DeviceDiscoveryDelegate Interface /////////
     void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
+    bool IsDiscoverOnce() { return mDiscoverOnce.ValueOr(false); }
 
 private:
     CHIP_ERROR RunInternal(NodeId remoteId);
@@ -160,6 +162,7 @@ private:
     Command::AddressWithInterface mRemoteAddr;
     NodeId mNodeId;
     chip::Optional<uint16_t> mTimeout;
+    chip::Optional<bool> mDiscoverOnce;
     uint16_t mRemotePort;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;

--- a/examples/darwin-framework-tool/commands/pairing/PairingDelegateBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/PairingDelegateBridge.mm
@@ -35,6 +35,9 @@
         ChipLogError(chipTool, "Secure Pairing Failed");
         _commandBridge->SetCommandExitStatus(CHIP_ERROR_INCORRECT_STATE);
         break;
+    case MTRPairingStatusDiscoveringMoreDevices:
+        ChipLogProgress(chipTool, "Secure Pairing Discovering More Devices");
+        break;
     case MTRPairingStatusUnknown:
         ChipLogError(chipTool, "Uknown Pairing Status");
         break;

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -254,6 +254,9 @@ void PairingCommand::OnStatusUpdate(DevicePairingDelegate::Status status)
     case DevicePairingDelegate::Status::SecurePairingFailed:
         ChipLogError(AppServer, "Secure Pairing Failed");
         break;
+    case DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices:
+        ChipLogProgress(AppServer, "Secure Pairing Discovering More Device");
+        break;
     }
 }
 

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
@@ -83,6 +83,8 @@ void CommissionerCommands::OnStatusUpdate(DevicePairingDelegate::Status status)
         ChipLogError(chipTool, "Secure Pairing Failed");
         OnResponse(ConvertToStatusIB(CHIP_ERROR_INCORRECT_STATE), nullptr);
         break;
+    case DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices:
+        break;
     }
 }
 

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -40,6 +40,7 @@ public:
     {
         SecurePairingSuccess = 0,
         SecurePairingFailed,
+        SecurePairingDiscoveringMoreDevices,
     };
 
     /**

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -405,14 +405,14 @@ void SetUpCodePairer::OnStatusUpdate(DevicePairingDelegate::Status status)
         if (!mDiscoveredParameters.empty())
         {
             ChipLogProgress(Controller, "Ignoring SecurePairingFailed status for now; we have more discovered devices to try");
-            return;
+            status = DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices;
         }
 
         if (DiscoveryInProgress())
         {
             ChipLogProgress(Controller,
                             "Ignoring SecurePairingFailed status for now; we are waiting to see if we discover more devices");
-            return;
+            status = DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices;
         }
     }
 

--- a/src/darwin/Framework/CHIP/MTRDevicePairingDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDevicePairingDelegate.h
@@ -22,7 +22,8 @@ NS_ASSUME_NONNULL_BEGIN
 typedef NS_ENUM(NSUInteger, MTRPairingStatus) {
     MTRPairingStatusUnknown = 0,
     MTRPairingStatusSuccess = 1,
-    MTRPairingStatusFailed = 2
+    MTRPairingStatusFailed = 2,
+    MTRPairingStatusDiscoveringMoreDevices = 3
 };
 
 /**

--- a/src/darwin/Framework/CHIP/MTRDevicePairingDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDevicePairingDelegateBridge.mm
@@ -46,6 +46,9 @@ MTRPairingStatus MTRDevicePairingDelegateBridge::MapStatus(chip::Controller::Dev
     case chip::Controller::DevicePairingDelegate::Status::SecurePairingFailed:
         rv = MTRPairingStatusFailed;
         break;
+    case chip::Controller::DevicePairingDelegate::Status::SecurePairingDiscoveringMoreDevices:
+        rv = MTRPairingStatusDiscoveringMoreDevices;
+        break;
     }
     return rv;
 }


### PR DESCRIPTION
#### Problem
#21152 
The chip-tool will repeat to establish the PASESession for `pairing code` command if the DUT publish mdns services on both IPv4 address and IPv6 address. In current test verification steps for TC-CADMIN-1.9, we need to send `./chip-tool pairing code {node-id} {setup-payload} --timeout 3` 20 times, but we don't know how many times the commissioner tries to establish PASESession with the DUT. Sometimes the secure pairing will fail for twice times, sometimes the secure pairing can't be started before timeout.

#### Change overview
Add an option `--discover-once` for chip-tool so it will return failure once the secure pairing fails when we run the `pairing code` command

#### Testing
Tested on ESP32, the chip-tool will return failure once the secure pairing fails when enabling the option. 
```
./chip-tool pairing code 2 35576750139 --commissioner-name beta --discover-once 1
```
And the chip-tool will repeat secure pairing for twice or three times when disabling the option.
```
chip-tool pairing code 2 35576750139 --commissioner-name beta
```