### PR TITLE
Lock app minor fixes

### DIFF
--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -171,7 +171,6 @@ public:
 
 private:
     friend LockManager & LockMgr();
-    chip::EndpointId mEndpointId;
     State_t mState;
 
     Callback_fn_initiated mActionInitiated_CB;

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -643,7 +643,7 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
     // If a pin code is not given
     if (!pin.HasValue())
     {
-        ChipLogDetail(Zcl, "Door Lock App: PIN code is not specified, but it is required [endpointId=%d]", mEndpointId);
+        ChipLogDetail(Zcl, "Door Lock App: PIN code is not specified [endpointId=%d]", mEndpointId);
 
         // If a pin code is not required
         if (!requirePin)
@@ -655,6 +655,8 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
 
             return true;
         }
+
+        ChipLogError(Zcl, "Door Lock App: PIN code is not specified, but it is required [endpointId=%d]", mEndpointId);
 
         return false;
     }

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -643,7 +643,7 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
     // If a pin code is not given
     if (!pin.HasValue())
     {
-        ChipLogDetail(Zcl, "Door Lock App: PIN code is not specified [endpointId=%d]", mEndpointId);
+        ChipLogDetail(Zcl, "Door Lock App: PIN code is not specified [endpointId=%d]", endpointId);
 
         // If a pin code is not required
         if (!requirePin)
@@ -656,7 +656,7 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
             return true;
         }
 
-        ChipLogError(Zcl, "Door Lock App: PIN code is not specified, but it is required [endpointId=%d]", mEndpointId);
+        ChipLogError(Zcl, "Door Lock App: PIN code is not specified, but it is required [endpointId=%d]", endpointId);
 
         return false;
     }
@@ -674,7 +674,7 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
         {
             ChipLogDetail(Zcl,
                           "Lock App: specified PIN code was found in the database, setting lock state to \"%s\" [endpointId=%d]",
-                          lockStateToString(lockState), mEndpointId);
+                          lockStateToString(lockState), endpointId);
 
             DoorLockServer::Instance().SetLockState(endpointId, lockState);
 
@@ -685,7 +685,7 @@ bool LockManager::setLockState(chip::EndpointId endpointId, DlLockState lockStat
     ChipLogDetail(Zcl,
                   "Door Lock App: specified PIN code was not found in the database, ignoring command to set lock state to \"%s\" "
                   "[endpointId=%d]",
-                  lockStateToString(lockState), mEndpointId);
+                  lockStateToString(lockState), endpointId);
 
     err = DlOperationError::kInvalidCredential;
     return false;

--- a/examples/lock-app/linux/src/LockEndpoint.cpp
+++ b/examples/lock-app/linux/src/LockEndpoint.cpp
@@ -17,6 +17,7 @@
  */
 #include "LockEndpoint.h"
 #include <cstring>
+#include <app-common/zap-generated/attributes/Accessors.h>
 
 using chip::to_underlying;
 
@@ -362,15 +363,29 @@ DlStatus LockEndpoint::SetSchedule(uint8_t holidayIndex, DlScheduleStatus status
 
 bool LockEndpoint::setLockState(DlLockState lockState, const Optional<chip::ByteSpan> & pin, DlOperationError & err)
 {
+    // Assume pin is required until told otherwise
+    bool requirePin = true;
+    chip::app::Clusters::DoorLock::Attributes::RequirePINforRemoteOperation::Get(mEndpointId, &requirePin);
+
+    // If a pin code is not given
     if (!pin.HasValue())
     {
-        ChipLogDetail(Zcl, "Lock App: PIN code is not specified, setting door lock state to \"%s\" [endpointId=%d]",
-                      lockStateToString(lockState), mEndpointId);
+        ChipLogDetail(Zcl, "Door Lock App: PIN code is not specified [endpointId=%d]", mEndpointId);
 
-        mLockState = lockState;
-        DoorLockServer::Instance().SetLockState(mEndpointId, mLockState);
+        // If a pin code is not required
+        if (!requirePin)
+        {
+            ChipLogDetail(Zcl, "Door Lock App: setting door lock state to \"%s\" [endpointId=%d]", lockStateToString(lockState),
+                          mEndpointId);
 
-        return true;
+            DoorLockServer::Instance().SetLockState(mEndpointId, lockState);
+
+            return true;
+        }
+
+        ChipLogError(Zcl, "Door Lock App: PIN code is not specified, but it is required [endpointId=%d]", mEndpointId);
+
+        return false;
     }
 
     // Find the credential so we can make sure it is not absent right away

--- a/examples/lock-app/linux/src/LockEndpoint.cpp
+++ b/examples/lock-app/linux/src/LockEndpoint.cpp
@@ -16,8 +16,8 @@
  *    limitations under the License.
  */
 #include "LockEndpoint.h"
-#include <cstring>
 #include <app-common/zap-generated/attributes/Accessors.h>
+#include <cstring>
 
 using chip::to_underlying;
 


### PR DESCRIPTION
#### Problem
[EFR32] Misleading log statement in efr32 lock-app example.
There is an unused mEndpointId in efr32 lock example

#### Change overview
Fix the misleading log statement in efr32 example
Remove unused mEndpointId in efr32 example

#### Testing
Tested on efr32. If a pincode is not given, and is not required the following prints
ChipLogDetail(Zcl, "Door Lock App: PIN code is not specified [endpointId=%d]", mEndpointId);
ChipLogDetail(Zcl, "Door Lock App: setting door lock state to \"%s\" [endpointId=%d]", lockStateToString(lockState),
                endpointId);

If a pincode is not given, but it is required the following prints
ChipLogDetail(Zcl, "Door Lock App: PIN code is not specified [endpointId=%d]", mEndpointId);
ChipLogError(Zcl, "Door Lock App: PIN code is not specified, but it is required [endpointId=%d]", mEndpointId);

