### PR TITLE
[EFR32] Opaque keypair bugfixes.

### DIFF
--- a/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
+++ b/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
@@ -118,9 +118,15 @@ EFR32OpaqueKeypair::EFR32OpaqueKeypair()
 
 EFR32OpaqueKeypair::~EFR32OpaqueKeypair()
 {
-    // Free dynamic resource
+    // Free key resources
     if (mContext != nullptr)
     {
+        // Delete volatile keys, since nobody else can after we drop the key ID.
+        if (!mIsPersistent)
+        {
+            Delete();
+        }
+
         MemoryFree(mContext);
         mContext = nullptr;
     }
@@ -244,7 +250,7 @@ CHIP_ERROR EFR32OpaqueKeypair::Create(EFR32OpaqueKeyId opaque_id, EFR32OpaqueKey
 
     // Store the key ID and mark the key as valid
     mHasKey       = true;
-    mIsPersistent = key_id != kEFR32OpaqueKeyIdVolatile;
+    mIsPersistent = opaque_id != kEFR32OpaqueKeyIdVolatile;
 
 exit:
     psa_reset_key_attributes(&attr);


### PR DESCRIPTION
#### Problem
Errors found on Efr32PsaOpaqueKeypair:
* The destructor in EFR32OpaqueKeypair did not remove volatile keys from the PSA RAM storage.
* mIsPersistent set error in EFR32OpaqueKeypair::Create().

#### Change overview
Found errors fixed.

#### Testing
Tested on EFR32MG12.
