### PR TITLE
Fixing assign -> copy in Darwin

### DIFF
--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -61,7 +61,7 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
  *
  * Otherwise its value is made up of the MTRDiscoveryCapabilities flags.
  */
-@property (nonatomic, assign, nullable) NSNumber * rendezvousInformation;
+@property (nonatomic, copy, nullable) NSNumber * rendezvousInformation;
 @property (nonatomic, copy) NSNumber * discriminator;
 @property (nonatomic, assign) BOOL hasShortDiscriminator;
 @property (nonatomic, copy) NSNumber * setUpPINCode;


### PR DESCRIPTION
#### Problem
A parameter has a poor type, should be copy
Resolves: https://github.com/project-chip/connectedhomeip/pull/22017
#### Change overview
Swap assign -> copy

#### Testing
Builds without warnings