### PR TITLE
[BL602]fix problems to generate the OTA StateTransition and VersionApplied event

### DIFF
--- a/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.cpp
+++ b/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.cpp
@@ -17,6 +17,7 @@
  */
 
 #include <app/clusters/ota-requestor/OTADownloader.h>
+#include <app/clusters/ota-requestor/OTARequestorInterface.h>
 
 #include "OTAImageProcessorImpl.h"
 extern "C" {
@@ -24,7 +25,42 @@ extern "C" {
 #include <hosal_ota.h>
 }
 
+using namespace chip::System;
+using namespace ::chip::DeviceLayer::Internal;
+
 namespace chip {
+
+bool OTAImageProcessorImpl::IsFirstImageRun()
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor == nullptr)
+    {
+        return false;
+    }
+
+    return requestor->GetCurrentUpdateState() == OTARequestorInterface::OTAUpdateStateEnum::kApplying;
+}
+
+CHIP_ERROR OTAImageProcessorImpl::ConfirmCurrentImage()
+{
+    OTARequestorInterface * requestor = chip::GetRequestorInstance();
+    if (requestor == nullptr)
+    {
+        return CHIP_ERROR_INTERNAL;
+    }
+
+    uint32_t currentVersion;
+    uint32_t targetVersion = requestor->GetTargetVersion();
+    ReturnErrorOnFailure(DeviceLayer::ConfigurationMgr().GetSoftwareVersion(currentVersion));
+    if (currentVersion != targetVersion)
+    {
+        ChipLogError(SoftwareUpdate, "Current software version = %" PRIu32 ", expected software version = %" PRIu32, currentVersion,
+                     targetVersion);
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
+
+    return CHIP_NO_ERROR;
+}
 
 CHIP_ERROR OTAImageProcessorImpl::PrepareDownload()
 {
@@ -121,7 +157,14 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
         return;
     }
 
-    hal_reboot();
+    DeviceLayer::SystemLayer().StartTimer(
+        System::Clock::Seconds32(2),
+        [](Layer *, void *) {
+            ChipLogProgress(SoftwareUpdate, "Rebooting...");
+            hal_reboot();
+        },
+        nullptr
+    );
 }
 
 void OTAImageProcessorImpl::HandleAbort(intptr_t context)

--- a/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.cpp
+++ b/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.cpp
@@ -163,8 +163,7 @@ void OTAImageProcessorImpl::HandleApply(intptr_t context)
             ChipLogProgress(SoftwareUpdate, "Rebooting...");
             hal_reboot();
         },
-        nullptr
-    );
+        nullptr);
 }
 
 void OTAImageProcessorImpl::HandleAbort(intptr_t context)

--- a/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.h
+++ b/src/platform/bouffalolab/BL602/OTAImageProcessorImpl.h
@@ -34,8 +34,8 @@ public:
     CHIP_ERROR Apply() override;
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
-    bool IsFirstImageRun() override { return false; }
-    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
+    bool IsFirstImageRun() override;
+    CHIP_ERROR ConfirmCurrentImage() override;
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 


### PR DESCRIPTION
#### Problem
* Fix the "Applying" StateTransition event could not sent out issue.
* Fix the VersionApplied event is not generated issue.

#### Change overview
* in HandleApply(), add 2 seconds delay before reboot chip to ensure the "Applying" StateTransition event is sent out.
* Implement IsFirstImageRun() and ConfirmCurrentImage() in order to generate  the VersionApplied event.

#### Testing
Verified above two events are successfully sent out during OTA.
