### PR TITLE
Fix build warning on Android in CHIPCryptoPALOpenSSL.cpp

### DIFF
--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1669,6 +1669,8 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
         VerifyOrExit(asn1Time.ExportTo_UnixTime(unixEpoch),
                      (result = CertificateChainValidationResult::kLeafFormatInvalid, err = CHIP_ERROR_INTERNAL));
 
+        VerifyOrExit(CanCastTo<time_t>(unixEpoch),
+                     (result = CertificateChainValidationResult::kLeafFormatInvalid, err = CHIP_ERROR_INTERNAL));
         X509_VERIFY_PARAM_set_time(param, static_cast<time_t>(unixEpoch));
     }
 

--- a/src/crypto/CHIPCryptoPALOpenSSL.cpp
+++ b/src/crypto/CHIPCryptoPALOpenSSL.cpp
@@ -1669,7 +1669,7 @@ CHIP_ERROR ValidateCertificateChain(const uint8_t * rootCertificate, size_t root
         VerifyOrExit(asn1Time.ExportTo_UnixTime(unixEpoch),
                      (result = CertificateChainValidationResult::kLeafFormatInvalid, err = CHIP_ERROR_INTERNAL));
 
-        X509_VERIFY_PARAM_set_time(param, unixEpoch);
+        X509_VERIFY_PARAM_set_time(param, static_cast<time_t>(unixEpoch));
     }
 
     status = X509_verify_cert(verifyCtx);


### PR DESCRIPTION
X509_VERIFY_PARAM_set_time takes in time_t as the unix epoch parameter.
On Android this is defined as a 'long', so need to cast the value to
suppress the warning.

src/crypto/CHIPCryptoPALOpenSSL.cpp:1672:43: error: implicit conversion changes signedness: 'uint32_t' (aka 'unsigned int') to 'time_t' (aka 'long') [-Werror,-Wsign-conversion]
        X509_VERIFY_PARAM_set_time(param, unixEpoch);
