### PR TITLE
Use new (std::nothrow) instead of new where the result is checked aga…

### DIFF
--- a/src/controller/CommissioningWindowOpener.cpp
+++ b/src/controller/CommissioningWindowOpener.cpp
@@ -323,7 +323,7 @@ CHIP_ERROR AutoCommissioningWindowOpener::OpenBasicCommissioningWindow(DeviceCon
                                                                        Seconds16 timeout)
 {
     // Not using Platform::New because we want to keep our constructor private.
-    auto * opener = new AutoCommissioningWindowOpener(controller);
+    auto * opener = new (std::nothrow) AutoCommissioningWindowOpener(controller);
     if (opener == nullptr)
     {
         return CHIP_ERROR_NO_MEMORY;
@@ -345,7 +345,7 @@ CHIP_ERROR AutoCommissioningWindowOpener::OpenCommissioningWindow(DeviceControll
                                                                   SetupPayload & payload, bool readVIDPIDAttributes)
 {
     // Not using Platform::New because we want to keep our constructor private.
-    auto * opener = new AutoCommissioningWindowOpener(controller);
+    auto * opener = new (std::nothrow) AutoCommissioningWindowOpener(controller);
     if (opener == nullptr)
     {
         return CHIP_ERROR_NO_MEMORY;

--- a/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
+++ b/src/controller/python/ChipCommissionableNodeController-ScriptBinding.cpp
@@ -50,7 +50,7 @@ void pychip_CommissionableNodeController_PrintDiscoveredCommissioners(
 ChipError::StorageType
 pychip_CommissionableNodeController_NewController(chip::Controller::CommissionableNodeController ** outCommissionableNodeCtrl)
 {
-    *outCommissionableNodeCtrl = new chip::Controller::CommissionableNodeController();
+    *outCommissionableNodeCtrl = new (std::nothrow) chip::Controller::CommissionableNodeController();
     VerifyOrReturnError(*outCommissionableNodeCtrl != nullptr, CHIP_ERROR_NO_MEMORY.AsInteger());
     return CHIP_NO_ERROR.AsInteger();
 }

--- a/src/controller/python/chip/interaction_model/Delegate.cpp
+++ b/src/controller/python/chip/interaction_model/Delegate.cpp
@@ -55,7 +55,7 @@ chip::ChipError::StorageType pychip_InteractionModel_GetCommandSenderHandle(uint
 {
     chip::app::CommandSender * commandSenderObj = nullptr;
     VerifyOrReturnError(commandSender != nullptr, CHIP_ERROR_INVALID_ARGUMENT.AsInteger());
-    commandSenderObj = new chip::app::CommandSender(nullptr, nullptr);
+    commandSenderObj = new (std::nothrow) chip::app::CommandSender(nullptr, nullptr);
     VerifyOrReturnError(commandSenderObj != nullptr, (CHIP_ERROR_NO_MEMORY).AsInteger());
     *commandSender = reinterpret_cast<uint64_t>(commandSenderObj);
     return CHIP_NO_ERROR.AsInteger();

--- a/src/lib/dnssd/minimal_mdns/core/tests/QNameStrings.h
+++ b/src/lib/dnssd/minimal_mdns/core/tests/QNameStrings.h
@@ -44,7 +44,7 @@ public:
             mStrings[i] = strdup(data[i]);
         }
 
-        mSerializedQNameBuffer = new uint8_t[neededSize];
+        mSerializedQNameBuffer = new (std::nothrow) uint8_t[neededSize];
         VerifyOrDie(mSerializedQNameBuffer != nullptr);
 
         chip::Encoding::BigEndian::BufferWriter writer(mSerializedQNameBuffer, neededSize);

--- a/src/system/tests/TestSystemPacketBuffer.cpp
+++ b/src/system/tests/TestSystemPacketBuffer.cpp
@@ -221,7 +221,7 @@ int PacketBufferTest::TestSetup(void * inContext)
         return FAILURE;
 
     TestContext * const theContext = reinterpret_cast<TestContext *>(inContext);
-    theContext->test               = new PacketBufferTest(theContext);
+    theContext->test               = new (std::nothrow) PacketBufferTest(theContext);
     if (theContext->test == nullptr)
     {
         return FAILURE;


### PR DESCRIPTION
…inst nullptr

#### Problem

Some code is expecting new to return `nullptr` without using `std::nothrow`

#### Change overview
 * Use `std::nothrow` 

#### Testing
I have just compiles it as it is not super convenient to test a failing new.