### PR TITLE
Spin up commissioners in chip-tool as needed.

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -124,7 +124,7 @@ protected:
     chip::PersistentStorageOperationalKeystore mOperationalKeystore;
     chip::Credentials::PersistentStorageOpCertStore mOpCertStore;
 
-    chip::Credentials::GroupDataProviderImpl mGroupDataProvider{ kMaxGroupsPerFabric, kMaxGroupKeysPerFabric };
+    static chip::Credentials::GroupDataProviderImpl sGroupDataProvider;
     CredentialIssuerCommands * mCredIssuerCmds;
 
     std::string GetIdentity();
@@ -135,14 +135,15 @@ protected:
     // --identity "instance name" when running a command.
     ChipDeviceCommissioner & CurrentCommissioner();
 
-    ChipDeviceCommissioner & GetCommissioner(const char * identity);
+    ChipDeviceCommissioner & GetCommissioner(std::string identity);
 
 private:
     CHIP_ERROR MaybeSetUpStack();
     void MaybeTearDownStack();
 
-    CHIP_ERROR InitializeCommissioner(std::string key, chip::FabricId fabricId,
-                                      const chip::Credentials::AttestationTrustStore * trustStore);
+    CHIP_ERROR EnsureCommissionerForIdentity(std::string identity);
+
+    CHIP_ERROR InitializeCommissioner(std::string key, chip::FabricId fabricId);
     void ShutdownCommissioner(std::string key);
     chip::FabricId CurrentCommissionerId();
     static std::map<std::string, std::unique_ptr<ChipDeviceCommissioner>> mCommissioners;
@@ -152,6 +153,10 @@ private:
     chip::Optional<chip::NodeId> mCommissionerNodeId;
     chip::Optional<uint16_t> mBleAdapterId;
     chip::Optional<char *> mPaaTrustStorePath;
+
+    // Cached trust store so commands other than the original startup command
+    // can spin up commissioners as needed.
+    static const chip::Credentials::AttestationTrustStore * sPaaTrustStore;
 
     static void RunQueuedCommand(intptr_t commandArg);
 


### PR DESCRIPTION
The basic change is that instead of spinning up commissioners during "stack
startup" for the three default identities plus the command's identity (in case
that's not one of the three defaults) we:

1) Spin up the commissioner for the command's identity when we're actually
   running the command (on the Matter event loop).  This allows commands in
   interactive mode to use an identity that is not one of the three default
   identities and fixes https://github.com/project-chip/connectedhomeip/issues/21828

2) Spin up commissioners as needed when they are requested.  This allows YAML
   test steps (which are not distinct commands) to use an identity that is not
   one of the three default identities.

#### Problem
See #21828 

#### Change overview
See above.

#### Testing
Checked the steps from #21828.  CI should check YAML bits.