### PR TITLE
Make chip-tool subscription shutdown commands easier to use.

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -59,15 +59,15 @@ public:
     static constexpr uint16_t kMaxGroupsPerFabric    = 5;
     static constexpr uint16_t kMaxGroupKeysPerFabric = 8;
 
-    CHIPCommand(const char * commandName, CredentialIssuerCommands * credIssuerCmds) :
-        Command(commandName), mCredIssuerCmds(credIssuerCmds)
+    CHIPCommand(const char * commandName, CredentialIssuerCommands * credIssuerCmds, const char * helpText = nullptr) :
+        Command(commandName, helpText), mCredIssuerCmds(credIssuerCmds)
     {
         AddArgument("paa-trust-store-path", &mPaaTrustStorePath,
                     "Path to directory holding PAA certificate information.  Can be absolute or relative to the current working "
                     "directory.");
-        AddArgument(
-            "commissioner-name", &mCommissionerName,
-            "Name of fabric to use. Valid values are \"alpha\", \"beta\", \"gamma\", and integers greater than or equal to 4.");
+        AddArgument("commissioner-name", &mCommissionerName,
+                    "Name of fabric to use. Valid values are \"alpha\", \"beta\", \"gamma\", and integers greater than or equal to "
+                    "4.  The default if not specified is \"alpha\".");
         AddArgument("commissioner-nodeid", 0, UINT64_MAX, &mCommissionerNodeId,
                     "The node id to use for chip-tool.  If not provided, kTestControllerNodeId (112233, 0x1B669) will be used.");
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED

--- a/examples/chip-tool/commands/common/Command.h
+++ b/examples/chip-tool/commands/common/Command.h
@@ -105,10 +105,11 @@ public:
         ::chip::Inet::InterfaceId interfaceId;
     };
 
-    Command(const char * commandName) : mName(commandName) {}
+    Command(const char * commandName, const char * helpText = nullptr) : mName(commandName), mHelpText(helpText) {}
     virtual ~Command() {}
 
     const char * GetName(void) const { return mName; }
+    const char * GetHelpText() const { return mHelpText; }
     const char * GetAttribute(void) const;
     const char * GetEvent(void) const;
     const char * GetArgumentName(size_t index) const;
@@ -271,7 +272,8 @@ private:
      */
     size_t AddArgumentToList(Argument && argument);
 
-    const char * mName  = nullptr;
-    bool mIsInteractive = false;
+    const char * mName     = nullptr;
+    const char * mHelpText = nullptr;
+    bool mIsInteractive    = false;
     std::vector<Argument> mArgs;
 };

--- a/examples/chip-tool/commands/common/Commands.cpp
+++ b/examples/chip-tool/commands/common/Commands.cpp
@@ -350,6 +350,11 @@ void Commands::ShowCommand(std::string executable, std::string clusterName, Comm
     }
     fprintf(stderr, "  %s %s %s\n", executable.c_str(), clusterName.c_str(), arguments.c_str());
 
+    if (command->GetHelpText())
+    {
+        fprintf(stderr, "\n%s\n", command->GetHelpText());
+    }
+
     if (description.size() > 0)
     {
         fprintf(stderr, "%s\n", description.c_str());

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -279,6 +279,17 @@ void InteractionModelEngine::ShutdownSubscriptions(FabricIndex aFabricIndex, Nod
     }
 }
 
+void InteractionModelEngine::ShutdownAllSubscriptions()
+{
+    for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
+    {
+        if (readClient->IsSubscriptionType())
+        {
+            readClient->Close(CHIP_NO_ERROR);
+        }
+    }
+}
+
 void InteractionModelEngine::OnDone(CommandHandler & apCommandObj)
 {
     mCommandHandlerObjs.ReleaseObject(&apCommandObj);

--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -139,6 +139,11 @@ public:
     void ShutdownSubscriptions(FabricIndex aFabricIndex, NodeId aPeerNodeId);
 
     /**
+     * Tears down all active subscriptions.
+     */
+    void ShutdownAllSubscriptions();
+
+    /**
      * Expire active transactions and release related objects for the given fabric index.
      * This is used for releasing transactions that won't be closed when a fabric is removed.
      */


### PR DESCRIPTION
* Removes redundant "subscription" from the command names, since it's part of
  the "cluster" already.
* Removes the need to specify fabric-index (which was ambiguous anyway, in terms
  of whether it was the fabric-index on the server or the client), deriving
  fabric information from the command's identity (--commissioner-name) instead.
* Adds a shutdown-all command.
* Adds various documentation bits.

Fixes https://github.com/project-chip/connectedhomeip/issues/21724

#### Problem
See issue above.

#### Change overview
See above.

#### Testing
Tried running these commands; they seem to work.