### PR TITLE
[ota-r] API to rekick the periodic query timer

### DIFF
--- a/examples/platform/esp32/ota/OTAHelper.cpp
+++ b/examples/platform/esp32/ota/OTAHelper.cpp
@@ -118,6 +118,14 @@ CHIP_ERROR RequestorCanConsentHandler(int argc, char ** argv)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR SetPeriodicQueryTimeoutHandler(int argc, char ** argv)
+{
+    VerifyOrReturnError(argc == 1, CHIP_ERROR_INVALID_ARGUMENT);
+    gRequestorUser.SetPeriodicQueryTimeout(strtoul(argv[0], NULL, 0));
+    gRequestorUser.RekickPeriodicQueryTimer();
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR OTARequestorHandler(int argc, char ** argv)
 {
     if (argc == 0)
@@ -147,6 +155,9 @@ void OTARequestorCommands::Register()
         { &RequestorCanConsentHandler, "requestorCanConsent",
           "Set requestorCanConsent for QueryImageCommand\n"
           "Usage: OTARequestor requestorCanConsent <true/false>" },
+        { &SetPeriodicQueryTimeoutHandler, "PeriodicQueryTimeout",
+          "Set timeout for querying the OTA provider for an update\n"
+          "Usage: OTARequestor PeriodicQueryTimeout <seconds>" },
 
     };
 

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.cpp
@@ -388,6 +388,13 @@ void DefaultOTARequestorDriver::StopPeriodicQueryTimer()
     CancelDelayedAction(PeriodicQueryTimerHandler, this);
 }
 
+void DefaultOTARequestorDriver::RekickPeriodicQueryTimer(void)
+{
+    ChipLogProgress(SoftwareUpdate, "Rekicking the Periodic Query timer");
+    StopPeriodicQueryTimer();
+    StartPeriodicQueryTimer();
+}
+
 void DefaultOTARequestorDriver::WatchdogTimerHandler(System::Layer * systemLayer, void * appState)
 {
     DefaultOTARequestorDriver * driver = ToDriver(appState);

--- a/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestorDriver.h
@@ -52,6 +52,9 @@ public:
         }
     }
 
+    // Restart the periodic query timer
+    void RekickPeriodicQueryTimer(void);
+
     // Set the timeout (in seconds) for the watchdog timer; must be non-zero
     void SetWatchdogTimeout(uint32_t timeout)
     {


### PR DESCRIPTION
#### Problem
* If someone sets the periodic query timeout after the initial timer gets kicked off then calling `SetPeriodicQueryTimeout()` will take effect after the initial timer is expired. Default timeout is 24 hours.

* On ESP32 there's no way to set the periodic query timeout for quick tests.

#### Change overview
* Added an API to re-kick the timer.
* CLI option in EPS32 for setting periodic query timeout.

#### Testing
* Set the timeout to 60 seconds on esp32 using following command and verified that timer was kicking in at every 60 seconds
    ```
    > matter OTARequestor PeriodicQueryTimeout 60
    ```