### PR TITLE
Remove Alarms/Poll Control non-Matter clusters from Matter devices XML

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1602,8 +1602,6 @@ limitations under the License.
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
             <include cluster="Door Lock" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Alarms" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Poll Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Electrical Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Time" client="false" server="false" clientLocked="false" serverLocked="true"></include>
             <include cluster="Time Synchronization" client="false" server="false" clientLocked="false" serverLocked="false"></include>
@@ -1850,7 +1848,6 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="Alarms" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thermostat" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Thermostat User Interface Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Fan Control" client="false" server="false" clientLocked="false" serverLocked="false"></include>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2147,9 +2147,6 @@ limitations under the License.
                 <requireCommand>RemoveAllGroups</requireCommand>
                 <requireCommand>AddGroupIfIdentifying</requireCommand>
             </include>
-            <include cluster="IAS Zone" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireCommand>ZoneEnrollResponse</requireCommand>
-            </include>
             <include cluster="Level Control" client="true" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>CURRENT_LEVEL</requireAttribute>
                 <requireCommand>MoveToLevel</requireCommand>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -62,7 +62,6 @@ limitations under the License.
             <include cluster="General Commissioning" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireCommand>SetRegulatoryConfig</requireCommand>
             </include>
-            <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Time Synchronization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Group Key Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
@@ -82,32 +81,6 @@ limitations under the License.
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="WiFi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-        </clusters>
-    </deviceType>
-    <deviceType>
-        <name>MA-powersource</name>
-        <domain>CHIP</domain>
-        <typeName>Matter Power Source</typeName>
-        <profileId editable="false">0x0103</profileId>
-        <deviceId editable="false">0x0011</deviceId>
-        <clusters lockOthers="true">
-            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>IDENTIFY_TIME</requireAttribute>
-                <requireAttribute>IDENTIFY_TYPE</requireAttribute>
-                <requireCommand>Identify</requireCommand>
-                <requireCommand>IdentifyQuery</requireCommand>
-                <requireCommand>TriggerEffect</requireCommand>
-            </include>
-            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
-                <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
-                <requireAttribute>SERVER_LIST</requireAttribute>
-                <requireAttribute>CLIENT_LIST</requireAttribute>
-                <requireAttribute>PARTS_LIST</requireAttribute>
-            </include>
-            <include cluster="Binding" client="true" server="false" clientLocked="false" serverLocked="true">
-                <requireAttribute>BINDING</requireAttribute>
-            </include>
-            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -216,7 +189,6 @@ limitations under the License.
             <include cluster="Bridged Device Basic" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>REACHABLE</requireAttribute>
             </include>
-            <include cluster="Power Source Configuration" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
@@ -1603,7 +1575,6 @@ limitations under the License.
             </include>
             <include cluster="Door Lock" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Electrical Measurement" client="false" server="false" clientLocked="true" serverLocked="false"></include>
-            <include cluster="Time" client="false" server="false" clientLocked="false" serverLocked="true"></include>
             <include cluster="Time Synchronization" client="false" server="false" clientLocked="false" serverLocked="false"></include>
         </clusters>
     </deviceType>
@@ -1789,7 +1760,6 @@ limitations under the License.
             <include cluster="Fan Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Level Control" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="On/Off" client="false" server="true" clientLocked="true" serverLocked="true"></include>
-            <include cluster="Time" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -1854,7 +1824,6 @@ limitations under the License.
             <include cluster="Temperature Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
             <include cluster="Occupancy Sensing" client="false" server="false" clientLocked="false" serverLocked="false"></include>
             <include cluster="Relative Humidity Measurement" client="false" server="false" clientLocked="false" serverLocked="false"></include>
-            <include cluster="Time" client="false" server="false" clientLocked="false" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>

--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -62,6 +62,7 @@ limitations under the License.
             <include cluster="General Commissioning" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireCommand>SetRegulatoryConfig</requireCommand>
             </include>
+            <include cluster="Power Source Configuration" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Time Synchronization" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Group Key Management" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
@@ -81,6 +82,32 @@ limitations under the License.
             <include cluster="Ethernet Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="WiFi Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
             <include cluster="Thread Network Diagnostics" client="false" server="false" clientLocked="true" serverLocked="false"></include>
+        </clusters>
+    </deviceType>
+    <deviceType>
+        <name>MA-powersource</name>
+        <domain>CHIP</domain>
+        <typeName>Matter Power Source</typeName>
+        <profileId editable="false">0x0103</profileId>
+        <deviceId editable="false">0x0011</deviceId>
+        <clusters lockOthers="true">
+            <include cluster="Identify" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>IDENTIFY_TIME</requireAttribute>
+                <requireAttribute>IDENTIFY_TYPE</requireAttribute>
+                <requireCommand>Identify</requireCommand>
+                <requireCommand>IdentifyQuery</requireCommand>
+                <requireCommand>TriggerEffect</requireCommand>
+            </include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
+                <requireAttribute>SERVER_LIST</requireAttribute>
+                <requireAttribute>CLIENT_LIST</requireAttribute>
+                <requireAttribute>PARTS_LIST</requireAttribute>
+            </include>
+            <include cluster="Binding" client="true" server="false" clientLocked="false" serverLocked="true">
+                <requireAttribute>BINDING</requireAttribute>
+            </include>
+            <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>
     <deviceType>
@@ -189,6 +216,7 @@ limitations under the License.
             <include cluster="Bridged Device Basic" client="false" server="true" clientLocked="true" serverLocked="true">
                 <requireAttribute>REACHABLE</requireAttribute>
             </include>
+            <include cluster="Power Source Configuration" client="false" server="true" clientLocked="true" serverLocked="true"></include>
             <include cluster="Power Source" client="false" server="true" clientLocked="true" serverLocked="true"></include>
         </clusters>
     </deviceType>


### PR DESCRIPTION
#### Problem
`matter-devices.xml` contains non-Matter Clusters which have been removed in e9960d4a577a ("Remove various non-Matter clusters from Matter XML.")..

Fixes: e9960d4a577a ("Remove various non-Matter clusters from Matter XML.").

#### Change overview
Removes non-Matter Clusters from `matter-devices.xml` as well.

#### Testing
Makes device generation from `mattter-devices.xml` with our scripts work correctly.
