### PR TITLE
[all-clusters-app][esp32] Add LockManager/LockEndpoint and the door lock plugin handlers methods to the example application

### DIFF
--- a/examples/all-clusters-app/esp32/main/CMakeLists.txt
+++ b/examples/all-clusters-app/esp32/main/CMakeLists.txt
@@ -21,6 +21,7 @@ set(PRIV_INCLUDE_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/all-clusters-app"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/include"
                       "${CMAKE_CURRENT_LIST_DIR}/include"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/lock-app/linux/include"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/third_party/nlfaultinjection/repo/include"                      
@@ -30,6 +31,7 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/all-clusters-app/zap-generated"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated/attributes"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/zzz_generated/app-common/app-common/zap-generated"
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/lock-app/linux/src"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/providers"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/route_hook"
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/platform/esp32/ota"
@@ -93,6 +95,10 @@ set(SRC_DIRS_LIST
                       "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/all-clusters-app/all-clusters-common/src"
 )
 
+set(EXCLUDE_SRCS_LIST
+                      "${CMAKE_SOURCE_DIR}/third_party/connectedhomeip/examples/lock-app/linux/src/LockAppCommandDelegate.cpp"
+)
+
 if (CONFIG_ENABLE_PW_RPC)
 # Append additional directories for RPC build
 set(PRIV_INCLUDE_DIRS_LIST  "${PRIV_INCLUDE_DIRS_LIST}"
@@ -128,6 +134,7 @@ endif()
 
 idf_component_register(PRIV_INCLUDE_DIRS ${PRIV_INCLUDE_DIRS_LIST}
                        SRC_DIRS ${SRC_DIRS_LIST}
+                       EXCLUDE_SRCS ${EXCLUDE_SRCS_LIST}
                        PRIV_REQUIRES ${PRIV_REQUIRES_LIST})
 
 set_property(TARGET ${COMPONENT_LIB} PROPERTY CXX_STANDARD 17)

--- a/examples/all-clusters-app/esp32/partitions.csv
+++ b/examples/all-clusters-app/esp32/partitions.csv
@@ -3,6 +3,6 @@
 nvs,      data, nvs,     ,        0x6000,
 otadata,  data, ota,     ,        0x2000,
 phy_init, data, phy,     ,        0x1000,
-ota_0,    app,  ota_0,   ,        1500K,
-ota_1,    app,  ota_1,   ,        1500K,
+ota_0,    app,  ota_0,   ,        1700K,
+ota_1,    app,  ota_1,   ,        1700K,
 ot_storage, data, 0x3a,            , 0x2000,

--- a/examples/lock-app/linux/main.cpp
+++ b/examples/lock-app/linux/main.cpp
@@ -17,6 +17,7 @@
  */
 
 #include "AppMain.h"
+#include <app-common/zap-generated/ids/Clusters.h>
 #include <app/clusters/network-commissioning/network-commissioning.h>
 #include <platform/Linux/NetworkCommissioningDriver.h>
 
@@ -78,4 +79,14 @@ int main(int argc, char * argv[])
     VerifyOrDie(ChipLinuxAppInit(argc, argv) == 0);
     ChipLinuxAppMainLoop();
     return 0;
+}
+
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+                                       uint8_t * value)
+{
+    // TODO: Watch for LockState, DoorState, Mode, etc changes and trigger appropriate action
+    if (attributePath.mClusterId == Clusters::DoorLock::Id)
+    {
+        emberAfDoorLockClusterPrintln("Door Lock attribute changed");
+    }
 }

--- a/examples/lock-app/linux/src/ZCLDoorLockCallbacks.cpp
+++ b/examples/lock-app/linux/src/ZCLDoorLockCallbacks.cpp
@@ -88,16 +88,6 @@ DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t h
     return LockManager::Instance().SetSchedule(endpointId, holidayIndex, status, localStartTime, localEndTime, operatingMode);
 }
 
-void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
-                                       uint8_t * value)
-{
-    // TODO: Watch for LockState, DoorState, Mode, etc changes and trigger appropriate action
-    if (attributePath.mClusterId == DoorLock::Id)
-    {
-        emberAfDoorLockClusterPrintln("Door Lock attribute changed");
-    }
-}
-
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)
 {
     DoorLockServer::Instance().InitServer(endpoint);


### PR DESCRIPTION
#### Problem

PR #18289 has moved the lock implementation out of the all-clusters-app-common build file. As a result the ESP32 version has a different behaviour than the linux version.

fix #19322 but that is only for the esp32 platform. In the long run and if we want to have a common implementation it would be nice to do an implementation that is dedicated to constrained platforms as suggested in https://github.com/project-chip/connectedhomeip/issues/19322#issuecomment-1151559482

#### Change overview
 * Add missing `lock-app` files to be built along the esp32 version of the `all-clusters-app`

#### Testing
It was tested with a esp32 board flashed with this patch and commissioned over `chip-tool` and by looking at the logs after having issued the following command with `chip-tool`:
`./out/debug/standalone/chip-tool operationalcredentials remove-fabric 1 0x12344321 0`
