### PR TITLE
Ignore DeviceCommissioner::OnDeviceConnectionFailureFn for unexpected devices.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1634,6 +1634,13 @@ void DeviceCommissioner::OnDeviceConnectionFailureFn(void * context, const Scope
         error = CHIP_ERROR_INTERNAL;
     }
 
+    if (commissioner->mDeviceBeingCommissioned == nullptr ||
+        commissioner->mDeviceBeingCommissioned->GetDeviceId() != peerId.GetNodeId())
+    {
+        // Not the device we are trying to commission.
+        return;
+    }
+
     if (commissioner->mCommissioningStage == CommissioningStage::kFindOperational &&
         commissioner->mCommissioningDelegate != nullptr)
     {


### PR DESCRIPTION
Just like we ignore DeviceCommissioner::OnDeviceConnectedFn if the
device id does not match mDeviceBeingCommissioned, we should ignore
OnDeviceConnectionFailureFn.

Fixes https://github.com/project-chip/connectedhomeip/issues/22244

#### Problem
See crash analysis in #22244 

#### Change overview
See above.

#### Testing
Happy path should be tested by CI.  Trying to figure out a way to test the failure case.