### PR TITLE
SystemLayerImplSelect: add libev support: CHIP_SYSTEM_CONFIG_USE_LIBEV

### DIFF
--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -54,8 +54,10 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 
     mRunLoopSem = dispatch_semaphore_create(0);
 
+#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
     // Ensure there is a dispatch queue available
     static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer()).SetDispatchQueue(GetWorkQueue());
+#endif
 
     // Call _InitChipStack() on the generic implementation base class
     // to finish the initialization process.

--- a/src/platform/Darwin/SystemPlatformConfig.h
+++ b/src/platform/Darwin/SystemPlatformConfig.h
@@ -34,9 +34,14 @@ struct ChipDeviceEvent;
 
 // ==================== Platform Adaptations ====================
 
+#if !CHIP_SYSTEM_CONFIG_USE_LIBEV
+// FIXME: these should not be hardcoded here, it is set via build config
+// Need to exclude these for now in libev case
 #define CHIP_SYSTEM_CONFIG_POSIX_LOCKING 0
 #define CHIP_SYSTEM_CONFIG_FREERTOS_LOCKING 0
 #define CHIP_SYSTEM_CONFIG_NO_LOCKING 1
+#endif
+
 #define CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME 1
 #define CHIP_SYSTEM_CONFIG_USE_POSIX_TIME_FUNCTS 1
 #define CHIP_SYSTEM_CONFIG_POOL_USE_HEAP 1

--- a/src/system/BUILD.gn
+++ b/src/system/BUILD.gn
@@ -73,6 +73,7 @@ buildconfig_header("system_buildconfig") {
     "CHIP_SYSTEM_CONFIG_TEST=${chip_build_tests}",
     "CHIP_WITH_NLFAULTINJECTION=${chip_with_nlfaultinjection}",
     "CHIP_SYSTEM_CONFIG_USE_DISPATCH=${chip_system_config_use_dispatch}",
+    "CHIP_SYSTEM_CONFIG_USE_LIBEV=${chip_system_config_use_libev}",
     "CHIP_SYSTEM_CONFIG_USE_LWIP=${chip_system_config_use_lwip}",
     "CHIP_SYSTEM_CONFIG_USE_OPEN_THREAD_ENDPOINT=${chip_system_config_use_open_thread_inet_endpoints}",
     "CHIP_SYSTEM_CONFIG_USE_SOCKETS=${chip_system_config_use_sockets}",

--- a/src/system/SystemLayer.h
+++ b/src/system/SystemLayer.h
@@ -43,7 +43,9 @@
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
 #include <dispatch/dispatch.h>
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+#include <ev.h>
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH/LIBEV
 
 #include <utility>
 
@@ -171,7 +173,7 @@ public:
 
 private:
     // Copy and assignment NOT DEFINED
-    Layer(const Layer &) = delete;
+    Layer(const Layer &)             = delete;
     Layer & operator=(const Layer &) = delete;
 };
 
@@ -250,7 +252,9 @@ public:
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     virtual void SetDispatchQueue(dispatch_queue_t dispatchQueue) = 0;
     virtual dispatch_queue_t GetDispatchQueue()                   = 0;
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+    virtual void SetLibEvLoop(struct ev_loop * aLibEvLoopP) = 0;
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH/LIBEV
 };
 
 #endif // CHIP_SYSTEM_CONFIG_USE_SOCKETS

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -82,11 +82,25 @@ void LayerImplSelect::Shutdown()
     {
         w.DisableAndClear();
     }
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+    TimerList::Node * timer;
+    while ((timer = mTimerList.PopEarliest()) != nullptr)
+    {
+        if (ev_is_active(&timer->mLibEvTimer))
+        {
+            ev_timer_stop(mLibEvLoopP, &timer->mLibEvTimer);
+        }
+    }
+    mTimerPool.ReleaseAll();
 
-#else  // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+    for (auto & w : mSocketWatchPool)
+    {
+        w.DisableAndClear();
+    }
+#else
     mTimerList.Clear();
     mTimerPool.ReleaseAll();
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH/LIBEV
 
     mWakeEvent.Close(*this);
 
@@ -156,13 +170,26 @@ CHIP_ERROR LayerImplSelect::StartTimer(Clock::Timeout delay, TimerCompleteCallba
         return CHIP_NO_ERROR;
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
-
+#if CHIP_SYSTEM_CONFIG_USE_LIBEV
+    if (mLibEvLoopP == nullptr)
+    {
+        chipDie();
+    }
+    ev_timer_init(&timer->mLibEvTimer, &LayerImplSelect::HandleLibEvTimer, 1, 0);
+    timer->mLibEvTimer.data = timer;
+    auto t                  = Clock::Milliseconds64(delay).count();
+    ev_timer_set(&timer->mLibEvTimer, static_cast<double>(t) / 1E3, 0.);
+    (void) mTimerList.Add(timer);
+    ev_timer_start(mLibEvLoopP, &timer->mLibEvTimer);
+    return CHIP_NO_ERROR;
+#else
     if (mTimerList.Add(timer) == timer)
     {
         // The new timer is the earliest, so the time until the next event has probably changed.
         Signal();
     }
     return CHIP_NO_ERROR;
+#endif // !CHIP_SYSTEM_CONFIG_USE_LIBEV
 }
 
 void LayerImplSelect::CancelTimer(TimerCompleteCallback onComplete, void * appState)
@@ -178,7 +205,13 @@ void LayerImplSelect::CancelTimer(TimerCompleteCallback onComplete, void * appSt
         dispatch_source_cancel(timer->mTimerSource);
         dispatch_release(timer->mTimerSource);
     }
-#endif
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+    if (mLibEvLoopP == nullptr)
+    {
+        chipDie();
+    }
+    ev_timer_stop(mLibEvLoopP, &timer->mLibEvTimer);
+#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH/LIBEV
 
     mTimerPool.Release(timer);
     Signal();
@@ -198,7 +231,10 @@ CHIP_ERROR LayerImplSelect::ScheduleWork(TimerCompleteCallback onComplete, void 
         return CHIP_NO_ERROR;
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
-
+#if CHIP_SYSTEM_CONFIG_USE_LIBEV
+    // just a timer with no delay
+    return StartTimer(Clock::Timeout(0), onComplete, appState);
+#else
     CancelTimer(onComplete, appState);
 
     TimerList::Node * timer = mTimerPool.Create(*this, SystemClock().GetMonotonicTimestamp(), onComplete, appState);
@@ -210,6 +246,7 @@ CHIP_ERROR LayerImplSelect::ScheduleWork(TimerCompleteCallback onComplete, void 
         Signal();
     }
     return CHIP_NO_ERROR;
+#endif // !CHIP_SYSTEM_CONFIG_USE_LIBEV
 }
 
 CHIP_ERROR LayerImplSelect::StartWatchingSocket(int fd, SocketWatchToken * tokenOut)
@@ -231,6 +268,11 @@ CHIP_ERROR LayerImplSelect::StartWatchingSocket(int fd, SocketWatchToken * token
     VerifyOrReturnError(watch != nullptr, CHIP_ERROR_ENDPOINT_POOL_FULL);
 
     watch->mFD = fd;
+#if CHIP_SYSTEM_CONFIG_USE_LIBEV
+    ev_io_init(&watch->mIoWatcher, &LayerImplSelect::HandleLibEvIoWatcher, 0, 0);
+    watch->mIoWatcher.data   = watch;
+    watch->mLayerImplSelectP = this;
+#endif
 
     *tokenOut = reinterpret_cast<SocketWatchToken>(watch);
     return CHIP_NO_ERROR;
@@ -283,6 +325,24 @@ CHIP_ERROR LayerImplSelect::RequestCallbackOnPendingRead(SocketWatchToken token)
             dispatch_activate(watch->mRdSource);
         }
     }
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+    if (mLibEvLoopP == nullptr)
+    {
+        chipDie();
+    }
+    int evs = (watch->mPendingIO.Has(SocketEventFlags::kRead) ? EV_READ : 0) |
+        (watch->mPendingIO.Has(SocketEventFlags::kWrite) ? EV_WRITE : 0);
+    if (!ev_is_active(&watch->mIoWatcher))
+    {
+        // First time actually using that watch
+        ev_io_set(&watch->mIoWatcher, watch->mFD, evs);
+        ev_io_start(mLibEvLoopP, &watch->mIoWatcher);
+    }
+    else
+    {
+        // already active, just change flags
+        ev_io_modify(&watch->mIoWatcher, evs);
+    }
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
     return CHIP_NO_ERROR;
@@ -322,9 +382,26 @@ CHIP_ERROR LayerImplSelect::RequestCallbackOnPendingWrite(SocketWatchToken token
                 }
             });
             // only now we are sure the source exists and can become active
-            watch->mPendingIO.Set(SocketEventFlags::kWrite);
             dispatch_activate(watch->mWrSource);
         }
+    }
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+    if (mLibEvLoopP == nullptr)
+    {
+        chipDie();
+    }
+    int evs = (watch->mPendingIO.Has(SocketEventFlags::kRead) ? EV_READ : 0) |
+        (watch->mPendingIO.Has(SocketEventFlags::kWrite) ? EV_WRITE : 0);
+    if (!ev_is_active(&watch->mIoWatcher))
+    {
+        // First time actually using that watch
+        ev_io_set(&watch->mIoWatcher, watch->mFD, evs);
+        ev_io_start(mLibEvLoopP, &watch->mIoWatcher);
+    }
+    else
+    {
+        // already active, just change flags
+        ev_io_modify(&watch->mIoWatcher, evs);
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
@@ -338,6 +415,14 @@ CHIP_ERROR LayerImplSelect::ClearCallbackOnPendingRead(SocketWatchToken token)
 
     watch->mPendingIO.Clear(SocketEventFlags::kRead);
 
+#if CHIP_SYSTEM_CONFIG_USE_LIBEV
+    if (ev_is_active(&watch->mIoWatcher) && watch->mPendingIO.Raw() == 0)
+    {
+        // all flags cleared now, stop watching
+        ev_io_stop(mLibEvLoopP, &watch->mIoWatcher);
+    }
+#endif
+
     return CHIP_NO_ERROR;
 }
 
@@ -347,6 +432,14 @@ CHIP_ERROR LayerImplSelect::ClearCallbackOnPendingWrite(SocketWatchToken token)
     VerifyOrReturnError(watch != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
 
     watch->mPendingIO.Clear(SocketEventFlags::kWrite);
+
+#if CHIP_SYSTEM_CONFIG_USE_LIBEV
+    if (ev_is_active(&watch->mIoWatcher) && watch->mPendingIO.Raw() == 0)
+    {
+        // all flags cleared now, stop watching
+        ev_io_stop(mLibEvLoopP, &watch->mIoWatcher);
+    }
+#endif
 
     return CHIP_NO_ERROR;
 }
@@ -499,7 +592,40 @@ void LayerImplSelect::HandleTimerComplete(TimerList::Node * timer)
     mTimerList.Remove(timer);
     mTimerPool.Invoke(timer);
 }
-#endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
+#endif
+
+#if CHIP_SYSTEM_CONFIG_USE_LIBEV
+void LayerImplSelect::HandleLibEvTimer(EV_P_ struct ev_timer * t, int revents)
+{
+    TimerList::Node * timer = static_cast<TimerList::Node *>(t->data);
+    VerifyOrDie(timer);
+    LayerImplSelect * layerP = dynamic_cast<LayerImplSelect *>(timer->mCallback.mSystemLayer);
+    VerifyOrDie(layerP);
+    layerP->mTimerList.Remove(timer);
+    layerP->mTimerPool.Invoke(timer);
+}
+
+void LayerImplSelect::HandleLibEvIoWatcher(EV_P_ struct ev_io * i, int revents)
+{
+    SocketWatch * watch = static_cast<SocketWatch *>(i->data);
+    if (watch != nullptr && watch->mCallback != nullptr && watch->mLayerImplSelectP != nullptr)
+    {
+        SocketEvents events;
+        if (revents & EV_READ)
+        {
+            events.Set(SocketEventFlags::kRead);
+        }
+        if (revents & EV_WRITE)
+        {
+            events.Set(SocketEventFlags::kWrite);
+        }
+        if (events.HasAny())
+        {
+            watch->mCallback(events, watch->mCallbackData);
+        }
+    }
+}
+#endif // CHIP_SYSTEM_CONFIG_USE_LIBEV
 
 void LayerImplSelect::SocketWatch::Clear()
 {
@@ -510,6 +636,8 @@ void LayerImplSelect::SocketWatch::Clear()
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     mRdSource = nullptr;
     mWrSource = nullptr;
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+    mLayerImplSelectP = nullptr;
 #endif
 }
 
@@ -525,6 +653,15 @@ void LayerImplSelect::SocketWatch::DisableAndClear()
     {
         dispatch_source_cancel(mWrSource);
         dispatch_release(mWrSource);
+    }
+    Clear();
+}
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+void LayerImplSelect::SocketWatch::DisableAndClear()
+{
+    if (mLayerImplSelectP != nullptr && mLayerImplSelectP->mLibEvLoopP != nullptr)
+    {
+        ev_io_stop(mLayerImplSelectP->mLibEvLoopP, &mIoWatcher);
     }
     Clear();
 }

--- a/src/system/SystemTimer.h
+++ b/src/system/SystemTimer.h
@@ -64,6 +64,9 @@ public:
         Layer * GetSystemLayer() const { return mSystemLayer; }
 
     private:
+#if CHIP_SYSTEM_CONFIG_USE_LIBEV
+        friend class LayerImplSelect;
+#endif
         Layer * mSystemLayer;
         TimerCompleteCallback mOnComplete;
         void * mAppState;
@@ -77,12 +80,18 @@ public:
     /**
      * Return the expiration time.
      */
-    Clock::Timestamp AwakenTime() const { return mAwakenTime; }
+    Clock::Timestamp AwakenTime() const
+    {
+        return mAwakenTime;
+    }
 
     /**
      * Return callback information.
      */
-    const Callback & GetCallback() const { return mCallback; }
+    const Callback & GetCallback() const
+    {
+        return mCallback;
+    }
 
 private:
     Clock::Timestamp mAwakenTime;
@@ -91,10 +100,13 @@ private:
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
     friend class LayerImplSelect;
     dispatch_source_t mTimerSource = nullptr;
+#elif CHIP_SYSTEM_CONFIG_USE_LIBEV
+    friend class LayerImplSelect;
+    struct ev_timer mLibEvTimer;
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
     // Not defined
-    TimerData(const TimerData &) = delete;
+    TimerData(const TimerData &)             = delete;
     TimerData & operator=(const TimerData &) = delete;
 };
 

--- a/src/system/system.gni
+++ b/src/system/system.gni
@@ -37,7 +37,9 @@ declare_args() {
 }
 
 declare_args() {
-  # use the dispatch library
+  # do not use libev by default
+  chip_system_config_use_libev = false
+  # use the dispatch library on darwin targets
   chip_system_config_use_dispatch = chip_system_config_use_sockets &&
                                     (current_os == "mac" || current_os == "ios")
 }


### PR DESCRIPTION
When CHIP_SYSTEM_CONFIG_USE_LIBEV is set, SystemLayerImplSelect expects a *libev* [[1]] mainloop to be present to schedule timers and socket watches (similar to CHIP_SYSTEM_CONFIG_USE_DISPATCH for Darwin).

A libev mainloop must be passed to SystemLayer using `SetLibEvLoop()` before any timers or socket watches are used - otherwise, `chipDie()` is invoked.

# Usage
The entire project needs to be build with `CHIP_SYSTEM_CONFIG_USE_LIBEV=1` (this can be done via invoking a project-specific extra config via the `default_configs_extra` argument in args.gni)

Setting up the libev mainloop and handing it over to SystemLayer must be done in application specific code, outside the code provided by chip examples. Also adding libev as a dependency must be done in the application's BUILD.gn.

# Background
*libev* is a multi-platform event library often used in embedded linux context to handle events, and builds the basis for various libraries with non-blocking APIs. This changeset allows using the *connectedhomeip* stack with libev based applications.

# Testing
* verified with regular chip-tool build that change does not affect builds with `CHIP_SYSTEM_CONFIG_USE_LIBEV` *not* set.
* tested with an application which bases on libev and sets `CHIP_SYSTEM_CONFIG_USE_LIBEV=1`: chip timer and socket watches work the same way as with select or dispatch based applications.

[1]: http://software.schmorp.de/pkg/libev.html "libev"