### PR TITLE
[QPG] Re-enable bloat reporting for QPG builds

### DIFF
--- a/.github/workflows/examples-qpg.yaml
+++ b/.github/workflows/examples-qpg.yaml
@@ -81,6 +81,17 @@ jobs:
               run: |
                   config/qpg/chip-gn/build.sh
 
+            - name: Prepare some bloat report from the previous builds
+              run: |
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    qpg qpg6105+debug lighting-app \
+                    out/qpg-light/chip-qpg6105-lighting-example.out \
+                    /tmp/bloat_reports/
+                  .environment/pigweed-venv/bin/python3 scripts/tools/memory/gh_sizes.py \
+                    qpg qpg6105+debug lock-app \
+                    out/qpg-lock/chip-qpg6105-lock-example.out \
+                    /tmp/bloat_reports/
+
             - name: Uploading Size Reports
               uses: actions/upload-artifact@v2
               if: ${{ !env.ACT }}


### PR DESCRIPTION
#### Problem
Generation of bloat reports got disabled in CI

#### Change overview
Add generation of required bloat artifacts

#### Testing
CI run passed. Check in this PR