### PR TITLE
Fix use-after-free in AndroidDeviceControllerWrapper

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -20,6 +20,9 @@
 
 #include <algorithm>
 #include <memory>
+#include <vector>
+
+#include <string.h>
 
 #include <lib/support/CodeUtils.h>
 #include <lib/support/JniReferences.h>
@@ -223,9 +226,24 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
         JniByteArray jniIcac(env, intermediateCertificate);
         JniByteArray jniNoc(env, nodeOperationalCertificate);
 
-        setupParams.controllerRCAC = jniRcac.byteSpan();
-        setupParams.controllerICAC = jniIcac.byteSpan();
-        setupParams.controllerNOC  = jniNoc.byteSpan();
+        // Make copies of the cert that outlive the scope so that future factor init does not
+        // cause loss of scope from the JNI refs going away. Also, this keeps the certs
+        // handy for debugging commissioner init.
+        wrapper->mRcacCertificate = std::vector<uint8_t>(jniRcac.byteSpan().begin(), jniRcac.byteSpan().end());
+        if (!jniIcac.byteSpan().empty())
+        {
+            wrapper->mIcacCertificate = std::vector<uint8_t>(jniIcac.byteSpan().begin(), jniIcac.byteSpan().end());
+        }
+        else
+        {
+            wrapper->mIcacCertificate.clear();
+        }
+
+        wrapper->mNocCertificate = std::vector<uint8_t>(jniNoc.byteSpan().begin(), jniNoc.byteSpan().end());
+
+        setupParams.controllerRCAC = chip::ByteSpan(wrapper->mRcacCertificate.data(), wrapper->mRcacCertificate.size());
+        setupParams.controllerICAC = chip::ByteSpan(wrapper->mIcacCertificate.data(), wrapper->mIcacCertificate.size());
+        setupParams.controllerNOC  = chip::ByteSpan(wrapper->mNocCertificate.data(), wrapper->mNocCertificate.size());
     }
     else
     {
@@ -275,10 +293,12 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     ChipLogByteSpan(Support, compressedFabricIdSpan);
 
     chip::ByteSpan ipkSpan;
+    std::vector<uint8_t> ipkBuffer;
     if (ipkEpochKey != nullptr)
     {
         JniByteArray jniIpk(env, ipkEpochKey);
-        ipkSpan = jniIpk.byteSpan();
+        ipkBuffer = std::vector<uint8_t>(jniIpk.byteSpan().begin(), jniIpk.byteSpan().end());
+        ipkSpan = chip::ByteSpan(ipkBuffer.data(), ipkBuffer.size());
     }
     else
     {
@@ -287,6 +307,9 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
 
     *errInfoOnFailure = chip::Credentials::SetSingleIpkEpochKey(
         &wrapper->mGroupDataProvider, wrapper->Controller()->GetFabricIndex(), ipkSpan, compressedFabricIdSpan);
+
+    memset(ipkBuffer.data(), 0, ipkBuffer.size());
+
     if (*errInfoOnFailure != CHIP_NO_ERROR)
     {
         return nullptr;

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -298,7 +298,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     {
         JniByteArray jniIpk(env, ipkEpochKey);
         ipkBuffer = std::vector<uint8_t>(jniIpk.byteSpan().begin(), jniIpk.byteSpan().end());
-        ipkSpan = chip::ByteSpan(ipkBuffer.data(), ipkBuffer.size());
+        ipkSpan   = chip::ByteSpan(ipkBuffer.data(), ipkBuffer.size());
     }
     else
     {

--- a/src/controller/java/AndroidDeviceControllerWrapper.h
+++ b/src/controller/java/AndroidDeviceControllerWrapper.h
@@ -20,6 +20,7 @@
 #include <lib/support/JniReferences.h>
 
 #include <memory>
+#include <vector>
 
 #include <jni.h>
 
@@ -176,6 +177,10 @@ private:
     const char * password              = nullptr;
     jbyteArray operationalDatasetBytes = nullptr;
     jbyte * operationalDataset         = nullptr;
+
+    std::vector<uint8_t> mNocCertificate;
+    std::vector<uint8_t> mIcacCertificate;
+    std::vector<uint8_t> mRcacCertificate;
 
     chip::Controller::AutoCommissioner mAutoCommissioner;
 


### PR DESCRIPTION
#### Problem
- Some JNI array refererences we used beyond their live scope in init
  of the `AndroidDeviceControllerWrapper`, causing either crashes or
  errors, in probabilistic situations (not easily reproducible, but
  seen in larger scale testing)

Fixes: #22279

#### Change overview
- Ensures a copy exists of the originally "passed by JNI reference" data,
  up to the point it is no longer used, for NOC, ICAC, RCAC and IPK.

#### Testing
- Integrations test pass
- Testing done also in field trials by some participants
