### PR TITLE
Add DevinfoInit to Relevant CC13xx apps

### DIFF
--- a/examples/all-clusters-app/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/BUILD.gn
@@ -78,6 +78,7 @@ ti_simplelink_executable("all-clusters-app") {
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp",
+    "${chip_root}/examples/providers/DeviceInfoProviderImpl.cpp",
     "${project_dir}/main/AppTask.cpp",
     "${project_dir}/main/ClusterManager.cpp",
     "${project_dir}/main/Globals.cpp",
@@ -102,6 +103,7 @@ ti_simplelink_executable("all-clusters-app") {
     "${project_dir}",
     "${project_dir}/main",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/include",
+    "${chip_root}/examples/providers/",
   ]
 
   cflags = [

--- a/examples/all-clusters-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -28,6 +28,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
+#include <DeviceInfoProviderImpl.h>
 #include <platform/CHIPDeviceLayer.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
@@ -64,6 +65,7 @@ static QueueHandle_t sAppEventQueue;
 
 static Button_Handle sAppLeftHandle;
 static Button_Handle sAppRightHandle;
+static DeviceInfoProviderImpl sExampleDeviceInfoProvider;
 
 AppTask AppTask::sAppTask;
 
@@ -243,6 +245,11 @@ int AppTask::Init()
     PLAT_LOG("Initialize Server");
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+
+    // Initialize info provider
+    sExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
+    SetDeviceInfoProvider(&sExampleDeviceInfoProvider);
+
     chip::Server::GetInstance().Init(initParams);
 
     ConfigurationMgr().LogDeviceConfig();

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/BUILD.gn
@@ -78,6 +78,7 @@ ti_simplelink_executable("all-clusters-minimal-app") {
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/binding-handler.cpp",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/bridged-actions-stub.cpp",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/src/static-supported-modes-manager.cpp",
+    "${chip_root}/examples/providers/DeviceInfoProviderImpl.cpp",
     "${project_dir}/main/AppTask.cpp",
     "${project_dir}/main/ClusterManager.cpp",
     "${project_dir}/main/Globals.cpp",
@@ -102,6 +103,7 @@ ti_simplelink_executable("all-clusters-minimal-app") {
     "${project_dir}",
     "${project_dir}/main",
     "${chip_root}/examples/all-clusters-app/all-clusters-common/include",
+    "${chip_root}/examples/providers/",
   ]
 
   cflags = [

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -28,6 +28,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
+#include <DeviceInfoProviderImpl.h>
 #include <platform/CHIPDeviceLayer.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
@@ -64,6 +65,7 @@ static QueueHandle_t sAppEventQueue;
 
 static Button_Handle sAppLeftHandle;
 static Button_Handle sAppRightHandle;
+static DeviceInfoProviderImpl sExampleDeviceInfoProvider;
 
 AppTask AppTask::sAppTask;
 
@@ -243,6 +245,11 @@ int AppTask::Init()
     PLAT_LOG("Initialize Server");
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+
+    // Initialize info provider
+    sExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
+    SetDeviceInfoProvider(&sExampleDeviceInfoProvider);
+
     chip::Server::GetInstance().Init(initParams);
 
     ConfigurationMgr().LogDeviceConfig();

--- a/examples/lock-app/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/lock-app/cc13x2x7_26x2x7/BUILD.gn
@@ -78,6 +78,7 @@ ti_simplelink_executable("lock_app") {
     "${project_dir}/main/BoltLockManager.cpp",
     "${project_dir}/main/ZclCallbacks.cpp",
     "${project_dir}/main/main.cpp",
+    "${chip_root}/examples/providers/DeviceInfoProviderImpl.cpp",
   ]
 
   deps = [
@@ -96,6 +97,7 @@ ti_simplelink_executable("lock_app") {
   include_dirs = [
     "${project_dir}",
     "${project_dir}/main",
+    "${chip_root}/examples/providers/",
   ]
 
   cflags = [

--- a/examples/lock-app/cc13x2x7_26x2x7/BUILD.gn
+++ b/examples/lock-app/cc13x2x7_26x2x7/BUILD.gn
@@ -74,11 +74,11 @@ ti_simplelink_executable("lock_app") {
   output_name = "chip-${ti_simplelink_board}-lock-example.out"
 
   sources = [
+    "${chip_root}/examples/providers/DeviceInfoProviderImpl.cpp",
     "${project_dir}/main/AppTask.cpp",
     "${project_dir}/main/BoltLockManager.cpp",
     "${project_dir}/main/ZclCallbacks.cpp",
     "${project_dir}/main/main.cpp",
-    "${chip_root}/examples/providers/DeviceInfoProviderImpl.cpp",
   ]
 
   deps = [

--- a/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
+++ b/examples/lock-app/cc13x2x7_26x2x7/main/AppTask.cpp
@@ -27,6 +27,7 @@
 #include <credentials/DeviceAttestationCredsProvider.h>
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
+#include <DeviceInfoProviderImpl.h>
 #include <platform/CHIPDeviceLayer.h>
 
 #if CHIP_DEVICE_CONFIG_ENABLE_OTA_REQUESTOR
@@ -63,6 +64,7 @@ static LED_Handle sAppRedHandle;
 static LED_Handle sAppGreenHandle;
 static Button_Handle sAppLeftHandle;
 static Button_Handle sAppRightHandle;
+static DeviceInfoProviderImpl sExampleDeviceInfoProvider;
 
 AppTask AppTask::sAppTask;
 
@@ -166,6 +168,11 @@ int AppTask::Init()
     PLAT_LOG("Initialize Server");
     static chip::CommonCaseDeviceServerInitParams initParams;
     (void) initParams.InitializeStaticResourcesBeforeServerInit();
+
+    // Initialize info provider
+    sExampleDeviceInfoProvider.SetStorageDelegate(initParams.persistentStorageDelegate);
+    SetDeviceInfoProvider(&sExampleDeviceInfoProvider);
+
     chip::Server::GetInstance().Init(initParams);
 
     // Initialize device attestation config


### PR DESCRIPTION
#### Problem
Device info cluster is not initialized at the correct location.

#### Change overview
Initialize dev info cluster
#### Testing
Verified labels are able to be correctly created in all clusters cc13xx implementation and that the projects build.
