### PR TITLE
iOS TvCasting app: Fixing typo in mapping mediaPlayback_stopPlayback correctly

### DIFF
--- a/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
+++ b/examples/tv-casting-app/darwin/MatterTvCastingBridge/MatterTvCastingBridge/CastingServerBridge.mm
@@ -309,7 +309,7 @@
 
     _mediaPlayback_pauseResponseCallback = responseCallback;
     dispatch_async(_chipWorkQueue, ^{
-        CHIP_ERROR err = CastingServer::GetInstance()->MediaPlayback_Pause([](CHIP_ERROR err) {
+        CHIP_ERROR err = CastingServer::GetInstance()->MediaPlayback_StopPlayback([](CHIP_ERROR err) {
             [CastingServerBridge getSharedInstance].mediaPlayback_stopPlaybackResponseCallback(CHIP_NO_ERROR == err);
         });
         dispatch_async(clientQueue, ^{


### PR DESCRIPTION
#### Problem
* mediaPlayback_stopPlayback was getting mapped incorrectly to MediaPlayback_Pause in CastingServerBridge.mm

#### Change overview
Fixed the Copy/paste error