### PR TITLE
Log the instance name when publishing dns-sd services.

### DIFF
--- a/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Advertiser_ImplMinimalMdns.cpp
@@ -525,7 +525,7 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const OperationalAdvertisingParameters &
         return CHIP_ERROR_NO_MEMORY;
     }
 
-    ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Operational device'.");
+    ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Operational device'; instance name: %s.", instanceName.names[0]);
 
     AdvertiseRecords(BroadcastAdvertiseType::kStarted);
 
@@ -722,11 +722,13 @@ CHIP_ERROR AdvertiserMinMdns::Advertise(const CommissionAdvertisingParameters & 
 
     if (params.GetCommissionAdvertiseMode() == CommssionAdvertiseMode::kCommissionableNode)
     {
-        ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Commissionable node device'.");
+        ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Commissionable node device'; instance name: %s.",
+                        instanceName.names[0]);
     }
     else
     {
-        ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Commissioner device'.");
+        ChipLogProgress(Discovery, "CHIP minimal mDNS configured as 'Commissioner device'; instance name: %s.",
+                        instanceName.names[0]);
     }
 
     AdvertiseRecords(BroadcastAdvertiseType::kStarted);

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -433,11 +433,11 @@ CHIP_ERROR DiscoveryImplPlatform::UpdateCommissionableInstanceName()
     return CHIP_NO_ERROR;
 }
 
-void DiscoveryImplPlatform::HandleDnssdPublish(void * context, const char * type, CHIP_ERROR error)
+void DiscoveryImplPlatform::HandleDnssdPublish(void * context, const char * type, const char * instanceName, CHIP_ERROR error)
 {
     if (CHIP_NO_ERROR == error)
     {
-        ChipLogProgress(Discovery, "mDNS service published: %s", type);
+        ChipLogProgress(Discovery, "mDNS service published: %s; instance name: %s", type, instanceName);
     }
     else
     {

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -70,7 +70,7 @@ private:
 
     static void HandleDnssdInit(void * context, CHIP_ERROR initError);
     static void HandleDnssdError(void * context, CHIP_ERROR initError);
-    static void HandleDnssdPublish(void * context, const char * type, CHIP_ERROR error);
+    static void HandleDnssdPublish(void * context, const char * type, const char * instanceName, CHIP_ERROR error);
     static CHIP_ERROR GenerateRotatingDeviceId(char rotatingDeviceIdHexBuffer[], size_t & rotatingDeviceIdHexBufferSize);
     CHIP_ERROR PublishService(const char * serviceType, TextEntry * textEntries, size_t textEntrySize, const char ** subTypes,
                               size_t subTypeSize, const OperationalAdvertisingParameters & params);

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -118,12 +118,13 @@ using DnssdBrowseCallback = void (*)(void * context, DnssdService * services, si
  * The callback function SHALL NOT take the ownership of the service pointer or
  * any pointer inside this structure.
  *
- * @param[in] context       The context passed to ChipDnssdPublish.
- * @param[in] type          The published type if no errors has occured, nullptr otherwise.
+ * @param[in] context       The context passed to ChipDnssdPublishService.
+ * @param[in] type          The published type if no errors have occured, nullptr otherwise.
+ * @param[in] instanceName  The published instance name if no errors have occured, nullptr otherwise.
  * @param[in] error         The error code.
  *
  */
-using DnssdPublishCallback = void (*)(void * context, const char * type, CHIP_ERROR error);
+using DnssdPublishCallback = void (*)(void * context, const char * type, const char * instanceName, CHIP_ERROR error);
 
 using DnssdAsyncReturnCallback = void (*)(void * context, CHIP_ERROR error);
 

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -251,26 +251,27 @@ CHIP_ERROR MdnsContexts::GetRegisterContextOfType(const char * type, RegisterCon
     return found ? CHIP_NO_ERROR : CHIP_ERROR_KEY_NOT_FOUND;
 }
 
-RegisterContext::RegisterContext(const char * sType, DnssdPublishCallback cb, void * cbContext)
+RegisterContext::RegisterContext(const char * sType, const char * instanceName, DnssdPublishCallback cb, void * cbContext)
 {
     type     = ContextType::Register;
     context  = cbContext;
     callback = cb;
 
-    mType = sType;
+    mType         = sType;
+    mInstanceName = instanceName;
 }
 
 void RegisterContext::DispatchFailure(DNSServiceErrorType err)
 {
     ChipLogError(Discovery, "Mdns: Register failure (%s)", Error::ToString(err));
-    callback(context, nullptr, CHIP_ERROR_INTERNAL);
+    callback(context, nullptr, nullptr, CHIP_ERROR_INTERNAL);
     MdnsContexts::GetInstance().Remove(this);
 }
 
 void RegisterContext::DispatchSuccess()
 {
     std::string typeWithoutSubTypes = GetFullTypeWithoutSubTypes(mType);
-    callback(context, typeWithoutSubTypes.c_str(), CHIP_NO_ERROR);
+    callback(context, typeWithoutSubTypes.c_str(), mInstanceName.c_str(), CHIP_NO_ERROR);
 }
 
 BrowseContext::BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServiceProtocol cbContextProtocol)

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -185,7 +185,7 @@ CHIP_ERROR Register(void * context, DnssdPublishCallback callback, uint32_t inte
         return CHIP_NO_ERROR;
     }
 
-    sdCtx = chip::Platform::New<RegisterContext>(type, callback, context);
+    sdCtx = chip::Platform::New<RegisterContext>(type, name, callback, context);
     VerifyOrReturnError(nullptr != sdCtx, CHIP_ERROR_NO_MEMORY);
 
     DNSServiceRef sdRef;

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -92,8 +92,9 @@ struct RegisterContext : public GenericContext
 {
     DnssdPublishCallback callback;
     std::string mType;
+    std::string mInstanceName;
 
-    RegisterContext(const char * sType, DnssdPublishCallback cb, void * cbContext);
+    RegisterContext(const char * sType, const char * instanceName, DnssdPublishCallback cb, void * cbContext);
     virtual ~RegisterContext() {}
 
     void DispatchFailure(DNSServiceErrorType err) override;

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -517,11 +517,11 @@ exit:
     // The code needs to be updated to support that callback properly.
     if (CHIP_NO_ERROR == error)
     {
-        callback(context, type.c_str(), CHIP_NO_ERROR);
+        callback(context, type.c_str(), service.mName, CHIP_NO_ERROR);
     }
     else
     {
-        callback(context, nullptr, error);
+        callback(context, nullptr, nullptr, error);
     }
 
     return error;

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -91,13 +91,13 @@ void OnRegister(dnssd_error_e result, dnssd_service_h service, void * data)
     if (result != DNSSD_ERROR_NONE)
     {
         ChipLogError(DeviceLayer, "DNSsd %s: Error: %d", __func__, result);
-        rCtx->mCallback(rCtx->mCbContext, nullptr, GetChipError(result));
+        rCtx->mCallback(rCtx->mCbContext, nullptr, nullptr, GetChipError(result));
         // After this point, the context might be no longer valid
         rCtx->mInstance->RemoveContext(rCtx);
         return;
     }
 
-    rCtx->mCallback(rCtx->mCbContext, rCtx->mType, CHIP_NO_ERROR);
+    rCtx->mCallback(rCtx->mCbContext, rCtx->mType, rCtx->mName, CHIP_NO_ERROR);
 }
 
 gboolean RegisterAsync(GMainLoop * mainLoop, gpointer userData)
@@ -524,7 +524,7 @@ CHIP_ERROR DnssdTizen::RegisterService(const DnssdService & service, DnssdPublis
                 if (ret != DNSSD_ERROR_NONE)
                 {
                     ChipLogError(DeviceLayer, "dnssd_service_add_txt_record() failed. ret: %d", ret);
-                    callback(context, nullptr, err = GetChipError(ret));
+                    callback(context, nullptr, nullptr, err = GetChipError(ret));
                 }
             }
 
@@ -573,7 +573,7 @@ CHIP_ERROR DnssdTizen::RegisterService(const DnssdService & service, DnssdPublis
 exit:
     if (err != CHIP_NO_ERROR)
     { // Notify caller about error
-        callback(context, nullptr, err);
+        callback(context, nullptr, nullptr, err);
         RemoveContext(serviceCtx);
     }
     return err;

--- a/src/platform/tests/TestDnssd.cpp
+++ b/src/platform/tests/TestDnssd.cpp
@@ -50,7 +50,7 @@ static void HandleBrowse(void * context, DnssdService * services, size_t service
     }
 }
 
-static void HandlePublish(void * context, const char * type, CHIP_ERROR error) {}
+static void HandlePublish(void * context, const char * type, const char * instanceName, CHIP_ERROR error) {}
 
 static void InitCallback(void * context, CHIP_ERROR error)
 {

--- a/src/platform/webos/DnssdImpl.cpp
+++ b/src/platform/webos/DnssdImpl.cpp
@@ -515,11 +515,11 @@ exit:
     // The code needs to be updated to support that callback properly.
     if (CHIP_NO_ERROR == error)
     {
-        callback(context, type.c_str(), CHIP_NO_ERROR);
+        callback(context, type.c_str(), service.mName, CHIP_NO_ERROR);
     }
     else
     {
-        callback(context, nullptr, error);
+        callback(context, nullptr, nullptr, error);
     }
 
     return error;


### PR DESCRIPTION
Makes it easier to correlate server logs against what clients are seeing.

This does not work on all platforms, since some platform impls of
ChipDnssdPublishService never call the callback...

#### Problem
Hard to tell what instance names are being advertised by Matter

#### Change overview
Log the instance name

#### Testing
Checked that on Mac (platform mdns) and esp32 (minimal mdns) the logs appear as expected.