### PR TITLE
Increase the chip-tool timeout for data model commands.

### DIFF
--- a/examples/chip-tool/commands/clusters/ModelCommand.h
+++ b/examples/chip-tool/commands/clusters/ModelCommand.h
@@ -54,7 +54,7 @@ public:
 
     /////////// CHIPCommand Interface /////////
     CHIP_ERROR RunCommand() override;
-    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.ValueOr(10)); }
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(mTimeout.ValueOr(20)); }
 
     virtual CHIP_ERROR SendCommand(chip::DeviceProxy * device, std::vector<chip::EndpointId> endPointIds) = 0;
 


### PR DESCRIPTION
10s is not enough for a typical CASE establishment plus command
execution on less-high-powered devices.

Fixes https://github.com/project-chip/connectedhomeip/issues/22213

#### Problem
Commands timing out because 10s is not long enough to establish CASE.

#### Change overview
Increase default timeout.

#### Testing
@bluebin14 tested this with the slow devices he's dealing with and it helps a lot.