### PR TITLE
Fix crashes when last controller is shut down while a PASE session is outstanding.

### DIFF
--- a/src/controller/CommissioneeDeviceProxy.cpp
+++ b/src/controller/CommissioneeDeviceProxy.cpp
@@ -109,7 +109,14 @@ CHIP_ERROR CommissioneeDeviceProxy::SetConnected(const SessionHandle & session)
     return CHIP_NO_ERROR;
 }
 
-CommissioneeDeviceProxy::~CommissioneeDeviceProxy() {}
+CommissioneeDeviceProxy::~CommissioneeDeviceProxy()
+{
+    auto session = GetSecureSession();
+    if (session.HasValue())
+    {
+        session.Value()->AsSecureSession()->MarkForEviction();
+    }
+}
 
 CHIP_ERROR CommissioneeDeviceProxy::SetPeerId(ByteSpan rcac, ByteSpan noc)
 {


### PR DESCRIPTION
Commissioner shutdown shuts down the CASE sessions associated with the
commissioner, but not the PASE sessions.  Those sessions then get shut down
much later in shutdown, at which point various objects that are needed to
handle the shutdown are no longer present.

The fix is to shut down PASE sessions when we destroy CommissioneeDeviceProxy
objects, and ensure that we always destroy CommissioneeDeviceProxy via
ReleaseCommissioneeDevice, so we don't end up with dangling pointers to the
objects.

Fixes https://github.com/project-chip/connectedhomeip/issues/16440

Should vastly improve, if not completely fix,
https://github.com/project-chip/connectedhomeip/issues/20880 which is a very common crash we are seeing.

#### Problem
Crashes during shutdown of the Matter stack.

#### Change overview
Clean up PASE sessions earlier in shutdown.

#### Testing
Should pass existing tests.