### PR TITLE
Updating SHA for latest supported beta release

### DIFF
--- a/docs/guides/darwin.md
+++ b/docs/guides/darwin.md
@@ -39,8 +39,6 @@ Note: These steps are supported on:
 Each developer preview release is compatible with a certain SHA from this
 repository.
 
--   iOS/iPadOS/tvOS 15.6 Developer Preview:
-    [`aa9457e6b94b735076dff6297176183bf9780177`](https://github.com/project-chip/connectedhomeip/commits/aa9457e6b94b735076dff6297176183bf9780177)
 -   iOS/iPadOS/tvOS 16.0 Developer Preview:
     [`aa9457e6b94b735076dff6297176183bf9780177`](https://github.com/project-chip/connectedhomeip/commits/aa9457e6b94b735076dff6297176183bf9780177)
 

--- a/docs/guides/darwin.md
+++ b/docs/guides/darwin.md
@@ -40,9 +40,9 @@ Each developer preview release is compatible with a certain SHA from this
 repository.
 
 -   iOS/iPadOS/tvOS 15.6 Developer Preview:
-    [`cfc35951be66a664a6efdadea56d1b8ea6e63e96`](https://github.com/project-chip/connectedhomeip/commits/cfc35951be66a664a6efdadea56d1b8ea6e63e96)
+    [`aa9457e6b94b735076dff6297176183bf9780177`](https://github.com/project-chip/connectedhomeip/commits/aa9457e6b94b735076dff6297176183bf9780177)
 -   iOS/iPadOS/tvOS 16.0 Developer Preview:
-    [`cfc35951be66a664a6efdadea56d1b8ea6e63e96`](https://github.com/project-chip/connectedhomeip/commits/cfc35951be66a664a6efdadea56d1b8ea6e63e96)
+    [`aa9457e6b94b735076dff6297176183bf9780177`](https://github.com/project-chip/connectedhomeip/commits/aa9457e6b94b735076dff6297176183bf9780177)
 
 ## Profile Installation
 
@@ -97,8 +97,8 @@ To enable developer mode, please follow the instructions
 1. Clone the [Matter repo](https://github.com/project-chip/connectedhomeip.git)
 2. Checkout the specific commit hash (from [above](#source-compatibility)) for
    maximum compatibility with your installed release:
-    - Example command for SHA `cfc35951be66a664a6efdadea56d1b8ea6e63e96`:
-      `$ git checkout cfc35951be66a664a6efdadea56d1b8ea6e63e96`
+    - Example command for SHA `aa9457e6b94b735076dff6297176183bf9780177`:
+      `$ git checkout aa9457e6b94b735076dff6297176183bf9780177`
 
 In order to work with iOS/iPadOS/tvOS 15.6 or greater, device types as defined
 in the Matter Device Library spec are used to determine accessory categories.


### PR DESCRIPTION
#### Problem
The latest iOS beta supports a newer SHA, updating it.

#### Change overview
Updated SHA

#### Testing
Docs