### PR TITLE
[CC13x2_26x2 & CC32xx] Fixing error in KVS read function

### DIFF
--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
@@ -156,10 +156,7 @@ CHIP_ERROR CC13X2_26X2Config::ReadConfigValueBin(Key key, uint8_t * buf, size_t 
     VerifyOrExit(sNvoctpFps.readItem(key.nvID, 0, (uint16_t) len, buf) == NVINTF_SUCCESS,
                  err = CHIP_ERROR_PERSISTED_STORAGE_FAILED);
 
-    if (outLen)
-    {
-        outLen = len;
-    }
+    outLen = len;
 
 exit:
     return err;

--- a/src/platform/cc32xx/CC32XXConfig.cpp
+++ b/src/platform/cc32xx/CC32XXConfig.cpp
@@ -378,10 +378,7 @@ CHIP_ERROR CC32XXConfig::ReadConfigValueBin(Key key, uint8_t * buf, size_t bufSi
     VerifyOrReturnError(pEntry != nullptr, CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND);
 
     pEntry->ReadVal(buf, bufSize);
-    if (outLen)
-    {
-        outLen = pEntry->Len();
-    }
+    outLen = pEntry->Len();
     return CHIP_NO_ERROR;
 }
 


### PR DESCRIPTION
#### Problem
What is being fixed? 
* Fix error when the passed outLen value it set to 0 it will not set to correct length read from KVS and results in the function returning an outLen of 0, looking like nothing was actually read.

#### Change overview
Removed invalid check perform on outLen.

#### Testing
How was this tested? 
* If manually tested, on cc2652 launchpad and custom HW based on that platform.
