### PR TITLE
[nrfconnect] Improve SoftwareUpdateCompleted boot reason detection

### DIFF
--- a/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/Zephyr/DiagnosticDataProviderImpl.cpp
@@ -31,7 +31,9 @@
 #include <drivers/hwinfo.h>
 #include <sys/util.h>
 
-#ifdef CONFIG_MCUBOOT_IMG_MANAGER
+#if CHIP_DEVICE_LAYER_TARGET_NRFCONNECT
+#include <platform/nrfconnect/Reboot.h>
+#elif defined(CONFIG_MCUBOOT_IMG_MANAGER)
 #include <dfu/mcuboot.h>
 #endif
 
@@ -88,7 +90,12 @@ BootReasonType DetermineBootReason()
 
     if (reason & RESET_SOFTWARE)
     {
-#ifdef CONFIG_MCUBOOT_IMG_MANAGER
+#if CHIP_DEVICE_LAYER_TARGET_NRFCONNECT
+        if (GetSoftwareRebootReason() == SoftwareRebootReason::kSoftwareUpdate)
+        {
+            return BootReasonType::kSoftwareUpdateCompleted;
+        }
+#elif defined(CONFIG_MCUBOOT_IMG_MANAGER)
         if (mcuboot_swap_type() == BOOT_SWAP_TYPE_REVERT)
         {
             return BootReasonType::kSoftwareUpdateCompleted;

--- a/src/platform/nrfconnect/BUILD.gn
+++ b/src/platform/nrfconnect/BUILD.gn
@@ -46,6 +46,8 @@ static_library("nrfconnect") {
     "InetPlatformConfig.h",
     "KeyValueStoreManagerImpl.h",
     "PlatformManagerImpl.h",
+    "Reboot.cpp",
+    "Reboot.h",
     "SystemPlatformConfig.h",
   ]
 

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -17,6 +17,8 @@
 
 #include "OTAImageProcessorImpl.h"
 
+#include "Reboot.h"
+
 #include <app/clusters/ota-requestor/OTADownloader.h>
 #include <app/clusters/ota-requestor/OTARequestorInterface.h>
 #include <lib/support/CodeUtils.h>
@@ -35,7 +37,6 @@
 #include <dfu/mcuboot.h>
 #include <logging/log.h>
 #include <pm/device.h>
-#include <sys/reboot.h>
 
 #if CONFIG_CHIP_CERTIFICATION_DECLARATION_STORAGE
 // Cd globals are needed to be accessed from dfu image writer lambdas
@@ -123,7 +124,7 @@ CHIP_ERROR OTAImageProcessorImpl::Apply()
             [](System::Layer *, void * /* context */) {
                 PlatformMgr().HandleServerShuttingDown();
                 k_msleep(CHIP_DEVICE_CONFIG_SERVER_SHUTDOWN_ACTIONS_SLEEP_MS);
-                sys_reboot(SYS_REBOOT_WARM);
+                Reboot(SoftwareRebootReason::kSoftwareUpdate);
             },
             nullptr /* context */);
     }

--- a/src/platform/nrfconnect/Reboot.cpp
+++ b/src/platform/nrfconnect/Reboot.cpp
@@ -1,0 +1,85 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "Reboot.h"
+
+#include <lib/support/TypeTraits.h>
+
+#include <zephyr/sys/reboot.h>
+
+#ifndef CONFIG_ARCH_POSIX
+#include <hal/nrf_power.h>
+#endif
+
+namespace chip {
+namespace DeviceLayer {
+
+#ifdef CONFIG_ARCH_POSIX
+
+void Reboot(SoftwareRebootReason reason)
+{
+    sys_reboot(SYS_REBOOT_WARM);
+}
+
+SoftwareRebootReason GetSoftwareRebootReason()
+{
+    return SoftwareRebootReason::kOther;
+}
+
+#else
+
+using RetainedReason = decltype(nrf_power_gpregret_get(NRF_POWER));
+
+constexpr RetainedReason EncodeReason(SoftwareRebootReason reason)
+{
+    // Set MSB to avoid collission with Zephyr's pre-defined reboot reasons.
+    constexpr RetainedReason kCustomReasonFlag = 0x80;
+
+    return static_cast<RetainedReason>(reason) | kCustomReasonFlag;
+}
+
+void Reboot(SoftwareRebootReason reason)
+{
+    const RetainedReason retainedReason = EncodeReason(reason);
+
+    // The parameter passed to sys_reboot() is retained in GPREGRET (general-purpose
+    // retention register) on nRF52 SOC family, but nRF53 ignores the parameter, so
+    // set it manually.
+
+#ifdef CONFIG_SOC_SERIES_NRF53X
+    nrf_power_gpregret_set(NRF_POWER, retainedReason);
+#endif
+
+    sys_reboot(retainedReason);
+}
+
+SoftwareRebootReason GetSoftwareRebootReason()
+{
+    switch (nrf_power_gpregret_get(NRF_POWER))
+    {
+    case EncodeReason(SoftwareRebootReason::kSoftwareUpdate):
+        nrf_power_gpregret_set(NRF_POWER, 0);
+        return SoftwareRebootReason::kSoftwareUpdate;
+    default:
+        return SoftwareRebootReason::kOther;
+    }
+}
+
+#endif
+
+} // namespace DeviceLayer
+} // namespace chip

--- a/src/platform/nrfconnect/Reboot.h
+++ b/src/platform/nrfconnect/Reboot.h
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+
+namespace chip {
+namespace DeviceLayer {
+
+enum class SoftwareRebootReason : uint8_t
+{
+    kSoftwareUpdate,
+    kOther
+};
+
+[[noreturn]] void Reboot(SoftwareRebootReason reason);
+SoftwareRebootReason GetSoftwareRebootReason();
+
+} // namespace DeviceLayer
+} // namespace chip


### PR DESCRIPTION
#### Problem
The existing code relies on a specific bootloader mode to detect that the last reboot was due to software update.
This method will not work correctly if a user chooses a different bootloader mode, or clears the "tentative" flag in the current firmware image before the diagnostic data provider is initialized.

#### Change overview
Store the software reboot reason explicitly in one of the retention registers on nRF SOCs.
Kept the previous implementation for other Zephyr platforms.

#### Testing
Tested OTA on nRF52 and nRF53, observed that correct boot reason (5) is detected after applying new firmware.
