### PR TITLE
[Infineon] Label Cluster support for Infineon P6 example apps

### DIFF
--- a/examples/all-clusters-app/p6/BUILD.gn
+++ b/examples/all-clusters-app/p6/BUILD.gn
@@ -121,6 +121,7 @@ p6_executable("clusters_app") {
     ":all_clusters_app_sdk_sources",
     "${chip_root}/examples/all-clusters-app/all-clusters-common",
     "${chip_root}/examples/common/QRCode",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/all-clusters-app/p6/src/AppTask.cpp
+++ b/examples/all-clusters-app/p6/src/AppTask.cpp
@@ -40,6 +40,7 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
+#include <DeviceInfoProviderImpl.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/P6/NetworkCommissioningDriver.h>
 
@@ -104,6 +105,7 @@ using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
 
 AppTask AppTask::sAppTask;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 namespace {
 app::Clusters::NetworkCommissioning::Instance
@@ -127,6 +129,9 @@ static void InitServer(intptr_t context)
 
     // We only have network commissioning on endpoint 0.
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/all-clusters-minimal-app/p6/BUILD.gn
+++ b/examples/all-clusters-minimal-app/p6/BUILD.gn
@@ -121,6 +121,7 @@ p6_executable("clusters_minimal_app") {
     ":all_clusters_app_sdk_sources",
     "${chip_root}/examples/all-clusters-minimal-app/all-clusters-common",
     "${chip_root}/examples/common/QRCode",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/all-clusters-minimal-app/p6/src/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/p6/src/AppTask.cpp
@@ -40,6 +40,7 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
+#include <DeviceInfoProviderImpl.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/P6/NetworkCommissioningDriver.h>
 
@@ -104,6 +105,7 @@ using namespace ::chip::DeviceLayer;
 using namespace ::chip::System;
 
 AppTask AppTask::sAppTask;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 namespace {
 app::Clusters::NetworkCommissioning::Instance
@@ -127,6 +129,9 @@ static void InitServer(intptr_t context)
 
     // We only have network commissioning on endpoint 0.
     emberAfEndpointEnableDisable(kNetworkCommissioningEndpointSecondary, false);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/lighting-app/p6/BUILD.gn
+++ b/examples/lighting-app/p6/BUILD.gn
@@ -118,6 +118,7 @@ p6_executable("lighting_app") {
     ":lighting_app_sdk_sources",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lighting-app/lighting-common",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/lighting-app/p6/src/AppTask.cpp
+++ b/examples/lighting-app/p6/src/AppTask.cpp
@@ -38,6 +38,7 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
+#include <DeviceInfoProviderImpl.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/P6/NetworkCommissioningDriver.h>
 
@@ -108,6 +109,7 @@ using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 
 AppTask AppTask::sAppTask;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 namespace {
 app::Clusters::NetworkCommissioning::Instance
@@ -125,6 +127,9 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     chip::Server::GetInstance().Init(initParams);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());

--- a/examples/lock-app/p6/BUILD.gn
+++ b/examples/lock-app/p6/BUILD.gn
@@ -105,6 +105,7 @@ p6_executable("lock_app") {
     ":lock_app_sdk_sources",
     "${chip_root}/examples/common/QRCode",
     "${chip_root}/examples/lock-app/lock-common",
+    "${chip_root}/examples/providers:device_info_provider",
     "${chip_root}/src/lib",
     "${chip_root}/src/setup_payload",
   ]

--- a/examples/lock-app/p6/src/AppTask.cpp
+++ b/examples/lock-app/p6/src/AppTask.cpp
@@ -46,6 +46,7 @@
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/P6/NetworkCommissioningDriver.h>
 
+#include <DeviceInfoProviderImpl.h>
 #include <app/clusters/door-lock-server/door-lock-server.h>
 #include <app/clusters/identify-server/identify-server.h>
 
@@ -120,6 +121,7 @@ using namespace ::chip::System;
 using namespace P6DoorLock::LockInitParams;
 
 AppTask AppTask::sAppTask;
+static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 namespace {
 app::Clusters::NetworkCommissioning::Instance
@@ -137,6 +139,9 @@ static void InitServer(intptr_t context)
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
     chip::Server::GetInstance().Init(initParams);
+
+    gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initialize device attestation config
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());


### PR DESCRIPTION
#### Problem
Label Cluster, localizationconfiguration Cluster not working as expected for Infineon P6 example apps

#### Change overview
Set DeviceInfoProvider Info properly during example Init to fix label and localization Cluster read/write

#### Testing
Manually verified label and Localization Cluster with the changes and it works.

TC-ULABEL-* TC-LCFG-* Test cases verified
