### PR TITLE
[linux] Set DeviceInfoProvider before Server::Init to setup the stora…

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -315,11 +315,11 @@ void ChipLinuxAppMainLoop()
     initParams.testEventTriggerDelegate = &testEventTriggerDelegate;
 #endif
 
+    // We need to set DeviceInfoProvider before Server::Init to setup the storage of DeviceInfoProvider properly.
+    DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
+
     // Init ZCL Data Model and CHIP App Server
     Server::GetInstance().Init(initParams);
-
-    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
-    DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Now that the server has started and we are done with our startup logging,
     // log our discovery/onboarding information again so it's not lost in the


### PR DESCRIPTION
…ge of DeviceInfoProvider properly.

#### Problem
What is being fixed?  Examples:
* We have initialization sequence issue in Linux example app. We setup the storage delegate of DeviceInfoprovider in Server::Init (this is common to all platforms) which need DeviceInfoProvider get setup first.
```
    deviceInfoprovider = DeviceLayer::GetDeviceInfoProvider();
    if (deviceInfoprovider)
    {
        deviceInfoprovider->SetStorageDelegate(mDeviceStorage);
    }
```
* But we setup DeviceInfoProvider after Server::Init in ChipLinuxAppMainLoop  
```
    // Init ZCL Data Model and CHIP App Server
    Server::GetInstance().Init(initParams);
    DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
```
* I saw we force setup  SetStorageDelegate again in ChipLinuxAppMainLoop to workaround this issue, but it does not fix the initialization order issue , we need to first setup DeviceInfoProvider then setup the storage delegate of DeviceInfoProvider.   


#### Change overview
Set DeviceInfoProvider before Server::Init to setup the storage of DeviceInfoProvider properly

#### Testing
How was this tested? (at least one bullet point required)
* Verify the userlabel can be read properly from DeviceInfoProvider

```
. /chip-tool userlabel read label-list 12344321 0
[1660154187.682463][1583886:1583891] CHIP:DMG: ReportDataMessage =
[1660154187.682478][1583886:1583891] CHIP:DMG: {
[1660154187.682489][1583886:1583891] CHIP:DMG:  AttributeReportIBs =
[1660154187.682508][1583886:1583891] CHIP:DMG:  [
[1660154187.682522][1583886:1583891] CHIP:DMG:      AttributeReportIB =
[1660154187.682540][1583886:1583891] CHIP:DMG:      {
[1660154187.682553][1583886:1583891] CHIP:DMG:          AttributeDataIB =
[1660154187.682568][1583886:1583891] CHIP:DMG:          {
[1660154187.682583][1583886:1583891] CHIP:DMG:              DataVersion = 0x24ff1d32,
[1660154187.682597][1583886:1583891] CHIP:DMG:              AttributePathIB =
[1660154187.682613][1583886:1583891] CHIP:DMG:              {
[1660154187.682627][1583886:1583891] CHIP:DMG:                  Endpoint = 0x0,
[1660154187.682642][1583886:1583891] CHIP:DMG:                  Cluster = 0x41,
[1660154187.682657][1583886:1583891] CHIP:DMG:                  Attribute = 0x0000_0000,
[1660154187.682671][1583886:1583891] CHIP:DMG:              }
[1660154187.682687][1583886:1583891] CHIP:DMG:                  
[1660154187.682701][1583886:1583891] CHIP:DMG:              Data = [
[1660154187.682716][1583886:1583891] CHIP:DMG:                      
[1660154187.682731][1583886:1583891] CHIP:DMG:              ],
[1660154187.682745][1583886:1583891] CHIP:DMG:          },
[1660154187.682762][1583886:1583891] CHIP:DMG:          
[1660154187.682775][1583886:1583891] CHIP:DMG:      },
[1660154187.682799][1583886:1583891] CHIP:DMG:      
[1660154187.682811][1583886:1583891] CHIP:DMG:      AttributeReportIB =
[1660154187.682830][1583886:1583891] CHIP:DMG:      {
[1660154187.682843][1583886:1583891] CHIP:DMG:          AttributeDataIB =
[1660154187.682856][1583886:1583891] CHIP:DMG:          {
[1660154187.682870][1583886:1583891] CHIP:DMG:              DataVersion = 0x24ff1d32,
[1660154187.682883][1583886:1583891] CHIP:DMG:              AttributePathIB =
[1660154187.682897][1583886:1583891] CHIP:DMG:              {
[1660154187.682911][1583886:1583891] CHIP:DMG:                  Endpoint = 0x0,
[1660154187.682925][1583886:1583891] CHIP:DMG:                  Cluster = 0x41,
[1660154187.682940][1583886:1583891] CHIP:DMG:                  Attribute = 0x0000_0000,
[1660154187.682954][1583886:1583891] CHIP:DMG:                  ListIndex = Null,
[1660154187.682968][1583886:1583891] CHIP:DMG:              }
[1660154187.682983][1583886:1583891] CHIP:DMG:                  
[1660154187.682997][1583886:1583891] CHIP:DMG:              Data = 
[1660154187.683012][1583886:1583891] CHIP:DMG:              {
[1660154187.683028][1583886:1583891] CHIP:DMG:                  0x0 = "label1" (6 chars), 
[1660154187.683043][1583886:1583891] CHIP:DMG:                  0x1 = "value1" (6 chars), 
[1660154187.683059][1583886:1583891] CHIP:DMG:              },
[1660154187.683072][1583886:1583891] CHIP:DMG:          },
[1660154187.683091][1583886:1583891] CHIP:DMG:          
[1660154187.683103][1583886:1583891] CHIP:DMG:      },
[1660154187.683130][1583886:1583891] CHIP:DMG:      
[1660154187.683142][1583886:1583891] CHIP:DMG:      AttributeReportIB =
[1660154187.683162][1583886:1583891] CHIP:DMG:      {
[1660154187.683174][1583886:1583891] CHIP:DMG:          AttributeDataIB =
[1660154187.683187][1583886:1583891] CHIP:DMG:          {
[1660154187.683201][1583886:1583891] CHIP:DMG:              DataVersion = 0x24ff1d32,
[1660154187.683214][1583886:1583891] CHIP:DMG:              AttributePathIB =
[1660154187.683228][1583886:1583891] CHIP:DMG:              {
[1660154187.683241][1583886:1583891] CHIP:DMG:                  Endpoint = 0x0,
[1660154187.683255][1583886:1583891] CHIP:DMG:                  Cluster = 0x41,
[1660154187.683270][1583886:1583891] CHIP:DMG:                  Attribute = 0x0000_0000,
[1660154187.683301][1583886:1583891] CHIP:DMG:                  ListIndex = Null,
[1660154187.683315][1583886:1583891] CHIP:DMG:              }
[1660154187.683331][1583886:1583891] CHIP:DMG:                  
[1660154187.683344][1583886:1583891] CHIP:DMG:              Data = 
[1660154187.683359][1583886:1583891] CHIP:DMG:              {
[1660154187.683374][1583886:1583891] CHIP:DMG:                  0x0 = "label2" (6 chars), 
[1660154187.683389][1583886:1583891] CHIP:DMG:                  0x1 = "value2" (6 chars), 
[1660154187.683403][1583886:1583891] CHIP:DMG:              },
[1660154187.683416][1583886:1583891] CHIP:DMG:          },
[1660154187.683436][1583886:1583891] CHIP:DMG:          
[1660154187.683448][1583886:1583891] CHIP:DMG:      },
[1660154187.683467][1583886:1583891] CHIP:DMG:      
[1660154187.683479][1583886:1583891] CHIP:DMG:  ],
[1660154187.683510][1583886:1583891] CHIP:DMG:  
[1660154187.683523][1583886:1583891] CHIP:DMG:  SuppressResponse = true, 
[1660154187.683537][1583886:1583891] CHIP:DMG:  InteractionModelRevision = 1
[1660154187.683549][1583886:1583891] CHIP:DMG: }
[1660154187.683827][1583886:1583891] CHIP:TOO: Endpoint: 0 Cluster: 0x0000_0041 Attribute 0x0000_0000 DataVersion: 620698930
[1660154187.683892][1583886:1583891] CHIP:TOO:   label list: 2 entries
[1660154187.683916][1583886:1583891] CHIP:TOO:     [1]: {
[1660154187.683928][1583886:1583891] CHIP:TOO:       Label: label1
[1660154187.683940][1583886:1583891] CHIP:TOO:       Value: value1
[1660154187.683953][1583886:1583891] CHIP:TOO:      }
[1660154187.683969][1583886:1583891] CHIP:TOO:     [2]: {
[1660154187.683981][1583886:1583891] CHIP:TOO:       Label: label2
[1660154187.683993][1583886:1583891] CHIP:TOO:       Value: value2
[1660154187.684004][1583886:1583891] CHIP:TOO:      }


```