### PR TITLE
TC-OO-2.3: Wait 10 seconds before performing step 21b

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_OO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_3.yaml
@@ -854,6 +854,14 @@ tests:
               minValue: 255
               maxValue: 345
 
+    - label: "Wait 10000ms"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 10000
+
     - label: "21a:Sends OnWithTimedOff command to DUT"
       command: "OnWithTimedOff"
       PICS: OO.S.C42.Rsp

--- a/src/app/tests/suites/certification/Test_TC_OO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_3.yaml
@@ -854,14 +854,6 @@ tests:
               minValue: 255
               maxValue: 345
 
-    - label: "Wait 10000ms"
-      cluster: "DelayCommands"
-      command: "WaitForMs"
-      arguments:
-          values:
-              - name: "ms"
-                value: 10000
-
     - label: "21a:Sends OnWithTimedOff command to DUT"
       command: "OnWithTimedOff"
       PICS: OO.S.C42.Rsp
@@ -873,6 +865,14 @@ tests:
                 value: 300
               - name: "OffWaitTime"
                 value: 300
+
+    - label: "Wait 10000ms"
+      cluster: "DelayCommands"
+      command: "WaitForMs"
+      arguments:
+          values:
+              - name: "ms"
+                value: 10000
 
     - label: "21b:Reads OnOff attribute from DUT"
       command: "readAttribute"


### PR DESCRIPTION
see https://github.com/CHIP-Specifications/chip-test-plans/issues/2024 and https://github.com/CHIP-Specifications/chip-test-plans/pull/2025
 
In the OnOff test plan a wait time of 10 seconds was forgotten before step 21b.
This PR adds the missing 10 seconds wait time before step 21b
within the timer callback
