### PR TITLE
[ota-requestor] Reset to Idle on failed NotifyUpdateApplied

### DIFF
--- a/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
+++ b/src/app/clusters/ota-requestor/DefaultOTARequestor.cpp
@@ -492,12 +492,9 @@ void DefaultOTARequestor::OnConnectionFailure(void * context, const ScopedNodeId
     switch (requestorCore->mOnConnectedAction)
     {
     case kQueryImage:
-        requestorCore->RecordErrorUpdateState(error);
-        break;
     case kDownload:
-        requestorCore->RecordErrorUpdateState(error);
-        break;
     case kApplyUpdate:
+    case kNotifyUpdateApplied:
         requestorCore->RecordErrorUpdateState(error);
         break;
     default:


### PR DESCRIPTION
#### Problem
When OTA requestor tries to send `NotifyUpdateApplied` command and fails to establish the connection with the OTA provider, it stays in Applying state instead of switching back to Idle. As a result, it no longer queries for a new software update.

#### Change overview
Reset to Idle state on connection failure when trying to send `NotifyUpdateApplied` command.
Fixes #22129.

#### Testing
Moved OTA requestor initialization before Thread stack initialization and tested that when the connection to the OTA provider fails, the requestor switches back to Idle and kicks off the periodic query timer.
