### PR TITLE
[ci] Install ccache in chip-build docker image

### DIFF
--- a/integrations/docker/images/chip-build/Dockerfile
+++ b/integrations/docker/images/chip-build/Dockerfile
@@ -11,6 +11,7 @@ RUN set -x \
     automake \
     bison \
     bridge-utils \
+    ccache \
     clang \
     clang-format \
     clang-tidy \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.93 Version bump reason: [ESP32] Update ESP-IDF to release v4.4.2
+0.5.94 Version bump reason: Install ccache to the chip-build image


### PR DESCRIPTION
#### Problem
* CI builds can be speed up using ccache

#### Change overview
* Installed ccache to chip-build docker image

#### Testing
* Built the docker image locally and verified that ccache is present in that image