### PR TITLE
[EFR32]Add new boards support

### DIFF
--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -91,8 +91,8 @@ chip_data_model("chef-common") {
   is_server = true
 }
 
-# BRD4166A --> ThunderBoard Sense 2 (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
+# ThunderBoards  (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -92,7 +92,7 @@ chip_data_model("chef-common") {
 }
 
 # ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -84,8 +84,8 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# BRD4166A --> ThunderBoard Sense 2 (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
+# ThunderBoards  (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -85,7 +85,7 @@ if (chip_enable_wifi) {
 }
 
 # ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -84,8 +84,8 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# BRD4166A --> ThunderBoard Sense 2 (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
+# ThunderBoards  (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -85,7 +85,7 @@ if (chip_enable_wifi) {
 }
 
 # ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -84,8 +84,8 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# BRD4166A --> ThunderBoard Sense 2 (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
+# ThunderBoards  (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -85,7 +85,7 @@ if (chip_enable_wifi) {
 }
 
 # ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/thermostat/efr32/BUILD.gn
+++ b/examples/thermostat/efr32/BUILD.gn
@@ -81,8 +81,8 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# BRD4166A --> ThunderBoard Sense 2 (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
+# ThunderBoards  (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/thermostat/efr32/BUILD.gn
+++ b/examples/thermostat/efr32/BUILD.gn
@@ -82,7 +82,7 @@ if (chip_enable_wifi) {
 }
 
 # ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -77,8 +77,8 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# BRD4166A --> ThunderBoard Sense 2 (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD4180A") {
+# ThunderBoards  (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -78,7 +78,7 @@ if (chip_enable_wifi) {
 }
 
 # ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2106B") {
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/third_party/silabs/efr32_board.gni
+++ b/third_party/silabs/efr32_board.gni
@@ -65,8 +65,17 @@ if (efr32_board == "BRD4304A") {
 } else if (efr32_board == "BRD4186A" || efr32_board == "BRD4187A") {
   efr32_family = "efr32mg24"
   efr32_mcu = "EFR32MG24A010F1536GM48"
+} else if (efr32_board == "BRD4186C") { 
+  efr32_family = "efr32mg24"
+  efr32_mcu = "EFR32MG24B210F1536IM48"
+} else if (efr32_board == "BRD4187C") {
+  efr32_family = "efr32mg24"
+  efr32_mcu = "EFR32MG24B220F1536IM48"
+} else if (efr32_board == "BRD2601B") {
+  efr32_family = "efr32mg24"
+  efr32_mcu = "EFR32MG24B310F1536IM48"
 } else {
   print(
       "Please provide a valid value for EFR32_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186A, BRD4187A)")
-  assert(false, "The board ${efr32_board} is unsupported as for now.")
+  assert(false, "The board ${efr32_board} is unsupported")
 }

--- a/third_party/silabs/efr32_board.gni
+++ b/third_party/silabs/efr32_board.gni
@@ -59,13 +59,14 @@ if (efr32_board == "BRD4304A") {
 } else if (efr32_board == "BRD4180A") {
   assert(
       false,
-      "The board ${efr32_board} not currentlt supported due to RAM limitation")
+      "The board ${efr32_board} not currently supported due to RAM limitation")
   efr32_family = "efr32mg21"
   efr32_mcu = "EFR32MG21A020F1024IM32"
 } else if (efr32_board == "BRD4186A" || efr32_board == "BRD4187A") {
+  print("RevA is deprecated, We suggest using BRD4186C (rev C)")
   efr32_family = "efr32mg24"
   efr32_mcu = "EFR32MG24A010F1536GM48"
-} else if (efr32_board == "BRD4186C") { 
+} else if (efr32_board == "BRD4186C") {
   efr32_family = "efr32mg24"
   efr32_mcu = "EFR32MG24B210F1536IM48"
 } else if (efr32_board == "BRD4187C") {
@@ -76,6 +77,6 @@ if (efr32_board == "BRD4304A") {
   efr32_mcu = "EFR32MG24B310F1536IM48"
 } else {
   print(
-      "Please provide a valid value for EFR32_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186A, BRD4187A)")
+      "Please provide a valid value for EFR32_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186C, BRD4187C, BRD2601B)")
   assert(false, "The board ${efr32_board} is unsupported")
 }

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -219,7 +219,6 @@ template("efr32_sdk") {
 
     if (efr32_family == "efr32mg12") {
       _include_dirs += [
-        "${efr32_sdk_root}/hardware/kit/EFR32MG12_${efr32_board}/config",
         "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG12P/Include",
         "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg1x",
         "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F",
@@ -236,7 +235,6 @@ template("efr32_sdk") {
       defines += [ "EFR32MG12" ]
     } else if (efr32_family == "efr32mg21") {
       _include_dirs += [
-        "${efr32_sdk_root}/hardware/kit/EFR32MG21_${efr32_board}/config",
         "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG21/Include",
         "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg2x",
         "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
@@ -257,7 +255,6 @@ template("efr32_sdk") {
       ]
     } else if (efr32_family == "efr32mg24") {
       _include_dirs += [
-        "${efr32_sdk_root}/hardware/kit/EFR32MG24_${efr32_board}/config",
         "${efr32_sdk_root}/platform/Device/SiliconLabs/EFR32MG24/Include",
         "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg2x",
         "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",


### PR DESCRIPTION
#### Problem
n/a

#### Change overview
Add new boards
BRD2601B ( Thunderboard for MG24 family) No LCD on this board, so we also disable that feature for it
BRD4186C and BRD4187C. This is the rev C of the already supported rev A. Rev C is the officially released board version.
Update matter_support submodule that adds bring up code, initialization and configs for those news boards

#### Testing
Build lighting app on all 3 new boards and commission them.
