### PR TITLE
Allow endpoint ID to be specified when adding content app dynamically

### DIFF
--- a/examples/tv-app/android/java/MyUserPrompterResolver-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompterResolver-JNI.cpp
@@ -48,6 +48,7 @@ JNI_METHOD(void, OnPinCodeDeclined)(JNIEnv *, jobject)
 JNI_METHOD(void, OnPromptAccepted)(JNIEnv *, jobject)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    chip::DeviceLayer::StackLock lock;
     ChipLogProgress(Zcl, "OnPromptAccepted");
     GetCommissionerDiscoveryController()->Ok();
 #endif
@@ -56,6 +57,7 @@ JNI_METHOD(void, OnPromptAccepted)(JNIEnv *, jobject)
 JNI_METHOD(void, OnPromptDeclined)(JNIEnv *, jobject)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    chip::DeviceLayer::StackLock lock;
     ChipLogProgress(Zcl, "OnPromptDeclined");
     GetCommissionerDiscoveryController()->Cancel();
 #endif

--- a/examples/tv-app/android/java/TVApp-JNI.cpp
+++ b/examples/tv-app/android/java/TVApp-JNI.cpp
@@ -193,6 +193,7 @@ JNI_METHOD(void, setChipDeviceEventProvider)(JNIEnv *, jobject, jobject provider
 JNI_METHOD(jint, addContentApp)
 (JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jobject manager)
 {
+    chip::DeviceLayer::StackLock lock;
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
 
     JniUtfString vName(env, vendorName);

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -118,7 +118,7 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
         mContentApps[index] = app;
         EmberAfStatus ret;
         EndpointId initEndpointId = mCurrentEndpointId;
-        
+
         do {
             ret = emberAfSetDynamicEndpoint(index, mCurrentEndpointId, ep, dataVersionStorage, deviceTypeList);
             if (ret == EMBER_ZCL_STATUS_SUCCESS)

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -119,12 +119,13 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
         EmberAfStatus ret;
         EndpointId initEndpointId = mCurrentEndpointId;
 
-        do {
+        do
+        {
             ret = emberAfSetDynamicEndpoint(index, mCurrentEndpointId, ep, dataVersionStorage, deviceTypeList);
             if (ret == EMBER_ZCL_STATUS_SUCCESS)
             {
-                ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)",
-                                vendorApp.applicationId, mCurrentEndpointId, index);
+                ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)", vendorApp.applicationId,
+                                mCurrentEndpointId, index);
                 app->SetEndpointId(mCurrentEndpointId);
                 IncrementCurrentEndpointID();
                 return app->GetEndpointId();
@@ -135,8 +136,7 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
                 return kNoCurrentEndpointId;
             }
             IncrementCurrentEndpointID();
-        }
-        while (initEndpointId != mCurrentEndpointId);
+        } while (initEndpointId != mCurrentEndpointId);
         ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: No endpoints available!");
         return kNoCurrentEndpointId;
     }
@@ -165,7 +165,8 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
         index++;
     }
 
-    if (desiredEndpointId < FIXED_ENDPOINT_COUNT || emberAfGetDynamicIndexFromEndpoint(desiredEndpointId) != kEmberInvalidEndpointIndex)
+    if (desiredEndpointId < FIXED_ENDPOINT_COUNT ||
+        emberAfGetDynamicIndexFromEndpoint(desiredEndpointId) != kEmberInvalidEndpointIndex)
     {
         // invalid desiredEndpointId
         ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: desired endpointID is invalid!");
@@ -181,7 +182,7 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
             continue;
         }
         mContentApps[index] = app;
-        EmberAfStatus ret = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
+        EmberAfStatus ret   = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
         if (ret != EMBER_ZCL_STATUS_SUCCESS)
         {
             ChipLogError(DeviceLayer, "Adding ContentApp error=%d", ret);

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -181,7 +181,7 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
             index++;
             continue;
         }
-        EmberAfStatus ret   = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
+        EmberAfStatus ret = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
         if (ret != EMBER_ZCL_STATUS_SUCCESS)
         {
             ChipLogError(DeviceLayer, "Adding ContentApp error=%d", ret);

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -88,8 +88,7 @@ namespace AppPlatform {
 
 EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointType * ep,
                                              const Span<DataVersion> & dataVersionStorage,
-                                             const Span<const EmberAfDeviceType> & deviceTypeList,
-                                             EndpointId desiredEndpointId)
+                                             const Span<const EmberAfDeviceType> & deviceTypeList, EndpointId desiredEndpointId)
 {
     CatalogVendorApp vendorApp = app->GetApplicationBasicDelegate()->GetCatalogVendorApp();
 
@@ -108,8 +107,9 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
         index++;
     }
 
-
-    if (desiredEndpointId >= emberAfFixedEndpointCount() && emberAfGetDynamicIndexFromEndpoint(desiredEndpointId) != kEmberInvalidEndpointIndex) {
+    if (desiredEndpointId >= emberAfFixedEndpointCount() &&
+        emberAfGetDynamicIndexFromEndpoint(desiredEndpointId) != kEmberInvalidEndpointIndex)
+    {
         // an endpoint already exists with the desiredEndpointId. return error.
         ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: desired endpointID already in use!");
         return kNoCurrentEndpointId;
@@ -123,20 +123,21 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
             mContentApps[index] = app;
             EmberAfStatus ret;
 
-            if (desiredEndpointId >= emberAfFixedEndpointCount()) {
-                    ret = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
-                    if (ret == EMBER_ZCL_STATUS_SUCCESS)
-                    {
-                        ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)", vendorApp.applicationId,
-                                        desiredEndpointId, index);
-                        app->SetEndpointId(desiredEndpointId);
-                        return app->GetEndpointId();
-                    }
-                    else
-                    {
-                        ChipLogError(DeviceLayer, "Adding ContentApp error=%d", ret);
-                        return kNoCurrentEndpointId;
-                    }
+            if (desiredEndpointId >= emberAfFixedEndpointCount())
+            {
+                ret = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
+                if (ret == EMBER_ZCL_STATUS_SUCCESS)
+                {
+                    ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)", vendorApp.applicationId,
+                                    desiredEndpointId, index);
+                    app->SetEndpointId(desiredEndpointId);
+                    return app->GetEndpointId();
+                }
+                else
+                {
+                    ChipLogError(DeviceLayer, "Adding ContentApp error=%d", ret);
+                    return kNoCurrentEndpointId;
+                }
             }
             else
             {
@@ -145,8 +146,8 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
                     ret = emberAfSetDynamicEndpoint(index, mCurrentEndpointId, ep, dataVersionStorage, deviceTypeList);
                     if (ret == EMBER_ZCL_STATUS_SUCCESS)
                     {
-                        ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)", vendorApp.applicationId,
-                                        mCurrentEndpointId, index);
+                        ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)",
+                                        vendorApp.applicationId, mCurrentEndpointId, index);
                         app->SetEndpointId(mCurrentEndpointId);
                         return app->GetEndpointId();
                     }

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -88,6 +88,64 @@ namespace AppPlatform {
 
 EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointType * ep,
                                              const Span<DataVersion> & dataVersionStorage,
+                                             const Span<const EmberAfDeviceType> & deviceTypeList)
+{
+    CatalogVendorApp vendorApp = app->GetApplicationBasicDelegate()->GetCatalogVendorApp();
+
+    ChipLogProgress(DeviceLayer, "Adding ContentApp with appid %s ", vendorApp.applicationId);
+    uint8_t index = 0;
+    // check if already loaded
+    while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+    {
+        if (mContentApps[index] == app)
+        {
+            ChipLogProgress(DeviceLayer, "Already added");
+            // already added, return endpointId of already added endpoint.
+            // desired endpointId does not have any impact
+            return app->GetEndpointId();
+        }
+        index++;
+    }
+
+    index = 0;
+    while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
+    {
+        if (mContentApps[index] != nullptr)
+        {
+            index++;
+            continue;
+        }
+        mContentApps[index] = app;
+        EmberAfStatus ret;
+        EndpointId initEndpointId = mCurrentEndpointId;
+        
+        do {
+            ret = emberAfSetDynamicEndpoint(index, mCurrentEndpointId, ep, dataVersionStorage, deviceTypeList);
+            if (ret == EMBER_ZCL_STATUS_SUCCESS)
+            {
+                ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)",
+                                vendorApp.applicationId, mCurrentEndpointId, index);
+                app->SetEndpointId(mCurrentEndpointId);
+                IncrementCurrentEndpointID();
+                return app->GetEndpointId();
+            }
+            else if (ret != EMBER_ZCL_STATUS_DUPLICATE_EXISTS)
+            {
+                ChipLogError(DeviceLayer, "Adding ContentApp error=%d", ret);
+                return kNoCurrentEndpointId;
+            }
+            IncrementCurrentEndpointID();
+        }
+        while (initEndpointId != mCurrentEndpointId);
+        ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: No endpoints available!");
+        return kNoCurrentEndpointId;
+    }
+    ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: max endpoint count reached!");
+    return kNoCurrentEndpointId;
+}
+
+EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointType * ep,
+                                             const Span<DataVersion> & dataVersionStorage,
                                              const Span<const EmberAfDeviceType> & deviceTypeList, EndpointId desiredEndpointId)
 {
     CatalogVendorApp vendorApp = app->GetApplicationBasicDelegate()->GetCatalogVendorApp();
@@ -107,67 +165,44 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
         index++;
     }
 
-    if (desiredEndpointId >= emberAfFixedEndpointCount() &&
-        emberAfGetDynamicIndexFromEndpoint(desiredEndpointId) != kEmberInvalidEndpointIndex)
+    if (desiredEndpointId < FIXED_ENDPOINT_COUNT || emberAfGetDynamicIndexFromEndpoint(desiredEndpointId) != kEmberInvalidEndpointIndex)
     {
-        // an endpoint already exists with the desiredEndpointId. return error.
-        ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: desired endpointID already in use!");
+        // invalid desiredEndpointId
+        ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: desired endpointID is invalid!");
         return kNoCurrentEndpointId;
     }
 
     index = 0;
     while (index < CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT)
     {
-        if (nullptr == mContentApps[index])
+        if (mContentApps[index] != nullptr)
         {
-            mContentApps[index] = app;
-            EmberAfStatus ret;
-
-            if (desiredEndpointId >= emberAfFixedEndpointCount())
-            {
-                ret = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
-                if (ret == EMBER_ZCL_STATUS_SUCCESS)
-                {
-                    ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)", vendorApp.applicationId,
-                                    desiredEndpointId, index);
-                    app->SetEndpointId(desiredEndpointId);
-                    return app->GetEndpointId();
-                }
-                else
-                {
-                    ChipLogError(DeviceLayer, "Adding ContentApp error=%d", ret);
-                    return kNoCurrentEndpointId;
-                }
-            }
-            else
-            {
-                while (1)
-                {
-                    ret = emberAfSetDynamicEndpoint(index, mCurrentEndpointId, ep, dataVersionStorage, deviceTypeList);
-                    if (ret == EMBER_ZCL_STATUS_SUCCESS)
-                    {
-                        ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)",
-                                        vendorApp.applicationId, mCurrentEndpointId, index);
-                        app->SetEndpointId(mCurrentEndpointId);
-                        return app->GetEndpointId();
-                    }
-                    else if (ret != EMBER_ZCL_STATUS_DUPLICATE_EXISTS)
-                    {
-                        ChipLogError(DeviceLayer, "Adding ContentApp error=%d", ret);
-                        return kNoCurrentEndpointId;
-                    }
-                    // Handle wrap condition
-                    if (++mCurrentEndpointId < mFirstDynamicEndpointId)
-                    {
-                        mCurrentEndpointId = mFirstDynamicEndpointId;
-                    }
-                }
-            }
+            index++;
+            continue;
         }
-        index++;
+        mContentApps[index] = app;
+        EmberAfStatus ret = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
+        if (ret != EMBER_ZCL_STATUS_SUCCESS)
+        {
+            ChipLogError(DeviceLayer, "Adding ContentApp error=%d", ret);
+            return kNoCurrentEndpointId;
+        }
+        ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)", vendorApp.applicationId,
+                        desiredEndpointId, index);
+        app->SetEndpointId(desiredEndpointId);
+        return app->GetEndpointId();
     }
-    ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: No endpoints available!");
+    ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: max endpoint count reached!");
     return kNoCurrentEndpointId;
+}
+
+void ContentAppPlatform::IncrementCurrentEndpointID()
+{
+    // Handle wrap condition
+    if (++mCurrentEndpointId < mFirstDynamicEndpointId)
+    {
+        mCurrentEndpointId = mFirstDynamicEndpointId;
+    }
 }
 
 EndpointId ContentAppPlatform::RemoveContentApp(ContentApp * app)

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -115,7 +115,6 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
             index++;
             continue;
         }
-        mContentApps[index] = app;
         EmberAfStatus ret;
         EndpointId initEndpointId = mCurrentEndpointId;
 
@@ -127,6 +126,7 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
                 ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)", vendorApp.applicationId,
                                 mCurrentEndpointId, index);
                 app->SetEndpointId(mCurrentEndpointId);
+                mContentApps[index] = app;
                 IncrementCurrentEndpointID();
                 return app->GetEndpointId();
             }
@@ -181,7 +181,6 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
             index++;
             continue;
         }
-        mContentApps[index] = app;
         EmberAfStatus ret   = emberAfSetDynamicEndpoint(index, desiredEndpointId, ep, dataVersionStorage, deviceTypeList);
         if (ret != EMBER_ZCL_STATUS_SUCCESS)
         {
@@ -191,6 +190,7 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
         ChipLogProgress(DeviceLayer, "Added ContentApp %s to dynamic endpoint %d (index=%d)", vendorApp.applicationId,
                         desiredEndpointId, index);
         app->SetEndpointId(desiredEndpointId);
+        mContentApps[index] = app;
         return app->GetEndpointId();
     }
     ChipLogError(DeviceLayer, "Failed to add dynamic endpoint: max endpoint count reached!");

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -101,7 +101,7 @@ EndpointId ContentAppPlatform::AddContentApp(ContentApp * app, EmberAfEndpointTy
         if (mContentApps[index] == app)
         {
             ChipLogProgress(DeviceLayer, "Already added");
-            // already added, return endpointId of already added endpoint. 
+            // already added, return endpointId of already added endpoint.
             // desired endpointId does not have any impact
             return app->GetEndpointId();
         }

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -80,7 +80,7 @@ public:
 
     // add apps to the platform.
     // This will assign the app to an endpoint (if it is not already added) and make it accessible via Matter
-    // returns the global endpoint for this app, or 0 if an error occurred.
+    // returns the global endpoint for this app, or kNoCurrentEndpointId if an error occurred.
     // dataVersionStorage.size() needs to be at least as big as the number of
     // server clusters in the EmberAfEndpointType passed in.
     EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, const Span<DataVersion> & dataVersionStorage,
@@ -89,7 +89,7 @@ public:
     // add apps to the platform.
     // This will assign the app to the desiredEndpointId (if it is not already used)
     // and make it accessible via Matter, return the global endpoint for this app(if app is already added)
-    // , or 0 if an error occurred. desiredEndpointId cannot be less that Fixed endpoint count
+    // , or kNoCurrentEndpointId if an error occurred. desiredEndpointId cannot be less that Fixed endpoint count
     // dataVersionStorage.size() needs to be at least as big as the number of
     // server clusters in the EmberAfEndpointType passed in.
     EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, const Span<DataVersion> & dataVersionStorage,

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -80,14 +80,20 @@ public:
 
     // add apps to the platform.
     // This will assign the app to an endpoint (if it is not already added) and make it accessible via Matter
-    // returns the global endpoint for this app, or 0 if an error occurred
-    // If a desiredEndpointId is passed (cannot be less that Fixed endpoint count)
-    // framework will attempt to add the endpoint and assign the desiredEndpointId
-    // if desiredEndpointId is already taken endpoint is not added and 0 is returned.
+    // returns the global endpoint for this app, or 0 if an error occurred.
     // dataVersionStorage.size() needs to be at least as big as the number of
     // server clusters in the EmberAfEndpointType passed in.
     EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, const Span<DataVersion> & dataVersionStorage,
-                             const Span<const EmberAfDeviceType> & deviceTypeList, EndpointId desiredEndpointId = 0);
+                             const Span<const EmberAfDeviceType> & deviceTypeList);
+
+    // add apps to the platform.
+    // This will assign the app to the desiredEndpointId (if it is not already used)
+    // and make it accessible via Matter, return the global endpoint for this app(if app is already added)
+    // , or 0 if an error occurred. desiredEndpointId cannot be less that Fixed endpoint count
+    // dataVersionStorage.size() needs to be at least as big as the number of
+    // server clusters in the EmberAfEndpointType passed in.
+    EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, const Span<DataVersion> & dataVersionStorage,
+                             const Span<const EmberAfDeviceType> & deviceTypeList, EndpointId desiredEndpointId);
 
     // remove app from the platform.
     // returns the endpoint id where the app was, or 0 if app was not loaded
@@ -157,6 +163,10 @@ protected:
     EndpointId mCurrentEndpointId;
     EndpointId mFirstDynamicEndpointId;
     ContentApp * mContentApps[CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT];
+
+private:
+    void IncrementCurrentEndpointID();
+
 };
 
 } // namespace AppPlatform

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -166,7 +166,6 @@ protected:
 
 private:
     void IncrementCurrentEndpointID();
-
 };
 
 } // namespace AppPlatform

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -81,11 +81,13 @@ public:
     // add apps to the platform.
     // This will assign the app to an endpoint (if it is not already added) and make it accessible via Matter
     // returns the global endpoint for this app, or 0 if an error occurred
-    //
+    // If a desiredEndpointId is passed (cannot be less that Fixed endpoint count)
+    // framework will attempt to add the endpoint and assign the desiredEndpointId
+    // if desiredEndpointId is already taken endpoint is not added and 0 is returned.
     // dataVersionStorage.size() needs to be at least as big as the number of
     // server clusters in the EmberAfEndpointType passed in.
     EndpointId AddContentApp(ContentApp * app, EmberAfEndpointType * ep, const Span<DataVersion> & dataVersionStorage,
-                             const Span<const EmberAfDeviceType> & deviceTypeList);
+                             const Span<const EmberAfDeviceType> & deviceTypeList, EndpointId desiredEndpointId = 0);
 
     // remove app from the platform.
     // returns the endpoint id where the app was, or 0 if app was not loaded


### PR DESCRIPTION
#### Problem
The content app platform currently does not allow the tv-app to specify the endpoint ID to use. It will be required to manage endpoints across restarts of the app/device

Fixes #22285 

#### Change overview
Add and use a new parameter to the AddContentApp method to accept a desired endpoint ID.

#### Testing
Manual testing using the tv-casting-app