### PR TITLE
Expose `Credentials::ConvertX509CertToChipCert` to Obj-C.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRCertificates.h
+++ b/src/darwin/Framework/CHIP/MTRCertificates.h
@@ -125,6 +125,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSData *)generateCertificateSigningRequest:(id<MTRKeypair>)keypair
                                                  error:(NSError * __autoreleasing _Nullable * _Nullable)error;
 
+/** Converts the given X.509v3 certificate to the CHIP certificate format. */
++ (nullable NSData *)convertToCHIPCertFromX509Cert:(NSData *)x509Certificate;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -16,6 +16,7 @@
 
 #import "MTRCertificates.h"
 #import "MTRError_Internal.h"
+#import "MTRLogging.h"
 #import "MTRMemory.h"
 #import "MTROperationalCredentialsDelegate.h"
 #import "MTRP256KeypairBridge.h"
@@ -194,6 +195,21 @@ using namespace chip::Credentials;
         *error = [MTRError errorForCHIPErrorCode:err];
     }
     return nil;
+}
+
++ (nullable NSData *)convertToCHIPCertFromX509Cert:(NSData *)x509Certificate {
+
+  chip::ByteSpan x509CertBytes = chip::ByteSpan((uint8_t *) x509Certificate.bytes, x509Certificate.length);
+
+  NSMutableData * chipCertBuffer = [[NSMutableData alloc] initWithLength:chip::Credentials::kMaxCHIPCertLength];
+  chip::MutableByteSpan chipCertBytes((uint8_t *) chipCertBuffer.mutableBytes, chip::Credentials::kMaxCHIPCertLength);
+
+  CHIP_ERROR errorCode = chip::Credentials::ConvertX509CertToChipCert(x509CertBytes, chipCertBytes);
+  MTR_LOG_ERROR("ConvertX509CertToChipCert: %{public}s", chip::ErrorStr(errorCode));
+
+  if (errorCode != CHIP_NO_ERROR) return nil;
+
+  return [NSData dataWithBytes:chipCertBytes.data() length:chipCertBytes.size()];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -197,19 +197,21 @@ using namespace chip::Credentials;
     return nil;
 }
 
-+ (nullable NSData *)convertToCHIPCertFromX509Cert:(NSData *)x509Certificate {
++ (nullable NSData *)convertToCHIPCertFromX509Cert:(NSData *)x509Certificate
+{
 
-  chip::ByteSpan x509CertBytes = chip::ByteSpan((uint8_t *) x509Certificate.bytes, x509Certificate.length);
+    chip::ByteSpan x509CertBytes = chip::ByteSpan((uint8_t *) x509Certificate.bytes, x509Certificate.length);
 
-  NSMutableData * chipCertBuffer = [[NSMutableData alloc] initWithLength:chip::Credentials::kMaxCHIPCertLength];
-  chip::MutableByteSpan chipCertBytes((uint8_t *) chipCertBuffer.mutableBytes, chip::Credentials::kMaxCHIPCertLength);
+    NSMutableData * chipCertBuffer = [[NSMutableData alloc] initWithLength:chip::Credentials::kMaxCHIPCertLength];
+    chip::MutableByteSpan chipCertBytes((uint8_t *) chipCertBuffer.mutableBytes, chip::Credentials::kMaxCHIPCertLength);
 
-  CHIP_ERROR errorCode = chip::Credentials::ConvertX509CertToChipCert(x509CertBytes, chipCertBytes);
-  MTR_LOG_ERROR("ConvertX509CertToChipCert: %{public}s", chip::ErrorStr(errorCode));
+    CHIP_ERROR errorCode = chip::Credentials::ConvertX509CertToChipCert(x509CertBytes, chipCertBytes);
+    MTR_LOG_ERROR("ConvertX509CertToChipCert: %{public}s", chip::ErrorStr(errorCode));
 
-  if (errorCode != CHIP_NO_ERROR) return nil;
+    if (errorCode != CHIP_NO_ERROR)
+        return nil;
 
-  return [NSData dataWithBytes:chipCertBytes.data() length:chipCertBytes.size()];
+    return [NSData dataWithBytes:chipCertBytes.data() length:chipCertBytes.size()];
 }
 
 @end


### PR DESCRIPTION
#### Problem
* Expose `Credentials::ConvertX509CertToChipCert` to Obj-C.

#### Change overview
Added function `convertToCHIPCertFromX509Cert` to `MTRCertificates` to expose `Credentials::ConvertX509CertToChipCert` to Obj-C.
