### PR TITLE
[EFR32] Setting the network interface type to WIFI for wifi devices

### DIFF
--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -283,12 +283,13 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             case Inet::InterfaceType::Cellular:
                 ifp->type = EMBER_ZCL_INTERFACE_TYPE_CELLULAR;
                 break;
+            default:
+                ifp->type = EMBER_ZCL_INTERFACE_TYPE_WI_FI;
+                break;
             }
         }
         else
         {
-            // Setting the type to EMBER_ZCL_INTERFACE_TYPE_WI_FI since GetInterfaceType returns CHIP_ERROR_NOT_IMPLEMENTED for LWIP
-            ifp->type = EMBER_ZCL_INTERFACE_TYPE_WI_FI;
             ChipLogError(DeviceLayer, "Failed to get interface type");
         }
 

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -264,7 +264,7 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         ifp->name          = CharSpan::fromCharString(ifp->Name);
         ifp->isOperational = true;
         Inet::InterfaceType interfaceType;
-        CHIP_ERROR err = interfaceIterator.GetInterfaceType(interfaceType)
+        CHIP_ERROR err = interfaceIterator.GetInterfaceType(interfaceType);
         if (err == CHIP_NO_ERROR || err == CHIP_ERROR_NOT_IMPLEMENTED)
         {
             switch (interfaceType)

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -264,7 +264,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         ifp->name          = CharSpan::fromCharString(ifp->Name);
         ifp->isOperational = true;
         Inet::InterfaceType interfaceType;
-        if (interfaceIterator.GetInterfaceType(interfaceType) == CHIP_NO_ERROR)
+        CHIP_ERROR err = interfaceIterator.GetInterfaceType(interfaceType)
+        if (err == CHIP_NO_ERROR || err == CHIP_ERROR_NOT_IMPLEMENTED)
         {
             switch (interfaceType)
             {

--- a/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/EFR32/DiagnosticDataProviderImpl.cpp
@@ -287,6 +287,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
         }
         else
         {
+            // Setting the type to EMBER_ZCL_INTERFACE_TYPE_WI_FI since GetInterfaceType returns CHIP_ERROR_NOT_IMPLEMENTED for LWIP
+            ifp->type = EMBER_ZCL_INTERFACE_TYPE_WI_FI;
             ChipLogError(DeviceLayer, "Failed to get interface type");
         }
 


### PR DESCRIPTION
#### Problem
The network interface type was returning 0 for the WIFI examples.

#### Change overview
GetInterfaceType() returns CHIP_ERROR_NOT_IMPLEMENTED for LWIP causing the D for Ltype to return Unspecified.
Setting the Interfacetype to WIFI.

#### Testing
Tested manually using MG12+RS9116 and MG12+WF200

**Note: To be cherry picked in SVE2 Branch**