### PR TITLE
Fix read client matching for unsolicited report

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -257,7 +257,7 @@ CHIP_ERROR InteractionModelEngine::ShutdownSubscription(SubscriptionId aSubscrip
 {
     for (auto * readClient = mpActiveReadClientList; readClient != nullptr; readClient = readClient->GetNextClient())
     {
-        if (readClient->IsSubscriptionType() && readClient->IsMatchingClient(aSubscriptionId))
+        if (readClient->IsSubscriptionType() && readClient->IsMatchingSubscriptionId(aSubscriptionId))
         {
             readClient->Close(CHIP_NO_ERROR);
             return CHIP_NO_ERROR;
@@ -538,8 +538,9 @@ Status InteractionModelEngine::OnUnsolicitedReportData(Messaging::ExchangeContex
         {
             continue;
         }
-
-        if (!readClient->IsMatchingClient(subscriptionId))
+        auto peer = apExchangeContext->GetSessionHandle()->GetPeer();
+        if (readClient->GetFabricIndex() != peer.GetFabricIndex() || readClient->GetPeerNodeId() != peer.GetNodeId() ||
+            !readClient->IsMatchingSubscriptionId(subscriptionId))
         {
             continue;
         }

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -509,7 +509,7 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
         {
             mSubscriptionId = subscriptionId;
         }
-        else if (!IsMatchingClient(subscriptionId))
+        else if (!IsMatchingSubscriptionId(subscriptionId))
         {
             err = CHIP_ERROR_INVALID_SUBSCRIPTION;
         }
@@ -838,7 +838,7 @@ CHIP_ERROR ReadClient::ProcessSubscribeResponse(System::PacketBufferHandle && aP
 
     SubscriptionId subscriptionId = 0;
     VerifyOrReturnError(subscribeResponse.GetSubscriptionId(&subscriptionId) == CHIP_NO_ERROR, CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrReturnError(IsMatchingClient(subscriptionId), CHIP_ERROR_INVALID_SUBSCRIPTION);
+    VerifyOrReturnError(IsMatchingSubscriptionId(subscriptionId), CHIP_ERROR_INVALID_SUBSCRIPTION);
     ReturnErrorOnFailure(subscribeResponse.GetMaxInterval(&mMaxInterval));
 
     ChipLogProgress(DataManagement,

--- a/src/app/ReadClient.h
+++ b/src/app/ReadClient.h
@@ -411,7 +411,7 @@ private:
         SubscriptionActive,        ///< The client is maintaining subscription
     };
 
-    bool IsMatchingClient(SubscriptionId aSubscriptionId)
+    bool IsMatchingSubscriptionId(SubscriptionId aSubscriptionId)
     {
         return aSubscriptionId == mSubscriptionId && mInteractionType == InteractionType::Subscribe;
     }


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/21593

#### Change overview
Use fabric index, peer node id, subscription id to identify a subscription uniquely on the client side
Rename IsMatchingClient to IsMatchingSubscriptionId

#### Testing
Existing test covers
