### PR TITLE
[ESP32] Fix namespace for unique id and added rotating device id unique id key in chip-factory namespace

### DIFF
--- a/scripts/tools/generate_esp32_chip_factory_bin.py
+++ b/scripts/tools/generate_esp32_chip_factory_bin.py
@@ -140,7 +140,7 @@ FACTORY_DATA = {
         'encoding': 'string',
         'value': None,
     },
-    'unique-id': {
+    'rd-id-uid': {
         'type': 'data',
         'encoding': 'hex2bin',
         'value': None,
@@ -260,7 +260,7 @@ def validate_args(args):
     check_str_range(args.product_name, 1, 32, 'Product name')
     check_str_range(args.hw_ver_str, 1, 64, 'Hardware version string')
     check_str_range(args.mfg_date, 8, 16, 'Manufacturing date')
-    check_str_range(args.unique_id, 32, 32, 'Unique id')
+    check_str_range(args.rd_id_uid, 32, 32, 'Rotating device Unique id')
 
     logging.info('Discriminator:{} Passcode:{}'.format(args.discriminator, args.passcode))
 
@@ -295,8 +295,8 @@ def populate_factory_data(args, spake2p_params):
 
     if args.serial_num is not None:
         FACTORY_DATA['serial-num']['value'] = args.serial_num
-    if args.unique_id is not None:
-        FACTORY_DATA['unique-id']['value'] = args.unique_id
+    if args.rd_id_uid is not None:
+        FACTORY_DATA['rd-id-uid']['value'] = args.rd_id_uid
     if args.mfg_date is not None:
         FACTORY_DATA['mfg-date']['value'] = args.mfg_date
     if args.vendor_id is not None:
@@ -460,8 +460,8 @@ def main():
     parser.add_argument('--hw-ver-str', type=str, required=False, help='Hardware version string')
     parser.add_argument('--mfg-date', type=str, required=False, help='Manufacturing date in format YYYY-MM-DD')
     parser.add_argument('--serial-num', type=str, required=False, help='Serial number')
-    parser.add_argument('--unique-id', type=str, required=False,
-                        help='128-bit unique identifier, provide 32-byte hex string, e.g. "1234567890abcdef1234567890abcdef"')
+    parser.add_argument('--rd-id-uid', type=str, required=False,
+                        help='128-bit unique identifier for generating rotating device identifier, provide 32-byte hex string, e.g. "1234567890abcdef1234567890abcdef"')
 
     # These will be used by DeviceInfoProvider
     parser.add_argument('--calendar-types', type=str, nargs='+', required=False,

--- a/src/platform/ESP32/ESP32Config.cpp
+++ b/src/platform/ESP32/ESP32Config.cpp
@@ -72,9 +72,9 @@ const ESP32Config::Key ESP32Config::kConfigKey_VendorId              = { kConfig
 const ESP32Config::Key ESP32Config::kConfigKey_VendorName            = { kConfigNamespace_ChipFactory, "vendor-name" };
 const ESP32Config::Key ESP32Config::kConfigKey_ProductId             = { kConfigNamespace_ChipFactory, "product-id" };
 const ESP32Config::Key ESP32Config::kConfigKey_ProductName           = { kConfigNamespace_ChipFactory, "product-name" };
-const ESP32Config::Key ESP32Config::kConfigKey_UniqueId              = { kConfigNamespace_ChipFactory, "unique-id" };
 const ESP32Config::Key ESP32Config::kConfigKey_SupportedCalTypes     = { kConfigNamespace_ChipFactory, "cal-types" };
 const ESP32Config::Key ESP32Config::kConfigKey_SupportedLocaleSize   = { kConfigNamespace_ChipFactory, "locale-sz" };
+const ESP32Config::Key ESP32Config::kConfigKey_RotatingDevIdUniqueId = { kConfigNamespace_ChipFactory, "rd-id-uid" };
 
 // Keys stored in the chip-config namespace
 const ESP32Config::Key ESP32Config::kConfigKey_ServiceConfig      = { kConfigNamespace_ChipConfig, "service-config" };
@@ -85,6 +85,7 @@ const ESP32Config::Key ESP32Config::kConfigKey_FailSafeArmed      = { kConfigNam
 const ESP32Config::Key ESP32Config::kConfigKey_WiFiStationSecType = { kConfigNamespace_ChipConfig, "sta-sec-type" };
 const ESP32Config::Key ESP32Config::kConfigKey_RegulatoryLocation = { kConfigNamespace_ChipConfig, "reg-location" };
 const ESP32Config::Key ESP32Config::kConfigKey_CountryCode        = { kConfigNamespace_ChipConfig, "country-code" };
+const ESP32Config::Key ESP32Config::kConfigKey_UniqueId           = { kConfigNamespace_ChipConfig, "unique-id" };
 
 // Keys stored in the Chip-counters namespace
 const ESP32Config::Key ESP32Config::kCounterKey_RebootCount           = { kConfigNamespace_ChipCounters, "reboot-count" };

--- a/src/platform/ESP32/ESP32Config.h
+++ b/src/platform/ESP32/ESP32Config.h
@@ -53,7 +53,6 @@ public:
 
     // Key definitions for well-known keys.
     static const Key kConfigKey_SerialNum;
-    static const Key kConfigKey_UniqueId;
     static const Key kConfigKey_MfrDeviceId;
     static const Key kConfigKey_MfrDeviceCert;
     static const Key kConfigKey_MfrDeviceICACerts;
@@ -62,15 +61,7 @@ public:
     static const Key kConfigKey_HardwareVersionString;
     static const Key kConfigKey_ManufacturingDate;
     static const Key kConfigKey_SetupPinCode;
-    static const Key kConfigKey_ServiceConfig;
-    static const Key kConfigKey_PairedAccountId;
-    static const Key kConfigKey_ServiceId;
-    static const Key kConfigKey_LastUsedEpochKeyId;
-    static const Key kConfigKey_FailSafeArmed;
-    static const Key kConfigKey_WiFiStationSecType;
     static const Key kConfigKey_SetupDiscriminator;
-    static const Key kConfigKey_RegulatoryLocation;
-    static const Key kConfigKey_CountryCode;
     static const Key kConfigKey_Spake2pIterationCount;
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
@@ -85,6 +76,18 @@ public:
     static const Key kConfigKey_ProductName;
     static const Key kConfigKey_SupportedCalTypes;
     static const Key kConfigKey_SupportedLocaleSize;
+    static const Key kConfigKey_RotatingDevIdUniqueId;
+
+    // CHIP Config keys
+    static const Key kConfigKey_ServiceConfig;
+    static const Key kConfigKey_PairedAccountId;
+    static const Key kConfigKey_ServiceId;
+    static const Key kConfigKey_LastUsedEpochKeyId;
+    static const Key kConfigKey_FailSafeArmed;
+    static const Key kConfigKey_WiFiStationSecType;
+    static const Key kConfigKey_RegulatoryLocation;
+    static const Key kConfigKey_CountryCode;
+    static const Key kConfigKey_UniqueId;
 
     // CHIP Counter keys
     static const Key kCounterKey_RebootCount;

--- a/src/platform/ESP32/ESP32FactoryDataProvider.cpp
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.cpp
@@ -198,12 +198,13 @@ CHIP_ERROR ESP32FactoryDataProvider::GetHardwareVersionString(char * buf, size_t
 CHIP_ERROR ESP32FactoryDataProvider::GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan)
 {
     ChipError err = CHIP_ERROR_WRONG_KEY_TYPE;
-#if CHIP_ENABLE_ROTATING_DEVICE_ID && defined(CHIP_DEVICE_CONFIG_ROTATING_DEVICE_ID_UNIQUE_ID)
+#if CHIP_ENABLE_ROTATING_DEVICE_ID
     static_assert(ConfigurationManager::kRotatingDeviceIDUniqueIDLength >= ConfigurationManager::kMinRotatingDeviceIDUniqueIDLength,
                   "Length of unique ID for rotating device ID is smaller than minimum.");
 
     size_t uniqueIdLen = 0;
-    err = ESP32Config::ReadConfigValueBin(ESP32Config::kConfigKey_UniqueId, uniqueIdSpan.data(), uniqueIdSpan.size(), uniqueIdLen);
+    err = ESP32Config::ReadConfigValueBin(ESP32Config::kConfigKey_RotatingDevIdUniqueId, uniqueIdSpan.data(), uniqueIdSpan.size(),
+                                          uniqueIdLen);
     ReturnErrorOnFailure(err);
     uniqueIdSpan.reduce_size(uniqueIdLen);
 #endif


### PR DESCRIPTION
#### Problem
Unique-id should be changed after every factory reset and to do that it
should be stored in chip-config namespace.
Earlier it was stored in chip-factory which is not erased on factory reset.

#### Change overview
* Store unique-id in chip-config namespace
* Added rotating device id unique id key in chip-factory namespace
* Related changes in factory partition generator script

#### Testing
Flashed the generated partition and made sure the value of rotating device id unique id is same as that was flashed.
