### PR TITLE
Bump Pigweed to origin/main and fix Python Constraints

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -194,7 +194,6 @@ config("optimize_default") {
 config("disabled_warnings") {
   cflags = [
     "-Wno-deprecated-declarations",
-    "-Wno-unknown-warning-option",
     "-Wno-maybe-uninitialized",
     "-Wno-missing-field-initializers",
     "-Wno-unused-parameter",
@@ -202,6 +201,9 @@ config("disabled_warnings") {
   if (!is_debug) {
     # assert() causes unused variable warnings in release.
     cflags += [ "-Wno-unused" ]
+  }
+  if (is_clang) {
+    cflags += [ "-Wno-unknown-warning-option" ]
   }
   if (!is_clang) {
     cflags += [

--- a/config/ameba/args.gni
+++ b/config/ameba/args.gni
@@ -16,7 +16,6 @@
 # options are used from examples/.
 
 import("//build_overrides/pigweed.gni")
-import("$dir_pw_span/polyfill.gni")
 
 chip_device_platform = "ameba"
 
@@ -38,5 +37,4 @@ custom_toolchain = "//third_party/connectedhomeip/config/ameba/toolchain:ameba"
 
 pw_build_PIP_CONSTRAINTS =
     [ "//third_party/connectedhomeip/scripts/constraints.txt" ]
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 cpp_standard = "c++17"

--- a/config/bouffalolab/bl602/lib/pw_rpc/pw_rpc.gni
+++ b/config/bouffalolab/bl602/lib/pw_rpc/pw_rpc.gni
@@ -19,7 +19,6 @@ pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 pw_sys_io_BACKEND =
     "${chip_root}/examples/platform/bouffalolab/bl602/pw_sys_io:pw_sys_io_bl602"
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 
 pw_string_CONFIG =
     "${chip_root}/config/bouffalolab/bl602/lib/pw_rpc:pw_string_dep"

--- a/config/bouffalolab/bl702/lib/pw_rpc/pw_rpc.gni
+++ b/config/bouffalolab/bl702/lib/pw_rpc/pw_rpc.gni
@@ -19,7 +19,6 @@ pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log"
 pw_sys_io_BACKEND =
     "${chip_root}/examples/platform/bouffalolab/bl702/pw_sys_io:pw_sys_io_bl702"
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 
 pw_string_CONFIG =
     "${chip_root}/config/bouffalolab/bl702/lib/pw_rpc:pw_string_dep"

--- a/config/efr32/lib/pw_rpc/pw_rpc.gni
+++ b/config/efr32/lib/pw_rpc/pw_rpc.gni
@@ -19,7 +19,6 @@ pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 pw_sys_io_BACKEND =
     "${chip_root}/examples/platform/efr32/pw_sys_io:pw_sys_io_efr32"
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/config/esp32/args.gni
+++ b/config/esp32/args.gni
@@ -15,7 +15,6 @@
 # Options from standalone-chip.mk that differ from configure defaults. These
 # options are used from examples/.
 import("//build_overrides/pigweed.gni")
-import("$dir_pw_span/polyfill.gni")
 chip_device_platform = "esp32"
 
 chip_project_config_include = ""
@@ -39,4 +38,3 @@ custom_toolchain = "//third_party/connectedhomeip/config/esp32/toolchain:esp32"
 # whatever pigweed ships with
 pw_build_PIP_CONSTRAINTS =
     [ "//third_party/connectedhomeip/scripts/constraints.txt" ]
-pw_span_ENABLE_STD_SPAN_POLYFILL = false

--- a/config/mbed/chip-gn/lib/pw_rpc/pw_rpc.gni
+++ b/config/mbed/chip-gn/lib/pw_rpc/pw_rpc.gni
@@ -21,7 +21,6 @@ pw_sys_io_BACKEND =
     "${chip_root}/examples/platform/mbed/pw_sys_io:pw_sys_io_mbed"
 pw_rpc_system_server_BACKEND =
     "${chip_root}/examples/common/pigweed:system_rpc_server"
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/config/qpg/lib/pw_rpc/pw_rpc.gni
+++ b/config/qpg/lib/pw_rpc/pw_rpc.gni
@@ -18,7 +18,6 @@ import("//build_overrides/pigweed.gni")
 pw_log_BACKEND = "$dir_pw_log_basic"
 pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 pw_sys_io_BACKEND = "${chip_root}/examples/platform/qpg/pw_sys_io:pw_sys_io_qpg"
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/examples/build_overrides/pigweed_environment.gni
+++ b/examples/build_overrides/pigweed_environment.gni
@@ -20,10 +20,11 @@ _bootstrap_root = "//third_party/connectedhomeip"
 import("${_bootstrap_root}/build_overrides/pigweed_environment.gni")
 
 # Rebase paths to our root.
-dir_cipd_arm = get_path_info("${_bootstrap_root}/${dir_cipd_arm}", "abspath")
+dir_cipd_arm =
+    get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_ARM}", "abspath")
 dir_cipd_pigweed =
-    get_path_info("${_bootstrap_root}/${dir_cipd_pigweed}", "abspath")
+    get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PIGWEED}", "abspath")
 dir_cipd_python =
-    get_path_info("${_bootstrap_root}/${dir_cipd_python}", "abspath")
+    get_path_info("${_bootstrap_root}/${pw_env_setup_CIPD_PYTHON}", "abspath")
 dir_virtual_env =
     get_path_info("${_bootstrap_root}/${pw_env_setup_VIRTUAL_ENV}", "abspath")

--- a/examples/chef/linux/BUILD.gn
+++ b/examples/chef/linux/BUILD.gn
@@ -92,7 +92,10 @@ executable("${sample_name}") {
 
     deps += pw_build_LINK_DEPS
 
-    cflags = [ "-Wno-gnu-designator" ]
+    cflags = []
+    if (is_clang) {
+      cflags += [ "-Wno-gnu-designator" ]
+    }
 
     include_dirs += [ "${chip_root}/examples/common" ]
   } else {

--- a/examples/chef/linux/with_pw_rpc.gni
+++ b/examples/chef/linux/with_pw_rpc.gni
@@ -32,7 +32,6 @@ pw_rpc_system_server_BACKEND = "${chip_root}/config/linux/lib/pw_rpc:pw_rpc"
 dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
 pw_chrono_SYSTEM_CLOCK_BACKEND = "$dir_pw_chrono_stl:system_clock"
 pw_sync_MUTEX_BACKEND = "$dir_pw_sync_stl:mutex_backend"
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/examples/dynamic-bridge-app/linux/with_pw_rpc.gni
+++ b/examples/dynamic-bridge-app/linux/with_pw_rpc.gni
@@ -32,7 +32,6 @@ pw_rpc_system_server_BACKEND = "${chip_root}/config/linux/lib/pw_rpc:pw_rpc"
 dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
 pw_chrono_SYSTEM_CLOCK_BACKEND = "$dir_pw_chrono_stl:system_clock"
 pw_sync_MUTEX_BACKEND = "$dir_pw_sync_stl:mutex_backend"
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/examples/lighting-app/linux/with_pw_rpc.gni
+++ b/examples/lighting-app/linux/with_pw_rpc.gni
@@ -32,7 +32,6 @@ pw_rpc_system_server_BACKEND = "${chip_root}/config/linux/lib/pw_rpc:pw_rpc"
 dir_pw_third_party_nanopb = "${chip_root}/third_party/nanopb/repo"
 pw_chrono_SYSTEM_CLOCK_BACKEND = "$dir_pw_chrono_stl:system_clock"
 pw_sync_MUTEX_BACKEND = "$dir_pw_sync_stl:mutex_backend"
-pw_span_ENABLE_STD_SPAN_POLYFILL = false
 
 pw_build_LINK_DEPS = [
   "$dir_pw_assert:impl",

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -55,6 +55,11 @@ _bootstrap_or_activate() {
 
     local _PW_BANNER_FUNC="_chip_bootstrap_banner"
 
+    # Force the Pigweed environment directory to be '.environment'
+    if [ -z "$PW_ENVIRONMENT_ROOT" ]; then
+        export PW_ENVIRONMENT_ROOT="$PW_PROJECT_ROOT/.environment"
+    fi
+
     export _PW_ACTUAL_ENVIRONMENT_ROOT="$(pw_get_env_root)"
     local _SETUP_SH="$_PW_ACTUAL_ENVIRONMENT_ROOT/activate.sh"
 

--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -162,6 +162,12 @@ mbed-tools==7.55.1.dev1 ; platform_machine != "aarch64" and sys_platform == "lin
     # via -r requirements.mbed.txt
 mobly==1.11.1
     # via -r requirements.txt
+mypy==0.971
+    # via -r requirements.txt
+mypy-extensions==0.4.3
+    # via mypy
+mypy-protobuf==3.2.0
+    # via -r requirements.txt
 numpy==1.23.0
     # via pandas
 packaging==20.9
@@ -198,13 +204,12 @@ prettytable==2.5.0
     #   mbed-os-tools
 prompt-toolkit==3.0.26
     # via ipython
-protobuf==3.17.3
-    # via -r requirements.txt
-psutil==5.9.1
+protobuf==3.20.1
     # via
     #   -r requirements.txt
-    #   mobly
-    #   mbed-tools
+    #   mypy-protobuf
+psutil==5.9.1
+    # via -r requirements.txt
 ptyprocess==0.7.0
     # via pexpect
 py==1.11.0
@@ -282,7 +287,6 @@ six==1.16.0
     #   idf-component-manager
     #   junit-xml
     #   mbed-os-tools
-    #   protobuf
     #   python-dateutil
     #   python-engineio
     #   python-socketio
@@ -304,6 +308,8 @@ toml==0.10.2
     # via
     #   pep517
     #   pytest
+tomli==2.0.1
+    # via mypy
 tornado==6.1
     # via -r requirements.txt
 tqdm==4.61.1
@@ -314,10 +320,15 @@ traitlets==5.0.5
     # via
     #   ipython
     #   matplotlib-inline
+types-protobuf==3.19.22
+    # via
+    #   -r requirements.txt
+    #   mypy-protobuf
 typing-extensions==4.3.0 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via
     #   -r requirements.mbed.txt
-    #   mbed-tools
+    #   mobly
+    #   mypy
 urllib3==1.26.5
     # via requests
 virtualenv==20.4.7

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -43,7 +43,10 @@ appnope
 appdirs
 coloredlogs
 watchdog
-protobuf
+mypy==0.971
+mypy-protobuf==3.2.0
+protobuf==3.20.1
+types-protobuf==3.19.22
 
 # scripts/tools/memory
 anytree


### PR DESCRIPTION
#### Problem
Pigweed roll fails due to conflicting Python package constraints 
dependabot PR: https://github.com/project-chip/connectedhomeip/pull/22066

#### Change overview
Rolls to latest Pigweed and sets compatible mypy and protobuf package versions. Both are minor version bumps.
Pigweed updated `mypy` to the latest version due to a bug in mypy itself. Context: https://pigweed-review.googlesource.com/c/pigweed/pigweed/+/106841

#### Testing
Tested with
```sh
. ./scripts/bootstrap.sh
gn gen out
ninja -C out python_packages default check
```