### PR TITLE
[ESP32] Remove stale USE_ECHO_CLIENT and ECHO_HOST_IP kconfig options

### DIFF
--- a/examples/all-clusters-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-app/esp32/main/Kconfig.projbuild
@@ -64,13 +64,6 @@ menu "Demo"
           bool "BLE / On-Network"
     endchoice
 
-    config ECHO_HOST_IP
-        string "IPV4 address"
-        default "127.0.0.1"
-        depends on USE_ECHO_CLIENT
-        help
-            The IPV4 Address of the ECHO Server.
-
     # NOTE: This config is not displayed as a input in the Kconfig menu, as its value is
     # entirely derived from the Device Type choice.  However the CONFIG_EXAMPLE_DISPLAY_TYPE
     # define that is produced is needed to configure the TFT library correctly.

--- a/examples/all-clusters-minimal-app/esp32/main/Kconfig.projbuild
+++ b/examples/all-clusters-minimal-app/esp32/main/Kconfig.projbuild
@@ -64,13 +64,6 @@ menu "Demo"
           bool "BLE / On-Network"
     endchoice
 
-    config ECHO_HOST_IP
-        string "IPV4 address"
-        default "127.0.0.1"
-        depends on USE_ECHO_CLIENT
-        help
-            The IPV4 Address of the ECHO Server.
-
     # NOTE: This config is not displayed as a input in the Kconfig menu, as its value is
     # entirely derived from the Device Type choice.  However the CONFIG_EXAMPLE_DISPLAY_TYPE
     # define that is produced is needed to configure the TFT library correctly.

--- a/examples/chef/esp32/main/Kconfig.projbuild
+++ b/examples/chef/esp32/main/Kconfig.projbuild
@@ -66,13 +66,6 @@ menu "Demo"
           bool "BLE / On-Network"
     endchoice
 
-    config ECHO_HOST_IP
-        string "IPV4 address"
-        default "127.0.0.1"
-        depends on USE_ECHO_CLIENT
-        help
-            The IPV4 Address of the ECHO Server.
-
     # NOTE: This config is not displayed as a input in the Kconfig menu, as its value is
     # entirely derived from the Device Type choice.  However the CONFIG_EXAMPLE_DISPLAY_TYPE
     # define that is produced is needed to configure the TFT library correctly.

--- a/examples/lock-app/esp32/main/Kconfig.projbuild
+++ b/examples/lock-app/esp32/main/Kconfig.projbuild
@@ -36,20 +36,6 @@ menu "Demo"
           bool "Ethernet"
     endchoice
 
-    config USE_ECHO_CLIENT
-        bool "Enable the built-in Echo Client"
-        default "n"
-        help
-            This enables a local FreeRTOS Echo Client so that the end-to-end echo server can be
-            tested easily
-
-    config ECHO_HOST_IP
-        string "IPV4 address"
-        default "127.0.0.1"
-        depends on USE_ECHO_CLIENT
-        help
-            The IPV4 Address of the ECHO Server.
-
     config RENDEZVOUS_MODE
        int
        range 0 8

--- a/examples/temperature-measurement-app/esp32/main/Kconfig.projbuild
+++ b/examples/temperature-measurement-app/esp32/main/Kconfig.projbuild
@@ -36,20 +36,6 @@ menu "Demo"
           bool "Ethernet"
     endchoice
 
-    config USE_ECHO_CLIENT
-        bool "Enable the built-in Echo Client"
-        default "n"
-        help
-            This enables a local FreeRTOS Echo Client so that the end-to-end echo server can be
-            tested easily
-
-    config ECHO_HOST_IP
-        string "IPV4 address"
-        default "127.0.0.1"
-        depends on USE_ECHO_CLIENT
-        help
-            The IPV4 Address of the ECHO Server.
-
     config RENDEZVOUS_MODE
        int
        range 0 8


### PR DESCRIPTION
#### Problem
USE_ECHO_CLIENT and ECHO_HOST_IP config options are stale and not required anymore

#### Change overview
Removed the config options for the same

#### Testing
Not required as removes the unused bits