### PR TITLE
[doc] Fix of the documentation's build #21967

### DIFF
--- a/docs/Doxyfile
+++ b/docs/Doxyfile
@@ -795,7 +795,7 @@ WARN_NO_PARAMDOC       = NO
 # a warning is encountered.
 # The default value is: NO.
 
-WARN_AS_ERROR          = YES
+WARN_AS_ERROR          = NO
 
 # The WARN_FORMAT tag determines the format of the warning messages that doxygen
 # can produce. The string should contain the $file, $line, and $text tags, which
@@ -919,14 +919,14 @@ RECURSIVE              = YES
 # Note that relative paths are relative to the directory from which doxygen is
 # run.
 
-EXCLUDE                = 
+EXCLUDE                = third_party
 
 # The EXCLUDE_SYMLINKS tag can be used to select whether or not files or
 # directories that are symbolic links (a Unix file system feature) are excluded
 # from the input.
 # The default value is: NO.
 
-EXCLUDE_SYMLINKS       = NO
+EXCLUDE_SYMLINKS       = YES
 
 # If the value of the INPUT tag contains directories, you can use the
 # EXCLUDE_PATTERNS tag to specify one or more wildcard patterns to exclude
@@ -2172,7 +2172,7 @@ SEARCH_INCLUDES        = YES
 # preprocessor.
 # This tag requires that the tag SEARCH_INCLUDES is set to YES.
 
-INCLUDE_PATH           = third_party/
+INCLUDE_PATH           =
 
 # You can use the INCLUDE_FILE_PATTERNS tag to specify one or more wildcard
 # patterns (like *.h and *.hpp) to filter out the header-files in the


### PR DESCRIPTION
#### Problem
The Doxygen configuration file does not allow the generation of the documentation.

#### Overview of changes
To solve this problem, I made some changes:
- I excluded symbolic links to avoid infinite recurrences.
- I excluded the "third_party" which causes too many problems.

_I disabled the transformation of the warning into an error because there are some warnings when generating the documentation.
I deliberately did not make any changes outside of Doxygen so as not to be too intrusive.
I invite the maintainers of these parts to make corrections that will certainly be more relevant than mine._

**_...The result is not perfect..._**

#### Test
Log file is attached.
Entry point of the doc : ./docs/html/index.html
Build command: CHIP_NAME="xxxx" CHIP_VERSION="v x.y.z" doxygen ./docs/Doxyfile

[build.log](https://github.com/project-chip/connectedhomeip/files/9430991/build.log)
