### PR TITLE
Allow and ignore '-' characters in manual pairing codes.

### DIFF
--- a/src/setup_payload/ManualSetupPayloadParser.h
+++ b/src/setup_payload/ManualSetupPayloadParser.h
@@ -25,6 +25,7 @@
 
 #include "SetupPayload.h"
 
+#include <algorithm>
 #include <lib/core/CHIPError.h>
 #include <string>
 #include <utility>
@@ -41,7 +42,15 @@ private:
     std::string mDecimalStringRepresentation;
 
 public:
-    ManualSetupPayloadParser(std::string decimalRepresentation) : mDecimalStringRepresentation(std::move(decimalRepresentation)) {}
+    ManualSetupPayloadParser(std::string decimalRepresentation) : mDecimalStringRepresentation(std::move(decimalRepresentation))
+    {
+        // '-' might be being used in the decimal code as a digit group
+        // separator, to aid in readability.  It's not actually part of the
+        // decomal code, so strip it out.
+        mDecimalStringRepresentation.erase(
+            std::remove(mDecimalStringRepresentation.begin(), mDecimalStringRepresentation.end(), '-'),
+            mDecimalStringRepresentation.end());
+    }
     CHIP_ERROR populatePayload(SetupPayload & outPayload);
 
     static CHIP_ERROR CheckDecimalStringValidity(std::string decimalString, std::string & decimalStringWithoutCheckDigit);


### PR DESCRIPTION
The spec does not mention these, but the brand guidelines apparently talk about
using them.  While ideally all SDK consumers would do the right thing and strip
them out on input, we should probably also try for maximal interop and do the
same stripping in the SDK itself.

#### Problem
Using something with dashes in it as a manual pairing code does not work.

#### Change overview
Strip out '-' when initializing the manual code parser.

#### Testing
Tried doing `chip-tool pairing code` with a code with severa dashes inserted and made sure it worked.