### PR TITLE
Prevent Reads/Subscription to attributes with no access privilege

### DIFF
--- a/src/app/MessageDef/AttributePathIB.cpp
+++ b/src/app/MessageDef/AttributePathIB.cpp
@@ -227,6 +227,62 @@ CHIP_ERROR AttributePathIB::Parser::GetListIndex(ConcreteDataAttributePath & aAt
     return err;
 }
 
+CHIP_ERROR AttributePathIB::Parser::ParsePath(AttributePathParams & aAttribute) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = GetEndpoint(&(aAttribute.mEndpointId));
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aAttribute.HasWildcardEndpointId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    err = GetCluster(&aAttribute.mClusterId);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(IsValidClusterId(aAttribute.mClusterId), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    err = GetAttribute(&aAttribute.mAttributeId);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(IsValidAttributeId(aAttribute.mAttributeId), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    // A wildcard cluster requires that the attribute path either be
+    // wildcard or a global attribute.
+    VerifyOrReturnError(!aAttribute.HasWildcardClusterId() || aAttribute.HasWildcardAttributeId() ||
+                            IsGlobalAttribute(aAttribute.mAttributeId),
+                        CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    err = GetListIndex(&aAttribute.mListIndex);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aAttribute.HasWildcardAttributeId() && !aAttribute.HasWildcardListIndex(),
+                            CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    return err;
+}
+
 AttributePathIB::Builder & AttributePathIB::Builder::EnableTagCompression(const bool aEnableTagCompression)
 {
     // skip if error has already been set

--- a/src/app/MessageDef/AttributePathIB.h
+++ b/src/app/MessageDef/AttributePathIB.h
@@ -153,6 +153,14 @@ public:
     CHIP_ERROR GetListIndex(ConcreteDataAttributePath & aAttributePath) const;
 
     // TODO(#14934) Add a function to get ConcreteDataAttributePath from AttributePathIB::Parser directly.
+
+    /**
+     * @brief Parse the attribute path into an AttributePathParams object. As part of parsing,
+     * validity checks for each path item will be done as well.
+     *
+     * If any errors are encountered, an IM error of 'InvalidAction' will be returned.
+     */
+    CHIP_ERROR ParsePath(AttributePathParams & attribute) const;
 };
 
 class Builder : public ListBuilder

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -26,6 +26,8 @@
 
 #include <app/AppConfig.h>
 
+#include <protocols/interaction_model/Constants.h>
+
 namespace chip {
 namespace app {
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
@@ -169,6 +171,49 @@ CHIP_ERROR EventPathIB::Parser::GetEventPath(ConcreteEventPath * const apPath) c
 CHIP_ERROR EventPathIB::Parser::GetIsUrgent(bool * const apIsUrgent) const
 {
     return GetSimpleValue(to_underlying(Tag::kIsUrgent), TLV::kTLVType_Boolean, apIsUrgent);
+}
+
+CHIP_ERROR EventPathIB::Parser::ParsePath(EventPathParams & aEvent) const
+{
+    CHIP_ERROR err = GetEndpoint(&(aEvent.mEndpointId));
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aEvent.HasWildcardEndpointId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    err = GetCluster(&(aEvent.mClusterId));
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aEvent.HasWildcardClusterId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    ReturnErrorOnFailure(err);
+
+    err = GetEvent(&(aEvent.mEventId));
+    if (CHIP_END_OF_TLV == err)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    else if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aEvent.HasWildcardEventId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    ReturnErrorOnFailure(err);
+
+    err = GetIsUrgent(&(aEvent.mIsUrgentEvent));
+    if (CHIP_END_OF_TLV == err)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    return err;
 }
 
 EventPathIB::Builder & EventPathIB::Builder::Node(const NodeId aNode)

--- a/src/app/MessageDef/EventPathIB.h
+++ b/src/app/MessageDef/EventPathIB.h
@@ -127,6 +127,8 @@ public:
      *          #CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB if the path from the reader is not a valid concrere event path.
      */
     CHIP_ERROR GetEventPath(ConcreteEventPath * const apPath) const;
+
+    CHIP_ERROR ParsePath(EventPathParams & aEvent) const;
 };
 
 class Builder : public ListBuilder

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -362,8 +362,8 @@ private:
     CHIP_ERROR SendSubscribeResponse();
     CHIP_ERROR ProcessSubscribeRequest(System::PacketBufferHandle && aPayload);
     CHIP_ERROR ProcessReadRequest(System::PacketBufferHandle && aPayload);
-    CHIP_ERROR ProcessAttributePathList(AttributePathIBs::Parser & aAttributePathListParser);
-    CHIP_ERROR ProcessEventPaths(EventPathIBs::Parser & aEventPathsParser);
+    CHIP_ERROR ProcessAttributePaths(AttributePathIBs::Parser & aAttributePathListParser, bool & aHasAttributePath);
+    CHIP_ERROR ProcessEventPaths(EventPathIBs::Parser & aEventPathsParser, bool & aHasEventPath);
     CHIP_ERROR ProcessEventFilters(EventFilterIBs::Parser & aEventFiltersParser);
     CHIP_ERROR OnStatusResponse(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload,
                                 bool & aSendStatusResponse);


### PR DESCRIPTION
#### Problem

Reads and Subscribes from nodes with no access still get serviced to completion (which for subs mean that a subscription is established). This ends up stealing precious resources from nodes that do have access.

#18485.
Rework from https://github.com/project-chip/connectedhomeip/pull/18645
merged spec change is https://github.com/CHIP-Specifications/connectedhomeip-spec/pull/5241

### Fix

Prevents reads/subs from moving past the processing stage to actual allocation of resources. A StatusResponse is returned immediately.

Caveat: This doesn't address lack of access for event paths. That will come separately.

### Testing
add unit test to validate empty attribute paths and event paths in read/subscribe request
add unit test to validate non-exist attribute path and event paths in read/subscribe request
working on unit test to validate acl-denied attribute path and event path in read/subscribe request