### PR TITLE
[EFR32] Fix resource leak on volatile keys

### DIFF
--- a/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
+++ b/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
@@ -118,9 +118,15 @@ EFR32OpaqueKeypair::EFR32OpaqueKeypair()
 
 EFR32OpaqueKeypair::~EFR32OpaqueKeypair()
 {
-    // Free dynamic resource
+    // Free key resources
     if (mContext != nullptr)
     {
+        // Delete volatile keys, since nobody else can after we drop the key ID.
+        if (!mIsPersistent)
+        {
+            Delete();
+        }
+
         MemoryFree(mContext);
         mContext = nullptr;
     }

--- a/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
+++ b/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
@@ -250,7 +250,7 @@ CHIP_ERROR EFR32OpaqueKeypair::Create(EFR32OpaqueKeyId opaque_id, EFR32OpaqueKey
 
     // Store the key ID and mark the key as valid
     mHasKey       = true;
-    mIsPersistent = key_id != kEFR32OpaqueKeyIdVolatile;
+    mIsPersistent = opaque_id != kEFR32OpaqueKeyIdVolatile;
 
 exit:
     psa_reset_key_attributes(&attr);


### PR DESCRIPTION
#### Problem

- Volatile keys were not correctly removed from the PSA Crypto backend upon destruction of their containing object

#### Change overview

- Volatile keys are now correctly removed from the PSA Crypto backend before dropping the associated key ID from memory.

#### Testing

- Manually tested by @jmartinez-silabs 
