### PR TITLE
[Telink]: Update to Zephyr with Telink OTA adaptation

### DIFF
--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -17,11 +17,12 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=8cf9cc52e4de98d0303d8fed6a57ae956954986d
+ARG ZEPHYR_REVISION=295b4e6dedc4f40701962e0ed0be1090be5c0eee
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \
     west==0.12.0 \
+    imgtool==1.7.0 \
     && git clone https://github.com/telink-semi/zephyr \
     && cd zephyr \
     && git reset ${ZEPHYR_REVISION} --hard \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.97 Version bump reason: [TI] Update SysConfig to 1.13.0
+0.5.98 Version bump reason: Update Telink Docker


### PR DESCRIPTION
**Problem**

Need Zephyr with Telink OTA adaptation.

**Change overview**

Updated to Telink Zephyr version with OTA adaptation.

**Testing**

Tested manually.
Steps:

- Build image
- Run docker
- Check if Telink examples able to be built successfully