### PR TITLE
Wrap all nlfaultinjection logic with build flag chip_with_nlfaultinje…

### DIFF
--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -88,7 +88,6 @@ static_library("inet") {
     "InetArgParser.h",
     "InetError.cpp",
     "InetError.h",
-    "InetFaultInjection.h",
     "InetInterface.cpp",
     "InetInterface.h",
     "InetLayer.h",
@@ -132,7 +131,10 @@ static_library("inet") {
   }
 
   if (chip_with_nlfaultinjection) {
-    sources += [ "InetFaultInjection.cpp" ]
+    sources += [
+      "InetFaultInjection.cpp",
+      "InetFaultInjection.h",
+    ]
     public_deps += [ "${nlfaultinjection_root}:nlfaultinjection" ]
   }
 

--- a/src/inet/tests/BUILD.gn
+++ b/src/inet/tests/BUILD.gn
@@ -35,14 +35,19 @@ static_library("helpers") {
     "TestInetCommonOptions.h",
     "TestInetCommonPosix.cpp",
     "TestInetLayerCommon.cpp",
-    "TestSetupFaultInjection.h",
-    "TestSetupFaultInjectionPosix.cpp",
     "TestSetupSignalling.h",
     "TestSetupSignallingPosix.cpp",
   ]
 
   if (current_os != "mbed") {
     sources += [ "TestInetLayer.cpp" ]
+  }
+
+  if (chip_with_nlfaultinjection) {
+    sources += [
+      "TestSetupFaultInjection.h",
+      "TestSetupFaultInjectionPosix.cpp",
+    ]
   }
 
   cflags = [ "-Wconversion" ]

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -177,7 +177,6 @@ static_library("system") {
     "SystemError.cpp",
     "SystemError.h",
     "SystemEvent.h",
-    "SystemFaultInjection.h",
     "SystemLayer.cpp",
     "SystemLayer.h",
     "SystemLayerImpl.h",
@@ -219,7 +218,10 @@ static_library("system") {
   }
 
   if (chip_with_nlfaultinjection) {
-    sources += [ "SystemFaultInjection.cpp" ]
+    sources += [
+      "SystemFaultInjection.cpp",
+      "SystemFaultInjection.h",
+    ]
     public_deps += [ "${nlfaultinjection_root}:nlfaultinjection" ]
   }
 }


### PR DESCRIPTION
…ction

#### Problem
What is being fixed?  Examples:
* Some of nlfaultinjection components are not wrapped in build flag chip_with_nlfaultinjection, we need to wrap all nlfaultinjection relative logic with build flag chip_with_nlfaultinjection, so that we can turn on and off this mechanism with build flag chip_with_nlfaultinjection=ture or chip_with_nlfaultinjection=false 

* Fixes #21941 

#### Change overview
Wrap all nlfaultinjection logic with build flag chip_with_nlfaultinjection

#### Testing
How was this tested? (at least one bullet point required)
* Covered by CI