### PR TITLE
Include missing Descriptor cluster in Secondary Network Commissioning…

### DIFF
--- a/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
+++ b/src/app/zap-templates/zcl/data-model/chip/matter-devices.xml
@@ -2043,6 +2043,12 @@ limitations under the License.
         <deviceId editable="false">0xF002</deviceId>
         <clusters lockOthers="true">
             <include cluster="Network Commissioning" client="false" server="true" clientLocked="true" serverLocked="true"></include>
+            <include cluster="Descriptor" client="false" server="true" clientLocked="true" serverLocked="true">
+                <requireAttribute>DEVICE_TYPE_LIST</requireAttribute>
+                <requireAttribute>SERVER_LIST</requireAttribute>
+                <requireAttribute>CLIENT_LIST</requireAttribute>
+                <requireAttribute>PARTS_LIST</requireAttribute>
+            </include>            
         </clusters>
     </deviceType>
 </configurator>


### PR DESCRIPTION
… Device Type

#### Problem
What is being fixed?  Examples:
* According spec, we have five base clusters defined for Matter
```
Base Cluster Requirements for Matter
Each device type definition SHALL include these clusters, as a minimum set, based on the conformance defined below. This conformance table SHALL assume the Matter conformance condition is TRUE (in Conformance column).
Descriptor
Binding
FixedLabel
UserLabel
```
Among those 5 Matter base clusters, Descriptor is mandatory and we need to include this cluster for each Device Type defination.

* Fixes #20809

#### Change overview
Include missing Descriptor cluster in Secondary Network Commissioning Device Type

#### Testing
How was this tested? (at least one bullet point required)
* xml update only.
