### PR TITLE
Improve IM PrettyPrint

### DIFF
--- a/config/esp32/components/chip/CMakeLists.txt
+++ b/config/esp32/components/chip/CMakeLists.txt
@@ -119,8 +119,8 @@ if (CONFIG_BUILD_CHIP_TESTS)
     chip_gn_arg_bool("chip_build_tests"     "true")
 endif()
 
-if (CONFIG_CHIP_ENABLE_SCHEMA_CHECK)
-    chip_gn_arg_bool("chip_enable_schema_check"	"true")
+if (CONFIG_IM_PRETTY_PRINT)
+    chip_gn_arg_bool("enable_im_pretty_print"	"true")
 endif()
 
 if (NOT CONFIG_USE_MINIMAL_MDNS)

--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -787,12 +787,11 @@ menu "CHIP Device Layer"
                 for the debug level events are disabled.
 
 
-	config CHIP_ENABLE_SCHEMA_CHECK
-	   bool "Enable Schema Check"
+	config CHIP_CONFIG_IM_PRETTY_PRINT
+	   bool "Enable IM Pretty Print"
 	   default y
 	   help
-	     If enabled, it checks incoming messages are following the expected schema,
-             and incoming message payloads are logged in detail.
+	     If enabled, incoming message payloads are logged in detail.
 	     To see detailed logging please set default log level to Debug.
 	     (Component config --> Log output --> Default log verbosity --> Debug)
 

--- a/examples/common/tracing/decoder/interaction_model/Decoder.cpp
+++ b/examples/common/tracing/decoder/interaction_model/Decoder.cpp
@@ -132,12 +132,12 @@ CHIP_ERROR LogAsProtocolMessage(uint8_t protocolCode, const uint8_t * data, size
 
 CHIP_ERROR DecodeStatusResponse(TLV::TLVReader & reader, bool decode)
 {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::StatusResponseMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        parser.PrettyPrint();
     }
 #endif
 
@@ -146,12 +146,12 @@ CHIP_ERROR DecodeStatusResponse(TLV::TLVReader & reader, bool decode)
 
 CHIP_ERROR DecodeReadRequest(TLV::TLVReader & reader, bool decode)
 {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::ReadRequestMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        return parser.PrettyPrint();
     }
 #endif
 
@@ -160,12 +160,12 @@ CHIP_ERROR DecodeReadRequest(TLV::TLVReader & reader, bool decode)
 
 CHIP_ERROR DecodeSubscribeRequest(TLV::TLVReader & reader, bool decode)
 {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::SubscribeRequestMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        return parser.PrettyPrint();
     }
 #endif
 
@@ -174,12 +174,12 @@ CHIP_ERROR DecodeSubscribeRequest(TLV::TLVReader & reader, bool decode)
 
 CHIP_ERROR DecodeSubscribeResponse(TLV::TLVReader & reader, bool decode)
 {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::SubscribeResponseMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        parser.PrettyPrint();
     }
 #endif
 
@@ -190,12 +190,12 @@ CHIP_ERROR DecodeReportData(TLV::TLVReader & reader, bool decode)
 {
     ReturnErrorOnFailure(MaybeDecodeNestedReadResponse(reader.GetReadPoint(), reader.GetTotalLength()));
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::ReportDataMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        parser.PrettyPrint();
     }
 #endif
 
@@ -204,12 +204,12 @@ CHIP_ERROR DecodeReportData(TLV::TLVReader & reader, bool decode)
 
 CHIP_ERROR DecodeWriteRequest(TLV::TLVReader & reader, bool decode)
 {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::WriteRequestMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        return parser.PrettyPrint();
     }
 #endif
 
@@ -218,12 +218,12 @@ CHIP_ERROR DecodeWriteRequest(TLV::TLVReader & reader, bool decode)
 
 CHIP_ERROR DecodeWriteResponse(TLV::TLVReader & reader, bool decode)
 {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::WriteResponseMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        return parser.PrettyPrint();
     }
 #endif
 
@@ -234,12 +234,12 @@ CHIP_ERROR DecodeInvokeCommandRequest(TLV::TLVReader & reader, bool decode)
 {
     ReturnErrorOnFailure(MaybeDecodeNestedCommandRequest(reader.GetReadPoint(), reader.GetTotalLength()));
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::InvokeRequestMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        return parser.PrettyPrint();
     }
 #endif
 
@@ -250,12 +250,12 @@ CHIP_ERROR DecodeInvokeCommandResponse(TLV::TLVReader & reader, bool decode)
 {
     ReturnErrorOnFailure(MaybeDecodeNestedCommandResponse(reader.GetReadPoint(), reader.GetTotalLength()));
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::InvokeResponseMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        parser.PrettyPrint();
     }
 #endif
 
@@ -264,12 +264,12 @@ CHIP_ERROR DecodeInvokeCommandResponse(TLV::TLVReader & reader, bool decode)
 
 CHIP_ERROR DecodeTimedRequest(TLV::TLVReader & reader, bool decode)
 {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     if (decode)
     {
         app::TimedRequestMessage::Parser parser;
         ReturnErrorOnFailure(parser.Init(reader));
-        return parser.CheckSchemaValidity();
+        parser.PrettyPrint();
     }
 #endif
 

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -20,7 +20,7 @@ import("common_flags.gni")
 
 declare_args() {
   # Enable strict schema checks.
-  chip_enable_schema_check =
+  enable_im_pretty_print =
       is_debug && (current_os == "linux" || current_os == "mac" ||
                    current_os == "ios" || current_os == "android")
 
@@ -46,7 +46,7 @@ buildconfig_header("app_buildconfig") {
   header_dir = "app"
 
   defines = [
-    "CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK=${chip_enable_schema_check}",
+    "CHIP_CONFIG_IM_PRETTY_PRINT=${enable_im_pretty_print}",
     "CHIP_CONFIG_IM_FORCE_FABRIC_QUOTA_CHECK=${chip_im_force_fabric_quota_check}",
     "CHIP_CONFIG_ENABLE_SESSION_RESUMPTION=${chip_enable_session_resumption}",
     "CHIP_CONFIG_ACCESS_CONTROL_POLICY_LOGGING_VERBOSITY=${chip_access_control_policy_logging_verbosity}",

--- a/src/app/CommandHandler.cpp
+++ b/src/app/CommandHandler.cpp
@@ -104,8 +104,8 @@ Status CommandHandler::ProcessInvokeRequest(System::PacketBufferHandle && payloa
     InvokeRequests::Parser invokeRequests;
     reader.Init(std::move(payload));
     VerifyOrReturnError(invokeRequestMessage.Init(reader) == CHIP_NO_ERROR, Status::InvalidAction);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    VerifyOrReturnError(invokeRequestMessage.CheckSchemaValidity() == CHIP_NO_ERROR, Status::InvalidAction);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    invokeRequestMessage.PrettyPrint();
 #endif
 
     VerifyOrReturnError(invokeRequestMessage.GetSuppressResponse(&mSuppressResponse) == CHIP_NO_ERROR, Status::InvalidAction);

--- a/src/app/CommandSender.cpp
+++ b/src/app/CommandSender.cpp
@@ -213,8 +213,8 @@ CHIP_ERROR CommandSender::ProcessInvokeResponse(System::PacketBufferHandle && pa
     reader.Init(std::move(payload));
     ReturnErrorOnFailure(invokeResponseMessage.Init(reader));
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    ReturnErrorOnFailure(invokeResponseMessage.CheckSchemaValidity());
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    invokeResponseMessage.PrettyPrint();
 #endif
 
     ReturnErrorOnFailure(invokeResponseMessage.GetSuppressResponse(&suppressResponse));

--- a/src/app/MessageDef/AttributeDataIB.h
+++ b/src/app/MessageDef/AttributeDataIB.h
@@ -42,23 +42,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
-
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
     /**
      *  @brief Get the DataVersion.
      *

--- a/src/app/MessageDef/AttributeDataIBs.cpp
+++ b/src/app/MessageDef/AttributeDataIBs.cpp
@@ -36,8 +36,8 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR AttributeDataIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR AttributeDataIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err        = CHIP_NO_ERROR;
     size_t numDataElement = 0;
@@ -59,7 +59,7 @@ CHIP_ERROR AttributeDataIBs::Parser::CheckSchemaValidity() const
             ReturnErrorOnFailure(data.Init(reader));
 
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(data.CheckSchemaValidity());
+            ReturnErrorOnFailure(data.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
 
@@ -81,7 +81,7 @@ CHIP_ERROR AttributeDataIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 AttributeDataIB::Builder & AttributeDataIBs::Builder::CreateAttributeDataIBBuilder()
 {

--- a/src/app/MessageDef/AttributeDataIBs.h
+++ b/src/app/MessageDef/AttributeDataIBs.h
@@ -40,22 +40,9 @@ namespace AttributeDataIBs {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/AttributePathIB.cpp
+++ b/src/app/MessageDef/AttributePathIB.cpp
@@ -29,11 +29,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR AttributePathIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR AttributePathIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("AttributePathIB =");
@@ -52,22 +51,15 @@ CHIP_ERROR AttributePathIB::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kEnableTagCompression):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEnableTagCompression))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEnableTagCompression));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool enableTagCompression;
-                ReturnErrorOnFailure(reader.Get(enableTagCompression));
-                PRETTY_PRINT("\tenableTagCompression = %s, ", enableTagCompression ? "true" : "false");
-            }
+        {
+            bool enableTagCompression;
+            ReturnErrorOnFailure(reader.Get(enableTagCompression));
+            PRETTY_PRINT("\tenableTagCompression = %s, ", enableTagCompression ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
+        break;
         case to_underlying(Tag::kNode):
-            // check if this tag has appeared before
-
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kNode))), err = CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kNode));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -79,9 +71,6 @@ CHIP_ERROR AttributePathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kEndpoint):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEndpoint))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEndpoint));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -92,9 +81,6 @@ CHIP_ERROR AttributePathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kCluster):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kCluster))), err = CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kCluster));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -106,9 +92,6 @@ CHIP_ERROR AttributePathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kAttribute):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kAttribute))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kAttribute));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -119,9 +102,6 @@ CHIP_ERROR AttributePathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kListIndex):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kListIndex))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kListIndex));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType() || TLV::kTLVType_Null == reader.GetType(),
                                 CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
@@ -149,21 +129,12 @@ CHIP_ERROR AttributePathIB::Parser::CheckSchemaValidity() const
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        if ((tagPresenceMask & (1 << to_underlying(Tag::kAttribute))) == 0 &&
-            (tagPresenceMask & (1 << to_underlying(Tag::kListIndex))) != 0)
-        {
-            err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_PATH_IB;
-        }
-        else
-        {
-            err = CHIP_NO_ERROR;
-        }
+        err = CHIP_NO_ERROR;
     }
-
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR AttributePathIB::Parser::GetEnableTagCompression(bool * const apEnableTagCompression) const
 {

--- a/src/app/MessageDef/AttributePathIB.h
+++ b/src/app/MessageDef/AttributePathIB.h
@@ -48,22 +48,10 @@ enum class Tag : uint8_t
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
+
     /**
      *  @brief Get the EnableTagCompression
      *

--- a/src/app/MessageDef/AttributePathIBs.cpp
+++ b/src/app/MessageDef/AttributePathIBs.cpp
@@ -27,8 +27,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR AttributePathIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR AttributePathIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err          = CHIP_NO_ERROR;
     size_t numAttributePath = 0;
@@ -48,7 +48,7 @@ CHIP_ERROR AttributePathIBs::Parser::CheckSchemaValidity() const
             AttributePathIB::Parser path;
             ReturnErrorOnFailure(path.Init(reader));
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(path.CheckSchemaValidity());
+            ReturnErrorOnFailure(path.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
 
@@ -70,7 +70,7 @@ CHIP_ERROR AttributePathIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 AttributePathIB::Builder & AttributePathIBs::Builder::CreatePath()
 {

--- a/src/app/MessageDef/AttributePathIBs.h
+++ b/src/app/MessageDef/AttributePathIBs.h
@@ -35,22 +35,9 @@ namespace AttributePathIBs {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/AttributeReportIB.cpp
+++ b/src/app/MessageDef/AttributeReportIB.cpp
@@ -28,11 +28,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR AttributeReportIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR AttributeReportIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("AttributeReportIB =");
@@ -50,32 +49,24 @@ CHIP_ERROR AttributeReportIB::Parser::CheckSchemaValidity() const
         uint32_t tagNum = TLV::TagNumFromTag(reader.GetTag());
         switch (tagNum)
         {
-        case to_underlying(Tag::kAttributeStatus):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kAttributeStatus))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kAttributeStatus));
-            {
-                AttributeStatusIB::Parser attributeStatus;
-                ReturnErrorOnFailure(attributeStatus.Init(reader));
+        case to_underlying(Tag::kAttributeStatus): {
+            AttributeStatusIB::Parser attributeStatus;
+            ReturnErrorOnFailure(attributeStatus.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(attributeStatus.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kAttributeData):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kAttributeData))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kAttributeData));
-            {
-                AttributeDataIB::Parser attributeData;
-                ReturnErrorOnFailure(attributeData.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(attributeStatus.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kAttributeData): {
+            AttributeDataIB::Parser attributeData;
+            ReturnErrorOnFailure(attributeData.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(attributeData.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(attributeData.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         default:
             PRETTY_PRINT("Unknown tag num %" PRIu32, tagNum);
             break;
@@ -87,30 +78,13 @@ CHIP_ERROR AttributeReportIB::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        // check for at most field:
-        const int CheckDataField   = 1 << to_underlying(Tag::kAttributeData);
-        const int CheckStatusField = (1 << to_underlying(Tag::kAttributeStatus));
-
-        if ((tagPresenceMask & CheckDataField) == CheckDataField && (tagPresenceMask & CheckStatusField) == CheckStatusField)
-        {
-            // kAttributeData and kAttributeStatus both exist
-            err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_REPORT_IB;
-        }
-        else if ((tagPresenceMask & CheckDataField) != CheckDataField && (tagPresenceMask & CheckStatusField) != CheckStatusField)
-        {
-            // kPath and kErrorStatus not exist
-            err = CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_REPORT_IB;
-        }
-        else
-        {
-            err = CHIP_NO_ERROR;
-        }
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR AttributeReportIB::Parser::GetAttributeStatus(AttributeStatusIB::Parser * const apAttributeStatus) const
 {

--- a/src/app/MessageDef/AttributeReportIB.h
+++ b/src/app/MessageDef/AttributeReportIB.h
@@ -41,22 +41,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the StatusIB. Next() must be called before accessing them.

--- a/src/app/MessageDef/AttributeReportIBs.cpp
+++ b/src/app/MessageDef/AttributeReportIBs.cpp
@@ -32,8 +32,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR AttributeReportIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR AttributeReportIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
@@ -51,7 +51,7 @@ CHIP_ERROR AttributeReportIBs::Parser::CheckSchemaValidity() const
             AttributeReportIB::Parser AttributeReport;
             ReturnErrorOnFailure(AttributeReport.Init(reader));
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(AttributeReport.CheckSchemaValidity());
+            ReturnErrorOnFailure(AttributeReport.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
     }
@@ -67,7 +67,7 @@ CHIP_ERROR AttributeReportIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 AttributeReportIB::Builder & AttributeReportIBs::Builder::CreateAttributeReport()
 {

--- a/src/app/MessageDef/AttributeReportIBs.h
+++ b/src/app/MessageDef/AttributeReportIBs.h
@@ -42,22 +42,9 @@ namespace AttributeReportIBs {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/AttributeStatusIB.cpp
+++ b/src/app/MessageDef/AttributeStatusIB.cpp
@@ -27,11 +27,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR AttributeStatusIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR AttributeStatusIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("AttributeStatusIB =");
@@ -49,32 +48,24 @@ CHIP_ERROR AttributeStatusIB::Parser::CheckSchemaValidity() const
         uint32_t tagNum = TLV::TagNumFromTag(reader.GetTag());
         switch (tagNum)
         {
-        case to_underlying(Tag::kPath):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kPath))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kPath));
-            {
-                AttributePathIB::Parser path;
-                ReturnErrorOnFailure(path.Init(reader));
+        case to_underlying(Tag::kPath): {
+            AttributePathIB::Parser path;
+            ReturnErrorOnFailure(path.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(path.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kErrorStatus):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kErrorStatus))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kErrorStatus));
-            {
-                StatusIB::Parser errorStatus;
-                ReturnErrorOnFailure(errorStatus.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(path.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kErrorStatus): {
+            StatusIB::Parser errorStatus;
+            ReturnErrorOnFailure(errorStatus.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(errorStatus.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(errorStatus.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         default:
             PRETTY_PRINT("Unknown tag num %" PRIu32, tagNum);
             break;
@@ -86,14 +77,13 @@ CHIP_ERROR AttributeStatusIB::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kPath)) | (1 << to_underlying(Tag::kErrorStatus));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_ATTRIBUTE_STATUS_IB;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR AttributeStatusIB::Parser::GetPath(AttributePathIB::Parser * const apPath) const
 {

--- a/src/app/MessageDef/AttributeStatusIB.h
+++ b/src/app/MessageDef/AttributeStatusIB.h
@@ -41,22 +41,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the AttributePathIB. Next() must be called before accessing them.

--- a/src/app/MessageDef/AttributeStatusIBs.cpp
+++ b/src/app/MessageDef/AttributeStatusIBs.cpp
@@ -44,8 +44,8 @@ AttributeStatusIBs::Builder & AttributeStatusIBs::Builder::EndOfAttributeStatuse
     return *this;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR AttributeStatusIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR AttributeStatusIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err            = CHIP_NO_ERROR;
     size_t NumAttributeStatus = 0;
@@ -65,7 +65,7 @@ CHIP_ERROR AttributeStatusIBs::Parser::CheckSchemaValidity() const
             ReturnErrorOnFailure(status.Init(reader));
 
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(status.CheckSchemaValidity());
+            ReturnErrorOnFailure(status.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
 
@@ -82,6 +82,6 @@ CHIP_ERROR AttributeStatusIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif
-}; // namespace app
-}; // namespace chip
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
+};     // namespace app
+};     // namespace chip

--- a/src/app/MessageDef/AttributeStatusIBs.h
+++ b/src/app/MessageDef/AttributeStatusIBs.h
@@ -56,22 +56,9 @@ private:
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 } // namespace AttributeStatusIBs
 } // namespace app

--- a/src/app/MessageDef/ClusterPathIB.cpp
+++ b/src/app/MessageDef/ClusterPathIB.cpp
@@ -25,11 +25,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR ClusterPathIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR ClusterPathIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("ClusterPathIB =");
@@ -48,10 +47,6 @@ CHIP_ERROR ClusterPathIB::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kNode):
-            // check if this tag has appeared before
-
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kNode))), err = CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kNode));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -63,9 +58,6 @@ CHIP_ERROR ClusterPathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kEndpoint):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEndpoint))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEndpoint));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -76,9 +68,6 @@ CHIP_ERROR ClusterPathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kCluster):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kCluster))), err = CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kCluster));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), err = CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -100,16 +89,13 @@ CHIP_ERROR ClusterPathIB::Parser::CheckSchemaValidity() const
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        // check for required fields:
-        const int requiredFields = (1 << to_underlying(Tag::kCluster));
-
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_CLUSTER_PATH_IB;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR ClusterPathIB::Parser::GetNode(NodeId * const apNode) const
 {

--- a/src/app/MessageDef/ClusterPathIB.h
+++ b/src/app/MessageDef/ClusterPathIB.h
@@ -41,22 +41,9 @@ enum class Tag : uint8_t
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get the NodeId

--- a/src/app/MessageDef/CommandDataIB.cpp
+++ b/src/app/MessageDef/CommandDataIB.cpp
@@ -28,12 +28,10 @@
 
 namespace chip {
 namespace app {
-
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR CommandDataIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR CommandDataIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("CommandDataIB =");
@@ -52,23 +50,16 @@ CHIP_ERROR CommandDataIB::Parser::CheckSchemaValidity() const
 
         switch (tagNum)
         {
-        case to_underlying(Tag::kPath):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kPath))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kPath));
-            {
-                CommandPathIB::Parser path;
-                ReturnErrorOnFailure(path.Init(reader));
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(path.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
+        case to_underlying(Tag::kPath): {
+            CommandPathIB::Parser path;
+            ReturnErrorOnFailure(path.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(path.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
 
-            break;
+        break;
         case to_underlying(Tag::kFields):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kFields))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kFields));
             PRETTY_PRINT_INCDEPTH();
             ReturnErrorOnFailure(CheckIMPayload(reader, 0, "CommandFields"));
             PRETTY_PRINT_DECDEPTH();
@@ -84,14 +75,13 @@ CHIP_ERROR CommandDataIB::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = 1 << to_underlying(Tag::kPath);
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_COMMAND_DATA_IB;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR CommandDataIB::Parser::GetPath(CommandPathIB::Parser * const apPath) const
 {

--- a/src/app/MessageDef/CommandDataIB.h
+++ b/src/app/MessageDef/CommandDataIB.h
@@ -42,22 +42,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the CommandPathIB. Next() must be called before accessing them.

--- a/src/app/MessageDef/CommandPathIB.cpp
+++ b/src/app/MessageDef/CommandPathIB.cpp
@@ -31,11 +31,10 @@ using namespace chip::TLV;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR CommandPathIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR CommandPathIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
     PRETTY_PRINT("CommandPathIB =");
     PRETTY_PRINT("{");
@@ -53,9 +52,6 @@ CHIP_ERROR CommandPathIB::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kEndpointId):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEndpointId))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEndpointId));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -67,9 +63,6 @@ CHIP_ERROR CommandPathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kClusterId):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kClusterId))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kClusterId));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -80,9 +73,6 @@ CHIP_ERROR CommandPathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kCommandId):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kCommandId))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kCommandId));
             VerifyOrReturnError(chip::TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -102,15 +92,12 @@ CHIP_ERROR CommandPathIB::Parser::CheckSchemaValidity() const
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        // check for required fields:
-        const uint16_t requiredFields = (1 << to_underlying(Tag::kCommandId)) | (1 << to_underlying(Tag::kClusterId));
-
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_COMMAND_PATH_IB;
+        err = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR CommandPathIB::Parser::GetEndpointId(chip::EndpointId * const apEndpointID) const
 {

--- a/src/app/MessageDef/CommandPathIB.h
+++ b/src/app/MessageDef/CommandPathIB.h
@@ -43,22 +43,9 @@ enum class Tag : uint8_t
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the EndpointId. Next() must be called before accessing them.

--- a/src/app/MessageDef/CommandStatusIB.cpp
+++ b/src/app/MessageDef/CommandStatusIB.cpp
@@ -27,8 +27,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR CommandStatusIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR CommandStatusIB::Parser::PrettyPrint() const
 {
     CHIP_ERROR err      = CHIP_NO_ERROR;
     int tagPresenceMask = 0;
@@ -58,7 +58,7 @@ CHIP_ERROR CommandStatusIB::Parser::CheckSchemaValidity() const
                 ReturnErrorOnFailure(path.Init(reader));
 
                 PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(path.CheckSchemaValidity());
+                ReturnErrorOnFailure(path.PrettyPrint());
                 PRETTY_PRINT_DECDEPTH();
             }
             break;
@@ -71,7 +71,7 @@ CHIP_ERROR CommandStatusIB::Parser::CheckSchemaValidity() const
                 ReturnErrorOnFailure(errorStatus.Init(reader));
 
                 PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(errorStatus.CheckSchemaValidity());
+                ReturnErrorOnFailure(errorStatus.PrettyPrint());
                 PRETTY_PRINT_DECDEPTH();
             }
             break;
@@ -86,14 +86,13 @@ CHIP_ERROR CommandStatusIB::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kPath)) | (1 << to_underlying(Tag::kErrorStatus));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_COMMAND_STATUS_IB;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR CommandStatusIB::Parser::GetPath(CommandPathIB::Parser * const apPath) const
 {

--- a/src/app/MessageDef/CommandStatusIB.h
+++ b/src/app/MessageDef/CommandStatusIB.h
@@ -42,22 +42,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the CommandPathIB. Next() must be called before accessing them.

--- a/src/app/MessageDef/DataVersionFilterIB.cpp
+++ b/src/app/MessageDef/DataVersionFilterIB.cpp
@@ -31,11 +31,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR DataVersionFilterIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR DataVersionFilterIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("DataVersionFilterIB =");
@@ -53,23 +52,16 @@ CHIP_ERROR DataVersionFilterIB::Parser::CheckSchemaValidity() const
         uint32_t tagNum = TLV::TagNumFromTag(reader.GetTag());
         switch (tagNum)
         {
-        case to_underlying(Tag::kPath):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kPath))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kPath));
-            {
-                ClusterPathIB::Parser path;
-                ReturnErrorOnFailure(path.Init(reader));
+        case to_underlying(Tag::kPath): {
+            ClusterPathIB::Parser path;
+            ReturnErrorOnFailure(path.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(path.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(path.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         case to_underlying(Tag::kDataVersion):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kDataVersion))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kDataVersion));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -91,14 +83,12 @@ CHIP_ERROR DataVersionFilterIB::Parser::CheckSchemaValidity() const
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        // check for required fields:
-        const int requiredFields = (1 << to_underlying(Tag::kPath)) | (1 << to_underlying(Tag::kDataVersion));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_DATA_VERSION_FILTER_IB;
+        err = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR DataVersionFilterIB::Parser::GetPath(ClusterPathIB::Parser * const apPath) const
 {

--- a/src/app/MessageDef/DataVersionFilterIB.h
+++ b/src/app/MessageDef/DataVersionFilterIB.h
@@ -39,22 +39,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the AttributePathIB. Next() must be called before accessing them.

--- a/src/app/MessageDef/DataVersionFilterIBs.cpp
+++ b/src/app/MessageDef/DataVersionFilterIBs.cpp
@@ -26,8 +26,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR DataVersionFilterIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR DataVersionFilterIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
@@ -45,7 +45,7 @@ CHIP_ERROR DataVersionFilterIBs::Parser::CheckSchemaValidity() const
             DataVersionFilterIB::Parser DataVersionFilter;
             ReturnErrorOnFailure(DataVersionFilter.Init(reader));
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(DataVersionFilter.CheckSchemaValidity());
+            ReturnErrorOnFailure(DataVersionFilter.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
     }
@@ -61,7 +61,7 @@ CHIP_ERROR DataVersionFilterIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 DataVersionFilterIB::Builder & DataVersionFilterIBs::Builder::CreateDataVersionFilter()
 {

--- a/src/app/MessageDef/DataVersionFilterIBs.h
+++ b/src/app/MessageDef/DataVersionFilterIBs.h
@@ -34,22 +34,9 @@ namespace DataVersionFilterIBs {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/EventDataIB.cpp
+++ b/src/app/MessageDef/EventDataIB.cpp
@@ -33,12 +33,10 @@
 
 namespace chip {
 namespace app {
-
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR EventDataIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("EventDataIB =");
@@ -56,23 +54,16 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
         uint32_t tagNum = TLV::TagNumFromTag(reader.GetTag());
         switch (tagNum)
         {
-        case to_underlying(Tag::kPath):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kPath))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kPath));
-            {
-                EventPathIB::Parser path;
-                ReturnErrorOnFailure(path.Init(reader));
+        case to_underlying(Tag::kPath): {
+            EventPathIB::Parser path;
+            ReturnErrorOnFailure(path.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(path.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(path.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         case to_underlying(Tag::kEventNumber):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEventNumber))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEventNumber));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -84,9 +75,6 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kPriority):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kPriority))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kPriority));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -98,10 +86,6 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kEpochTimestamp):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEpochTimestamp))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEpochTimestamp));
-
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -114,10 +98,6 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
             break;
 
         case to_underlying(Tag::kSystemTimestamp):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kSystemTimestamp))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kSystemTimestamp));
-
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -129,9 +109,6 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kDeltaEpochTimestamp):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kDeltaEpochTimestamp))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kDeltaEpochTimestamp));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -143,10 +120,6 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kDeltaSystemTimestamp):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kDeltaSystemTimestamp))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kDeltaSystemTimestamp));
-
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -158,10 +131,6 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kData):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kData))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kData));
-
             PRETTY_PRINT_INCDEPTH();
             ReturnErrorOnFailure(CheckIMPayload(reader, 0, "EventData"));
             PRETTY_PRINT_DECDEPTH();
@@ -177,15 +146,12 @@ CHIP_ERROR EventDataIB::Parser::CheckSchemaValidity() const
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
     {
-        // check for required fields:
-        const int requiredFields =
-            (1 << to_underlying(Tag::kPath)) | (1 << to_underlying(Tag::kPriority)) | (1 << to_underlying(Tag::kData));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_EVENT_DATA_IB;
+        err = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR EventDataIB::Parser::GetPath(EventPathIB::Parser * const apPath)
 {

--- a/src/app/MessageDef/EventDataIB.h
+++ b/src/app/MessageDef/EventDataIB.h
@@ -53,22 +53,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the EventPath. Next() must be called before accessing them.

--- a/src/app/MessageDef/EventFilterIB.cpp
+++ b/src/app/MessageDef/EventFilterIB.cpp
@@ -31,11 +31,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR EventFilterIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR EventFilterIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("EventFilterIB =");
@@ -54,29 +53,23 @@ CHIP_ERROR EventFilterIB::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kNode):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kNode))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kNode));
 #if CHIP_DETAIL_LOGGING
-            {
-                NodeId node;
-                ReturnErrorOnFailure(reader.Get(node));
-                PRETTY_PRINT("\tNode = 0x%" PRIx64 ",", node);
-            }
+        {
+            NodeId node;
+            ReturnErrorOnFailure(reader.Get(node));
+            PRETTY_PRINT("\tNode = 0x%" PRIx64 ",", node);
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
+        break;
         case to_underlying(Tag::kEventMin):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEventMin))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEventMin));
 #if CHIP_DETAIL_LOGGING
-            {
-                uint64_t eventMin;
-                ReturnErrorOnFailure(reader.Get(eventMin));
-                PRETTY_PRINT("\tEventMin = 0x%" PRIx64 ",", eventMin);
-            }
+        {
+            uint64_t eventMin;
+            ReturnErrorOnFailure(reader.Get(eventMin));
+            PRETTY_PRINT("\tEventMin = 0x%" PRIx64 ",", eventMin);
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
+        break;
         default:
             PRETTY_PRINT("Unknown tag num %" PRIu32, tagNum);
             break;
@@ -88,14 +81,13 @@ CHIP_ERROR EventFilterIB::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kEventMin));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_EVENT_FILTER_IB;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR EventFilterIB::Parser::GetNode(NodeId * const apNode) const
 {

--- a/src/app/MessageDef/EventFilterIB.h
+++ b/src/app/MessageDef/EventFilterIB.h
@@ -45,22 +45,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the NodeId. Next() must be called before accessing them.

--- a/src/app/MessageDef/EventFilterIBs.cpp
+++ b/src/app/MessageDef/EventFilterIBs.cpp
@@ -26,8 +26,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR EventFilterIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR EventFilterIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
@@ -45,7 +45,7 @@ CHIP_ERROR EventFilterIBs::Parser::CheckSchemaValidity() const
             EventFilterIB::Parser eventFilter;
             ReturnErrorOnFailure(eventFilter.Init(reader));
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(eventFilter.CheckSchemaValidity());
+            ReturnErrorOnFailure(eventFilter.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
     }
@@ -61,7 +61,7 @@ CHIP_ERROR EventFilterIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 EventFilterIB::Builder & EventFilterIBs::Builder::CreateEventFilter()
 {

--- a/src/app/MessageDef/EventFilterIBs.h
+++ b/src/app/MessageDef/EventFilterIBs.h
@@ -34,22 +34,9 @@ namespace EventFilterIBs {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -30,11 +30,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR EventPathIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR EventPathIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("EventPath =");
@@ -53,9 +52,6 @@ CHIP_ERROR EventPathIB::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kNode):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kNode))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kNode));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -66,9 +62,6 @@ CHIP_ERROR EventPathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kEndpoint):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEndpoint))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEndpoint));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -79,9 +72,6 @@ CHIP_ERROR EventPathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kCluster):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kCluster))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kCluster));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -93,9 +83,6 @@ CHIP_ERROR EventPathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kEvent):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEvent))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEvent));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -107,9 +94,6 @@ CHIP_ERROR EventPathIB::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kIsUrgent):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kIsUrgent))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kIsUrgent));
             VerifyOrReturnError(TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 
 #if CHIP_DETAIL_LOGGING
@@ -138,7 +122,7 @@ CHIP_ERROR EventPathIB::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR EventPathIB::Parser::GetNode(NodeId * const apNode) const
 {

--- a/src/app/MessageDef/EventPathIB.h
+++ b/src/app/MessageDef/EventPathIB.h
@@ -46,22 +46,9 @@ enum class Tag : uint8_t
 class Parser : public ListParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the NodeId. Next() must be called before accessing them.

--- a/src/app/MessageDef/EventPathIBs.cpp
+++ b/src/app/MessageDef/EventPathIBs.cpp
@@ -28,8 +28,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR EventPathIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR EventPathIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     size_t NumPath = 0;
@@ -51,7 +51,7 @@ CHIP_ERROR EventPathIBs::Parser::CheckSchemaValidity() const
             ReturnErrorOnFailure(path.Init(reader));
 
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(path.CheckSchemaValidity());
+            ReturnErrorOnFailure(path.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
 
@@ -69,7 +69,7 @@ CHIP_ERROR EventPathIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 EventPathIB::Builder & EventPathIBs::Builder::CreatePath()
 {

--- a/src/app/MessageDef/EventPathIBs.h
+++ b/src/app/MessageDef/EventPathIBs.h
@@ -36,22 +36,9 @@ namespace EventPathIBs {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/EventReportIB.h
+++ b/src/app/MessageDef/EventReportIB.h
@@ -41,22 +41,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the StatusIB. Next() must be called before accessing them.

--- a/src/app/MessageDef/EventReportIBs.cpp
+++ b/src/app/MessageDef/EventReportIBs.cpp
@@ -32,8 +32,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR EventReportIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
@@ -51,7 +51,7 @@ CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
             EventReportIB::Parser eventReport;
             ReturnErrorOnFailure(eventReport.Init(reader));
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(eventReport.CheckSchemaValidity());
+            ReturnErrorOnFailure(eventReport.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
     }
@@ -67,7 +67,7 @@ CHIP_ERROR EventReportIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 EventReportIB::Builder & EventReportIBs::Builder::CreateEventReport()
 {

--- a/src/app/MessageDef/EventReportIBs.h
+++ b/src/app/MessageDef/EventReportIBs.h
@@ -40,22 +40,9 @@ namespace EventReportIBs {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/EventStatusIB.cpp
+++ b/src/app/MessageDef/EventStatusIB.cpp
@@ -27,11 +27,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR EventStatusIB::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR EventStatusIB::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("EventStatusIB =");
@@ -49,32 +48,24 @@ CHIP_ERROR EventStatusIB::Parser::CheckSchemaValidity() const
         uint32_t tagNum = TLV::TagNumFromTag(reader.GetTag());
         switch (tagNum)
         {
-        case to_underlying(Tag::kPath):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kPath))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kPath));
-            {
-                EventPathIB::Parser path;
-                ReturnErrorOnFailure(path.Init(reader));
+        case to_underlying(Tag::kPath): {
+            EventPathIB::Parser path;
+            ReturnErrorOnFailure(path.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(path.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kErrorStatus):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kErrorStatus))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kErrorStatus));
-            {
-                StatusIB::Parser errorStatus;
-                ReturnErrorOnFailure(errorStatus.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(path.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kErrorStatus): {
+            StatusIB::Parser errorStatus;
+            ReturnErrorOnFailure(errorStatus.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(errorStatus.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(errorStatus.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         default:
             PRETTY_PRINT("Unknown tag num %" PRIu32, tagNum);
             break;
@@ -86,14 +77,13 @@ CHIP_ERROR EventStatusIB::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kPath)) | (1 << to_underlying(Tag::kErrorStatus));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_EVENT_STATUS_IB;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR EventStatusIB::Parser::GetPath(EventPathIB::Parser * const apPath) const
 {

--- a/src/app/MessageDef/EventStatusIB.h
+++ b/src/app/MessageDef/EventStatusIB.h
@@ -41,22 +41,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a TLVReader for the EventPathIB. Next() must be called before accessing them.

--- a/src/app/MessageDef/InvokeRequestMessage.cpp
+++ b/src/app/MessageDef/InvokeRequestMessage.cpp
@@ -25,11 +25,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR InvokeRequestMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR InvokeRequestMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("InvokeRequestMessage =");
@@ -48,43 +47,33 @@ CHIP_ERROR InvokeRequestMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kSuppressResponse):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kSuppressResponse))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kSuppressResponse));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool suppressResponse;
-                ReturnErrorOnFailure(reader.Get(suppressResponse));
-                PRETTY_PRINT("\tsuppressResponse = %s, ", suppressResponse ? "true" : "false");
-            }
+        {
+            bool suppressResponse;
+            ReturnErrorOnFailure(reader.Get(suppressResponse));
+            PRETTY_PRINT("\tsuppressResponse = %s, ", suppressResponse ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
+        break;
 
         case to_underlying(Tag::kTimedRequest):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kTimedRequest))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kTimedRequest));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool timedRequest;
-                ReturnErrorOnFailure(reader.Get(timedRequest));
-                PRETTY_PRINT("\ttimedRequest = %s, ", timedRequest ? "true" : "false");
-            }
+        {
+            bool timedRequest;
+            ReturnErrorOnFailure(reader.Get(timedRequest));
+            PRETTY_PRINT("\ttimedRequest = %s, ", timedRequest ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
-        case to_underlying(Tag::kInvokeRequests):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kInvokeRequests))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kInvokeRequests));
-            {
-                InvokeRequests::Parser invokeRequests;
-                ReturnErrorOnFailure(invokeRequests.Init(reader));
+        break;
+        case to_underlying(Tag::kInvokeRequests): {
+            InvokeRequests::Parser invokeRequests;
+            ReturnErrorOnFailure(invokeRequests.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(invokeRequests.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(invokeRequests.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         case kInteractionModelRevisionTag:
             ReturnErrorOnFailure(MessageParser::CheckInteractionModelRevision(reader));
             break;
@@ -99,15 +88,13 @@ CHIP_ERROR InvokeRequestMessage::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kSuppressResponse)) | (1 << to_underlying(Tag::kTimedRequest)) |
-            (1 << to_underlying(Tag::kInvokeRequests));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_INVOKE_REQUEST_MESSAGE;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR InvokeRequestMessage::Parser::GetSuppressResponse(bool * const apSuppressResponse) const
 {

--- a/src/app/MessageDef/InvokeRequestMessage.h
+++ b/src/app/MessageDef/InvokeRequestMessage.h
@@ -41,22 +41,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get SuppressResponse. Next() must be called before accessing them.

--- a/src/app/MessageDef/InvokeRequests.cpp
+++ b/src/app/MessageDef/InvokeRequests.cpp
@@ -26,8 +26,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR InvokeRequests::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR InvokeRequests::Parser::PrettyPrint() const
 {
     CHIP_ERROR err         = CHIP_NO_ERROR;
     size_t numCommandDatas = 0;
@@ -46,7 +46,7 @@ CHIP_ERROR InvokeRequests::Parser::CheckSchemaValidity() const
             CommandDataIB::Parser commandData;
             ReturnErrorOnFailure(commandData.Init(reader));
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(commandData.CheckSchemaValidity());
+            ReturnErrorOnFailure(commandData.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
 
@@ -68,7 +68,7 @@ CHIP_ERROR InvokeRequests::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CommandDataIB::Builder & InvokeRequests::Builder::CreateCommandData()
 {

--- a/src/app/MessageDef/InvokeRequests.h
+++ b/src/app/MessageDef/InvokeRequests.h
@@ -34,22 +34,9 @@ namespace InvokeRequests {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/InvokeResponseIB.h
+++ b/src/app/MessageDef/InvokeResponseIB.h
@@ -41,22 +41,9 @@ enum class Tag : uint8_t
 class Parser : public StructParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get a parser for a Command.

--- a/src/app/MessageDef/InvokeResponseIBs.cpp
+++ b/src/app/MessageDef/InvokeResponseIBs.cpp
@@ -26,8 +26,8 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR InvokeResponseIBs::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR InvokeResponseIBs::Parser::PrettyPrint() const
 {
     CHIP_ERROR err            = CHIP_NO_ERROR;
     size_t numInvokeResponses = 0;
@@ -46,7 +46,7 @@ CHIP_ERROR InvokeResponseIBs::Parser::CheckSchemaValidity() const
             InvokeResponseIB::Parser invokeResponse;
             ReturnErrorOnFailure(invokeResponse.Init(reader));
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(invokeResponse.CheckSchemaValidity());
+            ReturnErrorOnFailure(invokeResponse.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
         }
 
@@ -68,7 +68,7 @@ CHIP_ERROR InvokeResponseIBs::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 InvokeResponseIB::Builder & InvokeResponseIBs::Builder::CreateInvokeResponse()
 {

--- a/src/app/MessageDef/InvokeResponseIBs.h
+++ b/src/app/MessageDef/InvokeResponseIBs.h
@@ -34,22 +34,9 @@ namespace InvokeResponseIBs {
 class Parser : public ArrayParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 };
 
 class Builder : public ArrayBuilder

--- a/src/app/MessageDef/InvokeResponseMessage.cpp
+++ b/src/app/MessageDef/InvokeResponseMessage.cpp
@@ -25,11 +25,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR InvokeResponseMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR InvokeResponseMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("InvokeResponseMessage =");
@@ -48,30 +47,23 @@ CHIP_ERROR InvokeResponseMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kSuppressResponse):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kSuppressResponse))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kSuppressResponse));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool suppressResponse;
-                ReturnErrorOnFailure(reader.Get(suppressResponse));
-                PRETTY_PRINT("\tsuppressResponse = %s, ", suppressResponse ? "true" : "false");
-            }
+        {
+            bool suppressResponse;
+            ReturnErrorOnFailure(reader.Get(suppressResponse));
+            PRETTY_PRINT("\tsuppressResponse = %s, ", suppressResponse ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
-        case to_underlying(Tag::kInvokeResponses):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kInvokeResponses))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kInvokeResponses));
-            {
-                InvokeResponseIBs::Parser invokeResponses;
-                ReturnErrorOnFailure(invokeResponses.Init(reader));
+        break;
+        case to_underlying(Tag::kInvokeResponses): {
+            InvokeResponseIBs::Parser invokeResponses;
+            ReturnErrorOnFailure(invokeResponses.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(invokeResponses.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(invokeResponses.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         case kInteractionModelRevisionTag:
             ReturnErrorOnFailure(MessageParser::CheckInteractionModelRevision(reader));
             break;
@@ -86,15 +78,13 @@ CHIP_ERROR InvokeResponseMessage::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kSuppressResponse)) | (1 << to_underlying(Tag::kInvokeResponses));
-        err =
-            (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_INVOKE_RESPONSE_MESSAGE;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR InvokeResponseMessage::Parser::GetSuppressResponse(bool * const apSuppressResponse) const
 {

--- a/src/app/MessageDef/InvokeResponseMessage.h
+++ b/src/app/MessageDef/InvokeResponseMessage.h
@@ -40,22 +40,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get SuppressResponse. Next() must be called before accessing them.

--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -33,7 +33,7 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK && CHIP_DETAIL_LOGGING
+#if CHIP_CONFIG_IM_PRETTY_PRINT && CHIP_DETAIL_LOGGING
 // this is used to run in signle thread for IM message debug purpose
 namespace {
 uint32_t gPrettyPrintingDepthLevel = 0;
@@ -98,7 +98,7 @@ void DecreaseDepth()
 }
 #endif
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
 CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLabel)
 {
     if (aDepth == 0)
@@ -260,8 +260,7 @@ CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLa
 
     return CHIP_NO_ERROR;
 }
-
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 }; // namespace app
 }; // namespace chip

--- a/src/app/MessageDef/MessageDefHelper.h
+++ b/src/app/MessageDef/MessageDefHelper.h
@@ -38,7 +38,7 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK && CHIP_DETAIL_LOGGING
+#if CHIP_CONFIG_IM_PRETTY_PRINT && CHIP_DETAIL_LOGGING
 /**
  * Start a new "blank" line.  This will actually print out whitespace to the
  * current indent level, which can be followed with PRETTY_PRINT_SAMELINE calls.
@@ -81,11 +81,11 @@ void DecreaseDepth();
 #define PRETTY_PRINT_DECDEPTH()
 #endif
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
 // Parse an IM payload (attribute value, command fields, event fields,
 // recursively parsing any complex types encountered.
 CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLabel);
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 }; // namespace app
 }; // namespace chip

--- a/src/app/MessageDef/MessageParser.cpp
+++ b/src/app/MessageDef/MessageParser.cpp
@@ -36,7 +36,7 @@ CHIP_ERROR MessageParser::ExitContainer()
     return CHIP_NO_ERROR;
 }
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
 CHIP_ERROR MessageParser::CheckInteractionModelRevision(TLV::TLVReader & aReader) const
 {
 #if CHIP_DETAIL_LOGGING
@@ -48,7 +48,7 @@ CHIP_ERROR MessageParser::CheckInteractionModelRevision(TLV::TLVReader & aReader
 #endif // CHIP_DETAIL_LOGGING
     return CHIP_NO_ERROR;
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR MessageParser::GetInteractionModelRevision(InteractionModelRevision * const apInteractionModelRevision) const
 {

--- a/src/app/MessageDef/MessageParser.h
+++ b/src/app/MessageDef/MessageParser.h
@@ -30,9 +30,9 @@ class MessageParser : public StructParser
 public:
     CHIP_ERROR Init(TLV::TLVReader & aReader);
     CHIP_ERROR ExitContainer();
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     CHIP_ERROR CheckInteractionModelRevision(TLV::TLVReader & aReader) const;
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     CHIP_ERROR GetInteractionModelRevision(InteractionModelRevision * const apInteractionModelRevision) const;
 };

--- a/src/app/MessageDef/ReadRequestMessage.cpp
+++ b/src/app/MessageDef/ReadRequestMessage.cpp
@@ -25,11 +25,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR ReadRequestMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR ReadRequestMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("ReadRequestMessage =");
@@ -47,70 +46,51 @@ CHIP_ERROR ReadRequestMessage::Parser::CheckSchemaValidity() const
         uint32_t tagNum = TLV::TagNumFromTag(reader.GetTag());
         switch (tagNum)
         {
-        case to_underlying(Tag::kAttributeRequests):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kAttributeRequests))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kAttributeRequests));
-            {
-                AttributePathIBs::Parser attributeRequests;
-                ReturnErrorOnFailure(attributeRequests.Init(reader));
+        case to_underlying(Tag::kAttributeRequests): {
+            AttributePathIBs::Parser attributeRequests;
+            ReturnErrorOnFailure(attributeRequests.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(attributeRequests.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kDataVersionFilters):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kDataVersionFilters))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kDataVersionFilters));
-            {
-                DataVersionFilterIBs::Parser dataVersionFilters;
-                ReturnErrorOnFailure(dataVersionFilters.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(attributeRequests.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kDataVersionFilters): {
+            DataVersionFilterIBs::Parser dataVersionFilters;
+            ReturnErrorOnFailure(dataVersionFilters.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(dataVersionFilters.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kEventRequests):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEventRequests))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEventRequests));
-            {
-                EventPathIBs::Parser eventRequests;
-                ReturnErrorOnFailure(eventRequests.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(dataVersionFilters.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kEventRequests): {
+            EventPathIBs::Parser eventRequests;
+            ReturnErrorOnFailure(eventRequests.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(eventRequests.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kEventFilters):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEventFilters))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEventFilters));
-            {
-                EventFilterIBs::Parser eventFilters;
-                ReturnErrorOnFailure(eventFilters.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(eventRequests.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kEventFilters): {
+            EventFilterIBs::Parser eventFilters;
+            ReturnErrorOnFailure(eventFilters.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(eventFilters.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(eventFilters.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         case to_underlying(Tag::kIsFabricFiltered):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kIsFabricFiltered))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kIsFabricFiltered));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool isFabricFiltered;
-                ReturnErrorOnFailure(reader.Get(isFabricFiltered));
-                PRETTY_PRINT("\tisFabricFiltered = %s, ", isFabricFiltered ? "true" : "false");
-            }
+        {
+            bool isFabricFiltered;
+            ReturnErrorOnFailure(reader.Get(isFabricFiltered));
+            PRETTY_PRINT("\tisFabricFiltered = %s, ", isFabricFiltered ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
+        break;
         case kInteractionModelRevisionTag:
             ReturnErrorOnFailure(MessageParser::CheckInteractionModelRevision(reader));
             break;
@@ -125,14 +105,13 @@ CHIP_ERROR ReadRequestMessage::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kIsFabricFiltered));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_READ_REQUEST_MESSAGE;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR ReadRequestMessage::Parser::GetAttributeRequests(AttributePathIBs::Parser * const apAttributeRequests) const
 {

--- a/src/app/MessageDef/ReadRequestMessage.h
+++ b/src/app/MessageDef/ReadRequestMessage.h
@@ -45,22 +45,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
     /**
      *  @brief Get a TLVReader for the AttributePathIBs. Next() must be called before accessing them.
      *

--- a/src/app/MessageDef/ReportDataMessage.cpp
+++ b/src/app/MessageDef/ReportDataMessage.cpp
@@ -35,11 +35,10 @@ using namespace chip;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR ReportDataMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR ReportDataMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
     AttributeReportIBs::Parser attributeReportIBs;
     EventReportIBs::Parser eventReportIBs;
@@ -60,8 +59,6 @@ CHIP_ERROR ReportDataMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kSuppressResponse):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kSuppressResponse))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kSuppressResponse));
             VerifyOrReturnError(TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -72,8 +69,6 @@ CHIP_ERROR ReportDataMessage::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kSubscriptionId):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kSubscriptionId))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kSubscriptionId));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -84,38 +79,30 @@ CHIP_ERROR ReportDataMessage::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kAttributeReportIBs):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kAttributeReportIBs))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kAttributeReportIBs));
             VerifyOrReturnError(TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 attributeReportIBs.Init(reader);
 
                 PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(attributeReportIBs.CheckSchemaValidity());
+                ReturnErrorOnFailure(attributeReportIBs.PrettyPrint());
                 PRETTY_PRINT_DECDEPTH();
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kEventReports):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEventReports))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEventReports));
             VerifyOrReturnError(TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
                 eventReportIBs.Init(reader);
 
                 PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(eventReportIBs.CheckSchemaValidity());
+                ReturnErrorOnFailure(eventReportIBs.PrettyPrint());
                 PRETTY_PRINT_DECDEPTH();
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kMoreChunkedMessages):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kMoreChunkedMessages))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kMoreChunkedMessages));
             VerifyOrReturnError(TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -144,7 +131,7 @@ CHIP_ERROR ReportDataMessage::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR ReportDataMessage::Parser::GetSuppressResponse(bool * const apSuppressResponse) const
 {

--- a/src/app/MessageDef/ReportDataMessage.h
+++ b/src/app/MessageDef/ReportDataMessage.h
@@ -50,22 +50,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Check whether a response (a StatusResponseMessage specifically) is to be sent back to the request.

--- a/src/app/MessageDef/StatusIB.h
+++ b/src/app/MessageDef/StatusIB.h
@@ -56,23 +56,9 @@ struct StatusIB
     class Parser : public StructParser
     {
     public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-        /**
-         *  @brief Roughly verify the message is correctly formed
-         *   1) all mandatory tags are present
-         *   2) all elements have expected data type
-         *   3) any tag can only appear once
-         *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-         *  @note The main use of this function is to print out what we're
-         *    receiving during protocol development and debugging.
-         *    The encoding rule has changed in IM encoding spec so this
-         *    check is only "roughly" conformant now.
-         *
-         *  @return #CHIP_NO_ERROR on success
-         */
-        CHIP_ERROR CheckSchemaValidity() const;
-#endif
-
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+        CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
         /**
          * Decode the StatusIB
          *

--- a/src/app/MessageDef/StatusResponseMessage.cpp
+++ b/src/app/MessageDef/StatusResponseMessage.cpp
@@ -22,11 +22,10 @@ using namespace chip::Protocols::InteractionModel;
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR StatusResponseMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR StatusResponseMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
     PRETTY_PRINT("StatusResponseMessage =");
     PRETTY_PRINT("{");
@@ -44,8 +43,6 @@ CHIP_ERROR StatusResponseMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kStatus):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kStatus))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kStatus));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -68,14 +65,12 @@ CHIP_ERROR StatusResponseMessage::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kStatus));
-        err =
-            (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_STATUS_RESPONSE_MESSAGE;
+        err = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR StatusResponseMessage::Parser::GetStatus(Protocols::InteractionModel::Status & aStatus) const
 {

--- a/src/app/MessageDef/StatusResponseMessage.h
+++ b/src/app/MessageDef/StatusResponseMessage.h
@@ -38,22 +38,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
     /**
      *  @brief Get Status. Next() must be called before accessing them.

--- a/src/app/MessageDef/SubscribeRequestMessage.cpp
+++ b/src/app/MessageDef/SubscribeRequestMessage.cpp
@@ -19,11 +19,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR SubscribeRequestMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("SubscribeRequestMessage =");
@@ -42,8 +41,6 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kKeepSubscriptions):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kKeepSubscriptions))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kKeepSubscriptions));
             VerifyOrReturnError(TLV::kTLVType_Boolean == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -54,9 +51,6 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kMinIntervalFloorSeconds):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kMinIntervalFloorSeconds))),
-                                CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kMinIntervalFloorSeconds));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -67,9 +61,6 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kMaxIntervalCeilingSeconds):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kMaxIntervalCeilingSeconds))),
-                                CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kMaxIntervalCeilingSeconds));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -79,70 +70,51 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
             }
 #endif // CHIP_DETAIL_LOGGING
             break;
-        case to_underlying(Tag::kAttributeRequests):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kAttributeRequests))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kAttributeRequests));
-            {
-                AttributePathIBs::Parser attributeRequests;
-                ReturnErrorOnFailure(attributeRequests.Init(reader));
+        case to_underlying(Tag::kAttributeRequests): {
+            AttributePathIBs::Parser attributeRequests;
+            ReturnErrorOnFailure(attributeRequests.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(attributeRequests.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kDataVersionFilters):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kDataVersionFilters))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kDataVersionFilters));
-            {
-                DataVersionFilterIBs::Parser dataVersionFilters;
-                ReturnErrorOnFailure(dataVersionFilters.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(attributeRequests.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kDataVersionFilters): {
+            DataVersionFilterIBs::Parser dataVersionFilters;
+            ReturnErrorOnFailure(dataVersionFilters.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(dataVersionFilters.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kEventRequests):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEventRequests))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEventRequests));
-            {
-                EventPathIBs::Parser eventRequests;
-                ReturnErrorOnFailure(eventRequests.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(dataVersionFilters.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kEventRequests): {
+            EventPathIBs::Parser eventRequests;
+            ReturnErrorOnFailure(eventRequests.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(eventRequests.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
-        case to_underlying(Tag::kEventFilters):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kEventFilters))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kEventFilters));
-            {
-                EventFilterIBs::Parser eventFilters;
-                ReturnErrorOnFailure(eventFilters.Init(reader));
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(eventRequests.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
+        case to_underlying(Tag::kEventFilters): {
+            EventFilterIBs::Parser eventFilters;
+            ReturnErrorOnFailure(eventFilters.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(eventFilters.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(eventFilters.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         case to_underlying(Tag::kIsFabricFiltered):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kIsFabricFiltered))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kIsFabricFiltered));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool isFabricFiltered;
-                ReturnErrorOnFailure(reader.Get(isFabricFiltered));
-                PRETTY_PRINT("\tisFabricFiltered = %s, ", isFabricFiltered ? "true" : "false");
-            }
+        {
+            bool isFabricFiltered;
+            ReturnErrorOnFailure(reader.Get(isFabricFiltered));
+            PRETTY_PRINT("\tisFabricFiltered = %s, ", isFabricFiltered ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
+        break;
         case kInteractionModelRevisionTag:
             ReturnErrorOnFailure(MessageParser::CheckInteractionModelRevision(reader));
             break;
@@ -157,17 +129,13 @@ CHIP_ERROR SubscribeRequestMessage::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kIsFabricFiltered)) | (1 << to_underlying(Tag::kKeepSubscriptions)) |
-            (1 << to_underlying(Tag::kMinIntervalFloorSeconds)) | (1 << to_underlying(Tag::kMaxIntervalCeilingSeconds));
-
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR
-                                                                   : CHIP_ERROR_IM_MALFORMED_SUBSCRIBE_REQUEST_MESSAGE;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR SubscribeRequestMessage::Parser::GetKeepSubscriptions(bool * const apKeepExistingSubscription) const
 {

--- a/src/app/MessageDef/SubscribeRequestMessage.h
+++ b/src/app/MessageDef/SubscribeRequestMessage.h
@@ -48,21 +48,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
-
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
     /**
      *  @brief Check if subscription is kept.
      *  @return #CHIP_NO_ERROR on success

--- a/src/app/MessageDef/SubscribeResponseMessage.cpp
+++ b/src/app/MessageDef/SubscribeResponseMessage.cpp
@@ -19,11 +19,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR SubscribeResponseMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
     PRETTY_PRINT("SubscribeResponseMessage =");
     PRETTY_PRINT("{");
@@ -41,8 +40,6 @@ CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kSubscriptionId):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kSubscriptionId))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kSubscriptionId));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -53,8 +50,6 @@ CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
 #endif // CHIP_DETAIL_LOGGING
             break;
         case to_underlying(Tag::kMaxInterval):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kMaxInterval))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kMaxInterval));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -77,14 +72,12 @@ CHIP_ERROR SubscribeResponseMessage::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const uint16_t requiredFields = (1 << to_underlying(Tag::kSubscriptionId)) | (1 << to_underlying(Tag::kMaxInterval));
-        err                           = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR
-                                                                   : CHIP_ERROR_IM_MALFORMED_SUBSCRIBE_RESPONSE_MESSAGE;
+        err = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR SubscribeResponseMessage::Parser::GetSubscriptionId(SubscriptionId * const apSubscribeId) const
 {

--- a/src/app/MessageDef/SubscribeResponseMessage.h
+++ b/src/app/MessageDef/SubscribeResponseMessage.h
@@ -38,21 +38,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-#endif
-
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
     /**
      *  @brief Get Subscription ID. Next() must be called before accessing them.
      *

--- a/src/app/MessageDef/TimedRequestMessage.cpp
+++ b/src/app/MessageDef/TimedRequestMessage.cpp
@@ -19,11 +19,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR TimedRequestMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR TimedRequestMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
     PRETTY_PRINT("TimedRequestMessage =");
     PRETTY_PRINT("{");
@@ -41,8 +40,6 @@ CHIP_ERROR TimedRequestMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kTimeoutMs):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kTimeoutMs))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kTimeoutMs));
             VerifyOrReturnError(TLV::kTLVType_UnsignedInteger == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
 #if CHIP_DETAIL_LOGGING
             {
@@ -64,13 +61,12 @@ CHIP_ERROR TimedRequestMessage::Parser::CheckSchemaValidity() const
     PRETTY_PRINT_BLANK_LINE();
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = (1 << to_underlying(Tag::kTimeoutMs));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_TIMED_REQUEST_MESSAGE;
+        err = CHIP_NO_ERROR;
     }
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR TimedRequestMessage::Parser::GetTimeoutMs(uint16_t * const apTimeoutMs) const
 {

--- a/src/app/MessageDef/TimedRequestMessage.h
+++ b/src/app/MessageDef/TimedRequestMessage.h
@@ -36,21 +36,8 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *    The encoding rule has changed in IM encoding spec so this
-     *    check is only "roughly" conformant now.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
 #endif
 
     /**

--- a/src/app/MessageDef/WriteRequestMessage.cpp
+++ b/src/app/MessageDef/WriteRequestMessage.cpp
@@ -30,11 +30,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR WriteRequestMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR WriteRequestMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
 
     PRETTY_PRINT("WriteRequestMessage =");
@@ -53,55 +52,42 @@ CHIP_ERROR WriteRequestMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kSuppressResponse):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kSuppressResponse))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kSuppressResponse));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool suppressResponse;
-                ReturnErrorOnFailure(reader.Get(suppressResponse));
-                PRETTY_PRINT("\tsuppressResponse = %s, ", suppressResponse ? "true" : "false");
-            }
+        {
+            bool suppressResponse;
+            ReturnErrorOnFailure(reader.Get(suppressResponse));
+            PRETTY_PRINT("\tsuppressResponse = %s, ", suppressResponse ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
+        break;
 
         case to_underlying(Tag::kTimedRequest):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kTimedRequest))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kTimedRequest));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool timedRequest;
-                ReturnErrorOnFailure(reader.Get(timedRequest));
-                PRETTY_PRINT("\ttimedRequest = %s, ", timedRequest ? "true" : "false");
-            }
+        {
+            bool timedRequest;
+            ReturnErrorOnFailure(reader.Get(timedRequest));
+            PRETTY_PRINT("\ttimedRequest = %s, ", timedRequest ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
-        case to_underlying(Tag::kWriteRequests):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kWriteRequests))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kWriteRequests));
-            {
-                AttributeDataIBs::Parser writeRequests;
-                ReturnErrorOnFailure(writeRequests.Init(reader));
+        break;
+        case to_underlying(Tag::kWriteRequests): {
+            AttributeDataIBs::Parser writeRequests;
+            ReturnErrorOnFailure(writeRequests.Init(reader));
 
-                PRETTY_PRINT_INCDEPTH();
-                ReturnErrorOnFailure(writeRequests.CheckSchemaValidity());
-                PRETTY_PRINT_DECDEPTH();
-            }
-            break;
+            PRETTY_PRINT_INCDEPTH();
+            ReturnErrorOnFailure(writeRequests.PrettyPrint());
+            PRETTY_PRINT_DECDEPTH();
+        }
+        break;
         case to_underlying(Tag::kMoreChunkedMessages):
-            // check if this tag has appeared before
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kMoreChunkedMessages))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kMoreChunkedMessages));
 #if CHIP_DETAIL_LOGGING
-            {
-                bool moreChunkedMessages;
-                ReturnErrorOnFailure(reader.Get(moreChunkedMessages));
-                PRETTY_PRINT("\tmoreChunkedMessages = %s, ", moreChunkedMessages ? "true" : "false");
-            }
+        {
+            bool moreChunkedMessages;
+            ReturnErrorOnFailure(reader.Get(moreChunkedMessages));
+            PRETTY_PRINT("\tmoreChunkedMessages = %s, ", moreChunkedMessages ? "true" : "false");
+        }
 #endif // CHIP_DETAIL_LOGGING
-            break;
+        break;
         case kInteractionModelRevisionTag:
             ReturnErrorOnFailure(MessageParser::CheckInteractionModelRevision(reader));
             break;
@@ -116,14 +102,13 @@ CHIP_ERROR WriteRequestMessage::Parser::CheckSchemaValidity() const
 
     if (CHIP_END_OF_TLV == err)
     {
-        const int requiredFields = ((1 << to_underlying(Tag::kTimedRequest)) | (1 << to_underlying(Tag::kWriteRequests)));
-        err = (tagPresenceMask & requiredFields) == requiredFields ? CHIP_NO_ERROR : CHIP_ERROR_IM_MALFORMED_WRITE_REQUEST_MESSAGE;
+        err = CHIP_NO_ERROR;
     }
 
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR WriteRequestMessage::Parser::GetSuppressResponse(bool * const apSuppressResponse) const
 {

--- a/src/app/MessageDef/WriteRequestMessage.h
+++ b/src/app/MessageDef/WriteRequestMessage.h
@@ -45,19 +45,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
     /**
      *  @brief Get SuppressResponse boolean
      *

--- a/src/app/MessageDef/WriteResponseMessage.cpp
+++ b/src/app/MessageDef/WriteResponseMessage.cpp
@@ -25,11 +25,10 @@
 
 namespace chip {
 namespace app {
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-CHIP_ERROR WriteResponseMessage::Parser::CheckSchemaValidity() const
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+CHIP_ERROR WriteResponseMessage::Parser::PrettyPrint() const
 {
-    CHIP_ERROR err      = CHIP_NO_ERROR;
-    int tagPresenceMask = 0;
+    CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
     AttributeStatusIBs::Parser writeResponses;
     PRETTY_PRINT("WriteResponseMessage =");
@@ -48,13 +47,11 @@ CHIP_ERROR WriteResponseMessage::Parser::CheckSchemaValidity() const
         switch (tagNum)
         {
         case to_underlying(Tag::kWriteResponses):
-            VerifyOrReturnError(!(tagPresenceMask & (1 << to_underlying(Tag::kWriteResponses))), CHIP_ERROR_INVALID_TLV_TAG);
-            tagPresenceMask |= (1 << to_underlying(Tag::kWriteResponses));
             VerifyOrReturnError(TLV::kTLVType_Array == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
             ReturnErrorOnFailure(writeResponses.Init(reader));
 
             PRETTY_PRINT_INCDEPTH();
-            ReturnErrorOnFailure(writeResponses.CheckSchemaValidity());
+            ReturnErrorOnFailure(writeResponses.PrettyPrint());
             PRETTY_PRINT_DECDEPTH();
             break;
         case kInteractionModelRevisionTag:
@@ -77,7 +74,7 @@ CHIP_ERROR WriteResponseMessage::Parser::CheckSchemaValidity() const
     ReturnErrorOnFailure(err);
     return reader.ExitContainer(mOuterContainerType);
 }
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
 
 CHIP_ERROR WriteResponseMessage::Parser::GetWriteResponses(AttributeStatusIBs::Parser * const apWriteResponses) const
 {

--- a/src/app/MessageDef/WriteResponseMessage.h
+++ b/src/app/MessageDef/WriteResponseMessage.h
@@ -37,19 +37,9 @@ enum class Tag : uint8_t
 class Parser : public MessageParser
 {
 public:
-    /**
-     *  @brief Roughly verify the message is correctly formed
-     *   1) all mandatory tags are present
-     *   2) all elements have expected data type
-     *   3) any tag can only appear once
-     *   4) At the top level of the structure, unknown tags are ignored for forward compatibility
-     *  @note The main use of this function is to print out what we're
-     *    receiving during protocol development and debugging.
-     *
-     *  @return #CHIP_NO_ERROR on success
-     */
-    CHIP_ERROR CheckSchemaValidity() const;
-
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    CHIP_ERROR PrettyPrint() const;
+#endif // CHIP_CONFIG_IM_PRETTY_PRINT
     /**
      *  @brief Get a TLVReader for the AttributeStatusIBs. Next() must be called before accessing them.
      *

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -510,9 +510,8 @@ CHIP_ERROR ReadClient::ProcessReportData(System::PacketBufferHandle && aPayload)
     err = report.Init(reader);
     SuccessOrExit(err);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = report.CheckSchemaValidity();
-    SuccessOrExit(err);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    report.PrettyPrint();
 #endif
 
     err = report.GetSuppressResponse(&suppressResponse);
@@ -888,8 +887,8 @@ CHIP_ERROR ReadClient::ProcessSubscribeResponse(System::PacketBufferHandle && aP
     SubscribeResponseMessage::Parser subscribeResponse;
     ReturnErrorOnFailure(subscribeResponse.Init(reader));
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    ReturnErrorOnFailure(subscribeResponse.CheckSchemaValidity());
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    subscribeResponse.PrettyPrint();
 #endif
 
     SubscriptionId subscriptionId = 0;

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -304,8 +304,8 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
     reader.Init(std::move(aPayload));
 
     ReturnErrorOnFailure(readRequestParser.Init(reader));
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    ReturnErrorOnFailure(readRequestParser.CheckSchemaValidity());
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    readRequestParser.PrettyPrint();
 #endif
 
     err = readRequestParser.GetAttributeRequests(&attributePathListParser);
@@ -557,8 +557,8 @@ CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aP
 
     SubscribeRequestMessage::Parser subscribeRequestParser;
     ReturnErrorOnFailure(subscribeRequestParser.Init(reader));
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    ReturnErrorOnFailure(subscribeRequestParser.CheckSchemaValidity());
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    subscribeRequestParser.PrettyPrint();
 #endif
 
     AttributePathIBs::Parser attributePathListParser;

--- a/src/app/StatusResponse.cpp
+++ b/src/app/StatusResponse.cpp
@@ -50,8 +50,8 @@ CHIP_ERROR StatusResponse::ProcessStatusResponse(System::PacketBufferHandle && a
     System::PacketBufferTLVReader reader;
     reader.Init(std::move(aPayload));
     ReturnErrorOnFailure(response.Init(reader));
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    ReturnErrorOnFailure(response.CheckSchemaValidity());
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    response.PrettyPrint();
 #endif
     StatusIB status;
     ReturnErrorOnFailure(response.GetStatus(status.mStatus));

--- a/src/app/TimedHandler.cpp
+++ b/src/app/TimedHandler.cpp
@@ -114,8 +114,8 @@ CHIP_ERROR TimedHandler::HandleTimedRequestAction(Messaging::ExchangeContext * a
     TimedRequestMessage::Parser parser;
     ReturnErrorOnFailure(parser.Init(reader));
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    ReturnErrorOnFailure(parser.CheckSchemaValidity());
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    parser.PrettyPrint();
 #endif
 
     uint16_t timeoutMs;

--- a/src/app/WriteClient.cpp
+++ b/src/app/WriteClient.cpp
@@ -53,8 +53,8 @@ CHIP_ERROR WriteClient::ProcessWriteResponseMessage(System::PacketBufferHandle &
 
     ReturnErrorOnFailure(writeResponse.Init(reader));
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    ReturnErrorOnFailure(writeResponse.CheckSchemaValidity());
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    writeResponse.PrettyPrint();
 #endif
 
     err = writeResponse.GetWriteResponses(&attributeStatusesParser);

--- a/src/app/WriteHandler.cpp
+++ b/src/app/WriteHandler.cpp
@@ -554,9 +554,8 @@ Status WriteHandler::ProcessWriteRequest(System::PacketBufferHandle && aPayload,
     err = writeRequestParser.Init(reader);
     SuccessOrExit(err);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = writeRequestParser.CheckSchemaValidity();
-    SuccessOrExit(err);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    writeRequestParser.PrettyPrint();
 #endif
     err = writeRequestParser.GetSuppressResponse(&mSuppressResponse);
     if (err == CHIP_END_OF_TLV)

--- a/src/app/tests/TestCommandInteraction.cpp
+++ b/src/app/tests/TestCommandInteraction.cpp
@@ -588,14 +588,13 @@ void TestCommandInteraction::ValidateCommandHandlerWithSendCommand(nlTestSuite *
     err = commandHandler.Finalize(commandPacket);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     chip::System::PacketBufferTLVReader reader;
     InvokeResponseMessage::Parser invokeResponseMessageParser;
     reader.Init(std::move(commandPacket));
     err = invokeResponseMessageParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    err = invokeResponseMessageParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    invokeResponseMessageParser.PrettyPrint();
 #endif
 
     //
@@ -659,14 +658,13 @@ void TestCommandInteraction::TestCommandHandlerCommandDataEncoding(nlTestSuite *
     err = commandHandler.Finalize(commandPacket);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     chip::System::PacketBufferTLVReader reader;
     InvokeResponseMessage::Parser invokeResponseMessageParser;
     reader.Init(std::move(commandPacket));
     err = invokeResponseMessageParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    err = invokeResponseMessageParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    invokeResponseMessageParser.PrettyPrint();
 #endif
 
     //
@@ -695,14 +693,13 @@ void TestCommandInteraction::TestCommandHandlerCommandEncodeFailure(nlTestSuite 
     err = commandHandler.Finalize(commandPacket);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     chip::System::PacketBufferTLVReader reader;
     InvokeResponseMessage::Parser invokeResponseMessageParser;
     reader.Init(std::move(commandPacket));
     err = invokeResponseMessageParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    err = invokeResponseMessageParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    invokeResponseMessageParser.PrettyPrint();
 #endif
 
     //
@@ -1104,14 +1101,13 @@ void TestCommandInteraction::TestCommandHandlerCommandEncodeExternalFailure(nlTe
     err = commandHandler.Finalize(commandPacket);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
+#if CHIP_CONFIG_IM_PRETTY_PRINT
     chip::System::PacketBufferTLVReader reader;
     InvokeResponseMessage::Parser invokeResponseMessageParser;
     reader.Init(std::move(commandPacket));
     err = invokeResponseMessageParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-    err = invokeResponseMessageParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+    invokeResponseMessageParser.PrettyPrint();
 #endif
 
     //

--- a/src/app/tests/TestMessageDef.cpp
+++ b/src/app/tests/TestMessageDef.cpp
@@ -92,9 +92,8 @@ void ParseStatusIB(nlTestSuite * apSuite, StatusIB::Parser & aStatusIBParser)
     StatusIB::Parser StatusIBParser;
     StatusIB statusIB;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aStatusIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aStatusIBParser.PrettyPrint();
 #endif
     err = aStatusIBParser.DecodeStatusIB(statusIB);
     NL_TEST_ASSERT(apSuite,
@@ -120,9 +119,8 @@ void ParseClusterPathIB(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = clusterPathParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = clusterPathParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    clusterPathParser.PrettyPrint();
 #endif
 
     err = clusterPathParser.GetNode(&node);
@@ -153,9 +151,8 @@ void ParseDataVersionFilterIB(nlTestSuite * apSuite, chip::TLV::TLVReader & aRea
 
     err = dataVersionFilterIBParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = dataVersionFilterIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    dataVersionFilterIBParser.PrettyPrint();
 #endif
 
     err = dataVersionFilterIBParser.GetPath(&clusterPath);
@@ -181,9 +178,8 @@ void ParseDataVersionFilterIBs(nlTestSuite * apSuite, chip::TLV::TLVReader & aRe
 
     err = dataVersionFilterIBsParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = dataVersionFilterIBsParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    dataVersionFilterIBsParser.PrettyPrint();
 #endif
 }
 
@@ -202,9 +198,8 @@ void ParseEventFilterIB(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = eventFilterIBParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = eventFilterIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    eventFilterIBParser.PrettyPrint();
 #endif
     err = eventFilterIBParser.GetNode(&node);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && node == 1);
@@ -229,9 +224,8 @@ void ParseEventFilters(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = eventFiltersParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = eventFiltersParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    eventFiltersParser.PrettyPrint();
 #endif
 }
 
@@ -262,9 +256,8 @@ void ParseAttributePathIB(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = attributePathParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = attributePathParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    attributePathParser.PrettyPrint();
 #endif
 
     err = attributePathParser.GetEnableTagCompression(&enableTagCompression);
@@ -305,9 +298,8 @@ void ParseAttributePathList(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
     err = attributePathListParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = attributePathListParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    attributePathListParser.PrettyPrint();
 #endif
 }
 
@@ -328,9 +320,8 @@ void ParseEventPath(nlTestSuite * apSuite, EventPathIB::Parser & aEventPathParse
     chip::EventId event       = 4;
     bool isUrgent             = false;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aEventPathParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aEventPathParser.PrettyPrint();
 #endif
     err = aEventPathParser.GetNode(&node);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && node == 1);
@@ -365,9 +356,8 @@ void ParseEventPaths(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = eventPathListParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = eventPathListParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    eventPathListParser.PrettyPrint();
 #endif
 }
 
@@ -388,9 +378,8 @@ void ParseCommandPath(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = commandPathParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = commandPathParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    commandPathParser.PrettyPrint();
 #endif
     err = commandPathParser.GetEndpointId(&endpointId);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && endpointId == 1);
@@ -442,9 +431,8 @@ void ParseEventDataIB(nlTestSuite * apSuite, EventDataIB::Parser & aEventDataIBP
     uint64_t deltaUTCTimestamp    = 0;
     uint64_t deltaSystemTimestamp = 0;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aEventDataIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aEventDataIBParser.PrettyPrint();
 #endif
     {
         {
@@ -504,9 +492,8 @@ void ParseEventStatusIB(nlTestSuite * apSuite, EventStatusIB::Parser & aEventSta
     CHIP_ERROR err = CHIP_NO_ERROR;
     EventPathIB::Parser eventPathParser;
     StatusIB::Parser statusParser;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aEventStatusIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aEventStatusIBParser.PrettyPrint();
 #endif
     err = aEventStatusIBParser.GetPath(&eventPathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -531,9 +518,8 @@ void ParseEventReportIB(nlTestSuite * apSuite, EventReportIB::Parser & aEventRep
     EventStatusIB::Parser eventStatusParser;
     EventDataIB::Parser eventDataParser;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aEventReportIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aEventReportIBParser.PrettyPrint();
 #endif
 
     err = aEventReportIBParser.GetEventData(&eventDataParser);
@@ -556,9 +542,8 @@ void ParseEventReports(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
 
     err = eventReportsParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = eventReportsParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    eventReportsParser.PrettyPrint();
 #endif
 }
 
@@ -582,9 +567,8 @@ void ParseAttributeStatusIB(nlTestSuite * apSuite, AttributeStatusIB::Parser & a
     AttributePathIB::Parser attributePathParser;
     StatusIB::Parser StatusIBParser;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aAttributeStatusIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aAttributeStatusIBParser.PrettyPrint();
 #endif
     err = aAttributeStatusIBParser.GetPath(&attributePathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -611,9 +595,8 @@ void ParseAttributeStatuses(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
     err = attributeStatusParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = attributeStatusParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    attributeStatusParser.PrettyPrint();
 #endif
 }
 
@@ -652,9 +635,8 @@ void ParseAttributeDataIB(nlTestSuite * apSuite, AttributeDataIB::Parser & aAttr
     CHIP_ERROR err = CHIP_NO_ERROR;
     AttributePathIB::Parser attributePathParser;
     chip::DataVersion version = 0;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aAttributeDataIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aAttributeDataIBParser.PrettyPrint();
 #endif
     err = aAttributeDataIBParser.GetPath(&attributePathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -698,9 +680,8 @@ void ParseAttributeDataIBs(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader
 
     err = AttributeDataIBsParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = AttributeDataIBsParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    AttributeDataIBsParser.PrettyPrint();
 #endif
 }
 
@@ -720,9 +701,8 @@ void ParseAttributeReportIB(nlTestSuite * apSuite, AttributeReportIB::Parser & a
     AttributeStatusIB::Parser attributeStatusParser;
     AttributeDataIB::Parser attributeDataParser;
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aAttributeReportIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aAttributeReportIBParser.PrettyPrint();
 #endif
     err = aAttributeReportIBParser.GetAttributeData(&attributeDataParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -745,9 +725,8 @@ void ParseAttributeReportIBs(nlTestSuite * apSuite, chip::TLV::TLVReader & aRead
 
     err = attributeReportIBsParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = attributeReportIBsParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    attributeReportIBsParser.PrettyPrint();
 #endif
 }
 
@@ -782,9 +761,8 @@ void ParseCommandDataIB(nlTestSuite * apSuite, CommandDataIB::Parser & aCommandD
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandPathIB::Parser commandPathParser;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aCommandDataIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aCommandDataIBParser.PrettyPrint();
 #endif
     err = aCommandDataIBParser.GetPath(&commandPathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -827,9 +805,8 @@ void ParseCommandStatusIB(nlTestSuite * apSuite, CommandStatusIB::Parser & aComm
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandPathIB::Parser commandPathParser;
     StatusIB::Parser statusParser;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aCommandStatusIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aCommandStatusIBParser.PrettyPrint();
 #endif
     err = aCommandStatusIBParser.GetPath(&commandPathParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -840,13 +817,7 @@ void ParseCommandStatusIB(nlTestSuite * apSuite, CommandStatusIB::Parser & aComm
 
 void BuildWrongInvokeResponseIB(nlTestSuite * apSuite, InvokeResponseIB::Builder & aInvokeResponseIBBuilder)
 {
-    CommandDataIB::Builder & commandDataBuilder = aInvokeResponseIBBuilder.CreateCommand();
-    NL_TEST_ASSERT(apSuite, aInvokeResponseIBBuilder.GetError() == CHIP_NO_ERROR);
-    BuildCommandDataIB(apSuite, commandDataBuilder);
-    CommandStatusIB::Builder & commandStatusBuilder = aInvokeResponseIBBuilder.CreateStatus();
-    NL_TEST_ASSERT(apSuite, aInvokeResponseIBBuilder.GetError() == CHIP_NO_ERROR);
-    BuildCommandStatusIB(apSuite, commandStatusBuilder);
-    aInvokeResponseIBBuilder.EndOfInvokeResponseIB();
+    aInvokeResponseIBBuilder.CreateCommand();
     NL_TEST_ASSERT(apSuite, aInvokeResponseIBBuilder.GetError() == CHIP_NO_ERROR);
 }
 
@@ -873,9 +844,8 @@ void ParseInvokeResponseIBWithCommandDataIB(nlTestSuite * apSuite, InvokeRespons
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandDataIB::Parser commandDataParser;
     CommandStatusIB::Parser statusIBParser;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aInvokeResponseIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aInvokeResponseIBParser.PrettyPrint();
 #endif
     err = aInvokeResponseIBParser.GetCommand(&commandDataParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -886,22 +856,11 @@ void ParseInvokeResponseIBWithCommandStatusIB(nlTestSuite * apSuite, InvokeRespo
     CHIP_ERROR err = CHIP_NO_ERROR;
     CommandDataIB::Parser commandDataParser;
     CommandStatusIB::Parser statusIBParser;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = aInvokeResponseIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    aInvokeResponseIBParser.PrettyPrint();
 #endif
     err = aInvokeResponseIBParser.GetStatus(&statusIBParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-}
-
-void ParseWrongInvokeResponseIB(nlTestSuite * apSuite, InvokeResponseIB::Parser & aInvokeResponseIBParser)
-{
-    CommandDataIB::Parser commandDataParser;
-    CommandStatusIB::Parser statusIBParser;
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    CHIP_ERROR err = aInvokeResponseIBParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err != CHIP_NO_ERROR);
-#endif
 }
 
 void BuildInvokeRequests(nlTestSuite * apSuite, InvokeRequests::Builder & aInvokeRequestsBuilder)
@@ -921,9 +880,8 @@ void ParseInvokeRequests(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = invokeRequestsParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = invokeRequestsParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    invokeRequestsParser.PrettyPrint();
 #endif
 }
 
@@ -944,9 +902,8 @@ void ParseInvokeResponses(nlTestSuite * apSuite, chip::TLV::TLVReader & aReader)
     err = invokeResponsesParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = invokeResponsesParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    invokeResponsesParser.PrettyPrint();
 #endif
 }
 
@@ -980,9 +937,8 @@ void ParseInvokeRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRe
     invokeRequestMessageParser.GetTimedRequest(&timedRequest);
     NL_TEST_ASSERT(apSuite, suppressResponse == true);
     NL_TEST_ASSERT(apSuite, timedRequest == true);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = invokeRequestMessageParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    invokeRequestMessageParser.PrettyPrint();
 #endif
     NL_TEST_ASSERT(apSuite, invokeRequestMessageParser.ExitContainer() == CHIP_NO_ERROR);
 }
@@ -1013,9 +969,8 @@ void ParseInvokeResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aR
     bool suppressResponse = false;
     invokeResponseMessageParser.GetSuppressResponse(&suppressResponse);
     NL_TEST_ASSERT(apSuite, suppressResponse == true);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = invokeResponseMessageParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    invokeResponseMessageParser.PrettyPrint();
 #endif
     NL_TEST_ASSERT(apSuite, invokeResponseMessageParser.ExitContainer() == CHIP_NO_ERROR);
 }
@@ -1058,9 +1013,8 @@ void ParseReportDataMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aReade
     bool moreChunkedMessages = false;
     reportDataParser.Init(aReader);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = reportDataParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    reportDataParser.PrettyPrint();
 #endif
     err = reportDataParser.GetSuppressResponse(&suppressResponse);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && suppressResponse);
@@ -1124,9 +1078,8 @@ void ParseReadRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRead
 
     err = readRequestParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = readRequestParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    readRequestParser.PrettyPrint();
 #endif
     err = readRequestParser.GetAttributeRequests(&attributePathListParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -1182,9 +1135,8 @@ void ParseWriteRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRea
 
     err = writeRequestParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = writeRequestParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    writeRequestParser.PrettyPrint();
 #endif
     err = writeRequestParser.GetSuppressResponse(&suppressResponse);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR && suppressResponse);
@@ -1223,9 +1175,8 @@ void ParseWriteResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRe
     AttributeStatusIBs::Parser attributeStatusesParser;
     err = writeResponseParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = writeResponseParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    writeResponseParser.PrettyPrint();
 #endif
     err = writeResponseParser.GetWriteResponses(&attributeStatusesParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -1289,9 +1240,8 @@ void ParseSubscribeRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & 
 
     err = subscribeRequestParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = subscribeRequestParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    subscribeRequestParser.PrettyPrint();
 #endif
     err = subscribeRequestParser.GetAttributeRequests(&attributePathListParser);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
@@ -1346,9 +1296,8 @@ void ParseSubscribeResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVReader &
     uint16_t maxInterval                = 0;
     err                                 = subscribeResponseParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = subscribeResponseParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    subscribeResponseParser.PrettyPrint();
 #endif
     err = subscribeResponseParser.GetSubscriptionId(&subscriptionId);
     NL_TEST_ASSERT(apSuite, subscriptionId == 1 && err == CHIP_NO_ERROR);
@@ -1380,9 +1329,8 @@ void ParseTimedRequestMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aRea
 
     err = timedRequestMessageParser.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = timedRequestMessageParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    timedRequestMessageParser.PrettyPrint();
 #endif
     err = timedRequestMessageParser.GetTimeoutMs(&timeout);
     NL_TEST_ASSERT(apSuite, timeout == 1 && err == CHIP_NO_ERROR);
@@ -2037,8 +1985,8 @@ void InvokeResponseIBWithMalformDataTest(nlTestSuite * apSuite, void * apContext
     err = reader.Next();
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-    invokeResponseIBParser.Init(reader);
-    ParseWrongInvokeResponseIB(apSuite, invokeResponseIBParser);
+    err = invokeResponseIBParser.Init(reader);
+    NL_TEST_ASSERT(apSuite, err != CHIP_NO_ERROR);
 }
 
 void InvokeRequestsTest(nlTestSuite * apSuite, void * apContext)
@@ -2277,9 +2225,8 @@ void CheckPointRollbackTest(nlTestSuite * apSuite, void * apContext)
     err = AttributeDataIBsParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = AttributeDataIBsParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    AttributeDataIBsParser.PrettyPrint();
 #endif
     while (CHIP_NO_ERROR == (err = AttributeDataIBsParser.Next()))
     {

--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -667,11 +667,7 @@ void TestReadInteraction::TestReadHandlerInvalidAttributePath(nlTestSuite * apSu
 
         err = readHandler.ProcessReadRequest(std::move(readRequestbuf));
         ChipLogError(DataManagement, "The error is %s", ErrorStr(err));
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-        NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_IM_MALFORMED_READ_REQUEST_MESSAGE);
-#else
         NL_TEST_ASSERT(apSuite, err == CHIP_ERROR_END_OF_TLV);
-#endif // CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
 
         //
         // In the call above to ProcessReadRequest, the handler will not actually close out the EC since
@@ -728,9 +724,8 @@ void TestReadInteraction::TestReadClientGenerateOneEventPaths(nlTestSuite * apSu
     err = readRequestParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = readRequestParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    readRequestParser.PrettyPrint();
 #endif
 
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
@@ -780,9 +775,8 @@ void TestReadInteraction::TestReadClientGenerateTwoEventPaths(nlTestSuite * apSu
     err = readRequestParser.Init(reader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = readRequestParser.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    readRequestParser.PrettyPrint();
 #endif
 
     NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);

--- a/src/app/tests/TestStatusResponseMessage.cpp
+++ b/src/app/tests/TestStatusResponseMessage.cpp
@@ -58,9 +58,8 @@ void ParseStatusResponseMessage(nlTestSuite * apSuite, chip::TLV::TLVReader & aR
 
     err = statusResponse.Init(aReader);
     NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
-#if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
-    err = statusResponse.CheckSchemaValidity();
-    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+#if CHIP_CONFIG_IM_PRETTY_PRINT
+    statusResponse.PrettyPrint();
 #endif
 
     err = statusResponse.GetStatus(status);

--- a/src/platform/nxp/mw320/args.gni
+++ b/src/platform/nxp/mw320/args.gni
@@ -34,7 +34,7 @@ chip_detail_logging = false
 chip_build_tests = false
 chip_progress_logging = true
 chip_access_control_policy_logging_verbosity = 2
-chip_enable_schema_check = true
+enable_im_pretty_print = true
 
 chip_mdns = "minimal"
 mbedtls_target = "${chip_root}/third_party/nxp/mw320_sdk:mbedtls"


### PR DESCRIPTION
#### Problem
https://github.com/project-chip/connectedhomeip/issues/21698
CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK is only enabled in linux/darwin platform, there is extra element check inside CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK, which mean we are testing in CI is likely not what we are shipping on devices.

#### Change overview
--Remove minimum element check in CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK, then the element check would be unified/processed into same code path under IM client/handler with or without CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK.
--Rename CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK to CHIP_CONFIG_IM_PRETTY_PRINT
--Rename CheckSchemaValidity to PrettyPrint
--In IM client/server code, don't process the error from PrettyPrint.

#### Testing
The existing test covers.
