### PR TITLE
[EFR32] Window Covering app modified to compile on boards without LCD.

### DIFF
--- a/examples/window-app/efr32/include/WindowAppImpl.h
+++ b/examples/window-app/efr32/include/WindowAppImpl.h
@@ -26,6 +26,9 @@
 #include <string>
 #include <task.h>
 #include <timers.h>
+#ifdef DISPLAY_ENABLED
+#include <LcdPainter.h>
+#endif
 
 class WindowAppImpl : public WindowApp
 {
@@ -81,6 +84,8 @@ private:
 
     // Get QR Code and emulate its content using NFC tag
     char mQRCodeBuffer[chip::QRCodeBasicSetupPayloadGenerator::kMaxQRCodeBase38RepresentationLength + 1];
+#ifdef DISPLAY_ENABLED
     Timer mIconTimer;
     LcdIcon mIcon = LcdIcon::None;
+#endif
 };

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -137,12 +137,11 @@ WindowApp & WindowApp::Instance()
     return WindowAppImpl::sInstance;
 }
 
-WindowAppImpl::WindowAppImpl()
 #ifdef DISPLAY_ENABLED
-    :
-    mIconTimer("Timer:icon", LCD_ICON_TIMEOUT, OnIconTimeout, this)
+WindowAppImpl::WindowAppImpl() : mIconTimer("Timer:icon", LCD_ICON_TIMEOUT, OnIconTimeout, this) {}
+#else
+WindowAppImpl::WindowAppImpl() {}
 #endif
-{}
 
 void WindowAppImpl::OnTaskCallback(void * parameter)
 {

--- a/examples/window-app/efr32/src/WindowAppImpl.cpp
+++ b/examples/window-app/efr32/src/WindowAppImpl.cpp
@@ -16,12 +16,10 @@
  */
 
 #include <AppConfig.h>
-#include <LcdPainter.h>
 #include <WindowAppImpl.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/clusters/window-covering-server/window-covering-server.h>
 #include <app/server/OnboardingCodesUtil.h>
-#include <lcd.h>
 #include <lib/core/CHIPError.h>
 #include <lib/dnssd/Advertiser.h>
 #include <lib/support/CodeUtils.h>
@@ -35,6 +33,11 @@
 
 #ifdef SL_WIFI
 #include "wfx_host_events.h"
+#endif
+
+#ifdef DISPLAY_ENABLED
+#include <LcdPainter.h>
+SilabsLCD slLCD;
 #endif
 
 #define APP_TASK_STACK_SIZE (4096)
@@ -129,16 +132,17 @@ StaticQueue_t sAppEventQueueStruct;
 
 WindowAppImpl WindowAppImpl::sInstance;
 
-#ifdef DISPLAY_ENABLED
-SilabsLCD slLCD;
-#endif
-
 WindowApp & WindowApp::Instance()
 {
     return WindowAppImpl::sInstance;
 }
 
-WindowAppImpl::WindowAppImpl() : mIconTimer("Timer:icon", LCD_ICON_TIMEOUT, OnIconTimeout, this) {}
+WindowAppImpl::WindowAppImpl()
+#ifdef DISPLAY_ENABLED
+    :
+    mIconTimer("Timer:icon", LCD_ICON_TIMEOUT, OnIconTimeout, this)
+#endif
+{}
 
 void WindowAppImpl::OnTaskCallback(void * parameter)
 {
@@ -147,8 +151,10 @@ void WindowAppImpl::OnTaskCallback(void * parameter)
 
 void WindowAppImpl::OnIconTimeout(WindowApp::Timer & timer)
 {
+#ifdef DISPLAY_ENABLED
     sInstance.mIcon = LcdIcon::None;
     sInstance.UpdateLCD();
+#endif
 }
 
 CHIP_ERROR WindowAppImpl::Init()
@@ -331,6 +337,7 @@ void WindowAppImpl::DispatchEvent(const WindowApp::Event & event)
     case EventId::BLEConnectionsChanged:
         UpdateLEDs();
         break;
+#ifdef DISPLAY_ENABLED
     case EventId::CoverTypeChange:
         UpdateLCD();
         break;
@@ -344,6 +351,7 @@ void WindowAppImpl::DispatchEvent(const WindowApp::Event & event)
         mIcon = mTiltMode ? LcdIcon::Tilt : LcdIcon::Lift;
         UpdateLCD();
         break;
+#endif
     default:
         break;
     }
@@ -433,10 +441,12 @@ void WindowAppImpl::UpdateLCD()
         Attributes::CurrentPositionTilt::Get(cover.mEndpoint, tilt);
         chip::DeviceLayer::PlatformMgr().UnlockChipStack();
 
+#ifdef DISPLAY_ENABLED
         if (!tilt.IsNull() && !lift.IsNull())
         {
             LcdPainter::Paint(slLCD, type, lift.Value(), tilt.Value(), mIcon);
         }
+#endif
     }
 #ifdef QR_CODE_ENABLED
     else


### PR DESCRIPTION
#### Problem
The Window Covering app is not compiling for BRD4166a.

#### Change overview
Guards added to remove the LCD-dependent code from the app.

#### Testing
Tested on BRD4164a (WSTK) and BRD4166a (TBS2).