### PR TITLE
Add a recursive submodule checkout for cloudbuild builds

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,10 +1,10 @@
 steps:
     - name: gcr.io/cloud-builders/git
       args:
-        - submodule
-        - update
-        - '--init'
-        - '--recursive'
+          - submodule
+          - update
+          - "--init"
+          - "--recursive"
       id: Submodules
     - name: "connectedhomeip/chip-build-vscode:0.5.91"
       env:

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -1,4 +1,11 @@
 steps:
+    - name: gcr.io/cloud-builders/git
+      args:
+        - submodule
+        - update
+        - '--init'
+        - '--recursive'
+      id: Submodules
     - name: "connectedhomeip/chip-build-vscode:0.5.91"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -6,6 +13,8 @@ steps:
           - "-c"
           - source ./scripts/bootstrap.sh
       id: Bootstrap
+      waitFor:
+          - Submodules
       entrypoint: /usr/bin/bash
       volumes:
           - name: pwenv

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,10 +1,10 @@
 steps:
     - name: gcr.io/cloud-builders/git
       args:
-        - submodule
-        - update
-        - '--init'
-        - '--recursive'
+          - submodule
+          - update
+          - "--init"
+          - "--recursive"
       id: Submodules
     - name: "connectedhomeip/chip-build-vscode:0.5.91"
       env:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,4 +1,11 @@
 steps:
+    - name: gcr.io/cloud-builders/git
+      args:
+        - submodule
+        - update
+        - '--init'
+        - '--recursive'
+      id: Submodules
     - name: "connectedhomeip/chip-build-vscode:0.5.91"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -6,6 +13,8 @@ steps:
           - "-c"
           - source ./scripts/bootstrap.sh
       id: Bootstrap
+      waitFor:
+          - Submodules
       entrypoint: /usr/bin/bash
       volumes:
           - name: pwenv


### PR DESCRIPTION
#### Problem
after #21836, the openthread library for EFR32 is in a submodule of a submodule. This requires recursive submodule updates, which cloudbuild does not do.

#### Change overview
Add a step for recursive submodule update as part of cloudbuild and make bootstrap wait for it.

#### Testing
Manually tested a EFR32 build using these steps and it passed.