### PR TITLE
Fabric removal should only sync-deliver events for that fabric.

### DIFF
--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -350,6 +350,7 @@ public:
     // Gets called when a fabric is about to be deleted
     void FabricWillBeRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override
     {
+        ChipLogError(Zcl, "\n\nLeave event for fabric index: %u\n", fabricIndex);
         // The Leave event SHOULD be emitted by a Node prior to permanently leaving the Fabric.
         for (auto endpoint : EnabledEndpointsWithServerCluster(Basic::Id))
         {
@@ -364,13 +365,13 @@ public:
             }
         }
 
-        // Try to send the queued events as soon as possible. If the just emitted leave event won't
+        // Try to send the queued events as soon as possible for this fabric. If the just emitted leave event won't
         // be sent this time, it will likely not be delivered at all for the following reasons:
         // - removing the fabric expires all associated ReadHandlers, so all subscriptions to
         //   the leave event will be cancelled.
         // - removing the fabric removes all associated access control entries, so generating
         //   subsequent reports containing the leave event will fail the access control check.
-        InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleUrgentEventDeliverySync();
+        InteractionModelEngine::GetInstance()->GetReportingEngine().ScheduleUrgentEventDeliverySync(MakeOptional(fabricIndex));
     }
 
     // Gets called when a fabric is deleted

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -350,7 +350,6 @@ public:
     // Gets called when a fabric is about to be deleted
     void FabricWillBeRemoved(const FabricTable & fabricTable, FabricIndex fabricIndex) override
     {
-        ChipLogError(Zcl, "\n\nLeave event for fabric index: %u\n", fabricIndex);
         // The Leave event SHOULD be emitted by a Node prior to permanently leaving the Fabric.
         for (auto endpoint : EnabledEndpointsWithServerCluster(Basic::Id))
         {

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -981,10 +981,15 @@ CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBy
     return ScheduleBufferPressureEventDelivery(aBytesWritten);
 }
 
-void Engine::ScheduleUrgentEventDeliverySync()
+void Engine::ScheduleUrgentEventDeliverySync(Optional<FabricIndex> fabricIndex)
 {
-    InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject([](ReadHandler * handler) {
+    InteractionModelEngine::GetInstance()->mReadHandlers.ForEachActiveObject([fabricIndex](ReadHandler * handler) {
         if (handler->IsType(ReadHandler::InteractionType::Read))
+        {
+            return Loop::Continue;
+        }
+
+        if (fabricIndex.HasValue() && fabricIndex.Value() != handler->GetAccessingFabricIndex())
         {
             return Loop::Continue;
         }

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -119,7 +119,13 @@ public:
 
     uint64_t GetDirtySetGeneration() const { return mDirtyGeneration; }
 
-    void ScheduleUrgentEventDeliverySync();
+    /**
+     * Schedule event delivery to happen immediately and run reporting to get
+     * those reports into messages and on the wire.  This can be done either for
+     * a specific fabric, identified by the provided FabricIndex, or across all
+     * fabrics if no FabricIndex is provided.
+     */
+    void ScheduleUrgentEventDeliverySync(Optional<FabricIndex> fabricIndex = NullOptional);
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
     size_t GetGlobalDirtySetSize() { return mGlobalDirtySet.Allocated(); }


### PR DESCRIPTION
We were running into an issue where fabric removal would do sync event
delivery on other fabrics, and then removal of _those_ fabrics could
not deliver events (because there was a Report Data outstanding that
had not gotten a Status Response yet).

The fix is to only sync-deliver events for the fabric about to be
removed when a fabric is removed.

Fixes https://github.com/project-chip/connectedhomeip/issues/21744

#### Problem
See above.

#### Change overview
See above.

#### Testing
Ran the commands from #21744.  Output before this change:
```
(On fabric 1)
[1660064884674] [90390:8953652] CHIP: [TOO] Endpoint: 0 Cluster: 0x0000_0028 Event 0x0000_0002
[1660064884674] [90390:8953652] CHIP: [TOO]   Event number: 65541
[1660064884674] [90390:8953652] CHIP: [TOO]   Priority: Info
[1660064884674] [90390:8953652] CHIP: [TOO]   Timestamp: 126366
[1660064884676] [90390:8953652] CHIP: [TOO]   Leave: {
[1660064884676] [90390:8953652] CHIP: [TOO]     FabricIndex: 1
[1660064884676] [90390:8953652] CHIP: [TOO]    }

(On fabric 2)
[1660064885525] [90390:8955520] CHIP: [TOO] Endpoint: 0 Cluster: 0x0000_0028 Event 0x0000_0002
[1660064885525] [90390:8955520] CHIP: [TOO]   Event number: 65541
[1660064885525] [90390:8955520] CHIP: [TOO]   Priority: Info
[1660064885525] [90390:8955520] CHIP: [TOO]   Timestamp: 126366
[1660064885525] [90390:8955520] CHIP: [TOO]   Leave: {
[1660064885525] [90390:8955520] CHIP: [TOO]     FabricIndex: 1
[1660064885525] [90390:8955520] CHIP: [TOO]    }
```

Output after this change:
```
(On fabric 1)
[1660064884674] [90390:8953652] CHIP: [TOO] Endpoint: 0 Cluster: 0x0000_0028 Event 0x0000_0002
[1660064884674] [90390:8953652] CHIP: [TOO]   Event number: 65541
[1660064884674] [90390:8953652] CHIP: [TOO]   Priority: Info
[1660064884674] [90390:8953652] CHIP: [TOO]   Timestamp: 126366
[1660064884676] [90390:8953652] CHIP: [TOO]   Leave: {
[1660064884676] [90390:8953652] CHIP: [TOO]     FabricIndex: 1
[1660064884676] [90390:8953652] CHIP: [TOO]    }

(On fabric 2)
[1660064885525] [90390:8955520] CHIP: [TOO] Endpoint: 0 Cluster: 0x0000_0028 Event 0x0000_0002
[1660064885525] [90390:8955520] CHIP: [TOO]   Event number: 65541
[1660064885525] [90390:8955520] CHIP: [TOO]   Priority: Info
[1660064885525] [90390:8955520] CHIP: [TOO]   Timestamp: 126366
[1660064885525] [90390:8955520] CHIP: [TOO]   Leave: {
[1660064885525] [90390:8955520] CHIP: [TOO]     FabricIndex: 1
[1660064885525] [90390:8955520] CHIP: [TOO]    }
[1660064885525] [90390:8955520] CHIP: [TOO] Endpoint: 0 Cluster: 0x0000_0028 Event 0x0000_0002
[1660064885525] [90390:8955520] CHIP: [TOO]   Event number: 65542
[1660064885525] [90390:8955520] CHIP: [TOO]   Priority: Info
[1660064885525] [90390:8955520] CHIP: [TOO]   Timestamp: 127194
[1660064885525] [90390:8955520] CHIP: [TOO]   Leave: {
[1660064885525] [90390:8955520] CHIP: [TOO]     FabricIndex: 2
[1660064885525] [90390:8955520] CHIP: [TOO]    }
```