### PR TITLE
Update lockState attribute when lock/unlock action occurs

### DIFF
--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -650,6 +650,9 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
         {
             ChipLogDetail(Zcl, "Door Lock App: setting door lock state to \"%s\" [endpointId=%d]", lockStateToString(lockState),
                           endpointId);
+
+            DoorLockServer::Instance().SetLockState(endpointId, lockState);
+            
             return true;
         }
 
@@ -670,6 +673,8 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
             ChipLogDetail(Zcl,
                           "Lock App: specified PIN code was found in the database, setting lock state to \"%s\" [endpointId=%d]",
                           lockStateToString(lockState), mEndpointId);
+
+            DoorLockServer::Instance().SetLockState(endpointId, lockState);
 
             return true;
         }

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -652,7 +652,7 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
                           endpointId);
 
             DoorLockServer::Instance().SetLockState(endpointId, lockState);
-            
+
             return true;
         }
 


### PR DESCRIPTION
#### Problem
lockState attribute is not updated when a Remote Lock Operation is sent.

#### Change overview
Update the lockState when the Remote Lock Operation is sent

#### Testing
This was tested on EFR32. The lockState attribute is now properly updated when a Remote Lock Operation command reaches the example app.
