### PR TITLE
Introduce initial TC-RR-1.1

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -358,6 +358,12 @@ CHIP_ERROR CHIPCommand::InitializeCommissioner(std::string key, chip::FabricId f
         //        store the credentials in persistent storage, and
         //        generate when not available in the storage.
         ReturnLogErrorOnFailure(mCommissionerStorage.Init(key.c_str()));
+        if (mUseMaxSizedCerts.HasValue())
+        {
+            auto option = CredentialIssuerCommands::CredentialIssuerOptions::kMaximizeCertificateSizes;
+            mCredIssuerCmds->SetCredentialIssuerOption(option, mUseMaxSizedCerts.Value());
+        }
+
         ReturnLogErrorOnFailure(mCredIssuerCmds->InitializeCredentialsIssuer(mCommissionerStorage));
 
         chip::MutableByteSpan nocSpan(noc.Get(), chip::Controller::kMaxCHIPDERCertLength);

--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -70,6 +70,9 @@ public:
                     "4.  The default if not specified is \"alpha\".");
         AddArgument("commissioner-nodeid", 0, UINT64_MAX, &mCommissionerNodeId,
                     "The node id to use for chip-tool.  If not provided, kTestControllerNodeId (112233, 0x1B669) will be used.");
+        AddArgument("use-max-sized-certs", 0, 1, &mUseMaxSizedCerts,
+                    "Maximize the size of operational certificates. If not provided or 0 (\"false\"), normally sized operational "
+                    "certificates are generated.");
 #if CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
         AddArgument("trace_file", &mTraceFile);
         AddArgument("trace_log", 0, 1, &mTraceLog);
@@ -153,6 +156,7 @@ private:
     chip::Optional<chip::NodeId> mCommissionerNodeId;
     chip::Optional<uint16_t> mBleAdapterId;
     chip::Optional<char *> mPaaTrustStorePath;
+    chip::Optional<bool> mUseMaxSizedCerts;
 
     // Cached trust store so commands other than the original startup command
     // can spin up commissioners as needed.

--- a/examples/chip-tool/commands/common/CredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/common/CredentialIssuerCommands.h
@@ -74,4 +74,23 @@ public:
     virtual CHIP_ERROR GenerateControllerNOCChain(chip::NodeId nodeId, chip::FabricId fabricId, const chip::CATValues & cats,
                                                   chip::Crypto::P256Keypair & keypair, chip::MutableByteSpan & rcac,
                                                   chip::MutableByteSpan & icac, chip::MutableByteSpan & noc) = 0;
+
+    // All options must start false
+    enum CredentialIssuerOptions : uint8_t
+    {
+        kMaximizeCertificateSizes = 0, // If set, certificate chains will be maximized for testing via padding
+    };
+
+    virtual void SetCredentialIssuerOption(CredentialIssuerOptions option, bool isEnabled)
+    {
+        // Do nothing
+        (void) option;
+        (void) isEnabled;
+    }
+
+    virtual bool GetCredentialIssuerOption(CredentialIssuerOptions option)
+    {
+        // All options always start false
+        return false;
+    }
 };

--- a/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
+++ b/examples/chip-tool/commands/example/ExampleCredentialIssuerCommands.h
@@ -49,6 +49,33 @@ public:
         return mOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, fabricId, cats, keypair.Pubkey(), rcac, icac, noc);
     }
 
+    void SetCredentialIssuerOption(CredentialIssuerOptions option, bool isEnabled) override
+    {
+        switch (option)
+        {
+        case CredentialIssuerOptions::kMaximizeCertificateSizes:
+            mUsesMaxSizedCerts = isEnabled;
+            mOpCredsIssuer.SetMaximallyLargeCertsUsed(mUsesMaxSizedCerts);
+            break;
+        default:
+            break;
+        }
+    }
+
+    bool GetCredentialIssuerOption(CredentialIssuerOptions option) override
+    {
+        switch (option)
+        {
+        case CredentialIssuerOptions::kMaximizeCertificateSizes:
+            return mUsesMaxSizedCerts;
+        default:
+            return false;
+        }
+    }
+
+protected:
+    bool mUsesMaxSizedCerts = false;
+
 private:
     chip::Controller::ExampleOperationalCredentialsIssuer mOpCredsIssuer;
 };

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -146,8 +146,8 @@ CHIP_ERROR IssueX509Cert(uint32_t now, uint32_t validity, ChipDN issuerDn, ChipD
 
             ReturnErrorOnFailure(ConvertX509CertToChipCert(paddedDerSpan, paddedTlvSpan));
 
-            // TODO: REMOVE
-            printf("   TLV: %d DER: %d\n", (int)paddedTlvSpan.size(), (int)paddedDerSpan.size());
+            ChipLogProgress(Controller, "Generated maximized certificate with %u DER bytes, %u TLV bytes",
+                            static_cast<unsigned>(paddedDerSpan.size()), static_cast<unsigned>(paddedTlvSpan.size()));
             if (paddedDerSpan.size() <= kMaxDERCertLength && paddedTlvSpan.size() <= kMaxCHIPCertLength)
             {
                 return CopySpanToMutableSpan(paddedDerSpan, outX509Cert);

--- a/src/controller/ExampleOperationalCredentialsIssuer.cpp
+++ b/src/controller/ExampleOperationalCredentialsIssuer.cpp
@@ -39,6 +39,125 @@ using namespace Credentials;
 using namespace Crypto;
 using namespace TLV;
 
+namespace {
+
+enum CertType : uint8_t
+{
+    kRcac = 0,
+    kIcac = 1,
+    kNoc  = 2
+};
+
+CHIP_ERROR IssueX509Cert(uint32_t now, uint32_t validity, ChipDN issuerDn, ChipDN desiredDn, CertType certType, bool maximizeSize,
+                         const Crypto::P256PublicKey & subjectPublicKey, Crypto::P256Keypair & issuerKeypair,
+                         MutableByteSpan & outX509Cert)
+{
+    constexpr size_t kDERCertDnEncodingOverhead = 11;
+    constexpr size_t kTLVCertDnEncodingOverhead = 3;
+    constexpr size_t kMaxCertPaddingLength      = 150;
+    constexpr size_t kTLVDesiredSize            = kMaxCHIPCertLength - 50;
+
+    Platform::ScopedMemoryBuffer<uint8_t> derBuf;
+    ReturnErrorCodeIf(!derBuf.Alloc(kMaxDERCertLength), CHIP_ERROR_NO_MEMORY);
+    MutableByteSpan derSpan{ derBuf.Get(), kMaxDERCertLength };
+
+    int64_t serialNumber = 1;
+
+    switch (certType)
+    {
+    case CertType::kRcac: {
+        X509CertRequestParams rcacRequest = { serialNumber, now, now + validity, desiredDn, desiredDn };
+        ReturnErrorOnFailure(NewRootX509Cert(rcacRequest, issuerKeypair, derSpan));
+        break;
+    }
+    case CertType::kIcac: {
+        X509CertRequestParams icacRequest = { serialNumber, now, now + validity, desiredDn, issuerDn };
+        ReturnErrorOnFailure(NewICAX509Cert(icacRequest, subjectPublicKey, issuerKeypair, derSpan));
+        break;
+    }
+    case CertType::kNoc: {
+        X509CertRequestParams nocRequest = { serialNumber, now, now + validity, desiredDn, issuerDn };
+        ReturnErrorOnFailure(NewNodeOperationalX509Cert(nocRequest, subjectPublicKey, issuerKeypair, derSpan));
+        break;
+    }
+    default:
+        return CHIP_ERROR_INVALID_ARGUMENT;
+    }
+
+    if (maximizeSize && (desiredDn.RDNCount() < CHIP_CONFIG_CERT_MAX_RDN_ATTRIBUTES))
+    {
+        Platform::ScopedMemoryBuffer<uint8_t> paddedTlvBuf;
+        ReturnErrorCodeIf(!paddedTlvBuf.Alloc(kMaxCHIPCertLength + kMaxCertPaddingLength), CHIP_ERROR_NO_MEMORY);
+        MutableByteSpan paddedTlvSpan{ paddedTlvBuf.Get(), kMaxCHIPCertLength + kMaxCertPaddingLength };
+        ReturnErrorOnFailure(ConvertX509CertToChipCert(derSpan, paddedTlvSpan));
+
+        Platform::ScopedMemoryBuffer<uint8_t> paddedDerBuf;
+        ReturnErrorCodeIf(!paddedDerBuf.Alloc(kMaxDERCertLength + kMaxCertPaddingLength), CHIP_ERROR_NO_MEMORY);
+        MutableByteSpan paddedDerSpan{ paddedDerBuf.Get(), kMaxDERCertLength + kMaxCertPaddingLength };
+
+        Platform::ScopedMemoryBuffer<char> fillerBuf;
+        ReturnErrorCodeIf(!fillerBuf.Alloc(kMaxCertPaddingLength), CHIP_ERROR_NO_MEMORY);
+        memset(fillerBuf.Get(), 'A', kMaxCertPaddingLength);
+
+        int derPaddingLen = static_cast<int>(kMaxDERCertLength - kDERCertDnEncodingOverhead - derSpan.size());
+        int tlvPaddingLen = static_cast<int>(kTLVDesiredSize - kTLVCertDnEncodingOverhead - paddedTlvSpan.size());
+        if (certType == CertType::kRcac)
+        {
+            // For RCAC the issuer/subject DN are the same so padding will be present in both
+            derPaddingLen = (derPaddingLen - static_cast<int>(kDERCertDnEncodingOverhead)) / 2;
+            tlvPaddingLen = (tlvPaddingLen - static_cast<int>(kTLVCertDnEncodingOverhead)) / 2;
+        }
+
+        size_t paddingLen = 0;
+        if (derPaddingLen >= 1 && tlvPaddingLen >= 1)
+        {
+            paddingLen = std::min(static_cast<size_t>(std::min(derPaddingLen, tlvPaddingLen)), kMaxCertPaddingLength);
+        }
+
+        for (; paddingLen > 0; paddingLen--)
+        {
+            paddedDerSpan = MutableByteSpan{ paddedDerBuf.Get(), kMaxDERCertLength + kMaxCertPaddingLength };
+            paddedTlvSpan = MutableByteSpan{ paddedTlvBuf.Get(), kMaxCHIPCertLength + kMaxCertPaddingLength };
+
+            ChipDN certDn = desiredDn;
+            // Fill the padding in the DomainNameQualifier DN
+            certDn.AddAttribute_DNQualifier(CharSpan(fillerBuf.Get(), paddingLen), false);
+
+            switch (certType)
+            {
+            case CertType::kRcac: {
+                X509CertRequestParams rcacRequest = { serialNumber, now, now + validity, certDn, certDn };
+                ReturnErrorOnFailure(NewRootX509Cert(rcacRequest, issuerKeypair, paddedDerSpan));
+                break;
+            }
+            case CertType::kIcac: {
+                X509CertRequestParams icacRequest = { serialNumber, now, now + validity, certDn, issuerDn };
+                ReturnErrorOnFailure(NewICAX509Cert(icacRequest, subjectPublicKey, issuerKeypair, paddedDerSpan));
+                break;
+            }
+            case CertType::kNoc: {
+                X509CertRequestParams nocRequest = { serialNumber, now, now + validity, certDn, issuerDn };
+                ReturnErrorOnFailure(NewNodeOperationalX509Cert(nocRequest, subjectPublicKey, issuerKeypair, paddedDerSpan));
+                break;
+            }
+            default:
+                return CHIP_ERROR_INVALID_ARGUMENT;
+            }
+
+            ReturnErrorOnFailure(ConvertX509CertToChipCert(paddedDerSpan, paddedTlvSpan));
+
+            if (paddedDerSpan.size() <= kMaxDERCertLength && paddedTlvSpan.size() <= kMaxCHIPCertLength)
+            {
+                return CopySpanToMutableSpan(paddedDerSpan, outX509Cert);
+            }
+        }
+    }
+
+    return CopySpanToMutableSpan(derSpan, outX509Cert);
+}
+
+} // namespace
+
 CHIP_ERROR ExampleOperationalCredentialsIssuer::Initialize(PersistentStorageDelegate & storage)
 {
     using namespace ASN1;
@@ -137,10 +256,14 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
         ReturnErrorOnFailure(rcac_dn.AddAttribute_MatterRCACId(mIssuerId));
 
         ChipLogProgress(Controller, "Generating RCAC");
-        X509CertRequestParams rcac_request = { 0, mNow, mNow + mValidity, rcac_dn, rcac_dn };
-        ReturnErrorOnFailure(NewRootX509Cert(rcac_request, mIssuer, rcac));
-
+        ReturnErrorOnFailure(IssueX509Cert(mNow, mValidity, rcac_dn, rcac_dn, CertType::kRcac, mUseMaximallySizedCerts,
+                                           mIssuer.Pubkey(), mIssuer, rcac));
         VerifyOrReturnError(CanCastTo<uint16_t>(rcac.size()), CHIP_ERROR_INTERNAL);
+
+        // Re-extract DN based on final generated cert
+        rcac_dn = ChipDN{};
+        ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(rcac, rcac_dn));
+
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsRootCertificateStorage, key,
                           ReturnErrorOnFailure(mStorage->SyncSetKeyValue(key, rcac.data(), static_cast<uint16_t>(rcac.size()))));
     }
@@ -164,10 +287,14 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
         ReturnErrorOnFailure(icac_dn.AddAttribute_MatterICACId(mIntermediateIssuerId));
 
         ChipLogProgress(Controller, "Generating ICAC");
-        X509CertRequestParams icac_request = { 0, mNow, mNow + mValidity, icac_dn, rcac_dn };
-        ReturnErrorOnFailure(NewICAX509Cert(icac_request, mIntermediateIssuer.Pubkey(), mIssuer, icac));
-
+        ReturnErrorOnFailure(IssueX509Cert(mNow, mValidity, rcac_dn, icac_dn, CertType::kIcac, mUseMaximallySizedCerts,
+                                           mIntermediateIssuer.Pubkey(), mIssuer, icac));
         VerifyOrReturnError(CanCastTo<uint16_t>(icac.size()), CHIP_ERROR_INTERNAL);
+
+        // Re-extract DN based on final generated cert
+        icac_dn = ChipDN{};
+        ReturnErrorOnFailure(ExtractSubjectDNFromX509Cert(icac, icac_dn));
+
         PERSISTENT_KEY_OP(mIndex, kOperationalCredentialsIntermediateCertificateStorage, key,
                           ReturnErrorOnFailure(mStorage->SyncSetKeyValue(key, icac.data(), static_cast<uint16_t>(icac.size()))));
     }
@@ -175,11 +302,13 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChainAfterValidation(
     ChipDN noc_dn;
     ReturnErrorOnFailure(noc_dn.AddAttribute_MatterFabricId(fabricId));
     ReturnErrorOnFailure(noc_dn.AddAttribute_MatterNodeId(nodeId));
-    ReturnErrorOnFailure(noc_dn.AddCATs(cats));
+    CATValues actualCats = cats;
+    actualCats.values[0] = 0xFFF1'FFFF;
+    ReturnErrorOnFailure(noc_dn.AddCATs(actualCats));
 
     ChipLogProgress(Controller, "Generating NOC");
-    X509CertRequestParams noc_request = { 1, mNow, mNow + mValidity, noc_dn, icac_dn };
-    return NewNodeOperationalX509Cert(noc_request, pubkey, mIntermediateIssuer, noc);
+    return IssueX509Cert(mNow, mValidity, icac_dn, noc_dn, CertType::kNoc, mUseMaximallySizedCerts, pubkey, mIntermediateIssuer,
+                         noc);
 }
 
 CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan & csrElements, const ByteSpan & csrNonce,
@@ -227,16 +356,16 @@ CHIP_ERROR ExampleOperationalCredentialsIssuer::GenerateNOCChain(const ByteSpan 
     ReturnErrorOnFailure(VerifyCertificateSigningRequest(csr.data(), csr.size(), pubkey));
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> noc;
-    ReturnErrorCodeIf(!noc.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-    MutableByteSpan nocSpan(noc.Get(), kMaxCHIPDERCertLength);
+    ReturnErrorCodeIf(!noc.Alloc(kMaxDERCertLength), CHIP_ERROR_NO_MEMORY);
+    MutableByteSpan nocSpan(noc.Get(), kMaxDERCertLength);
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> icac;
-    ReturnErrorCodeIf(!icac.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-    MutableByteSpan icacSpan(icac.Get(), kMaxCHIPDERCertLength);
+    ReturnErrorCodeIf(!icac.Alloc(kMaxDERCertLength), CHIP_ERROR_NO_MEMORY);
+    MutableByteSpan icacSpan(icac.Get(), kMaxDERCertLength);
 
     chip::Platform::ScopedMemoryBuffer<uint8_t> rcac;
-    ReturnErrorCodeIf(!rcac.Alloc(kMaxCHIPDERCertLength), CHIP_ERROR_NO_MEMORY);
-    MutableByteSpan rcacSpan(rcac.Get(), kMaxCHIPDERCertLength);
+    ReturnErrorCodeIf(!rcac.Alloc(kMaxDERCertLength), CHIP_ERROR_NO_MEMORY);
+    MutableByteSpan rcacSpan(rcac.Get(), kMaxDERCertLength);
 
     ReturnErrorOnFailure(
         GenerateNOCChainAfterValidation(assignedId, mNextFabricId, chip::kUndefinedCATs, pubkey, rcacSpan, icacSpan, nocSpan));

--- a/src/controller/ExampleOperationalCredentialsIssuer.h
+++ b/src/controller/ExampleOperationalCredentialsIssuer.h
@@ -65,6 +65,8 @@ public:
         mNodeIdRequested     = true;
     }
 
+    void SetMaximallyLargeCertsUsed(bool areMaximallyLargeCertsUsed) { mUseMaximallySizedCerts = areMaximallyLargeCertsUsed; }
+
     void SetFabricIdForNextNOCRequest(FabricId fabricId) override { mNextFabricId = fabricId; }
 
     /**
@@ -108,8 +110,8 @@ private:
     Crypto::P256Keypair mIssuer;
     Crypto::P256Keypair mIntermediateIssuer;
     bool mInitialized              = false;
-    uint32_t mIssuerId             = 0;
-    uint32_t mIntermediateIssuerId = 1;
+    uint32_t mIssuerId             = 1;
+    uint32_t mIntermediateIssuerId = 2;
     uint32_t mNow                  = 0;
 
     // By default, let's set validity to 10 years
@@ -117,6 +119,7 @@ private:
 
     NodeId mNextAvailableNodeId          = 1;
     PersistentStorageDelegate * mStorage = nullptr;
+    bool mUseMaximallySizedCerts         = false;
 
     NodeId mNextRequestedNodeId = 1;
     FabricId mNextFabricId      = 1;

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -415,7 +415,6 @@ ChipError::StorageType pychip_OpCreds_SetMaximallyLargeCertsUsed(OpCredsContext 
     return CHIP_NO_ERROR.AsInteger();
 }
 
-
 void pychip_OpCreds_FreeDelegate(OpCredsContext * context)
 {
     Platform::Delete(context);

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -77,6 +77,8 @@ public:
         return mExampleOpCredsIssuer.GenerateNOCChainAfterValidation(nodeId, fabricId, cats, pubKey, rcac, icac, noc);
     }
 
+    void SetMaximallyLargeCertsUsed(bool enabled) { mExampleOpCredsIssuer.SetMaximallyLargeCertsUsed(enabled); }
+
 private:
     CHIP_ERROR GenerateNOCChain(const ByteSpan & csrElements, const ByteSpan & csrNonce, const ByteSpan & attestationSignature,
                                 const ByteSpan & attestationChallenge, const ByteSpan & DAC, const ByteSpan & PAI,
@@ -403,6 +405,16 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
 
     return CHIP_NO_ERROR.AsInteger();
 }
+
+ChipError::StorageType pychip_OpCreds_SetMaximallyLargeCertsUsed(OpCredsContext * context, bool enabled)
+{
+    VerifyOrReturnError(context != nullptr && context->mAdapter != nullptr, CHIP_ERROR_INCORRECT_STATE.AsInteger());
+
+    context->mAdapter->SetMaximallyLargeCertsUsed(enabled);
+
+    return CHIP_NO_ERROR.AsInteger();
+}
+
 
 void pychip_OpCreds_FreeDelegate(OpCredsContext * context)
 {

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -362,9 +362,10 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
 
     CATValues catValues;
 
-    if ((caseAuthTagLen + 1) > kMaxSubjectCATAttributeCount)
+    if (caseAuthTagLen > kMaxSubjectCATAttributeCount)
     {
-        ChipLogError(Controller, "# of CASE Tags exceeds kMaxSubjectCATAttributeCount");
+        ChipLogError(Controller, "Too many of CASE Tags (%u) exceeds kMaxSubjectCATAttributeCount",
+                     static_cast<unsigned>(caseAuthTagLen));
         return CHIP_ERROR_INVALID_ARGUMENT.AsInteger();
     }
 

--- a/src/controller/python/chip/CertificateAuthority.py
+++ b/src/controller/python/chip/CertificateAuthority.py
@@ -45,7 +45,7 @@ class CertificateAuthority:
 
          Each CertificateAuthority instance is associated with a single instance of the OperationalCredentialsAdapter. This adapter instance implements
          the OperationalCredentialsDelegate and is meant to provide a Python adapter to the functions in that delegate. It relies on the in-built
-         ExampleOperationalCredentialsIssuer to then generate certificate material for the CA.  This instance also uses the 'CA index' to 
+         ExampleOperationalCredentialsIssuer to then generate certificate material for the CA.  This instance also uses the 'CA index' to
          store/look-up the associated credential material from the provided PersistentStorage object.
     '''
     @classmethod
@@ -74,10 +74,14 @@ class CertificateAuthority:
         self._Handle().pychip_OpCreds_InitializeDelegate.restype = c_void_p
         self._Handle().pychip_OpCreds_InitializeDelegate.argtypes = [ctypes.py_object, ctypes.c_uint32, ctypes.c_void_p]
 
+        self._Handle().pychip_OpCreds_SetMaximallyLargeCertsUsed.restype = c_uint32
+        self._Handle().pychip_OpCreds_SetMaximallyLargeCertsUsed.argtypes = [ctypes.c_void_p, ctypes.c_bool]
+
         if (persistentStorage is None):
             persistentStorage = self._chipStack.GetStorageManager()
 
         self._persistentStorage = persistentStorage
+        self._maximizeCertChains = False
 
         self._closure = self._chipStack.Call(
             lambda: self._Handle().pychip_OpCreds_InitializeDelegate(
@@ -181,6 +185,22 @@ class CertificateAuthority:
     def adminList(self) -> list[FabricAdmin.FabricAdmin]:
         return self._activeAdmins
 
+    @property
+    def maximizeCertChains(self) -> bool:
+        return self._maximizeCertChains
+
+    @maximizeCertChains.setter
+    def maximizeCertChains(self, enabled: bool):
+        res = self._chipStack.Call(
+            lambda: self._Handle().pychip_OpCreds_SetMaximallyLargeCertsUsed(ctypes.c_void_p(self._closure), ctypes.c_bool(enabled))
+        )
+
+        if res != 0:
+            raise self._chipStack.ErrorToException(res)
+
+        self._maximizeCertChains = enabled
+
+
     def __del__(self):
         self.Shutdown()
 
@@ -243,7 +263,7 @@ class CertificateAuthorityManager:
             ca = self.NewCertificateAuthority(int(caIndex))
             ca.LoadFabricAdminsFromStorage()
 
-    def NewCertificateAuthority(self, caIndex: int = None):
+    def NewCertificateAuthority(self, caIndex: int = None, maximizeCertChains: bool = False):
         ''' Creates a new CertificateAuthority instance with the provided CA Index and the PersistentStorage
             instance previously setup in the constructor.
 
@@ -268,6 +288,7 @@ class CertificateAuthorityManager:
             self._persistentStorage.SetReplKey(key='caList', value=caList)
 
         ca = CertificateAuthority(chipStack=self._chipStack, caIndex=caIndex, persistentStorage=self._persistentStorage)
+        ca.maximizeCertChains = maximizeCertChains
         self._activeCaList.append(ca)
 
         return ca

--- a/src/controller/python/chip/CertificateAuthority.py
+++ b/src/controller/python/chip/CertificateAuthority.py
@@ -200,7 +200,6 @@ class CertificateAuthority:
 
         self._maximizeCertChains = enabled
 
-
     def __del__(self):
         self.Shutdown()
 

--- a/src/controller/python/chip/FabricAdmin.py
+++ b/src/controller/python/chip/FabricAdmin.py
@@ -102,7 +102,7 @@ class FabricAdmin:
                 raise RuntimeError(f"Provided NodeId {nodeId} collides with an existing controller instance!")
 
         self.logger().warning(
-            f"Allocating new controller with CaIndex: {self._certificateAuthority.caIndex}, FabricId: 0x{self._fabricId:016X}, NodeId: 0x{nodeId:016X}")
+            f"Allocating new controller with CaIndex: {self._certificateAuthority.caIndex}, FabricId: 0x{self._fabricId:016X}, NodeId: 0x{nodeId:016X}, CatTags: {catTags}")
 
         controller = ChipDeviceCtrl.ChipDeviceController(opCredsContext=self._certificateAuthority.GetOpCredsContext(), fabricId=self._fabricId, nodeId=nodeId,
                                                          adminVendorId=self._vendorId, paaTrustStorePath=paaTrustStorePath, useTestCommissioner=useTestCommissioner, fabricAdmin=self, catTags=catTags)

--- a/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
+++ b/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
@@ -30,7 +30,7 @@ from chip.clusters.Types import *
 
 _UINT16_MAX = 65535
 
-logger = logging.getLogger()
+logger = logging.getLogger('CommissioningBuildingBlocks')
 
 
 async def _IsNodeInFabricList(devCtrl, nodeId):
@@ -43,7 +43,7 @@ async def _IsNodeInFabricList(devCtrl, nodeId):
     return False
 
 
-async def GrantPrivilege(adminCtrl: ChipDeviceController, grantedCtrl: ChipDeviceController, privilege: Clusters.AccessControl.Enums.Privilege, targetNodeId: int):
+async def GrantPrivilege(adminCtrl: ChipDeviceController, grantedCtrl: ChipDeviceController, privilege: Clusters.AccessControl.Enums.Privilege, targetNodeId: int, targetCatTags: typing.List[int] = []):
     ''' Given an existing controller with admin privileges over a target node, grants the specified privilege to the new ChipDeviceController instance to the entire Node. This is achieved
         by updating the ACL entries on the target.
 
@@ -53,20 +53,29 @@ async def GrantPrivilege(adminCtrl: ChipDeviceController, grantedCtrl: ChipDevic
         Args:
             adminCtrl:      ChipDeviceController instance with admin privileges over the target node
             grantedCtrl:    ChipDeviceController instance that is being granted the new privilege.
-            privilege:      Privilege to grant to the granted controller
+            privilege:      Privilege to grant to the granted controller. If None, no privilege is granted.
             targetNodeId:   Target node to which the controller is granted privilege.
+            targetCatTag:   Target 32-bit CAT tag that is granted privilege. If provided, this will be used in the subject list instead of the nodeid of that of grantedCtrl.
     '''
-
     data = await adminCtrl.ReadAttribute(targetNodeId, [(Clusters.AccessControl.Attributes.Acl)])
     if 0 not in data:
         raise ValueError("Did not get back any data (possible cause: controller has no access..")
 
     currentAcls = data[0][Clusters.AccessControl][Clusters.AccessControl.Attributes.Acl]
 
+    if len(targetCatTags) != 0:
+        # Convert to a full-qualified 32-bit Node Identifier
+        targetSubjects = [tag | 0xFFFF_FFFD_0000_0000 for tag in targetCatTags]
+    else:
+        targetSubjects = [grantedCtrl.nodeId]
+
+    if (len(targetSubjects) > 4):
+        raise ValueError(f"List of target subjects of len {len(targetSubjects)} exceeeded the minima of 4!")
+
     # Step 1: Wipe the subject from all existing ACLs.
     for acl in currentAcls:
         if (acl.subjects != NullValue):
-            acl.subjects = [subject for subject in acl.subjects if subject != grantedCtrl.nodeId]
+            acl.subjects = [subject for subject in acl.subjects if subject not in targetSubjects]
 
     if (privilege):
         addedPrivilege = False
@@ -75,9 +84,11 @@ async def GrantPrivilege(adminCtrl: ChipDeviceController, grantedCtrl: ChipDevic
         #         the existing privilege in that entry matches our desired privilege.
         for acl in currentAcls:
             if acl.privilege == privilege:
-                if grantedCtrl.nodeId not in acl.subjects:
-                    acl.subjects.append(grantedCtrl.nodeId)
+                subjectSet = set(acl.subjects)
+                subjectSet.update(targetSubjects)
+                acl.subjects = list(subjectSet)
                 addedPrivilege = True
+                break
 
         # Step 3: If there isn't an existing entry to add to, make a new one.
         if (not(addedPrivilege)):
@@ -86,10 +97,12 @@ async def GrantPrivilege(adminCtrl: ChipDeviceController, grantedCtrl: ChipDevic
                     f"Cannot add another ACL entry to grant privilege to existing count of {currentAcls} ACLs -- will exceed minimas!")
 
             currentAcls.append(Clusters.AccessControl.Structs.AccessControlEntry(privilege=privilege, authMode=Clusters.AccessControl.Enums.AuthMode.kCase,
-                                                                                 subjects=[grantedCtrl.nodeId]))
+                                                                                 subjects=targetSubjects))
 
     # Step 4: Prune ACLs which have empty subjects.
     currentAcls = [acl for acl in currentAcls if acl.subjects != NullValue and len(acl.subjects) != 0]
+
+    logger.info(f'GrantPrivilege: Writing acls: {currentAcls}')
     await adminCtrl.WriteAttribute(targetNodeId, [(0, Clusters.AccessControl.Attributes.Acl(currentAcls))])
 
 
@@ -102,14 +115,14 @@ async def CreateControllersOnFabric(fabricAdmin: FabricAdmin, adminDevCtrl: Chip
             controllerNodeIds:          List of desired nodeIds for the controllers.
             privilege:                  The specific ACL privilege to grant to the newly minted controllers.
             targetNodeId:               The Node ID of the target.
-            catTags:                    CAT Tags to include in the NOC of controller
+            catTags:                    CAT Tags to include in the NOC of controller, as well as when setting up the ACLs on the target.
     '''
 
     controllerList = []
 
     for nodeId in controllerNodeIds:
         newController = fabricAdmin.NewController(nodeId=nodeId, catTags=catTags)
-        await GrantPrivilege(adminDevCtrl, newController, privilege, targetNodeId)
+        await GrantPrivilege(adminDevCtrl, newController, privilege, targetNodeId, catTags)
         controllerList.append(newController)
 
     return controllerList

--- a/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
+++ b/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
@@ -93,7 +93,7 @@ async def GrantPrivilege(adminCtrl: ChipDeviceController, grantedCtrl: ChipDevic
     await adminCtrl.WriteAttribute(targetNodeId, [(0, Clusters.AccessControl.Attributes.Acl(currentAcls))])
 
 
-async def CreateControllersOnFabric(fabricAdmin: FabricAdmin, adminDevCtrl: ChipDeviceController, controllerNodeIds: typing.List[int], privilege: Clusters.AccessControl.Enums.Privilege, targetNodeId: int) -> typing.List[ChipDeviceController]:
+async def CreateControllersOnFabric(fabricAdmin: FabricAdmin, adminDevCtrl: ChipDeviceController, controllerNodeIds: typing.List[int], privilege: Clusters.AccessControl.Enums.Privilege, targetNodeId: int, catTags: typing.List[int] = []) -> typing.List[ChipDeviceController]:
     ''' Create new ChipDeviceController instances on a given fabric with a specific privilege on a target node.
 
         Args:
@@ -102,12 +102,13 @@ async def CreateControllersOnFabric(fabricAdmin: FabricAdmin, adminDevCtrl: Chip
             controllerNodeIds:          List of desired nodeIds for the controllers.
             privilege:                  The specific ACL privilege to grant to the newly minted controllers.
             targetNodeId:               The Node ID of the target.
+            catTags:                    CAT Tags to include in the NOC of controller
     '''
 
     controllerList = []
 
     for nodeId in controllerNodeIds:
-        newController = fabricAdmin.NewController(nodeId=nodeId)
+        newController = fabricAdmin.NewController(nodeId=nodeId, catTags=catTags)
         await GrantPrivilege(adminDevCtrl, newController, privilege, targetNodeId)
         controllerList.append(newController)
 

--- a/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
+++ b/src/controller/python/chip/utils/CommissioningBuildingBlocks.py
@@ -64,7 +64,7 @@ async def GrantPrivilege(adminCtrl: ChipDeviceController, grantedCtrl: ChipDevic
     currentAcls = data[0][Clusters.AccessControl][Clusters.AccessControl.Attributes.Acl]
 
     if len(targetCatTags) != 0:
-        # Convert to a full-qualified 32-bit Node Identifier
+        # Convert to an ACL subject format in CAT range
         targetSubjects = [tag | 0xFFFF_FFFD_0000_0000 for tag in targetCatTags]
     else:
         targetSubjects = [grantedCtrl.nodeId]

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -40,6 +40,7 @@ import chip.CertificateAuthority
 import copy
 import secrets
 import faulthandler
+import ipdb
 
 logger = logging.getLogger('PythonMatterControllerTEST')
 logger.setLevel(logging.INFO)
@@ -389,31 +390,28 @@ class BaseTestHelper:
     async def TestControllerCATValues(self, nodeid: int):
         ''' This tests controllers using CAT Values
         '''
-
         # Allocate a new controller instance with a CAT tag.
-        newController = self.fabricAdmin.NewController(nodeId=300, catTags=[0x00010001])
+        newControllers = await CommissioningBuildingBlocks.CreateControllersOnFabric(fabricAdmin=self.fabricAdmin, adminDevCtrl=self.devCtrl, controllerNodeIds=[300], targetNodeId=nodeid, privilege=None, catTags=[0x0001_0001])
 
         # Read out an attribute using the new controller. It has no privileges, so this should fail with an UnsupportedAccess error.
-        res = await newController.ReadAttribute(nodeid=nodeid, attributes=[(0, Clusters.AccessControl.Attributes.Acl)])
+        res = await newControllers[0].ReadAttribute(nodeid=nodeid, attributes=[(0, Clusters.AccessControl.Attributes.Acl)])
         if(res[0][Clusters.AccessControl][Clusters.AccessControl.Attributes.Acl].Reason.status != IM.Status.UnsupportedAccess):
             self.logger.error(f"1: Received data instead of an error:{res}")
             return False
 
-        # Do a read-modify-write operation on the ACL list to add the CAT tag to the ACL list.
-        aclList = (await self.devCtrl.ReadAttribute(nodeid, [(0, Clusters.AccessControl.Attributes.Acl)]))[0][Clusters.AccessControl][Clusters.AccessControl.Attributes.Acl]
-        origAclList = copy.deepcopy(aclList)
-        aclList[0].subjects.append(0xFFFFFFFD00010001)
-        await self.devCtrl.WriteAttribute(nodeid, [(0, Clusters.AccessControl.Attributes.Acl(aclList))])
+        # Grant the new controller privilege by adding the CAT tag to the subject.
+        await CommissioningBuildingBlocks.GrantPrivilege(adminCtrl=self.devCtrl, grantedCtrl=newControllers[0], privilege=Clusters.AccessControl.Enums.Privilege.kAdminister, targetNodeId=nodeid, targetCatTags=[0x0001_0001])
 
         # Read out the attribute again - this time, it should succeed.
-        res = await newController.ReadAttribute(nodeid=nodeid, attributes=[(0, Clusters.AccessControl.Attributes.Acl)])
+        res = await newControllers[0].ReadAttribute(nodeid=nodeid, attributes=[(0, Clusters.AccessControl.Attributes.Acl)])
         if (type(res[0][Clusters.AccessControl][Clusters.AccessControl.Attributes.Acl][0]) != Clusters.AccessControl.Structs.AccessControlEntry):
             self.logger.error(f"2: Received something other than data:{res}")
             return False
 
-        # Write back the old entry to reset ACL list back.
-        await self.devCtrl.WriteAttribute(nodeid, [(0, Clusters.AccessControl.Attributes.Acl(origAclList))])
-        newController.Shutdown()
+        # Reset the privilege back to pre-test.
+        await CommissioningBuildingBlocks.GrantPrivilege(adminCtrl=self.devCtrl, grantedCtrl=newControllers[0], privilege=None, targetNodeId=nodeid)
+
+        newControllers[0].Shutdown()
 
         return True
 

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -309,7 +309,7 @@ class TC_RR_1_1(MatterBaseTest):
 
         # Step 9: Fill user label list
 
-        if has_user_labels:
+        if has_user_labels and not skip_user_label_cluster_steps:
             await self.fill_user_label_list(dev_ctrl, self.dut_node_id)
         else:
             logging.info("Step 9: Skipped due to no UserLabel cluster instances")

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -18,6 +18,7 @@
 from matter_testing_support import MatterBaseTest, default_matter_test_main, async_test_body
 import chip.clusters as Clusters
 import chip.FabricAdmin
+import chip.CertificateAuthority
 import logging
 from mobly import asserts
 from chip.utils import CommissioningBuildingBlocks
@@ -120,7 +121,9 @@ class TC_RR_1_1(MatterBaseTest):
         for i in range(num_fabrics_to_commission - 1):
             admin_index = 2 + i
             logging.info("Commissioning fabric %d/%d" % (admin_index, num_fabrics_to_commission))
-            new_fabric_admin = chip.FabricAdmin.FabricAdmin(vendorId=0xFFF1, adminIndex=admin_index)
+            new_certificate_authority = self.certificate_authority_manager.NewCertificateAuthority()
+            new_fabric_admin = new_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=admin_index)
+
             new_admin_ctrl = new_fabric_admin.NewController(nodeId=dev_ctrl.nodeId)
             new_admin_ctrl.name = all_names.pop(0)
             client_list.append(new_admin_ctrl)

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -311,10 +311,18 @@ class TC_RR_1_1(MatterBaseTest):
         if sub_test_failed:
             asserts.fail("Failed step 7 !")
 
-        # Step 8: TODO: Validate sessions have not changed by doing a read on NodeLabel from all clients
+        # Step 8: Validate sessions have not changed by doing a read on NodeLabel from all clients
+        logging.info("Step 8: Read back NodeLabel directly from all clients")
+        for sub_idx, client in enumerate(client_list):
+            logging.info("Reading NodeLabel (%d/%d) from controller node %s" % (sub_idx + 1, len(client_list), client.name))
+
+            label_readback = await self.read_single_attribute(client, node_id=self.dut_node_id, endpoint=0, attribute=Clusters.Basic.Attributes.NodeLabel)
+            asserts.assert_equal(label_readback, AFTER_LABEL)
+
+            # TODO: Compare before/after session IDs. Requires more native changes, and the
+            #       subcription method above is actually good enough we think.
 
         # Step 9: Fill user label list
-
         if has_user_labels and not skip_user_label_cluster_steps:
             await self.fill_user_label_list(dev_ctrl, self.dut_node_id)
         else:
@@ -421,4 +429,4 @@ class TC_RR_1_1(MatterBaseTest):
 
 
 if __name__ == "__main__":
-    default_matter_test_main()
+    default_matter_test_main(maximize_cert_chains=True)

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -75,6 +75,9 @@ class TC_RR_1_1(MatterBaseTest):
 
         # Pre-conditions
 
+        # Make sure all certificates are installed with maximal size
+        dev_ctrl.fabricAdmin.certificateAuthority.maximizeCertChains = True
+
         # TODO: Do from PICS list. The reflection approach here what a real client would do,
         #       and it respects that the test says "TH writes 4 entries per endpoint where LabelList is supported"
         logging.info("Pre-condition: determine whether any endpoints have UserLabel cluster (ULABEL.S.A0000(LabelList))")

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -1,0 +1,240 @@
+#
+#    Copyright (c) 2022 Project CHIP Authors
+#    All rights reserved.
+#
+#    Licensed under the Apache License, Version 2.0 (the "License");
+#    you may not use this file except in compliance with the License.
+#    You may obtain a copy of the License at
+#
+#        http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+from matter_testing_support import MatterBaseTest, default_matter_test_main, async_test_body
+import chip.clusters as Clusters
+import chip.FabricAdmin
+import logging
+from mobly import asserts
+from chip.utils import CommissioningBuildingBlocks
+from chip.clusters.Attribute import TypedAttributePath, SubscriptionTransaction, AttributeStatus
+from chip.interaction_model import Status as StatusEnum
+import queue
+import asyncio
+from binascii import hexlify
+from threading import Event
+import time
+import random
+
+from TC_SC_3_6 import AttributeChangeAccumulator, ResubscriptionCatcher
+
+# TODO: Overall, we need to add validation that session IDs have not changed throughout to be agnostic
+#       to some internal behavior assumptions of the SDK we are making relative to the write to
+#       the trigger the subscriptions not re-opening a new CASE session
+#
+
+class TC_RR_1_1(MatterBaseTest):
+    def setup_class(self):
+        self._pseudo_random_generator = random.Random(1234)
+        self._subscriptions = []
+
+    def teardown_class(self):
+        logging.info("Teardown: shutting down all subscription to avoid racy callbacks")
+        for subscription in self._subscriptions:
+            subscription.Shutdown()
+
+    @async_test_body
+    async def test_TC_RR_1_1(self):
+        dev_ctrl = self.default_controller
+
+        # Get overrides for debugging the test
+        num_fabrics_to_commission = self.user_params.get("num_fabrics_to_commission", 5)
+        num_controllers_per_fabric = self.user_params.get("num_controllers_per_fabric", 3)
+        # Immediate reporting
+        min_report_interval_sec = self.user_params.get("min_report_interval_sec", 0)
+        # 10 minutes max reporting interval --> We don't care about keep-alives per-se and
+        # want to avoid resubscriptions
+        max_report_interval_sec = self.user_params.get("max_report_interval_sec", 10 * 60)
+        # Time to wait after changing NodeLabel for subscriptions to all hit. This is dependant
+        # on MRP params of subscriber and on actual min_report_interval.
+        # TODO: Determine the correct max value depending on target. Test plan doesn't say!
+        timeout_delay_sec = self.user_params.get("timeout_delay_sec", max_report_interval_sec * 2)
+        # Whether to skip filling the label clusters
+        skip_label_cluster_steps = self.user_params.get("skip_label_cluster_steps", False)
+
+        BEFORE_LABEL = "Before Subscriptions"
+        AFTER_LABEL = "After Subscriptions"
+
+        await self.fill_user_label_list(dev_ctrl, self.dut_node_id)
+        return
+
+        # Generate list of all clients names
+        all_names = []
+        for fabric_idx in range(num_fabrics_to_commission):
+            for controller_idx in range(num_controllers_per_fabric):
+                all_names.append("RD%d%s" % (fabric_idx + 1, chr(ord('A') + controller_idx)))
+        logging.info("Client names that will be used: %s" % all_names)
+        client_list = []
+
+        logging.info("Pre-conditions: validate CapabilityMinima.CaseSessionsPerFabric >= 3")
+
+        capability_minima = await self.read_single_attribute(dev_ctrl, node_id=self.dut_node_id, endpoint=0, attribute=Clusters.Basic.Attributes.CapabilityMinima)
+        asserts.assert_greater_equal(capability_minima.caseSessionsPerFabric, 3)
+
+        logging.info("Step 1: use existing fabric to configure new fabrics so that total is %d fabrics" %
+                     num_fabrics_to_commission)
+
+        # Generate Node IDs for subsequent controllers start at 200, follow 200, 300, ...
+        node_ids = [200 + (i * 100) for i in range(num_controllers_per_fabric - 1)]
+
+        # Prepare clients for first fabric, that includes the default controller
+        dev_ctrl.name = all_names.pop(0)
+        client_list.append(dev_ctrl)
+
+        if num_controllers_per_fabric > 1:
+            new_controllers = await CommissioningBuildingBlocks.CreateControllersOnFabric(fabricAdmin=dev_ctrl.fabricAdmin, adminDevCtrl=dev_ctrl, controllerNodeIds=node_ids, privilege=Clusters.AccessControl.Enums.Privilege.kAdminister, targetNodeId=self.dut_node_id)
+            for controller in new_controllers:
+                controller.name = all_names.pop(0)
+            client_list.extend(new_controllers)
+
+        # Prepare clients for subsequent fabrics
+        for i in range(num_fabrics_to_commission - 1):
+            admin_index = 2 + i
+            logging.info("Commissioning fabric %d/%d" % (admin_index, num_fabrics_to_commission))
+            new_fabric_admin = chip.FabricAdmin.FabricAdmin(vendorId=0xFFF1, adminIndex=admin_index)
+            new_admin_ctrl = new_fabric_admin.NewController(nodeId=dev_ctrl.nodeId)
+            new_admin_ctrl.name = all_names.pop(0)
+            client_list.append(new_admin_ctrl)
+            await CommissioningBuildingBlocks.AddNOCForNewFabricFromExisting(commissionerDevCtrl=dev_ctrl, newFabricDevCtrl=new_admin_ctrl, existingNodeId=self.dut_node_id, newNodeId=self.dut_node_id)
+
+            if num_controllers_per_fabric > 1:
+                new_controllers = await CommissioningBuildingBlocks.CreateControllersOnFabric(fabricAdmin=new_fabric_admin, adminDevCtrl=new_admin_ctrl,
+                                                                                              controllerNodeIds=node_ids, privilege=Clusters.AccessControl.Enums.Privilege.kAdminister, targetNodeId=self.dut_node_id)
+                for controller in new_controllers:
+                    controller.name = all_names.pop(0)
+
+                client_list.extend(new_controllers)
+
+        asserts.assert_equal(len(client_list), num_fabrics_to_commission *
+                             num_controllers_per_fabric, "Must have the right number of clients")
+
+        # Before subscribing, set the NodeLabel to "Before Subscriptions"
+        logging.info("Pre-conditions: writing initial value of NodeLabel, so that we can control for change of attribute detection")
+        await client_list[0].WriteAttribute(self.dut_node_id, [(0, Clusters.Basic.Attributes.NodeLabel(value=BEFORE_LABEL))])
+
+        # Subscribe with all clients to NodeLabel attribute
+        sub_handlers = []
+        resub_catchers = []
+        output_queue = queue.Queue()
+
+        logging.info("Step 1 (first part): Establish subscription with all %d clients" % len(client_list))
+        for sub_idx, client in enumerate(client_list):
+            logging.info("Establishing subscription %d/%d from controller node %s" % (sub_idx + 1, len(client_list), client.name))
+
+            sub = await client.ReadAttribute(nodeid=self.dut_node_id, attributes=[(0, Clusters.Basic.Attributes.NodeLabel)],
+                                             reportInterval=(min_report_interval_sec, max_report_interval_sec), keepSubscriptions=False)
+            self._subscriptions.append(sub)
+
+            attribute_handler = AttributeChangeAccumulator(
+                name=client.name, expected_attribute=Clusters.Basic.Attributes.NodeLabel, output=output_queue)
+            sub.SetAttributeUpdateCallback(attribute_handler)
+            sub_handlers.append(attribute_handler)
+
+            # TODO: Replace resubscription catcher with API to disable re-subscription on failure
+            resub_catcher = ResubscriptionCatcher(name=client.name)
+            sub.SetResubscriptionAttemptedCallback(resub_catcher)
+            resub_catchers.append(resub_catcher)
+
+        asserts.assert_equal(len(self._subscriptions), len(client_list), "Must have the right number of subscriptions")
+
+        # Trigger a change on NodeLabel
+        logging.info(
+            "Step 1 (second part): Change attribute with one client, await all attributes changed within time")
+        await asyncio.sleep(1)
+        await client_list[0].WriteAttribute(self.dut_node_id, [(0, Clusters.Basic.Attributes.NodeLabel(value=AFTER_LABEL))])
+
+        all_changes = {client.name: False for client in client_list}
+
+        # Await a stabilization delay in increments to let the event loops run
+        start_time = time.time()
+        elapsed = 0
+        time_remaining = timeout_delay_sec
+
+        while time_remaining > 0:
+            try:
+                item = output_queue.get(block=True, timeout=time_remaining)
+                client_name, endpoint, attribute, value = item['name'], item['endpoint'], item['attribute'], item['value']
+
+                # Record arrival of an expected subscription change when seen
+                if endpoint == 0 and attribute == Clusters.Basic.Attributes.NodeLabel and value == AFTER_LABEL:
+                    if not all_changes[client_name]:
+                        logging.info("Got expected attribute change for client %s" % client_name)
+                        all_changes[client_name] = True
+
+                # We are done waiting when we have accumulated all results
+                if all(all_changes.values()):
+                    logging.info("All clients have reported, done waiting.")
+                    break
+            except queue.Empty:
+                # No error, we update timeouts and keep going
+                pass
+
+            elapsed = time.time() - start_time
+            time_remaining = timeout_delay_sec - elapsed
+
+        logging.info("Validation of results")
+        failed = False
+
+        for catcher in resub_catchers:
+            if catcher.caught_resubscription:
+                logging.error("Client %s saw a resubscription" % catcher.name)
+                failed = True
+            else:
+                logging.info("Client %s correctly did not see a resubscription" % catcher.name)
+
+        all_reports_gotten = all(all_changes.values())
+        if not all_reports_gotten:
+            logging.error("Missing reports from the following clients: %s" %
+                          ", ".join([name for name, value in all_changes.items() if value is False]))
+            failed = True
+        else:
+            logging.info("Got successful reports from all clients, meaning all concurrent CASE sessions worked")
+
+        # Determine final result
+        if failed:
+            asserts.fail("Failed test !")
+
+        # Pass is implicit if not failed
+
+    def random_string(self, length) -> str:
+        rnd = self._pseudo_random_generator
+        return "".join([rnd.choice("abcdef0123456789") for _ in range(length)])[:length]
+
+    async def fill_basic_labels(self, dev_ctrl, target_node_id):
+        pass
+
+    async def fill_user_label_list(self, dev_ctrl, target_node_id):
+        user_labels = await dev_ctrl.ReadAttribute(target_node_id, [ Clusters.UserLabel ] )
+
+        # Build 4 sets of maximized labels
+        random_label = self.random_string(16)
+        random_value = self.random_string(16)
+        labels = [Clusters.UserLabel.Structs.LabelStruct(label=random_label, value=random_value) for _ in range(4)]
+
+        for endpoint_id in user_labels:
+            clusters = user_labels[endpoint_id]
+            for cluster in clusters:
+                if cluster == Clusters.UserLabel:
+                    statuses = await dev_ctrl.WriteAttribute(target_node_id, [(10 + endpoint_id, Clusters.UserLabel.Attributes.LabelList(labels))])
+                    asserts.assert_equal(statuses[0].Status, StatusEnum.Success, "Label write must succeed")
+
+                    read_back_labels = await dev_ctrl.ReadAttribute(target_node_id, [ (endpoint_id, Clusters.UserLabel.Attributes.LabelList) ] )
+                    logging.info(read_back_labels)
+
+
+if __name__ == "__main__":
+    default_matter_test_main()

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -114,7 +114,7 @@ class TC_RR_1_1(MatterBaseTest):
         client_list.append(dev_ctrl)
 
         if num_controllers_per_fabric > 1:
-            new_controllers = await CommissioningBuildingBlocks.CreateControllersOnFabric(fabricAdmin=dev_ctrl.fabricAdmin, adminDevCtrl=dev_ctrl, controllerNodeIds=node_ids, privilege=Clusters.AccessControl.Enums.Privilege.kAdminister, targetNodeId=self.dut_node_id)
+            new_controllers = await CommissioningBuildingBlocks.CreateControllersOnFabric(fabricAdmin=dev_ctrl.fabricAdmin, adminDevCtrl=dev_ctrl, controllerNodeIds=node_ids, privilege=Clusters.AccessControl.Enums.Privilege.kAdminister, targetNodeId=self.dut_node_id, catTags=[0x0001_0001])
             for controller in new_controllers:
                 controller.name = all_names.pop(0)
             client_list.extend(new_controllers)
@@ -126,14 +126,14 @@ class TC_RR_1_1(MatterBaseTest):
             new_certificate_authority = self.certificate_authority_manager.NewCertificateAuthority()
             new_fabric_admin = new_certificate_authority.NewFabricAdmin(vendorId=0xFFF1, fabricId=admin_index)
 
-            new_admin_ctrl = new_fabric_admin.NewController(nodeId=dev_ctrl.nodeId)
+            new_admin_ctrl = new_fabric_admin.NewController(nodeId=dev_ctrl.nodeId, catTags=[0x0001_0001])
             new_admin_ctrl.name = all_names.pop(0)
             client_list.append(new_admin_ctrl)
             await CommissioningBuildingBlocks.AddNOCForNewFabricFromExisting(commissionerDevCtrl=dev_ctrl, newFabricDevCtrl=new_admin_ctrl, existingNodeId=self.dut_node_id, newNodeId=self.dut_node_id)
 
             if num_controllers_per_fabric > 1:
                 new_controllers = await CommissioningBuildingBlocks.CreateControllersOnFabric(fabricAdmin=new_fabric_admin, adminDevCtrl=new_admin_ctrl,
-                                                                                              controllerNodeIds=node_ids, privilege=Clusters.AccessControl.Enums.Privilege.kAdminister, targetNodeId=self.dut_node_id)
+                                                                                              controllerNodeIds=node_ids, privilege=Clusters.AccessControl.Enums.Privilege.kAdminister, targetNodeId=self.dut_node_id, catTags=[0x0001_0001])
                 for controller in new_controllers:
                     controller.name = all_names.pop(0)
 
@@ -376,14 +376,7 @@ class TC_RR_1_1(MatterBaseTest):
         # - Targets field: [{Cluster: 0xFFF1_FC40, DeviceType: 0xFFF1_FC20}, {Cluster: 0xFFF1_FC41, DeviceType: 0xFFF1_FC21}, {Cluster: 0xFFF1_FC02, DeviceType: 0xFFF1_FC42}]
 
         # Administer ACL entry
-        admin_subjects = [0xFFFF_FFFD_0001_0001]
-        # TODO: Replace the below with [0x2000_0000_0000_0001, 0x2000_0000_0000_0002, 0x2000_0000_0000_0003] once controllers
-        #       all have CAT tag 0001_0001 in their NOC
-
-        # Find node ID of all controllers (up to 3) and make them admin
-        for subject_idx in range(min(num_controllers_per_fabric, 3)):
-            subject_name = "RD%d%s" % (fabric_number, chr(ord('A') + subject_idx))
-            admin_subjects.append(client_by_name[subject_name].nodeId)
+        admin_subjects = [0xFFFF_FFFD_0001_0001, 0x2000_0000_0000_0001, 0x2000_0000_0000_0002, 0x2000_0000_0000_0003]
 
         admin_targets = [
             Clusters.AccessControl.Structs.Target(endpoint=0),
@@ -428,4 +421,4 @@ class TC_RR_1_1(MatterBaseTest):
 
 
 if __name__ == "__main__":
-    default_matter_test_main(maximize_cert_chains=True)
+    default_matter_test_main(maximize_cert_chains=True, controller_cat_tags=[0x0001_0001])

--- a/src/python_testing/TC_RR_1_1.py
+++ b/src/python_testing/TC_RR_1_1.py
@@ -79,7 +79,7 @@ class TC_RR_1_1(MatterBaseTest):
         dev_ctrl.fabricAdmin.certificateAuthority.maximizeCertChains = True
 
         # TODO: Do from PICS list. The reflection approach here what a real client would do,
-        #       and it respects that the test says "TH writes 4 entries per endpoint where LabelList is supported"
+        #       and it respects what the test says: "TH writes 4 entries per endpoint where LabelList is supported"
         logging.info("Pre-condition: determine whether any endpoints have UserLabel cluster (ULABEL.S.A0000(LabelList))")
         endpoints_with_user_label_list = await dev_ctrl.ReadAttribute(self.dut_node_id, [Clusters.UserLabel.Attributes.LabelList])
         has_user_labels = len(endpoints_with_user_label_list) > 0
@@ -94,7 +94,7 @@ class TC_RR_1_1(MatterBaseTest):
         for fabric_idx in range(num_fabrics_to_commission):
             for controller_idx in range(num_controllers_per_fabric):
                 all_names.append("RD%d%s" % (fabric_idx + 1, chr(ord('A') + controller_idx)))
-        logging.info("Client names that will be used: %s" % all_names)
+        logging.info(f"Client names that will be used: {all_names}")
         client_list = []
 
         # TODO: Shall we also verify SupportedFabrics attribute, and the CapabilityMinima attribute?
@@ -104,8 +104,7 @@ class TC_RR_1_1(MatterBaseTest):
         asserts.assert_greater_equal(capability_minima.caseSessionsPerFabric, 3)
 
         # Step 1: Commission 5 fabrics with maximized NOC chains
-        logging.info("Step 1: use existing fabric to configure new fabrics so that total is %d fabrics" %
-                     num_fabrics_to_commission)
+        logging.info(f"Step 1: use existing fabric to configure new fabrics so that total is {num_fabrics_to_commission} fabrics")
 
         # Generate Node IDs for subsequent controllers start at 200, follow 200, 300, ...
         node_ids = [200 + (i * 100) for i in range(num_controllers_per_fabric - 1)]
@@ -165,7 +164,7 @@ class TC_RR_1_1(MatterBaseTest):
             asserts.assert_equal(fabric_metadata[0].label, label, "Fabrics[x].label must match what was written")
 
         # Before subscribing, set the NodeLabel to "Before Subscriptions"
-        logging.info("Step 2b: Set BasicInformation.NodeLabel to '%s'" % BEFORE_LABEL)
+        logging.info(f"Step 2b: Set BasicInformation.NodeLabel to {BEFORE_LABEL}")
         await client_list[0].WriteAttribute(self.dut_node_id, [(0, Clusters.Basic.Attributes.NodeLabel(value=BEFORE_LABEL))])
 
         node_label = await self.read_single_attribute(client, node_id=self.dut_node_id, endpoint=0, attribute=Clusters.Basic.Attributes.NodeLabel)
@@ -182,10 +181,10 @@ class TC_RR_1_1(MatterBaseTest):
 
             acl = self.build_acl(fabric_number, client_by_name, num_controllers_per_fabric)
 
-            logging.info("Step 3a: Writing ACL entry for fabric %d" % fabric_number)
+            logging.info(f"Step 3a: Writing ACL entry for fabric {fabric_number}")
             await client.WriteAttribute(self.dut_node_id, [(0, Clusters.AccessControl.Attributes.Acl(acl))])
 
-            logging.info("Step 3b: Validating ACL entry for fabric %d" % fabric_number)
+            logging.info(f"Step 3b: Validating ACL entry for fabric {fabric_number}")
             acl_readback = await self.read_single_attribute(client, node_id=self.dut_node_id, endpoint=0, attribute=Clusters.AccessControl.Attributes.Acl)
             fabric_index = 9999
             for entry in acl_readback:
@@ -230,7 +229,7 @@ class TC_RR_1_1(MatterBaseTest):
 
         asserts.assert_equal(len(self._subscriptions), len(client_list), "Must have the right number of subscriptions")
 
-        # Step 6: TODO: Read 9 paths and validate success
+        # Step 6: Read 9 paths and validate success
         logging.info("Step 6: Read 9 paths (first 9 attributes of Basic Information cluster) and validate success")
 
         large_read_contents = [

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -186,11 +186,12 @@ class MatterStackState:
         if (len(self._certificate_authority_manager.activeCaList) == 0):
             self._logger.warn(
                 "Didn't find any CertificateAuthorities in storage -- creating a new CertificateAuthority + FabricAdmin...")
-            ca = self._certificate_authority_manager.NewCertificateAuthority()
-            ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=0xFFF1)
+            ca = self._certificate_authority_manager.NewCertificateAuthority(caIndex = self._config.root_of_trust_index)
+            ca.maximizeCertChains = True
+            ca.NewFabricAdmin(vendorId=0xFFF1, fabricId=self._config.fabric_id)
         elif (len(self._certificate_authority_manager.activeCaList[0].adminList) == 0):
             self._logger.warn("Didn't find any FabricAdmins in storage -- creating a new one...")
-            self._certificate_authority_manager.activeCaList[0].NewFabricAdmin(vendorId=0xFFF1, fabricId=0xFFF1)
+            self._certificate_authority_manager.activeCaList[0].NewFabricAdmin(vendorId=0xFFF1, fabricId=self._config.fabric_id)
 
     # TODO: support getting access to chip-tool credentials issuer's data
 
@@ -696,6 +697,7 @@ def default_matter_test_main(argv=None):
 
     # TODO: Steer to right FabricAdmin!
     # TODO: If CASE Admin Subject is a CAT tag range, then make sure to issue NOC with that CAT tag
+
     default_controller = stack.certificate_authorities[0].adminList[0].NewController(nodeId=matter_test_config.controller_node_id,
                                                                                      paaTrustStorePath=str(matter_test_config.paa_trust_store_path))
     test_config.user_params["default_controller"] = stash_globally(default_controller)

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -714,7 +714,7 @@ def default_matter_test_main(argv=None, **kwargs):
     # TODO: If CASE Admin Subject is a CAT tag range, then make sure to issue NOC with that CAT tag
 
     default_controller = stack.certificate_authorities[0].adminList[0].NewController(nodeId=matter_test_config.controller_node_id,
-                                                                                     paaTrustStorePath=str(matter_test_config.paa_trust_store_path))
+                                                                                     paaTrustStorePath=str(matter_test_config.paa_trust_store_path), catTags=matter_test_config.controller_cat_tags)
     test_config.user_params["default_controller"] = stash_globally(default_controller)
 
     test_config.user_params["matter_test_config"] = stash_globally(matter_test_config)

--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -146,6 +146,9 @@ class MatterTestConfig:
     dut_node_id: int = _DEFAULT_DUT_NODE_ID
     # Node ID to use for controller/commissioner
     controller_node_id: int = _DEFAULT_CONTROLLER_NODE_ID
+    # CAT Tags for default controller/commissioner
+    controller_cat_tags: List[int] = None
+
     # Fabric ID which to use
     fabric_id: int = None
     # "Alpha" by default
@@ -681,6 +684,10 @@ def default_matter_test_main(argv=None, **kwargs):
       argv: A list that is then parsed as command line args. If None, defaults to sys.argv
     """
     matter_test_config = parse_matter_test_args(argv)
+
+    # Allow override of command line from optional arguments
+    if matter_test_config.controller_cat_tags is None and "controller_cat_tags" in kwargs:
+        matter_test_config.controller_cat_tags = kwargs["controller_cat_tags"]
 
     # Find the test class in the test script.
     test_class = _find_test_class()


### PR DESCRIPTION
#### Problem    
- TC-RR-1.1 is a critical test to validate multi-fabric
  behavior is stable and actually works. The test, broadly,
  validates most of the minimas of the core elements of the spec,
  including ACL entries, certificate sizes, number of CASE
  sessions and subscriptions, number of paths, etc.

Issue #21736

#### Change overview
- This PR introduces the core test and all associated minor
  changes to infrastructure to make it work.
- Still TODO:
  - More extensive cert size maximization (closer to 400 TLV bytes)
  - Add controller and commissionee CAT tags (test is 95% equivalent
    to test plan, but a couple ACL fields differ because of this, in
    ways that don't detract from proving what needs proving
  - Validation that local/peer session IDs have not changed. This is
    not technically needed with the SDK as-is based on the methodology
    but it would future-proof the test against some future optimizations
    that may change subscription behavior in a way that the test would
    not validate CASE sessions remain.
  - Clean-up more after the test, so that a factory reset before/after
    is not needed.

#### Testing
- Passes on Linux against all-clusters, all-clusters-minimal and
  lighting app, with both minimal mdns and Avahi.
- Passes on some other platforms (not named here)

To run within SDK (from scratch: the build steps can be skipped thereafter):

- In one terminal:
  - Build chip-lighting-app linux
  - `clear && rm -f kvs1 && out/debug/standalone/chip-lighting-app --discriminator 1234 --KVS kvs1 --trace_decode 1`

- In another terminal:
  - Build
    - `rm -rf out/python*`
    - `scripts/build_python.sh -m platform -i separate`
  - Run
    - `source ./out/python_env/bin/activate`
    - `rm -f admin_storage.json && python3 src/python_testing/TC_RR_1_1.py --commissioning-method on-network --long-discriminator 1234 --passcode 20202021`
      - Add `--bool-arg skip_user_label_cluster_steps:true` to the end of the command line
        if your DUT has broken UserLabel clusters (but if you have those, fix them :)

