### PR TITLE
[EFR32] Add Board Support for efr32 boards

### DIFF
--- a/examples/chef/efr32/BUILD.gn
+++ b/examples/chef/efr32/BUILD.gn
@@ -91,8 +91,9 @@ chip_data_model("chef-common") {
   is_server = true
 }
 
-# ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
+# ThunderBoards and Explorer Kit (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B" ||
+    efr32_board == "BRD2703A") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/light-switch-app/efr32/BUILD.gn
+++ b/examples/light-switch-app/efr32/BUILD.gn
@@ -84,8 +84,9 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
+# ThunderBoards and Explorer Kit (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B" ||
+    efr32_board == "BRD2703A") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -84,8 +84,9 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
+# ThunderBoards and Explorer Kit (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B" ||
+    efr32_board == "BRD2703A") {
   show_qr_code = false
   disable_lcd = true
 }
@@ -93,7 +94,7 @@ if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
 # WiFi settings
 if (chip_enable_wifi) {
   # disabling LCD for MG24 for wifi
-  if (efr32_board == "BRD4186A" || efr32_board == "BRD4187A") {
+  if (efr32_board == "BRD4186C" || efr32_board == "BRD4187A") {
     show_qr_code = false
     disable_lcd = true
   }

--- a/examples/lighting-app/efr32/BUILD.gn
+++ b/examples/lighting-app/efr32/BUILD.gn
@@ -94,7 +94,7 @@ if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B" ||
 # WiFi settings
 if (chip_enable_wifi) {
   # disabling LCD for MG24 for wifi
-  if (efr32_board == "BRD4186C" || efr32_board == "BRD4187A") {
+  if (efr32_board == "BRD4186A" || efr32_board == "BRD4187A") {
     show_qr_code = false
     disable_lcd = true
   }

--- a/examples/lock-app/efr32/BUILD.gn
+++ b/examples/lock-app/efr32/BUILD.gn
@@ -84,8 +84,9 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
+# ThunderBoards and Explorer Kit (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B" ||
+    efr32_board == "BRD2703A") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/thermostat/efr32/BUILD.gn
+++ b/examples/thermostat/efr32/BUILD.gn
@@ -81,8 +81,9 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
+# ThunderBoards and Explorer Kit (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B" ||
+    efr32_board == "BRD2703A") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/examples/window-app/efr32/BUILD.gn
+++ b/examples/window-app/efr32/BUILD.gn
@@ -77,8 +77,9 @@ if (chip_enable_wifi) {
   assert(use_rs911x || use_wf200)
 }
 
-# ThunderBoards  (No LCD)
-if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B") {
+# ThunderBoards and Explorer Kit (No LCD)
+if (efr32_board == "BRD4166A" || efr32_board == "BRD2601B" ||
+    efr32_board == "BRD2703A") {
   show_qr_code = false
   disable_lcd = true
 }

--- a/third_party/silabs/efr32_board.gni
+++ b/third_party/silabs/efr32_board.gni
@@ -75,8 +75,11 @@ if (efr32_board == "BRD4304A") {
 } else if (efr32_board == "BRD2601B") {
   efr32_family = "efr32mg24"
   efr32_mcu = "EFR32MG24B310F1536IM48"
+} else if (efr32_board == "BRD2703A") {
+  efr32_family = "efr32mg24"
+  efr32_mcu = "EFR32MG24B020F1536IM48"
 } else {
   print(
-      "Please provide a valid value for EFR32_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186C, BRD4187C, BRD2601B)")
+      "Please provide a valid value for EFR32_BOARD env variable (currently supported BRD4304A, BRD4161A, BRD4163A, BRD4164A BRD4166A, BRD4170A, BRD4186C, BRD4187C, BRD2601B, BRD2703A)")
   assert(false, "The board ${efr32_board} is unsupported")
 }

--- a/third_party/silabs/efr32_board.gni
+++ b/third_party/silabs/efr32_board.gni
@@ -44,6 +44,9 @@ if (efr32_board == "BRD4304A") {
 } else if (efr32_board == "BRD4161A") {
   efr32_family = "efr32mg12"
   efr32_mcu = "EFR32MG12P432F1024GL125"
+} else if (efr32_board == "BRD4162A") {
+  efr32_family = "efr32mg12"
+  efr32_mcu = "EFR32MG12P332F1024GL125"
 } else if (efr32_board == "BRD4163A") {
   efr32_family = "efr32mg12"
   efr32_mcu = "EFR32MG12P433F1024GL125"

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -33,6 +33,11 @@ declare_args() {
   use_external_flash = true
 }
 
+# Explorer Kit does not have external flash
+if (efr32_board == "BRD2703A") {
+  use_external_flash = false
+}
+
 assert(efr32_sdk_root != "", "efr32_sdk_root must be specified")
 
 # Defines an efr32 SDK build target.
@@ -210,13 +215,14 @@ template("efr32_sdk") {
 
       if (defined(invoker.use_external_flash) && use_external_flash) {
         defines += [ "CONFIG_USE_EXTERNAL_FLASH" ]
+
+        _include_dirs += [ "${efr32_sdk_root}/hardware/driver/mx25_flash_shutdown/inc/sl_mx25_flash_shutdown_usart" ]
       }
 
       _include_dirs += [
         "${efr32_sdk_root}/platform/emdrv/uartdrv/inc",
         "${efr32_sdk_root}/platform/emdrv/uartdrv/config",
         "${efr32_sdk_root}/hardware/driver/memlcd/inc/memlcd_usart",
-        "${efr32_sdk_root}/hardware/driver/mx25_flash_shutdown/inc/sl_mx25_flash_shutdown_usart",
       ]
     }
 
@@ -531,13 +537,16 @@ template("efr32_sdk") {
         (defined(invoker.use_external_flash) && use_external_flash)) {
       sources += [
         "${efr32_sdk_root}/hardware/driver/memlcd/src/memlcd_usart/sl_memlcd_spi.c",
-        "${efr32_sdk_root}/hardware/driver/mx25_flash_shutdown/src/sl_mx25_flash_shutdown_usart/sl_mx25_flash_shutdown.c",
         "${efr32_sdk_root}/platform/emdrv/uartdrv/src/uartdrv.c",
         "${efr32_sdk_root}/platform/emlib/src/em_eusart.c",
         "${efr32_sdk_root}/platform/emlib/src/em_leuart.c",
         "${efr32_sdk_root}/platform/emlib/src/em_usart.c",
         "${sdk_support_root}/matter/efr32/${efr32_family}/${efr32_board}/autogen/sl_uartdrv_init.c",
       ]
+
+      if (defined(invoker.use_external_flash) && use_external_flash) {
+        sources += [ "${efr32_sdk_root}/hardware/driver/mx25_flash_shutdown/src/sl_mx25_flash_shutdown_usart/sl_mx25_flash_shutdown.c" ]
+      }
     }
 
     if ((defined(invoker.show_qr_code) && invoker.show_qr_code) ||

--- a/third_party/silabs/efr32_sdk.gni
+++ b/third_party/silabs/efr32_sdk.gni
@@ -226,6 +226,7 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/platform/radio/rail_lib/chip/efr32/efr32xg1x",
         "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM4F",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg1x/config",
+        "${efr32_sdk_root}/platform/service/device_init/config/s1/",
       ]
 
       libs += [
@@ -243,6 +244,7 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg21/config",
+        "${efr32_sdk_root}/platform/service/device_init/config/s2/",
       ]
 
       libs += [
@@ -263,6 +265,7 @@ template("efr32_sdk") {
         "${efr32_sdk_root}/util/third_party/freertos/kernel/portable/GCC/ARM_CM33_NTZ/non_secure",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24",
         "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/efr32xg24/config",
+        "${efr32_sdk_root}/platform/service/device_init/config/s2/",
       ]
 
       libs += [
@@ -365,6 +368,7 @@ template("efr32_sdk") {
       "${efr32_sdk_root}/platform/radio/rail_lib/hal/efr32/hal_efr.c",
       "${efr32_sdk_root}/platform/radio/rail_lib/plugin/pa-conversions/pa_conversions_efr32.c",
       "${efr32_sdk_root}/platform/radio/rail_lib/plugin/rail_util_pti/sl_rail_util_pti.c",
+      "${efr32_sdk_root}/platform/service/device_init/src/sl_device_init_lfrco.c",
       "${efr32_sdk_root}/platform/service/device_init/src/sl_device_init_nvic.c",
       "${efr32_sdk_root}/platform/service/hfxo_manager/src/sl_hfxo_manager.c",
       "${efr32_sdk_root}/platform/service/legacy_hal/src/token_legacy.c",


### PR DESCRIPTION
#### Problem
Some boards were not supported for Matter

#### Change overview
Add board support  for BRD2703A and BRD4162A

**Platform Specific changes** 
Add two more boards support since current Matter SDK is too restrictive for our available chip.
These Boards are more widely available and will enable a greater Matter development for 1.0

#### Testing
Manual tests with BRD2703A and BRD4162A boards 
