### PR TITLE
[Infineon] Add CYW30739 guide in darwin.md

### DIFF
--- a/docs/guides/darwin.md
+++ b/docs/guides/darwin.md
@@ -205,6 +205,7 @@ requirements
 ##### Guides
 
 -   [Bouffalo Lab](/examples/lighting-app/bouffalolab/bl602/README.md)
+-   [CYW30739 Lighting](/examples/lighting-app/cyw30739/README.md)
 -   [EFR32 Window Covering](/examples/window-app/efr32/README.md)
 -   [ESP32 All Clusters](/examples/all-clusters-app/esp32/README.md)
 -   [ESP32 Lighting](/examples/lighting-app/esp32/README.md)


### PR DESCRIPTION
#### Change overview
[Infineon] Add CYW30739 guide in darwin.md

#### Testing
Tested with iPhone and HomePod mimi of iOS 16 Beta.
Able to add the accessory using Apple Home app.
Light ON/OFF works.
