### PR TITLE
[Ameba] Support Matter Shell on 8710C platform

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -46,8 +46,11 @@ algs
 alloc
 AlarmCode
 Ameba
+AmebaD
 amebad
 amebaiot
+AmebaZ2
+amebaz2
 announcementReason
 AnnounceOTAProvider
 AnnounceOtaProviderRequest

--- a/examples/all-clusters-app/ameba/README.md
+++ b/examples/all-clusters-app/ameba/README.md
@@ -92,10 +92,18 @@ to be On or Off.
 ## Running RPC Console
 
 -   Connect a USB-TTL adapter as shown below
+-   For AmebaD
 
             Ameba         USB-TTL
             A19           TX
             A18           RX
+            GND           GND
+            
+-   For AmebaZ2
+
+            Ameba         USB-TTL
+            A13           TX
+            A14           RX
             GND           GND
 
 *   Build the

--- a/examples/all-clusters-app/ameba/README.md
+++ b/examples/all-clusters-app/ameba/README.md
@@ -98,7 +98,8 @@ to be On or Off.
             A19           TX
             A18           RX
             GND           GND
-            
+
+
 -   For AmebaZ2
 
             Ameba         USB-TTL

--- a/examples/all-clusters-app/ameba/README.md
+++ b/examples/all-clusters-app/ameba/README.md
@@ -99,29 +99,28 @@ to be On or Off.
             A18           RX
             GND           GND
 
-
--   For AmebaZ2
+*   For AmebaZ2
 
             Ameba         USB-TTL
             A13           TX
             A14           RX
             GND           GND
 
-*   Build the
+-   Build the
     [chip-rpc console](https://github.com/project-chip/connectedhomeip/tree/master/examples/common/pigweed/rpc_console)
 
-*   As part of building the example with RPCs enabled the chip_rpc python
+-   As part of building the example with RPCs enabled the chip_rpc python
     interactive console is installed into your venv. The python wheel files are
     also created in the output folder: out/debug/chip_rpc_console_wheels. To
     install the wheel files without rebuilding:
 
             $ pip3 install out/debug/chip_rpc_console_wheels/*.whl
 
--   Launch the chip-rpc console after resetting Ameba board
+*   Launch the chip-rpc console after resetting Ameba board
 
             $ chip-console --device /dev/tty<port connected to USB-TTL adapter> -b 115200
 
-*   Get and Set lighting directly using the RPC console
+-   Get and Set lighting directly using the RPC console
 
             python
             rpcs.chip.rpc.Lighting.Get()

--- a/examples/light-switch-app/ameba/README.md
+++ b/examples/light-switch-app/ameba/README.md
@@ -91,10 +91,18 @@ to be On or Off.
 ## Running RPC Console
 
 -   Connect a USB-TTL adapter as shown below
+-   For AmebaD
 
             Ameba         USB-TTL
             A19           TX
             A18           RX
+            GND           GND
+            
+-   For AmebaZ2
+
+            Ameba         USB-TTL
+            A13           TX
+            A14           RX
             GND           GND
 
 *   Build the

--- a/examples/light-switch-app/ameba/README.md
+++ b/examples/light-switch-app/ameba/README.md
@@ -97,7 +97,8 @@ to be On or Off.
             A19           TX
             A18           RX
             GND           GND
-            
+
+
 -   For AmebaZ2
 
             Ameba         USB-TTL

--- a/examples/light-switch-app/ameba/README.md
+++ b/examples/light-switch-app/ameba/README.md
@@ -98,29 +98,28 @@ to be On or Off.
             A18           RX
             GND           GND
 
-
--   For AmebaZ2
+*   For AmebaZ2
 
             Ameba         USB-TTL
             A13           TX
             A14           RX
             GND           GND
 
-*   Build the
+-   Build the
     [chip-rpc console](https://github.com/project-chip/connectedhomeip/tree/master/examples/common/pigweed/rpc_console)
 
-*   As part of building the example with RPCs enabled the chip_rpc python
+-   As part of building the example with RPCs enabled the chip_rpc python
     interactive console is installed into your venv. The python wheel files are
     also created in the output folder: out/debug/chip_rpc_console_wheels. To
     install the wheel files without rebuilding:
 
             $ pip3 install out/debug/chip_rpc_console_wheels/*.whl
 
--   Launch the chip-rpc console after resetting Ameba board
+*   Launch the chip-rpc console after resetting Ameba board
 
             $ chip-console --device /dev/tty<port connected to USB-TTL adapter> -b 115200
 
-*   Get and Set lighting directly using the RPC console
+-   Get and Set lighting directly using the RPC console
 
             python
             rpcs.chip.rpc.Lighting.Get()

--- a/examples/platform/ameba/shell/launch_shell.cpp
+++ b/examples/platform/ameba/shell/launch_shell.cpp
@@ -36,7 +36,7 @@ namespace chip {
 void LaunchShell()
 {
     chip::Shell::Engine::Root().Init();
-    xTaskCreate(&MatterShellTask, "matter_shell", 2048, NULL, tskIDLE_PRIORITY + 1, NULL);
+    xTaskCreate(MatterShellTask, "matter_shell", 2048, NULL, tskIDLE_PRIORITY + 1, NULL);
 }
 
 } // namespace chip

--- a/src/lib/shell/streamer_ameba.cpp
+++ b/src/lib/shell/streamer_ameba.cpp
@@ -28,13 +28,13 @@
 
 #include "serial_api.h"
 
-// UART pin location:
-// KM4 UART0:
-// PA_18  (TX)
-// PA_19  (RX)
-
+#if defined(CONFIG_PLATFORM_8721D)
 #define UART_TX PA_18 // UART0  TX
 #define UART_RX PA_19 // UART0  RX
+#elif defined(CONFIG_PLATFORM_8710C)
+#define UART_TX PA_14 // UART0  TX
+#define UART_RX PA_13 // UART0  RX
+#endif
 
 namespace chip {
 namespace Shell {


### PR DESCRIPTION
#### Problem
- Support Matter Shell on 8710C platform
- Wrong function address used when creating MatterShellTask with xTaskCreate

#### Change overview
- Use 8710C UART0 pins
- Use the correct MatterShellTask address for xTaskCreate
- Update README

#### Testing
- Tested Matter Shell on 8710C platform
