### PR TITLE
Fix efr32 app to return NotFound if no schedule exists

### DIFF
--- a/examples/lock-app/efr32/include/LockManager.h
+++ b/examples/lock-app/efr32/include/LockManager.h
@@ -29,6 +29,24 @@
 
 #include <lib/core/CHIPError.h>
 
+struct WeekDaysScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockWeekDaySchedule schedule;
+};
+
+struct YearDayScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockYearDaySchedule schedule;
+};
+
+struct HolidayScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockHolidaySchedule schedule;
+};
+
 namespace EFR32DoorLock {
 namespace ResourceRanges {
 // Used to size arrays
@@ -38,9 +56,6 @@ static constexpr uint8_t kMaxWeekdaySchedulesPerUser = 10;
 static constexpr uint8_t kMaxYeardaySchedulesPerUser = 10;
 static constexpr uint8_t kMaxHolidaySchedules        = 10;
 static constexpr uint8_t kMaxCredentialSize          = 8;
-
-// Indices received for user/credential/schedules are 1-indexed
-static constexpr uint8_t kStartIndexValue = 1;
 
 static constexpr uint8_t kMaxCredentials = kMaxUsers * kMaxCredentialsPerUser;
 } // namespace ResourceRanges
@@ -185,9 +200,9 @@ private:
 
     EmberAfPluginDoorLockUserInfo mLockUsers[kMaxUsers];
     EmberAfPluginDoorLockCredentialInfo mLockCredentials[kMaxCredentials];
-    EmberAfPluginDoorLockWeekDaySchedule mWeekdaySchedule[kMaxUsers][kMaxWeekdaySchedulesPerUser];
-    EmberAfPluginDoorLockYearDaySchedule mYeardaySchedule[kMaxUsers][kMaxYeardaySchedulesPerUser];
-    EmberAfPluginDoorLockHolidaySchedule mHolidaySchedule[kMaxHolidaySchedules];
+    WeekDaysScheduleInfo mWeekdaySchedule[kMaxUsers][kMaxWeekdaySchedulesPerUser];
+    YearDayScheduleInfo mYeardaySchedule[kMaxUsers][kMaxYeardaySchedulesPerUser];
+    HolidayScheduleInfo mHolidaySchedule[kMaxHolidaySchedules];
 
     char mUserNames[ArraySize(mLockUsers)][DOOR_LOCK_MAX_USER_NAME_SIZE];
     uint8_t mCredentialData[kMaxCredentials][kMaxCredentialSize];

--- a/examples/lock-app/efr32/src/LockManager.cpp
+++ b/examples/lock-app/efr32/src/LockManager.cpp
@@ -497,7 +497,13 @@ DlStatus LockManager::GetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
     VerifyOrReturnValue(IsValidWeekdayScheduleIndex(weekdayIndex), DlStatus::kFailure);
     VerifyOrReturnValue(IsValidUserIndex(userIndex), DlStatus::kFailure);
 
-    schedule = mWeekdaySchedule[userIndex][weekdayIndex];
+    const auto & scheduleInStorage = mWeekdaySchedule[userIndex][weekdayIndex];
+    if (DlScheduleStatus::kAvailable == scheduleInStorage.status)
+    {
+        return DlStatus::kNotFound;
+    }
+
+    schedule = scheduleInStorage.schedule;
 
     return DlStatus::kSuccess;
 }
@@ -518,11 +524,12 @@ DlStatus LockManager::SetWeekdaySchedule(chip::EndpointId endpointId, uint8_t we
 
     auto & scheduleInStorage = mWeekdaySchedule[userIndex][weekdayIndex];
 
-    scheduleInStorage.daysMask    = daysMask;
-    scheduleInStorage.startHour   = startHour;
-    scheduleInStorage.startMinute = startMinute;
-    scheduleInStorage.endHour     = endHour;
-    scheduleInStorage.endMinute   = endMinute;
+    scheduleInStorage.schedule.daysMask    = daysMask;
+    scheduleInStorage.schedule.startHour   = startHour;
+    scheduleInStorage.schedule.startMinute = startMinute;
+    scheduleInStorage.schedule.endHour     = endHour;
+    scheduleInStorage.schedule.endMinute   = endMinute;
+    scheduleInStorage.status               = status;
 
     // Save schedule information in NVM flash
     EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_WeekDaySchedules, reinterpret_cast<const uint8_t *>(mWeekdaySchedule),
@@ -544,9 +551,13 @@ DlStatus LockManager::GetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
     VerifyOrReturnValue(IsValidYeardayScheduleIndex(yearDayIndex), DlStatus::kFailure);
     VerifyOrReturnValue(IsValidUserIndex(userIndex), DlStatus::kFailure);
 
-    auto & scheduleInStorage = mYeardaySchedule[userIndex][yearDayIndex];
+    const auto & scheduleInStorage = mYeardaySchedule[userIndex][yearDayIndex];
+    if (DlScheduleStatus::kAvailable == scheduleInStorage.status)
+    {
+        return DlStatus::kNotFound;
+    }
 
-    schedule = scheduleInStorage;
+    schedule = scheduleInStorage.schedule;
 
     return DlStatus::kSuccess;
 }
@@ -565,8 +576,9 @@ DlStatus LockManager::SetYeardaySchedule(chip::EndpointId endpointId, uint8_t ye
 
     auto & scheduleInStorage = mYeardaySchedule[userIndex][yearDayIndex];
 
-    scheduleInStorage.localStartTime = localStartTime;
-    scheduleInStorage.localEndTime   = localEndTime;
+    scheduleInStorage.schedule.localStartTime = localStartTime;
+    scheduleInStorage.schedule.localEndTime   = localEndTime;
+    scheduleInStorage.status                  = status;
 
     // Save schedule information in NVM flash
     EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_YearDaySchedules, reinterpret_cast<const uint8_t *>(mYeardaySchedule),
@@ -585,9 +597,13 @@ DlStatus LockManager::GetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
 
     VerifyOrReturnValue(IsValidHolidayScheduleIndex(holidayIndex), DlStatus::kFailure);
 
-    auto & scheduleInStorage = mHolidaySchedule[holidayIndex];
+    const auto & scheduleInStorage = mHolidaySchedule[holidayIndex];
+    if (DlScheduleStatus::kAvailable == scheduleInStorage.status)
+    {
+        return DlStatus::kNotFound;
+    }
 
-    schedule = scheduleInStorage;
+    schedule = scheduleInStorage.schedule;
 
     return DlStatus::kSuccess;
 }
@@ -603,9 +619,10 @@ DlStatus LockManager::SetHolidaySchedule(chip::EndpointId endpointId, uint8_t ho
 
     auto & scheduleInStorage = mHolidaySchedule[holidayIndex];
 
-    scheduleInStorage.localStartTime = localStartTime;
-    scheduleInStorage.localEndTime   = localEndTime;
-    scheduleInStorage.operatingMode  = operatingMode;
+    scheduleInStorage.schedule.localStartTime = localStartTime;
+    scheduleInStorage.schedule.localEndTime   = localEndTime;
+    scheduleInStorage.schedule.operatingMode  = operatingMode;
+    scheduleInStorage.status                  = status;
 
     // Save schedule information in NVM flash
     EFR32Config::WriteConfigValueBin(EFR32Config::kConfigKey_HolidaySchedules,


### PR DESCRIPTION
#### Problem
efr32 does not return NotFound if no schedule exists

#### Change overview
Change efr32 to return NotFound 

#### Testing
Tested on efr32
Sent a getSchedule, followed by setSchedule, followed by another getSchedule.
First getSchedule responds with NotFound
Second getSchedule responds with the actual schedule
