### PR TITLE
Set the dispatch queue on system layer earlier in startup.

### DIFF
--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -55,7 +55,7 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     mRunLoopSem = dispatch_semaphore_create(0);
 
     // Ensure there is a dispatch queue available
-    GetWorkQueue();
+    static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer()).SetDispatchQueue(GetWorkQueue());
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.
@@ -69,8 +69,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 #endif // CHIP_DISABLE_PLATFORM_KVS
 
     mStartTime = System::SystemClock().GetMonotonicTimestamp();
-
-    static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer()).SetDispatchQueue(GetWorkQueue());
 
 exit:
     return err;


### PR DESCRIPTION
System layer init wants to use the queue.

Fixes https://github.com/project-chip/connectedhomeip/issues/21857

#### Problem
Spurious error logs at startup.

#### Change overview
Set the queue on the system layer before we init the generic platform manager, which inits the system layer, which tries to use the queue.

#### Testing
Ran chip-tool, it worked, no error log.