### PR TITLE
[darwin_framework_tool] Add a shortcut (CTL('^')) to restart the stac…

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -95,6 +95,8 @@ protected:
 
     static std::set<CHIPCommandBridge *> sDeferredCleanups;
 
+    void RestartCommissioners();
+
 private:
     CHIP_ERROR InitializeCommissioner(std::string key, chip::FabricId fabricId,
                                       const chip::Credentials::AttestationTrustStore * trustStore);

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -19,9 +19,8 @@
 #include "InteractiveCommands.h"
 #import <Matter/Matter.h>
 
+#include <editline.h>
 #include <iomanip>
-#include <readline/history.h>
-#include <readline/readline.h>
 #include <sstream>
 
 char kInteractiveModeName[] = "";
@@ -31,6 +30,22 @@ constexpr const char * kInteractiveModeHistoryFilePath = "/tmp/darwin_framework_
 constexpr const char * kInteractiveModeStopCommand = "quit()";
 
 namespace {
+
+class RestartCommand : public CHIPCommandBridge {
+public:
+    RestartCommand()
+        : CHIPCommandBridge("restart")
+    {
+    }
+
+    CHIP_ERROR RunCommand() override
+    {
+        RestartCommissioners();
+        return CHIP_NO_ERROR;
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(0); }
+};
 
 void ClearLine()
 {
@@ -63,6 +78,13 @@ char * GetCommand(char * command)
     return command;
 }
 
+el_status_t RestartFunction()
+{
+    RestartCommand cmd;
+    cmd.RunCommand();
+    return CSstay;
+}
+
 CHIP_ERROR InteractiveStartCommand::RunCommand()
 {
     read_history(kInteractiveModeHistoryFilePath);
@@ -70,6 +92,8 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
     // Logs needs to be redirected in order to refresh the screen appropriately when something
     // is dumped to stdout while the user is typing a command.
     chip::Logging::SetLogRedirectCallback(LoggingCallback);
+
+    el_bind_key(CTL('^'), RestartFunction);
 
     char * command = nullptr;
     while (YES) {


### PR DESCRIPTION
…k while in interactive mode

#### Problem

I'm trying to reproduce some crashes that happens on darwin. Some crashes seems related to the stack trying to shutting down.

With the current patch and the following steps I can reproduce 2 crashes:
```
# Shell 1
$ ./out/debug/standalone/chip-all-clusters-app --KVS /tmp/chip_allclusters_kvs

# Shell 2
$ ./out/debug/standalone/darwin-framework-tool interactive start
# In the interactive mode window, do a full commissioning
pairing code 0x12344321 MT:-24J042C00KA0648G00
# Wait for the pairing to succeed

# Shell 1
# Ctrl^C the all-clusters-app
$ rm -rf /tmp/chip_allclusters_kvs
$ ./out/debug/standalone/chip-all-clusters-app --KVS /tmp/chip_allclusters_kvs

# Shell 2
# In the interactive mode window, do a full commissioning
pairing code 0x12344321 MT:-24J042C00KA0648G00
# At the "right time" do a Ctrl + ^. For a definition of right time see below
```
The "right time" is hard to get since operations are going very fast locally. 

To make it easier to get some crashes, one can drop some `sleep` at the right place on the server side.
 For example `sleep(5)` at the beginning of `emberAfGeneralCommissioningClusterArmFailSafeCallback` should allow to reproduce #21811.
But adding `sleep(5)` at the beginning of `emberAfGeneralCommissioningClusterCommissioningCompleteCallback` should get you a different stack. Pretty similar to #21130 but not coming from a timer firing.
For reference the stack is: 
```
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x17f0000c4)
  * frame #0: 0x0000000104b81e84 Matter`chip::Controller::DeviceCommissioner::CommissioningStageComplete(this=0x0000623000001d00, err=(mError = 50, mFile = "../../../../../../../../../../src/app/CommandSender.cpp", mLine = 224), report=CommissioningReport @ 0x00007ffeefbfd608) at CHIPDeviceController.cpp:1551:58
    frame #1: 0x0000000104b85802 Matter`chip::Controller::OnBasicFailure(context=0x0000623000001d00, error=(mError = 50, mFile = "../../../../../../../../../../src/app/CommandSender.cpp", mLine = 224)) at CHIPDeviceController.cpp:1448:19
    frame #2: 0x0000000104088271 Matter`chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(this=0x000060f00001ab18, aError=(mError = 50, mFile = "../../../../../../../../../../src/app/CommandSender.cpp", mLine = 224))(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError)::operator()(chip::ChipError) const at CHIPCluster.h:83:70
    frame #3: 0x0000000104088203 Matter`decltype(__f=0x000060f00001ab18, __args=0x00007ffeefbfd800)(std::__1::forward<chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type const&, void*, void (*)(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError)&>(fp0)...)) std::__1::__invoke<chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type const&, void*, void (*)(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError)&, chip::ChipError>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type&&, chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type const&, void*, void (*)(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError)&...) at type_traits:3747:1
    frame #4: 0x0000000104088172 Matter`void std::__1::__invoke_void_return_wrapper<void>::__call<chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(__args=0x000060f00001ab18, __args=0x00007ffeefbfd800)(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError)&, chip::ChipError>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type&&...) at __functional_base:348:9
    frame #5: 0x0000000104088132 Matter`std::__1::__function::__alloc_func<chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type const&, void*, void (*)(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError), std::__1::allocator<chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type const&, void*, void (*)(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError)>, void (chip::ChipError)>::operator(this=0x000060f00001ab18, __arg=0x00007ffeefbfd800)(chip::ChipError&&) at functional:1553:16
    frame #6: 0x0000000104086e93 Matter`std::__1::__function::__func<chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type const&, void*, void (*)(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError), std::__1::allocator<chip::ChipError chip::Controller::ClusterBase::InvokeCommand<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type>(chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type const&, void*, void (*)(void*, chip::app::Clusters::GeneralCommissioning::Commands::CommissioningComplete::Type::ResponseType const&), void (*)(void*, chip::ChipError), chip::Optional<unsigned short> const&)::'lambda'(chip::ChipError)>, void (chip::ChipError)>::operator(this=0x000060f00001ab10, __arg=0x00007ffeefbfd800)(chip::ChipError&&) at functional:1727:12
    frame #7: 0x000000010343dded Matter`std::__1::__function::__value_func<void (chip::ChipError)>::operator(this=0x000060f00001ab10, __args=0x00007ffeefbfd800)(chip::ChipError&&) const at functional:1880:16
    frame #8: 0x000000010343227c Matter`std::__1::function<void (chip::ChipError)>::operator(this=0x000060f00001ab10, __arg=(mError = 50, mFile = "../../../../../../../../../../src/app/CommandSender.cpp", mLine = 224))(chip::ChipError) const at functional:2555:12
    frame #9: 0x0000000104082d23 Matter`chip::Controller::TypedCommandCallback<chip::app::Clusters::GeneralCommissioning::Commands::CommissioningCompleteResponse::DecodableType>::OnError(this=0x000060f00001aad0, apCommandSender=0x00006130000264c0, aError=(mError = 50, mFile = "../../../../../../../../../../src/app/CommandSender.cpp", mLine = 224)) at TypedCommandCallback.h:72:9
    frame #10: 0x0000000104b21f41 Matter`chip::app::CommandSender::OnResponseTimeout(this=0x00006130000264c0, apExchangeContext=0x000060c000032500) at CommandSender.cpp:224:21
    frame #11: 0x000000010344f085 Matter`chip::Messaging::ExchangeHolder::OnResponseTimeout(this=0x00006130000264c8, ec=0x000060c000032500) at ExchangeHolder.h:122:87
    frame #12: 0x0000000104c32c19 Matter`chip::Messaging::ExchangeContext::NotifyResponseTimeout(this=0x000060c000032500, aCloseIfNeeded=false) at ExchangeContext.cpp:481:19
    frame #13: 0x0000000104c32a71 Matter`chip::Messaging::ExchangeContext::OnSessionReleased(this=0x000060c000032500) at ExchangeContext.cpp:408:9
    frame #14: 0x0000000104b93010 Matter`chip::SessionHolderWithDelegate::SessionReleased(this=0x000060c000032540) at SessionHolder.h:98:19
    frame #15: 0x0000000104c65559 Matter`chip::Transport::Session::NotifySessionReleased(this=0x00006110001de100) at Session.h:124:31
    frame #16: 0x0000000104c5889c Matter`chip::Transport::SecureSession::MarkForEviction(this=0x00006110001de100) at SecureSession.cpp:149:9
    frame #17: 0x0000000104c65bf4 Matter`auto chip::SessionManager::ExpireAllSessionsForFabric(this=0x00007ffeefbfda98, session=0x00006110001de100)::$_2::operator()<chip::Transport::SecureSession*>(chip::Transport::SecureSession*) const at SessionManager.cpp:370:22
    frame #18: 0x0000000104c65b53 Matter`chip::internal::LambdaProxy<chip::Transport::SecureSession, chip::SessionManager::ExpireAllSessionsForFabric(unsigned char)::$_2>::Call(context=0x00007ffeefbfda98, target=0x00006110001de100) at Pool.h:126:16
    frame #19: 0x0000000104c2d217 Matter`chip::internal::HeapObjectList::ForEachNode(this=0x00006110001ad078, context=0x00007ffeefbfda98, lambda=(Matter`chip::internal::LambdaProxy<chip::Transport::SecureSession, chip::SessionManager::ExpireAllSessionsForFabric(unsigned char)::$_2>::Call(void*, void*) at Pool.h:125))(void*, void*)) at Pool.cpp:126:17
    frame #20: 0x0000000104c65add Matter`chip::Loop chip::HeapObjectPool<chip::Transport::SecureSession>::ForEachActiveObject<chip::SessionManager::ExpireAllSessionsForFabric(this=0x00006110001ad068, function=0x00007ffeefbfdaf8)::$_2>(chip::SessionManager::ExpireAllSessionsForFabric(unsigned char)::$_2&&) at Pool.h:401:25
    frame #21: 0x0000000104c5fda3 Matter`chip::Loop chip::Transport::SecureSessionTable::ForEachSession<chip::SessionManager::ExpireAllSessionsForFabric(unsigned char)::$_2>(this=0x00006110001ad060, function=0x00007ffeefbfdaf8)::$_2&&) at SecureSessionTable.h:84:25
    frame #22: 0x0000000104c5fd63 Matter`chip::SessionManager::ExpireAllSessionsForFabric(this=0x00006110001ad000, fabricIndex='\x01') at SessionManager.cpp:367:21
    frame #23: 0x0000000104b7e34d Matter`chip::Controller::DeviceController::Shutdown(this=0x0000623000001d00) at CHIPDeviceController.cpp:304:37
    frame #24: 0x0000000104b7fdaa Matter`chip::Controller::DeviceCommissioner::Shutdown(this=0x0000623000001d00) at CHIPDeviceController.cpp:495:23
    frame #25: 0x0000000103557030 Matter`-[MTRDeviceController shutDownCppController](self=0x000061b000000780, _cmd="shutDownCppController") at MTRDeviceController.mm:133:27
    frame #26: 0x000000010338956c Matter`-[MTRControllerFactory(self=0x000060b000084a90, _cmd="controllerShuttingDown:", controller=0x000061b000000780) controllerShuttingDown:] at MTRControllerFactory.mm:554:9
    frame #27: 0x0000000103556fdc Matter`-[MTRDeviceController cleanupAfterStartup](self=0x000061b000000780, _cmd="cleanupAfterStartup") at MTRDeviceController.mm:124:5
    frame #28: 0x0000000103556fa8 Matter`-[MTRDeviceController shutdown](self=0x000061b000000780, _cmd="shutdown") at MTRDeviceController.mm:118:5
    frame #29: 0x00000001000e01b2 darwin-framework-tool`CHIPCommandBridge::RestartCommissioners(this=0x00007ffeefbfe080) at CHIPCommandBridge.mm:142:9
    frame #30: 0x0000000101d81103 darwin-framework-tool`(anonymous namespace)::RestartCommand::RunCommand(this=0x00007ffeefbfe080) at InteractiveCommands.mm:43:9
    frame #31: 0x0000000101d80f0c darwin-framework-tool`RestartFunction() at InteractiveCommands.mm:84:9
    frame #32: 0x0000000101de5d44 darwin-framework-tool`emacs(c=30) at editline.c:1118:13
    frame #33: 0x0000000101de3c86 darwin-framework-tool`editinput(complete=1) at editline.c:1201:21
    frame #34: 0x0000000101de3e71 darwin-framework-tool`readline(prompt=">>> ") at editline.c:1580:22
    frame #35: 0x0000000101d80d24 darwin-framework-tool`GetCommand(command=0x0000000000000000) at InteractiveCommands.mm:70:15
    frame #36: 0x0000000101d81282 darwin-framework-tool`InteractiveStartCommand::RunCommand(this=0x0000611000001300) at InteractiveCommands.mm:100:19
    frame #37: 0x00000001000dc428 darwin-framework-tool`CHIPCommandBridge::Run(this=0x0000611000001300) at CHIPCommandBridge.mm:43:5
    frame #38: 0x000000010009a5fd darwin-framework-tool`Commands::RunCommand(this=0x00007ffeefbff640, argc=3, argv=0x00007ffeefbff768, interactive=false) at Commands.cpp:147:65
    frame #39: 0x0000000100098c55 darwin-framework-tool`Commands::Run(this=0x00007ffeefbff640, argc=3, argv=0x00007ffeefbff768) at Commands.cpp:51:11
    frame #40: 0x0000000100221f57 darwin-framework-tool`main(argc=3, argv=0x00007ffeefbff768) at main.mm:41:21

```

#### Change overview
* Add a new option in interactive mode for the `darwin-framework-tool` in order to restart the stack. Using a shortcut to make it fast.

#### Testing
Aș explained in the description I have used this setup to reproduce some crashes.
I am pretty sure that those are not related to darwin, one may implement a similar mechanism for `chip-tool`.

I would like to land that in `master` as I believed it does not affect the core SDK but only provide another way of reproducing some SDK behaviour via a tool.