### PR TITLE
Give ChipDeviceController.java public method to release connected device pointer

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -671,7 +671,7 @@ JNI_METHOD(void, getConnectedDevicePointer)(JNIEnv * env, jobject self, jlong ha
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error invoking GetConnectedDevice"));
 }
 
-JNI_METHOD(void, releaseConnectedDevicePointer)(JNIEnv * env, jobject self, jlong devicePtr)
+JNI_METHOD(void, releaseOperationalDevicePointer)(JNIEnv * env, jobject self, jlong devicePtr)
 {
     chip::DeviceLayer::StackLock lock;
     OperationalDeviceProxy * device = reinterpret_cast<OperationalDeviceProxy *>(devicePtr);

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -258,6 +258,10 @@ public class ChipDeviceController {
     getConnectedDevicePointer(deviceControllerPtr, nodeId, jniCallback.getCallbackHandle());
   }
 
+  public void releaseConnectedDevicePointer(long devicePtr) {
+    releaseOperationalDevicePointer(devicePtr);
+  }
+
   public boolean disconnectDevice(long deviceId) {
     return disconnectDevice(deviceControllerPtr, deviceId);
   }
@@ -630,7 +634,7 @@ public class ChipDeviceController {
   private native void getConnectedDevicePointer(
       long deviceControllerPtr, long deviceId, long callbackHandle);
 
-  private native void releaseConnectedDevicePointer(long devicePtr);
+  private native void releaseOperationalDevicePointer(long devicePtr);
 
   private native boolean disconnectDevice(long deviceControllerPtr, long deviceId);
 


### PR DESCRIPTION
#### Problem
* #21256 I forgot to make the `releaseConnectedDevicePointer` public in ChipDeviceController.java 

#### Change overview
* Expose public method for `releaseConnectedDevicePointer` in ChipDeviceController.java.
* Since the arguments are the same for the native jni function I changed the name to something that is accurate.

#### Testing
* CI compiles (especially making sure that the android CI job compiles)
