### PR TITLE
Dmalloc variant in build_example.py tests target

### DIFF
--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -338,7 +338,6 @@ def HostTargets():
     yield target_native.Extend('tests-clang', app=HostApp.TESTS, use_clang=True).GlobBlacklist("Non-default test")
     yield target_native.Extend('tests-clang-asan', app=HostApp.TESTS, use_clang=True, use_asan=True).GlobBlacklist("Non-default test")
     yield target_native.Extend('tests-dmalloc', app=HostApp.TESTS, use_dmalloc=True).GlobBlacklist("Non-default test")
-    yield target_native.Extend('tests-clang-dmalloc-asan', app=HostApp.TESTS, use_clang=True, use_asan=True, use_dmalloc=True).GlobBlacklist("Non-default test")
 
     test_target = Target(HostBoard.NATIVE.PlatformName(), HostBuilder)
     yield test_target.Extend(HostBoard.FAKE.BoardName() + '-tests', board=HostBoard.FAKE, app=HostApp.TESTS)

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -336,6 +336,9 @@ def HostTargets():
     yield target_native.Extend('tests-boringssl', app=HostApp.TESTS, crypto_library=HostCryptoLibrary.BORINGSSL).GlobBlacklist("Non-default test")
     yield target_native.Extend('tests-coverage', app=HostApp.TESTS, use_coverage=True).GlobBlacklist("Non-default test")
     yield target_native.Extend('tests-clang', app=HostApp.TESTS, use_clang=True).GlobBlacklist("Non-default test")
+    yield target_native.Extend('tests-clang-asan', app=HostApp.TESTS, use_clang=True, use_asan=True).GlobBlacklist("Non-default test")
+    yield target_native.Extend('tests-dmalloc', app=HostApp.TESTS, use_dmalloc=True).GlobBlacklist("Non-default test")
+    yield target_native.Extend('tests-clang-dmalloc-asan', app=HostApp.TESTS, use_clang=True, use_asan=True, use_dmalloc=True).GlobBlacklist("Non-default test")
 
     test_target = Target(HostBoard.NATIVE.PlatformName(), HostBuilder)
     yield test_target.Extend(HostBoard.FAKE.BoardName() + '-tests', board=HostBoard.FAKE, app=HostApp.TESTS)

--- a/scripts/build/builders/gn.py
+++ b/scripts/build/builders/gn.py
@@ -88,6 +88,17 @@ class GnBuilder(Builder):
         if self.build_command:
             cmd.append(self.build_command)
 
+        extra_env = self.GnBuildEnv()
+        if extra_env:
+            # convert the command into a bash command that includes
+            # setting environment variables
+            cmd = [
+                'bash', '-c', '\n' + ' '.join(
+                    ['%s="%s" \\\n' % (key, value) for key, value in extra_env.items()] +
+                    [shlex.join(cmd)]
+                )
+            ]
+
         self._Execute(cmd, title='Building ' + self.identifier)
 
         self.PostBuildCommand()

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -254,10 +254,10 @@ class HostBuilder(GnBuilder):
             self.extra_gn_options.append('chip_config_memory_debug_dmalloc=true')
 
             # this is from `dmalloc -b -l DMALLOC_LOG -i 1 high`
-            self.build_env['DMALLOC_OPTIONS']='debug=0x4f4ed03,inter=1,log=DMALLOC_LOG'
+            self.build_env['DMALLOC_OPTIONS'] = 'debug=0x4f4ed03,inter=1,log=DMALLOC_LOG'
 
             # glib interop with dmalloc
-            self.build_env['G_SLICE']='always-malloc'
+            self.build_env['G_SLICE'] = 'always-malloc'
 
         if not separate_event_loop:
             self.extra_gn_options.append('config_use_separate_eventloop=false')

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -322,115 +322,189 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/tv-casting-app/linux --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-tv-casting-app-ipv6only
 
 # Building linux-arm64-clang-all-clusters
-ninja -C {out}/linux-arm64-clang-all-clusters
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-all-clusters'
 
 # Building linux-arm64-clang-all-clusters-app-nodeps
-ninja -C {out}/linux-arm64-clang-all-clusters-app-nodeps
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-all-clusters-app-nodeps'
 
 # Building linux-arm64-clang-all-clusters-app-nodeps-ipv6only
-ninja -C {out}/linux-arm64-clang-all-clusters-app-nodeps-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-all-clusters-app-nodeps-ipv6only'
 
 # Building linux-arm64-clang-all-clusters-ipv6only
-ninja -C {out}/linux-arm64-clang-all-clusters-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-all-clusters-ipv6only'
 
 # Building linux-arm64-clang-all-clusters-minimal
-ninja -C {out}/linux-arm64-clang-all-clusters-minimal
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-all-clusters-minimal'
 
 # Building linux-arm64-clang-all-clusters-minimal-ipv6only
-ninja -C {out}/linux-arm64-clang-all-clusters-minimal-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-all-clusters-minimal-ipv6only'
 
 # Building linux-arm64-clang-bridge
-ninja -C {out}/linux-arm64-clang-bridge
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-bridge'
 
 # Building linux-arm64-clang-bridge-ipv6only
-ninja -C {out}/linux-arm64-clang-bridge-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-bridge-ipv6only'
 
 # Building linux-arm64-clang-chip-tool
-ninja -C {out}/linux-arm64-clang-chip-tool
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-chip-tool'
 
 # Building linux-arm64-clang-chip-tool-ipv6only
-ninja -C {out}/linux-arm64-clang-chip-tool-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-chip-tool-ipv6only'
 
 # Building linux-arm64-clang-chip-tool-nodeps
-ninja -C {out}/linux-arm64-clang-chip-tool-nodeps
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-chip-tool-nodeps'
 
 # Building linux-arm64-clang-chip-tool-nodeps-ipv6only
-ninja -C {out}/linux-arm64-clang-chip-tool-nodeps-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-chip-tool-nodeps-ipv6only'
 
 # Building linux-arm64-clang-light
-ninja -C {out}/linux-arm64-clang-light
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-light'
 
 # Building linux-arm64-clang-light-ipv6only
-ninja -C {out}/linux-arm64-clang-light-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-light-ipv6only'
 
 # Building linux-arm64-clang-light-rpc
-ninja -C {out}/linux-arm64-clang-light-rpc
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-light-rpc'
 
 # Building linux-arm64-clang-light-rpc-ipv6only
-ninja -C {out}/linux-arm64-clang-light-rpc-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-light-rpc-ipv6only'
 
 # Building linux-arm64-clang-lock
-ninja -C {out}/linux-arm64-clang-lock
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-lock'
 
 # Building linux-arm64-clang-lock-ipv6only
-ninja -C {out}/linux-arm64-clang-lock-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-lock-ipv6only'
 
 # Building linux-arm64-clang-minmdns
-ninja -C {out}/linux-arm64-clang-minmdns
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-minmdns'
 
 # Building linux-arm64-clang-minmdns-ipv6only
-ninja -C {out}/linux-arm64-clang-minmdns-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-minmdns-ipv6only'
 
 # Building linux-arm64-clang-ota-provider
-ninja -C {out}/linux-arm64-clang-ota-provider
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-ota-provider'
 
 # Building linux-arm64-clang-ota-provider-ipv6only
-ninja -C {out}/linux-arm64-clang-ota-provider-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-ota-provider-ipv6only'
 
 # Building linux-arm64-clang-ota-provider-nodeps
-ninja -C {out}/linux-arm64-clang-ota-provider-nodeps
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-ota-provider-nodeps'
 
 # Building linux-arm64-clang-ota-provider-nodeps-ipv6only
-ninja -C {out}/linux-arm64-clang-ota-provider-nodeps-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-ota-provider-nodeps-ipv6only'
 
 # Building linux-arm64-clang-ota-requestor
-ninja -C {out}/linux-arm64-clang-ota-requestor
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-ota-requestor'
 
 # Building linux-arm64-clang-ota-requestor-ipv6only
-ninja -C {out}/linux-arm64-clang-ota-requestor-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-ota-requestor-ipv6only'
 
 # Building linux-arm64-clang-ota-requestor-nodeps
-ninja -C {out}/linux-arm64-clang-ota-requestor-nodeps
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-ota-requestor-nodeps'
 
 # Building linux-arm64-clang-ota-requestor-nodeps-ipv6only
-ninja -C {out}/linux-arm64-clang-ota-requestor-nodeps-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-ota-requestor-nodeps-ipv6only'
 
 # Building linux-arm64-clang-python-bindings
-ninja -C {out}/linux-arm64-clang-python-bindings chip-repl
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-python-bindings chip-repl'
 
 # Building linux-arm64-clang-shell
-ninja -C {out}/linux-arm64-clang-shell
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-shell'
 
 # Building linux-arm64-clang-shell-ipv6only
-ninja -C {out}/linux-arm64-clang-shell-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-shell-ipv6only'
 
 # Building linux-arm64-clang-thermostat
-ninja -C {out}/linux-arm64-clang-thermostat
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-thermostat'
 
 # Building linux-arm64-clang-thermostat-ipv6only
-ninja -C {out}/linux-arm64-clang-thermostat-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-thermostat-ipv6only'
 
 # Building linux-arm64-clang-tv-app
-ninja -C {out}/linux-arm64-clang-tv-app
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-tv-app'
 
 # Building linux-arm64-clang-tv-app-ipv6only
-ninja -C {out}/linux-arm64-clang-tv-app-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-tv-app-ipv6only'
 
 # Building linux-arm64-clang-tv-casting-app
-ninja -C {out}/linux-arm64-clang-tv-casting-app
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-tv-casting-app'
 
 # Building linux-arm64-clang-tv-casting-app-ipv6only
-ninja -C {out}/linux-arm64-clang-tv-casting-app-ipv6only
+bash -c '
+PKG_CONFIG_PATH="SYSROOT_AARCH64/lib/aarch64-linux-gnu/pkgconfig" \
+ ninja -C {out}/linux-arm64-clang-tv-casting-app-ipv6only'
 
 # Building linux-fake-tests
 ninja -C {out}/linux-fake-tests check


### PR DESCRIPTION
** Reason for 1.0 inclusion **
  - improves developer debuggability and testing
  - does not alter core sdk development (additional build rules only, verified by CI). Only delta is in cross-compile environment which should be a noop in practice.

#### Problem

Fixes #22170

Want better debuggability, in particular it seems Linux TestRead experiences some dmalloc errors (which I have not yet been able to reproduce outside github CI). See #22160

#### Change overview
This adds dmalloc and asan targets to build_examples.

#### Testing
Ran the target locally, saw dmalloc being used (by checking amount of time it takes ... TestRead generally takes 2 seconds without it and 30 seconds with)