### PR TITLE
[nrfconnect] Increase default NVS lookup cache size

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -194,6 +194,10 @@ config NVS_LOOKUP_CACHE
     bool
     default y
 
+config NVS_LOOKUP_CACHE_SIZE
+    int
+    default 512
+
 # Increase the default RX stack size
 config IEEE802154_NRF5_RX_STACK_SIZE
     int


### PR DESCRIPTION
#### Problem
Apparently, we forgot to update the default NVS lookup cache size on nRF Connect examples. 512 entries in the cache is necessary to keep applications work efficiently even when there is a lot of settings written to the flash.

#### Change overview
Update the default NVS lookup cache size.

#### Testing
CI tested, verified the cache size is populated correctly.