### PR TITLE
Issue 15578 - assert before refcount overflow

### DIFF
--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -431,6 +431,7 @@ void PacketBuffer::AddRef()
     pbuf_ref(this);
 #else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
     LOCK_BUF_POOL();
+    assert(this->ref < UINT16_MAX);
     ++this->ref;
     UNLOCK_BUF_POOL();
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -46,6 +46,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <utility>
+#include <limits>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <lwip/mem.h>
@@ -431,7 +432,7 @@ void PacketBuffer::AddRef()
     pbuf_ref(this);
 #else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
     LOCK_BUF_POOL();
-    VerifyOrDieWithMsg(this->ref < UINT16_MAX, chipSystemLayer, "packet buffer refcount overflow");
+    VerifyOrDieWithMsg(this->ref < std::numeric_limits<decltype(this->ref)>::max(), chipSystemLayer, "packet buffer refcount overflow");
     ++this->ref;
     UNLOCK_BUF_POOL();
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -42,11 +42,11 @@
 #include <stdint.h>
 
 #include <limits.h>
+#include <limits>
 #include <stddef.h>
 #include <stdlib.h>
 #include <string.h>
 #include <utility>
-#include <limits>
 
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
 #include <lwip/mem.h>
@@ -432,7 +432,8 @@ void PacketBuffer::AddRef()
     pbuf_ref(this);
 #else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
     LOCK_BUF_POOL();
-    VerifyOrDieWithMsg(this->ref < std::numeric_limits<decltype(this->ref)>::max(), chipSystemLayer, "packet buffer refcount overflow");
+    VerifyOrDieWithMsg(this->ref < std::numeric_limits<decltype(this->ref)>::max(), chipSystemLayer,
+                       "packet buffer refcount overflow");
     ++this->ref;
     UNLOCK_BUF_POOL();
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP

--- a/src/system/SystemPacketBuffer.cpp
+++ b/src/system/SystemPacketBuffer.cpp
@@ -431,7 +431,7 @@ void PacketBuffer::AddRef()
     pbuf_ref(this);
 #else  // !CHIP_SYSTEM_CONFIG_USE_LWIP
     LOCK_BUF_POOL();
-    assert(this->ref < UINT16_MAX);
+    VerifyOrDieWithMsg(this->ref < UINT16_MAX, chipSystemLayer, "packet buffer refcount overflow");
     ++this->ref;
     UNLOCK_BUF_POOL();
 #endif // !CHIP_SYSTEM_CONFIG_USE_LWIP


### PR DESCRIPTION
#### Problem
As Issue #15578 points out - there is no protection for overflowing the refcount of PacketBuffer, and when that happens, another AddRef/Free would result in this memory getting deallocated, while there are still UINT16_MAX holders of the pointer, leading to use-after-free.

We could potentially have PacketBufferHandle do a check, and hold some error state, but 1) this doesn't prevent PacketBuffer itself from being broken, and 2) the change may introduce other issues.

Capping the refcount or making the refcount type larger just delay the use-after-free problem.

Seems like there is likely some other severe bug if the refcount gets incremented so much that it's about to overflow, and so making an assert here - to abort safely if this unexpected scenario should occur - is the only solution that makes sense.

#### Change overview
Before incrementing the refcount assert that the value is not already UINT16_MAX.

#### Testing
No testing done - this is a fairly trivial sanity safeguard for an edge case.
