### PR TITLE
Address feedback from https://github.com/project-chip/connectedhomeip/issues/22197

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -60,6 +60,7 @@ static NSString * const kErrorSigningKeypairInit = @"Init failure while creating
 static NSString * const kErrorOperationalCredentialsInit = @"Init failure while creating operational credentials delegate";
 static NSString * const kErrorOperationalKeypairInit = @"Init failure while creating operational keypair bridge";
 static NSString * const kErrorPairingInit = @"Init failure while creating a pairing delegate";
+static NSString * const kErrorPartialDacVerifierInit = @"Init failure while creating a partial DAC verifier";
 static NSString * const kErrorPairDevice = @"Failure while pairing the device";
 static NSString * const kErrorUnpairDevice = @"Failure while unpairing the device";
 static NSString * const kErrorStopPairing = @"Failure while trying to stop the pairing process";
@@ -101,6 +102,11 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
 
         _pairingDelegateBridge = new MTRDevicePairingDelegateBridge();
         if ([self checkForInitError:(_pairingDelegateBridge != nullptr) logMsg:kErrorPairingInit]) {
+            return nil;
+        }
+
+        _partialDACVerifier = new chip::Credentials::PartialDACVerifier();
+        if ([self checkForInitError:(_partialDACVerifier != nullptr) logMsg:kErrorPartialDacVerifierInit]) {
             return nil;
         }
 
@@ -238,8 +244,6 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         commissionerParams.pairingDelegate = _pairingDelegateBridge;
 
         _operationalCredentialsDelegate->SetDeviceCommissioner(_cppCommissioner);
-
-        _partialDACVerifier = new chip::Credentials::PartialDACVerifier();
 
         commissionerParams.operationalCredentialsDelegate = _operationalCredentialsDelegate;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -162,6 +162,11 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         delete _pairingDelegateBridge;
         _pairingDelegateBridge = nullptr;
     }
+
+    if (_partialDACVerifier) {
+        delete _partialDACVerifier;
+        _partialDACVerifier = nullptr;
+    }
 }
 
 - (BOOL)startup:(MTRDeviceControllerStartupParamsInternal *)startupParams
@@ -233,6 +238,8 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         commissionerParams.pairingDelegate = _pairingDelegateBridge;
 
         _operationalCredentialsDelegate->SetDeviceCommissioner(_cppCommissioner);
+
+        _partialDACVerifier = new chip::Credentials::PartialDACVerifier();
 
         commissionerParams.operationalCredentialsDelegate = _operationalCredentialsDelegate;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -149,6 +149,9 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         _cppCommissioner->Shutdown();
         delete _cppCommissioner;
         _cppCommissioner = nullptr;
+        if (_operationalCredentialsDelegate != nil) {
+            _operationalCredentialsDelegate->SetDeviceCommissioner(nullptr);
+        }
     }
 }
 
@@ -164,14 +167,14 @@ static NSString * const kErrorCSRValidation = @"Extracting public key from CSR f
         _operationalCredentialsDelegate = nullptr;
     }
 
-    if (_pairingDelegateBridge) {
-        delete _pairingDelegateBridge;
-        _pairingDelegateBridge = nullptr;
-    }
-
     if (_partialDACVerifier) {
         delete _partialDACVerifier;
         _partialDACVerifier = nullptr;
+    }
+
+    if (_pairingDelegateBridge) {
+        delete _pairingDelegateBridge;
+        _pairingDelegateBridge = nullptr;
     }
 }
 

--- a/src/darwin/Framework/CHIP/MTRNOCChainIssuer.h
+++ b/src/darwin/Framework/CHIP/MTRNOCChainIssuer.h
@@ -22,7 +22,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef BOOL (^MTRNOCChainGenerationCompleteHandler)(NSData * operationalCertificate, NSData * intermediateCertificate,
+typedef void (^MTRNOCChainGenerationCompleteHandler)(NSData * operationalCertificate, NSData * intermediateCertificate,
     NSData * rootCertificate, NSData * _Nullable ipk, NSNumber * _Nullable adminSubject, NSError * __autoreleasing * error);
 
 @protocol MTRNOCChainIssuer <NSObject>

--- a/src/darwin/Framework/CHIP/MTRNOCChainIssuer.h
+++ b/src/darwin/Framework/CHIP/MTRNOCChainIssuer.h
@@ -22,6 +22,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef BOOL (^MTRNOCChainGenerationCompleteHandler)(NSData * operationalCertificate, NSData * intermediateCertificate,
+    NSData * rootCertificate, NSData * _Nullable ipk, NSNumber * _Nullable adminSubject, NSError * __autoreleasing * error);
+
 @protocol MTRNOCChainIssuer <NSObject>
 @required
 
@@ -43,9 +46,7 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (void)onNOCChainGenerationNeeded:(CSRInfo *)csrInfo
                    attestationInfo:(AttestationInfo *)attestationInfo
-      onNOCChainGenerationComplete:(void (^)(NSData * operationalCertificate, NSData * intermediateCertificate,
-                                       NSData * rootCertificate, NSData * ipk, NSNumber * adminSubject,
-                                       NSError * __autoreleasing * error))onNOCChainGenerationComplete;
+      onNOCChainGenerationComplete:(MTRNOCChainGenerationCompleteHandler)onNOCChainGenerationComplete;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
@@ -57,7 +57,10 @@ public:
     void SetDeviceID(chip::NodeId deviceId) { mDeviceBeingPaired = deviceId; }
     void ResetDeviceID() { mDeviceBeingPaired = chip::kUndefinedNodeId; }
 
-    void SetDeviceCommissioner(chip::Controller::DeviceCommissioner * cppCommissioner) { mCppCommissioner = cppCommissioner; }
+    void SetDeviceCommissioner(chip::Controller::DeviceCommissioner * _Nullable cppCommissioner)
+    {
+        mCppCommissioner = cppCommissioner;
+    }
 
     chip::Optional<chip::Controller::CommissioningParameters> GetCommissioningParameters()
     {

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
@@ -127,7 +127,7 @@ private:
      * If ipk and adminSubject are non nil, then they will be used in the AddNOC command sent to the commissionee. If they are not
      * populated, then the values provided in the MTRDeviceController initialization will be used.
      */
-    BOOL onNOCChainGenerationComplete(NSData * operationalCertificate, NSData * intermediateCertificate, NSData * rootCertificate,
+    void onNOCChainGenerationComplete(NSData * operationalCertificate, NSData * intermediateCertificate, NSData * rootCertificate,
         NSData * _Nullable ipk, NSNumber * _Nullable adminSubject, NSError * __autoreleasing * error);
 
     void setNSError(CHIP_ERROR err, NSError * __autoreleasing * outError);

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.h
@@ -127,7 +127,7 @@ private:
      * If ipk and adminSubject are non nil, then they will be used in the AddNOC command sent to the commissionee. If they are not
      * populated, then the values provided in the MTRDeviceController initialization will be used.
      */
-    void onNOCChainGenerationComplete(NSData * operationalCertificate, NSData * intermediateCertificate, NSData * rootCertificate,
+    BOOL onNOCChainGenerationComplete(NSData * operationalCertificate, NSData * intermediateCertificate, NSData * rootCertificate,
         NSData * _Nullable ipk, NSNumber * _Nullable adminSubject, NSError * __autoreleasing * error);
 
     void setNSError(CHIP_ERROR err, NSError * __autoreleasing * outError);

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -232,6 +232,7 @@ void MTROperationalCredentialsDelegate::onNOCChainGenerationComplete(NSData * op
         setNSError(CHIP_ERROR_INCORRECT_STATE, error);
         return;
     }
+
     __block chip::Optional<chip::Controller::CommissioningParameters> commissioningParameters;
     dispatch_sync(mChipWorkQueue, ^{
         commissioningParameters = mCppCommissioner->GetCommissioningParameters();

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -147,7 +147,7 @@ CHIP_ERROR MTROperationalCredentialsDelegate::CallbackGenerateNOCChain(const chi
     const chip::ByteSpan & DAC, const chip::ByteSpan & PAI,
     chip::Callback::Callback<chip::Controller::OnNOCChainGeneration> * onCompletion)
 {
-    VerifyOrReturnError(mCppCommissioner != nil, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(mCppCommissioner != nullptr, CHIP_ERROR_INCORRECT_STATE);
     mOnNOCCompletionCallback = onCompletion;
 
     TLVReader reader;

--- a/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTROperationalCredentialsDelegate.mm
@@ -228,7 +228,7 @@ void MTROperationalCredentialsDelegate::onNOCChainGenerationComplete(NSData * op
         return;
     }
 
-    if (mCppCommissioner == nil) {
+    if (mCppCommissioner == nullptr) {
         setNSError(CHIP_ERROR_INCORRECT_STATE, error);
         return;
     }


### PR DESCRIPTION
#### Problem
This addresses feedback captured in a previous PR and tracked as part of this issue: https://github.com/project-chip/connectedhomeip/issues/22197
Also, addressing the comment in https://github.com/project-chip/connectedhomeip/pull/22115#pullrequestreview-1087634372

#### Change overview
1. Made ipk and adminSubject params Nullable explicitly in the protocol def.
2. Removed sync dispatches to get commissioning params from the MTROperationalCredentialsDelegate.mm
3. Allocated and Deallocated partialDacVerifier before assignment (https://github.com/project-chip/connectedhomeip/pull/22115#pullrequestreview-1087634372)

#### Testing
Built and tested using the iOS chip controller.