### PR TITLE
[EFR32] Add openthread lib with coap api enabled

### DIFF
--- a/scripts/examples/gn_efr32_example.sh
+++ b/scripts/examples/gn_efr32_example.sh
@@ -156,6 +156,10 @@ else
                 optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" "
                 shift
                 ;;
+            --use_ot_coap_lib)
+                optArgs+="use_silabs_thread_lib=true chip_openthread_target=$SILABS_THREAD_TARGET openthread_external_platform=\"""\" use_thread_coap_lib=true "
+                shift
+                ;;
             *)
                 if [ "$1" =~ *"use_rs911x=true"* ] || [ "$1" =~ *"use_wf200=true"* ]; then
                     USE_WIFI=true

--- a/third_party/silabs/BUILD.gn
+++ b/third_party/silabs/BUILD.gn
@@ -23,6 +23,7 @@ declare_args() {
   efr32_sdk_target = ""
   sl_ot_efr32_root = "${chip_root}/third_party/openthread/ot-efr32"
   sl_openthread_root = "${chip_root}/third_party/openthread/ot-efr32/openthread"
+  use_thread_coap_lib = false
 }
 
 assert(efr32_sdk_target != "", "efr32_sdk_target must be specified")
@@ -131,7 +132,7 @@ if (use_silabs_thread_lib) {
       ":libopenthread-platform",
       ":openthread_core_config_efr32",
       "${segger_rtt_root}:segger_rtt",
-      "${sl_openthread_root}/include/openthread:openthread-platform",
+      "${sl_openthread_root}/include/openthread:openthread",
       "${sl_openthread_root}/src/core/:libopenthread_core_headers",
     ]
 
@@ -143,10 +144,16 @@ if (use_silabs_thread_lib) {
       XTD = "mtd"
     }
 
+    # Use silabs openthread library stack with or without coap api enabled
+    COAP_API = ""
+    if (use_thread_coap_lib) {
+      COAP_API = "coap_"
+    }
+
     public_configs += [ "${sl_openthread_root}:openthread_${XTD}_config" ]
 
     libs = [
-      "${sl_ot_efr32_root}/libs/libsl_ot_stack_${XTD}_${efr32_family}_gcc.a",
+      "${sl_ot_efr32_root}/libs/libsl_ot_stack_${XTD}_${COAP_API}${efr32_family}_gcc.a",
       "${sl_ot_efr32_root}/libs/libsl_platform_${XTD}_dmp_${efr32_family}_gcc.a",
     ]
   }


### PR DESCRIPTION
#### Problem
Some clients want to use the silabs openthread library but with coap api feature enabled

#### Change overview
Provide this new libs option and provide a way for client to use with to run SVE 2.
- ot-efr32 submodule update that adds and supports the coap lib
- Add build argument to be able that selects the coap lib rather and the standard lib
- set a new prefix that set all the arguments to build the coap lib in the efr32 build example script

#### Testing
Build all 3 options for efr32 (Openthread from source, from standard lib, from lib with coap) with lighting app
Commission and control all 3 resultant apps with chip-tool


