### PR TITLE
More cleanup for the openthread build targets and EFR32

### DIFF
--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -207,6 +207,7 @@ efr32_executable("chef_app") {
   if (chip_enable_openthread) {
     deps += [
       "${chip_root}/third_party/openthread:openthread",
+      "${chip_root}/third_party/openthread:openthread_device",
       "${examples_plat_dir}:efr-matter-shell",
     ]
   }

--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -200,6 +200,7 @@ efr32_executable("light_switch_app") {
   if (chip_enable_openthread) {
     deps += [
       "${chip_root}/third_party/openthread:openthread",
+      "${chip_root}/third_party/openthread:openthread_device",
       "${examples_plat_dir}:efr-matter-shell",
     ]
   }

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -205,6 +205,7 @@ efr32_executable("lighting_app") {
   if (chip_enable_openthread) {
     deps += [
       "${chip_root}/third_party/openthread:openthread",
+      "${chip_root}/third_party/openthread:openthread_device",
       "${examples_plat_dir}:efr-matter-shell",
     ]
   }

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -202,6 +202,7 @@ efr32_executable("lock_app") {
   if (chip_enable_openthread) {
     deps += [
       "${chip_root}/third_party/openthread:openthread",
+      "${chip_root}/third_party/openthread:openthread_device",
       "${examples_plat_dir}:efr-matter-shell",
     ]
   }

--- a/examples/shell/shell_common/BUILD.gn
+++ b/examples/shell/shell_common/BUILD.gn
@@ -52,17 +52,10 @@ static_library("shell_common") {
 
   if (chip_enable_openthread &&
       (current_os == "freertos" || current_os == "zephyr")) {
-    if (chip_openthread_ftd) {
-      public_deps += [
-        "${chip_root}/third_party/openthread/repo:libopenthread-cli-ftd",
-        "${chip_root}/third_party/openthread/repo:libopenthread-ftd",
-      ]
-    } else {
-      public_deps += [
-        "${chip_root}/third_party/openthread/repo:libopenthread-cli-mtd",
-        "${chip_root}/third_party/openthread/repo:libopenthread-mtd",
-      ]
-    }
+    public_deps += [
+      "${chip_root}/third_party/openthread:openthread_cli",
+      "${chip_root}/third_party/openthread:openthread_device",
+    ]
   }
 
   if (chip_shell_cmd_server) {

--- a/examples/thermostat/efr32/BUILD.gn
+++ b/examples/thermostat/efr32/BUILD.gn
@@ -196,6 +196,7 @@ efr32_executable("thermostat_app") {
   if (chip_enable_openthread) {
     deps += [
       "${chip_root}/third_party/openthread:openthread",
+      "${chip_root}/third_party/openthread:openthread_device",
       "${examples_plat_dir}:efr-matter-shell",
     ]
   }

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -188,6 +188,7 @@ efr32_executable("window_app") {
   if (chip_enable_openthread) {
     deps += [
       "${chip_root}/third_party/openthread:openthread",
+      "${chip_root}/third_party/openthread:openthread_device",
       "${examples_plat_dir}:efr-matter-shell",
     ]
   }

--- a/src/inet/BUILD.gn
+++ b/src/inet/BUILD.gn
@@ -108,7 +108,7 @@ static_library("inet") {
   }
 
   if (chip_system_config_use_open_thread_inet_endpoints) {
-    public_deps += [ "${chip_root}/third_party/openthread:openthread" ]
+    public_deps += [ "${chip_root}/third_party/openthread:openthread_device" ]
   }
 
   if (chip_inet_config_enable_tcp_endpoint) {

--- a/src/platform/EFR32/BUILD.gn
+++ b/src/platform/EFR32/BUILD.gn
@@ -98,9 +98,9 @@ static_library("EFR32") {
     "$dir_pw_kvs",
   ]
   if (chip_enable_openthread) {
-    public_deps += [ "${chip_root}/third_party/openthread:openthread" ]
+    public_deps += [ "${chip_root}/third_party/openthread:openthread_device" ]
 
-    deps += [ "${chip_root}/third_party/silabs:openthread_cli" ]
+    deps += [ "${chip_root}/third_party/openthread:openthread_cli" ]
 
     sources += [
       "../OpenThread/OpenThreadUtils.cpp",

--- a/src/test_driver/efr32/BUILD.gn
+++ b/src/test_driver/efr32/BUILD.gn
@@ -96,6 +96,7 @@ efr32_executable("efr32_device_tests") {
   if (chip_enable_openthread) {
     deps += [
       "${chip_root}/third_party/openthread:openthread",
+      "${chip_root}/third_party/openthread:openthread_device",
       "${examples_plat_dir}:efr-matter-shell",
     ]
   }

--- a/third_party/openthread/BUILD.gn
+++ b/third_party/openthread/BUILD.gn
@@ -16,10 +16,27 @@ group("openthread") {
       "${chip_root}/third_party/openthread/platforms:libopenthread-platform",
       "${chip_root}/third_party/openthread/platforms:libopenthread-platform-utils",
     ]
+  }
+}
+
+group("openthread_device") {
+  if (chip_openthread_target != "") {
+    public_deps = [ chip_openthread_target ]
+  } else {
     if (chip_openthread_ftd) {
-      public_deps += [ "${openthread_root}:libopenthread-ftd" ]
+      public_deps = [ "${openthread_root}:libopenthread-ftd" ]
     } else {
-      public_deps += [ "${openthread_root}:libopenthread-mtd" ]
+      public_deps = [ "${openthread_root}:libopenthread-mtd" ]
+    }
+  }
+}
+
+group("openthread_cli") {
+  if (chip_openthread_target == "") {
+    if (chip_openthread_ftd) {
+      public_deps = [ "${openthread_root}:libopenthread-cli-ftd" ]
+    } else {
+      public_deps = [ "${openthread_root}:libopenthread-cli-mtd" ]
     }
   }
 }

--- a/third_party/silabs/BUILD.gn
+++ b/third_party/silabs/BUILD.gn
@@ -31,18 +31,6 @@ group("efr32_sdk") {
   public_deps = [ efr32_sdk_target ]
 }
 
-if (chip_enable_openthread) {
-  group("openthread_cli") {
-    if (!use_silabs_thread_lib) {
-      if (chip_openthread_ftd) {
-        public_deps = [ "${sl_openthread_root}:libopenthread-cli-ftd" ]
-      } else {
-        public_deps = [ "${sl_openthread_root}:libopenthread-cli-mtd" ]
-      }
-    }
-  }
-}
-
 if (use_silabs_thread_lib) {
   config("libopenthread-platform_config") {
     include_dirs = [ "${sl_openthread_root}/examples/platforms" ]
@@ -74,7 +62,6 @@ if (use_silabs_thread_lib) {
       "RADIO_CONFIG_DMP_SUPPORT=1",
       "${efr32_board}=1",
       "${efr32_mcu}",
-      "USE_SL_THREAD_CERT_LIB",
       "OPENTHREAD_CORE_CONFIG_PLATFORM_CHECK_FILE=\"openthread-core-efr32-config-check.h\"",
     ]
 
@@ -88,7 +75,6 @@ if (use_silabs_thread_lib) {
 
   source_set("openthread_core_config_efr32") {
     sources = [
-      "${sl_openthread_root}/src/cli/cli_config.h",
       "${sl_ot_efr32_root}/src/src/openthread-core-efr32-config-check.h",
       "${sl_ot_efr32_root}/src/src/openthread-core-efr32-config.h",
     ]
@@ -102,37 +88,39 @@ if (use_silabs_thread_lib) {
   }
 
   source_set("ot-efr32-cert") {
-    sources = [
-      "${sl_openthread_root}/examples/apps/cli/cli_uart.cpp",
-      "${sl_openthread_root}/src/cli/cli.cpp",
-      "${sl_openthread_root}/src/cli/cli.hpp",
-      "${sl_openthread_root}/src/cli/cli_coap.cpp",
-      "${sl_openthread_root}/src/cli/cli_coap.hpp",
-      "${sl_openthread_root}/src/cli/cli_coap_secure.cpp",
-      "${sl_openthread_root}/src/cli/cli_coap_secure.hpp",
-      "${sl_openthread_root}/src/cli/cli_commissioner.cpp",
-      "${sl_openthread_root}/src/cli/cli_commissioner.hpp",
-      "${sl_openthread_root}/src/cli/cli_config.h",
-      "${sl_openthread_root}/src/cli/cli_dataset.cpp",
-      "${sl_openthread_root}/src/cli/cli_dataset.hpp",
-      "${sl_openthread_root}/src/cli/cli_history.cpp",
-      "${sl_openthread_root}/src/cli/cli_history.hpp",
-      "${sl_openthread_root}/src/cli/cli_joiner.cpp",
-      "${sl_openthread_root}/src/cli/cli_joiner.hpp",
-      "${sl_openthread_root}/src/cli/cli_network_data.cpp",
-      "${sl_openthread_root}/src/cli/cli_network_data.hpp",
-      "${sl_openthread_root}/src/cli/cli_output.cpp",
-      "${sl_openthread_root}/src/cli/cli_output.hpp",
-      "${sl_openthread_root}/src/cli/cli_srp_client.cpp",
-      "${sl_openthread_root}/src/cli/cli_srp_client.hpp",
-      "${sl_openthread_root}/src/cli/cli_srp_server.cpp",
-      "${sl_openthread_root}/src/cli/cli_srp_server.hpp",
-      "${sl_openthread_root}/src/cli/cli_tcp.cpp",
-      "${sl_openthread_root}/src/cli/cli_tcp.hpp",
-      "${sl_openthread_root}/src/cli/cli_udp.cpp",
-      "${sl_openthread_root}/src/cli/cli_udp.hpp",
-      "${sl_openthread_root}/src/cli/x509_cert_key.hpp",
-    ]
+    if (enable_openthread_cli) {
+      sources = [
+        "${sl_openthread_root}/examples/apps/cli/cli_uart.cpp",
+        "${sl_openthread_root}/src/cli/cli.cpp",
+        "${sl_openthread_root}/src/cli/cli.hpp",
+        "${sl_openthread_root}/src/cli/cli_coap.cpp",
+        "${sl_openthread_root}/src/cli/cli_coap.hpp",
+        "${sl_openthread_root}/src/cli/cli_coap_secure.cpp",
+        "${sl_openthread_root}/src/cli/cli_coap_secure.hpp",
+        "${sl_openthread_root}/src/cli/cli_commissioner.cpp",
+        "${sl_openthread_root}/src/cli/cli_commissioner.hpp",
+        "${sl_openthread_root}/src/cli/cli_config.h",
+        "${sl_openthread_root}/src/cli/cli_dataset.cpp",
+        "${sl_openthread_root}/src/cli/cli_dataset.hpp",
+        "${sl_openthread_root}/src/cli/cli_history.cpp",
+        "${sl_openthread_root}/src/cli/cli_history.hpp",
+        "${sl_openthread_root}/src/cli/cli_joiner.cpp",
+        "${sl_openthread_root}/src/cli/cli_joiner.hpp",
+        "${sl_openthread_root}/src/cli/cli_network_data.cpp",
+        "${sl_openthread_root}/src/cli/cli_network_data.hpp",
+        "${sl_openthread_root}/src/cli/cli_output.cpp",
+        "${sl_openthread_root}/src/cli/cli_output.hpp",
+        "${sl_openthread_root}/src/cli/cli_srp_client.cpp",
+        "${sl_openthread_root}/src/cli/cli_srp_client.hpp",
+        "${sl_openthread_root}/src/cli/cli_srp_server.cpp",
+        "${sl_openthread_root}/src/cli/cli_srp_server.hpp",
+        "${sl_openthread_root}/src/cli/cli_tcp.cpp",
+        "${sl_openthread_root}/src/cli/cli_tcp.hpp",
+        "${sl_openthread_root}/src/cli/cli_udp.cpp",
+        "${sl_openthread_root}/src/cli/cli_udp.hpp",
+        "${sl_openthread_root}/src/cli/x509_cert_key.hpp",
+      ]
+    }
 
     public_configs = [
       ":openthread_efr32_config",


### PR DESCRIPTION
#### Problem
Follow up to #21836 

#### Change overview
- Split libopenthread-platform and libopenthread-ftd/mtd in two groups
- Add libopenthread-cli-ftd/mtd group in openthread/build.gn
- remote it from silabs/build.gn
- clean up and fix for EFR32, Building with matter shell or thread lib without thread CLI
- update ot-efr32 submodule for the lastest openthread libs and tweaks

#### Testing
Test builds on EFR32 lighting-app :
- Default
- With thread lib
- With matter shell enabled
- With openthread cli disabled

Manually Commission and control with chip-tool + test the shell/cli
