### PR TITLE
[Infineon PSoC6] Fix for Door lock and Software Diagnostics Cluster

### DIFF
--- a/examples/lock-app/p6/include/LockManager.h
+++ b/examples/lock-app/p6/include/LockManager.h
@@ -30,6 +30,24 @@
 
 #include <lib/core/CHIPError.h>
 
+struct WeekDaysScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockWeekDaySchedule schedule;
+};
+
+struct YearDayScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockYearDaySchedule schedule;
+};
+
+struct HolidayScheduleInfo
+{
+    DlScheduleStatus status;
+    EmberAfPluginDoorLockHolidaySchedule schedule;
+};
+
 namespace P6DoorLock {
 namespace ResourceRanges {
 // Used to size arrays
@@ -187,9 +205,9 @@ private:
 
     EmberAfPluginDoorLockUserInfo mLockUsers[kMaxUsers];
     EmberAfPluginDoorLockCredentialInfo mLockCredentials[kMaxCredentials];
-    EmberAfPluginDoorLockWeekDaySchedule mWeekdaySchedule[kMaxUsers][kMaxWeekdaySchedulesPerUser];
-    EmberAfPluginDoorLockYearDaySchedule mYeardaySchedule[kMaxUsers][kMaxYeardaySchedulesPerUser];
-    EmberAfPluginDoorLockHolidaySchedule mHolidaySchedule[kMaxHolidaySchedules];
+    WeekDaysScheduleInfo mWeekdaySchedule[kMaxUsers][kMaxWeekdaySchedulesPerUser];
+    YearDayScheduleInfo mYeardaySchedule[kMaxUsers][kMaxYeardaySchedulesPerUser];
+    HolidayScheduleInfo mHolidaySchedule[kMaxHolidaySchedules];
 
     char mUserNames[ArraySize(mLockUsers)][DOOR_LOCK_MAX_USER_NAME_SIZE];
     uint8_t mCredentialData[kMaxCredentials][kMaxCredentialSize];

--- a/src/platform/P6/DiagnosticDataProviderImpl.h
+++ b/src/platform/P6/DiagnosticDataProviderImpl.h
@@ -55,7 +55,7 @@ namespace chip {
 namespace DeviceLayer {
 
 /**
- * Concrete implementation of the PlatformManager singleton object for Linux platforms.
+ * Concrete implementation of the PlatformManager singleton object for Infineon PSoC6 platforms.
  */
 class DiagnosticDataProviderImpl : public DiagnosticDataProvider
 {
@@ -94,6 +94,8 @@ public:
     void ReadCounters(WiFiStatsCountType Counttype, uint64_t & count, wl_cnt_ver_30_t * cnt, wl_cnt_ge40mcst_v1_t * cnt_ge40);
     /* Function to update ipv4 and ipv6 off premise service capability bit */
     void UpdateoffPremiseService(bool ipv4service, bool ipv6service);
+    CHIP_ERROR GetThreadMetrics(ThreadMetrics ** threadMetricsOut) override;
+    void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
     /* These variables will be set to 0 during start up and will be updated when reset-counts
      * zcl command is received.
      * These are considered as base for below attributes of WiFi Diagnostics Cluster:

--- a/third_party/p6/p6_sdk/configs/lwipopts.h
+++ b/third_party/p6/p6_sdk/configs/lwipopts.h
@@ -195,7 +195,7 @@
 /**
  * PBUF_POOL_SIZE: the number of buffers in the pbuf pool.
  */
-#define PBUF_POOL_SIZE 24
+#define PBUF_POOL_SIZE 48
 
 /**
  * MEMP_NUM_NETBUF: the number of struct netbufs.


### PR DESCRIPTION
#### Problem
Fix for DRLK2.2 , DRLK-2.3 and DRLK-2.5
Fix for ThreadMetrics read in Software Diagnostics Cluster

#### Change overview
Update LockManager to support Lock/Unlock state properly based on Pin configuration
Add Support for ThreadMetrics in Software Diagnostics Cluster
Updated POOL Buffer to 48 to fix Packet Empty intermittent error


#### Testing
Manually tested DRLK2.2 , DRLK-2.3 and DRLK-2.5 using Chip-tool
Verified thread metrics read using chip-tool
Heap usage/free verified after pool buffer increase