### PR TITLE
[Android] Fix OnCommissioningStatusUpdate jni typo

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -425,7 +425,7 @@ void AndroidDeviceControllerWrapper::OnCommissioningStatusUpdate(PeerId peerId, 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     jmethodID onCommissioningStatusUpdateMethod;
     CHIP_ERROR err = JniReferences::GetInstance().FindMethod(env, mJavaObjectRef, "onCommissioningStatusUpdate",
-                                                             "(JLjava/lang/string;I)V", &onCommissioningStatusUpdateMethod);
+                                                             "(JLjava/lang/String;I)V", &onCommissioningStatusUpdateMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error finding Java method: %" CHIP_ERROR_FORMAT, err.Format()));
 
     UtfString jStageCompleted(env, StageToString(stageCompleted));


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* During Android controller commissioning, Android Controller crash occurs.

08-19 11:02:27.933 F 26329    26442    e.chip.chiptoo:                                       java_vm_ext.cc:577] JNI DETECTED ERROR IN APPLICATION: JNI GetObjectClass called with pending exception java.lang.NoSuchMethodError: no non-static method "Lchip/devicecontroller/ChipDeviceController;.onCommissioningStatusUpdate(J**Ljava/lang/string**;I)V" 


#### Change overview
Change java String class typo.

#### Testing
How was this tested? (at least one bullet point required)
* Android Commissioning Test. After fixing this, commissioning is successful.