### PR TITLE
Fix efr32-brd4161a-lock-rpc build

### DIFF
--- a/examples/platform/efr32/BaseApplication.cpp
+++ b/examples/platform/efr32/BaseApplication.cpp
@@ -391,7 +391,7 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
             CancelFunctionTimer();
             mFunction = kFunction_NoneSelected;
 
-#ifdef DISPLAY_ENABLED
+#ifdef QR_CODE_ENABLED
             // TOGGLE QRCode/LCD demo UI
             slLCD.ToggleQRCode();
 #endif

--- a/examples/platform/efr32/display/lcd.cpp
+++ b/examples/platform/efr32/display/lcd.cpp
@@ -122,10 +122,12 @@ int SilabsLCD::Update(void)
 
 void SilabsLCD::WriteDemoUI(bool state)
 {
+#ifdef QR_CODE_ENABLED
     if (mShowQRCode)
     {
         mShowQRCode = false;
     }
+#endif
     dState.mainState = state;
     WriteDemoUI();
 }


### PR DESCRIPTION
#### Problem

Building  efr32-brd4161a-lock-rpc  fails as of b94c8edc7 ("[EFR32] Upgrade LCD (#22016)")

```
2022-08-25 13:26:54 INFO    ../../examples/lock-app/efr32/third_party/connectedhomeip/examples/platform/efr32/display/lcd.cpp: In member function 'void SilabsLCD::WriteDemoUI(bool)':
2022-08-25 13:26:54 INFO    ../../examples/lock-app/efr32/third_party/connectedhomeip/examples/platform/efr32/display/lcd.cpp:125:9: error: 'mShowQRCode' was not declared in this scope
2022-08-25 13:26:54 INFO      125 |     if (mShowQRCode)
2022-08-25 13:26:54 INFO          |         ^~~~~~~~~~~

2022-08-25 13:27:57 INFO    ../../examples/lock-app/efr32/third_party/connectedhomeip/examples/platform/efr32/BaseApplication.cpp: In static member function 'static void BaseApplication::ButtonHandler(AppEvent*)':
2022-08-25 13:27:57 INFO    ../../examples/lock-app/efr32/third_party/connectedhomeip/examples/platform/efr32/BaseApplication.cpp:396:19: error: 'class SilabsLCD' has no member named 'ToggleQRCode'
2022-08-25 13:27:57 INFO      396 |             slLCD.ToggleQRCode();
2022-08-25 13:27:57 INFO          |                   ^~~~~~~~~~~~
```

#### Change overview

Fix the conditional compilation in the EFR32 sources to match
their headers. 

#### Testing

```
./scripts/build/build_examples.py --enable-flashbundle --target efr32-brd4161a-lock-rpc build 
```