### PR TITLE
[TC-OO-2.3] increase timout to 400 seconds

### DIFF
--- a/src/app/tests/suites/certification/Test_TC_OO_2_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_OO_2_3.yaml
@@ -21,7 +21,7 @@ PICS:
 config:
     nodeId: 0x12344321
     cluster: "On/Off"
-    timeout: 350
+    timeout: 400
     endpoint: 1
 
 tests:


### PR DESCRIPTION
fixes https://github.com/CHIP-Specifications/chip-test-scripts/issues/370

#### Problem
When performing TC-OO-2.3 on an embedded device with the LT feature enabled then the timeout value of 350 seconds is too short because the sum of all wait times in this test case is already 300 seconds and the command turnaround time is also non-zero which leads into a total time of slightly more than 6 minutes.


#### Change overview
Increase timout to 400 seconds

#### Testing
Tested on latest TH v2.2 with TC-OO-2.3 on a nRF52-based device