### PR TITLE
Fix EFR32 build in cloud build

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -25,6 +25,19 @@ steps:
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
+          - "-c"
+          - ./scripts/checkout_submodules.py --shallow --recursive --platform efr32
+      id: Checkout EFR32
+      entrypoint: /usr/bin/bash
+      volumes:
+          - name: pwenv
+            path: /pwenv
+      timeout: 900s
+
+    - name: "connectedhomeip/chip-build-vscode:0.5.91"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
               --target-glob '*' --skip-target-glob

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -22,6 +22,19 @@ steps:
       timeout: 900s
 
     - name: "connectedhomeip/chip-build-vscode:0.5.91"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - "-c"
+          - ./scripts/checkout_submodules.py --shallow --recursive --platform efr32
+      id: Checkout EFR32
+      entrypoint: /usr/bin/bash
+      volumes:
+          - name: pwenv
+            path: /pwenv
+      timeout: 900s
+
+    - name: "connectedhomeip/chip-build-vscode:0.5.91"
       id: ESP32
       env:
           - PW_ENVIRONMENT_ROOT=/pwenv


### PR DESCRIPTION
#### Problem

This needs an additional checkout step now, unlike other platforms. The
reason is that this build requires recursive submodules.

#### Change overview

Checkout EFR32 recursively.

#### Testing

Cloud Build.
