### PR TITLE
Disable imx docker CI check step because it always fails with no spac…

### DIFF
--- a/.github/workflows/docker_img.yaml
+++ b/.github/workflows/docker_img.yaml
@@ -42,7 +42,12 @@ jobs:
                     - "-esp32"
                     - "-esp32-qemu"
                     - "-infineon"
-                    - "-imx"
+                    # NOTE: imx image requires too much space for GitHub-hosted runners. It fails with:
+                    # ```
+                    # ....
+                    # ApplyLayer exit status 1 stdout:  stderr: write /opt/fsl-imx-xwayland/5.15-kirkstone/sysroots/armv8a-poky-linux/opt/ltp/testcases/bin/fanotify15: no space left on device
+                    # ```
+                    # - "-imx"
                     - "-k32w"
                     - "-mbed-os"
                     - "-nrf-platform"


### PR DESCRIPTION
…e left on device

#### Problem
```
---> 9d969ae1f2dd
8339
Step 7/8 : COPY --from=build /opt/fsl-imx-xwayland /opt/fsl-imx-xwayland
8340
ApplyLayer exit status 1 stdout:  stderr: write /opt/fsl-imx-xwayland/5.15-kirkstone/sysroots/armv8a-poky-linux/opt/ltp/testcases/bin/fanotify15: no space left on device
```

see https://github.com/project-chip/connectedhomeip/runs/7924060219?check_suite_focus=true

#### Change overview
comment out iMX check for docker images.

#### Testing
N/A
