### PR TITLE
[nrfconnect] Factory data generation enhancements

### DIFF
--- a/config/nrfconnect/chip-module/generate_factory_data.cmake
+++ b/config/nrfconnect/chip-module/generate_factory_data.cmake
@@ -25,7 +25,6 @@
 # - To use default certification paths set CONFIG_CHIP_FACTORY_DATA_USE_DEFAULTS_CERTS_PATH=y 
 # 
 # During generation process a some file will be created in zephyr's build directory:
-# - <factory_data_target>.args a file containing arguments for nrfconnect_generate_partition.py script.
 # - <factory_data_target>.json a file containing all factory data written in JSON format.
 #
 # [Args]:
@@ -80,6 +79,7 @@ string(APPEND script_args "--spake2_it \"${CONFIG_CHIP_DEVICE_SPAKE2_IT}\"\n")
 string(APPEND script_args "--spake2_salt \"${CONFIG_CHIP_DEVICE_SPAKE2_SALT}\"\n")
 string(APPEND script_args "--discriminator ${CONFIG_CHIP_DEVICE_DISCRIMINATOR}\n")
 string(APPEND script_args "--passcode ${CONFIG_CHIP_DEVICE_SPAKE2_PASSCODE}\n")
+string(APPEND script_args "--overwrite\n")
 
 # check if spake2 verifier should be generated using script
 if(CONFIG_CHIP_FACTORY_DATA_GENERATE_SPAKE2_VERIFIER)
@@ -98,14 +98,20 @@ string(APPEND script_args "--enable_key \"${CONFIG_CHIP_DEVICE_ENABLE_KEY}\"\n")
 endif()
 
 # Set output JSON file and path to SCHEMA file to validate generated factory data
-string(APPEND script_args "-o \"${output_path}/${factory_data_target}.json\"\n")
+set(factory_data_json ${output_path}/${factory_data_target}.json)
+string(APPEND script_args "-o \"${factory_data_json}\"\n")
 string(APPEND script_args "-s \"${schema_path}\"\n")
 
 # execute first script to create a JSON file
 separate_arguments(separated_script_args NATIVE_COMMAND ${script_args})
-add_custom_target(${factory_data_target} ALL
+add_custom_command(
+    OUTPUT ${factory_data_json}
+    DEPENDS ${FACTORY_DATA_SCRIPT_PATH}
     COMMAND ${Python3_EXECUTABLE} ${FACTORY_DATA_SCRIPT_PATH} ${separated_script_args}
     COMMENT "Generating new Factory Data..."
+    )
+add_custom_target(${factory_data_target} ALL
+    DEPENDS ${factory_data_json}
     )
 
 endfunction()
@@ -117,17 +123,16 @@ endfunction()
 #
 # 
 # During generation process some files will be created in zephyr's build directory:
-# - <factory_data_target>_cbor.args a file containing arguments for nrfconnect_generate_partition.py script.
 # - <factory_data_target>.hex a file containing all factory data in CBOR format.
 # - <factory_data_target>.bin a binary file containing all raw factory data in CBOR format.
 # - <factory_data_target>.cbor a file containing all factory data in CBOR format.
 #
 # [Args]:
-#   factory_data_target - a name for target to generate factory_data.
-#   script_path         - a path to script that makes a factory data .hex file from given arguments.
-#   output_path         - a path to output directory, where created JSON file will be stored.
-#   output_hex          - an output variable to store a .hex file. This variable can be used to merge with firmware .hex file.
-function(nrfconnect_create_factory_data_hex_file factory_data_target script_path output_path output_hex)
+#   factory_data_hex_target - a name for target to generate factory data HEX file.
+#   factory_data_target     - a name for target to generate factory data JSON file.
+#   script_path             - a path to script that makes a factory data .hex file from given arguments.
+#   output_path             - a path to output directory, where created JSON file will be stored.
+function(nrfconnect_create_factory_data_hex_file factory_data_hex_target factory_data_target script_path output_path)
 
 # Pass the argument list via file
 set(cbor_script_args "-i ${output_path}/${factory_data_target}.json\n")
@@ -141,12 +146,13 @@ string(APPEND cbor_script_args "-r\n")
 separate_arguments(separated_cbor_script_args NATIVE_COMMAND ${cbor_script_args})
 set(factory_data_hex ${output_path}/${factory_data_target}.hex)
 
-# return output hex to parent scope
-set(${output_hex} ${factory_data_hex} PARENT_SCOPE)
 add_custom_command(OUTPUT ${factory_data_hex}
     COMMAND ${Python3_EXECUTABLE} ${script_path} ${separated_cbor_script_args}
     COMMENT "Generating factory data HEX file..."
-    DEPENDS ${factory_data_target}
+    DEPENDS ${factory_data_target} ${script_path}
+    )
+add_custom_target(${factory_data_hex_target}
+    DEPENDS ${factory_data_hex}
     )
 
 endfunction()
@@ -170,7 +176,6 @@ endif()
 # Localize all scripts needed to generate factory data partition
 set(FACTORY_DATA_SCRIPT_PATH ${CHIP_ROOT}/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py)
 set(GENERATE_CBOR_SCRIPT_PATH ${CHIP_ROOT}/scripts/tools/nrfconnect/nrfconnect_generate_partition.py)
-SET(MERGE_HEX_SCRIPT_PATH ${CHIP_ROOT}/config/nrfconnect/chip-module/merge_factory_data.py)
 set(FACTORY_DATA_SCHEMA_PATH ${CHIP_ROOT}/scripts/tools/nrfconnect/nrfconnect_factory_data.schema)
 set(OUTPUT_FILE_PATH ${APPLICATION_BINARY_DIR}/zephyr)
 
@@ -181,24 +186,15 @@ nrfconnect_create_factory_data_json(factory_data
                                     ${OUTPUT_FILE_PATH})
 
 # create a .hex file with factory data in CBOR format based on the JSON file created previously 
-nrfconnect_create_factory_data_hex_file(factory_data
+nrfconnect_create_factory_data_hex_file(factory_data_hex
+                                        factory_data
                                         ${GENERATE_CBOR_SCRIPT_PATH} 
-                                        ${OUTPUT_FILE_PATH} 
-                                        factory_data_hex)
+                                        ${OUTPUT_FILE_PATH})
 
 if(CONFIG_CHIP_FACTORY_DATA_MERGE_WITH_FIRMWARE)                                   
     # set custom target for merging factory_data hex file
-    add_custom_target(factory_data_merge
-        DEPENDS ${factory_data_hex}
-        )
-    set_property(GLOBAL PROPERTY 
-    factory_data_PM_HEX_FILE 
-        ${factory_data_hex}
-        )
-    set_property(GLOBAL PROPERTY
-        ${parent_slot}_PM_TARGET
-        ${target_name}_merge
-        )
+    set_property(GLOBAL PROPERTY factory_data_PM_HEX_FILE ${OUTPUT_FILE_PATH}/factory_data.hex)
+    set_property(GLOBAL PROPERTY factory_data_PM_TARGET factory_data_hex)
 endif()
 
 

--- a/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
+++ b/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
@@ -70,6 +70,7 @@ def gen_test_certs(chip_cert_exe: str,
                    product_id: int,
                    device_name: str,
                    generate_cd: bool = False,
+                   cd_type: int = 1,
                    paa_cert_path: str = None,
                    paa_key_path: str = None):
     """
@@ -109,15 +110,15 @@ def gen_test_certs(chip_cert_exe: str,
                "--key", CD_KEY_PATH,
                "--cert", CD_PATH,
                "--out", output + "/CD.der",
-               "--format-version",  str(1),
+               "--format-version",  "1",
                "--vendor-id",  hex(vendor_id),
                "--product-id",  hex(product_id),
-               "--device-type-id", "0xA",
-               "--certificate-id", "ZIG20142ZB330003-24",
-               "--security-level",  str(0),
-               "--security-info",  str(0),
-               "--certification-type",  str(0),
-               "--version-number", "0x2694",
+               "--device-type-id", "0",
+               "--certificate-id", "FFFFFFFFFFFFFFFFFFF",
+               "--security-level",  "0",
+               "--security-info",  "0",
+               "--certification-type",  str(cd_type),
+               "--version-number", "0xFFFF",
                ]
         subprocess.run(cmd)
 
@@ -270,6 +271,7 @@ class FactoryDataGenerator:
                                    self._args.product_id,
                                    self._args.vendor_name + "_" + self._args.product_name,
                                    self._args.gen_cd,
+                                   self._args.cd_type,
                                    self._args.paa_cert,
                                    self._args.paa_key)
             dac_cert = certs.dac_cert
@@ -464,6 +466,8 @@ def main():
                                     help="[string] Provide additional user-specific keys in JSON format: {'name_1': 'value_1', 'name_2': 'value_2', ... 'name_n', 'value_n'}.")
     optional_arguments.add_argument("--gen_cd", action="store_true", default=False,
                                     help="Generate a new Certificate Declaration in .der format according to used Vendor ID and Product ID. This certificate will not be included to the factory data.")
+    optional_arguments.add_argument("--cd_type", type=int, default=1,
+                                    help="[int] Type of generated Certification Declaration: 0 - development, 1 - provisional, 2 - official")
     optional_arguments.add_argument("--paa_cert", type=str,
                                     help="Provide a path to the Product Attestation Authority (PAA) certificate to generate the PAI certificate. Without providing it, a testing PAA stored in the Matter repository will be used.")
     optional_arguments.add_argument("--paa_key", type=str,


### PR DESCRIPTION
**Merge justification: This is a change to an optional and platform-specific feature**

#### Problem
Factory data generation mechanism does not allow to rebuild the factory data when anything changes.
Generated Certification Declaration uses a dummy/random certification ID, which may be confusing to a user.

#### Change overview
Fix CMake file to check for dependencies of the generation script and allow to overwrite the factory data when something changes.
By default, generate provisional CD with certification ID and version set to all `F`-s.

#### Testing
Ran it manually to verified a proper behavior.
