### PR TITLE
[EFR32] Increasing the heap size for wifi devices

### DIFF
--- a/examples/platform/efr32/FreeRTOSConfig.h
+++ b/examples/platform/efr32/FreeRTOSConfig.h
@@ -198,7 +198,7 @@ See http://www.FreeRTOS.org/RTOS-Cortex-M3-M4.html. */
 
 #ifndef configTOTAL_HEAP_SIZE
 #ifdef SL_WIFI
-#define configTOTAL_HEAP_SIZE ((size_t)(30 * 1024))
+#define configTOTAL_HEAP_SIZE ((size_t)(34 * 1024))
 #else
 #define configTOTAL_HEAP_SIZE ((size_t)(20 * 1024))
 #endif


### PR DESCRIPTION
#### Problem

Heap overflow was noticed when adding more than 3 controllers in multiadmin.

#### Change overview

Increasing the heap size for the wifi devices to support 5 controllers

#### Testing

Tested manually using 
MG12+RS9116
MG12+WF200
MG24+RS9116

**Note: To be cherrypicked in SVE2 branch**