### PR TITLE
Ensure full initialization of ChipDN/ChipRDN

### DIFF
--- a/src/credentials/CHIPCert.cpp
+++ b/src/credentials/CHIPCert.cpp
@@ -607,7 +607,10 @@ bool ChipRDN::IsEqual(const ChipRDN & other) const
     return mString.data_equal(other.mString);
 }
 
-ChipDN::ChipDN() {}
+ChipDN::ChipDN()
+{
+    Clear();
+}
 
 ChipDN::~ChipDN() {}
 

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -193,7 +193,13 @@ struct ChipRDN
 
     bool IsEqual(const ChipRDN & other) const;
     bool IsEmpty() const { return mAttrOID == chip::ASN1::kOID_NotSpecified; }
-    void Clear() { mAttrOID = chip::ASN1::kOID_NotSpecified; }
+    void Clear()
+    {
+        mAttrOID = chip::ASN1::kOID_NotSpecified;
+        mAttrIsPrintableString = false;
+        mChipVal = 0;
+        mString = CharSpan{};
+    }
 };
 
 /**

--- a/src/credentials/CHIPCert.h
+++ b/src/credentials/CHIPCert.h
@@ -195,10 +195,10 @@ struct ChipRDN
     bool IsEmpty() const { return mAttrOID == chip::ASN1::kOID_NotSpecified; }
     void Clear()
     {
-        mAttrOID = chip::ASN1::kOID_NotSpecified;
+        mAttrOID               = chip::ASN1::kOID_NotSpecified;
         mAttrIsPrintableString = false;
-        mChipVal = 0;
-        mString = CharSpan{};
+        mChipVal               = 0;
+        mString                = CharSpan{};
     }
 };
 

--- a/src/credentials/tests/TestChipCert.cpp
+++ b/src/credentials/tests/TestChipCert.cpp
@@ -220,15 +220,24 @@ static void TestChipCert_ChipDN(nlTestSuite * inSuite, void * inContext)
     const static CATValues noc_cats = { { 0xABCD0001, chip::kUndefinedCAT, chip::kUndefinedCAT } };
 
     ChipDN chip_dn;
+    uint8_t certType = kCertType_FirmwareSigning; // Start with non-default value
+
+    NL_TEST_ASSERT(inSuite, chip_dn.IsEmpty());
+    NL_TEST_ASSERT(inSuite, chip_dn.RDNCount() == 0);
+    NL_TEST_ASSERT(inSuite, chip_dn.GetCertType(certType) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, chip_dn.IsEmpty() == true);
+    NL_TEST_ASSERT(inSuite, certType == kCertType_NotSpecified);
+
     NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_CommonName(CharSpan(noc_rdn, strlen(noc_rdn)), false) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_MatterNodeId(0xAAAABBBBCCCCDDDD) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_MatterFabricId(0xFAB00000FAB00001) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_GivenName(CharSpan(noc_rdn2, strlen(noc_rdn2)), true) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, chip_dn.AddCATs(noc_cats) == CHIP_NO_ERROR);
+    NL_TEST_ASSERT(inSuite, chip_dn.RDNCount() == 5);
 
     NL_TEST_ASSERT(inSuite, chip_dn.AddAttribute_GivenName(CharSpan(noc_rdn2, strlen(noc_rdn2)), true) == CHIP_ERROR_NO_MEMORY);
+    NL_TEST_ASSERT(inSuite, chip_dn.RDNCount() == 5);
 
-    uint8_t certType;
     NL_TEST_ASSERT(inSuite, chip_dn.GetCertType(certType) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, certType == kCertType_Node);
 


### PR DESCRIPTION
#### Problem
- ChipDN did not initialize all internal fields by default,
  which, in some situations, led to potention usage of uninitialized
  values in the ChipRDN entries

Fixes #22196

#### Change overview
- Adds default initialization of the ChipDN/ChipRDN classes

#### Testing
- Added new tests to ensure we have basic initialization
