### PR TITLE
Add status check in timed related test

### DIFF
--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -1064,8 +1064,16 @@ void TestCommandInteraction::TestCommandHandlerWithProcessReceivedEmptyDataMsg(n
 
             chip::isCommandDispatched = false;
             GenerateInvokeRequest(apSuite, apContext, commandDatabuf, messageIsTimed, kTestCommandIdNoData);
-            commandHandler.ProcessInvokeRequest(std::move(commandDatabuf), transactionIsTimed);
-
+            Protocols::InteractionModel::Status status =
+                commandHandler.ProcessInvokeRequest(std::move(commandDatabuf), transactionIsTimed);
+            if (messageIsTimed != transactionIsTimed)
+            {
+                NL_TEST_ASSERT(apSuite, status == Protocols::InteractionModel::Status::UnsupportedAccess);
+            }
+            else
+            {
+                NL_TEST_ASSERT(apSuite, status == Protocols::InteractionModel::Status::Success);
+            }
             NL_TEST_ASSERT(apSuite, chip::isCommandDispatched == (messageIsTimed == transactionIsTimed));
         }
     }


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/21863

#### Change overview
TestCommandHandlerWithProcessReceivedEmptyDataMsg not quite checking the
status returned from ProcessInvokeRequest, add the status check for ProcessInvokeRequest


#### Testing
improve existing test