### PR TITLE
Sync window covering device type with specs

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -1565,10 +1565,7 @@ limitations under the License.
                 <requireAttribute>CLIENT_LIST</requireAttribute>
                 <requireAttribute>PARTS_LIST</requireAttribute>
             </include>
-            <include cluster="Binding" client="true" server="false" clientLocked="false" serverLocked="true">
-                <requireAttribute>BINDING</requireAttribute>
-            </include>
-            <include cluster="Scenes" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Scenes" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>SCENE_COUNT</requireAttribute>
                 <requireAttribute>CURRENT_SCENE</requireAttribute>
                 <requireAttribute>CURRENT_GROUP</requireAttribute>
@@ -1588,7 +1585,7 @@ limitations under the License.
                 <requireCommand>GetSceneMembership</requireCommand>
                 <requireCommand>GetSceneMembershipResponse</requireCommand>
             </include>
-            <include cluster="Groups" client="false" server="true" clientLocked="true" serverLocked="true">
+            <include cluster="Groups" client="false" server="false" clientLocked="true" serverLocked="false">
                 <requireAttribute>GROUP_NAME_SUPPORT</requireAttribute>
                 <requireCommand>AddGroup</requireCommand>
                 <requireCommand>AddGroupResponse</requireCommand>


### PR DESCRIPTION
#### Problem
What is being fixed? Examples:
* Window covering device type was not matching specs

Change overview
Sync window covering device type with specs

Testing
How was this tested? (at least one bullet point required)
* Verified window covering device type syncs with specs
