### PR TITLE
Fix chef lock state not changed when lock / unlock

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -13,13 +13,15 @@ bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const c
                                             chip::app::Clusters::DoorLock::DlOperationError & err)
 {
     err = DlOperationError::kUnspecified;
-    return true;
+    // TBD: LockManager, check pinCode, ...
+    return DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kLocked);;
 }
 
 bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const chip::Optional<chip::ByteSpan> & pinCode,
                                               chip::app::Clusters::DoorLock::DlOperationError & err)
 {
     err = DlOperationError::kUnspecified;
-    return true;
+    // TBD: LockManager, check pinCode, ...
+    return DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kUnlocked);;
 }
 #endif /* EMBER_AF_PLUGIN_DOOR_LOCK_SERVER */


### PR DESCRIPTION
* Description
The current chef lock callback emberAfPluginDoorLockOnDoorLockCommand
actually does nothing but just return true. So when lock/unlock is
called, the state is not stored.

* Fix
Call DoorLockServer::SetLockState to save the lock state

#### Problem
What is being fixed?  Examples:
* Fix crash on startup
* Fixes #12345 Frobnozzle is leaky (exactly like that, so GitHub will auto-close the issue).

#### Change overview
What's in this PR

#### Testing
How was this tested? (at least one bullet point required)
* If unit tests were added, how do they cover this issue?
* If unit tests existed, how were they fixed/modified to prevent this in future?
* If new unit tests are not added, why not?
* If integration tests were added, how do they verify this change?
* If new integration tests are not added, why not?
* If manually tested, what platforms controller and device platforms were manually tested, and how?
* If no testing is required, why not?
