### PR TITLE
[EFR32] Added fix to change network in CNET and setting DGWIFI to correct value for security

### DIFF
--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
@@ -125,10 +125,11 @@ Status SlWiFiDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, MutableCh
 
 CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen)
 {
-    if(ConnectivityMgr().IsWiFiStationProvisioned()){
-        ChipLogProgress(DeviceLayer,"Disconecting for current wifi");
+    if (ConnectivityMgr().IsWiFiStationProvisioned())
+    {
+        ChipLogProgress(DeviceLayer, "Disconecting for current wifi");
         int32_t status = wfx_sta_discon();
-        if(status != 0)
+        if (status != 0)
         {
             return CHIP_ERROR_INTERNAL;
         }

--- a/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/EFR32/NetworkCommissioningWiFiDriver.cpp
@@ -125,6 +125,14 @@ Status SlWiFiDriver::ReorderNetwork(ByteSpan networkId, uint8_t index, MutableCh
 
 CHIP_ERROR SlWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen, const char * key, uint8_t keyLen)
 {
+    if(ConnectivityMgr().IsWiFiStationProvisioned()){
+        ChipLogProgress(DeviceLayer,"Disconecting for current wifi");
+        int32_t status = wfx_sta_discon();
+        if(status != 0)
+        {
+            return CHIP_ERROR_INTERNAL;
+        }
+    }
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));
     // Set the wifi configuration
     wfx_wifi_provision_t wifiConfig = {};


### PR DESCRIPTION
#### Problem
Added fix to change network in CNET and setting DGWIFI to correct value for security

#### Change overview
Disconnecting the station so that it can connect to the new network. 
Security type was returning a wrong value for WPA3 setting it to return 3

#### Testing
Tested manually using EFR32+RS9116
