### PR TITLE
Map CHIP_ERROR_FABRIC_EXISTS into a dedicated Darwin error code.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRError.h
+++ b/src/darwin/Framework/CHIP/MTRError.h
@@ -23,12 +23,15 @@ FOUNDATION_EXPORT NSErrorDomain const MTRErrorDomain;
 FOUNDATION_EXPORT NSErrorDomain const MTRInteractionErrorDomain;
 
 /**
- * ChipErrorDomain contains errors caused by data processing the framework
+ * MTRErrorDomain contains errors caused by data processing the framework
  * itself is performing.  These can be caused by invalid values provided to a
  * framework API, failure to decode an incoming message, and so forth.
  *
- * Errors reported by the other side of a Matter interaction use
- * MTRInteractionErrorDomain instead.
+ * This error domain also contains errors that are communicated via success
+ * responses from a server but mapped to an error on the client.
+ *
+ * Errors reported by the server side of a Matter interaction via the normal
+ * Matter error-reporting mechanisms use MTRInteractionErrorDomain instead.
  */
 // clang-format off
 typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
@@ -51,6 +54,11 @@ typedef NS_ERROR_ENUM(MTRErrorDomain, MTRErrorCode){
     MTRErrorCodeIntegrityCheckFailed = 8,
     MTRErrorCodeTimeout              = 9,
     MTRErrorCodeBufferTooSmall       = 10,
+    /**
+     * MTRErrorCodeFabricExists is returned when trying to commission a device
+     * into a fabric when it's already part of that fabric.
+     */
+    MTRErrorCodeFabricExists         = 11,
 };
 // clang-format on
 

--- a/src/darwin/Framework/CHIP/MTRError.mm
+++ b/src/darwin/Framework/CHIP/MTRError.mm
@@ -80,6 +80,11 @@ NSString * const MTRInteractionErrorDomain = @"MTRInteractionErrorDomain";
     } else if (errorCode == CHIP_ERROR_BUFFER_TOO_SMALL) {
         code = MTRErrorCodeBufferTooSmall;
         [userInfo addEntriesFromDictionary:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"A buffer is too small.", nil) }];
+    } else if (errorCode == CHIP_ERROR_FABRIC_EXISTS) {
+        code = MTRErrorCodeFabricExists;
+        [userInfo addEntriesFromDictionary:@{
+            NSLocalizedDescriptionKey : NSLocalizedString(@"The device is already a member of this fabric.", nil)
+        }];
     } else {
         code = MTRErrorCodeGeneralError;
         [userInfo addEntriesFromDictionary:@{


### PR DESCRIPTION
This allows detection of this case without having to examine the
"underlyingError" of the NSError's userInfo.

Fixes https://github.com/project-chip/connectedhomeip/issues/22214

#### Problem
See #22214

#### Change overview
Add a new Objective C error code constant for the "fabric exists" case.
