### PR TITLE
Fix default initialization of CAT values in Matter Testing Support

### DIFF
--- a/src/python_testing/matter_testing_support.py
+++ b/src/python_testing/matter_testing_support.py
@@ -147,7 +147,7 @@ class MatterTestConfig:
     # Node ID to use for controller/commissioner
     controller_node_id: int = _DEFAULT_CONTROLLER_NODE_ID
     # CAT Tags for default controller/commissioner
-    controller_cat_tags: List[int] = None
+    controller_cat_tags: List[int] = field(default_factory=list)
 
     # Fabric ID which to use
     fabric_id: int = None


### PR DESCRIPTION
Addresses #22114 

This fixes the default initialization of the `controller_cat_tags` field in `MatterTestingSupport` class to correctly be initialized to an empty list, since that is what is expected by `FabricAdmin.NewController` (and
others).

### Testing:
Repro'ed the failure described in #22114, and then confirmed this fixes
it.