### PR TITLE
Fix chunking of ACL reads.

### DIFF
--- a/src/app/clusters/access-control-server/access-control-server.cpp
+++ b/src/app/clusters/access-control-server/access-control-server.cpp
@@ -461,7 +461,11 @@ CHIP_ERROR ChipErrorToImErrorMap(CHIP_ERROR err)
 
 CHIP_ERROR AccessControlAttribute::Read(const ConcreteReadAttributePath & aPath, AttributeValueEncoder & aEncoder)
 {
-    return ChipErrorToImErrorMap(ReadImpl(aPath, aEncoder));
+    // Note: We are not generating any errors under ReadImpl ourselves; it's
+    // just the IM encoding machinery that does it.  And we should propagate
+    // those errors through as-is, without mapping them to other errors, because
+    // they are used to communicate various state within said enoding machinery.
+    return ReadImpl(aPath, aEncoder);
 }
 
 CHIP_ERROR AccessControlAttribute::Write(const ConcreteDataAttributePath & aPath, AttributeValueDecoder & aDecoder)


### PR DESCRIPTION
The chunking mechanism relies on errors being propagated as-is from the encoder
to the caller of AttributeAccessInterface::Read.  So we don't want to do any
error mapping on the read errors, unlike write errors.

#### Problem
ACL reads cannot get chunked, because the cluster converts the NO_MEMORY error code into an IM code.

#### Change overview
Stop messing with the error codes.

#### Testing
Used the steps in https://github.com/project-chip/connectedhomeip/issues/22255#issuecomment-1231830923 and verified that those do the right thing with this PR (and fail without).

Fixes https://github.com/project-chip/connectedhomeip/issues/22255