### PR TITLE
[mrp] Fix #22167 - adjust default idle interval to match spec.

### DIFF
--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -57,7 +57,7 @@ namespace chip {
  * needs (e.g. sleeping period) using Service Discovery TXT record CRI key.
  */
 #ifndef CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
-#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL (5000_ms32)
+#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL (300_ms32)
 #endif // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
 
 /**


### PR DESCRIPTION
#### Problem
Fix #22167 
Default MRP idle interval doesn't match spec.

#### Change overview
Adjust default idle interval to match spec.

#### Testing
CI
