### PR TITLE
[EFR32] Fix CSR length.

### DIFF
--- a/src/platform/EFR32/CHIPCryptoPALPsaEfr32.cpp
+++ b/src/platform/EFR32/CHIPCryptoPALPsaEfr32.cpp
@@ -894,7 +894,9 @@ P256Keypair::~P256Keypair()
 CHIP_ERROR P256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
 {
     MutableByteSpan csr(out_csr, csr_length);
-    return GenerateCertificateSigningRequest(this, csr);
+    CHIP_ERROR err = GenerateCertificateSigningRequest(this, csr);
+    csr_length     = (CHIP_NO_ERROR == err) ? csr.size() : 0;
+    return err;
 }
 
 CHIP_ERROR VerifyCertificateSigningRequest(const uint8_t * csr_buf, size_t csr_length, P256PublicKey & pubkey)

--- a/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
+++ b/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
@@ -407,7 +407,9 @@ CHIP_ERROR EFR32OpaqueP256Keypair::Deserialize(P256SerializedKeypair & input)
 CHIP_ERROR EFR32OpaqueP256Keypair::NewCertificateSigningRequest(uint8_t * out_csr, size_t & csr_length) const
 {
     MutableByteSpan csr(out_csr, csr_length);
-    return GenerateCertificateSigningRequest(this, csr);
+    CHIP_ERROR err = GenerateCertificateSigningRequest(this, csr);
+    csr_length     = (CHIP_NO_ERROR == err) ? csr.size() : 0;
+    return err;
 }
 
 CHIP_ERROR EFR32OpaqueP256Keypair::ECDSA_sign_msg(const uint8_t * msg, size_t msg_length, P256ECDSASignature & out_signature) const


### PR DESCRIPTION
#### Problem
The csr_length argument is not updated upon returnn of EFR32OpaqueP256Keypair::NewCertificateSigningRequest(). In consequence, the CSR is sent with the wrong length.

#### Change overview
CSR updated with the actual value.

#### Testing
Tested on EFR32xMG12.