### PR TITLE
RPC: Fix RPC console install

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -116,10 +116,15 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     source_packages = _matter_python_packages + _pigweed_python_packages
   }
 
+  pw_internal_pip_install("pip_install_matter_packages") {
+    packages = [ "//examples/common/pigweed/rpc_console:chip_rpc_distribution" ]
+  }
+
   # Python packages installed during bootstrap.
   pw_python_group("python_packages") {
     python_deps = [
       ":pip_install_editable_matter_packages",
+      ":pip_install_matter_packages",
       "$dir_pw_env_setup:pip_install_pigweed_package",
     ]
   }
@@ -129,7 +134,6 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
     packages = [
       "//integrations/mobly:chip_mobly",
       "//examples/chef",
-      "//examples/common/pigweed/rpc_console/py:chip_rpc",
     ]
     editable = true
   }

--- a/examples/common/pigweed/rpc_console/BUILD.gn
+++ b/examples/common/pigweed/rpc_console/BUILD.gn
@@ -33,6 +33,7 @@ pw_create_python_source_tree("chip_rpc_distribution") {
   packages = [ "py:chip_rpc" ]
   generate_setup_cfg = {
     common_config_file = "common_setup.cfg"
+    append_date_to_version = true
   }
   extra_files = [ "py/pyproject.toml > pyproject.toml" ]
 }


### PR DESCRIPTION


#### Problem
rpc console is not including proto dependencies
```
~/connectedhomeip% chip-console                       
Traceback (most recent call last):
  File "/home/spang/connectedhomeip/.environment/pigweed-venv/bin/chip-console", line 5, in <module>
    from chip_rpc.console import main
  File "/ssd/src/connectedhomeip/examples/common/pigweed/rpc_console/py/chip_rpc/console.py", line 66, in <module>
    from attributes_service import attributes_service_pb2
ModuleNotFoundError: No module named 'attributes_service'
```
#### Change overview
Use `chip_rpc_distribution` which includes the proto dependencies.

#### Testing
clean bootstrap, and started console.
