### PR TITLE
[Mbed] Update mbed-tools version

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -28,7 +28,7 @@ steps:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
               --target-glob '*' --skip-target-glob
-              '{mbed-*,tizen-*,*-tests*,*-chip-test}' build --create-archives
+              '{tizen-*,*-tests*,*-chip-test}' build --create-archives
               /workspace/artifacts/
       id: CompileAll
       waitFor:

--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -41,6 +41,7 @@ click==8.1.3
     #   -r requirements.txt
     #   flask
     #   idf-component-manager
+    #   mbed-tools
     #   pip-tools
 colorama==0.4.4
     # via
@@ -102,7 +103,9 @@ ghapi==0.1.19
 gitdb==4.0.9
     # via gitpython
 gitpython==3.1.27 ; platform_machine != "aarch64" and sys_platform == "linux"
-    # via -r requirements.mbed.txt
+    # via
+    #   -r requirements.mbed.txt
+    #   mbed-tools
 greenlet==1.1.0
     # via gevent
 humanfriendly==9.2
@@ -126,7 +129,9 @@ itsdangerous==2.0.1
 jedi==0.18.0
     # via ipython
 jinja2==3.0.1
-    # via flask
+    # via
+    #   flask
+    #   mbed-tools
 jsonschema==4.4.0
     # via -r requirements.txt
 junit-xml==1.9
@@ -153,6 +158,8 @@ mbed-ls==1.8.11 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via -r requirements.mbed.txt
 mbed-os-tools==1.8.13
     # via mbed-ls
+mbed-tools==7.55.1.dev1 ; platform_machine != "aarch64" and sys_platform == "linux"
+    # via -r requirements.mbed.txt
 mobly==1.11.1
     # via -r requirements.txt
 numpy==1.23.0
@@ -197,6 +204,7 @@ psutil==5.9.1
     # via
     #   -r requirements.txt
     #   mobly
+    #   mbed-tools
 ptyprocess==0.7.0
     # via pexpect
 py==1.11.0
@@ -223,6 +231,7 @@ pyserial==3.5
     # via
     #   -c constraints.esp32.txt
     #   mbed-os-tools
+    #   mbed-tools
     #   mobly
 pytest==6.2.5 ; platform_machine != "aarch64" and sys_platform == "linux"
     # via -r requirements.mbed.txt
@@ -231,7 +240,9 @@ python-dateutil==2.8.1
     #   pandas
     #   pykwalify
 python-dotenv==0.20.0 ; platform_machine != "aarch64" and sys_platform == "linux"
-    # via -r requirements.mbed.txt
+    # via
+    #   -r requirements.mbed.txt
+    #   mbed-tools
 python-engineio==3.14.2
     # via python-socketio
 python-socketio==4.6.1
@@ -241,7 +252,9 @@ python-socketio==4.6.1
 pytz==2021.1
     # via pandas
 pyudev==0.23.2 ; platform_machine != "aarch64" and sys_platform == "linux"
-    # via -r requirements.mbed.txt
+    # via
+    #   -r requirements.mbed.txt
+    #   mbed-tools
 pyyaml==6.0
     # via
     #   idf-component-manager
@@ -254,6 +267,7 @@ requests==2.25.1
     #   -r requirements.txt
     #   idf-component-manager
     #   mbed-os-tools
+    #   mbed-tools
     #   requests-toolbelt
 requests-toolbelt==0.9.1
     # via idf-component-manager
@@ -281,7 +295,9 @@ soupsieve==2.3.2.post1
 stringcase==1.2.0
     # via -r requirements.txt
 tabulate==0.8.10
-    # via -r requirements.txt
+    # via
+    #   -r requirements.txt
+    #   mbed-tools
 timeout-decorator==0.5.0
     # via mobly
 toml==0.10.2
@@ -291,13 +307,17 @@ toml==0.10.2
 tornado==6.1
     # via -r requirements.txt
 tqdm==4.61.1
-    # via idf-component-manager
+    # via
+    #   idf-component-manager
+    #   mbed-tools
 traitlets==5.0.5
     # via
     #   ipython
     #   matplotlib-inline
 typing-extensions==4.3.0 ; platform_machine != "aarch64" and sys_platform == "linux"
-    # via -r requirements.mbed.txt
+    # via
+    #   -r requirements.mbed.txt
+    #   mbed-tools
 urllib3==1.26.5
     # via requests
 virtualenv==20.4.7

--- a/scripts/requirements.mbed.txt
+++ b/scripts/requirements.mbed.txt
@@ -1,4 +1,4 @@
-#mbed-tools>=7.49.1 ; platform_machine != 'aarch64' and sys_platform == 'linux'
+mbed-tools>=7.55.1.dev1 ; platform_machine != 'aarch64' and sys_platform == 'linux'
 pytest==6.2.5 ; platform_machine != 'aarch64' and sys_platform == 'linux'
 mbed-ls==1.8.11 ; platform_machine != 'aarch64' and sys_platform == 'linux'
 pdoc3 ; platform_machine != 'aarch64' and sys_platform == 'linux'


### PR DESCRIPTION
#### Problem
Fix compatibility of click package between mbed-tools and pw environment. #20191
Restore mbed builds in cloudbuild CI #20616

#### Change overview
- Restore and update mbed-tools in pw environment - the latest mbed-tools version supports click>=8.1and it is compatible with requirements for Python 3.10
- Restore mbed builds in cloudbuild

#### Testing
Not required
