### PR TITLE
Fix chef lock state not changed when lock / unlock

### DIFF
--- a/examples/chef/common/stubs.cpp
+++ b/examples/chef/common/stubs.cpp
@@ -13,13 +13,15 @@ bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const c
                                             chip::app::Clusters::DoorLock::DlOperationError & err)
 {
     err = DlOperationError::kUnspecified;
-    return true;
+    // TBD: LockManager, check pinCode, ...
+    return DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kLocked);
 }
 
 bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const chip::Optional<chip::ByteSpan> & pinCode,
                                               chip::app::Clusters::DoorLock::DlOperationError & err)
 {
     err = DlOperationError::kUnspecified;
-    return true;
+    // TBD: LockManager, check pinCode, ...
+    return DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kUnlocked);
 }
 #endif /* EMBER_AF_PLUGIN_DOOR_LOCK_SERVER */


### PR DESCRIPTION

#### Problem
The current chef lock callback `emberAfPluginDoorLockOnDoorLockCommand`
actually does nothing but just return true. So when lock/unlock is
called, the state is not stored.


#### Change overview
Call DoorLockServer::SetLockState in `emberAfPluginDoorLockOnDoorLockCommand` 
and `emberAfPluginDoorLockOnDoorUnlockCommandto` save the lock state

#### Testing
* Verified with chip-tool with Linux device and ESP32 (m5stack)
