### PR TITLE
Fix overlapping execution for TriggerEffect and Identify commands in Identify Server

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -48,11 +48,9 @@ algs
 alloc
 Ameba
 amebad
-AmebaD
 amebaiot
 AmebaZ
 amebaz2
-AmebaZ2
 announcementReason
 AnnounceOTAProvider
 AnnounceOtaProviderRequest
@@ -84,8 +82,6 @@ args
 argv
 armeabi
 armino
-Armino
-ARMINO
 ARMmbed
 armv
 ASAN
@@ -294,8 +290,8 @@ connstring
 conntype
 const
 ContentApp
-ContentApp's
 ContentAppPlatform
+ContentApp's
 ContentLaunch
 ContentLauncher
 continuousHinting
@@ -1116,8 +1112,8 @@ REPL
 repo
 req
 Requestor
-Requestor's
 RequestorCanConsent
+Requestor's
 Requestors
 responder
 RestrictedEvent
@@ -1164,8 +1160,8 @@ SDB
 SDC
 SDHC
 SDK
-SDK's
 sdkconfig
+SDK's
 SDKs
 SDKTARGETSYSROOT
 sdl
@@ -1342,6 +1338,7 @@ trackFree
 TransferSession
 transitionTime
 TransportMgrBase
+TriggerEffect
 TRNG
 TrustedRootCertificates
 tsan

--- a/examples/lighting-app/nxp/k32w/k32w0/README.md
+++ b/examples/lighting-app/nxp/k32w/k32w0/README.md
@@ -167,6 +167,22 @@ DS3, which can be found on the DK6 board.
 Also, by long pressing the **USERINTERFACE** button, the factory reset action
 will be initiated.
 
+### Identify cluster LED state
+
+The Identify cluster server supports two identification commands: **Identify** and **TriggerEffect**. These commands allow a user to identify a particular device. For these commands, the **LED D3** is used.
+
+The **Identify command** will use the **LED D3** to flash with a period of 0.5 seconds.
+
+The **TriggerEffect command** will use the **LED D3** with the following effects:
+
+* _Blink_ &mdash; flash with a 1 second period for 2 seconds
+* _Breathe_ &mdash; flash with a 1 second period for 15 seconds
+* _Okay_ &mdash; flash with a 1 second period for 4 seconds
+* _Channel change_ &mdash; same as Blink
+* _Finish effect_ &mdash; complete current effect sequence and terminate
+* _Stop effect_ &mdash; terminate as soon as possible
+
+
 <a name="building"></a>
 
 ## Building

--- a/examples/lighting-app/nxp/k32w/k32w0/README.md
+++ b/examples/lighting-app/nxp/k32w/k32w0/README.md
@@ -169,19 +169,22 @@ will be initiated.
 
 ### Identify cluster LED state
 
-The Identify cluster server supports two identification commands: **Identify** and **TriggerEffect**. These commands allow a user to identify a particular device. For these commands, the **LED D3** is used.
+The Identify cluster server supports two identification commands: **Identify**
+and **TriggerEffect**. These commands allow a user to identify a particular
+device. For these commands, the **LED D3** is used.
 
-The **Identify command** will use the **LED D3** to flash with a period of 0.5 seconds.
+The **Identify command** will use the **LED D3** to flash with a period of 0.5
+seconds.
 
-The **TriggerEffect command** will use the **LED D3** with the following effects:
+The **TriggerEffect command** will use the **LED D3** with the following
+effects:
 
-* _Blink_ &mdash; flash with a 1 second period for 2 seconds
-* _Breathe_ &mdash; flash with a 1 second period for 15 seconds
-* _Okay_ &mdash; flash with a 1 second period for 4 seconds
-* _Channel change_ &mdash; same as Blink
-* _Finish effect_ &mdash; complete current effect sequence and terminate
-* _Stop effect_ &mdash; terminate as soon as possible
-
+-   _Blink_ &mdash; flash with a 1 second period for 2 seconds
+-   _Breathe_ &mdash; flash with a 1 second period for 15 seconds
+-   _Okay_ &mdash; flash with a 1 second period for 4 seconds
+-   _Channel change_ &mdash; same as Blink
+-   _Finish effect_ &mdash; complete current effect sequence and terminate
+-   _Stop effect_ &mdash; terminate as soon as possible
 
 <a name="building"></a>
 

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -85,17 +85,12 @@ using namespace chip;
 
 AppTask AppTask::sAppTask;
 
-static Identify gIdentify = {
-    chip::EndpointId{1},
-    AppTask::OnIdentifyStart,
-    AppTask::OnIdentifyStop,
-    EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
-	AppTask::OnTriggerEffect,
-	//Use invalid value for identifiers to enable TriggerEffect command
-	//to stop Identify command for each effect
-	(EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10),
-	EMBER_ZCL_IDENTIFY_EFFECT_VARIANT_DEFAULT
-};
+static Identify gIdentify = { chip::EndpointId{ 1 }, AppTask::OnIdentifyStart, AppTask::OnIdentifyStop,
+                              EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED, AppTask::OnTriggerEffect,
+                              // Use invalid value for identifiers to enable TriggerEffect command
+                              // to stop Identify command for each effect
+                              (EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10),
+                              EMBER_ZCL_IDENTIFY_EFFECT_VARIANT_DEFAULT };
 
 /* OTA related variables */
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
@@ -687,7 +682,7 @@ void AppTask::ActionCompleted(LightingManager::Action_t aAction)
 
 void AppTask::RestoreLightingState(void)
 {
-	/* restore initial state for the LED indicating Lighting state */
+    /* restore initial state for the LED indicating Lighting state */
     if (LightingMgr().IsTurnedOff())
     {
         sLightLED.Set(false);
@@ -698,91 +693,90 @@ void AppTask::RestoreLightingState(void)
     }
 }
 
-void AppTask::OnIdentifyStart(Identify* identify)
+void AppTask::OnIdentifyStart(Identify * identify)
 {
-	if ((kFunction_NoneSelected != sAppTask.mFunction) && (kFunction_TriggerEffect != sAppTask.mFunction))
-	{
-		K32W_LOG("Another function is scheduled. Could not initiate Identify process!");
-		return;
-	}
+    if ((kFunction_NoneSelected != sAppTask.mFunction) && (kFunction_TriggerEffect != sAppTask.mFunction))
+    {
+        K32W_LOG("Another function is scheduled. Could not initiate Identify process!");
+        return;
+    }
 
-	if (kFunction_TriggerEffect == sAppTask.mFunction)
-	{
-		chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerEffectComplete, identify);
-		OnTriggerEffectComplete(&chip::DeviceLayer::SystemLayer(), identify);
-	}
+    if (kFunction_TriggerEffect == sAppTask.mFunction)
+    {
+        chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerEffectComplete, identify);
+        OnTriggerEffectComplete(&chip::DeviceLayer::SystemLayer(), identify);
+    }
 
-	ChipLogProgress(Zcl,"Identify process has started. Status LED should blink with a period of 0.5 seconds.");
-	sAppTask.mFunction = kFunction_Identify;
-	sLightLED.Set(false);
-	sLightLED.Blink(250);
+    ChipLogProgress(Zcl, "Identify process has started. Status LED should blink with a period of 0.5 seconds.");
+    sAppTask.mFunction = kFunction_Identify;
+    sLightLED.Set(false);
+    sLightLED.Blink(250);
 }
 
-void AppTask::OnIdentifyStop(Identify* identify)
+void AppTask::OnIdentifyStop(Identify * identify)
 {
-	if (kFunction_Identify == sAppTask.mFunction)
-	{
-		ChipLogProgress(Zcl,"Identify process has stopped.");
-		sAppTask.mFunction = kFunction_NoneSelected;
+    if (kFunction_Identify == sAppTask.mFunction)
+    {
+        ChipLogProgress(Zcl, "Identify process has stopped.");
+        sAppTask.mFunction = kFunction_NoneSelected;
 
-		RestoreLightingState();
-
-	}
+        RestoreLightingState();
+    }
 }
 
 void AppTask::OnTriggerEffectComplete(chip::System::Layer * systemLayer, void * appState)
 {
-	//Let Identify command take over if called during TriggerEffect already running
-	if (kFunction_TriggerEffect == sAppTask.mFunction)
-	{
-		ChipLogProgress(Zcl,"TriggerEffect has stopped.");
-		sAppTask.mFunction = kFunction_NoneSelected;
+    // Let Identify command take over if called during TriggerEffect already running
+    if (kFunction_TriggerEffect == sAppTask.mFunction)
+    {
+        ChipLogProgress(Zcl, "TriggerEffect has stopped.");
+        sAppTask.mFunction = kFunction_NoneSelected;
 
-		//TriggerEffect finished - reset identifiers
-		//Use invalid value for identifiers to enable TriggerEffect command
-		//to stop Identify command for each effect
-		gIdentify.mCurrentEffectIdentifier = (EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10);
-		gIdentify.mTargetEffectIdentifier = (EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10);
-		gIdentify.mEffectVariant = EMBER_ZCL_IDENTIFY_EFFECT_VARIANT_DEFAULT;
+        // TriggerEffect finished - reset identifiers
+        // Use invalid value for identifiers to enable TriggerEffect command
+        // to stop Identify command for each effect
+        gIdentify.mCurrentEffectIdentifier =
+            (EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10);
+        gIdentify.mTargetEffectIdentifier =
+            (EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10);
+        gIdentify.mEffectVariant = EMBER_ZCL_IDENTIFY_EFFECT_VARIANT_DEFAULT;
 
-		RestoreLightingState();
-	}
+        RestoreLightingState();
+    }
 }
 
-void AppTask::OnTriggerEffect(Identify* identify)
+void AppTask::OnTriggerEffect(Identify * identify)
 {
-	//Allow overlapping TriggerEffect calls
-	if ((kFunction_NoneSelected != sAppTask.mFunction) && (kFunction_TriggerEffect != sAppTask.mFunction))
-	{
-		K32W_LOG("Another function is scheduled. Could not initiate Identify process!");
-		return;
-	}
+    // Allow overlapping TriggerEffect calls
+    if ((kFunction_NoneSelected != sAppTask.mFunction) && (kFunction_TriggerEffect != sAppTask.mFunction))
+    {
+        K32W_LOG("Another function is scheduled. Could not initiate Identify process!");
+        return;
+    }
 
-	sAppTask.mFunction = kFunction_TriggerEffect;
-	uint16_t timerDelay = 0;
+    sAppTask.mFunction  = kFunction_TriggerEffect;
+    uint16_t timerDelay = 0;
 
-	ChipLogProgress(Zcl,"TriggerEffect has started.");
-
+    ChipLogProgress(Zcl, "TriggerEffect has started.");
 
     switch (identify->mCurrentEffectIdentifier)
     {
     case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
-    	timerDelay = 2;
-    	break;
+        timerDelay = 2;
+        break;
 
     case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
-    	timerDelay = 15;
-    	break;
+        timerDelay = 15;
+        break;
 
     case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
-    	timerDelay = 4;
+        timerDelay = 4;
         break;
 
     case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
-    	ChipLogProgress(Zcl,"Channel Change effect not supported, using effect %d",
-    				EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK);
-    	timerDelay = 2;
-    	break;
+        ChipLogProgress(Zcl, "Channel Change effect not supported, using effect %d", EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK);
+        timerDelay = 2;
+        break;
 
     case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_FINISH_EFFECT:
         chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerEffectComplete, identify);
@@ -798,13 +792,12 @@ void AppTask::OnTriggerEffect(Identify* identify)
         ChipLogProgress(Zcl, "Invalid effect identifier.");
     }
 
-    if(timerDelay)
+    if (timerDelay)
     {
-    	sLightLED.Set(false);
-    	sLightLED.Blink(500);
+        sLightLED.Set(false);
+        sLightLED.Blink(500);
 
-    	chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(timerDelay), OnTriggerEffectComplete,
-    	                                                           identify);
+        chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(timerDelay), OnTriggerEffectComplete, identify);
     }
 }
 

--- a/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/AppTask.cpp
@@ -82,9 +82,20 @@ extern "C" void K32WUartProcess(void);
 using namespace ::chip::Credentials;
 using namespace ::chip::DeviceLayer;
 using namespace chip;
-;
 
 AppTask AppTask::sAppTask;
+
+static Identify gIdentify = {
+    chip::EndpointId{1},
+    AppTask::OnIdentifyStart,
+    AppTask::OnIdentifyStop,
+    EMBER_ZCL_IDENTIFY_IDENTIFY_TYPE_VISIBLE_LED,
+	AppTask::OnTriggerEffect,
+	//Use invalid value for identifiers to enable TriggerEffect command
+	//to stop Identify command for each effect
+	(EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10),
+	EMBER_ZCL_IDENTIFY_EFFECT_VARIANT_DEFAULT
+};
 
 /* OTA related variables */
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
@@ -415,15 +426,7 @@ void AppTask::ResetActionEventHandler(AppEvent * aEvent)
         sAppTask.CancelTimer();
         sAppTask.mFunction = kFunction_NoneSelected;
 
-        /* restore initial state for the LED indicating Lighting state */
-        if (LightingMgr().IsTurnedOff())
-        {
-            sLightLED.Set(false);
-        }
-        else
-        {
-            sLightLED.Set(true);
-        }
+        RestoreLightingState();
 
         K32W_LOG("Factory Reset was cancelled!");
     }
@@ -680,6 +683,129 @@ void AppTask::ActionCompleted(LightingManager::Action_t aAction)
     }
 
     sAppTask.mFunction = kFunction_NoneSelected;
+}
+
+void AppTask::RestoreLightingState(void)
+{
+	/* restore initial state for the LED indicating Lighting state */
+    if (LightingMgr().IsTurnedOff())
+    {
+        sLightLED.Set(false);
+    }
+    else
+    {
+        sLightLED.Set(true);
+    }
+}
+
+void AppTask::OnIdentifyStart(Identify* identify)
+{
+	if ((kFunction_NoneSelected != sAppTask.mFunction) && (kFunction_TriggerEffect != sAppTask.mFunction))
+	{
+		K32W_LOG("Another function is scheduled. Could not initiate Identify process!");
+		return;
+	}
+
+	if (kFunction_TriggerEffect == sAppTask.mFunction)
+	{
+		chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerEffectComplete, identify);
+		OnTriggerEffectComplete(&chip::DeviceLayer::SystemLayer(), identify);
+	}
+
+	ChipLogProgress(Zcl,"Identify process has started. Status LED should blink with a period of 0.5 seconds.");
+	sAppTask.mFunction = kFunction_Identify;
+	sLightLED.Set(false);
+	sLightLED.Blink(250);
+}
+
+void AppTask::OnIdentifyStop(Identify* identify)
+{
+	if (kFunction_Identify == sAppTask.mFunction)
+	{
+		ChipLogProgress(Zcl,"Identify process has stopped.");
+		sAppTask.mFunction = kFunction_NoneSelected;
+
+		RestoreLightingState();
+
+	}
+}
+
+void AppTask::OnTriggerEffectComplete(chip::System::Layer * systemLayer, void * appState)
+{
+	//Let Identify command take over if called during TriggerEffect already running
+	if (kFunction_TriggerEffect == sAppTask.mFunction)
+	{
+		ChipLogProgress(Zcl,"TriggerEffect has stopped.");
+		sAppTask.mFunction = kFunction_NoneSelected;
+
+		//TriggerEffect finished - reset identifiers
+		//Use invalid value for identifiers to enable TriggerEffect command
+		//to stop Identify command for each effect
+		gIdentify.mCurrentEffectIdentifier = (EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10);
+		gIdentify.mTargetEffectIdentifier = (EmberAfIdentifyEffectIdentifier)(EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT - 0x10);
+		gIdentify.mEffectVariant = EMBER_ZCL_IDENTIFY_EFFECT_VARIANT_DEFAULT;
+
+		RestoreLightingState();
+	}
+}
+
+void AppTask::OnTriggerEffect(Identify* identify)
+{
+	//Allow overlapping TriggerEffect calls
+	if ((kFunction_NoneSelected != sAppTask.mFunction) && (kFunction_TriggerEffect != sAppTask.mFunction))
+	{
+		K32W_LOG("Another function is scheduled. Could not initiate Identify process!");
+		return;
+	}
+
+	sAppTask.mFunction = kFunction_TriggerEffect;
+	uint16_t timerDelay = 0;
+
+	ChipLogProgress(Zcl,"TriggerEffect has started.");
+
+
+    switch (identify->mCurrentEffectIdentifier)
+    {
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK:
+    	timerDelay = 2;
+    	break;
+
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BREATHE:
+    	timerDelay = 15;
+    	break;
+
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_OKAY:
+    	timerDelay = 4;
+        break;
+
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_CHANNEL_CHANGE:
+    	ChipLogProgress(Zcl,"Channel Change effect not supported, using effect %d",
+    				EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_BLINK);
+    	timerDelay = 2;
+    	break;
+
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_FINISH_EFFECT:
+        chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerEffectComplete, identify);
+        timerDelay = 1;
+        break;
+
+    case EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT:
+        chip::DeviceLayer::SystemLayer().CancelTimer(OnTriggerEffectComplete, identify);
+        OnTriggerEffectComplete(&chip::DeviceLayer::SystemLayer(), identify);
+        break;
+
+    default:
+        ChipLogProgress(Zcl, "Invalid effect identifier.");
+    }
+
+    if(timerDelay)
+    {
+    	sLightLED.Set(false);
+    	sLightLED.Blink(500);
+
+    	chip::DeviceLayer::SystemLayer().StartTimer(chip::System::Clock::Seconds16(timerDelay), OnTriggerEffectComplete,
+    	                                                           identify);
+    }
 }
 
 void AppTask::PostTurnOnActionRequest(int32_t aActor, LightingManager::Action_t aAction)

--- a/examples/lighting-app/nxp/k32w/k32w0/main/include/AppTask.h
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/include/AppTask.h
@@ -24,8 +24,8 @@
 #include "AppEvent.h"
 #include "LightingManager.h"
 
-#include <platform/CHIPDeviceLayer.h>
 #include <app/clusters/identify-server/identify-server.h>
+#include <platform/CHIPDeviceLayer.h>
 
 #include "FreeRTOS.h"
 #include "timers.h"
@@ -51,9 +51,9 @@ public:
     void UpdateDeviceState(void);
 
     // Identify cluster callbacks.
-    static void OnIdentifyStart(Identify* identify);
-    static void OnIdentifyStop(Identify* identify);
-    static void OnTriggerEffect(Identify* identify);
+    static void OnIdentifyStart(Identify * identify);
+    static void OnIdentifyStop(Identify * identify);
+    static void OnTriggerEffect(Identify * identify);
     static void OnTriggerEffectComplete(chip::System::Layer * systemLayer, void * appState);
 
 private:
@@ -103,7 +103,7 @@ private:
         kFunction_FactoryReset,
         kFunctionTurnOnTurnOff,
         kFunction_Identify,
-		kFunction_TriggerEffect,
+        kFunction_TriggerEffect,
 
         kFunction_Invalid
     } Function;

--- a/examples/lighting-app/nxp/k32w/k32w0/main/include/AppTask.h
+++ b/examples/lighting-app/nxp/k32w/k32w0/main/include/AppTask.h
@@ -25,6 +25,7 @@
 #include "LightingManager.h"
 
 #include <platform/CHIPDeviceLayer.h>
+#include <app/clusters/identify-server/identify-server.h>
 
 #include "FreeRTOS.h"
 #include "timers.h"
@@ -48,6 +49,12 @@ public:
 
     void UpdateClusterState(void);
     void UpdateDeviceState(void);
+
+    // Identify cluster callbacks.
+    static void OnIdentifyStart(Identify* identify);
+    static void OnIdentifyStop(Identify* identify);
+    static void OnTriggerEffect(Identify* identify);
+    static void OnTriggerEffectComplete(chip::System::Layer * systemLayer, void * appState);
 
 private:
     friend AppTask & GetAppTask(void);
@@ -77,6 +84,8 @@ private:
     static void ThreadProvisioningHandler(const chip::DeviceLayer::ChipDeviceEvent * event, intptr_t arg);
     void StartTimer(uint32_t aTimeoutInMs);
 
+    static void RestoreLightingState(void);
+
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
     static void InitOTA(intptr_t arg);
     static void StartOTAQuery(intptr_t arg);
@@ -93,6 +102,8 @@ private:
         kFunction_SoftwareUpdate = 0,
         kFunction_FactoryReset,
         kFunctionTurnOnTurnOff,
+        kFunction_Identify,
+		kFunction_TriggerEffect,
 
         kFunction_Invalid
     } Function;

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -179,9 +179,7 @@ void MatterIdentifyClusterServerAttributeChangedCallback(const app::ConcreteAttr
                 /* finish identify process */
                 if (EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_FINISH_EFFECT == identify->mCurrentEffectIdentifier && identifyTime > 0)
                 {
-                    (void) chip::DeviceLayer::SystemLayer().StartTimer(System::Clock::Seconds16(1), onIdentifyClusterTick,
-                                                                       identify);
-                    return;
+                	Clusters::Identify::Attributes::IdentifyTime::Set(endpoint, 1);
                 }
                 /* stop identify process */
                 if (EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT == identify->mCurrentEffectIdentifier && identifyTime > 0)

--- a/src/app/clusters/identify-server/identify-server.cpp
+++ b/src/app/clusters/identify-server/identify-server.cpp
@@ -179,7 +179,7 @@ void MatterIdentifyClusterServerAttributeChangedCallback(const app::ConcreteAttr
                 /* finish identify process */
                 if (EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_FINISH_EFFECT == identify->mCurrentEffectIdentifier && identifyTime > 0)
                 {
-                	Clusters::Identify::Attributes::IdentifyTime::Set(endpoint, 1);
+                    Clusters::Identify::Attributes::IdentifyTime::Set(endpoint, 1);
                 }
                 /* stop identify process */
                 if (EMBER_ZCL_IDENTIFY_EFFECT_IDENTIFIER_STOP_EFFECT == identify->mCurrentEffectIdentifier && identifyTime > 0)


### PR DESCRIPTION

#### Problem
What is being fixed?  Examples:

The Identify cluster server's Identify and TriggerEffect commands don't work well in overlapping execution especially when Identify is executing and TriggerEffect is called. This behaviour is not clarified on the spec either, I opened [an issue](https://github.com/CHIP-Specifications/connectedhomeip-spec/issues/5540).

In the [identify server code](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/identify-server/identify-server.cpp#L175) the Identify command can be canceled by TriggerEffect but only if `identify->mTargetEffectIdentifier != identify->mCurrentEffectIdentifier` which is correct if TriggerEffect command is called with all effect identifiers **but one**, the one used to initialize the mTargetEffectIdentifier and mCurrentEffectIdentifier at Identify instance creation in AppTask.cpp, in which case it will let Identify command continue. I fixed it on k32w0 by using invalid effect identifiers for initialization.

Moreover, if TriggerEffect command is called with finish effect, it also [won't stop](https://github.com/project-chip/connectedhomeip/blob/master/src/app/clusters/identify-server/identify-server.cpp#L182) the Identify command since the same callback `onIdentifyClusterTick` is called. I know that finish effect lets the device complete the current effect sequence but is this the whole Identify command or the current effect (e.g current led flash period)?

The other way around (Identify command called during TriggerEffect running) can be solved on the app task (e.g. reset internal flags, structures, enable/disable led effects though callbacks).


#### Change overview
What's in this PR
This PR tries to come up with a solution to the problem mentioned. It may need more work and clarifications.

#### Testing
How was this tested? (at least one bullet point required)

Tested on k32w0 with chip-tool commands.
