### PR TITLE
Update headers to compile in isolation

### DIFF
--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -31,6 +31,8 @@
 
 namespace chip {
 
+class OperationalSessionSetupPoolDelegate;
+
 struct CASESessionManagerConfig
 {
     DeviceProxyInitParams sessionInitParams;

--- a/src/app/ObjectList.h
+++ b/src/app/ObjectList.h
@@ -18,6 +18,9 @@
 
 #pragma once
 
+#include <inttypes.h>
+#include <stddef.h>
+
 namespace chip {
 namespace app {
 


### PR DESCRIPTION
* Include headers defining int types,
* Forward declare OperationalSessionSetupPoolDelegate since there's a
  dependency loop with OperationalSessionSetup.h and OperationalSessionSetupPool.h