### PR TITLE
Remove "TV Linux App" from shared linux main logs - it is confusiong …

### DIFF
--- a/examples/all-clusters-app/linux/main-common.cpp
+++ b/examples/all-clusters-app/linux/main-common.cpp
@@ -261,6 +261,6 @@ void ApplicationExit()
 
 void emberAfLowPowerClusterInitCallback(EndpointId endpoint)
 {
-    ChipLogProgress(NotSpecified, "TV Linux App: LowPower::SetDefaultDelegate");
+    ChipLogProgress(NotSpecified, "Setting LowPower default delegate to global manager");
     chip::app::Clusters::LowPower::SetDefaultDelegate(endpoint, &sLowPowerManager);
 }


### PR DESCRIPTION
…when the app is not TV

**Reason for 1.0 inclusion**: 

I was confused during testing of non-tv app by the log saying "TV app".
This is only affecting example apps not core SDK.

#### Problem
Log says "TV app" for any common linux app.

#### Change overview
Change the text.

#### Testing
N/A - it is just a text change.