### PR TITLE
[Infineon] Fix "Failed to write calendar type with error: 0x87"

### DIFF
--- a/examples/lighting-app/cyw30739/src/main.cpp
+++ b/examples/lighting-app/cyw30739/src/main.cpp
@@ -151,6 +151,8 @@ void InitApp(intptr_t args)
     /* Start CHIP datamodel server */
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    gExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
     nativeParams.lockCb                = [] { ThreadStackMgr().LockThreadStack(); };
     nativeParams.unlockCb              = [] { ThreadStackMgr().UnlockThreadStack(); };
@@ -159,8 +161,6 @@ void InitApp(intptr_t args)
     chip::Server::GetInstance().Init(initParams);
 
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     LightMgr().Init();
     LightMgr().SetCallbacks(LightManagerCallback, nullptr);

--- a/examples/lock-app/cyw30739/src/main.cpp
+++ b/examples/lock-app/cyw30739/src/main.cpp
@@ -176,6 +176,8 @@ void InitApp(intptr_t args)
     /* Start CHIP datamodel server */
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+    gExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
+    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
     chip::Inet::EndPointStateOpenThread::OpenThreadEndpointInitParam nativeParams;
     nativeParams.lockCb                = [] { ThreadStackMgr().LockThreadStack(); };
     nativeParams.unlockCb              = [] { ThreadStackMgr().UnlockThreadStack(); };
@@ -184,8 +186,6 @@ void InitApp(intptr_t args)
     chip::Server::GetInstance().Init(initParams);
 
     SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
-    gExampleDeviceInfoProvider.SetStorageDelegate(&chip::Server::GetInstance().GetPersistentStorage());
-    chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
 
     // Initial lock state
     chip::app::DataModel::Nullable<chip::app::Clusters::DoorLock::DlLockState> state;


### PR DESCRIPTION
#### Problem
There are errors in DUT log: 
ErrM CHIP:ZCL: DeviceInfoProvider is not registered
ErrM CHIP:ZCL: Trying to write invalid Calendar Type
ErrM CHIP:ZCL: Failed to write calendar type with error: 0x87

#### Change overview
Change initialization order.
