### PR TITLE
[Tizen] Add a header guard for thread

### DIFF
--- a/config/tizen/chip-gn/platform/BUILD.gn
+++ b/config/tizen/chip-gn/platform/BUILD.gn
@@ -45,9 +45,6 @@ if (chip_enable_wifi) {
   pkg_config("capi-network-wifi-manager") {
     packages = [ "capi-network-wifi-manager" ]
   }
-  pkg_config("capi-network-softap") {
-    packages = [ "capi-network-softap" ]
-  }
 }
 
 if (chip_enable_ble) {
@@ -74,10 +71,7 @@ source_set("tizen") {
   }
 
   if (chip_enable_wifi) {
-    public_configs += [
-      ":capi-network-wifi-manager",
-      ":capi-network-softap",
-    ]
+    public_configs += [ ":capi-network-wifi-manager" ]
   }
 
   if (chip_enable_ble) {

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -32,7 +32,9 @@
 
 #include <dns-sd-internal.h>
 #include <glib.h>
+#if CHIP_DEVICE_CONFIG_ENABLE_THREAD
 #include <platform/ThreadStackManager.h>
+#endif
 
 using namespace chip::Dnssd;
 using namespace chip::DeviceLayer::Internal;


### PR DESCRIPTION
#### Problem
There is no header guard for ThreadStackManager.h
And softap module is not currently used.

#### Summary of Changes
Add the header guard for ThreadStackManager.h using CHIP_DEVICE_CONFIG_ENABLE_THREAD.
Remove the softap content from the pkg config.

#### Summary of Changes
chip-tool and chip-lighting-app examples