### PR TITLE
Make the timing inside on-off server cluster more accurate

### DIFF
--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -472,8 +472,6 @@ uint32_t OnOffServer::calculateNextWaitTimeMS(void)
         }
     }
 
-    emberAfOnOffClusterPrintln("startTimeMS:%lld currentTimeMS:%lld elapsed:%lld latency:%lld desiredWaitTimeMS:%d waitTimeMS:%lld", onWithTimedOffStartTimestamp.count(), currentTime.count(), elapsed.count(), latency.count(), UPDATE_TIME_MS.count(), waitTime.count());
-
     onWithTimedOffStartTimestamp = currentTime;
 
     return (uint32_t)waitTime.count();

--- a/src/app/clusters/on-off-server/on-off-server.cpp
+++ b/src/app/clusters/on-off-server/on-off-server.cpp
@@ -454,9 +454,9 @@ bool OnOffServer::OnWithRecallGlobalSceneCommand(app::CommandHandler * commandOb
 
 uint32_t OnOffServer::calculateNextWaitTimeMS(void)
 {
-    const chip::System::Clock::Timestamp    currentTime = chip::System::SystemClock().GetMonotonicTimestamp();
-    chip::System::Clock::Timestamp          waitTime = UPDATE_TIME_MS;
-    chip::System::Clock::Timestamp          latency;
+    const chip::System::Clock::Timestamp currentTime = chip::System::SystemClock().GetMonotonicTimestamp();
+    chip::System::Clock::Timestamp waitTime          = UPDATE_TIME_MS;
+    chip::System::Clock::Timestamp latency;
 
     if (currentTime > nextDesiredOnWithTimedOffTimestamp)
     {
@@ -469,7 +469,7 @@ uint32_t OnOffServer::calculateNextWaitTimeMS(void)
 
     nextDesiredOnWithTimedOffTimestamp += UPDATE_TIME_MS;
 
-    return (uint32_t)waitTime.count();
+    return (uint32_t) waitTime.count();
 }
 
 bool OnOffServer::OnWithTimedOffCommand(const app::ConcreteCommandPath & commandPath,
@@ -524,7 +524,7 @@ bool OnOffServer::OnWithTimedOffCommand(const app::ConcreteCommandPath & command
     if (currentOnTime < MAX_TIME_VALUE && currentOffWaitTime < MAX_TIME_VALUE)
     {
         nextDesiredOnWithTimedOffTimestamp = chip::System::SystemClock().GetMonotonicTimestamp() + UPDATE_TIME_MS;
-        emberEventControlSetDelayMS(configureEventControl(endpoint), (uint32_t)UPDATE_TIME_MS.count());
+        emberEventControlSetDelayMS(configureEventControl(endpoint), (uint32_t) UPDATE_TIME_MS.count());
     }
 
 exit:

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -30,7 +30,7 @@ using chip::app::Clusters::OnOff::OnOffFeature;
  *********************************************************/
 
 static constexpr chip::System::Clock::Milliseconds32 UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
-static constexpr uint16_t TRANSITION_TIME_1S = 10;
+static constexpr uint16_t TRANSITION_TIME_1S                        = 10;
 
 static constexpr uint16_t MAX_TIME_VALUE = 0xFFFF;
 static constexpr uint8_t MIN_TIME_VALUE  = 1;
@@ -86,7 +86,7 @@ private:
 
     static OnOffServer instance;
     EmberEventControl eventControls[EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT];
-    chip::System::Clock::Timestamp      nextDesiredOnWithTimedOffTimestamp;
+    chip::System::Clock::Timestamp nextDesiredOnWithTimedOffTimestamp;
 };
 
 struct OnOffEffect

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -86,7 +86,7 @@ private:
 
     static OnOffServer instance;
     EmberEventControl eventControls[EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT];
-    chip::System::Clock::Timestamp      onWithTimedOffStartTimestamp;
+    chip::System::Clock::Timestamp      nextDesiredOnWithTimedOffTimestamp;
 };
 
 struct OnOffEffect

--- a/src/app/clusters/on-off-server/on-off-server.h
+++ b/src/app/clusters/on-off-server/on-off-server.h
@@ -29,7 +29,7 @@ using chip::app::Clusters::OnOff::OnOffFeature;
  * Defines and Macros
  *********************************************************/
 
-static constexpr uint8_t UPDATE_TIME_MS      = 100;
+static constexpr chip::System::Clock::Milliseconds32 UPDATE_TIME_MS = chip::System::Clock::Milliseconds32(100);
 static constexpr uint16_t TRANSITION_TIME_1S = 10;
 
 static constexpr uint16_t MAX_TIME_VALUE = 0xFFFF;
@@ -79,12 +79,14 @@ private:
     EmberEventControl * getEventControl(chip::EndpointId endpoint);
     EmberEventControl * configureEventControl(chip::EndpointId endpoint);
 
+    uint32_t calculateNextWaitTimeMS(void);
     /**********************************************************
      * Attributes Declaration
      *********************************************************/
 
     static OnOffServer instance;
     EmberEventControl eventControls[EMBER_AF_ON_OFF_CLUSTER_SERVER_ENDPOINT_COUNT];
+    chip::System::Clock::Timestamp      onWithTimedOffStartTimestamp;
 };
 
 struct OnOffEffect


### PR DESCRIPTION
#### Problem
The original approach was to always wait 100ms between timer callbacks for counting down an attribute. Due to latencies within the system the real elapsed time is typically higher than 100ms. In some embedded systems it is even up to 25% higher. This leads into very inaccurate values of time-based attributes and thus has a bad user experience.

#### Change overview
In the PR we do our best to compensate the system latency by having a timeline with fixed 100ms intervals instead of simple 100ms delays without knowing anything about system latencies

#### Testing
Perform the latest version of the TC-OO-2.3 test case which succeeds now.
Running this code change on a nRF52 platform
