### PR TITLE
Remove methods from DeviceController that are no longer valid

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -56,11 +56,6 @@ void CASESessionManager::FindOrEstablishSession(const ScopedNodeId & peerId, Cal
     session->Connect(onConnection, onFailure);
 }
 
-void CASESessionManager::ReleaseSession(const ScopedNodeId & peerId)
-{
-    ReleaseSession(FindExistingSessionSetup(peerId));
-}
-
 void CASESessionManager::ReleaseSessionsForFabric(FabricIndex fabricIndex)
 {
     mConfig.sessionSetupPool->ReleaseAllSessionSetupsForFabric(fabricIndex);

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -80,8 +80,6 @@ public:
 
     OperationalSessionSetup * FindExistingSessionSetup(const ScopedNodeId & peerId, bool forAddressUpdate = false) const;
 
-    void ReleaseSession(const ScopedNodeId & peerId);
-
     void ReleaseSessionsForFabric(FabricIndex fabricIndex);
 
     void ReleaseAllSessions();

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -78,6 +78,8 @@ public:
     void FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
                                 Callback::Callback<OnDeviceConnectionFailure> * onFailure);
 
+    // TODO(#21885): Once this is no longer called from `DisconnectDevice` this can become a private method and
+    // we can remove the default for forAddressUpdate.
     OperationalSessionSetup * FindExistingSessionSetup(const ScopedNodeId & peerId, bool forAddressUpdate = false) const;
 
     void ReleaseSessionsForFabric(FabricIndex fabricIndex);

--- a/src/app/CASESessionManager.h
+++ b/src/app/CASESessionManager.h
@@ -78,10 +78,6 @@ public:
     void FindOrEstablishSession(const ScopedNodeId & peerId, Callback::Callback<OnDeviceConnected> * onConnection,
                                 Callback::Callback<OnDeviceConnectionFailure> * onFailure);
 
-    // TODO(#21885): Once this is no longer called from `DisconnectDevice` this can become a private method and
-    // we can remove the default for forAddressUpdate.
-    OperationalSessionSetup * FindExistingSessionSetup(const ScopedNodeId & peerId, bool forAddressUpdate = false) const;
-
     void ReleaseSessionsForFabric(FabricIndex fabricIndex);
 
     void ReleaseAllSessions();
@@ -103,6 +99,8 @@ public:
     void UpdatePeerAddress(ScopedNodeId peerId) override;
 
 private:
+    OperationalSessionSetup * FindExistingSessionSetup(const ScopedNodeId & peerId, bool forAddressUpdate = false) const;
+
     Optional<SessionHandle> FindExistingSession(const ScopedNodeId & peerId) const;
 
     CASESessionManagerConfig mConfig;

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -267,6 +267,8 @@ void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error)
     //
     while (failureReady.mNext != &failureReady)
     {
+        // We expect that we only have callbacks if we are not performing just address update.
+        VerifyOrDie(!mPerformingAddressUpdate);
         Callback::Callback<OnDeviceConnectionFailure> * cb =
             Callback::Callback<OnDeviceConnectionFailure>::FromCancelable(failureReady.mNext);
 
@@ -278,11 +280,10 @@ void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error)
         }
     }
 
-    // One noteworthy comment is that in the case where IsForAddressUpdate() is true, there are no callbacks.
-    // As a result, the two while loops in this function never run. This is an important detail because in
-    // the case we are performing a lookup we will not have SessionHandle.
     while (successReady.mNext != &successReady)
     {
+        // We expect that we only have callbacks if we are not performing just address update.
+        VerifyOrDie(!mPerformingAddressUpdate);
         Callback::Callback<OnDeviceConnected> * cb = Callback::Callback<OnDeviceConnected>::FromCancelable(successReady.mNext);
 
         cb->Cancel();

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -261,14 +261,6 @@ void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error)
     mConnectionFailure.DequeueAll(failureReady);
     mConnectionSuccess.DequeueAll(successReady);
 
-    // TODO Issue #20452: For now we need to make a copy of member fields inside `this` before calling any of the
-    // callbacks since the callbacks themselves can potentially release `this` OperationalSessionSetup.
-    auto * exchangeMgr = mInitParams.exchangeMgr;
-    auto sessionHandle = mSecureSession.Get();
-    auto peerId        = mPeerId;
-    VerifyOrDie(mReleaseDelegate != nullptr);
-    auto * releaseDelegate = mReleaseDelegate;
-
     //
     // If we encountered no error, go ahead and call all success callbacks. Otherwise,
     // call the failure callbacks.
@@ -282,10 +274,13 @@ void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error)
 
         if (error != CHIP_NO_ERROR)
         {
-            cb->mCall(cb->mContext, peerId, error);
+            cb->mCall(cb->mContext, mPeerId, error);
         }
     }
 
+    // One noteworthy comment is that in the case where IsForAddressUpdate() is true, there are no callbacks.
+    // As a result, the two while loops in this function never run. This is an important detail because in
+    // the case we are performing a lookup we will not have SessionHandle.
     while (successReady.mNext != &successReady)
     {
         Callback::Callback<OnDeviceConnected> * cb = Callback::Callback<OnDeviceConnected>::FromCancelable(successReady.mNext);
@@ -293,26 +288,21 @@ void OperationalSessionSetup::DequeueConnectionCallbacks(CHIP_ERROR error)
         cb->Cancel();
         if (error == CHIP_NO_ERROR)
         {
-            // We know that we for sure have the SessionHandle in the successful case.
+            auto * exchangeMgr = mInitParams.exchangeMgr;
             VerifyOrDie(exchangeMgr);
-            cb->mCall(cb->mContext, *exchangeMgr, sessionHandle.Value());
+            // We know that we for sure have the SessionHandle in the successful case.
+            auto optionalSessionHandle = mSecureSession.Get();
+            cb->mCall(cb->mContext, *exchangeMgr, optionalSessionHandle.Value());
         }
     }
-
-    releaseDelegate->ReleaseSession(this);
+    VerifyOrDie(mReleaseDelegate != nullptr);
+    mReleaseDelegate->ReleaseSession(this);
 }
 
 void OperationalSessionSetup::OnSessionEstablishmentError(CHIP_ERROR error)
 {
     VerifyOrReturn(mState != State::Uninitialized && mState != State::NeedsAddress,
                    ChipLogError(Controller, "HandleCASEConnectionFailure was called while the device was not initialized"));
-
-    //
-    // We don't need to reset the state all the way back to NeedsAddress since all that transpired
-    // was just CASE connection failure. So let's re-use the cached address to re-do CASE again
-    // if need-be.
-    //
-    MoveToState(State::HasAddress);
 
     DequeueConnectionCallbacks(error);
     // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
@@ -332,26 +322,6 @@ void OperationalSessionSetup::OnSessionEstablished(const SessionHandle & session
     // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
 }
 
-void OperationalSessionSetup::Disconnect()
-{
-    VerifyOrReturn(mState == State::SecureConnected);
-
-    if (mSecureSession)
-    {
-        //
-        // Mark the session as defunct to signal that we no longer want to use this
-        // session anymore for further interactions to this peer. However, if we receive
-        // messages back from that peer on the defunct session, it will bring it back into an active
-        // state again.
-        //
-        mSecureSession.Get().Value()->AsSecureSession()->MarkAsDefunct();
-    }
-
-    mSecureSession.Release();
-
-    MoveToState(State::HasAddress);
-}
-
 void OperationalSessionSetup::CleanupCASEClient()
 {
     if (mCASEClient)
@@ -364,11 +334,6 @@ void OperationalSessionSetup::CleanupCASEClient()
 void OperationalSessionSetup::OnSessionReleased()
 {
     MoveToState(State::HasAddress);
-}
-
-void OperationalSessionSetup::OnSessionHang()
-{
-    Disconnect();
 }
 
 OperationalSessionSetup::~OperationalSessionSetup()
@@ -456,12 +421,7 @@ void OperationalSessionSetup::OnNodeAddressResolutionFailed(const PeerId & peerI
     ChipLogError(Discovery, "OperationalSessionSetup[%u:" ChipLogFormatX64 "]: operational discovery failed: %" CHIP_ERROR_FORMAT,
                  mPeerId.GetFabricIndex(), ChipLogValueX64(mPeerId.GetNodeId()), reason.Format());
 
-    if (IsResolvingAddress())
-    {
-        MoveToState(State::NeedsAddress);
-    }
-
-    // No need to set mPerformingAddressUpdate to false since call below releases `this`.
+    // No need to modify any variables in `this` since call below releases `this`.
     DequeueConnectionCallbacks(reason);
     // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
 }

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -140,19 +140,29 @@ private:
  * application code does incorrectly hold onto this information so do not follow those incorrect
  * implementations as an example.
  */
-// TODO: OnDeviceConnected should not return ExchangeManager. Application should have this already. This
-// was provided initially to keep code churn down during a large refactor of OnDeviceConnected.
 typedef void (*OnDeviceConnected)(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
 typedef void (*OnDeviceConnectionFailure)(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
 
 /**
- * Represents a connection path to a device that is in an operational state.
+ * Object used to either establish a connection to peer or performing address lookup to a peer.
  *
- * Handles the lifetime of communicating with such a device:
- *    - Discover the device using DNSSD (find out what IP address to use and what
- *      communication parameters are appropriate for it)
- *    - Establish a secure channel to it via CASE
- *    - Expose to consumers the secure session for talking to the device.
+ * OperationalSessionSetup is capable of either:
+ *    1. Establishing a CASE session connection to a peer. Upon success or failure, the OnDeviceConnected or
+ *       OnDeviceConnectionFailure callback will be called to notify the caller the results of trying to
+ *       estblish a CASE session. Some additional details about the steps to establish a connection are:
+ *          - Discover the device using DNSSD (find out what IP address to use and what
+ *            communication parameters are appropriate for it)
+ *          - Establish a secure channel to it via CASE
+ *          - Expose to consumers the secure session for talking to the device via OnDeviceConnected
+ *            callback.
+ *    2. Peforming an address lookup. Upon success, it will notify the SessionManager of the
+ *       result of the address.
+ *
+ * OperationalSessionSetup has a very limited lifetime, once it has completed its purpose outlined above it
+ * will use `releaseDelegate` to release itself.
+ *
+ * It is possible to determine which of the two purposes the OperationalSessionSetup is for by calling
+ * IsForAddressUpdate().
  */
 class DLL_EXPORT OperationalSessionSetup : public SessionDelegate,
                                            public SessionEstablishmentDelegate,
@@ -198,20 +208,9 @@ public:
      */
     void Connect(Callback::Callback<OnDeviceConnected> * onConnection, Callback::Callback<OnDeviceConnectionFailure> * onFailure);
 
-    bool IsConnected() const { return mState == State::SecureConnected; }
-
     bool IsConnecting() const { return mState == State::Connecting; }
 
     bool IsForAddressUpdate() const { return mPerformingAddressUpdate; }
-
-    /**
-     * IsResolvingAddress returns true if we are doing an address resolution
-     * that needs to happen before we can establish CASE.  We can be in the
-     * middle of doing address updates at other times too (e.g. when we are
-     * IsConnected()), but those will not cause a true return from
-     * IsResolvingAddress().
-     */
-    bool IsResolvingAddress() const { return mState == State::ResolvingAddress; }
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
     void OnSessionEstablished(const SessionHandle & session) override;
@@ -221,18 +220,8 @@ public:
 
     // Called when a connection is closing. The object releases all resources associated with the connection.
     void OnSessionReleased() override;
-    // Called when a connection is hanging. Try to re-establish another session, and shift to the new session when done, the
-    // original session won't be touched during the period.
-    void OnSessionHang() override;
-
-    /**
-     *  Mark any open session with the device as expired.
-     */
-    void Disconnect();
 
     ScopedNodeId GetPeerId() const { return mPeerId; }
-
-    Transport::PeerAddress GetPeerAddress() const { return mDeviceAddress; }
 
     static Transport::PeerAddress ToPeerAddress(const Dnssd::ResolvedNodeData & nodeData)
     {
@@ -255,11 +244,6 @@ public:
      * @brief Get the fabricIndex
      */
     FabricIndex GetFabricIndex() const { return mPeerId.GetFabricIndex(); }
-
-    /**
-     * Triggers a DNSSD lookup to find a usable peer address for this operational device.
-     */
-    CHIP_ERROR LookupPeerAddress();
 
     void PerformAddressUpdate();
 
@@ -331,8 +315,16 @@ private:
      * If error == CHIP_NO_ERROR, only success callbacks are invoked.
      * Otherwise, only failure callbacks are invoked.
      *
+     * This uses mReleaseDelegate to release ourselves (aka `this`). As a
+     * result any caller should return right away without touching `this`.
+     *
      */
     void DequeueConnectionCallbacks(CHIP_ERROR error);
+
+    /**
+     * Triggers a DNSSD lookup to find a usable peer address.
+     */
+    CHIP_ERROR LookupPeerAddress();
 
     /**
      * This function will set new IP address, port and MRP retransmission intervals of the device.

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -155,11 +155,11 @@ typedef void (*OnDeviceConnectionFailure)(void * context, const ScopedNodeId & p
  *          - Establish a secure channel to it via CASE
  *          - Expose to consumers the secure session for talking to the device via OnDeviceConnected
  *            callback.
- *    2. Peforming an address lookup. Upon success, it will notify the SessionManager of the
- *       result of the address.
+ *    2. Performing an address lookup for given a scoped nodeid. On success, it will call into
+ *       SessionManager to update the addresses for all matching sessions in the session table.
  *
- * OperationalSessionSetup has a very limited lifetime, once it has completed its purpose outlined above it
- * will use `releaseDelegate` to release itself.
+ * OperationalSessionSetup has a very limited lifetime. Once it has completed its purpose outlined above,
+ * it will use `releaseDelegate` to release itself.
  *
  * It is possible to determine which of the two purposes the OperationalSessionSetup is for by calling
  * IsForAddressUpdate().

--- a/src/app/clusters/bindings/BindingManager.cpp
+++ b/src/app/clusters/bindings/BindingManager.cpp
@@ -111,7 +111,6 @@ CHIP_ERROR BindingManager::EstablishConnection(const ScopedNodeId & nodeId)
         if (mPendingNotificationMap.FindLRUConnectPeer(peerToRemove) == CHIP_NO_ERROR)
         {
             mPendingNotificationMap.RemoveAllEntriesForNode(peerToRemove);
-            mInitParams.mCASESessionManager->ReleaseSession(peerToRemove);
 
             // Now retry
             mLastSessionEstablishmentError = CHIP_NO_ERROR;
@@ -160,7 +159,6 @@ void BindingManager::HandleDeviceConnectionFailure(const ScopedNodeId & peerId, 
 {
     // Simply release the entry, the connection will be re-established as needed.
     ChipLogError(AppServer, "Failed to establish connection to node 0x" ChipLogFormatX64, ChipLogValueX64(peerId.GetNodeId()));
-    mInitParams.mCASESessionManager->ReleaseSession(peerId);
     mLastSessionEstablishmentError = error;
 }
 

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -296,18 +296,6 @@ void FailSafeCleanup(const chip::DeviceLayer::ChipDeviceEvent * event)
     // Session Context at the Server.
     if (event->FailSafeTimerExpired.addNocCommandHasBeenInvoked || event->FailSafeTimerExpired.updateNocCommandHasBeenInvoked)
     {
-        // TODO(#19259): The following scope will no longer need to exist after #19259 is fixed
-        {
-            CASESessionManager * caseSessionManager = Server::GetInstance().GetCASESessionManager();
-            if (caseSessionManager)
-            {
-                const FabricInfo * fabricInfo = Server::GetInstance().GetFabricTable().FindFabricWithIndex(fabricIndex);
-                VerifyOrReturn(fabricInfo != nullptr);
-
-                caseSessionManager->ReleaseSessionsForFabric(fabricInfo->GetFabricIndex());
-            }
-        }
-
         SessionManager & sessionMgr = Server::GetInstance().GetSecureSessionManager();
         CleanupSessionsForFabric(sessionMgr, fabricIndex);
     }

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -484,6 +484,7 @@ void DefaultOTARequestor::OnConnectionFailure(void * context, const ScopedNodeId
 {
     DefaultOTARequestor * requestorCore = static_cast<DefaultOTARequestor *>(context);
     VerifyOrDie(requestorCore != nullptr);
+    requestorCore->mSessionHolder.Release();
 
     ChipLogError(SoftwareUpdate, "Failed to connect to node 0x" ChipLogFormatX64 ": %" CHIP_ERROR_FORMAT,
                  ChipLogValueX64(peerId.GetNodeId()), error.Format());

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -331,6 +331,7 @@ private:
     // persistent storage (if available), used for sending the NotifyApplied message, and then cleared. This will ensure determinism
     // in the OTARequestorDriver on reboot.
     Optional<ProviderLocationType> mProviderLocation;
+    SessionHolder mSessionHolder;
 };
 
 } // namespace chip

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -353,34 +353,6 @@ void DeviceController::Shutdown()
     mDeviceDiscoveryDelegate = nullptr;
 }
 
-CHIP_ERROR DeviceController::DisconnectDevice(NodeId nodeId)
-{
-    ChipLogProgress(Controller, "Force close session for node 0x%" PRIx64, nodeId);
-
-    if (SessionMgr()->MarkSessionsAsDefunct(GetPeerScopedId(nodeId), MakeOptional(Transport::SecureSession::Type::kCASE)))
-    {
-        return CHIP_NO_ERROR;
-    }
-
-    OperationalSessionSetup * proxy = mSystemState->CASESessionMgr()->FindExistingSessionSetup(GetPeerScopedId(nodeId));
-    if (proxy == nullptr)
-    {
-        ChipLogProgress(Controller, "Attempted to close a session that does not exist.");
-        return CHIP_NO_ERROR;
-    }
-
-    if (proxy->IsConnecting())
-    {
-        ChipLogError(Controller, "Attempting to disconnect while connection in progress");
-        return CHIP_ERROR_INCORRECT_STATE;
-    }
-
-    // TODO: logic here is unclear. Possible states are "uninitialized, needs address, initialized"
-    // and disconnecting in those states is unclear (especially for needds-address).
-    ChipLogProgress(Controller, "Disconnect attempt while not in connected/connecting state");
-    return CHIP_NO_ERROR;
-}
-
 CHIP_ERROR DeviceController::GetPeerAddressAndPort(NodeId peerId, Inet::IPAddress & addr, uint16_t & port)
 {
     VerifyOrReturnError(mState == State::Initialized, CHIP_ERROR_INCORRECT_STATE);

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -296,24 +296,6 @@ public:
     OperationalCredentialsDelegate * GetOperationalCredentialsDelegate() { return mOperationalCredentialsDelegate; }
 
     /**
-     * TODO(#21885): This needs to be removed. This currently is not disconnecting anything.
-     *
-     * DEPRECATED - DO NOT USE or if you use please request review on why/how to
-     * officially support such an API.
-     *
-     * This was added to support the 'reuse session' logic in cirque integration
-     * tests however since that is the only client, the correct update is to
-     * use 'ConnectDevice' and wait for connect success/failure inside the CI
-     * logic. The current code does not do that because python was not set up
-     * to wait for timeouts on success/fail, hence this temporary method.
-     *
-     * TODO(andy31415): update cirque test and remove this method.
-     *
-     * Returns success if a session with the given peer does not exist yet.
-     */
-    CHIP_ERROR DisconnectDevice(NodeId nodeId);
-
-    /**
      * @brief
      *   Reconfigures a new set of operational credentials to be used with this
      *   controller given ControllerInitParams state.

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -215,14 +215,6 @@ public:
     }
 
     /**
-     * DEPRECATED - to be removed
-     *
-     * Forces a DNSSD lookup for the specified device. It finds the corresponding session
-     * for the given peerNodeId and initiates a DNSSD lookup to find/update the node address
-     */
-    CHIP_ERROR UpdateDevice(NodeId peerNodeId);
-
-    /**
      * @brief
      *   Compute a PASE verifier and passcode ID for the desired setup pincode.
      *
@@ -301,15 +293,12 @@ public:
         return mSystemState->Fabrics();
     }
 
-    // TODO(#20452): This should be removed/renamed once #20452 is fixed
-    void ReleaseOperationalDevice(NodeId remoteNodeId);
-
     OperationalCredentialsDelegate * GetOperationalCredentialsDelegate() { return mOperationalCredentialsDelegate; }
 
     /**
-     * TODO(#20452): This needs to be refactored to reflect what it actually does (which is not disconnecting anything)
+     * TODO(#21885): This needs to be removed. This currently is not disconnecting anything.
      *
-     * TEMPORARY - DO NOT USE or if you use please request review on why/how to
+     * DEPRECATED - DO NOT USE or if you use please request review on why/how to
      * officially support such an API.
      *
      * This was added to support the 'reuse session' logic in cirque integration
@@ -369,14 +358,7 @@ protected:
 
     chip::VendorId mVendorId;
 
-    /// Fetches the session to use for the current device. Allows overriding
-    /// in case subclasses want to create the session if it does not yet exist
-    virtual OperationalSessionSetup * GetDeviceSession(const ScopedNodeId & peerId);
-
     DiscoveredNodeList GetDiscoveredNodes() override { return DiscoveredNodeList(mCommissionableNodes); }
-
-private:
-    void ReleaseOperationalDevice(OperationalSessionSetup * device);
 };
 
 #if CHIP_DEVICE_CONFIG_ENABLE_COMMISSIONER_DISCOVERY
@@ -659,9 +641,6 @@ public:
 
     // ClusterStateCache::Callback impl
     void OnDone(app::ReadClient *) override;
-
-    // Commissioner will establish new device connections after PASE.
-    OperationalSessionSetup * GetDeviceSession(const ScopedNodeId & peerId) override;
 
     // Issue an NOC chain using the associated OperationalCredentialsDelegate. The NOC chain will
     // be provided in X509 DER format.

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -681,15 +681,6 @@ JNI_METHOD(void, releaseOperationalDevicePointer)(JNIEnv * env, jobject self, jl
     }
 }
 
-JNI_METHOD(void, disconnectDevice)(JNIEnv * env, jobject self, jlong handle, jlong deviceId)
-{
-    chip::DeviceLayer::StackLock lock;
-    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-
-    ChipLogProgress(Controller, "disconnectDevice() called with deviceId");
-    wrapper->Controller()->ReleaseOperationalDevice(deviceId);
-}
-
 JNI_METHOD(void, shutdownSubscriptions)(JNIEnv * env, jobject self, jlong handle, jlong devicePtr)
 {
     chip::DeviceLayer::StackLock lock;
@@ -785,20 +776,6 @@ JNI_METHOD(jlong, getCompressedFabricId)(JNIEnv * env, jobject self, jlong handl
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
 
     return wrapper->Controller()->GetCompressedFabricId();
-}
-
-JNI_METHOD(void, updateDevice)(JNIEnv * env, jobject self, jlong handle, jlong fabricId, jlong deviceId)
-{
-    chip::DeviceLayer::StackLock lock;
-
-    AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-
-    CHIP_ERROR err = wrapper->Controller()->UpdateDevice(static_cast<chip::NodeId>(deviceId));
-    if (err != CHIP_NO_ERROR)
-    {
-        ChipLogError(Controller, "Failed to update device");
-        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, err);
-    }
 }
 
 JNI_METHOD(void, discoverCommissionableNodes)(JNIEnv * env, jobject self, jlong handle)

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -262,10 +262,6 @@ public class ChipDeviceController {
     releaseOperationalDevicePointer(devicePtr);
   }
 
-  public boolean disconnectDevice(long deviceId) {
-    return disconnectDevice(deviceControllerPtr, deviceId);
-  }
-
   public void onConnectDeviceComplete() {
     completionListener.onConnectDeviceComplete();
   }
@@ -635,8 +631,6 @@ public class ChipDeviceController {
       long deviceControllerPtr, long deviceId, long callbackHandle);
 
   private native void releaseOperationalDevicePointer(long devicePtr);
-
-  private native boolean disconnectDevice(long deviceControllerPtr, long deviceId);
 
   private native void deleteDeviceController(long deviceControllerPtr);
 

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -453,12 +453,17 @@ ChipError::StorageType pychip_DeviceController_SetWiFiCredentials(const char * s
 
 ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
-    devCtrl->SessionMgr()->ForEachMatchingSession(ScopedNodeId(nodeid, devCtrl->GetFabricIndex()), [](auto * session) {
-        if (session->IsActiveSession())
-        {
-            session->MarkAsDefunct();
-        }
-    });
+    //
+    // Since we permit multiple controllers per fabric and each is associated with a unique fabric index, closing a session
+    // requires us to do so across all controllers on the same logical fabric.
+    //
+    devCtrl->SessionMgr()->ForEachMatchingSessionOnLogicalFabric(ScopedNodeId(nodeid, devCtrl->GetFabricIndex()),
+                                                                 [](auto * session) {
+                                                                     if (session->IsActiveSession())
+                                                                     {
+                                                                         session->MarkAsDefunct();
+                                                                     }
+                                                                 });
 
     return CHIP_NO_ERROR.AsInteger();
 }

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -378,8 +378,6 @@ ChipError::StorageType pychip_DeviceController_ConnectIP(chip::Controller::Devic
     addr.SetTransportType(chip::Transport::Type::kUdp).SetIPAddress(peerAddr);
     params.SetPeerAddress(addr).SetDiscriminator(0);
 
-    devCtrl->ReleaseOperationalDevice(nodeid);
-
     return devCtrl->PairDevice(nodeid, params, sCommissioningParameters).AsInteger();
 }
 
@@ -455,28 +453,11 @@ ChipError::StorageType pychip_DeviceController_SetWiFiCredentials(const char * s
 
 ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
-#if 0
-    //
-    // Since we permit multiple controllers per fabric and each is associated with a unique fabric index, closing a session
-    // requires us to do so across all controllers on the same logical fabric.
-    //
-    // TODO: Enable this and remove the call below to DisconnectDevice once #19259 is completed. This is because
-    //       OperationalDeviceProxy instances that are currently active will remain un-affected by this call and still
-    //       provide a valid SessionHandle in the OnDeviceConnected call later when we call DeviceController::GetConnectedDevice.
-    //       However, it provides a SessionHandle that is incapable of actually vending exchanges since it is in a defunct state.
-    //
-    //       For now, calling DisconnectDevice will at least just correctly de-activate a currently active OperationalDeviceProxy
-    //       instance and ensure that subsequent attempts to acquire one will correctly re-establish CASE on the fabric associated
-    //       with the provided devCtrl.
-    //
-    auto err = devCtrl->SessionMgr()->ForEachCollidingSession(ScopedNodeId(nodeid, devCtrl->GetFabricIndex()), [](auto *session) {
+    devCtrl->SessionMgr()->ForEachMatchingSession(ScopedNodeId(nodeid, devCtrl->GetFabricIndex()), [](auto *session) {
         session->MarkAsDefunct();
     });
 
-    ReturnErrorOnFailure(err.AsInteger());
-#else
-    return devCtrl->DisconnectDevice(nodeid).AsInteger();
-#endif
+    return CHIP_NO_ERROR.AsInteger();
 }
 
 ChipError::StorageType pychip_DeviceController_EstablishPASESessionIP(chip::Controller::DeviceCommissioner * devCtrl,
@@ -724,7 +705,6 @@ ChipError::StorageType pychip_GetDeviceBeingCommissioned(chip::Controller::Devic
 ChipError::StorageType pychip_ExpireSessions(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeId)
 {
     VerifyOrReturnError((devCtrl != nullptr) && (devCtrl->SessionMgr() != nullptr), CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    (void) devCtrl->ReleaseOperationalDevice(nodeId);
 
     //
     // Since we permit multiple controllers on the same fabric each associated with a different fabric index, expiring a session

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -453,9 +453,8 @@ ChipError::StorageType pychip_DeviceController_SetWiFiCredentials(const char * s
 
 ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
-    devCtrl->SessionMgr()->ForEachMatchingSession(ScopedNodeId(nodeid, devCtrl->GetFabricIndex()), [](auto *session) {
-        session->MarkAsDefunct();
-    });
+    devCtrl->SessionMgr()->ForEachMatchingSession(ScopedNodeId(nodeid, devCtrl->GetFabricIndex()),
+                                                  [](auto * session) { session->MarkAsDefunct(); });
 
     return CHIP_NO_ERROR.AsInteger();
 }

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -453,8 +453,12 @@ ChipError::StorageType pychip_DeviceController_SetWiFiCredentials(const char * s
 
 ChipError::StorageType pychip_DeviceController_CloseSession(chip::Controller::DeviceCommissioner * devCtrl, chip::NodeId nodeid)
 {
-    devCtrl->SessionMgr()->ForEachMatchingSession(ScopedNodeId(nodeid, devCtrl->GetFabricIndex()),
-                                                  [](auto * session) { session->MarkAsDefunct(); });
+    devCtrl->SessionMgr()->ForEachMatchingSession(ScopedNodeId(nodeid, devCtrl->GetFabricIndex()), [](auto * session) {
+        if (session->IsActiveSession())
+        {
+            session->MarkAsDefunct();
+        }
+    });
 
     return CHIP_NO_ERROR.AsInteger();
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -808,11 +808,8 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         auto sessionMgr = self->_cppCommissioner->SessionMgr();
         VerifyOrDie(sessionMgr != nullptr);
 
-        sessionMgr->ForEachMatchingSession(self->_cppCommissioner->GetPeerScopedId(nodeID), [](auto * session) {
-            if (session->IsActiveSession() && session->GetSecureSessionType() == chip::Transport::SecureSession::Type::kCASE) {
-                session->MarkAsDefunct();
-            }
-        });
+        sessionMgr->MarkSessionsAsDefunct(
+            self->_cppCommissioner->GetPeerScopedId(nodeID), chip::Transport::SecureSession::Type::kCASE)
     });
 }
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -809,7 +809,7 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         VerifyOrDie(sessionMgr != nullptr);
 
         sessionMgr->MarkSessionsAsDefunct(
-            self->_cppCommissioner->GetPeerScopedId(nodeID), chip::Transport::SecureSession::Type::kCASE)
+            self->_cppCommissioner->GetPeerScopedId(nodeID), chip::MakeOptional(chip::Transport::SecureSession::Type::kCASE));
     });
 }
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -805,8 +805,10 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
             return;
         }
 
-        // TODO(#21885): This is a hack and needs to go away or use some sane API.
-        self->_cppCommissioner->DisconnectDevice(nodeID);
+        auto sessionMgr = self->_cppCommissioner->SessionMgr();
+        VerifyOrDie(sessionMgr != nullptr);
+
+        sessionMgr->MarkSessionsAsDefunct(self->_cppCommissioner->GetPeerScopedId(nodeID), MakeOptional(Transport::SecureSession::Type::kCASE));
     });
 }
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -805,7 +805,7 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
             return;
         }
 
-        // TODO: This is a hack and needs to go away or use some sane API.
+        // TODO(#21885): This is a hack and needs to go away or use some sane API.
         self->_cppCommissioner->DisconnectDevice(nodeID);
     });
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -808,7 +808,11 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         auto sessionMgr = self->_cppCommissioner->SessionMgr();
         VerifyOrDie(sessionMgr != nullptr);
 
-        sessionMgr->MarkSessionsAsDefunct(self->_cppCommissioner->GetPeerScopedId(nodeID), MakeOptional(Transport::SecureSession::Type::kCASE));
+        sessionMgr->ForEachMatchingSession(self->_cppCommissioner->GetPeerScopedId(nodeID), [](auto * session) {
+            if (session->IsActiveSession() && session->GetSecureSessionType() == Transport::SecureSession::Type::kCASE) {
+                session->MarkAsDefunct();
+            }
+        });
     });
 }
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -809,7 +809,7 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         VerifyOrDie(sessionMgr != nullptr);
 
         sessionMgr->ForEachMatchingSession(self->_cppCommissioner->GetPeerScopedId(nodeID), [](auto * session) {
-            if (session->IsActiveSession() && session->GetSecureSessionType() == Transport::SecureSession::Type::kCASE) {
+            if (session->IsActiveSession() && session->GetSecureSessionType() == chip::Transport::SecureSession::Type::kCASE) {
                 session->MarkAsDefunct();
             }
         });

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -445,22 +445,6 @@ void SessionManager::ExpireAllPASESessions()
     });
 }
 
-bool SessionManager::MarkSessionsAsDefunct(const ScopedNodeId & node, const Optional<Transport::SecureSession::Type> & type)
-{
-    bool found = false;
-    mSecureSessions.ForEachSession([&node, &type, &found](auto session) {
-        if (session->IsActiveSession() && session->GetPeer() == node &&
-            (!type.HasValue() || type.Value() == session->GetSecureSessionType()))
-        {
-            session->MarkAsDefunct();
-            found = true;
-        }
-        return Loop::Continue;
-    });
-
-    return found;
-}
-
 void SessionManager::UpdateAllSessionsPeerAddress(const ScopedNodeId & node, const Transport::PeerAddress & addr)
 {
     mSecureSessions.ForEachSession([&node, &addr](auto session) {

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -445,6 +445,18 @@ void SessionManager::ExpireAllPASESessions()
     });
 }
 
+void SessionManager::MarkSessionsAsDefunct(const ScopedNodeId & node, const Optional<Transport::SecureSession::Type> & type)
+{
+    mSecureSessions.ForEachSession([&node, &type](auto session) {
+        if (session->IsActiveSession() && session->GetPeer() == node &&
+            (!type.HasValue() || type.Value() == session->GetSecureSessionType()))
+        {
+            session->MarkAsDefunct();
+        }
+        return Loop::Continue;
+    });
+}
+
 void SessionManager::UpdateAllSessionsPeerAddress(const ScopedNodeId & node, const Transport::PeerAddress & addr)
 {
     mSecureSessions.ForEachSession([&node, &addr](auto session) {

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -351,6 +351,17 @@ public:
 
     /**
      * @brief
+     *   Marks all active sessions that match provided arguments as defunct.
+     *
+     * @param node    Scoped node ID of the active sessions we should mark as defunct.
+     * @param type    Type of session we are looking to mark as defunct. If matching
+     *                against all types of sessions is desired, NullOptional should
+     *                be passed into type.
+     */
+    void MarkSessionsAsDefunct(const ScopedNodeId & node, const Optional<Transport::SecureSession::Type> & type);
+
+    /**
+     * @brief
      *   Update all CASE sessions that match `node` with the provided transport peer address.
      *
      * @param node    Scoped node ID of the active sessions we want to update.

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -352,7 +352,7 @@ public:
     /**
      * @brief
      *   Marks all active sessions that match provided arguments as defunct.
-     * 
+     *
      * TODO(#21885): This needs to be removed. This was added to reduce code churn
      * on PR that was a large refactor.
      *

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -351,25 +351,6 @@ public:
 
     /**
      * @brief
-     *   Marks all active sessions that match provided arguments as defunct.
-     *
-     * TODO(#21885): This needs to be removed. This was added to reduce code churn
-     * on PR that was a large refactor.
-     *
-     * DEPRECATED - DO NOT USE or if you use please request review on why/how to
-     * officially support such an API.
-     *
-     * @param node    Scoped node ID of the active sessions we should mark as defunct.
-     * @param type    Type of session we are looking to mark as defunct. If matching
-     *                against all types of sessions is desired, NullOptional should
-     *                be passed into type.
-     * @return        True, if at least one session was marked as defunct, otherwise
-     *                return is False.
-     */
-    bool MarkSessionsAsDefunct(const ScopedNodeId & node, const Optional<Transport::SecureSession::Type> & type);
-
-    /**
-     * @brief
      *   Update all CASE sessions that match `node` with the provided transport peer address.
      *
      * @param node    Scoped node ID of the active sessions we want to update.

--- a/src/transport/SessionManager.h
+++ b/src/transport/SessionManager.h
@@ -352,6 +352,12 @@ public:
     /**
      * @brief
      *   Marks all active sessions that match provided arguments as defunct.
+     * 
+     * TODO(#21885): This needs to be removed. This was added to reduce code churn
+     * on PR that was a large refactor.
+     *
+     * DEPRECATED - DO NOT USE or if you use please request review on why/how to
+     * officially support such an API.
      *
      * @param node    Scoped node ID of the active sessions we should mark as defunct.
      * @param type    Type of session we are looking to mark as defunct. If matching


### PR DESCRIPTION
With the refactor for OperationalSessionSetup, there are methods in DeviceController that we can now permanently remove.

#### Problem
* Fixes #20452

#### Change overview
* Remove methods in DeviceController that we can now permanently remove after the OperationalSessionSetup refactor.

#### Testing
* CI passes
* Tried commissioning device with chip-tool
