### PR TITLE
[EFR32] Platform init refactoring

### DIFF
--- a/examples/platform/efr32/init_efrPlatform.cpp
+++ b/examples/platform/efr32/init_efrPlatform.cpp
@@ -57,6 +57,7 @@ extern "C" {
 #include "sl_system_init.h"
 
 void initAntenna(void);
+void wifi_board_init(void);
 
 void init_efrPlatform(void)
 {
@@ -66,6 +67,9 @@ void init_efrPlatform(void)
 #if EFR32_LOG_ENABLED
     efr32InitLog();
 #endif
+
+    /* host init ( SPI and GPIO ) */
+    wifi_board_init();
 
 #if CHIP_ENABLE_OPENTHREAD
     sl_ot_sys_init();


### PR DESCRIPTION
#### Problem
Platform init refactoring.

#### Change overview
We changed the GPIO and Bus init functions, now both these functions are called from
init_efr_platform().

#### Testing
How was this tested? (at least one bullet point required)

- Tested on HW ( MG12 + RS9116 & MG12 + WF200 )
- Commissioning 20 times.
- Sanity TC's
