### PR TITLE
Drop-off fabric sensitive event when fabric is undefined

### DIFF
--- a/src/app/EventLogging.h
+++ b/src/app/EventLogging.h
@@ -73,6 +73,8 @@ CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aE
     eventOptions.mPriority    = aEventData.GetPriorityLevel();
     eventOptions.mFabricIndex = aEventData.GetFabricIndex();
 
+    VerifyOrReturnError(eventOptions.mFabricIndex != kUndefinedFabricIndex, CHIP_NO_ERROR);
+
     //
     // Unlike attributes which have a different 'EncodeForRead' for fabric-scoped structs,
     // fabric-sensitive events don't require that since the actual omission of the event in its entirety

--- a/src/app/clusters/test-cluster-server/test-cluster-server.cpp
+++ b/src/app/clusters/test-cluster-server/test-cluster-server.cpp
@@ -797,7 +797,7 @@ bool emberAfTestClusterClusterTestEmitTestFabricScopedEventRequestCallback(
 {
     Commands::TestEmitTestFabricScopedEventResponse::Type responseData;
     Events::TestFabricScopedEvent::Type event{ commandData.arg1 };
-
+    event.fabricIndex = commandData.arg1;
     if (CHIP_NO_ERROR != LogEvent(event, commandPath.mEndpointId, responseData.value))
     {
         emberAfSendImmediateDefaultResponse(EMBER_ZCL_STATUS_FAILURE);

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -316,6 +316,7 @@ class ClusterObjectTests:
         await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestFabricScopedEventRequest(arg1=0))
         await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestFabricScopedEventRequest(arg1=1))
 
+
     @classmethod
     async def _RetryForContent(cls, request, until, retryCount=10, intervalSeconds=1):
         for i in range(retryCount):
@@ -330,6 +331,15 @@ class ClusterObjectTests:
     async def TriggerAndWaitForEvents(cls, devCtrl, req):
         await cls._TriggerEvent(devCtrl)
         await cls._RetryForContent(request=lambda: devCtrl.ReadEvent(nodeid=NODE_ID, events=req), until=lambda res: res != 0)
+
+    @classmethod
+    @base.test_case
+    async def TestGenerateUndefinedFabricScopedEventRequests(cls, devCtrl, expectEventsNum):
+        await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestFabricScopedEventRequest(arg1=0))
+        res = await devCtrl.ReadEvent(nodeid=NODE_ID, events=[
+            (1, Clusters.TestCluster.Events.TestEvent, 0),
+        ])
+        logger.info(f"{res}")
 
     @classmethod
     @base.test_case
@@ -557,6 +567,7 @@ class ClusterObjectTests:
             await cls.TestWriteRequest(devCtrl)
             await cls.TestTimedRequest(devCtrl)
             await cls.TestTimedRequestTimeout(devCtrl)
+            await cls.TestGenerateUndefinedFabricScopedEventRequests(devCtrl)
         except Exception as ex:
             logger.error(
                 f"Unexpected error occurred when running tests: {ex}")


### PR DESCRIPTION
Problem
https://github.com/project-chip/connectedhomeip/issues/14366

Change overview
Drop-off fabric sensitive event when fabric is undefined

Testing
Add python testing for it
