### PR TITLE
chip_data_model.gni: add option for custom-implemented clusters

### DIFF
--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -84,6 +84,7 @@ template("chip_data_model") {
                            "*",
                            [
                              "zap_pregenerated_dir",
+                             "zap_clusters_with_custom_implementation",
                              "zap_file",
                              "is_server",
                            ])
@@ -137,8 +138,22 @@ template("chip_data_model") {
                                      [ invoker.zap_file ])
     }
 
+    _cust_impl_clusters = []
+    if (defined(invoker.zap_clusters_with_custom_implementation)) {
+      _cust_impl_clusters = invoker.zap_clusters_with_custom_implementation
+    }
+
     foreach(cluster, _cluster_sources) {
-      if (cluster == "door-lock-server") {
+      _cust_impl = false
+      foreach(ci, _cust_impl_clusters) {
+        if (cluster == ci) {
+          _cust_impl = true
+        }
+      }
+
+      if (_cust_impl) {
+        # do not include any sources, we have a custom implementation for this cluster
+      } else if (cluster == "door-lock-server") {
         sources += [
           "${_app_root}/clusters/${cluster}/door-lock-server-callback.cpp",
           "${_app_root}/clusters/${cluster}/door-lock-server.cpp",

--- a/src/app/chip_data_model.gni
+++ b/src/app/chip_data_model.gni
@@ -138,20 +138,20 @@ template("chip_data_model") {
                                      [ invoker.zap_file ])
     }
 
-    _cust_impl_clusters = []
+    _custom_impl_clusters = []
     if (defined(invoker.zap_clusters_with_custom_implementation)) {
-      _cust_impl_clusters = invoker.zap_clusters_with_custom_implementation
+      _custom_impl_clusters = invoker.zap_clusters_with_custom_implementation
     }
 
     foreach(cluster, _cluster_sources) {
-      _cust_impl = false
-      foreach(ci, _cust_impl_clusters) {
+      _custom_impl = false
+      foreach(ci, _custom_impl_clusters) {
         if (cluster == ci) {
-          _cust_impl = true
+          _custom_impl = true
         }
       }
 
-      if (_cust_impl) {
+      if (_custom_impl) {
         # do not include any sources, we have a custom implementation for this cluster
       } else if (cluster == "door-lock-server") {
         sources += [


### PR DESCRIPTION
Add `zap_clusters_with_custom_implementation` option to `chip_data_model()` template, which allows to list clusters that need to be available in a device, but don't use the standard implementation in `src/app/clusters/<clustername>/<clustername>.cpp`.

# Usage
To exclude a particular cluster's standard implementation in favor of an application level implementation:
- in the BUILD.gn file for the application specific `.zap` file
- in the instantiation of the `chip_data_model` template
- add a variable `zap_clusters_with_custom_implementation`
- assign it a list of strings with cluster names, corresponding to directories in the `src/app/clusters` directory.
- this causes the cluster implementation file(s) not to be included in the build, allowing re-implementation at the application level.

Example, excluding standard implementation of level-control:
```
chip_data_model("zap") {
  zap_file = "myproject.zap"
  zap_clusters_with_custom_implementation = [ "level-control" ]
  zap_pregenerated_dir = "//zap-generated"
}
```

# Background
Some clusters, for example Level Control, are implemented with the assumption of direct low-level access to the device hardware. For bridged devices, the actual interface might be much more high level, as in my case where I have lights which are fully capable of performing parametrized smooth transitions but are NOT capable of receiving output changes in millisecond intervals. In such cases, a cluster might need application-specific re-implementation.

This changeset allows, from the application's ZAP BUILD.gn, to exclude the standard cluster implementation file, allowing re-implementation of the needed ember callbacks in a application specific file outside the connectedhomeip repo.

#### Testing
* tested to not affect normal builds not using this feature
* tested with an application which re-implements level-control in a separate .cpp file. Without the feature, linking has duplicate symbol errors (from both custom and standard implementations) - using the feature as shown in the example above, the app links and runs ok.
