### PR TITLE
[ESP32] Update ESP-IDF to release v4.4.2

### DIFF
--- a/docs/guides/esp32/setup_idf_chip.md
+++ b/docs/guides/esp32/setup_idf_chip.md
@@ -13,27 +13,27 @@ step.
 
 ### Install Prerequisites
 
--   [Linux](https://docs.espressif.com/projects/esp-idf/en/v4.4.1/esp32/get-started/linux-setup.html)
--   [macOS](https://docs.espressif.com/projects/esp-idf/en/v4.4.1/esp32/get-started/macos-setup.html)
+-   [Linux](https://docs.espressif.com/projects/esp-idf/en/v4.4.2/esp32/get-started/linux-setup.html)
+-   [macOS](https://docs.espressif.com/projects/esp-idf/en/v4.4.2/esp32/get-started/macos-setup.html)
 
-### Get IDF v4.4.1
+### Get IDF v4.4.2
 
 -   Clone ESP-IDF
-    [v4.4.1 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.1)
+    [v4.4.2 release](https://github.com/espressif/esp-idf/releases/tag/v4.4.2)
 
     ```
-    $ git clone -b v4.4.1 --recursive https://github.com/espressif/esp-idf.git
+    $ git clone -b v4.4.2 --recursive https://github.com/espressif/esp-idf.git
     $ cd esp-idf
     $ ./install.sh
     ```
 
--   To update an existing esp-idf toolchain to v4.4.1:
+-   To update an existing esp-idf toolchain to v4.4.2:
 
     ```
     $ cd path/to/esp-idf
     $ git fetch origin
-    $ git checkout v4.4.1
-    $ git reset --hard origin/v4.4.1
+    $ git checkout v4.4.2
+    $ git reset --hard origin/v4.4.2
     $ git submodule update --recursive --init
     $ git clean -fdx
     $ ./install.sh

--- a/integrations/docker/images/chip-build-esp32/Dockerfile
+++ b/integrations/docker/images/chip-build-esp32/Dockerfile
@@ -10,7 +10,7 @@ RUN set -x \
     && : # last line
 
 RUN set -x \
-    && git clone --recursive -b v4.4.1 https://github.com/espressif/esp-idf.git /tmp/esp-idf \
+    && git clone --recursive -b v4.4.2 --depth 1 --shallow-submodule https://github.com/espressif/esp-idf.git /tmp/esp-idf \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.92 Version bump reason: [TIZEN] Support for installing Tizen SDK without docker
+0.5.93 Version bump reason: [ESP32] Update ESP-IDF to release v4.4.2


### PR DESCRIPTION
#### Problem
* ESP-IDF v4.4.2 is released

#### Change overview
* Update the docs and Dockerfile for ESP32 chip builds 

#### Testing
* Tested light and light switch examples: It covers so commissioning, cluster control, binding, access control.
* Also, tested ESP32 factory provider