### PR TITLE
[Ameba] Fix incorrect SSID problem during AddOrUpdateNetwork

### DIFF
--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -109,7 +109,7 @@ Status AmebaWiFiDriver::RemoveNetwork(ByteSpan networkId, MutableCharSpan & outD
     VerifyOrReturnError(NetworkMatch(mStagingNetwork, networkId), Status::kNetworkIDNotFound);
 
     // Use empty ssid for representing invalid network
-    mStagingNetwork = {};
+    mStagingNetwork         = {};
     mStagingNetwork.ssidLen = 0;
     return Status::kSuccess;
 }

--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -92,6 +92,7 @@ Status AmebaWiFiDriver::AddOrUpdateNetwork(ByteSpan ssid, ByteSpan credentials, 
     VerifyOrReturnError(credentials.size() <= sizeof(mStagingNetwork.credentials), Status::kOutOfRange);
     VerifyOrReturnError(ssid.size() <= sizeof(mStagingNetwork.ssid), Status::kOutOfRange);
 
+    memset(&mStagingNetwork, 0, sizeof(mStagingNetwork))
     memcpy(mStagingNetwork.credentials, credentials.data(), credentials.size());
     mStagingNetwork.credentialsLen = static_cast<decltype(mStagingNetwork.credentialsLen)>(credentials.size());
 

--- a/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
+++ b/src/platform/Ameba/NetworkCommissioningWiFiDriver.cpp
@@ -92,7 +92,7 @@ Status AmebaWiFiDriver::AddOrUpdateNetwork(ByteSpan ssid, ByteSpan credentials, 
     VerifyOrReturnError(credentials.size() <= sizeof(mStagingNetwork.credentials), Status::kOutOfRange);
     VerifyOrReturnError(ssid.size() <= sizeof(mStagingNetwork.ssid), Status::kOutOfRange);
 
-    memset(&mStagingNetwork, 0, sizeof(mStagingNetwork))
+    mStagingNetwork = {};
     memcpy(mStagingNetwork.credentials, credentials.data(), credentials.size());
     mStagingNetwork.credentialsLen = static_cast<decltype(mStagingNetwork.credentialsLen)>(credentials.size());
 
@@ -109,6 +109,7 @@ Status AmebaWiFiDriver::RemoveNetwork(ByteSpan networkId, MutableCharSpan & outD
     VerifyOrReturnError(NetworkMatch(mStagingNetwork, networkId), Status::kNetworkIDNotFound);
 
     // Use empty ssid for representing invalid network
+    mStagingNetwork = {};
     mStagingNetwork.ssidLen = 0;
     return Status::kSuccess;
 }


### PR DESCRIPTION
#### Problem
- After RemoveNetwork and calling AddOrUpdateNetwork function, when the new SSID len is shorter than old SSID len, it will result in incorrect SSID value
- For eg, old SSID = "abcdefg", new SSID = "xyz". After memcpy, the new mStagingNetwork will become "xyzdefg".
- In ConnectWiFiNetwork, it will get ssidLen+1, so the retrieved SSID will be "xyzd".
- Same issue for credentials

#### Change overview
- Clear mStagingNetwork in RemoveNetwork instead of just making the len = 0
- Clear mStagingNetwork before memcpy in AddOrUpdateNetwork

#### Testing
- Tested by updating mStagingNetwork with SSID with shorter ssidLen
