### PR TITLE
Fix Darwin codegen support for grouping in YAML expressions.

### DIFF
--- a/src/darwin/Framework/CHIP/templates/helper.js
+++ b/src/darwin/Framework/CHIP/templates/helper.js
@@ -56,7 +56,7 @@ async function asTypedExpressionFromObjectiveC(value, type)
   let expr = [];
   for (let i = 0; i < tokens.length; i++) {
     const token = tokens[i];
-    if ([ '+', '-', '/', '*', '%' ].includes(token)) {
+    if ([ '+', '-', '/', '*', '%', '(', ')' ].includes(token)) {
       expr[i] = token;
     } else if (!isNaN(token.replace(/ULL$|UL$|U$|LL$|L$/i, ''))) {
       expr[i] = await appHelper.asTypedLiteral.call(this, token, type);


### PR DESCRIPTION
#### Problem
Using parentheses in YAML will fail darwin-framework-tool codegen.

#### Change overview
Make it work.

#### Testing
Added a parenthesized expression, ensured codegen worked.