### PR TITLE
[python] Add script interface for node discovery in REPL

### DIFF
--- a/docs/guides/repl/.ipynb_checkpoints/Matter - Basic Interactions-checkpoint.ipynb
+++ b/docs/guides/repl/.ipynb_checkpoints/Matter - Basic Interactions-checkpoint.ipynb
@@ -523,7 +523,7 @@
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">(</span>To Be Commissioned By<span style=\"font-weight: bold\">)</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'caIndex(1)/fabricId(0x0000000000000001)/nodeId(0x000000000001B669)'</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"color: #800080; text-decoration-color: #800080; font-weight: bold\">CommissionableNode</span><span style=\"font-weight: bold\">(</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">instanceName</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'B2D5B11D799BB1E0'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">hostName</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'DCA63289ABCD0000'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">hostName</span>=<span style=\"color: #008000; text-decoration-color: #008000\">'DCA632A54C510000'</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">port</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">5540</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">longDiscriminator</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">3840</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">vendorId</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">65521</span>,\n",
@@ -537,8 +537,8 @@
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">mrpRetryIntervalActive</span>=<span style=\"color: #008080; text-decoration-color: #008080; font-weight: bold\">300</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">supportsTcp</span>=<span style=\"color: #00ff00; text-decoration-color: #00ff00; font-style: italic\">True</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"color: #808000; text-decoration-color: #808000\">addresses</span>=<span style=\"font-weight: bold\">[</span>\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'fd1e:1a94:d591:6914:dea6:32ff:fe89:abcd'</span>,\n",
-       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'fe80::dea6:32ff:fe89:abcd'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'fd1e:1a94:d591:6914:dea6:32ff:fea5:4c51'</span>,\n",
+       "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'fe80::dea6:32ff:fea5:4c51'</span>,\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   │   </span><span style=\"color: #008000; text-decoration-color: #008000\">'172.16.243.198'</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   │   </span><span style=\"font-weight: bold\">]</span>\n",
        "<span style=\"color: #7fbf7f; text-decoration-color: #7fbf7f\">│   │   </span><span style=\"font-weight: bold\">)</span>\n",
@@ -553,7 +553,7 @@
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m(\u001b[0mTo Be Commissioned By\u001b[1m)\u001b[0m=\u001b[32m'caIndex\u001b[0m\u001b[32m(\u001b[0m\u001b[32m1\u001b[0m\u001b[32m)\u001b[0m\u001b[32m/fabricId\u001b[0m\u001b[32m(\u001b[0m\u001b[32m0x0000000000000001\u001b[0m\u001b[32m)\u001b[0m\u001b[32m/nodeId\u001b[0m\u001b[32m(\u001b[0m\u001b[32m0x000000000001B669\u001b[0m\u001b[32m)\u001b[0m\u001b[32m'\u001b[0m,\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1;35mCommissionableNode\u001b[0m\u001b[1m(\u001b[0m\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[33minstanceName\u001b[0m=\u001b[32m'B2D5B11D799BB1E0'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   \u001b[0m\u001b[33mhostName\u001b[0m=\u001b[32m'DCA63289ABCD0000'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   \u001b[0m\u001b[33mhostName\u001b[0m=\u001b[32m'DCA632A54C510000'\u001b[0m,\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[33mport\u001b[0m=\u001b[1;36m5540\u001b[0m,\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[33mlongDiscriminator\u001b[0m=\u001b[1;36m3840\u001b[0m,\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[33mvendorId\u001b[0m=\u001b[1;36m65521\u001b[0m,\n",
@@ -567,9 +567,9 @@
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[33mmrpRetryIntervalActive\u001b[0m=\u001b[1;36m300\u001b[0m,\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[33msupportsTcp\u001b[0m=\u001b[3;92mTrue\u001b[0m,\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[33maddresses\u001b[0m=\u001b[1m[\u001b[0m\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[32m'fd1e:1a94:d591:6914:dea6:32ff:fe89:abcd'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[32m'fe80::dea6:32ff:fe89:abcd'\u001b[0m,\n",
-       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[32m'192.168.2.1'\u001b[0m\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[32m'fd1e:1a94:d591:6914:dea6:32ff:fea5:4c51'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[32m'fe80::dea6:32ff:fea5:4c51'\u001b[0m,\n",
+       "\u001b[2;32m│   │   │   │   \u001b[0m\u001b[32m'172.16.243.198'\u001b[0m\n",
        "\u001b[2;32m│   │   │   \u001b[0m\u001b[1m]\u001b[0m\n",
        "\u001b[2;32m│   │   \u001b[0m\u001b[1m)\u001b[0m\n",
        "\u001b[2;32m│   \u001b[0m\u001b[1m)\u001b[0m\n",
@@ -578,6 +578,13 @@
      },
      "metadata": {},
      "output_type": "display_data"
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "2022-08-19 14:57:45 songguo.sha.corp.google.com chip.DIS[3192750] ERROR Timeout waiting for mDNS resolution.\n"
+     ]
     }
    ],
    "source": [

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -51,6 +51,7 @@ shared_library("ChipDeviceCtrl") {
   if (chip_controller) {
     sources += [
       "ChipCommissionableNodeController-ScriptBinding.cpp",
+      "ChipDeviceController-Discovery.cpp",
       "ChipDeviceController-IssueNocChain.cpp",
       "ChipDeviceController-ScriptBinding.cpp",
       "ChipDeviceController-ScriptDevicePairingDelegate.cpp",
@@ -109,6 +110,7 @@ shared_library("ChipDeviceCtrl") {
     public_deps += [
       "${chip_root}/src/controller/data_model",
       "${chip_root}/src/credentials:file_attestation_trust_store",
+      "${chip_root}/third_party/jsoncpp",
     ]
   } else {
     public_deps += [ "$chip_data_model" ]

--- a/src/controller/python/ChipDeviceController-Discovery.cpp
+++ b/src/controller/python/ChipDeviceController-Discovery.cpp
@@ -1,0 +1,218 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ *    @file
+ *      Implementation of the native methods expected by the Python
+ *      version of Chip Device Manager.
+ *
+ */
+
+#include <controller/CHIPDeviceController.h>
+#include <json/json.h>
+#include <lib/core/CHIPError.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/dnssd/Resolver.h>
+
+using namespace chip;
+
+typedef void (*IterateDiscoveredCommissionableNodesFunct)(const char * deviceInfoJson, size_t deviceInfoLen);
+
+extern "C" {
+
+bool pychip_DeviceController_HasDiscoveredCommissionableNode(Controller::DeviceCommissioner * devCtrl)
+{
+    for (int i = 0; i < devCtrl->GetMaxCommissionableNodesSupported(); ++i)
+    {
+        const Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
+        if (dnsSdInfo == nullptr)
+        {
+            continue;
+        }
+        return true;
+    }
+    return false;
+}
+
+ChipError::StorageType pychip_DeviceController_DiscoverCommissionableNodes(Controller::DeviceCommissioner * devCtrl,
+                                                                           const uint8_t filterType, const char * filterParam)
+{
+    Dnssd::DiscoveryFilter filter(static_cast<Dnssd::DiscoveryFilterType>(filterType));
+    switch (static_cast<Dnssd::DiscoveryFilterType>(filterType))
+    {
+    case Dnssd::DiscoveryFilterType::kNone:
+        break;
+    case Dnssd::DiscoveryFilterType::kShortDiscriminator:
+    case Dnssd::DiscoveryFilterType::kLongDiscriminator:
+    case Dnssd::DiscoveryFilterType::kCompressedFabricId:
+    case Dnssd::DiscoveryFilterType::kVendorId:
+    case Dnssd::DiscoveryFilterType::kDeviceType: {
+        // For any numerical filter, convert the string to a filter value
+        errno                               = 0;
+        unsigned long long int numericalArg = strtoull(filterParam, nullptr, 0);
+        if ((numericalArg == ULLONG_MAX) && (errno == ERANGE))
+        {
+            return CHIP_ERROR_INVALID_ARGUMENT.AsInteger();
+        }
+        filter.code = static_cast<uint64_t>(numericalArg);
+        break;
+    }
+    case Dnssd::DiscoveryFilterType::kCommissioningMode:
+        break;
+    case Dnssd::DiscoveryFilterType::kCommissioner:
+        filter.code = 1;
+        break;
+    case Dnssd::DiscoveryFilterType::kInstanceName:
+        filter.code         = 0;
+        filter.instanceName = filterParam;
+        break;
+    default:
+        return CHIP_ERROR_INVALID_ARGUMENT.AsInteger();
+    }
+
+    return devCtrl->DiscoverCommissionableNodes(filter).AsInteger();
+}
+
+void pychip_DeviceController_IterateDiscoveredCommissionableNodes(Controller::DeviceCommissioner * devCtrl,
+                                                                  IterateDiscoveredCommissionableNodesFunct cb)
+{
+    VerifyOrReturn(cb != nullptr);
+
+    for (int i = 0; i < devCtrl->GetMaxCommissionableNodesSupported(); ++i)
+    {
+        const Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
+        if (dnsSdInfo == nullptr)
+        {
+            continue;
+        }
+
+        Json::Value jsonVal;
+
+        char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->commissionData.rotatingId, dnsSdInfo->commissionData.rotatingIdLen,
+                                            rotatingId, sizeof(rotatingId));
+
+        ChipLogProgress(Discovery, "Commissionable Node %d", i);
+        jsonVal["instanceName"]       = dnsSdInfo->commissionData.instanceName;
+        jsonVal["hostName"]           = dnsSdInfo->resolutionData.hostName;
+        jsonVal["port"]               = dnsSdInfo->resolutionData.port;
+        jsonVal["longDiscriminator"]  = dnsSdInfo->commissionData.longDiscriminator;
+        jsonVal["vendorId"]           = dnsSdInfo->commissionData.vendorId;
+        jsonVal["productId"]          = dnsSdInfo->commissionData.productId;
+        jsonVal["commissioningMode"]  = dnsSdInfo->commissionData.commissioningMode;
+        jsonVal["deviceType"]         = dnsSdInfo->commissionData.deviceType;
+        jsonVal["deviceName"]         = dnsSdInfo->commissionData.deviceName;
+        jsonVal["pairingInstruction"] = dnsSdInfo->commissionData.pairingInstruction;
+        jsonVal["pairingHint"]        = dnsSdInfo->commissionData.pairingHint;
+        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
+        {
+            jsonVal["mrpRetryIntervalIdle"] = dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().Value().count();
+        }
+        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().HasValue())
+        {
+            jsonVal["mrpRetryIntervalActive"] = dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().Value().count();
+        }
+        jsonVal["supportsTcp"] = dnsSdInfo->resolutionData.supportsTcp;
+        {
+            Json::Value addresses;
+            for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
+            {
+                char buf[Inet::IPAddress::kMaxStringLength];
+                dnsSdInfo->resolutionData.ipAddress[j].ToString(buf);
+                addresses[j] = buf;
+            }
+            jsonVal["addresses"] = addresses;
+        }
+
+        {
+            auto str = jsonVal.toStyledString();
+            cb(str.c_str(), str.size());
+        }
+    }
+}
+
+void pychip_DeviceController_PrintDiscoveredDevices(Controller::DeviceCommissioner * devCtrl)
+{
+    for (int i = 0; i < devCtrl->GetMaxCommissionableNodesSupported(); ++i)
+    {
+        const Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
+        if (dnsSdInfo == nullptr)
+        {
+            continue;
+        }
+        char rotatingId[Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
+        Encoding::BytesToUppercaseHexString(dnsSdInfo->commissionData.rotatingId, dnsSdInfo->commissionData.rotatingIdLen,
+                                            rotatingId, sizeof(rotatingId));
+
+        ChipLogProgress(Discovery, "Commissionable Node %d", i);
+        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->commissionData.instanceName);
+        ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->resolutionData.hostName);
+        ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->resolutionData.port);
+        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->commissionData.longDiscriminator);
+        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->commissionData.vendorId);
+        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->commissionData.productId);
+        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->commissionData.commissioningMode);
+        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->commissionData.deviceType);
+        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->commissionData.deviceName);
+        ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
+        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->commissionData.pairingInstruction);
+        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->commissionData.pairingHint);
+        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
+        {
+            ChipLogProgress(Discovery, "\tMrp Interval idle\t%u",
+                            dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().Value().count());
+        }
+        else
+        {
+            ChipLogProgress(Discovery, "\tMrp Interval idle\tNot present");
+        }
+        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().HasValue())
+        {
+            ChipLogProgress(Discovery, "\tMrp Interval active\t%u",
+                            dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().Value().count());
+        }
+        else
+        {
+            ChipLogProgress(Discovery, "\tMrp Interval active\tNot present");
+        }
+        ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
+        for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
+        {
+            char buf[Inet::IPAddress::kMaxStringLength];
+            dnsSdInfo->resolutionData.ipAddress[j].ToString(buf);
+            ChipLogProgress(Discovery, "\tAddress %d:\t\t%s", j, buf);
+        }
+    }
+}
+
+bool pychip_DeviceController_GetIPForDiscoveredDevice(Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
+                                                      uint32_t len)
+{
+    const Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(idx);
+    if (dnsSdInfo == nullptr)
+    {
+        return false;
+    }
+    // TODO(cecille): Select which one we actually want.
+    if (dnsSdInfo->resolutionData.ipAddress[0].ToString(addrStr, len) == addrStr)
+    {
+        return true;
+    }
+    return false;
+}
+}

--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -60,6 +60,7 @@
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 #include <inet/IPAddress.h>
+#include <lib/core/CHIPTLV.h>
 #include <lib/dnssd/Resolver.h>
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CHIPMem.h>
@@ -547,76 +548,6 @@ ChipError::StorageType pychip_DeviceController_OpenCommissioningWindow(chip::Con
     }
 
     return CHIP_ERROR_INVALID_ARGUMENT.AsInteger();
-}
-
-void pychip_DeviceController_PrintDiscoveredDevices(chip::Controller::DeviceCommissioner * devCtrl)
-{
-    for (int i = 0; i < devCtrl->GetMaxCommissionableNodesSupported(); ++i)
-    {
-        const chip::Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(i);
-        if (dnsSdInfo == nullptr)
-        {
-            continue;
-        }
-        char rotatingId[chip::Dnssd::kMaxRotatingIdLen * 2 + 1] = "";
-        Encoding::BytesToUppercaseHexString(dnsSdInfo->commissionData.rotatingId, dnsSdInfo->commissionData.rotatingIdLen,
-                                            rotatingId, sizeof(rotatingId));
-
-        ChipLogProgress(Discovery, "Commissionable Node %d", i);
-        ChipLogProgress(Discovery, "\tInstance name:\t\t%s", dnsSdInfo->commissionData.instanceName);
-        ChipLogProgress(Discovery, "\tHost name:\t\t%s", dnsSdInfo->resolutionData.hostName);
-        ChipLogProgress(Discovery, "\tPort:\t\t\t%u", dnsSdInfo->resolutionData.port);
-        ChipLogProgress(Discovery, "\tLong discriminator:\t%u", dnsSdInfo->commissionData.longDiscriminator);
-        ChipLogProgress(Discovery, "\tVendor ID:\t\t%u", dnsSdInfo->commissionData.vendorId);
-        ChipLogProgress(Discovery, "\tProduct ID:\t\t%u", dnsSdInfo->commissionData.productId);
-        ChipLogProgress(Discovery, "\tCommissioning Mode\t%u", dnsSdInfo->commissionData.commissioningMode);
-        ChipLogProgress(Discovery, "\tDevice Type\t\t%u", dnsSdInfo->commissionData.deviceType);
-        ChipLogProgress(Discovery, "\tDevice Name\t\t%s", dnsSdInfo->commissionData.deviceName);
-        ChipLogProgress(Discovery, "\tRotating Id\t\t%s", rotatingId);
-        ChipLogProgress(Discovery, "\tPairing Instruction\t%s", dnsSdInfo->commissionData.pairingInstruction);
-        ChipLogProgress(Discovery, "\tPairing Hint\t\t%u", dnsSdInfo->commissionData.pairingHint);
-        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().HasValue())
-        {
-            ChipLogProgress(Discovery, "\tMrp Interval idle\t%u",
-                            dnsSdInfo->resolutionData.GetMrpRetryIntervalIdle().Value().count());
-        }
-        else
-        {
-            ChipLogProgress(Discovery, "\tMrp Interval idle\tNot present");
-        }
-        if (dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().HasValue())
-        {
-            ChipLogProgress(Discovery, "\tMrp Interval active\t%u",
-                            dnsSdInfo->resolutionData.GetMrpRetryIntervalActive().Value().count());
-        }
-        else
-        {
-            ChipLogProgress(Discovery, "\tMrp Interval active\tNot present");
-        }
-        ChipLogProgress(Discovery, "\tSupports TCP\t\t%d", dnsSdInfo->resolutionData.supportsTcp);
-        for (unsigned j = 0; j < dnsSdInfo->resolutionData.numIPs; ++j)
-        {
-            char buf[chip::Inet::IPAddress::kMaxStringLength];
-            dnsSdInfo->resolutionData.ipAddress[j].ToString(buf);
-            ChipLogProgress(Discovery, "\tAddress %d:\t\t%s", j, buf);
-        }
-    }
-}
-
-bool pychip_DeviceController_GetIPForDiscoveredDevice(chip::Controller::DeviceCommissioner * devCtrl, int idx, char * addrStr,
-                                                      uint32_t len)
-{
-    const chip::Dnssd::DiscoveredNodeData * dnsSdInfo = devCtrl->GetDiscoveredDevice(idx);
-    if (dnsSdInfo == nullptr)
-    {
-        return false;
-    }
-    // TODO(cecille): Select which one we actually want.
-    if (dnsSdInfo->resolutionData.ipAddress[0].ToString(addrStr, len) == addrStr)
-    {
-        return true;
-    }
-    return false;
 }
 
 ChipError::StorageType

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -41,12 +41,16 @@ from .clusters import Objects as GeneratedObjects
 from .clusters.CHIPClusters import *
 from . import clusters as Clusters
 from .FabricAdmin import FabricAdmin
+from . import discovery
 import enum
 import threading
 import typing
 import builtins
 import ctypes
 import copy
+import json
+import time
+import dacite
 
 __all__ = ["ChipDeviceController"]
 
@@ -63,6 +67,8 @@ _DeviceAvailableFunct = CFUNCTYPE(None, c_void_p, c_uint32)
 
 _IssueNOCChainCallbackPythonCallbackFunct = CFUNCTYPE(
     None, py_object, c_uint32, c_void_p, c_size_t, c_void_p, c_size_t, c_void_p, c_size_t, c_void_p, c_size_t, c_uint64)
+
+_ChipDeviceController_IterateDiscoveredCommissionableNodesFunct = CFUNCTYPE(None, c_char_p, c_size_t)
 
 
 @dataclass
@@ -117,6 +123,27 @@ class DCState(enum.IntEnum):
     COMMISSIONING = 5
 
 
+class CommissionableNode(discovery.CommissionableNode):
+    def SetDeviceController(self, devCtrl: 'ChipDeviceController'):
+        self._devCtrl = devCtrl
+
+    def Commission(self, nodeId: int, setupPinCode: int):
+        ''' Commission the device using the device controller discovered this device.
+
+        nodeId: The nodeId commissioned to the device
+        setupPinCode: The setup pin code of the device
+        '''
+        self._devCtrl.CommissionOnNetwork(
+            nodeId, setupPinCode, filterType=discovery.FilterType.INSTANCE_NAME, filter=self.instanceName)
+
+    def __rich_repr__(self):
+        yield "(To Be Commissioned By)", self._devCtrl.name
+
+        for k in self.__dataclass_fields__.keys():
+            if k in self.__dict__:
+                yield k, self.__dict__[k]
+
+
 class DeviceProxyWrapper():
     ''' Encapsulates a pointer to OperationalDeviceProxy on the c++ side that needs to be
         freed when DeviceProxyWrapper goes out of scope. There is a potential issue where
@@ -141,17 +168,7 @@ class DeviceProxyWrapper():
         return self._deviceProxy
 
 
-class DiscoveryFilterType(enum.IntEnum):
-    # These must match chip::Dnssd::DiscoveryFilterType values (barring the naming convention)
-    NONE = 0
-    SHORT_DISCRIMINATOR = 1
-    LONG_DISCRIMINATOR = 2
-    VENDOR_ID = 3
-    DEVICE_TYPE = 4
-    COMMISSIONING_MODE = 5
-    INSTANCE_NAME = 6
-    COMMISSIONER = 7
-    COMPRESSED_FABRIC_ID = 8
+DiscoveryFilterType = discovery.FilterType
 
 
 class ChipDeviceController():
@@ -552,7 +569,49 @@ class ChipDeviceController():
 
         return (address.value.decode(), port.value) if error == 0 else None
 
+    def DiscoverCommissionableNodes(self, filterType: discovery.FilterType = discovery.FilterType.NONE, filter: typing.Any = None, stopOnFirst: bool = False, timeoutSecond: int = 5) -> typing.Union[None, CommissionableNode, typing.List[CommissionableNode]]:
+        ''' Discover commissionable nodes via DNS-SD with specified filters.
+            Supported filters are:
+
+                discovery.FilterType.NONE
+                discovery.FilterType.SHORT_DISCRIMINATOR
+                discovery.FilterType.LONG_DISCRIMINATOR
+                discovery.FilterType.VENDOR_ID
+                discovery.FilterType.DEVICE_TYPE
+                discovery.FilterType.COMMISSIONING_MODE
+                discovery.FilterType.INSTANCE_NAME
+                discovery.FilterType.COMMISSIONER
+                discovery.FilterType.COMPRESSED_FABRIC_ID
+
+            This function will always return a list of CommissionableDevice. When stopOnFirst is set, this function will return when at least one device is discovered or on timeout.
+        '''
+        self.CheckIsActive()
+
+        if isinstance(filter, int):
+            filter = str(filter)
+
+        res = self._ChipStack.Call(
+            lambda: self._dmLib.pychip_DeviceController_DiscoverCommissionableNodes(
+                self.devCtrl, int(filterType), str(filter).encode("utf-8") + b"\x00"))
+
+        if res != 0:
+            raise self._ChipStack.ErrorToException(res)
+
+        if timeoutSecond != 0:
+            if stopOnFirst:
+                target = time.time() + timeoutSecond
+                while time.time() < target:
+                    if self._ChipStack.Call(lambda: self._dmLib.pychip_DeviceController_HasDiscoveredCommissionableNode(self.devCtrl)):
+                        break
+                    time.sleep(0.1)
+            else:
+                time.sleep(timeoutSecond)
+
+        return self.GetDiscoveredDevices()
+
     def DiscoverCommissionableNodesLongDiscriminator(self, long_discriminator):
+        ''' Deprecated, use DiscoverCommissionableNodes
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(
@@ -561,6 +620,8 @@ class ChipDeviceController():
         )
 
     def DiscoverCommissionableNodesShortDiscriminator(self, short_discriminator):
+        ''' Deprecated, use DiscoverCommissionableNodes
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(
@@ -569,6 +630,8 @@ class ChipDeviceController():
         )
 
     def DiscoverCommissionableNodesVendor(self, vendor):
+        ''' Deprecated, use DiscoverCommissionableNodes
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(
@@ -577,6 +640,8 @@ class ChipDeviceController():
         )
 
     def DiscoverCommissionableNodesDeviceType(self, device_type):
+        ''' Deprecated, use DiscoverCommissionableNodes
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(
@@ -585,6 +650,8 @@ class ChipDeviceController():
         )
 
     def DiscoverCommissionableNodesCommissioningEnabled(self):
+        ''' Deprecated, use DiscoverCommissionableNodes
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(
@@ -593,12 +660,30 @@ class ChipDeviceController():
         )
 
     def PrintDiscoveredDevices(self):
+        ''' Deprecated, use GetCommissionableNodes
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(
             lambda: self._dmLib.pychip_DeviceController_PrintDiscoveredDevices(
                 self.devCtrl)
         )
+
+    def GetDiscoveredDevices(self):
+        def GetDevices(devCtrl):
+            devices = []
+
+            @_ChipDeviceController_IterateDiscoveredCommissionableNodesFunct
+            def HandleDevice(deviceJson, deviceJsonLen):
+                jsonStr = ctypes.string_at(deviceJson, deviceJsonLen).decode("utf-8")
+                device = dacite.from_dict(data_class=CommissionableNode, data=json.loads(jsonStr))
+                device.SetDeviceController(devCtrl)
+                devices.append(device)
+
+            self._dmLib.pychip_DeviceController_IterateDiscoveredCommissionableNodes(devCtrl.devCtrl, HandleDevice)
+            return devices
+
+        return self._ChipStack.Call(lambda: GetDevices(self))
 
     def ParseQRCode(self, qrCode, output):
         self.CheckIsActive()
@@ -618,6 +703,8 @@ class ChipDeviceController():
         )
 
     def DiscoverAllCommissioning(self):
+        ''' Deprecated, use DiscoverCommissionableNodes
+        '''
         self.CheckIsActive()
 
         return self._ChipStack.Call(
@@ -1202,7 +1289,7 @@ class ChipDeviceController():
             self._dmLib.pychip_DeviceController_OnNetworkCommission.restype = c_uint32
 
             self._dmLib.pychip_DeviceController_DiscoverAllCommissionableNodes.argtypes = [
-                c_void_p]
+                c_void_p, c_uint8, c_char_p]
             self._dmLib.pychip_DeviceController_DiscoverAllCommissionableNodes.restype = c_uint32
 
             self._dmLib.pychip_DeviceController_DiscoverCommissionableNodesLongDiscriminator.argtypes = [
@@ -1233,6 +1320,10 @@ class ChipDeviceController():
                 c_void_p]
             self._dmLib.pychip_DeviceController_PrintDiscoveredDevices.argtypes = [
                 c_void_p]
+            self._dmLib.pychip_DeviceController_PrintDiscoveredDevices.argtypes = [
+                c_void_p, _ChipDeviceController_IterateDiscoveredCommissionableNodesFunct]
+            self._dmLib.pychip_DeviceController_HasDiscoveredCommissionableNode.argtypes = [c_void_p]
+            self._dmLib.pychip_DeviceController_HasDiscoveredCommissionableNode.restype = c_bool
 
             self._dmLib.pychip_DeviceController_GetIPForDiscoveredDevice.argtypes = [
                 c_void_p, c_int, c_char_p, c_uint32]

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -14,6 +14,7 @@ import builtins
 import chip.FabricAdmin
 import chip.CertificateAuthority
 import chip.native
+import chip.discovery
 from chip.utils import CommissioningBuildingBlocks
 import atexit
 

--- a/src/controller/python/chip/discovery/__init__.py
+++ b/src/controller/python/chip/discovery/__init__.py
@@ -17,12 +17,26 @@
 import logging
 import time
 import threading
+import enum
 
 from dataclasses import dataclass
 from typing import List, Dict, Set, Callable
 
 from chip.discovery.library_handle import _GetDiscoveryLibraryHandle
 from chip.discovery.types import DiscoverSuccessCallback_t, DiscoverFailureCallback_t
+
+
+class FilterType(enum.IntEnum):
+    # These must match chip::Dnssd::DiscoveryFilterType values (barring the naming convention)
+    NONE = 0
+    SHORT_DISCRIMINATOR = 1
+    LONG_DISCRIMINATOR = 2
+    VENDOR_ID = 3
+    DEVICE_TYPE = 4
+    COMMISSIONING_MODE = 5
+    INSTANCE_NAME = 6
+    COMMISSIONER = 7
+    COMPRESSED_FABRIC_ID = 8
 
 
 @dataclass(unsafe_hash=True)
@@ -54,6 +68,25 @@ class PendingDiscovery:
     callback: Callable[[AggregatedDiscoveryResults], None]
     expireTime: int
     firstResultTime: int
+
+
+@dataclass
+class CommissionableNode():
+    instanceName: str = None
+    hostName: str = None
+    port: int = None
+    longDiscriminator: int = None
+    vendorId: int = None
+    productId: int = None
+    commissioningMode: int = None
+    deviceType: int = None
+    deviceName: str = None
+    pairingInstruction: str = None
+    pairingHint: int = None
+    mrpRetryIntervalIdle: int = None
+    mrpRetryIntervalActive: int = None
+    supportsTcp: bool = None
+    addresses: List[str] = None
 
 
 # Milliseconds to wait for additional results onece a single result has

--- a/src/controller/python/test/test_scripts/base.py
+++ b/src/controller/python/test/test_scripts/base.py
@@ -37,6 +37,7 @@ from chip.ChipStack import *
 import chip.native
 import chip.FabricAdmin
 import chip.CertificateAuthority
+import chip.discovery
 import copy
 import secrets
 import faulthandler
@@ -222,15 +223,14 @@ class BaseTestHelper:
     def TestDiscovery(self, discriminator: int):
         self.logger.info(
             f"Discovering commissionable nodes with discriminator {discriminator}")
-        self.devCtrl.DiscoverCommissionableNodesLongDiscriminator(
-            ctypes.c_uint16(int(discriminator)))
-        res = self._WaitForOneDiscoveredDevice()
+        res = self.devCtrl.DiscoverCommissionableNodes(
+            chip.discovery.FilterType.LONG_DISCRIMINATOR, discriminator, stopOnFirst=True, timeoutSecond=3)
         if not res:
             self.logger.info(
                 f"Device not found")
             return False
-        self.logger.info(f"Found device at {res}")
-        return res
+        self.logger.info(f"Found device {res[0]}")
+        return res[0]
 
     def TestPaseOnly(self, ip: str, setuppin: int, nodeid: int):
         self.logger.info(

--- a/src/controller/python/test/test_scripts/mobile-device-test.py
+++ b/src/controller/python/test/test_scripts/mobile-device-test.py
@@ -59,8 +59,10 @@ ALL_TESTS = ['network_commissioning', 'datamodel']
 
 def ethernet_commissioning(test: BaseTestHelper, discriminator: int, setup_pin: int, address_override: str, device_nodeid: int):
     logger.info("Testing discovery")
-    address = test.TestDiscovery(discriminator=discriminator)
-    FailIfNot(address, "Failed to discover any devices.")
+    device = test.TestDiscovery(discriminator=discriminator)
+    FailIfNot(device, "Failed to discover any devices.")
+
+    address = device.addresses[0]
 
     # FailIfNot(test.SetNetworkCommissioningParameters(dataset=TEST_THREAD_NETWORK_DATASET_TLV),
     #           "Failed to finish network commissioning")


### PR DESCRIPTION
#### Problem
Script API for DNS-SD discovery in REPL is missing

#### Change overview
- Implements `devCtrl.DiscoverCommissionableNodes(...)`
- Implements `devCtrl.GetDiscoveredCommissionableNodes(...)`
- Updates the ipynb guide

Note: The returned CommissionableNode has a `Commission` method to commmission it directly.

Example (also in the ipynb doc)

```python
In [1]: devices = devCtrl.DiscoverCommissionableNodes(filterType=chip.discovery.FilterType.LONG_DISCRIMINATOR, filter=3840, stopOnFirst=True, timeoutSecond=2)
   ...: devices
Out[1]: 
[
│   CommissionableNode(
│   │   (To Be Commissioned By)='caIndex(1)/fabricId(0x0000000000000001)/nodeId(0x000000000001B669)',
│   │   CommissionableNode(
│   │   │   instanceName='A73CD79C9F59134F',
│   │   │   hostName='DCA632ABCDEF0000',
│   │   │   port=5540,
│   │   │   longDiscriminator=3840,
│   │   │   vendorId=65521,
│   │   │   productId=32769,
│   │   │   commissioningMode=1,
│   │   │   deviceType=0,
│   │   │   deviceName='',
│   │   │   pairingInstruction='',
│   │   │   pairingHint=33,
│   │   │   mrpRetryIntervalIdle=5000,
│   │   │   mrpRetryIntervalActive=300,
│   │   │   supportsTcp=True,
│   │   │   addresses=[
│   │   │   │   'fd1e:1a94:d591:6914:dea6:32ff:feab:cdef',
│   │   │   │   'fe80::dea6:32ff:feab:cdef',
│   │   │   │   '172.16.243.198'
│   │   │   ]
│   │   )
│   )
]

In [2]: devices[0].Commission(233, 20202021)
Established secure session with Device
Commissioning complete

In [3]: 
```

#### Testing
The tests is using `DiscoverCommissionableNodes` instead of the old API now.
