### PR TITLE
EFR: Fix efr lock rpc build

### DIFF
--- a/examples/lock-app/efr32/with_pw_rpc.gni
+++ b/examples/lock-app/efr32/with_pw_rpc.gni
@@ -29,3 +29,4 @@ cpp_standard = "gnu++17"
 
 # To fit in flash
 chip_detail_logging = false
+show_qr_code = false


### PR DESCRIPTION

#### Problem
efr32-brd4161a-lock-rpc build is failing to build from insufficient flash.

#### Change overview
Disable `show_qr_code` on the RPC variant, as it's not needed.

#### Testing
Compiled the example.