### PR TITLE
Fix DeviceProxy selection in AutoCommissioner.

### DIFF
--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -562,7 +562,7 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
 DeviceProxy * AutoCommissioner::GetDeviceProxyForStep(CommissioningStage nextStage)
 {
     if (nextStage == CommissioningStage::kSendComplete ||
-        (nextStage == CommissioningStage::kCleanup && mOperationalDeviceProxy.ConnectionReady()))
+        (nextStage == CommissioningStage::kCleanup && mOperationalDeviceProxy.GetDeviceId() != kUndefinedNodeId))
     {
         return &mOperationalDeviceProxy;
     }


### PR DESCRIPTION
Before https://github.com/project-chip/connectedhomeip/pull/21256
AutoCommissioner used the operational proxy if it existed at all.  This could
happen even if it was disconnected, as long as it had been connected at some
point in the past.

This was accidentally changed to "use the operational proxy only if it's
connected" in https://github.com/project-chip/connectedhomeip/pull/21256.

This can lead to a crash, as described in
https://github.com/project-chip/connectedhomeip/pull/22268#issuecomment-1231859000,
if shutdown happens after the operational proxy is connected but before we get
a response to CommissioningComplete.  In that case, we will evict our CASE
session, which will error out the CommissioningComplete command we sent and try
to clean up, but it will select the (now dangling!) mCommissioneeDeviceProxy
instead of correctly selecting mOperationalDeviceProxy, because the
mOperationalDeviceProxy no longer has a session at that point.

The fix is to check for an "initialized" (in the sense that it has a valid peer
node id) mOperationalDeviceProxy instead of checking for a connected one.  This
matches the semantics of the check we used to have before
https://github.com/project-chip/connectedhomeip/pull/21256.

Fixes https://github.com/project-chip/connectedhomeip/issues/22293

#### Problem
See above.

#### Change overview
See above.

#### Testing
Used the steps in https://github.com/project-chip/connectedhomeip/pull/22268#issuecomment-1231859000 and verified that this fix fixes the crash there.