### PR TITLE
[Tizen] Implement getter for Thread primary address

### DIFF
--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -422,8 +422,18 @@ CHIP_ERROR ThreadStackManagerImpl::_GetAndLogThreadTopologyFull()
 
 CHIP_ERROR ThreadStackManagerImpl::_GetPrimary802154MACAddress(uint8_t * buf)
 {
-    ChipLogError(DeviceLayer, "Not implemented");
-    return CHIP_ERROR_NOT_IMPLEMENTED;
+    uint64_t extAddr;
+    int threadErr;
+
+    threadErr = thread_get_extended_address(mThreadInstance, &extAddr);
+    VerifyOrReturnError(
+        threadErr == THREAD_ERROR_NONE,
+        (ChipLogError(DeviceLayer, "thread_get_extended_address() failed. ret: %d", threadErr), CHIP_ERROR_INTERNAL));
+
+    extAddr = htobe64(extAddr);
+    memcpy(buf, &extAddr, sizeof(extAddr));
+
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_GetExternalIPv6Address(chip::Inet::IPAddress & addr)

--- a/src/platform/Tizen/ThreadStackManagerImpl.cpp
+++ b/src/platform/Tizen/ThreadStackManagerImpl.cpp
@@ -562,26 +562,22 @@ exit:
 
 CHIP_ERROR ThreadStackManagerImpl::_SetupSrpHost(const char * aHostName)
 {
-    CHIP_ERROR error = CHIP_NO_ERROR;
-    int threadErr    = THREAD_ERROR_NONE;
+    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_WELL_UNINITIALIZED);
+    VerifyOrReturnError(aHostName != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(strlen(aHostName) <= Dnssd::kHostNameMaxLength, CHIP_ERROR_INVALID_STRING_LENGTH);
 
-    VerifyOrReturnError(mIsInitialized, CHIP_ERROR_INCORRECT_STATE);
-    VerifyOrExit(aHostName, error = CHIP_ERROR_INVALID_ARGUMENT);
-    VerifyOrExit(strlen(aHostName) <= Dnssd::kHostNameMaxLength, error = CHIP_ERROR_INVALID_STRING_LENGTH);
+    int threadErr;
 
     threadErr = thread_srp_client_set_host_name(mThreadInstance, aHostName);
     if (threadErr != THREAD_ERROR_NONE && threadErr != THREAD_ERROR_ALREADY_DONE)
-        ChipLogError(DeviceLayer, "FAIL: thread_srp_client_set_host_name");
+        ChipLogError(DeviceLayer, "thread_srp_client_set_host_name() failed. ret: %d", threadErr);
 
     /* Get external ip address */
     threadErr = thread_get_ipaddr(mThreadInstance, _ThreadIpAddressCb, THREAD_IPADDR_TYPE_MLEID, nullptr);
-    VerifyOrExit(threadErr == THREAD_ERROR_NONE, error = CHIP_ERROR_INTERNAL);
+    VerifyOrReturnError(threadErr == THREAD_ERROR_NONE,
+                        (ChipLogError(DeviceLayer, "thread_get_ipaddr() failed. ret: %d", threadErr), CHIP_ERROR_INTERNAL));
 
     return CHIP_NO_ERROR;
-
-exit:
-    ChipLogError(DeviceLayer, "FAIL: thread_srp_client_set_host_address");
-    return error;
 }
 
 CHIP_ERROR ThreadStackManagerImpl::_ClearSrpHost(const char * aHostName)


### PR DESCRIPTION
#### Problem

When using Thread, Tizen does not use Thread address for hostname.

```
...
D/CHIP    ( 1797): DL: DNSsd UnregisterAllServices: 0
E/CHIP    ( 1797): DL: Not implemented
D/CHIP    ( 1797): DL: Using wifi MAC for hostname
...
```

#### Change overview

- implement `ThreadStackManagerImpl::_GetPrimary802154MACAddress`

#### Testing

Verified that Thread MAC is used when running example app:
```
app_launcher -s org.tizen.matter.example.lighting thread true
...
D/CHIP    ( 1914): DL: DNSsd UnregisterAllServices: 0
D/CHIP    ( 1914): DL: Using Thread extended MAC for hostname
...
```
