### PR TITLE
Python CAT Value support for Controllers

### DIFF
--- a/src/controller/python/chip/FabricAdmin.py
+++ b/src/controller/python/chip/FabricAdmin.py
@@ -73,7 +73,7 @@ class FabricAdmin:
         self._isActive = True
         self._activeControllers = []
 
-    def NewController(self, nodeId: int = None, paaTrustStorePath: str = "", useTestCommissioner: bool = False):
+    def NewController(self, nodeId: int = None, paaTrustStorePath: str = "", useTestCommissioner: bool = False, catTags: List[int] = []):
         ''' Create a new chip.ChipDeviceCtrl.ChipDeviceController instance on this fabric.
 
             When vending ChipDeviceController instances on a given fabric, each controller instance
@@ -85,12 +85,13 @@ class FabricAdmin:
 
             paaTrustStorePath:      Path to the PAA trust store. If one isn't provided, a suitable default is selected.
             useTestCommissioner:    If a test commmisioner is to be created.
+            catTags:			    A list of CAT tags that will added to the NOC generated for this controller.
         '''
         if (not(self._isActive)):
             raise RuntimeError(
                 f"FabricAdmin object was previously shutdown and is no longer valid!")
 
-        nodeIdList = [controller.nodeId for controller in self._activeControllers]
+        nodeIdList = [controller.nodeId for controller in self._activeControllers if controller.isActive]
         if (nodeId is None):
             if (len(nodeIdList) != 0):
                 nodeId = max(nodeIdList) + 1
@@ -103,8 +104,8 @@ class FabricAdmin:
         self.logger().warning(
             f"Allocating new controller with CaIndex: {self._certificateAuthority.caIndex}, FabricId: 0x{self._fabricId:016X}, NodeId: 0x{nodeId:016X}")
 
-        controller = ChipDeviceCtrl.ChipDeviceController(
-            self._certificateAuthority.GetOpCredsContext(), self._fabricId, nodeId, self._vendorId, paaTrustStorePath, useTestCommissioner, fabricAdmin=self)
+        controller = ChipDeviceCtrl.ChipDeviceController(opCredsContext=self._certificateAuthority.GetOpCredsContext(), fabricId=self._fabricId, nodeId=nodeId,
+                                                         adminVendorId=self._vendorId, paaTrustStorePath=paaTrustStorePath, useTestCommissioner=useTestCommissioner, fabricAdmin=self, catTags=catTags)
 
         self._activeControllers.append(controller)
         return controller

--- a/src/controller/python/chip/FabricAdmin.py
+++ b/src/controller/python/chip/FabricAdmin.py
@@ -85,7 +85,7 @@ class FabricAdmin:
 
             paaTrustStorePath:      Path to the PAA trust store. If one isn't provided, a suitable default is selected.
             useTestCommissioner:    If a test commmisioner is to be created.
-            catTags:			    A list of CAT tags that will added to the NOC generated for this controller.
+            catTags:			    A list of 32-bit CAT tags that will added to the NOC generated for this controller.
         '''
         if (not(self._isActive)):
             raise RuntimeError(

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -391,7 +391,7 @@ class BaseTestHelper:
         '''
 
         # Allocate a new controller instance with a CAT tag.
-        newController = self.fabricAdmin.NewController(nodeId=300, catTags=[0xFFFFFFFD00010001])
+        newController = self.fabricAdmin.NewController(nodeId=300, catTags=[0x00010001])
 
         # Read out an attribute using the new controller. It has no privileges, so this should fail with an UnsupportedAccess error.
         res = await newController.ReadAttribute(nodeid=nodeid, attributes=[(0, Clusters.AccessControl.Attributes.Acl)])

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -386,6 +386,37 @@ class BaseTestHelper:
             return True
         return False
 
+    async def TestControllerCATValues(self, nodeid: int):
+        ''' This tests controllers using CAT Values
+        '''
+
+        # Allocate a new controller instance with a CAT tag.
+        newController = self.fabricAdmin.NewController(nodeId=300, catTags=[0xFFFFFFFD00010001])
+
+        # Read out an attribute using the new controller. It has no privileges, so this should fail with an UnsupportedAccess error.
+        res = await newController.ReadAttribute(nodeid=nodeid, attributes=[(0, Clusters.AccessControl.Attributes.Acl)])
+        if(res[0][Clusters.AccessControl][Clusters.AccessControl.Attributes.Acl].Reason.status != IM.Status.UnsupportedAccess):
+            self.logger.error(f"1: Received data instead of an error:{res}")
+            return False
+
+        # Do a read-modify-write operation on the ACL list to add the CAT tag to the ACL list.
+        aclList = (await self.devCtrl.ReadAttribute(nodeid, [(0, Clusters.AccessControl.Attributes.Acl)]))[0][Clusters.AccessControl][Clusters.AccessControl.Attributes.Acl]
+        origAclList = copy.deepcopy(aclList)
+        aclList[0].subjects.append(0xFFFFFFFD00010001)
+        await self.devCtrl.WriteAttribute(nodeid, [(0, Clusters.AccessControl.Attributes.Acl(aclList))])
+
+        # Read out the attribute again - this time, it should succeed.
+        res = await newController.ReadAttribute(nodeid=nodeid, attributes=[(0, Clusters.AccessControl.Attributes.Acl)])
+        if (type(res[0][Clusters.AccessControl][Clusters.AccessControl.Attributes.Acl][0]) != Clusters.AccessControl.Structs.AccessControlEntry):
+            self.logger.error(f"2: Received something other than data:{res}")
+            return False
+
+        # Write back the old entry to reset ACL list back.
+        await self.devCtrl.WriteAttribute(nodeid, [(0, Clusters.AccessControl.Attributes.Acl(origAclList))])
+        newController.Shutdown()
+
+        return True
+
     async def TestMultiControllerFabric(self, nodeid: int):
         ''' This tests having multiple controller instances on the same fabric.
         '''

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -77,6 +77,9 @@ def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: 
     logger.info("Testing multi-controller setup on the same fabric")
     FailIfNot(asyncio.run(test.TestMultiControllerFabric(nodeid=device_nodeid)), "Failed the multi-controller test")
 
+    logger.info("Testing CATs used on controllers")
+    FailIfNot(asyncio.run(test.TestControllerCATValues(nodeid=device_nodeid)), "Failed the controller CAT test")
+
     ok = asyncio.run(test.TestMultiFabric(ip=address,
                                           setuppin=20202021,
                                           nodeid=1))


### PR DESCRIPTION
This adds CAT value support to the Python `ChipDeviceController` class.

### Testing

Added a new test to the existing REPL test suite to validate the creation of a new controller that is granted a CAT tag, that then can read an admin attribute without further ACL modifications.