### PR TITLE
TC_RR_1_1: Updated Method that Was Used to Generate Large Sized Operational Certificates

### DIFF
--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -507,6 +507,12 @@ CHIP_ERROR ConvertChipCertToX509Cert(const ByteSpan chipCert, MutableByteSpan & 
  */
 CHIP_ERROR ValidateChipRCAC(const ByteSpan & rcac);
 
+struct FutureExtension
+{
+    ByteSpan OID;
+    ByteSpan Extension;
+};
+
 struct X509CertRequestParams
 {
     int64_t SerialNumber;
@@ -514,6 +520,7 @@ struct X509CertRequestParams
     uint32_t ValidityEnd;
     ChipDN SubjectDN;
     ChipDN IssuerDN;
+    Optional<FutureExtension> FutureExt;
 };
 
 /**

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -103,7 +103,7 @@ static const BitFlags<KeyUsageFlags> sKCandEO(sKC, sEO);
 static const BitFlags<KeyUsageFlags> sKCandDO(sKC, sDO);
 
 constexpr uint8_t sOID_Extension_SubjectAltName[] = { 0x55, 0x1d, 0x11 };
-constexpr char kExtension_SubjectAltName[]        = "test@chip.org";
+constexpr char kExtension_SubjectAltName[]        = "test@example.com";
 
 FutureExtension ext{ ByteSpan(sOID_Extension_SubjectAltName),
                      ByteSpan(reinterpret_cast<uint8_t *>(const_cast<char *>(kExtension_SubjectAltName)),

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -102,6 +102,14 @@ static const BitFlags<KeyUsageFlags> sKCandCR(sKC, sCR);
 static const BitFlags<KeyUsageFlags> sKCandEO(sKC, sEO);
 static const BitFlags<KeyUsageFlags> sKCandDO(sKC, sDO);
 
+constexpr uint8_t sOID_Extension_SubjectAltName[] = { 0x55, 0x1d, 0x11 };
+constexpr char kExtension_SubjectAltName[]        = "test@chip.org";
+
+FutureExtension ext{ ByteSpan(sOID_Extension_SubjectAltName),
+                     ByteSpan(reinterpret_cast<uint8_t *>(const_cast<char *>(kExtension_SubjectAltName)),
+                              strlen(kExtension_SubjectAltName)) };
+Optional<FutureExtension> kSubjectAltNameAsFutureExt(ext);
+
 static CHIP_ERROR LoadTestCertSet01(ChipCertificateSet & certSet)
 {
     CHIP_ERROR err;
@@ -1247,6 +1255,15 @@ static void TestChipCert_GenerateRootCert(nlTestSuite * inSuite, void * inContex
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
 
+    // Test with FutureExtension
+    X509CertRequestParams root_params2 = { 1234, 631161876, 729942000, root_dn, root_dn, kSubjectAltNameAsFutureExt };
+    MutableByteSpan signed_cert_span2(signed_cert);
+    NL_TEST_ASSERT(inSuite, NewRootX509Cert(root_params2, keypair, signed_cert_span2) == CHIP_NO_ERROR);
+    outCert = MutableByteSpan(outCertBuf);
+
+    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span2, outCert) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+
     // Test error case: root cert subject provided ICA OID Attribute.
     root_params.SubjectDN.Clear();
     NL_TEST_ASSERT(inSuite, root_params.SubjectDN.AddAttribute_MatterICACId(0xabcdabcd) == CHIP_NO_ERROR);
@@ -1325,6 +1342,15 @@ static void TestChipCert_GenerateICACert(nlTestSuite * inSuite, void * inContext
 
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
 
+    // Test with FutureExtension
+    X509CertRequestParams ica_params2 = { 1234, 631161876, 729942000, ica_dn, issuer_dn, kSubjectAltNameAsFutureExt };
+    MutableByteSpan signed_cert_span2(signed_cert);
+    NL_TEST_ASSERT(inSuite, NewICAX509Cert(ica_params2, ica_keypair.Pubkey(), keypair, signed_cert_span2) == CHIP_NO_ERROR);
+    outCert = MutableByteSpan(outCertBuf);
+
+    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span2, outCert) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+
     // Test error case: ICA cert subject provided a node ID attribute
     ica_params.SubjectDN.Clear();
     NL_TEST_ASSERT(inSuite, ica_params.SubjectDN.AddAttribute_MatterNodeId(0xABCDABCDABCDABCD) == CHIP_NO_ERROR);
@@ -1370,6 +1396,16 @@ static void TestChipCert_GenerateNOCRoot(nlTestSuite * inSuite, void * inContext
 
     NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span, outCert) == CHIP_NO_ERROR);
 
+    NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
+
+    // Test with FutureExtension
+    X509CertRequestParams noc_params2 = { 123456, 631161876, 729942000, noc_dn, issuer_dn, kSubjectAltNameAsFutureExt };
+    MutableByteSpan signed_cert_span2(signed_cert);
+    NL_TEST_ASSERT(inSuite,
+                   NewNodeOperationalX509Cert(noc_params2, noc_keypair.Pubkey(), keypair, signed_cert_span2) == CHIP_NO_ERROR);
+    outCert = MutableByteSpan(outCertBuf);
+
+    NL_TEST_ASSERT(inSuite, ConvertX509CertToChipCert(signed_cert_span2, outCert) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, DecodeChipCert(outCert, certData) == CHIP_NO_ERROR);
 
     // Test error case: NOC cert subject doesn't have NodeId attribute

--- a/src/tools/chip-cert/CertUtils.cpp
+++ b/src/tools/chip-cert/CertUtils.cpp
@@ -772,7 +772,7 @@ bool WriteChipCert(const char * fileName, const ByteSpan & chipCert, CertFormat 
 }
 
 bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey, const struct tm & validFrom,
-              uint32_t validDays, int pathLen, const FutureExtension * futureExts, uint8_t futureExtsCount, X509 * newCert,
+              uint32_t validDays, int pathLen, const FutureExtensionWithNID * futureExts, uint8_t futureExtsCount, X509 * newCert,
               EVP_PKEY * newKey, CertStructConfig & certConfig)
 {
     bool res  = true;
@@ -925,7 +925,7 @@ exit:
 }
 
 CHIP_ERROR MakeCertChipTLV(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey,
-                           const struct tm & validFrom, uint32_t validDays, int pathLen, const FutureExtension * futureExts,
+                           const struct tm & validFrom, uint32_t validDays, int pathLen, const FutureExtensionWithNID * futureExts,
                            uint8_t futureExtsCount, X509 * x509Cert, EVP_PKEY * newKey, CertStructConfig & certConfig,
                            MutableByteSpan & chipCert)
 {

--- a/src/tools/chip-cert/Cmd_GenCert.cpp
+++ b/src/tools/chip-cert/Cmd_GenCert.cpp
@@ -243,19 +243,19 @@ OptionSet *gCmdOptionSets[] =
 // clang-format on
 
 ToolChipDN gSubjectDN;
-uint8_t gCertType                    = kCertType_NotSpecified;
-int gPathLengthConstraint            = kPathLength_NotSpecified;
-bool gSelfSign                       = false;
-const char * gCACertFileName         = nullptr;
-const char * gCAKeyFileName          = nullptr;
-const char * gInKeyFileName          = nullptr;
-const char * gOutCertFileName        = nullptr;
-const char * gOutKeyFileName         = nullptr;
-CertFormat gOutCertFormat            = kCertFormat_Default;
-KeyFormat gOutKeyFormat              = kKeyFormat_Default;
-uint32_t gValidDays                  = kCertValidDays_Undefined;
-FutureExtension gFutureExtensions[3] = { { 0, nullptr } };
-uint8_t gFutureExtensionsCount       = 0;
+uint8_t gCertType                           = kCertType_NotSpecified;
+int gPathLengthConstraint                   = kPathLength_NotSpecified;
+bool gSelfSign                              = false;
+const char * gCACertFileName                = nullptr;
+const char * gCAKeyFileName                 = nullptr;
+const char * gInKeyFileName                 = nullptr;
+const char * gOutCertFileName               = nullptr;
+const char * gOutKeyFileName                = nullptr;
+CertFormat gOutCertFormat                   = kCertFormat_Default;
+KeyFormat gOutKeyFormat                     = kKeyFormat_Default;
+uint32_t gValidDays                         = kCertValidDays_Undefined;
+FutureExtensionWithNID gFutureExtensions[3] = { { 0, nullptr } };
+uint8_t gFutureExtensionsCount              = 0;
 struct tm gValidFrom;
 CertStructConfig gCertConfig;
 

--- a/src/tools/chip-cert/chip-cert.h
+++ b/src/tools/chip-cert/chip-cert.h
@@ -141,7 +141,7 @@ enum AttCertType
     kAttCertType_DAC,              /**< Device Attestation Certificate (DAC). */
 };
 
-struct FutureExtension
+struct FutureExtensionWithNID
 {
     int nid;
     const char * info;
@@ -410,12 +410,12 @@ extern bool WriteCert(const char * fileName, X509 * cert, CertFormat certFmt);
 extern bool WriteChipCert(const char * fileName, const chip::ByteSpan & cert, CertFormat certFmt);
 
 extern bool MakeCert(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey, const struct tm & validFrom,
-                     uint32_t validDays, int pathLen, const FutureExtension * futureExts, uint8_t futureExtsCount, X509 * newCert,
-                     EVP_PKEY * newKey, CertStructConfig & certConfig);
+                     uint32_t validDays, int pathLen, const FutureExtensionWithNID * futureExts, uint8_t futureExtsCount,
+                     X509 * newCert, EVP_PKEY * newKey, CertStructConfig & certConfig);
 extern CHIP_ERROR MakeCertChipTLV(uint8_t certType, const ToolChipDN * subjectDN, X509 * caCert, EVP_PKEY * caKey,
-                                  const struct tm & validFrom, uint32_t validDays, int pathLen, const FutureExtension * futureExts,
-                                  uint8_t futureExtsCount, X509 * x509Cert, EVP_PKEY * newKey, CertStructConfig & certConfig,
-                                  chip::MutableByteSpan & chipCert);
+                                  const struct tm & validFrom, uint32_t validDays, int pathLen,
+                                  const FutureExtensionWithNID * futureExts, uint8_t futureExtsCount, X509 * x509Cert,
+                                  EVP_PKEY * newKey, CertStructConfig & certConfig, chip::MutableByteSpan & chipCert);
 extern bool ResignCert(X509 * cert, X509 * caCert, EVP_PKEY * caKey);
 
 extern bool MakeAttCert(AttCertType attCertType, const char * subjectCN, uint16_t subjectVID, uint16_t subjectPID,


### PR DESCRIPTION
#### Problem
In continuation of #22032. Need a way to generate maximum sized operational certificates. 

#### Change overview
Instead of padding the subject DN this method adds size by adding Future Extension.

This new approach doesn't have certain limitations compare to the previous approach and
allows generation of larger certificates of approximate sizes:
{RCAC, ICAC, NOC} ~ {400, 400, 350} bytes in TLV encoded form.

#### Testing
Added new tests