### PR TITLE
Restrict esp32 build dependencies to x64 linux. Mac seems to fail on …

### DIFF
--- a/scripts/requirements.esp32.txt
+++ b/scripts/requirements.esp32.txt
@@ -1,12 +1,12 @@
-click>=7.0
-future>=0.15.2
-pyparsing>=2.0.3,<2.4.0
-idf-component-manager>=0.2.99-beta
-gdbgui==0.13.2.0
-pygdbmi<=0.9.0.2
-reedsolo>=1.5.3,<=1.5.4
-bitstring>=3.1.6
-ecdsa>=0.16.0
-kconfiglib==13.7.1
-construct==2.10.54
-python-socketio<5
+click>=7.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+future>=0.15.2 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+pyparsing>=2.0.3,<2.4.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+idf-component-manager>=0.2.99-beta ; platform_machine != 'aarch64' and sys_platform == 'linux'
+gdbgui==0.13.2.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+pygdbmi<=0.9.0.2 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+reedsolo>=1.5.3,<=1.5.4 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+bitstring>=3.1.6 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+ecdsa>=0.16.0 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+kconfiglib==13.7.1 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+construct==2.10.54 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+python-socketio<5 ; platform_machine != 'aarch64' and sys_platform == 'linux'


### PR DESCRIPTION
…gevent which is brought by gdbgui

#### Problem
This cherrypicks #22071 to SVE branch
