### PR TITLE
Mark zap_file argument required in zap_cluster_list.py

### DIFF
--- a/src/app/zap_cluster_list.py
+++ b/src/app/zap_cluster_list.py
@@ -242,6 +242,7 @@ def main():
     parser = argparse.ArgumentParser()
     parser.add_argument('--zap_file',
                         help='Path to .zap file',
+                        required=True,
                         type=pathlib.Path)
 
     args = parser.parse_args()


### PR DESCRIPTION
#### Problem

zap_cluster_list.py generates a type error when run with no arguments.

#### Change overview

Mark the argument required.

#### Testing

src/app/zap_cluster_list.py