### PR TITLE
[Infineon][SVE] Fix CYW30739 KVS read/write methods.

### DIFF
--- a/src/platform/CYW30739/CYW30739Config.h
+++ b/src/platform/CYW30739/CYW30739Config.h
@@ -110,6 +110,9 @@ public:
     static bool ConfigValueExists(Key key);
     static CHIP_ERROR FactoryResetConfig(void);
     static void RunConfigUnitTest(void);
+
+private:
+    static bool IsDataFromFlash(const void * data);
 };
 
 } // namespace Internal

--- a/src/platform/CYW30739/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/CYW30739/KeyValueStoreManagerImpl.cpp
@@ -82,6 +82,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::_Get(const char * key, void * value, size_t
 
     entry = FindEntry(key);
     VerifyOrExit(entry != nullptr, err = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+    VerifyOrExit(value_size != 0, err = CHIP_ERROR_BUFFER_TOO_SMALL);
 
     size_t byte_count;
     err = CYW30739Config::ReadConfigValueBin(entry->GetValueConfigKey(), value, value_size, byte_count);


### PR DESCRIPTION
#### Problem
* The platform NVRAM write API doesn't support writing data from the flash.
* The platform NVRAM read API always fails if the given buffer size is zero.

#### Change overview
* Write methods should copy data to RAM before calling the platform API which doesn't support writing data from the flash.
* Read methods should return `CHIP_ERROR_BUFFER_TOO_SMALL` if the specified entry exists but the given buffer size is zero.

#### Testing
* Run some TC-SU-XXX cases