### PR TITLE
[Level Control] transitionTime only set to NonNull if value is available

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -993,6 +993,7 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
 {
     app::DataModel::Nullable<uint8_t> resolvedLevel;
     app::DataModel::Nullable<uint8_t> temporaryCurrentLevelCache;
+    app::DataModel::Nullable<uint16_t> transitionTime;
 
     uint16_t currentOnOffTransitionTime;
     EmberAfStatus status;
@@ -1059,17 +1060,15 @@ void emberAfOnOffClusterLevelControlEffectCallback(EndpointId endpoint, bool new
             emberAfLevelControlClusterPrintln("ERR: reading current level %x", status);
             return;
         }
+        transitionTime.SetNonNull(currentOnOffTransitionTime);
     }
     else
     {
-        currentOnOffTransitionTime = 0xFFFF;
+        transitionTime.SetNull();
     }
 #else
-    currentOnOffTransitionTime = 0xFFFF;
+    transitionTime.SetNull();
 #endif // IGNORE_LEVEL_CONTROL_CLUSTER_ON_OFF_TRANSITION_TIME
-
-    app::DataModel::Nullable<uint16_t> transitionTime;
-    transitionTime.SetNonNull(currentOnOffTransitionTime);
 
     if (newValue)
     {


### PR DESCRIPTION
#### Problem
What is being fixed?  
Fixes #21882, transition time is not handled properly in On and Off commands when not supported

#### Change overview
transitionTime only set to NonNull if value is available

#### Testing
Manually tested on TI CC2652 based device 
