### PR TITLE
Enable faultinjection mechnism when chip_with_nlfaultinjection build …

### DIFF
--- a/src/inet/InetFaultInjection.cpp
+++ b/src/inet/InetFaultInjection.cpp
@@ -25,8 +25,6 @@
 
 #include <nlassert.h>
 
-#if INET_CONFIG_TEST
-
 namespace chip {
 namespace Inet {
 namespace FaultInjection {
@@ -55,5 +53,3 @@ nl::FaultInjection::Manager & GetManager()
 } // namespace FaultInjection
 } // namespace Inet
 } // namespace chip
-
-#endif // INET_CONFIG_TEST

--- a/src/inet/InetFaultInjection.h
+++ b/src/inet/InetFaultInjection.h
@@ -25,7 +25,7 @@
 
 #include <inet/InetConfig.h>
 
-#if INET_CONFIG_TEST && CHIP_WITH_NLFAULTINJECTION
+#if CHIP_WITH_NLFAULTINJECTION
 
 #include <nlfaultinjection.hpp>
 
@@ -67,8 +67,8 @@ DLL_EXPORT nl::FaultInjection::Manager & GetManager();
  */
 #define INET_FAULT_INJECT(aFaultID, aStatement) nlFAULT_INJECT(Inet::FaultInjection::GetManager(), aFaultID, aStatement)
 
-#else // INET_CONFIG_TEST
+#else // CHIP_WITH_NLFAULTINJECTION
 
 #define INET_FAULT_INJECT(aFaultID, aStatement)
 
-#endif // INET_CONFIG_TEST
+#endif // CHIP_WITH_NLFAULTINJECTION

--- a/src/lib/support/CHIPFaultInjection.cpp
+++ b/src/lib/support/CHIPFaultInjection.cpp
@@ -26,8 +26,6 @@
 
 #include <string.h>
 
-#if CHIP_CONFIG_TEST && CHIP_WITH_NLFAULTINJECTION
-
 namespace chip {
 namespace FaultInjection {
 
@@ -91,5 +89,3 @@ DLL_EXPORT void FuzzExchangeHeader(uint8_t * p, int32_t arg)
 
 } // namespace FaultInjection
 } // namespace chip
-
-#endif // CHIP_CONFIG_TEST

--- a/src/lib/support/CHIPFaultInjection.h
+++ b/src/lib/support/CHIPFaultInjection.h
@@ -18,7 +18,7 @@
 
 /**
  *    @file
- *      Header file for the fault-injection utilities for Inet.
+ *      Header file for the fault-injection utilities for CHIP.
  */
 
 #pragma once
@@ -26,7 +26,7 @@
 #include <lib/core/CHIPConfig.h>
 #include <lib/core/CHIPEventLoggingConfig.h>
 
-#if CHIP_CONFIG_TEST && CHIP_WITH_NLFAULTINJECTION
+#if CHIP_WITH_NLFAULTINJECTION
 
 #include <nlfaultinjection.hpp>
 
@@ -128,10 +128,10 @@ DLL_EXPORT void FuzzExchangeHeader(uint8_t * p, int32_t arg);
 #define CHIP_FAULT_INJECTION_EXCH_HEADER_NUM_FIELDS 4
 #define CHIP_FAULT_INJECTION_EXCH_HEADER_NUM_FIELDS_RMP 5
 
-#else // CHIP_CONFIG_TEST
+#else // CHIP_WITH_NLFAULTINJECTION
 
 #define CHIP_FAULT_INJECT(aFaultID, aStatements)
 #define CHIP_FAULT_INJECT_WITH_ARGS(aFaultID, aProtectedStatements, aUnprotectedStatements)
 #define CHIP_FAULT_INJECT_MAX_ARG(aFaultID, aMaxArg, aProtectedStatements, aUnprotectedStatements)
 
-#endif // CHIP_CONFIG_TEST
+#endif // CHIP_WITH_NLFAULTINJECTION

--- a/src/system/SystemFaultInjection.cpp
+++ b/src/system/SystemFaultInjection.cpp
@@ -22,7 +22,6 @@
  *    @file
  *      Implementation of the fault-injection utilities for CHIP System Layer.
  */
-#if CHIP_SYSTEM_CONFIG_TEST
 /* module header, also carries config, comes first */
 #include <system/SystemFaultInjection.h>
 
@@ -106,5 +105,3 @@ void SetAsyncEventCallbacks(int32_t (*aGetNumEventsAvailable)(), void (*aInjectA
 } // namespace FaultInjection
 } // namespace System
 } // namespace chip
-
-#endif // CHIP_SYSTEM_CONFIG_TEST

--- a/src/system/SystemFaultInjection.h
+++ b/src/system/SystemFaultInjection.h
@@ -25,7 +25,7 @@
 
 #include <system/SystemConfig.h>
 
-#if CHIP_SYSTEM_CONFIG_TEST && CHIP_WITH_NLFAULTINJECTION
+#if CHIP_WITH_NLFAULTINJECTION
 
 #include <nlfaultinjection.hpp>
 
@@ -119,10 +119,10 @@ DLL_EXPORT void InjectAsyncEvent();
         chip::System::FaultInjection::InjectAsyncEvent();                                                                          \
     } while (0)
 
-#else // CHIP_SYSTEM_CONFIG_TEST
+#else // CHIP_WITH_NLFAULTINJECTION
 
 #define CHIP_SYSTEM_FAULT_INJECT(aFaultId, aStatement)
 
 #define CHIP_SYSTEM_FAULT_INJECT_ASYNC_EVENT()
 
-#endif // CHIP_SYSTEM_CONFIG_TEST
+#endif // CHIP_WITH_NLFAULTINJECTION


### PR DESCRIPTION
…flag is set

#### Problem
What is being fixed?  Examples:
* Nest Labs Fault Injection (nlfaultinjection) is designed to provide a simple, portable fault injection framework, this framework has been integrated in Matter SDK from the beginning, but only get enabled for unit test. We also need to enable this farmework in chip-all-cluster app when chip_with_nlfaultinjection build flag is set so that we can use this mechanism within yaml test

#### Change overview
Enable faultinjection mechnism when chip_with_nlfaultinjection build flag is set

#### Testing
How was this tested? (at least one bullet point required)
* Build  all-clusters-app with chip_with_nlfaultinjection=true and confirm nlfaultinjection components are built into the excutable 
`scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone chip_config_network_layer_ble=false chip_with_nlfaultinjection=true`
