### PR TITLE
OTA:  Add SetMetadataForProvider to requestor 

### DIFF
--- a/examples/common/pigweed/protos/device_service.options
+++ b/examples/common/pigweed/protos/device_service.options
@@ -5,3 +5,4 @@ chip.rpc.PairingInfo.qr_code max_size:256
 chip.rpc.PairingInfo.qr_code_url max_size:256
 chip.rpc.SpakeInfo.verifier max_size:97  // kSpake2p_VerifierSerialized_Length
 chip.rpc.SpakeInfo.salt max_size:32      // kSpake2p_Max_PBKDF_Salt_Length
+chip.rpc.MetadataForProvider.tlv max_size:512 // length defined in chip spec 11.20.6.7

--- a/examples/common/pigweed/protos/device_service.proto
+++ b/examples/common/pigweed/protos/device_service.proto
@@ -41,10 +41,15 @@ message PairingState {
   bool pairing_enabled = 1;
 }
 
+message MetadataForProvider {
+  bytes tlv = 1;
+}
+
 service Device {
   rpc FactoryReset(pw.protobuf.Empty) returns (pw.protobuf.Empty){}
   rpc Reboot(pw.protobuf.Empty) returns (pw.protobuf.Empty){}
   rpc TriggerOta(pw.protobuf.Empty) returns (pw.protobuf.Empty){}
+  rpc SetOtaMetadataForProvider(MetadataForProvider) returns (pw.protobuf.Empty){}
   rpc GetDeviceInfo(pw.protobuf.Empty) returns (DeviceInfo){}
   rpc GetDeviceState(pw.protobuf.Empty) returns (DeviceState){}
   rpc SetPairingState(PairingState) returns (pw.protobuf.Empty){}

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -767,6 +767,7 @@ CHIP_ERROR DefaultOTARequestor::SendQueryImageRequest(Messaging::ExchangeManager
         args.location.SetValue(CharSpan("XX", strlen("XX")));
     }
 
+    args.metadataForProvider = mMetadataForProvider;
     Controller::OtaSoftwareUpdateProviderCluster cluster(exchangeMgr, sessionHandle, mProviderLocation.Value().endpoint);
 
     return cluster.InvokeCommand(args, this, OnQueryImageResponse, OnQueryImageFailure);

--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.h
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.h
@@ -92,6 +92,10 @@ public:
 
     void GetProviderLocation(Optional<ProviderLocationType> & providerLocation) override { providerLocation = mProviderLocation; }
 
+    // Set the metadata value for the provider to be used in the next query and OTA update process
+    // NOTE: Does not persist across reboot.
+    void SetMetadataForProvider(ByteSpan metadataForProvider) override { mMetadataForProvider.SetValue(metadataForProvider); }
+
     // Add a default OTA provider to the cached list
     CHIP_ERROR AddDefaultOtaProvider(const ProviderLocationType & providerLocation) override;
 
@@ -319,6 +323,7 @@ private:
     BDXDownloader * mBdxDownloader           = nullptr; // TODO: this should be OTADownloader
     BDXMessenger mBdxMessenger;                         // TODO: ideally this is held by the application
     uint8_t mUpdateTokenBuffer[kMaxUpdateTokenLen];
+    Optional<ByteSpan> mMetadataForProvider;
     ByteSpan mUpdateToken;
     uint32_t mCurrentVersion = 0;
     uint32_t mTargetVersion  = 0;

--- a/src/app/clusters/ota-requestor/OTARequestorInterface.h
+++ b/src/app/clusters/ota-requestor/OTARequestorInterface.h
@@ -203,6 +203,9 @@ public:
     // Set the provider location to be used in the next query and OTA update process
     virtual void SetCurrentProviderLocation(ProviderLocationType providerLocation) = 0;
 
+    // Set the metadata value for the provider to be used in the next query and OTA update process
+    virtual void SetMetadataForProvider(chip::ByteSpan metadataForProvider) = 0;
+
     // If there is an OTA update in progress, returns the provider location for the current OTA update, otherwise, returns the
     // provider location that was last used
     virtual void GetProviderLocation(Optional<ProviderLocationType> & providerLocation) = 0;


### PR DESCRIPTION
#### Problem
OTA requestor has no method for setting the metadataForProvider value.

#### Change overview
Add a setter on the OTA requester interface to set the metadataForProvider value.

Implement this method on for the DefaultOTARequestor as an optional bytespan property which can be set at runtime. 

Provide an RPC to set the value at runtime. 

#### Testing
Tested using the included RPC on m5, verified the metadata was correctly included to the provider during image query.
