### PR TITLE
[SetUpCodePairer] Only search on network if no credentials are provid…

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -72,22 +72,26 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
     bool isRunning = false;
 
     bool searchOverAll = !payload.rendezvousInformation.HasValue();
-    if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kBLE))
-    {
-        if (CHIP_NO_ERROR == (err = StartDiscoverOverBle(payload)))
-        {
-            isRunning = true;
-        }
-        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
-    }
 
-    if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kSoftAP))
+    if (mConnectionType != SetupCodePairerBehaviour::kCommissionOnNetwork)
     {
-        if (CHIP_NO_ERROR == (err = StartDiscoverOverSoftAP(payload)))
+        if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kBLE))
         {
-            isRunning = true;
+            if (CHIP_NO_ERROR == (err = StartDiscoverOverBle(payload)))
+            {
+                isRunning = true;
+            }
+            VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
         }
-        VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
+
+        if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kSoftAP))
+        {
+            if (CHIP_NO_ERROR == (err = StartDiscoverOverSoftAP(payload)))
+            {
+                isRunning = true;
+            }
+            VerifyOrReturnError(searchOverAll || CHIP_NO_ERROR == err || CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE == err, err);
+        }
     }
 
     // We always want to search on network because any node that has already been commissioned will use on-network regardless of the
@@ -225,7 +229,8 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
         ExpectPASEEstablishment();
 
         CHIP_ERROR err;
-        if (mConnectionType == SetupCodePairerBehaviour::kCommission)
+        if (mConnectionType == SetupCodePairerBehaviour::kCommission ||
+            mConnectionType == SetupCodePairerBehaviour::kCommissionOnNetwork)
         {
             err = mCommissioner->PairDevice(mRemoteId, params);
         }

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -51,6 +51,7 @@ class DeviceCommissioner;
 enum class SetupCodePairerBehaviour : uint8_t
 {
     kCommission,
+    kCommissionOnNetwork,
     kPaseOnly,
 };
 


### PR DESCRIPTION
…ed to chip-tool pairing code commands

#### Problem

In #21664 `chip-tool` is used to add an other commissioner after having opened a commissioning window. In theory this operation should only happens on-network. But the fact that the qr code provided for the initial pairing is used get the setup code pairer to issue a BLE scan. That is not necessary and that is also an issue when testing in a lab with a lot of ble devices.

fix #21664

#### Change overview
 * If no credentials are provided to the setup code pairer issue a on-network only commissioning.

#### Testing
```
./out/debug/standalone/chip-tool pairing code-wifi 0x12344321 SSID PASSWORD MT:-24J042C00KA0648G00
./out/debug/standalone/chip-tool administratorcommissioning open-basic-commissioning-window 180 0x12344321 0 --timedInteractionTimeoutMs 100
./out/debug/standalone/chip-tool pairing code 0x43211234 MT:-24J042C00KA0648G00 --commissioner-name beta
```