### PR TITLE
Use the latest docker image for for CI and cloud builds

### DIFF
--- a/.github/workflows/examples-esp32.yaml
+++ b/.github/workflows/examples-esp32.yaml
@@ -31,7 +31,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.5.91
+            image: connectedhomeip/chip-build-esp32:0.5.96
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 
@@ -117,7 +117,7 @@ jobs:
         if: github.actor != 'restyled-io[bot]'
 
         container:
-            image: connectedhomeip/chip-build-esp32:0.5.91
+            image: connectedhomeip/chip-build-esp32:0.5.96
             volumes:
                 - "/tmp/bloat_reports:/tmp/bloat_reports"
 

--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -6,7 +6,7 @@ steps:
           - "--init"
           - "--recursive"
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -21,7 +21,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -1,5 +1,5 @@
 steps:
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -12,7 +12,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -26,7 +26,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -6,7 +6,7 @@ steps:
           - "--init"
           - "--recursive"
       id: Submodules
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
@@ -21,7 +21,7 @@ steps:
             path: /pwenv
       timeout: 900s
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -37,7 +37,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       id: NRFConnect
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -54,7 +54,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       id: EFR32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -71,7 +71,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       id: Linux
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
@@ -88,7 +88,7 @@ steps:
           - name: pwenv
             path: /pwenv
 
-    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+    - name: "connectedhomeip/chip-build-vscode:0.5.96"
       id: Android
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
After the merge of #21815, ToT supports ESP-IDF v4.4.2.
Also, the chip-build-esp32 docker image is uploaded to the dockerhub.

#### Problem
* ESP32 examples build CI is using docker container with ESP-IDF v4.4.1
* Update the image in cloudbuilds to 0.5.96

#### Change overview
Start using the latest docker container with ESP-IDF v4.4.2

#### Testing
CI should be green