### PR TITLE
Log the commissioning mode when logging start of commissioning advertising

### DIFF
--- a/src/app/server/Dnssd.cpp
+++ b/src/app/server/Dnssd.cpp
@@ -299,9 +299,10 @@ CHIP_ERROR DnssdServer::Advertise(bool commissionableNode, chip::Dnssd::Commissi
 
     auto & mdnsAdvertiser = chip::Dnssd::ServiceAdvertiser::Instance();
 
-    ChipLogProgress(Discovery, "Advertise commission parameter vendorID=%u productID=%u discriminator=%04u/%02u",
+    ChipLogProgress(Discovery, "Advertise commission parameter vendorID=%u productID=%u discriminator=%04u/%02u cm=%u",
                     advertiseParameters.GetVendorId().ValueOr(0), advertiseParameters.GetProductId().ValueOr(0),
-                    advertiseParameters.GetLongDiscriminator(), advertiseParameters.GetShortDiscriminator());
+                    advertiseParameters.GetLongDiscriminator(), advertiseParameters.GetShortDiscriminator(),
+                    to_underlying(advertiseParameters.GetCommissioningMode()));
     return mdnsAdvertiser.Advertise(advertiseParameters);
 }
 


### PR DESCRIPTION
It's hard to say from logs whether things are advertising CM=0 or CM=1/2.

#### Problem
See above.

#### Change overview
Add logging.

#### Testing
Ran all-clusters-app, looked at the log.