### PR TITLE
follow-up for fabric-scoped event

### DIFF
--- a/src/app/EventLogging.h
+++ b/src/app/EventLogging.h
@@ -73,7 +73,7 @@ CHIP_ERROR LogEvent(const T & aEventData, EndpointId aEndpoint, EventNumber & aE
     eventOptions.mPriority    = aEventData.GetPriorityLevel();
     eventOptions.mFabricIndex = aEventData.GetFabricIndex();
     // this skips logging the event if it's fabric-scoped but no fabric association exists yet.
-    VerifyOrReturnError(eventOptions.mFabricIndex != kUndefinedFabricIndex, CHIP_NO_ERROR);
+    VerifyOrReturnError(eventOptions.mFabricIndex != kUndefinedFabricIndex, CHIP_ERROR_INVALID_FABRIC_INDEX);
 
     //
     // Unlike attributes which have a different 'EncodeForRead' for fabric-scoped structs,

--- a/src/controller/python/test/test_scripts/cluster_objects.py
+++ b/src/controller/python/test/test_scripts/cluster_objects.py
@@ -313,8 +313,6 @@ class ClusterObjectTests:
         await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestEventRequest())
         await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestEventRequest())
         await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestEventRequest())
-        await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestFabricScopedEventRequest(arg1=0))
-        await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestFabricScopedEventRequest(arg1=1))
 
     @classmethod
     async def _RetryForContent(cls, request, until, retryCount=10, intervalSeconds=1):
@@ -335,11 +333,19 @@ class ClusterObjectTests:
     @base.test_case
     async def TestGenerateUndefinedFabricScopedEventRequests(cls, devCtrl):
         logger.info("Running TestGenerateUndefinedFabricScopedEventRequests")
-        await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestFabricScopedEventRequest(arg1=0))
+        try:
+            res = await devCtrl.SendCommand(nodeid=NODE_ID, endpoint=1, payload=Clusters.TestCluster.Commands.TestEmitTestFabricScopedEventRequest(arg1=0))
+            raise ValueError(f"Unexpected Failure")
+        except chip.interaction_model.InteractionModelError as ex:
+            logger.info(f"Recevied {ex} from server.")
         res = await devCtrl.ReadEvent(nodeid=NODE_ID, events=[
-            (1, Clusters.TestCluster.Events.TestEvent, 0),
+            (1, Clusters.TestCluster.Events.TestFabricScopedEvent, 0),
         ])
         logger.info(f"return result is {res}")
+        if len(res) != 0:
+            raise AssertionError("failure: not expect to receive fabric-scoped event when fabric is undefined")
+        else:
+            logger.info("TestGenerateUndefinedFabricScopedEventRequests: Success")
 
     @classmethod
     @base.test_case


### PR DESCRIPTION
#### Problem
follow-up for fabric-scoped event

#### Change overview
Return the error when logging fabric scoped event and fabric is undefined.
Fix the test

#### Testing
Fix the test that validated the fabric-scoped event cannot be logged when fabric is undefined.