### PR TITLE
fix(python): fix no event loop on resubscribe

### DIFF
--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -745,7 +745,8 @@ class AsyncReadTransaction:
                 self._event_loop.create_task(self._subscription_handler._onresubscriptionattemptedcb(
                     self._subscription_handler, terminationCause, nextResubscribeIntervalMsec))
         else:
-            self._subscription_handler._onResubscriptionAttemptedCb(self._subscription_handler, terminationCause, nextResubscribeIntervalMsec)
+            self._subscription_handler._onResubscriptionAttemptedCb(
+                self._subscription_handler, terminationCause, nextResubscribeIntervalMsec)
 
     def _handleReportBegin(self):
         pass


### PR DESCRIPTION
#### Problem
The initial event loop passed to [AsyncReadTransaction](https://github.com/project-chip/connectedhomeip/blob/93d72d265b449488ed260264620a6344a40550c6/src/controller/python/chip/clusters/Attribute.py#L625) is closed by the time a resubscribe occurs.  It only lives until [ZCLSubscribeAttribute](https://github.com/project-chip/connectedhomeip/blob/93d72d265b449488ed260264620a6344a40550c6/src/controller/python/chip/ChipDeviceCtrl.py#L1091) returns.

```
2022-08-09 21:50:17 548360307136 ERROR    chip.DMG             _RedirectToPythonLogging:38 Subscription Liveness timeout with SubscriptionID = 0xc2da39a0, Peer = 01:000000008BD4493D
2022-08-09 21:50:17 548360307136 INFO     chip.DMG             _RedirectToPythonLogging:40 Will try to resubscribe to 01:000000008BD4493D at retry index 0 after 0ms due to error ../../src/app/ReadClient.cpp:824: CHIP Error 0x00000032: Timeout
Exception ignored on calling ctypes callback function: <function _OnResubscriptionAttemptedCallback at 0x7fb2084c10>
Traceback (most recent call last):
  File "/home/pi/matterlib/.venv/lib/python3.9/site-packages/chip/clusters/Attribute.py", line 865, in _OnResubscriptionAttemptedCallback
    closure.handleResubscriptionAttempted(terminationCause, nextResubscribeIntervalMsec)
  File "/home/pi/matterlib/.venv/lib/python3.9/site-packages/chip/clusters/Attribute.py", line 736, in handleResubscriptionAttempted
    self._event_loop.call_soon_threadsafe(
  File "/usr/lib/python3.9/asyncio/base_events.py", line 791, in call_soon_threadsafe
     self._check_closed()
   File "/usr/lib/python3.9/asyncio/base_events.py", line 510, in _check_closed
     raise RuntimeError('Event loop is closed')
 RuntimeError: Event loop is closed
2022-08-09 21:50:17 548360307136 INFO     chip.DMG             _RedirectToPythonLogging:40 OnResubscribeTimerCallback: DoCASE = 1
2022-08-09 21:50:17 548360307136 INFO     chip.SC              _RedirectToPythonLogging:40 SecureSession[0x7f9403aaf0]: Moving from state 'kActive' --> 'kDefunct'
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 UDP:[fd0b:ca5d:4d1d:1:9f94:5c40:bf3e:d03a%eth0]:5540: new best score: 6
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Checking node lookup status after 4 ms
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Keeping DNSSD lookup active
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 UDP:[fd0b:ca5d:4d1d:1:9f94:5c40:bf3e:d03a%eth0]:5540: score has not improved: 6
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Checking node lookup status after 8 ms
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Keeping DNSSD lookup active
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 UDP:[fd0b:ca5d:4d1d:1:9f94:5c40:bf3e:d03a%docker0]:5540: score has not improved: 6
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Checking node lookup status after 13 ms
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Keeping DNSSD lookup active
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 UDP:[fd0b:ca5d:4d1d:1:9f94:5c40:bf3e:d03a%docker0]:5540: score has not improved: 6
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Checking node lookup status after 18 ms
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Keeping DNSSD lookup active
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 UDP:[fd0b:ca5d:4d1d:1:9f94:5c40:bf3e:d03a%veth72ba261]:5540: score has not improved: 6
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Checking node lookup status after 22 ms
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Keeping DNSSD lookup active
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 UDP:[fd0b:ca5d:4d1d:1:9f94:5c40:bf3e:d03a%veth72ba261]:5540: score has not improved: 6
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Checking node lookup status after 27 ms
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Keeping DNSSD lookup active
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 UDP:[fd0b:ca5d:4d1d:1:9f94:5c40:bf3e:d03a%eth0]:5540: score has not improved: 6
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Checking node lookup status after 35 ms
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Keeping DNSSD lookup active
2022-08-09 21:50:17 548360307136 INFO     chip.DIS             _RedirectToPythonLogging:40 Checking node lookup status after 200 ms
2022-08-09 21:50:17 548360307136 INFO     chip.SC              _RedirectToPythonLogging:40 Initiating session on local FabricIndex 1 from 0x0000000000000001 -> 0x000000008BD4493D
2022-08-09 21:50:17 548360307136 INFO     chip.IN              _RedirectToPythonLogging:40 Prepared unauthenticated message 0x7f94037908 to 0x0000000000000000 (0)  of type 0x30 and protocolId (0, 0) on exchange 17328i with MessageCounter:205122604.
2022-08-09 21:50:17 548360307136 INFO     chip.IN              _RedirectToPythonLogging:40 Sending unauthenticated msg 0x7f94037908 with MessageCounter:205122604 to 0x0000000000000000 at monotonic time: 0000000018B8AE8F msec
2022-08-09 21:50:17 548360307136 INFO     chip.SC              _RedirectToPythonLogging:40 Sent Sigma1 msg
2022-08-09 21:50:17 548360307136 INFO     chip.EM              _RedirectToPythonLogging:40 Received message of type 0x10 with protocolId (0, 0) and MessageCounter:261366575 on exchange 17328i
2022-08-09 21:50:17 548360307136 INFO     chip.EM              _RedirectToPythonLogging:40 Received message of type 0x33 with protocolId (0, 0) and MessageCounter:261366576 on exchange 17328i
2022-08-09 21:50:17 548360307136 INFO     root                 SetSdkKey:151 SetSdkKey: g/sri = b'\x16\x15$\x01\x01&\x02\xa8\x83$\x9c\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\x    baS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\    x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85    \x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\xf6\xd7\xa7g\x18\x15$\x01\x01&\x02\xf6\xd7\xa7g\x18\x15$\x01\x01&\x02\xf6\xd7\xa7g\x18\x15$\x01\x01&\x0    2\xf6\xd7\xa7g\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02=I\xd4\x8b\x18\x18'
2022-08-09 21:50:17 548360307136 INFO     root                 SetSdkKey:151 SetSdkKey: f/1/s/000000008BD4493D = b'\x150\x03\x10\xbbJ\xc0s\xca\xbd\xcf\xde\xe7@\x83\xd8\x84\xe7\x00\xab0\x04 ,\xa5\xbc\xda2\x02\xe3y\x84\x9c\xa3\xcbn\xe5V\x05\xf2\xdd\xa23\xe9?\xeda\x83\xd4\x11\xe6\x1c\x1fGJ0\x05\x0c\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18'
2022-08-09 21:50:17 548360307136 INFO     root                 SetSdkKey:151 SetSdkKey: g/s/u0rAc8q9z97nQIPYhOcAqw== = b'\x15$\x01\x01&\x02=I\xd4\x8b\x18'
2022-08-09 21:50:17 548360307136 INFO     root                 SetSdkKey:151 SetSdkKey: g/sri = b'\x16\x15$\x01\x01&\x02\xa8\x83$\x9c\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\x    baS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\    x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85    \x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\x94\xbaS\x85\x18\x15$\x01\x01&\x02\xf6\xd7\xa7g\x18\x15$\x01\x01&\x02\xf6\xd7\xa7g\x18\x15$\x01\x01&\x02\xf6\xd7\xa7g\x18\x15$\x01\x01&\x0    2\xf6\xd7\xa7g\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02\x14\x141z\x18\x15$\x01\x01&\x02=I\xd4\x8b\x18\x15$\x01\x01&\x02=I\xd4\x8b\x18\x18'
2022-08-09 21:50:17 548360307136 INFO     chip.IN              _RedirectToPythonLogging:40 Prepared unauthenticated message 0x7f9401b4d8 to 0x0000000000000000 (0)  of type 0x40 and protocolId (0, 0) on exchange 17328i with MessageCounter:205122605.
2022-08-09 21:50:17 548360307136 INFO     chip.IN              _RedirectToPythonLogging:40 Sending unauthenticated msg 0x7f9401b4d8 with MessageCounter:205122605 to 0x0000000000000000 at monotonic time: 0000000018B8AED1 msec
2022-08-09 21:50:17 548360307136 INFO     chip.SC              _RedirectToPythonLogging:40 SecureSession[0x7f94055880]: Moving from state 'kEstablishing' --> 'kActive'
2022-08-09 21:50:17 548360307136 INFO     chip.DMG             _RedirectToPythonLogging:40 HandleDeviceConnected
2022-08-09 21:50:17 548360307136 INFO     chip.IN              _RedirectToPythonLogging:40 Prepared secure message 0x7f94033c78 to 0x000000008BD4493D (1)  of type 0x3 and protocolId (0, 1) on exchange 17329i with MessageCounter:125897414.
2022-08-09 21:50:17 548360307136 INFO     chip.IN              _RedirectToPythonLogging:40 Sending encrypted msg 0x7f94033c78 with MessageCounter:125897414 to 0x000000008BD4493D (1) at monotonic time: 0000000018B8AED7 msec
2022-08-09 21:50:17 548360307136 INFO     chip.EM              _RedirectToPythonLogging:40 Received message of type 0x10 with protocolId (0, 0) and MessageCounter:261366577 on exchange 17328i
2022-08-09 21:50:17 548360307136 INFO     chip.EM              _RedirectToPythonLogging:40 Received message of type 0x5 with protocolId (0, 1) and MessageCounter:66357020 on exchange 17329i
2022-08-09 21:50:17 547868369344 INFO     matter_manager       _handle_zcl_report_data:277 attribute updated: ZclAttributeUpdatedEvent(cluster=6, attribute=0, node_id=2345945405, endpoint_id=1, group_id=None, value=True, subscription_id=3269081504, data_version=761109445)
2022-08-09 21:50:17 548377354688 INFO     matter_manager       _handle_zcl_subscribe:359 zcl_subscribe successful: ZclSubscribeEvent(cluster=6, attribute=0, node_id=2345945405, endpoint_id=1, min_interval=0, max_interval=20)
2022-08-09 21:50:17 548360307136 INFO     chip.IN              _RedirectToPythonLogging:40 Prepared secure message 0x7f940350a8 to 0x000000008BD4493D (1)  of type 0x1 and protocolId (0, 1) on exchange 17329i with MessageCounter:125897415.
2022-08-09 21:50:17 547868369344 DEBUG    root                 matter_command_callback:419 matter command callback invoked: ZclSubscribeEvent(cluster=6, attribute=0, node_id=2345945405, endpoint_id=1, min_interval=0, max_interval=20)
2022-08-09 21:50:17 548360307136 INFO     chip.IN              _RedirectToPythonLogging:40 Sending encrypted msg 0x7f940350a8 with MessageCounter:125897415 to 0x000000008BD4493D (1) at monotonic time: 0000000018B8AF02 msec
2022-08-09 21:50:17 548360307136 INFO     chip.EM              _RedirectToPythonLogging:40 Received message of type 0x4 with protocolId (0, 1) and MessageCounter:66357021 on exchange 17329i
2022-08-09 21:50:17 548360307136 INFO     chip.DMG             _RedirectToPythonLogging:40 SubscribeResponse is received
2022-08-09 21:50:17 548360307136 INFO     chip.DMG             _RedirectToPythonLogging:40 Subscription established with SubscriptionID = 0x804addd6 MinInterval = 0s MaxInterval = 20s Peer = 01:000000008BD4493D
Exception ignored on calling ctypes callback function: <function _OnSubscriptionEstablishedCallback at 0x7fb2084b80>
Traceback (most recent call last):
  File "/home/pi/matterlib/.venv/lib/python3.9/site-packages/chip/clusters/Attribute.py", line 860, in _OnSubscriptionEstablishedCallback
    closure.handleSubscriptionEstablished(subscriptionId)
  File "/home/pi/matterlib/.venv/lib/python3.9/site-packages/chip/clusters/Attribute.py", line 728, in handleSubscriptionEstablished
    self._event_loop.call_soon_threadsafe(
 File "/usr/lib/python3.9/asyncio/base_events.py", line 791, in call_soon_threadsafe
   self._check_closed()
 File "/usr/lib/python3.9/asyncio/base_events.py", line 510, in _check_closed
    raise RuntimeError('Event loop is closed')
RuntimeError: Event loop is closed
```

#### Change overview
Uses asyncio.run if the event loop that is passed upon initialization of the object is closed.

#### Testing
Manually tested on an RPi.