### PR TITLE
urgent event needs to honor min interval for subscription.

### DIFF
--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -244,7 +244,6 @@ CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload, b
     {
         mPreviousReportsBeginGeneration = mCurrentReportsBeginGeneration;
         ClearForceDirtyFlag();
-        ClearUrgentEventFlag();
         InteractionModelEngine::GetInstance()->ReleaseDataVersionFilterList(mpDataVersionFilterList);
     }
 

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -243,7 +243,8 @@ CHIP_ERROR ReadHandler::SendReportData(System::PacketBufferHandle && aPayload, b
     if (!aMoreChunks)
     {
         mPreviousReportsBeginGeneration = mCurrentReportsBeginGeneration;
-        ClearDirty();
+        ClearForceDirtyFlag();
+        ClearUrgentEventFlag();
         InteractionModelEngine::GetInstance()->ReleaseDataVersionFilterList(mpDataVersionFilterList);
     }
 

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -198,9 +198,7 @@ private:
     enum class ReadHandlerFlags : uint8_t
     {
         // mHoldReport is used to prevent subscription data delivery while we are
-        // waiting for the min reporting interval to elapse.  If we have to send a
-        // report immediately due to an urgent event being queued,
-        // UnblockUrgentEventDelivery can be used to force mHoldReport to false.
+        // waiting for the min reporting interval to elapse.
         HoldReport = (1 << 0),
 
         // mHoldSync is used to prevent subscription empty report delivery while we
@@ -219,7 +217,6 @@ private:
         PrimingReports     = (1 << 3),
         ActiveSubscription = (1 << 4),
         FabricFiltered     = (1 << 5),
-
         // For subscriptions, we record the dirty set generation when we started to generate the last report.
         // The mCurrentReportsBeginGeneration records the generation at the start of the current report.  This only/
         // has a meaningful value while IsReporting() is true.
@@ -227,10 +224,9 @@ private:
         // mPreviousReportsBeginGeneration will be set to mCurrentReportsBeginGeneration after we send the last
         // chunk of the current report.  Anything that was dirty with a generation earlier than
         // mPreviousReportsBeginGeneration has had its value sent to the client.
-        ForceDirty = (1 << 6),
-
-        // Don't need the response for report data if true
-        SuppressResponse = (1 << 7),
+        // when receiving initial request, it needs mark current handler as dirty
+        ForceDirty  = (1 << 6),
+        UrgentEvent = (1 << 7),
     };
 
     /**
@@ -298,10 +294,11 @@ private:
     void SetDirty(const AttributePathParams & aAttributeChanged);
     bool IsDirty() const
     {
-        return (mDirtyGeneration > mPreviousReportsBeginGeneration) || mFlags.Has(ReadHandlerFlags::ForceDirty);
+        return (mDirtyGeneration > mPreviousReportsBeginGeneration) || mFlags.Has(ReadHandlerFlags::UrgentEvent) ||
+            mFlags.Has(ReadHandlerFlags::ForceDirty);
     }
-    void ClearDirty() { mFlags.Clear(ReadHandlerFlags::ForceDirty); }
-
+    void ClearUrgentEventFlag() { mFlags.Clear(ReadHandlerFlags::UrgentEvent); }
+    void ClearForceDirtyFlag() { mFlags.Clear(ReadHandlerFlags::ForceDirty); }
     NodeId GetInitiatorNodeId() const
     {
         auto session = GetSession();
@@ -319,11 +316,7 @@ private:
 
     auto GetTransactionStartGeneration() const { return mTransactionStartGeneration; }
 
-    void UnblockUrgentEventDelivery()
-    {
-        mFlags.Clear(ReadHandlerFlags::HoldReport);
-        mFlags.Set(ReadHandlerFlags::ForceDirty);
-    }
+    void UnblockUrgentEventDelivery() { mFlags.Set(ReadHandlerFlags::UrgentEvent); }
 
     const AttributeValueEncoder::AttributeEncodeState & GetAttributeEncodeState() const { return mAttributeEncoderState; }
     void SetAttributeEncodeState(const AttributeValueEncoder::AttributeEncodeState & aState) { mAttributeEncoderState = aState; }

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -224,9 +224,12 @@ private:
         // mPreviousReportsBeginGeneration will be set to mCurrentReportsBeginGeneration after we send the last
         // chunk of the current report.  Anything that was dirty with a generation earlier than
         // mPreviousReportsBeginGeneration has had its value sent to the client.
-        // when receiving initial request, it needs mark current handler as dirty
-        ForceDirty  = (1 << 6),
-        UrgentEvent = (1 << 7),
+        // when receiving initial request, it needs mark current handler as dirty.
+        // when there is urgent event, it needs mark current handler as dirty.
+        ForceDirty = (1 << 6),
+
+        // Don't need the response for report data if true
+        SuppressResponse = (1 << 7),
     };
 
     /**
@@ -294,10 +297,8 @@ private:
     void SetDirty(const AttributePathParams & aAttributeChanged);
     bool IsDirty() const
     {
-        return (mDirtyGeneration > mPreviousReportsBeginGeneration) || mFlags.Has(ReadHandlerFlags::UrgentEvent) ||
-            mFlags.Has(ReadHandlerFlags::ForceDirty);
+        return (mDirtyGeneration > mPreviousReportsBeginGeneration) || mFlags.Has(ReadHandlerFlags::ForceDirty);
     }
-    void ClearUrgentEventFlag() { mFlags.Clear(ReadHandlerFlags::UrgentEvent); }
     void ClearForceDirtyFlag() { mFlags.Clear(ReadHandlerFlags::ForceDirty); }
     NodeId GetInitiatorNodeId() const
     {
@@ -316,7 +317,7 @@ private:
 
     auto GetTransactionStartGeneration() const { return mTransactionStartGeneration; }
 
-    void UnblockUrgentEventDelivery() { mFlags.Set(ReadHandlerFlags::UrgentEvent); }
+    void UnblockUrgentEventDelivery() { mFlags.Set(ReadHandlerFlags::ForceDirty); }
 
     const AttributeValueEncoder::AttributeEncodeState & GetAttributeEncodeState() const { return mAttributeEncoderState; }
     void SetAttributeEncodeState(const AttributeValueEncoder::AttributeEncodeState & aState) { mAttributeEncoderState = aState; }

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -171,12 +171,6 @@ private:
                                    const ConcreteReadAttributePath & aPath);
 
     /**
-     * Check all active subscription, if the subscription has no paths that intersect with global dirty set,
-     * it would clear dirty flag for that subscription
-     *
-     */
-    void UpdateReadHandlerDirty(ReadHandler & aReadHandler);
-    /**
      * Send Report via ReadHandler
      *
      */

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1559,6 +1559,7 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         // Test report with 2 different path
         delegate.mpReadHandler->mFlags.Set(ReadHandler::ReadHandlerFlags::HoldReport, false);
         delegate.mGotReport            = false;
+        delegate.mGotEventResponse     = false;
         delegate.mNumAttributeResponse = 0;
 
         printf("HereHere\n");


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/21864
In latest spec, urgent event needs to honor min interval for
subscription.

#### Change overview
-- Add new flag, UrgentEvent, and remove unused flag, SuppressResponse
-- ForceDirty would be used when receiving the initial request, where it
marks the corresponding handler with dirtiness.
-- When there is urgent event, we would set new flag, UrgentEvent, in
readHandler, after minInterval elapsed,
the urgent event would be sent out. 
--Remove UpdateReadHandlerDirty in reporting engine. After sending out all chunked report, it would clear out UrgentEvent flag and ForceDirty flag, and mark mPreviousReportsBeginGeneration with mCurrentReportsBeginGeneration, which means the readHandler would be clear at that moment, we don't need extra UpdateReadHandlerDirty to check overlapped/intersected path between global dirty set and interested attribute paths.

#### Testing
Modify the existing urgent event test and check if event can be generated after minInterval elapsed.