### PR TITLE
Don't notify OnSessionEstablishmentError after OnSessionEstablished.

### DIFF
--- a/src/protocols/secure_channel/CASESession.cpp
+++ b/src/protocols/secure_channel/CASESession.cpp
@@ -131,7 +131,7 @@ void CASESession::OnSessionReleased()
 {
     Clear();
     // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
+    NotifySessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
 }
 
 void CASESession::Clear()
@@ -294,7 +294,7 @@ void CASESession::AbortPendingEstablish(CHIP_ERROR err)
 {
     Clear();
     // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablishmentError(err);
+    NotifySessionEstablishmentError(err);
 }
 
 CHIP_ERROR CASESession::DeriveSecureSession(CryptoContext & session) const

--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -72,7 +72,7 @@ void PASESession::OnSessionReleased()
 {
     Clear();
     // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
+    NotifySessionEstablishmentError(CHIP_ERROR_CONNECTION_ABORTED);
 }
 
 void PASESession::Finish()
@@ -242,7 +242,7 @@ void PASESession::OnResponseTimeout(ExchangeContext * ec)
     DiscardExchange();
     Clear();
     // Do this last in case the delegate frees us.
-    mDelegate->OnSessionEstablishmentError(CHIP_ERROR_TIMEOUT);
+    NotifySessionEstablishmentError(CHIP_ERROR_TIMEOUT);
 }
 
 CHIP_ERROR PASESession::DeriveSecureSession(CryptoContext & session) const
@@ -859,7 +859,7 @@ exit:
         Clear();
         ChipLogError(SecureChannel, "Failed during PASE session setup: %" CHIP_ERROR_FORMAT, err.Format());
         // Do this last in case the delegate frees us.
-        mDelegate->OnSessionEstablishmentError(err);
+        NotifySessionEstablishmentError(err);
     }
     return err;
 }

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -192,6 +192,12 @@ protected:
     // TODO: remove Clear, we should create a new instance instead reset the old instance.
     void Clear();
 
+    /**
+     * Notify our delegate about a session establishment error, if we have not
+     * notified it of an error or success before.
+     */
+    void NotifySessionEstablishmentError(CHIP_ERROR error);
+
 protected:
     CryptoContext::SessionRole mRole;
     SessionHolderWithDelegate mSecureSessionHolder;

--- a/src/protocols/secure_channel/SessionEstablishmentDelegate.h
+++ b/src/protocols/secure_channel/SessionEstablishmentDelegate.h
@@ -36,7 +36,9 @@ class DLL_EXPORT SessionEstablishmentDelegate
 {
 public:
     /**
-     *   Called when session establishment fails with an error
+     *   Called when session establishment fails with an error.  This will be
+     *   called at most once per session establishment and will not be called if
+     *   OnSessionEstablished is called.
      */
     virtual void OnSessionEstablishmentError(CHIP_ERROR error) {}
 
@@ -46,7 +48,9 @@ public:
     virtual void OnSessionEstablishmentStarted() {}
 
     /**
-     *   Called when the new secure session has been established
+     *   Called when the new secure session has been established.  This is
+     *   mututally exclusive with OnSessionEstablishmentError for a give session
+     *   establishment.
      */
     virtual void OnSessionEstablished(const SessionHandle & session) {}
 


### PR DESCRIPTION
A PairingSession that has sent an OnSessionEstablished notification should not
send an OnSessionEstablishmentError notification after that (e.g. if the session
gets evicted).  The session is established at that point, and the
_establishment_ cannot hit an error.

This is needed to allow PASE sessions to be sanely evicted (e.g. when we're done
with them) without triggering spurious errors.

#### Problem
If we try to evict PASE sessions when CommissioneeDeviceProxy is destroyed (needed for safe shutdown), we get spurious errors in tests because the PASE session establishment state machine delivers an `OnSessionEstablishmentError` even though the session is long-since established.

#### Change overview
Stop doing that.

#### Testing
Should pass all existing tests, adds new unit test bit that fails without these changes.