### PR TITLE
Fix endpoint index lookups to handle invalid endpoint ids correctly.

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -187,6 +187,11 @@ void emberAfSetDynamicEndpointCount(uint16_t dynamicEndpointCount)
 
 uint16_t emberAfGetDynamicIndexFromEndpoint(EndpointId id)
 {
+    if (id == kInvalidEndpointId)
+    {
+        return kEmberInvalidEndpointIndex;
+    }
+
     uint16_t index;
     for (index = FIXED_ENDPOINT_COUNT; index < MAX_ENDPOINT_COUNT; index++)
     {
@@ -831,6 +836,11 @@ static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterI
         {
             break;
         }
+        if (emAfEndpoints[i].endpoint == kInvalidEndpointId)
+        {
+            // Not actually a configured endpoint.
+            continue;
+        }
         epi = static_cast<uint16_t>(
             epi + ((emberAfFindClusterIncludingDisabledEndpoints(emAfEndpoints[i].endpoint, clusterId, mask) != nullptr) ? 1 : 0));
     }
@@ -840,6 +850,11 @@ static uint16_t findClusterEndpointIndex(EndpointId endpoint, ClusterId clusterI
 
 static uint16_t findIndexFromEndpoint(EndpointId endpoint, bool ignoreDisabledEndpoints)
 {
+    if (endpoint == kInvalidEndpointId)
+    {
+        return kEmberInvalidEndpointIndex;
+    }
+
     uint16_t epi;
     for (epi = 0; epi < emberAfEndpointCount(); epi++)
     {


### PR DESCRIPTION
There are some code paths that loop over all endpoint indices (including ones
that do not have an endpoint defined yet) and then use the endpoint id to look
up endpoint indices.  Make sure we don't claim an endpoint index for the "not an
endpoint" endpoint id.

Also fixes findClusterEndpointIndex to check for the invalid endpoint id before
working with it, since that means the endpoint index it's looking at does not
correspond to a defined endpoint.

Fixes https://github.com/project-chip/connectedhomeip/issues/22272

#### Problem
Crashes due to trying to work with not-actually-defined endpoints.

#### Change overview
Make sure we don't do that.

#### Testing
@latch-danielkneip verified that this fixes #22272 for him.