### PR TITLE
Expose `DeviceCommissioner::ComputePASEVerifier` to Obj-C.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -140,7 +140,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 - (nullable NSData *)computePaseVerifier:(uint32_t)setupPincode
                               iterations:(uint32_t)iterations
                                     salt:(NSData *)salt;
-                                    
+
 /**
  * Shutdown the controller. Calls to shutdown after the first one are NO-OPs.
  */

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -137,9 +137,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
  * @param[in] iterations      The number of iterations to use when generating the verifier
  * @param[in] salt            The 16-byte salt for verifier computation
  */
-- (nullable NSData *)computePaseVerifier:(uint32_t)setupPincode
-                              iterations:(uint32_t)iterations
-                                    salt:(NSData *)salt;
+- (nullable NSData *)computePaseVerifier:(uint32_t)setupPincode iterations:(uint32_t)iterations salt:(NSData *)salt;
 
 /**
  * Shutdown the controller. Calls to shutdown after the first one are NO-OPs.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -131,6 +131,17 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 - (void)setNocChainIssuer:(id<MTRNOCChainIssuer>)nocChainIssuer queue:(dispatch_queue_t)queue;
 
 /**
+ * Compute a PASE verifier and passcode ID for the desired setup pincode.
+ *
+ * @param[in] setupPincode    The desired PIN code to use
+ * @param[in] iterations      The number of iterations to use when generating the verifier
+ * @param[in] salt            The 16-byte salt for verifier computation
+ */
+- (nullable NSData *)computePaseVerifier:(uint32_t)setupPincode
+                              iterations:(uint32_t)iterations
+                                    salt:(NSData *)salt;
+                                    
+/**
  * Shutdown the controller. Calls to shutdown after the first one are NO-OPs.
  */
 - (void)shutdown;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -668,6 +668,38 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
     });
 }
 
+- (nullable NSData *)computePaseVerifier:(uint32_t)setupPincode
+                              iterations:(uint32_t)iterations
+                                    salt:(NSData *)salt {
+  __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
+  if (![self isRunning]) {
+    [self checkForError:errorCode logMsg:kErrorNotRunning error:nil];
+    return nil;
+  }
+
+  __block NSData *result;
+  __block chip::Spake2pVerifier paseVerifier;
+  __block chip::ByteSpan saltByteSpan =
+      chip::ByteSpan(static_cast<const uint8_t *>(salt.bytes), salt.length);
+
+  dispatch_sync(_chipWorkQueue, ^{
+    if ([self isRunning]) {
+      errorCode = self.cppCommissioner->ComputePASEVerifier(iterations, setupPincode, saltByteSpan,
+                                                            paseVerifier);
+      MTR_LOG_ERROR("ComputePaseVerifier: %s", chip::ErrorStr(errorCode));
+
+      uint8_t serializedVerifier[sizeof(paseVerifier.mW0) + sizeof(paseVerifier.mL)];
+      memcpy(serializedVerifier, paseVerifier.mW0, chip::kSpake2p_WS_Length);
+      memcpy(&serializedVerifier[sizeof(paseVerifier.mW0)], paseVerifier.mL,
+             sizeof(paseVerifier.mL));
+
+      result = [NSData dataWithBytes:serializedVerifier length:sizeof(serializedVerifier)];
+    }
+  });
+
+  return result;
+}
+
 - (BOOL)checkForInitError:(BOOL)condition logMsg:(NSString *)logMsg
 {
     if (condition) {

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -668,36 +668,32 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
     });
 }
 
-- (nullable NSData *)computePaseVerifier:(uint32_t)setupPincode
-                              iterations:(uint32_t)iterations
-                                    salt:(NSData *)salt {
-  __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
-  if (![self isRunning]) {
-    [self checkForError:errorCode logMsg:kErrorNotRunning error:nil];
-    return nil;
-  }
-
-  __block NSData *result;
-  __block chip::Spake2pVerifier paseVerifier;
-  __block chip::ByteSpan saltByteSpan =
-      chip::ByteSpan(static_cast<const uint8_t *>(salt.bytes), salt.length);
-
-  dispatch_sync(_chipWorkQueue, ^{
-    if ([self isRunning]) {
-      errorCode = self.cppCommissioner->ComputePASEVerifier(iterations, setupPincode, saltByteSpan,
-                                                            paseVerifier);
-      MTR_LOG_ERROR("ComputePaseVerifier: %s", chip::ErrorStr(errorCode));
-
-      uint8_t serializedVerifier[sizeof(paseVerifier.mW0) + sizeof(paseVerifier.mL)];
-      memcpy(serializedVerifier, paseVerifier.mW0, chip::kSpake2p_WS_Length);
-      memcpy(&serializedVerifier[sizeof(paseVerifier.mW0)], paseVerifier.mL,
-             sizeof(paseVerifier.mL));
-
-      result = [NSData dataWithBytes:serializedVerifier length:sizeof(serializedVerifier)];
+- (nullable NSData *)computePaseVerifier:(uint32_t)setupPincode iterations:(uint32_t)iterations salt:(NSData *)salt
+{
+    __block CHIP_ERROR errorCode = CHIP_ERROR_INCORRECT_STATE;
+    if (![self isRunning]) {
+        [self checkForError:errorCode logMsg:kErrorNotRunning error:nil];
+        return nil;
     }
-  });
 
-  return result;
+    __block NSData * result;
+    __block chip::Spake2pVerifier paseVerifier;
+    __block chip::ByteSpan saltByteSpan = chip::ByteSpan(static_cast<const uint8_t *>(salt.bytes), salt.length);
+
+    dispatch_sync(_chipWorkQueue, ^{
+        if ([self isRunning]) {
+            errorCode = self.cppCommissioner->ComputePASEVerifier(iterations, setupPincode, saltByteSpan, paseVerifier);
+            MTR_LOG_ERROR("ComputePaseVerifier: %s", chip::ErrorStr(errorCode));
+
+            uint8_t serializedVerifier[sizeof(paseVerifier.mW0) + sizeof(paseVerifier.mL)];
+            memcpy(serializedVerifier, paseVerifier.mW0, chip::kSpake2p_WS_Length);
+            memcpy(&serializedVerifier[sizeof(paseVerifier.mW0)], paseVerifier.mL, sizeof(paseVerifier.mL));
+
+            result = [NSData dataWithBytes:serializedVerifier length:sizeof(serializedVerifier)];
+        }
+    });
+
+    return result;
 }
 
 - (BOOL)checkForInitError:(BOOL)condition logMsg:(NSString *)logMsg


### PR DESCRIPTION
#### Problem
* Expose `DeviceCommissioner::ComputePASEVerifier` to Obj-C.

#### Change overview
Added function`computePaseVerifier:iterations:salt:` to `MTRDeviceController` to expose `DeviceCommissioner ::ComputePASEVerifier` to Obj-C.