### PR TITLE
Add missing null checks on PacketBufferHandle::New calls

### DIFF
--- a/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
+++ b/examples/chip-tool/commands/pairing/CloseSessionCommand.cpp
@@ -44,7 +44,9 @@ CHIP_ERROR CloseSessionCommand::CloseSession(Messaging::ExchangeManager & exchan
                                              SecureChannel::kProtocolCodeCloseSession);
 
     size_t reportSize = statusReport.Size();
-    Encoding::LittleEndian::PacketBufferWriter bbuf(MessagePacketBuffer::New(reportSize), reportSize);
+    auto packetBuffer = MessagePacketBuffer::New(reportSize);
+    VerifyOrReturnError(!packetBuffer.IsNull(), CHIP_ERROR_NO_MEMORY);
+    Encoding::LittleEndian::PacketBufferWriter bbuf(std::move(packetBuffer), reportSize);
     statusReport.WriteToBuffer(bbuf);
 
     System::PacketBufferHandle msg = bbuf.Finalize();

--- a/src/app/BufferedReadCallback.cpp
+++ b/src/app/BufferedReadCallback.cpp
@@ -117,6 +117,7 @@ CHIP_ERROR BufferedReadCallback::BufferListItem(TLV::TLVReader & reader)
     // we can improve this.
     //
     handle = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
+    VerifyOrReturnError(!handle.IsNull(), CHIP_ERROR_NO_MEMORY);
 
     writer.Init(std::move(handle), false);
 

--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -128,6 +128,7 @@ CHIP_ERROR ClusterStateCache::UpdateEventCache(const EventHeader & aEventHeader,
             return CHIP_NO_ERROR;
         }
         System::PacketBufferHandle handle = System::PacketBufferHandle::New(chip::app::kMaxSecureSduLengthBytes);
+        VerifyOrReturnError(!handle.IsNull(), CHIP_ERROR_NO_MEMORY);
 
         System::PacketBufferTLVWriter writer;
         writer.Init(std::move(handle), false);

--- a/src/protocols/secure_channel/PairingSession.h
+++ b/src/protocols/secure_channel/PairingSession.h
@@ -142,7 +142,10 @@ protected:
 
         Protocols::SecureChannel::StatusReport statusReport(generalCode, Protocols::SecureChannel::Id, protocolCode);
 
-        Encoding::LittleEndian::PacketBufferWriter bbuf(System::PacketBufferHandle::New(statusReport.Size()));
+        auto handle = System::PacketBufferHandle::New(statusReport.Size());
+        VerifyOrReturn(!handle.IsNull(), ChipLogError(SecureChannel, "Failed to allocate status report message"));
+        Encoding::LittleEndian::PacketBufferWriter bbuf(std::move(handle));
+
         statusReport.WriteToBuffer(bbuf);
 
         System::PacketBufferHandle msg = bbuf.Finalize();

--- a/src/setup_payload/AdditionalDataPayloadGenerator.cpp
+++ b/src/setup_payload/AdditionalDataPayloadGenerator.cpp
@@ -53,7 +53,9 @@ AdditionalDataPayloadGenerator::generateAdditionalDataPayload(AdditionalDataPayl
     TLVWriter innerWriter;
 
     // Initialize TLVWriter
-    writer.Init(chip::System::PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize));
+    auto tempBuffer = chip::System::PacketBufferHandle::New(chip::System::PacketBuffer::kMaxSize);
+    VerifyOrReturnError(!tempBuffer.IsNull(), CHIP_ERROR_NO_MEMORY);
+    writer.Init(std::move(tempBuffer));
 
     ReturnErrorOnFailure(writer.OpenContainer(AnonymousTag(), kTLVType_Structure, innerWriter));
 


### PR DESCRIPTION
#### Problem
- Some callers of PacketBufferHandle::New did not null-check on
  failure to allocate. This is strongly linked to some crashes

Fixes #22262

#### Change overview
- Adds missing null checks required by API contract

#### Testing
- Unit tests still pass
- Conditions under which a crash previously occured no longer see
  a crash occur in manual testing against a real DUT
