### PR TITLE
Add a call to start status LED timer in lock and light app for efr32

### DIFF
--- a/examples/light-switch-app/efr32/src/AppTask.cpp
+++ b/examples/light-switch-app/efr32/src/AppTask.cpp
@@ -204,7 +204,7 @@ void AppTask::OnIdentifyStart(Identify * identify)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
     sAppTask.StartStatusLEDTimer();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+#endif
 }
 
 void AppTask::OnIdentifyStop(Identify * identify)
@@ -213,7 +213,7 @@ void AppTask::OnIdentifyStop(Identify * identify)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
     sAppTask.StopStatusLEDTimer();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+#endif
 }
 
 void AppTask::SwitchActionEventHandler(AppEvent * aEvent)

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -163,6 +163,10 @@ void AppTask::AppTaskMain(void * pvParameter)
         appError(err);
     }
 
+#if !(defined(CHIP_DEVICE_CONFIG_ENABLE_SED) && CHIP_DEVICE_CONFIG_ENABLE_SED)
+    sAppTask.StartStatusLEDTimer();
+#endif    
+
     EFR32_LOG("App Task started");
 
     while (true)

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -165,7 +165,7 @@ void AppTask::AppTaskMain(void * pvParameter)
 
 #if !(defined(CHIP_DEVICE_CONFIG_ENABLE_SED) && CHIP_DEVICE_CONFIG_ENABLE_SED)
     sAppTask.StartStatusLEDTimer();
-#endif    
+#endif
 
     EFR32_LOG("App Task started");
 

--- a/examples/lighting-app/efr32/src/AppTask.cpp
+++ b/examples/lighting-app/efr32/src/AppTask.cpp
@@ -68,7 +68,12 @@ EmberAfIdentifyEffectIdentifier sIdentifyEffect = EMBER_ZCL_IDENTIFY_EFFECT_IDEN
 namespace {
 void OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState)
 {
+    ChipLogProgress(Zcl, "Trigger Identify Complete");
     sIdentifyEffect = EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    AppTask::GetAppTask().StopStatusLEDTimer();
+#endif
 }
 } // namespace
 
@@ -82,6 +87,10 @@ void OnTriggerIdentifyEffect(Identify * identify)
                         identify->mEffectVariant);
         sIdentifyEffect = static_cast<EmberAfIdentifyEffectIdentifier>(identify->mEffectVariant);
     }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    AppTask::GetAppTask().StartStatusLEDTimer();
+#endif
 
     switch (sIdentifyEffect)
     {
@@ -107,8 +116,8 @@ void OnTriggerIdentifyEffect(Identify * identify)
 
 Identify gIdentify = {
     chip::EndpointId{ 1 },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
+    AppTask::GetAppTask().OnIdentifyStart,
+    AppTask::GetAppTask().OnIdentifyStop,
     EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
     OnTriggerIdentifyEffect,
 };
@@ -178,6 +187,24 @@ void AppTask::AppTaskMain(void * pvParameter)
             eventReceived = xQueueReceive(sAppEventQueue, &event, 0);
         }
     }
+}
+
+void AppTask::OnIdentifyStart(Identify * identify)
+{
+    ChipLogProgress(Zcl, "onIdentifyStart");
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    sAppTask.StartStatusLEDTimer();
+#endif
+}
+
+void AppTask::OnIdentifyStop(Identify * identify)
+{
+    ChipLogProgress(Zcl, "onIdentifyStop");
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    sAppTask.StopStatusLEDTimer();
+#endif
 }
 
 void AppTask::LightActionEventHandler(AppEvent * aEvent)

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -242,6 +242,10 @@ void AppTask::AppTaskMain(void * pvParameter)
         appError(err);
     }
 
+#if !(defined(CHIP_DEVICE_CONFIG_ENABLE_SED) && CHIP_DEVICE_CONFIG_ENABLE_SED)
+    sAppTask.StartStatusLEDTimer();
+#endif
+
     EFR32_LOG("App Task started");
 
     // Users and credentials should be checked once from nvm flash on boot

--- a/examples/lock-app/efr32/src/AppTask.cpp
+++ b/examples/lock-app/efr32/src/AppTask.cpp
@@ -78,7 +78,12 @@ EmberAfIdentifyEffectIdentifier sIdentifyEffect = EMBER_ZCL_IDENTIFY_EFFECT_IDEN
 namespace {
 void OnTriggerIdentifyEffectCompleted(chip::System::Layer * systemLayer, void * appState)
 {
+    ChipLogProgress(Zcl, "Trigger Identify Complete");
     sIdentifyEffect = EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT;
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    AppTask::GetAppTask().StopStatusLEDTimer();
+#endif
 }
 
 void OnTriggerIdentifyEffect(Identify * identify)
@@ -91,6 +96,10 @@ void OnTriggerIdentifyEffect(Identify * identify)
                         identify->mEffectVariant);
         sIdentifyEffect = static_cast<EmberAfIdentifyEffectIdentifier>(identify->mEffectVariant);
     }
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    AppTask::GetAppTask().StartStatusLEDTimer();
+#endif
 
     switch (sIdentifyEffect)
     {
@@ -116,8 +125,8 @@ void OnTriggerIdentifyEffect(Identify * identify)
 
 Identify gIdentify = {
     chip::EndpointId{ 1 },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStart"); },
-    [](Identify *) { ChipLogProgress(Zcl, "onIdentifyStop"); },
+    AppTask::GetAppTask().OnIdentifyStart,
+    AppTask::GetAppTask().OnIdentifyStop,
     EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
     OnTriggerIdentifyEffect,
 };
@@ -260,6 +269,24 @@ void AppTask::AppTaskMain(void * pvParameter)
             eventReceived = xQueueReceive(sAppEventQueue, &event, 0);
         }
     }
+}
+
+void AppTask::OnIdentifyStart(Identify * identify)
+{
+    ChipLogProgress(Zcl, "onIdentifyStart");
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    sAppTask.StartStatusLEDTimer();
+#endif
+}
+
+void AppTask::OnIdentifyStop(Identify * identify)
+{
+    ChipLogProgress(Zcl, "onIdentifyStop");
+
+#if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
+    sAppTask.StopStatusLEDTimer();
+#endif
 }
 
 void AppTask::LockActionEventHandler(AppEvent * aEvent)

--- a/examples/thermostat/efr32/src/AppTask.cpp
+++ b/examples/thermostat/efr32/src/AppTask.cpp
@@ -189,7 +189,7 @@ void AppTask::OnIdentifyStart(Identify * identify)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
     sAppTask.StartStatusLEDTimer();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+#endif
 }
 
 void AppTask::OnIdentifyStop(Identify * identify)
@@ -198,7 +198,7 @@ void AppTask::OnIdentifyStop(Identify * identify)
 
 #if CHIP_DEVICE_CONFIG_ENABLE_SED == 1
     sAppTask.StopStatusLEDTimer();
-#endif // CHIP_DEVICE_CONFIG_ENABLE_SED
+#endif
 }
 
 void AppTask::ThermostatActionEventHandler(AppEvent * aEvent)


### PR DESCRIPTION
#### Problem
- status LED timer was not started in the lighting and lock examples

#### Change overview
- Add a call to status LED timer 

#### Testing
efr32 platform
