### PR TITLE
Add FailRandomlyAtFault command to Fault Injection cluster

### DIFF
--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -3850,7 +3850,14 @@ server cluster FaultInjection = 4294048774 {
     BOOLEAN takeMutex = 4;
   }
 
+  request struct FailRandomlyAtFaultRequest {
+    FaultType type = 0;
+    INT32U id = 1;
+    INT8U percentage = 2;
+  }
+
   command access(invoke: manage) FailAtFault(FailAtFaultRequest): DefaultSuccess = 0;
+  command access(invoke: manage) FailRandomlyAtFault(FailRandomlyAtFaultRequest): DefaultSuccess = 1;
 }
 
 endpoint 0 {

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.zap
@@ -8461,6 +8461,14 @@
               "source": "client",
               "incoming": 1,
               "outgoing": 1
+            },
+            {
+              "name": "FailRandomlyAtFault",
+              "code": 1,
+              "mfgCode": null,
+              "source": "client",
+              "incoming": 1,
+              "outgoing": 0
             }
           ],
           "attributes": [

--- a/src/app/clusters/fault-injection-server/fault-injection-server.cpp
+++ b/src/app/clusters/fault-injection-server/fault-injection-server.cpp
@@ -36,6 +36,34 @@ using namespace chip::app;
 using namespace chip::app::Clusters::FaultInjection;
 using chip::Protocols::InteractionModel::Status;
 
+namespace {
+
+#if CHIP_WITH_NLFAULTINJECTION
+nl::FaultInjection::Manager * GetFaultInjectionManager(FaultType type)
+{
+    nl::FaultInjection::Manager * faultInjectionMgr = nullptr;
+
+    switch (type)
+    {
+    case FaultType::kSystemFault:
+        faultInjectionMgr = &chip::System::FaultInjection::GetManager();
+        break;
+    case FaultType::kInetFault:
+        faultInjectionMgr = &chip::Inet::FaultInjection::GetManager();
+        break;
+    case FaultType::kChipFault:
+        faultInjectionMgr = &chip::FaultInjection::GetManager();
+        break;
+    default:
+        break;
+    }
+
+    return faultInjectionMgr;
+}
+#endif
+
+} // anonymous namespace
+
 bool emberAfFaultInjectionClusterFailAtFaultCallback(CommandHandler * commandObj, const ConcreteCommandPath & commandPath,
                                                      const Commands::FailAtFault::DecodableType & commandData)
 {
@@ -48,24 +76,7 @@ bool emberAfFaultInjectionClusterFailAtFaultCallback(CommandHandler * commandObj
 
 #if CHIP_WITH_NLFAULTINJECTION
     Status returnStatus                             = Status::Success;
-    nl::FaultInjection::Manager * faultInjectionMgr = nullptr;
-
-    switch (commandData.type)
-    {
-    case FaultType::kSystemFault:
-        faultInjectionMgr = &chip::System::FaultInjection::GetManager();
-        break;
-    case FaultType::kInetFault:
-        faultInjectionMgr = &chip::Inet::FaultInjection::GetManager();
-        break;
-    case FaultType::kChipFault:
-        faultInjectionMgr = &chip::FaultInjection::GetManager();
-        break;
-    default:
-        ChipLogError(Zcl, "FaultInjection: Unsupported Fault type received");
-        returnStatus = Status::InvalidCommand;
-        break;
-    }
+    nl::FaultInjection::Manager * faultInjectionMgr = GetFaultInjectionManager(commandData.type);
 
     if (faultInjectionMgr != nullptr)
     {
@@ -111,24 +122,7 @@ bool emberAfFaultInjectionClusterFailRandomlyAtFaultCallback(CommandHandler * co
 
 #if CHIP_WITH_NLFAULTINJECTION
     Status returnStatus                             = Status::Success;
-    nl::FaultInjection::Manager * faultInjectionMgr = nullptr;
-
-    switch (commandData.type)
-    {
-    case FaultType::kSystemFault:
-        faultInjectionMgr = &chip::System::FaultInjection::GetManager();
-        break;
-    case FaultType::kInetFault:
-        faultInjectionMgr = &chip::Inet::FaultInjection::GetManager();
-        break;
-    case FaultType::kChipFault:
-        faultInjectionMgr = &chip::FaultInjection::GetManager();
-        break;
-    default:
-        ChipLogError(Zcl, "FaultInjection: Unsupported Fault type received");
-        returnStatus = Status::InvalidCommand;
-        break;
-    }
+    nl::FaultInjection::Manager * faultInjectionMgr = GetFaultInjectionManager(commandData.type);
 
     if (faultInjectionMgr != nullptr)
     {

--- a/src/app/zap-templates/zcl/data-model/chip/fault-injection-cluster.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/fault-injection-cluster.xml
@@ -39,5 +39,12 @@ limitations under the License.
       <arg name="TakeMutex" type="BOOLEAN"/>      
       <access op="invoke" role="manage"/>
     </command>
+    <command source="client" code="0x01" name="FailRandomlyAtFault" optional="false">
+      <description>Configure a fault to be triggered randomly, with a given probability defined as a percentage</description>
+      <arg name="Type" type="FaultType"/>      
+      <arg name="Id" type="INT32U"/>
+      <arg name="Percentage" type="INT8U"/>   
+      <access op="invoke" role="manage"/>
+    </command>    
   </cluster>
 </configurator>

--- a/src/controller/python/chip/clusters/Objects.py
+++ b/src/controller/python/chip/clusters/Objects.py
@@ -29040,6 +29040,25 @@ class FaultInjection(Cluster):
             numCallsToFail: 'uint' = 0
             takeMutex: 'bool' = False
 
+        @dataclass
+        class FailRandomlyAtFault(ClusterCommand):
+            cluster_id: typing.ClassVar[int] = 0xFFF1FC06
+            command_id: typing.ClassVar[int] = 0x0001
+            is_client: typing.ClassVar[bool] = True
+
+            @ChipUtility.classproperty
+            def descriptor(cls) -> ClusterObjectDescriptor:
+                return ClusterObjectDescriptor(
+                    Fields = [
+                            ClusterObjectFieldDescriptor(Label="type", Tag=0, Type=FaultInjection.Enums.FaultType),
+                            ClusterObjectFieldDescriptor(Label="id", Tag=1, Type=uint),
+                            ClusterObjectFieldDescriptor(Label="percentage", Tag=2, Type=uint),
+                    ])
+
+            type: 'FaultInjection.Enums.FaultType' = 0
+            id: 'uint' = 0
+            percentage: 'uint' = 0
+
 
     class Attributes:
         @dataclass

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -21998,6 +21998,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)failAtFaultWithParams:(MTRFaultInjectionClusterFailAtFaultParams *)params
             completionHandler:(StatusCompletion)completionHandler;
+- (void)failRandomlyAtFaultWithParams:(MTRFaultInjectionClusterFailRandomlyAtFaultParams *)params
+                    completionHandler:(StatusCompletion)completionHandler;
 
 - (void)readAttributeGeneratedCommandListWithCompletionHandler:(void (^)(NSArray * _Nullable value,
                                                                    NSError * _Nullable error))completionHandler;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -1702,6 +1702,7 @@ typedef NS_ENUM(uint32_t, MTRClusterCommandIDType) {
 
     // Cluster FaultInjection commands
     MTRClusterFaultInjectionCommandFailAtFaultID = 0x00000000,
+    MTRClusterFaultInjectionCommandFailRandomlyAtFaultID = 0x00000001,
 
 };
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -5297,6 +5297,10 @@ NS_ASSUME_NONNULL_BEGIN
                expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
         expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
             completionHandler:(StatusCompletion)completionHandler;
+- (void)failRandomlyAtFaultWithParams:(MTRFaultInjectionClusterFailRandomlyAtFaultParams *)params
+                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
+                expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
+                    completionHandler:(StatusCompletion)completionHandler;
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params;
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -6078,5 +6078,31 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(nullable NSZone *)zone;
 @end
+@interface MTRFaultInjectionClusterFailRandomlyAtFaultParams : NSObject <NSCopying>
+
+@property (nonatomic, copy) NSNumber * _Nonnull type;
+
+@property (nonatomic, copy) NSNumber * _Nonnull id;
+
+@property (nonatomic, copy) NSNumber * _Nonnull percentage;
+/**
+ * Controls whether the command is a timed command (using Timed Invoke).
+ *
+ * If nil (the default value), a regular invoke is done for commands that do
+ * not require a timed invoke and a timed invoke with some default timed request
+ * timeout is done for commands that require a timed invoke.
+ *
+ * If not nil, a timed invoke is done, with the provided value used as the timed
+ * request timeout.  The value should be chosen small enough to provide the
+ * desired security properties but large enough that it will allow a round-trip
+ * from the sever to the client (for the status response and actual invoke
+ * request) within the timeout window.
+ *
+ */
+@property (nonatomic, copy, nullable) NSNumber * timedInvokeTimeoutMs;
+
+- (instancetype)init;
+- (id)copyWithZone:(nullable NSZone *)zone;
+@end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -8158,5 +8158,40 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
+@implementation MTRFaultInjectionClusterFailRandomlyAtFaultParams
+- (instancetype)init
+{
+    if (self = [super init]) {
+
+        _type = @(0);
+
+        _id = @(0);
+
+        _percentage = @(0);
+        _timedInvokeTimeoutMs = nil;
+    }
+    return self;
+}
+
+- (id)copyWithZone:(nullable NSZone *)zone;
+{
+    auto other = [[MTRFaultInjectionClusterFailRandomlyAtFaultParams alloc] init];
+
+    other.type = self.type;
+    other.id = self.id;
+    other.percentage = self.percentage;
+    other.timedInvokeTimeoutMs = self.timedInvokeTimeoutMs;
+
+    return other;
+}
+
+- (NSString *)description
+{
+    NSString * descriptionString = [NSString
+        stringWithFormat:@"<%@: type:%@; id:%@; percentage:%@; >", NSStringFromClass([self class]), _type, _id, _percentage];
+    return descriptionString;
+}
+
+@end
 
 NS_ASSUME_NONNULL_END

--- a/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
+++ b/zzz_generated/all-clusters-app/zap-generated/IMClusterCommandHandler.cpp
@@ -591,6 +591,15 @@ void DispatchServerCommand(CommandHandler * apCommandObj, const ConcreteCommandP
             }
             break;
         }
+        case Commands::FailRandomlyAtFault::Id: {
+            Commands::FailRandomlyAtFault::DecodableType commandData;
+            TLVError = DataModel::Decode(aDataTlv, commandData);
+            if (TLVError == CHIP_NO_ERROR)
+            {
+                wasHandled = emberAfFaultInjectionClusterFailRandomlyAtFaultCallback(apCommandObj, aCommandPath, commandData);
+            }
+            break;
+        }
         default: {
             // Unrecognized command ID, error status will apply.
             apCommandObj->AddStatus(aCommandPath, Protocols::InteractionModel::Status::UnsupportedCommand);

--- a/zzz_generated/all-clusters-app/zap-generated/access.h
+++ b/zzz_generated/all-clusters-app/zap-generated/access.h
@@ -431,6 +431,7 @@
     257, /* Cluster: Door Lock, Command: GetCredentialStatus, Privilege: administer */ \
     257, /* Cluster: Door Lock, Command: ClearCredential, Privilege: administer */ \
     4294048774, /* Cluster: Fault Injection, Command: FailAtFault, Privilege: manage */ \
+    4294048774, /* Cluster: Fault Injection, Command: FailRandomlyAtFault, Privilege: manage */ \
 }
 
 // Parallel array data (cluster, *command*, privilege) for invoke command
@@ -482,6 +483,7 @@
     36, /* Cluster: Door Lock, Command: GetCredentialStatus, Privilege: administer */ \
     38, /* Cluster: Door Lock, Command: ClearCredential, Privilege: administer */ \
     0, /* Cluster: Fault Injection, Command: FailAtFault, Privilege: manage */ \
+    1, /* Cluster: Fault Injection, Command: FailRandomlyAtFault, Privilege: manage */ \
 }
 
 // Parallel array data (cluster, command, *privilege*) for invoke command
@@ -533,6 +535,7 @@
     kMatterAccessPrivilegeAdminister, /* Cluster: Door Lock, Command: GetCredentialStatus, Privilege: administer */ \
     kMatterAccessPrivilegeAdminister, /* Cluster: Door Lock, Command: ClearCredential, Privilege: administer */ \
     kMatterAccessPrivilegeManage, /* Cluster: Fault Injection, Command: FailAtFault, Privilege: manage */ \
+    kMatterAccessPrivilegeManage, /* Cluster: Fault Injection, Command: FailRandomlyAtFault, Privilege: manage */ \
 }
 
 ////////////////////////////////////////////////////////////////////////////////

--- a/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
+++ b/zzz_generated/all-clusters-app/zap-generated/endpoint_config.h
@@ -1675,14 +1675,15 @@
   /* Endpoint: 0, Cluster: Fault Injection (server) */\
   /*   AcceptedCommandList (index=76) */ \
   0x00000000 /* FailAtFault */, \
+  0x00000001 /* FailRandomlyAtFault */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Identify (server) */\
-  /*   AcceptedCommandList (index=78) */ \
+  /*   AcceptedCommandList (index=79) */ \
   0x00000000 /* Identify */, \
   0x00000040 /* TriggerEffect */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Groups (server) */\
-  /*   AcceptedCommandList (index=81) */ \
+  /*   AcceptedCommandList (index=82) */ \
   0x00000000 /* AddGroup */, \
   0x00000001 /* ViewGroup */, \
   0x00000002 /* GetGroupMembership */, \
@@ -1690,14 +1691,14 @@
   0x00000004 /* RemoveAllGroups */, \
   0x00000005 /* AddGroupIfIdentifying */, \
   chip::kInvalidCommandId /* end of list */, \
-  /*   GeneratedCommandList (index=88)*/ \
+  /*   GeneratedCommandList (index=89)*/ \
   0x00000000 /* AddGroupResponse */, \
   0x00000001 /* ViewGroupResponse */, \
   0x00000002 /* GetGroupMembershipResponse */, \
   0x00000003 /* RemoveGroupResponse */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Scenes (server) */\
-  /*   AcceptedCommandList (index=93) */ \
+  /*   AcceptedCommandList (index=94) */ \
   0x00000000 /* AddScene */, \
   0x00000001 /* ViewScene */, \
   0x00000002 /* RemoveScene */, \
@@ -1706,7 +1707,7 @@
   0x00000005 /* RecallScene */, \
   0x00000006 /* GetSceneMembership */, \
   chip::kInvalidCommandId /* end of list */, \
-  /*   GeneratedCommandList (index=101)*/ \
+  /*   GeneratedCommandList (index=102)*/ \
   0x00000000 /* AddSceneResponse */, \
   0x00000001 /* ViewSceneResponse */, \
   0x00000002 /* RemoveSceneResponse */, \
@@ -1715,7 +1716,7 @@
   0x00000006 /* GetSceneMembershipResponse */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: On/Off (server) */\
-  /*   AcceptedCommandList (index=108) */ \
+  /*   AcceptedCommandList (index=109) */ \
   0x00000000 /* Off */, \
   0x00000001 /* On */, \
   0x00000002 /* Toggle */, \
@@ -1724,7 +1725,7 @@
   0x00000042 /* OnWithTimedOff */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Level Control (server) */\
-  /*   AcceptedCommandList (index=115) */ \
+  /*   AcceptedCommandList (index=116) */ \
   0x00000000 /* MoveToLevel */, \
   0x00000001 /* Move */, \
   0x00000002 /* Step */, \
@@ -1735,11 +1736,11 @@
   0x00000007 /* StopWithOnOff */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Mode Select (server) */\
-  /*   AcceptedCommandList (index=124) */ \
+  /*   AcceptedCommandList (index=125) */ \
   0x00000000 /* ChangeToMode */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Door Lock (server) */\
-  /*   AcceptedCommandList (index=126) */ \
+  /*   AcceptedCommandList (index=127) */ \
   0x00000000 /* LockDoor */, \
   0x00000001 /* UnlockDoor */, \
   0x00000003 /* UnlockWithTimeout */, \
@@ -1755,7 +1756,7 @@
   0x00000024 /* GetCredentialStatus */, \
   0x00000026 /* ClearCredential */, \
   chip::kInvalidCommandId /* end of list */, \
-  /*   GeneratedCommandList (index=141)*/ \
+  /*   GeneratedCommandList (index=142)*/ \
   0x0000000C /* GetWeekDayScheduleResponse */, \
   0x0000000F /* GetYearDayScheduleResponse */, \
   0x0000001C /* GetUserResponse */, \
@@ -1763,7 +1764,7 @@
   0x00000025 /* GetCredentialStatusResponse */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Window Covering (server) */\
-  /*   AcceptedCommandList (index=147) */ \
+  /*   AcceptedCommandList (index=148) */ \
   0x00000000 /* UpOrOpen */, \
   0x00000001 /* DownOrClose */, \
   0x00000002 /* StopMotion */, \
@@ -1773,16 +1774,16 @@
   0x00000008 /* GoToTiltPercentage */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Barrier Control (server) */\
-  /*   AcceptedCommandList (index=155) */ \
+  /*   AcceptedCommandList (index=156) */ \
   0x00000000 /* BarrierControlGoToPercent */, \
   0x00000001 /* BarrierControlStop */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Thermostat (server) */\
-  /*   AcceptedCommandList (index=158) */ \
+  /*   AcceptedCommandList (index=159) */ \
   0x00000000 /* SetpointRaiseLower */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Color Control (server) */\
-  /*   AcceptedCommandList (index=160) */ \
+  /*   AcceptedCommandList (index=161) */ \
   0x00000000 /* MoveToHue */, \
   0x00000001 /* MoveHue */, \
   0x00000002 /* StepHue */, \
@@ -1804,32 +1805,32 @@
   0x0000004C /* StepColorTemperature */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Target Navigator (server) */\
-  /*   AcceptedCommandList (index=180) */ \
+  /*   AcceptedCommandList (index=181) */ \
   0x00000000 /* NavigateTarget */, \
   chip::kInvalidCommandId /* end of list */, \
-  /*   GeneratedCommandList (index=182)*/ \
+  /*   GeneratedCommandList (index=183)*/ \
   0x00000001 /* NavigateTargetResponse */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Media Input (server) */\
-  /*   AcceptedCommandList (index=184) */ \
+  /*   AcceptedCommandList (index=185) */ \
   0x00000000 /* SelectInput */, \
   0x00000001 /* ShowInputStatus */, \
   0x00000002 /* HideInputStatus */, \
   0x00000003 /* RenameInput */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Low Power (server) */\
-  /*   AcceptedCommandList (index=189) */ \
+  /*   AcceptedCommandList (index=190) */ \
   0x00000000 /* Sleep */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Keypad Input (server) */\
-  /*   AcceptedCommandList (index=191) */ \
+  /*   AcceptedCommandList (index=192) */ \
   0x00000000 /* SendKey */, \
   chip::kInvalidCommandId /* end of list */, \
-  /*   GeneratedCommandList (index=193)*/ \
+  /*   GeneratedCommandList (index=194)*/ \
   0x00000001 /* SendKeyResponse */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 1, Cluster: Test Cluster (server) */\
-  /*   AcceptedCommandList (index=195) */ \
+  /*   AcceptedCommandList (index=196) */ \
   0x00000000 /* Test */, \
   0x00000001 /* TestNotHandled */, \
   0x00000002 /* TestSpecific */, \
@@ -1849,7 +1850,7 @@
   0x00000014 /* TestEmitTestEventRequest */, \
   0x00000015 /* TestEmitTestFabricScopedEventRequest */, \
   chip::kInvalidCommandId /* end of list */, \
-  /*   GeneratedCommandList (index=214)*/ \
+  /*   GeneratedCommandList (index=215)*/ \
   0x00000000 /* TestSpecificResponse */, \
   0x00000001 /* TestAddArgumentsResponse */, \
   0x00000004 /* TestListInt8UReverseResponse */, \
@@ -1861,7 +1862,7 @@
   0x0000000B /* TestEmitTestFabricScopedEventResponse */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 2, Cluster: Groups (server) */\
-  /*   AcceptedCommandList (index=224) */ \
+  /*   AcceptedCommandList (index=225) */ \
   0x00000000 /* AddGroup */, \
   0x00000001 /* ViewGroup */, \
   0x00000002 /* GetGroupMembership */, \
@@ -1869,20 +1870,20 @@
   0x00000004 /* RemoveAllGroups */, \
   0x00000005 /* AddGroupIfIdentifying */, \
   chip::kInvalidCommandId /* end of list */, \
-  /*   GeneratedCommandList (index=231)*/ \
+  /*   GeneratedCommandList (index=232)*/ \
   0x00000000 /* AddGroupResponse */, \
   0x00000001 /* ViewGroupResponse */, \
   0x00000002 /* GetGroupMembershipResponse */, \
   0x00000003 /* RemoveGroupResponse */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 2, Cluster: On/Off (server) */\
-  /*   AcceptedCommandList (index=236) */ \
+  /*   AcceptedCommandList (index=237) */ \
   0x00000000 /* Off */, \
   0x00000001 /* On */, \
   0x00000002 /* Toggle */, \
   chip::kInvalidCommandId /* end of list */, \
   /* Endpoint: 65534, Cluster: Network Commissioning (server) */\
-  /*   AcceptedCommandList (index=240) */ \
+  /*   AcceptedCommandList (index=241) */ \
   0x00000000 /* ScanNetworks */, \
   0x00000002 /* AddOrUpdateWiFiNetwork */, \
   0x00000003 /* AddOrUpdateThreadNetwork */, \
@@ -1890,7 +1891,7 @@
   0x00000006 /* ConnectNetwork */, \
   0x00000008 /* ReorderNetwork */, \
   chip::kInvalidCommandId /* end of list */, \
-  /*   GeneratedCommandList (index=247)*/ \
+  /*   GeneratedCommandList (index=248)*/ \
   0x00000001 /* ScanNetworksResponse */, \
   0x00000005 /* NetworkConfigResponse */, \
   0x00000007 /* ConnectNetworkResponse */, \
@@ -2220,7 +2221,7 @@
       .clusterSize = 9, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(ATTRIBUTE_CHANGED_FUNCTION), \
       .functions = chipFuncArrayIdentifyServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 78 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 79 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2231,8 +2232,8 @@
       .clusterSize = 7, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayGroupsServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 81 ) ,\
-      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 88 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 82 ) ,\
+      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 89 ) ,\
     },\
   { \
       /* Endpoint: 1, Cluster: Scenes (server) */ \
@@ -2242,8 +2243,8 @@
       .clusterSize = 12, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayScenesServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 93 ) ,\
-      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 101 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 94 ) ,\
+      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 102 ) ,\
     },\
   { \
       /* Endpoint: 1, Cluster: On/Off (server) */ \
@@ -2253,7 +2254,7 @@
       .clusterSize = 13, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayOnOffServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 108 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 109 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2275,7 +2276,7 @@
       .clusterSize = 27, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayLevelControlServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 115 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 116 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2385,7 +2386,7 @@
       .clusterSize = 45, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(PRE_ATTRIBUTE_CHANGED_FUNCTION), \
       .functions = chipFuncArrayModeSelectServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 124 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 125 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2396,8 +2397,8 @@
       .clusterSize = 55, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(ATTRIBUTE_CHANGED_FUNCTION) | ZAP_CLUSTER_MASK(PRE_ATTRIBUTE_CHANGED_FUNCTION), \
       .functions = chipFuncArrayDoorLockServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 126 ) ,\
-      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 141 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 127 ) ,\
+      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 142 ) ,\
     },\
   { \
       /* Endpoint: 1, Cluster: Window Covering (server) */ \
@@ -2407,7 +2408,7 @@
       .clusterSize = 43, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(ATTRIBUTE_CHANGED_FUNCTION), \
       .functions = chipFuncArrayWindowCoveringServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 147 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 148 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2418,7 +2419,7 @@
       .clusterSize = 11, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 155 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 156 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2440,7 +2441,7 @@
       .clusterSize = 31, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION) | ZAP_CLUSTER_MASK(PRE_ATTRIBUTE_CHANGED_FUNCTION), \
       .functions = chipFuncArrayThermostatServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 158 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 159 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2473,7 +2474,7 @@
       .clusterSize = 345, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayColorControlServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 160 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 161 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2572,8 +2573,8 @@
       .clusterSize = 7, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 180 ) ,\
-      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 182 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 181 ) ,\
+      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 183 ) ,\
     },\
   { \
       /* Endpoint: 1, Cluster: Media Playback (server) */ \
@@ -2594,7 +2595,7 @@
       .clusterSize = 7, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 184 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 185 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2605,7 +2606,7 @@
       .clusterSize = 6, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 189 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 190 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2616,8 +2617,8 @@
       .clusterSize = 6, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 191 ) ,\
-      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 193 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 192 ) ,\
+      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 194 ) ,\
     },\
   { \
       /* Endpoint: 1, Cluster: Content Launcher (server) */ \
@@ -2693,8 +2694,8 @@
       .clusterSize = 2289, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 195 ) ,\
-      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 214 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 196 ) ,\
+      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 215 ) ,\
     },\
   { \
       /* Endpoint: 2, Cluster: Groups (server) */ \
@@ -2704,8 +2705,8 @@
       .clusterSize = 7, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayGroupsServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 224 ) ,\
-      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 231 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 225 ) ,\
+      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 232 ) ,\
     },\
   { \
       /* Endpoint: 2, Cluster: On/Off (server) */ \
@@ -2715,7 +2716,7 @@
       .clusterSize = 13, \
       .mask = ZAP_CLUSTER_MASK(SERVER) | ZAP_CLUSTER_MASK(INIT_FUNCTION), \
       .functions = chipFuncArrayOnOffServer, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 236 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 237 ) ,\
       .generatedCommandList = nullptr ,\
     },\
   { \
@@ -2759,8 +2760,8 @@
       .clusterSize = 0, \
       .mask = ZAP_CLUSTER_MASK(SERVER), \
       .functions = NULL, \
-      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 240 ) ,\
-      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 247 ) ,\
+      .acceptedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 241 ) ,\
+      .generatedCommandList = ZAP_GENERATED_COMMANDS_INDEX( 248 ) ,\
     },\
 }
 

--- a/zzz_generated/app-common/app-common/zap-generated/callback.h
+++ b/zzz_generated/app-common/app-common/zap-generated/callback.h
@@ -8919,6 +8919,12 @@ bool emberAfTestClusterClusterTestEmitTestFabricScopedEventRequestCallback(
 bool emberAfFaultInjectionClusterFailAtFaultCallback(
     chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
     const chip::app::Clusters::FaultInjection::Commands::FailAtFault::DecodableType & commandData);
+/**
+ * @brief Fault Injection Cluster FailRandomlyAtFault Command callback (from client)
+ */
+bool emberAfFaultInjectionClusterFailRandomlyAtFaultCallback(
+    chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
+    const chip::app::Clusters::FaultInjection::Commands::FailRandomlyAtFault::DecodableType & commandData);
 
 /** @brief Add To Current App Tasks
  *

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.cpp
@@ -20939,6 +20939,51 @@ CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
     return CHIP_NO_ERROR;
 }
 } // namespace FailAtFault.
+namespace FailRandomlyAtFault {
+CHIP_ERROR Type::Encode(TLV::TLVWriter & writer, TLV::Tag tag) const
+{
+    TLV::TLVType outer;
+    ReturnErrorOnFailure(writer.StartContainer(tag, TLV::kTLVType_Structure, outer));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kType)), type));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kId)), id));
+    ReturnErrorOnFailure(DataModel::Encode(writer, TLV::ContextTag(to_underlying(Fields::kPercentage)), percentage));
+    ReturnErrorOnFailure(writer.EndContainer(outer));
+    return CHIP_NO_ERROR;
+}
+
+CHIP_ERROR DecodableType::Decode(TLV::TLVReader & reader)
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+    TLV::TLVType outer;
+    VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_WRONG_TLV_TYPE);
+    ReturnErrorOnFailure(reader.EnterContainer(outer));
+    while ((err = reader.Next()) == CHIP_NO_ERROR)
+    {
+        if (!TLV::IsContextTag(reader.GetTag()))
+        {
+            continue;
+        }
+        switch (TLV::TagNumFromTag(reader.GetTag()))
+        {
+        case to_underlying(Fields::kType):
+            ReturnErrorOnFailure(DataModel::Decode(reader, type));
+            break;
+        case to_underlying(Fields::kId):
+            ReturnErrorOnFailure(DataModel::Decode(reader, id));
+            break;
+        case to_underlying(Fields::kPercentage):
+            ReturnErrorOnFailure(DataModel::Decode(reader, percentage));
+            break;
+        default:
+            break;
+        }
+    }
+
+    VerifyOrReturnError(err == CHIP_END_OF_TLV, err);
+    ReturnErrorOnFailure(reader.ExitContainer(outer));
+    return CHIP_NO_ERROR;
+}
+} // namespace FailRandomlyAtFault.
 } // namespace Commands
 
 namespace Attributes {

--- a/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
+++ b/zzz_generated/app-common/app-common/zap-generated/cluster-objects.h
@@ -28095,6 +28095,11 @@ struct Type;
 struct DecodableType;
 } // namespace FailAtFault
 
+namespace FailRandomlyAtFault {
+struct Type;
+struct DecodableType;
+} // namespace FailRandomlyAtFault
+
 } // namespace Commands
 
 namespace Commands {
@@ -28142,6 +28147,44 @@ public:
     CHIP_ERROR Decode(TLV::TLVReader & reader);
 };
 }; // namespace FailAtFault
+namespace FailRandomlyAtFault {
+enum class Fields
+{
+    kType       = 0,
+    kId         = 1,
+    kPercentage = 2,
+};
+
+struct Type
+{
+public:
+    // Use GetCommandId instead of commandId directly to avoid naming conflict with CommandIdentification in ExecutionOfACommand
+    static constexpr CommandId GetCommandId() { return Commands::FailRandomlyAtFault::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::FaultInjection::Id; }
+
+    FaultType type     = static_cast<FaultType>(0);
+    uint32_t id        = static_cast<uint32_t>(0);
+    uint8_t percentage = static_cast<uint8_t>(0);
+
+    CHIP_ERROR Encode(TLV::TLVWriter & writer, TLV::Tag tag) const;
+
+    using ResponseType = DataModel::NullObjectType;
+
+    static constexpr bool MustUseTimedInvoke() { return false; }
+};
+
+struct DecodableType
+{
+public:
+    static constexpr CommandId GetCommandId() { return Commands::FailRandomlyAtFault::Id; }
+    static constexpr ClusterId GetClusterId() { return Clusters::FaultInjection::Id; }
+
+    FaultType type     = static_cast<FaultType>(0);
+    uint32_t id        = static_cast<uint32_t>(0);
+    uint8_t percentage = static_cast<uint8_t>(0);
+    CHIP_ERROR Decode(TLV::TLVReader & reader);
+};
+}; // namespace FailRandomlyAtFault
 } // namespace Commands
 
 namespace Attributes {

--- a/zzz_generated/app-common/app-common/zap-generated/command-id.h
+++ b/zzz_generated/app-common/app-common/zap-generated/command-id.h
@@ -355,3 +355,4 @@
 
 // Commands for cluster: Fault Injection
 #define ZCL_FAIL_AT_FAULT_COMMAND_ID (0x00)
+#define ZCL_FAIL_RANDOMLY_AT_FAULT_COMMAND_ID (0x01)

--- a/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h
+++ b/zzz_generated/app-common/app-common/zap-generated/ids/Commands.h
@@ -1240,6 +1240,10 @@ namespace FailAtFault {
 static constexpr CommandId Id = 0x00000000;
 } // namespace FailAtFault
 
+namespace FailRandomlyAtFault {
+static constexpr CommandId Id = 0x00000001;
+} // namespace FailRandomlyAtFault
+
 } // namespace Commands
 } // namespace FaultInjection
 

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -8149,6 +8149,7 @@ private:
 |------------------------------------------------------------------------------|
 | Commands:                                                           |        |
 | * FailAtFault                                                       |   0x00 |
+| * FailRandomlyAtFault                                               |   0x01 |
 |------------------------------------------------------------------------------|
 | Attributes:                                                         |        |
 | * GeneratedCommandList                                              | 0xFFF8 |
@@ -8192,6 +8193,39 @@ public:
 
 private:
     chip::app::Clusters::FaultInjection::Commands::FailAtFault::Type mRequest;
+};
+
+/*
+ * Command FailRandomlyAtFault
+ */
+class FaultInjectionFailRandomlyAtFault : public ClusterCommand
+{
+public:
+    FaultInjectionFailRandomlyAtFault(CredentialIssuerCommands * credsIssuerConfig) :
+        ClusterCommand("fail-randomly-at-fault", credsIssuerConfig)
+    {
+        AddArgument("Type", 0, UINT8_MAX, &mRequest.type);
+        AddArgument("Id", 0, UINT32_MAX, &mRequest.id);
+        AddArgument("Percentage", 0, UINT8_MAX, &mRequest.percentage);
+        ClusterCommand::AddArguments();
+    }
+
+    CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endpointIds) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0xFFF1FC06) command (0x00000001) on endpoint %u", endpointIds.at(0));
+
+        return ClusterCommand::SendCommand(device, endpointIds.at(0), 0xFFF1FC06, 0x00000001, mRequest);
+    }
+
+    CHIP_ERROR SendGroupCommand(chip::GroupId groupId, chip::FabricIndex fabricIndex) override
+    {
+        ChipLogProgress(chipTool, "Sending cluster (0xFFF1FC06) command (0x00000001) on Group %u", groupId);
+
+        return ClusterCommand::SendGroupCommand(groupId, fabricIndex, 0xFFF1FC06, 0x00000001, mRequest);
+    }
+
+private:
+    chip::app::Clusters::FaultInjection::Commands::FailRandomlyAtFault::Type mRequest;
 };
 
 /*----------------------------------------------------------------------------*\
@@ -13266,8 +13300,9 @@ void registerClusterFaultInjection(Commands & commands, CredentialIssuerCommands
         //
         // Commands
         //
-        make_unique<ClusterCommand>(Id, credsIssuerConfig),        //
-        make_unique<FaultInjectionFailAtFault>(credsIssuerConfig), //
+        make_unique<ClusterCommand>(Id, credsIssuerConfig),                //
+        make_unique<FaultInjectionFailAtFault>(credsIssuerConfig),         //
+        make_unique<FaultInjectionFailRandomlyAtFault>(credsIssuerConfig), //
         //
         // Attributes
         //


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
*  Missing FailRandomlyAtFault command in Fault Injection cluster,  this command allow test harness to configure a fault to be triggered randomly, with a given probability defined as a percentage, this is meant to be used on live systems to generate a build that will encounter random failures.

* Fixes #21941

#### Change overview
Add FailRandomlyAtFault command to Fault Injection cluster

#### Testing
How was this tested? (at least one bullet point required)
* Build all-clusters-app with nlfaultinjection enabled
`scripts/examples/gn_build_example.sh examples/all-clusters-app/linux out/debug/standalone chip_config_network_layer_ble=false chip_with_nlfaultinjection=true`

* Configure a system fault from chip_tool
`./chip-tool faultinjection fail-randomly-at-fault 1 1 45 12344321 0`

* Confirm the fault is activated from all-clusters-app log
```
[1660840083.976320][3208798:3208798] CHIP:EM: Received message of type 0x8 with protocolId (0, 1) and MessageCounter:110067918 on exchange 46251r
[1660840083.976342][3208798:3208798] CHIP:EM: Handling via exchange: 46251r, Delegate: 0x5599f60e2928
[1660840083.976382][3208798:3208798] CHIP:DMG: InvokeRequestMessage =
[1660840083.976395][3208798:3208798] CHIP:DMG: {
[1660840083.976409][3208798:3208798] CHIP:DMG: 	suppressResponse = false, 
[1660840083.976422][3208798:3208798] CHIP:DMG: 	timedRequest = false, 
[1660840083.976435][3208798:3208798] CHIP:DMG: 	InvokeRequests =
[1660840083.976454][3208798:3208798] CHIP:DMG: 	[
[1660840083.976466][3208798:3208798] CHIP:DMG: 		CommandDataIB =
[1660840083.976480][3208798:3208798] CHIP:DMG: 		{
[1660840083.976492][3208798:3208798] CHIP:DMG: 			CommandPathIB =
[1660840083.976506][3208798:3208798] CHIP:DMG: 			{
[1660840083.976520][3208798:3208798] CHIP:DMG: 				EndpointId = 0x0,
[1660840083.976534][3208798:3208798] CHIP:DMG: 				ClusterId = 0xfff1fc06,
[1660840083.976548][3208798:3208798] CHIP:DMG: 				CommandId = 0x1,
[1660840083.976560][3208798:3208798] CHIP:DMG: 			},
[1660840083.976575][3208798:3208798] CHIP:DMG: 			
[1660840083.976588][3208798:3208798] CHIP:DMG: 			CommandFields = 
[1660840083.976602][3208798:3208798] CHIP:DMG: 			{
[1660840083.976617][3208798:3208798] CHIP:DMG: 				0x0 = 1, 
[1660840083.976631][3208798:3208798] CHIP:DMG: 				0x1 = 1, 
[1660840083.976645][3208798:3208798] CHIP:DMG: 				0x2 = 45, 
[1660840083.976659][3208798:3208798] CHIP:DMG: 			},
[1660840083.976671][3208798:3208798] CHIP:DMG: 		},
[1660840083.976689][3208798:3208798] CHIP:DMG: 		
[1660840083.976700][3208798:3208798] CHIP:DMG: 	],
[1660840083.976718][3208798:3208798] CHIP:DMG: 	
[1660840083.976730][3208798:3208798] CHIP:DMG: 	InteractionModelRevision = 1
[1660840083.976742][3208798:3208798] CHIP:DMG: },
[1660840083.976788][3208798:3208798] CHIP:DMG: AccessControl: checking f=1 a=c s=0x000000000001B669 t= c=0xFFF1_FC06 e=0 p=m
[1660840083.976808][3208798:3208798] CHIP:DMG: AccessControl: allowed
[1660840083.976824][3208798:3208798] CHIP:DMG: Received command for Endpoint=0 Cluster=0xFFF1_FC06 Command=0x0000_0001
[1660840083.976845][3208798:3208798] CHIP:ZCL: FaultInjection: Configure a fault of type: 1 and Id: 1 to be triggered randomly

```