### PR TITLE
[Infineon][SVE] Initialize CYW30739 OTA requestor after re-attaching to Thread network.

### DIFF
--- a/examples/lighting-app/cyw30739/src/main.cpp
+++ b/examples/lighting-app/cyw30739/src/main.cpp
@@ -47,8 +47,6 @@ using namespace ::chip::Shell;
 
 static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 static void InitApp(intptr_t args);
-static void EventHandler(const ChipDeviceEvent * event, intptr_t arg);
-static void HandleThreadStateChangeEvent(const ChipDeviceEvent * event);
 static void LightManagerCallback(LightingManager::Actor_t actor, LightingManager::Action_t action, uint8_t value);
 
 static wiced_led_config_t chip_lighting_led_config = {
@@ -148,7 +146,6 @@ void InitApp(intptr_t args)
 {
     ConfigurationMgr().LogDeviceConfig();
 
-    PlatformMgrImpl().AddEventHandler(EventHandler, 0);
     // Print QR Code URL
     PrintOnboardingCodes(chip::RendezvousInformationFlag(chip::RendezvousInformationFlag::kBLE));
     /* Start CHIP datamodel server */
@@ -173,20 +170,6 @@ void InitApp(intptr_t args)
     OTAConfig::Init();
 #endif
 }
-
-void EventHandler(const ChipDeviceEvent * event, intptr_t arg)
-{
-    switch (event->Type)
-    {
-    case DeviceEventType::kThreadStateChange:
-        HandleThreadStateChangeEvent(event);
-        break;
-    default:
-        break;
-    }
-}
-
-void HandleThreadStateChangeEvent(const ChipDeviceEvent * event) {}
 
 void LightManagerCallback(LightingManager::Actor_t actor, LightingManager::Action_t action, uint8_t level)
 {

--- a/examples/lock-app/cyw30739/src/main.cpp
+++ b/examples/lock-app/cyw30739/src/main.cpp
@@ -60,8 +60,6 @@ wiced_bool_t syncClusterToButtonAction = false;
 
 static chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 static void InitApp(intptr_t args);
-static void EventHandler(const ChipDeviceEvent * event, intptr_t arg);
-static void HandleThreadStateChangeEvent(const ChipDeviceEvent * event);
 static void ActionInitiated(LockManager::Action_t aAction, int32_t aActor);
 static void ActionCompleted(LockManager::Action_t aAction);
 static void WriteClusterState(uint8_t value);
@@ -173,7 +171,6 @@ APPLICATION_START()
 void InitApp(intptr_t args)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
-    PlatformMgrImpl().AddEventHandler(EventHandler, 0);
     // Print QR Code URL
     PrintOnboardingCodes(chip::RendezvousInformationFlag(chip::RendezvousInformationFlag::kBLE));
     /* Start CHIP datamodel server */
@@ -266,20 +263,6 @@ void InitApp(intptr_t args)
     OTAConfig::Init();
 #endif
 }
-
-void EventHandler(const ChipDeviceEvent * event, intptr_t arg)
-{
-    switch (event->Type)
-    {
-    case DeviceEventType::kThreadStateChange:
-        HandleThreadStateChangeEvent(event);
-        break;
-    default:
-        break;
-    }
-}
-
-void HandleThreadStateChangeEvent(const ChipDeviceEvent * event) {}
 
 void ActionInitiated(LockManager::Action_t aAction, int32_t aActor)
 {


### PR DESCRIPTION
#### Problem
OTA Requestor cannot send `NotifyApplied` until it is re-attached to the Thread network.

#### Change overview
Initialize OTA Requestor after it is re-attached back to the Thread network.

#### Testing
TC-SU-2.6
