### PR TITLE
chip-cert: Added Request To Check that KeyUsageFlags::kDigitalSignature is Set for NOC Validation

### DIFF
--- a/src/tools/chip-cert/Cmd_ValidateCert.cpp
+++ b/src/tools/chip-cert/Cmd_ValidateCert.cpp
@@ -191,6 +191,7 @@ bool Cmd_ValidateCert(int argc, char * argv[])
     uint32_t currentTime;
     res = chip::UnixEpochToChipEpochTime(static_cast<uint32_t>(time(nullptr)), currentTime);
     context.mEffectiveTime.Set<CurrentChipEpochTime>(currentTime);
+    context.mRequiredKeyUsages.Set(KeyUsageFlags::kDigitalSignature);
     VerifyTrueOrExit(res);
 
     err = certSet.FindValidCert(certToBeValidated->mSubjectDN, certToBeValidated->mSubjectKeyId, context, &validatedCert);


### PR DESCRIPTION
#### Problem
Need to align NOC chain validation done by the chip-cert tool and by the SDK code. 

#### Change overview
Added Request To Check that KeyUsageFlags::kDigitalSignature is Set for NOC Validation.

#### Testing
manual testing of the chip-cert tool 