### PR TITLE
[nrfconnect] Fix Docker build due to conflicting PIP packages

### DIFF
--- a/integrations/docker/images/chip-build-nrf-platform/Dockerfile
+++ b/integrations/docker/images/chip-build-nrf-platform/Dockerfile
@@ -61,7 +61,7 @@ RUN set -x \
     && (apt-get remove -fy python3-yaml && apt-get autoremove || exit 0) \
     && python3 -m pip install -U --no-cache-dir cmake==3.22.5 \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/zephyr/scripts/requirements.txt \
-    && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/nrf/scripts/requirements.txt \
+    && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/nrf/scripts/requirements-build.txt \
     && python3 -m pip install --no-cache-dir -r /opt/NordicSemiconductor/nrfconnect/bootloader/mcuboot/scripts/requirements.txt \
     && : # last line
 

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.94 Version bump reason: Install ccache to the chip-build image
+0.5.95 Version bump reason: Fix nrfconnect Docker build


### PR DESCRIPTION
#### Problem
nRF Connect Docker image build started to fail due to some conflicts in documentation dependencies. 

#### Change overview
We don't need documentatin dependencies in Matter CI, so get rid off them.

#### Testing
Built a Docker image and build an nRF Connect example using that image.
