### PR TITLE
[EFR32]Fix Boot Reason (TC-DGGEN-2.2)

### DIFF
--- a/examples/platform/efr32/init_efrPlatform.cpp
+++ b/examples/platform/efr32/init_efrPlatform.cpp
@@ -68,7 +68,8 @@ void init_efrPlatform(void)
 #endif
 
 #if CHIP_ENABLE_OPENTHREAD
-    sl_ot_sys_init();
+    efr32RadioInit();
+    efr32AlarmInit();
 #endif // CHIP_ENABLE_OPENTHREAD
 }
 

--- a/src/platform/EFR32/ConfigurationManagerImpl.cpp
+++ b/src/platform/EFR32/ConfigurationManagerImpl.cpp
@@ -97,7 +97,7 @@ CHIP_ERROR ConfigurationManagerImpl::IncreaseBootCount(void)
     return EFR32Config::WriteConfigValue(EFR32Config::kConfigKey_BootCount, bootCount + 1);
 }
 
-uint32_t ConfigurationManagerImpl::GetBootReason(void)
+CHIP_ERROR ConfigurationManagerImpl::GetBootReason(uint32_t & bootReason)
 {
     // rebootCause is obtained at bootup.
     BootReasonType matterBootCause;
@@ -150,7 +150,8 @@ uint32_t ConfigurationManagerImpl::GetBootReason(void)
     matterBootCause = BootReasonType::kUnspecified;
 #endif
 
-    return to_underlying(matterBootCause);
+    bootReason = to_underlying(matterBootCause);
+    return CHIP_NO_ERROR;
 }
 
 CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)

--- a/src/platform/EFR32/ConfigurationManagerImpl.h
+++ b/src/platform/EFR32/ConfigurationManagerImpl.h
@@ -40,7 +40,7 @@ public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 
-    uint32_t GetBootReason(void);
+    CHIP_ERROR GetBootReason(uint32_t & bootReason);
     CHIP_ERROR GetRebootCount(uint32_t & rebootCount);
     CHIP_ERROR IncreaseBootCount(void);
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours);


### PR DESCRIPTION
#### Problem
The boot-reasons always read 0
Read-event doesn't read anything. event isn't created a bootup

#### Change overview
Fix EFR32 Boot Reason prototype so it matches and overrides the generic one. 
The generic one return not_implemented so the event reboot event wasn't created

Replace sl_ot_sys_init by the needed call from things functions. Else efr32MiscInit from ot-efr32 code was being called and 'stealing' the reboot cause from the matter stack (read and clear the register).


#### Testing
Manual testing
Cause different reboot cause and test with
```
chip-tool generaldiagnostics read boot-reasons 17635 0
chip-tool generaldiagnostics read-event boot-reason 17635 0
```
