### PR TITLE
[EFR32] Destroy PSA key_id if exists.

### DIFF
--- a/src/platform/EFR32/Efr32PsaOperationalKeystore.cpp
+++ b/src/platform/EFR32/Efr32PsaOperationalKeystore.cpp
@@ -238,13 +238,6 @@ CHIP_ERROR Efr32PsaOperationalKeystore::NewOpKeypairForFabric(FabricIndex fabric
     error = mPendingKeypair->Create(id, EFR32OpaqueKeyUsages::ECDSA_P256_SHA256);
     if (error != CHIP_NO_ERROR)
     {
-        // Try deleting and recreating this key since keys don't get wiped on factory erase yet
-        mPendingKeypair->Delete();
-        error = mPendingKeypair->Create(id, EFR32OpaqueKeyUsages::ECDSA_P256_SHA256);
-    }
-
-    if (error != CHIP_NO_ERROR)
-    {
         ResetPendingKey();
         return error;
     }


### PR DESCRIPTION
#### Problem
EFR32 device can't recover when the key store is lost.

#### Change overview
* Destroy the PSA key if exists.
* Key Id variables renamed to clarify their use.

#### Testing
* Tested on BRD4161A with RS9116X