### PR TITLE
[mrp] Fix #23137 - adjust assumed idle interval to match spec.

### DIFF
--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -34,7 +34,7 @@ using namespace System::Clock::Literals;
 ReliableMessageProtocolConfig GetDefaultMRPConfig()
 {
     // Default MRP intervals are defined in spec <2.11.3. Parameters and Constants>
-    static constexpr const System::Clock::Milliseconds32 idleRetransTimeout   = 4000_ms32;
+    static constexpr const System::Clock::Milliseconds32 idleRetransTimeout   = 300_ms32;
     static constexpr const System::Clock::Milliseconds32 activeRetransTimeout = 300_ms32;
     return ReliableMessageProtocolConfig(idleRetransTimeout, activeRetransTimeout);
 }


### PR DESCRIPTION
#### Problem
Fix #23137

Spawned from issue #22167 and abandoned PR #22216.
Assumed MRP idle interval when none is advertised doesn't match spec.

#### Change overview
Adjust assumed idle interval to match spec.

#### Testing
CI.  The impact of this change should only be on when IDLE interval is elided from mDNS TXT records, and what value is assumed to be when elided.