### PR TITLE
EFR32: PSA crypto validations fixed.

### DIFF
--- a/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
+++ b/src/platform/EFR32/Efr32PsaOpaqueKeypair.cpp
@@ -417,6 +417,8 @@ CHIP_ERROR EFR32OpaqueP256Keypair::ECDSA_sign_msg(const uint8_t * msg, size_t ms
     CHIP_ERROR error     = CHIP_NO_ERROR;
     size_t output_length = 0;
 
+    VerifyOrExit((msg != nullptr) && (msg_length > 0), error = CHIP_ERROR_INVALID_ARGUMENT);
+
     error = Sign(msg, msg_length, out_signature.Bytes(), out_signature.Capacity(), &output_length);
 
     SuccessOrExit(error);


### PR DESCRIPTION
#### Problem
Multiple unit tests fail due to validation issues.

#### Change overview
* Validations added or corrected in CHIPCryptoPALPsaEfr32.cpp and Efr32PsaOpaqueKeypair.cpp.

#### Testing
Tested on BRD4164A (MG12) and BRD4186A (MG24).