### PR TITLE
Remove mRemoteMRPConfig member from OperationalSessionSetup

### DIFF
--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -125,10 +125,11 @@ void OperationalSessionSetup::Connect(Callback::Callback<OnDeviceConnected> * on
         isConnected = AttachToExistingSecureSession();
         if (!isConnected)
         {
-            // We should really be in State::HasAddress since in the same call
-            // we move to State::HasAddress we then moved to State::Connecting
-            // or call DequeueConnectionCallbacks with an error thus releasing
-            // ourselve.
+            // We should not actually every be in be in State::HasAddress. This
+            // is because in the same call that we moved to State::HasAddress
+            // we either move to State::Connecting or call
+            // DequeueConnectionCallbacks with an error thus releasing
+            // ourselves before any call would reach this section of code.
             err = CHIP_ERROR_INCORRECT_STATE;
         }
 

--- a/src/app/OperationalSessionSetup.h
+++ b/src/app/OperationalSessionSetup.h
@@ -208,8 +208,6 @@ public:
      */
     void Connect(Callback::Callback<OnDeviceConnected> * onConnection, Callback::Callback<OnDeviceConnectionFailure> * onFailure);
 
-    bool IsConnecting() const { return mState == State::Connecting; }
-
     bool IsForAddressUpdate() const { return mPerformingAddressUpdate; }
 
     //////////// SessionEstablishmentDelegate Implementation ///////////////
@@ -288,11 +286,9 @@ private:
     /// This is used when a node address is required.
     chip::AddressResolve::NodeLookupHandle mAddressLookupHandle;
 
-    ReliableMessageProtocolConfig mRemoteMRPConfig = GetDefaultMRPConfig();
-
     bool mPerformingAddressUpdate = false;
 
-    CHIP_ERROR EstablishConnection();
+    CHIP_ERROR EstablishConnection(const ReliableMessageProtocolConfig & config);
 
     /*
      * This checks to see if an existing CASE session exists to the peer within the SessionManager


### PR DESCRIPTION
#### Problem
* Fixes #21610

#### Change overview
* Remove  mRemoteMRPConfig member from OperationalSessionSetup since we can just rely on the information being on the stack.
* Remove unused method `OperationalSessionSetup::IsConnecting()`
* Make it more clear that we don't actually get into certain states anymore with the ephemeral `OperationalSessionSetup` refactor.

#### Testing
* CI passes
