### PR TITLE
Darwin: change crypto to boringssl from mbedtls

### DIFF
--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -24,7 +24,6 @@
 		2C222AD0255C620600E446B9 /* MTRBaseDevice.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C222ACE255C620600E446B9 /* MTRBaseDevice.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		2C222AD1255C620600E446B9 /* MTRBaseDevice.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2C222ACF255C620600E446B9 /* MTRBaseDevice.mm */; };
 		2C222ADF255C811800E446B9 /* MTRBaseDevice_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C222ADE255C811800E446B9 /* MTRBaseDevice_Internal.h */; };
-		2C4DF09E248B2C60009307CB /* libmbedtls.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 2C4DF09D248B2C60009307CB /* libmbedtls.a */; settings = {ATTRIBUTES = (Required, ); }; };
 		2C5EEEF6268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C5EEEF4268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h */; };
 		2C5EEEF7268A85C400CAE3D3 /* MTRDeviceConnectionBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = 2C5EEEF5268A85C400CAE3D3 /* MTRDeviceConnectionBridge.mm */; };
 		2C8C8FC0253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = 2C8C8FBD253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h */; };
@@ -156,7 +155,6 @@
 		2C222ACE255C620600E446B9 /* MTRBaseDevice.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBaseDevice.h; sourceTree = "<group>"; };
 		2C222ACF255C620600E446B9 /* MTRBaseDevice.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRBaseDevice.mm; sourceTree = "<group>"; };
 		2C222ADE255C811800E446B9 /* MTRBaseDevice_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBaseDevice_Internal.h; sourceTree = "<group>"; };
-		2C4DF09D248B2C60009307CB /* libmbedtls.a */ = {isa = PBXFileReference; lastKnownFileType = archive.ar; name = libmbedtls.a; path = lib/libmbedtls.a; sourceTree = BUILT_PRODUCTS_DIR; };
 		2C5EEEF4268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceConnectionBridge.h; sourceTree = "<group>"; };
 		2C5EEEF5268A85C400CAE3D3 /* MTRDeviceConnectionBridge.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceConnectionBridge.mm; sourceTree = "<group>"; };
 		2C8C8FBD253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRPersistentStorageDelegateBridge.h; sourceTree = "<group>"; };
@@ -272,7 +270,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				BA09EB43247477BA00605257 /* libCHIP.a in Frameworks */,
-				2C4DF09E248B2C60009307CB /* libmbedtls.a in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -461,7 +458,6 @@
 		BA09EB3E2474762900605257 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-				2C4DF09D248B2C60009307CB /* libmbedtls.a */,
 				BA09EB3F2474762900605257 /* libCHIP.a */,
 			);
 			name = Frameworks;

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -93,7 +93,7 @@ done
 
 declare -a args=(
     'default_configs_cosmetic=[]' # suppress colorization
-    'chip_crypto="mbedtls"'
+    'chip_crypto="boringssl"'
     'chip_build_tools=false'
     'chip_build_tests=false'
     'chip_log_message_max_size=4096' # might as well allow nice long log messages


### PR DESCRIPTION
#### Problem
For Issue #20955 - move to boringssl instead of mbedtls

#### Change overview
Changed `chip_xcode_build_connector.sh` to use boringssl, and removed references to mbedtls in the Matter Xcode project file.

#### Testing
* Built darwin-framework-tool
* Built CHIPTool+Matter framework in Xcode
