### PR TITLE
[esp32]: Fix random crash in M5 multi fabric test

### DIFF
--- a/examples/all-clusters-app/esp32/main/AppTask.cpp
+++ b/examples/all-clusters-app/esp32/main/AppTask.cpp
@@ -26,7 +26,6 @@
 #include "esp_log.h"
 #include "esp_spi_flash.h"
 #include "freertos/FreeRTOS.h"
-#include <DeviceInfoProviderImpl.h>
 #include <app/server/OnboardingCodesUtil.h>
 
 #define APP_TASK_NAME "APP"
@@ -39,8 +38,6 @@ namespace {
 
 QueueHandle_t sAppEventQueue;
 TaskHandle_t sAppTaskHandle;
-
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 } // namespace
 
@@ -87,8 +84,6 @@ CHIP_ERROR AppTask::Init()
 #if CONFIG_HAVE_DISPLAY
     InitDeviceDisplay();
 #endif
-
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     return err;
 }

--- a/examples/all-clusters-app/esp32/main/main.cpp
+++ b/examples/all-clusters-app/esp32/main/main.cpp
@@ -34,14 +34,14 @@
 #include "nvs_flash.h"
 #include "platform/PlatformManager.h"
 #include "shell_extension/launch.h"
-#include <common/CHIPDeviceManager.h>
-#include <credentials/DeviceAttestationCredsProvider.h>
-#include <credentials/examples/DeviceAttestationCredsExample.h>
-
+#include <DeviceInfoProviderImpl.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/util/af.h>
 #include <binding-handler.h>
+#include <common/CHIPDeviceManager.h>
 #include <common/Esp32AppServer.h>
+#include <credentials/DeviceAttestationCredsProvider.h>
+#include <credentials/examples/DeviceAttestationCredsExample.h>
 
 #if CONFIG_HAVE_DISPLAY
 #include "DeviceWithDisplay.h"
@@ -91,8 +91,10 @@ AppCallbacks sCallbacks;
 constexpr EndpointId kNetworkCommissioningEndpointSecondary = 0xFFFE;
 
 #if CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
-chip::DeviceLayer::ESP32FactoryDataProvider sFactoryDataProvider;
+DeviceLayer::ESP32FactoryDataProvider sFactoryDataProvider;
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
+
+DeviceLayer::DeviceInfoProviderImpl sExampleDeviceInfoProvider;
 
 } // namespace
 
@@ -136,6 +138,8 @@ extern "C" void app_main()
     LaunchOpenThread();
     ThreadStackMgr().InitThreadStack();
 #endif
+
+    DeviceLayer::SetDeviceInfoProvider(&sExampleDeviceInfoProvider);
 
     CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
     CHIP_ERROR error              = deviceMgr.Init(&EchoCallbacks);

--- a/examples/light-switch-app/esp32/main/AppTask.cpp
+++ b/examples/light-switch-app/esp32/main/AppTask.cpp
@@ -20,7 +20,6 @@
 #include "BindingHandler.h"
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
-#include <DeviceInfoProviderImpl.h>
 
 #define APP_TASK_NAME "APP"
 #define APP_EVENT_QUEUE_SIZE 10
@@ -38,8 +37,6 @@ namespace {
 
 QueueHandle_t sAppEventQueue;
 TaskHandle_t sAppTaskHandle;
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-
 } // namespace
 
 AppTask AppTask::sAppTask;
@@ -65,7 +62,6 @@ CHIP_ERROR AppTask::Init()
 
     AppButton.Init();
     AppButton.SetButtonPressCallback(ButtonPressCallback);
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     return err;
 }

--- a/examples/light-switch-app/esp32/main/main.cpp
+++ b/examples/light-switch-app/esp32/main/main.cpp
@@ -30,6 +30,7 @@
 #include "nvs_flash.h"
 #include "shell_extension/launch.h"
 
+#include <DeviceInfoProviderImpl.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
@@ -38,15 +39,17 @@
 #include <platform/ESP32/ESP32FactoryDataProvider.h>
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
 
-namespace {
-#if CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
-chip::DeviceLayer::ESP32FactoryDataProvider sFactoryDataProvider;
-#endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
-} // namespace
-
 using namespace ::chip;
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceManager;
+
+namespace {
+#if CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
+DeviceLayer::ESP32FactoryDataProvider sFactoryDataProvider;
+#endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
+
+DeviceLayer::DeviceInfoProviderImpl sExampleDeviceInfoProvider;
+} // namespace
 
 static const char * TAG = "light-switch-app";
 
@@ -80,9 +83,10 @@ extern "C" void app_main()
     chip::LaunchShell();
 #endif // CONFIG_ENABLE_CHIP_SHELL
 
-    CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
+    DeviceLayer::SetDeviceInfoProvider(&sExampleDeviceInfoProvider);
 
-    CHIP_ERROR error = deviceMgr.Init(&EchoCallbacks);
+    CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
+    CHIP_ERROR error              = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {
         ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(error));

--- a/examples/lighting-app/esp32/main/AppTask.cpp
+++ b/examples/lighting-app/esp32/main/AppTask.cpp
@@ -20,7 +20,6 @@
 #include "esp_log.h"
 #include "freertos/FreeRTOS.h"
 
-#include <DeviceInfoProviderImpl.h>
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
@@ -46,9 +45,6 @@ namespace {
 constexpr EndpointId kLightEndpointId = 1;
 QueueHandle_t sAppEventQueue;
 TaskHandle_t sAppTaskHandle;
-
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
-
 } // namespace
 
 AppTask AppTask::sAppTask;
@@ -76,8 +72,6 @@ CHIP_ERROR AppTask::Init()
     AppButton.Init();
 
     AppButton.SetButtonPressCallback(ButtonPressCallback);
-
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     return err;
 }

--- a/examples/lighting-app/esp32/main/main.cpp
+++ b/examples/lighting-app/esp32/main/main.cpp
@@ -28,6 +28,7 @@
 #include "freertos/task.h"
 #include "nvs_flash.h"
 #include "shell_extension/launch.h"
+#include <DeviceInfoProviderImpl.h>
 #include <app/server/Dnssd.h>
 #include <app/server/OnboardingCodesUtil.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -48,8 +49,10 @@ static AppDeviceCallbacks EchoCallbacks;
 
 namespace {
 #if CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
-chip::DeviceLayer::ESP32FactoryDataProvider sFactoryDataProvider;
+DeviceLayer::ESP32FactoryDataProvider sFactoryDataProvider;
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
+
+DeviceLayer::DeviceInfoProviderImpl sExampleDeviceInfoProvider;
 } // namespace
 
 static void InitServer(intptr_t context)
@@ -77,9 +80,11 @@ extern "C" void app_main()
 #if CONFIG_ENABLE_CHIP_SHELL
     chip::LaunchShell();
 #endif
-    CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
 
-    CHIP_ERROR error = deviceMgr.Init(&EchoCallbacks);
+    DeviceLayer::SetDeviceInfoProvider(&sExampleDeviceInfoProvider);
+
+    CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
+    CHIP_ERROR error              = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {
         ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(error));

--- a/examples/lock-app/esp32/main/AppTask.cpp
+++ b/examples/lock-app/esp32/main/AppTask.cpp
@@ -21,7 +21,6 @@
 #include "Button.h"
 #include "LEDWidget.h"
 #include "esp_log.h"
-#include <DeviceInfoProviderImpl.h>
 #include <app-common/zap-generated/attribute-id.h>
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/cluster-id.h>
@@ -57,8 +56,6 @@ QueueHandle_t sAppEventQueue;
 bool sHaveBLEConnections = false;
 
 StackType_t appStack[APP_TASK_STACK_SIZE / sizeof(StackType_t)];
-
-chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 } // namespace
 
 using namespace ::chip::DeviceLayer;
@@ -105,8 +102,6 @@ CHIP_ERROR AppTask::Init()
     lockButton.Init(APP_LOCK_BUTTON, APP_BUTTON_DEBOUNCE_PERIOD_MS);
 
     sLockLED.Set(!BoltLockMgr().IsUnlocked());
-
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     chip::DeviceLayer::SystemLayer().ScheduleWork(UpdateClusterState, nullptr);
 

--- a/examples/lock-app/esp32/main/main.cpp
+++ b/examples/lock-app/esp32/main/main.cpp
@@ -27,6 +27,7 @@
 #include "freertos/task.h"
 #include "nvs_flash.h"
 #include "shell_extension/launch.h"
+#include <DeviceInfoProviderImpl.h>
 #include <common/CHIPDeviceManager.h>
 #include <common/Esp32AppServer.h>
 #include <credentials/DeviceAttestationCredsProvider.h>
@@ -48,15 +49,17 @@
 #include <platform/ESP32/ESP32FactoryDataProvider.h>
 #endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
 
-namespace {
-#if CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
-chip::DeviceLayer::ESP32FactoryDataProvider sFactoryDataProvider;
-#endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
-} // namespace
-
 using namespace ::chip;
 using namespace ::chip::DeviceManager;
 using namespace ::chip::Credentials;
+
+namespace {
+#if CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
+DeviceLayer::ESP32FactoryDataProvider sFactoryDataProvider;
+#endif // CONFIG_ENABLE_ESP32_FACTORY_DATA_PROVIDER
+
+DeviceLayer::DeviceInfoProviderImpl sExampleDeviceInfoProvider;
+} // namespace
 
 static const char * TAG = "lock-app";
 
@@ -96,9 +99,10 @@ extern "C" void app_main()
     chip::LaunchShell();
 #endif
 
-    CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
+    DeviceLayer::SetDeviceInfoProvider(&sExampleDeviceInfoProvider);
 
-    CHIP_ERROR error = deviceMgr.Init(&EchoCallbacks);
+    CHIPDeviceManager & deviceMgr = CHIPDeviceManager::GetInstance();
+    CHIP_ERROR error              = deviceMgr.Init(&EchoCallbacks);
     if (error != CHIP_NO_ERROR)
     {
         ESP_LOGE(TAG, "device.Init() failed: %s", ErrorStr(error));


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* We have random crash  in M5 multi fabric test
`0x400fe779: chip::DeviceLayer::DeviceInfoProviderImpl::GetUserLabelLength(unsigned short, unsigned int&) at /Users/vganji/MATTER-iOS/connectedhomeip/examples/all-clusters-app/esp32/build/../third_party/connectedhomeip/examples/providers/DeviceInfoProviderImpl.cpp:132`

That's:

    return mStorage->SyncGetKeyValue(keyAlloc.UserLabelLengthKey(endpoint), &val, len);

The random crash is caused by the following race condition:

app_main calls deviceMgr.Init(&EchoCallbacks);. This starts the Matter event loop.
StartAppTask(). This starts the background thread running AppTaskMain.
app_main schedules InitServer to run on the Matter thread.
Now the Matter event loop and AppTaskMain are racing. If the Matter event loop wins the race, it will do Server::Init, which will do the setting up of the storage delegate on whatever the value of the device info provider is at that point (which is null, so nothing will happen). Then AppTaskMain will call AppTask::Init, which calls chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);

There is no guarantee, SetDeviceInfoProvider is called before Server::Init 

We need to make sure the AppTaskMain -> AppTask::Init -> chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider) run before the Server::Init run in the Matter event loop

* Fixes #21684

#### Change overview
Always call SetDeviceInfoProvider before Server::Init 

#### Testing
How was this tested? (at least one bullet point required)
* Keep doing chip-tool userlabel read label-list 12345 1 against the esp32 all-clusters app/ lighting app and lock app, and confirm no crash 
