### PR TITLE
Refactor to separate app platform code. support dynamic discovery.

### DIFF
--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/MainActivity.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/MainActivity.java
@@ -7,7 +7,7 @@ import com.google.android.material.bottomnavigation.BottomNavigationView;
 import com.matter.tv.server.fragments.ContentAppFragment;
 import com.matter.tv.server.fragments.QrCodeFragment;
 import com.matter.tv.server.fragments.TerminalFragment;
-import com.matter.tv.server.service.MatterServant;
+import com.matter.tv.server.service.AppPlatformService;
 import java.util.LinkedHashMap;
 
 public class MainActivity extends AppCompatActivity {
@@ -43,7 +43,7 @@ public class MainActivity extends AppCompatActivity {
 
     // MainActivity is needed to launch dialog prompt
     // in UserPrompter
-    MatterServant.get().setActivity(this);
+    AppPlatformService.get().setActivity(this);
 
     BottomNavigationView bottomNavigationView = findViewById(R.id.bottom_navigation);
     bottomNavigationView.setOnItemSelectedListener(navListener);

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/AppPlatformService.java
@@ -1,0 +1,114 @@
+/*
+ *   Copyright (c) 2021-2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.matter.tv.server.service;
+
+import android.app.Activity;
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import androidx.annotation.NonNull;
+import com.matter.tv.server.MatterCommissioningPrompter;
+import com.matter.tv.server.handlers.ContentAppEndpointManagerImpl;
+import com.matter.tv.server.model.ContentApp;
+import com.matter.tv.server.receivers.ContentAppDiscoveryService;
+import com.matter.tv.server.tvapp.AppPlatform;
+
+public class AppPlatformService {
+
+  private AppPlatform mAppPlatform;
+  private BroadcastReceiver mBroadcastReceiver;
+
+  private AppPlatformService() {}
+
+  private static class SingletonHolder {
+    static AppPlatformService instance = new AppPlatformService();
+  }
+
+  public static AppPlatformService get() {
+    return SingletonHolder.instance;
+  }
+
+  private Context context;
+  private Activity activity;
+
+  public void init(@NonNull Context context) {
+    this.context = context;
+    mAppPlatform =
+        new AppPlatform(
+            new MatterCommissioningPrompter(activity), new ContentAppEndpointManagerImpl(context));
+    ContentAppDiscoveryService.getReceiverInstance().registerSelf(context.getApplicationContext());
+    for (ContentApp app :
+        ContentAppDiscoveryService.getReceiverInstance().getDiscoveredContentApps().values()) {
+      addContentApp(app);
+    }
+    registerReceiver();
+  }
+
+  private void registerReceiver() {
+    mBroadcastReceiver =
+        new BroadcastReceiver() {
+          @Override
+          public void onReceive(Context context, Intent intent) {
+            String action = intent.getAction();
+            String packageName =
+                intent.getStringExtra(
+                    ContentAppDiscoveryService.DISCOVERY_APPAGENT_EXTRA_PACKAGENAME);
+            if (action.equals(ContentAppDiscoveryService.DISCOVERY_APPAGENT_ACTION_ADD)) {
+              ContentApp app =
+                  ContentAppDiscoveryService.getReceiverInstance()
+                      .getDiscoveredContentApps()
+                      .get(packageName);
+              addContentApp(app);
+            } else if (action.equals(ContentAppDiscoveryService.DISCOVERY_APPAGENT_ACTION_REMOVE)) {
+              int endpointId =
+                  intent.getIntExtra(
+                      ContentAppDiscoveryService.DISCOVERY_APPAGENT_EXTRA_ENDPOINTID, -1);
+              if (endpointId != -1) {
+                removeContentApp(endpointId);
+              }
+            }
+          }
+        };
+    context.registerReceiver(
+        mBroadcastReceiver,
+        new IntentFilter(ContentAppDiscoveryService.DISCOVERY_APPAGENT_ACTION_ADD));
+    context.registerReceiver(
+        mBroadcastReceiver,
+        new IntentFilter(ContentAppDiscoveryService.DISCOVERY_APPAGENT_ACTION_REMOVE));
+  }
+
+  public void setActivity(Activity activity) {
+    this.activity = activity;
+  }
+
+  public void addContentApp(ContentApp app) {
+    app.setEndpointId(
+        mAppPlatform.addContentApp(
+            app.getVendorName(),
+            app.getVendorId(),
+            app.getAppName(),
+            app.getProductId(),
+            "1.0",
+            new ContentAppEndpointManagerImpl(context)));
+  }
+
+  public int removeContentApp(int endpointID) {
+    return mAppPlatform.removeContentApp(endpointID);
+  }
+}

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/MatterServant.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/MatterServant.java
@@ -17,7 +17,6 @@
  */
 package com.matter.tv.server.service;
 
-import android.app.Activity;
 import android.content.Context;
 import android.util.Log;
 import androidx.annotation.NonNull;
@@ -30,9 +29,6 @@ import chip.platform.NsdManagerServiceBrowser;
 import chip.platform.NsdManagerServiceResolver;
 import chip.platform.PreferencesConfigurationManager;
 import chip.platform.PreferencesKeyValueStoreManager;
-import com.matter.tv.server.MatterCommissioningPrompter;
-import com.matter.tv.server.handlers.ContentAppEndpointManagerImpl;
-import com.matter.tv.server.model.ContentApp;
 import com.matter.tv.server.tvapp.ChannelManagerStub;
 import com.matter.tv.server.tvapp.Clusters;
 import com.matter.tv.server.tvapp.ContentLaunchManagerStub;
@@ -69,7 +65,6 @@ public class MatterServant {
   }
 
   private Context context;
-  private Activity activity;
 
   public void init(@NonNull Context context) {
 
@@ -117,7 +112,6 @@ public class MatterServant {
               }
             });
     mTvApp.setDACProvider(new DACProviderStub());
-    mTvApp.setUserPrompter(new MatterCommissioningPrompter(activity));
 
     mTvApp.setChipDeviceEventProvider(
         new DeviceEventProvider() {
@@ -144,8 +138,6 @@ public class MatterServant {
 
     chipAppServer = new ChipAppServer();
     chipAppServer.startApp();
-
-    mTvApp.postServerInit(new ContentAppEndpointManagerImpl(context));
   }
 
   public void restart() {
@@ -158,10 +150,6 @@ public class MatterServant {
     mIsOn = !mIsOn;
   }
 
-  public void setActivity(Activity activity) {
-    this.activity = activity;
-  }
-
   public void sendCustomCommand(String customCommand) {
     Log.i(MatterServant.class.getName(), customCommand);
     // TODO: insert logic ot send custom command here
@@ -169,19 +157,5 @@ public class MatterServant {
 
   public void updateLevel(int value) {
     mTvApp.setCurrentLevel(mLevelEndpoint, value);
-  }
-
-  public int addContentApp(ContentApp app) {
-    return mTvApp.addContentApp(
-        app.getVendorName(),
-        app.getVendorId(),
-        app.getAppName(),
-        app.getProductId(),
-        "1.0",
-        new ContentAppEndpointManagerImpl(context));
-  }
-
-  public void sendTestMessage(int endpoint, String message) {
-    mTvApp.sendTestMessage(endpoint, message);
   }
 }

--- a/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/MatterServantService.java
+++ b/examples/tv-app/android/App/platform-app/src/main/java/com/matter/tv/server/service/MatterServantService.java
@@ -12,8 +12,6 @@ import androidx.annotation.Nullable;
 import androidx.core.app.NotificationCompat;
 import com.matter.tv.server.MainActivity;
 import com.matter.tv.server.R;
-import com.matter.tv.server.model.ContentApp;
-import com.matter.tv.server.receivers.ContentAppDiscoveryService;
 
 public class MatterServantService extends Service {
   private static final String CHANNEL_ID = "Matter";
@@ -24,12 +22,7 @@ public class MatterServantService extends Service {
     // Start Matter Server
     MatterServant.get().init(this.getApplicationContext());
 
-    // Register for packages updates
-    ContentAppDiscoveryService.getReceiverInstance().registerSelf(this.getApplicationContext());
-    for (ContentApp app :
-        ContentAppDiscoveryService.getReceiverInstance().getDiscoveredContentApps().values()) {
-      app.setEndpointId(MatterServant.get().addContentApp(app));
-    }
+    AppPlatformService.get().init(this.getApplicationContext());
   }
 
   @Nullable

--- a/examples/tv-app/android/BUILD.gn
+++ b/examples/tv-app/android/BUILD.gn
@@ -39,6 +39,8 @@ shared_library("jni") {
     "include/target-navigator/TargetNavigatorManager.h",
     "java/AppImpl.cpp",
     "java/AppImpl.h",
+    "java/AppPlatform-JNI.cpp",
+    "java/AppPlatform-JNI.h",
     "java/AppPlatformShellCommands-JNI.cpp",
     "java/AppPlatformShellCommands-JNI.h",
     "java/ChannelManager.cpp",
@@ -105,6 +107,7 @@ android_library("java") {
   ]
 
   sources = [
+    "java/src/com/matter/tv/server/tvapp/AppPlatform.java",
     "java/src/com/matter/tv/server/tvapp/AppPlatformShellCommands.java",
     "java/src/com/matter/tv/server/tvapp/ChannelInfo.java",
     "java/src/com/matter/tv/server/tvapp/ChannelLineupInfo.java",

--- a/examples/tv-app/android/java/AppImpl.h
+++ b/examples/tv-app/android/java/AppImpl.h
@@ -53,10 +53,9 @@
 #include <app/clusters/target-navigator-server/target-navigator-delegate.h>
 
 CHIP_ERROR InitVideoPlayerPlatform(JNIMyUserPrompter * userPrompter, jobject contentAppEndpointManager);
-CHIP_ERROR PreServerInit();
 EndpointId AddContentApp(const char * szVendorName, uint16_t vendorId, const char * szApplicationName, uint16_t productId,
                          const char * szApplicationVersion, jobject manager);
-void SendTestMessage(EndpointId epID, const char * message);
+EndpointId RemoveContentApp(EndpointId epId);
 
 #if CHIP_DEVICE_CONFIG_APP_PLATFORM_ENABLED
 
@@ -133,7 +132,7 @@ public:
 
     EndpointId AddContentApp(ContentAppImpl * app, jobject contentAppEndpointManager);
 
-    void SendTestMessage(EndpointId epID, const char * message);
+    EndpointId RemoveContentApp(EndpointId epId);
 
     // Gets the catalog vendor ID used by this platform
     uint16_t GetPlatformCatalogVendorId() override;

--- a/examples/tv-app/android/java/AppPlatform-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatform-JNI.cpp
@@ -1,0 +1,66 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+#include "AppPlatform-JNI.h"
+#include "AppImpl.h"
+
+#include "MyUserPrompter-JNI.h"
+
+#include <jni.h>
+#include <lib/core/CHIPError.h>
+#include <lib/support/CHIPJNIError.h>
+#include <lib/support/JniReferences.h>
+#include <lib/support/JniTypeWrappers.h>
+
+using namespace chip;
+using namespace chip::app;
+using namespace chip::AppPlatform;
+using namespace chip::Credentials;
+
+#define JNI_METHOD(RETURN, METHOD_NAME)                                                                                            \
+    extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_tv_server_tvapp_AppPlatform_##METHOD_NAME
+
+AppPlatformJNI AppPlatformJNI::sInstance;
+
+JNI_METHOD(void, nativeInit)(JNIEnv *, jobject app, jobject prompter, jobject contentAppEndpointManager)
+{
+    chip::DeviceLayer::StackLock lock;
+    InitVideoPlayerPlatform(new JNIMyUserPrompter(prompter), contentAppEndpointManager);
+}
+
+JNI_METHOD(jint, addContentApp)
+(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jobject manager)
+{
+    chip::DeviceLayer::StackLock lock;
+    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
+
+    JniUtfString vName(env, vendorName);
+    JniUtfString aName(env, appName);
+    JniUtfString aVersion(env, appVersion);
+    EndpointId epId = AddContentApp(vName.c_str(), static_cast<uint16_t>(vendorId), aName.c_str(), static_cast<uint16_t>(productId),
+                                    aVersion.c_str(), manager);
+    return static_cast<uint16_t>(epId);
+}
+
+JNI_METHOD(jint, removeContentApp)
+(JNIEnv *, jobject, jint endpointId)
+{
+    chip::DeviceLayer::StackLock lock;
+    EndpointId epId = RemoveContentApp(static_cast<EndpointId>(endpointId));
+    return static_cast<uint16_t>(epId);
+}

--- a/examples/tv-app/android/java/AppPlatform-JNI.h
+++ b/examples/tv-app/android/java/AppPlatform-JNI.h
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <jni.h>
+
+class AppPlatformJNI
+{
+
+private:
+    friend AppPlatformJNI & AppPlatformJNIMgr();
+
+    static AppPlatformJNI sInstance;
+};
+
+inline class AppPlatformJNI & AppPlatformJNIMgr()
+{
+    return AppPlatformJNI::sInstance;
+}

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.cpp
@@ -37,31 +37,6 @@ namespace AppPlatform {
 using CommandHandlerInterface = chip::app::CommandHandlerInterface;
 using LaunchResponseType      = chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::Type;
 
-const char * ContentAppCommandDelegate::sendCommand(chip::EndpointId epID, std::string commandPayload)
-{
-    // to support the hardcoded sample apps.
-    if (mSendCommandMethod == nullptr)
-    {
-        return "Failed";
-    }
-
-    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-    UtfString jCommandPayload(env, commandPayload.c_str());
-    ChipLogProgress(Zcl, "ContentAppCommandDelegate::sendCommand with payload %s", commandPayload.c_str());
-    jstring resp = (jstring) env->CallObjectMethod(mContentAppEndpointManager, mSendCommandMethod, static_cast<jint>(epID),
-                                                   jCommandPayload.jniValue());
-    if (env->ExceptionCheck())
-    {
-        ChipLogError(Zcl, "Java exception in ContentAppCommandDelegate::sendCommand");
-        env->ExceptionDescribe();
-        env->ExceptionClear();
-        // TODO : Need to have proper errors passed back.
-        return "Failed";
-    }
-    const char * ret = env->GetStringUTFChars(resp, 0);
-    return ret;
-}
-
 void ContentAppCommandDelegate::InvokeCommand(CommandHandlerInterface::HandlerContext & handlerContext)
 {
     if (handlerContext.mRequestPath.mEndpointId >= FIXED_ENDPOINT_COUNT)

--- a/examples/tv-app/android/java/ContentAppCommandDelegate.h
+++ b/examples/tv-app/android/java/ContentAppCommandDelegate.h
@@ -59,8 +59,6 @@ public:
 
     void InvokeCommand(CommandHandlerInterface::HandlerContext & handlerContext) override;
 
-    const char * sendCommand(chip::EndpointId epID, std::string commandPayload);
-
 private:
     void InitializeJNIObjects(jobject manager)
     {

--- a/examples/tv-app/android/java/MyUserPrompterResolver-JNI.cpp
+++ b/examples/tv-app/android/java/MyUserPrompterResolver-JNI.cpp
@@ -31,6 +31,7 @@ using namespace chip;
 JNI_METHOD(void, OnPinCodeEntered)(JNIEnv *, jobject, jint jPinCode)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    chip::DeviceLayer::StackLock lock;
     uint32_t pinCode = (uint32_t) jPinCode;
     ChipLogProgress(Zcl, "OnPinCodeEntered %d", pinCode);
     GetCommissionerDiscoveryController()->CommissionWithPincode(pinCode);
@@ -40,6 +41,7 @@ JNI_METHOD(void, OnPinCodeEntered)(JNIEnv *, jobject, jint jPinCode)
 JNI_METHOD(void, OnPinCodeDeclined)(JNIEnv *, jobject)
 {
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
+    chip::DeviceLayer::StackLock lock;
     ChipLogProgress(Zcl, "OnPinCodeDeclined");
     GetCommissionerDiscoveryController()->Cancel();
 #endif

--- a/examples/tv-app/android/java/TVApp-JNI.cpp
+++ b/examples/tv-app/android/java/TVApp-JNI.cpp
@@ -17,7 +17,6 @@
  */
 
 #include "TvApp-JNI.h"
-#include "AppImpl.h"
 #include "ChannelManager.h"
 #include "ContentLauncherManager.h"
 #include "DeviceCallbacks.h"
@@ -43,7 +42,6 @@
 
 using namespace chip;
 using namespace chip::app;
-using namespace chip::AppPlatform;
 using namespace chip::Credentials;
 
 #define JNI_METHOD(RETURN, METHOD_NAME) extern "C" JNIEXPORT RETURN JNICALL Java_com_matter_tv_server_tvapp_TvApp_##METHOD_NAME
@@ -153,16 +151,12 @@ JNI_METHOD(void, preServerInit)(JNIEnv *, jobject app)
 {
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(Zcl, "TvAppJNI::preServerInit");
-
-    PreServerInit();
 }
 
 JNI_METHOD(void, postServerInit)(JNIEnv *, jobject app, jobject contentAppEndpointManager)
 {
     chip::DeviceLayer::StackLock lock;
     ChipLogProgress(Zcl, "TvAppJNI::postServerInit");
-
-    InitVideoPlayerPlatform(userPrompter, contentAppEndpointManager);
 }
 
 JNI_METHOD(void, setOnOffManager)(JNIEnv *, jobject, jint endpoint, jobject manager)
@@ -188,26 +182,4 @@ JNI_METHOD(jboolean, setCurrentLevel)(JNIEnv *, jobject, jint endpoint, jboolean
 JNI_METHOD(void, setChipDeviceEventProvider)(JNIEnv *, jobject, jobject provider)
 {
     DeviceCallbacks::NewManager(provider);
-}
-
-JNI_METHOD(jint, addContentApp)
-(JNIEnv *, jobject, jstring vendorName, jint vendorId, jstring appName, jint productId, jstring appVersion, jobject manager)
-{
-    chip::DeviceLayer::StackLock lock;
-    JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
-
-    JniUtfString vName(env, vendorName);
-    JniUtfString aName(env, appName);
-    JniUtfString aVersion(env, appVersion);
-    EndpointId epId = AddContentApp(vName.c_str(), static_cast<uint16_t>(vendorId), aName.c_str(), static_cast<uint16_t>(productId),
-                                    aVersion.c_str(), manager);
-    return static_cast<uint16_t>(epId);
-}
-
-JNI_METHOD(void, sendTestMessage)(JNIEnv *, jobject, jint endpoint, jstring message)
-{
-    JNIEnv * env          = JniReferences::GetInstance().GetEnvForCurrentThread();
-    const char * nmessage = env->GetStringUTFChars(message, 0);
-    ChipLogProgress(Zcl, "TvApp-JNI SendTestMessage called with message %s", nmessage);
-    SendTestMessage(static_cast<EndpointId>(endpoint), nmessage);
 }

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/AppPlatform.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/AppPlatform.java
@@ -1,0 +1,42 @@
+/*
+ *   Copyright (c) 2021 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.matter.tv.server.tvapp;
+
+public class AppPlatform {
+  private static final String TAG = "AppPlatform";
+
+  public AppPlatform(UserPrompter userPrompter, ContentAppEndpointManager manager) {
+    nativeInit(userPrompter, manager);
+  }
+
+  public native void nativeInit(UserPrompter userPrompter, ContentAppEndpointManager manager);
+
+  public native int addContentApp(
+      String vendorName,
+      int vendorId,
+      String appName,
+      int productId,
+      String appVersion,
+      ContentAppEndpointManager manager);
+
+  public native int removeContentApp(int endpointId);
+
+  static {
+    System.loadLibrary("TvApp");
+  }
+}

--- a/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/TvApp.java
+++ b/examples/tv-app/android/java/src/com/matter/tv/server/tvapp/TvApp.java
@@ -69,18 +69,6 @@ public class TvApp {
 
   public native void setChipDeviceEventProvider(DeviceEventProvider provider);
 
-  public native int addContentApp(
-      String vendorName,
-      int vendorId,
-      String appName,
-      int productId,
-      String appVersion,
-      ContentAppEndpointManager manager);
-
-  public native void sendTestMessage(int endpoint, String message);
-
-  public native void setUserPrompter(UserPrompter userPrompter);
-
   static {
     System.loadLibrary("TvApp");
   }


### PR DESCRIPTION
#### Problem
Content apps were not being updated after first startup of the platform-app.

#### Change overview
Started supporting dynamic update of content apps on uninstall/install when the platform-app is already running.
Also refactored the code to separate out chip server startup code from contentappplatform initialization.

#### Testing
Testing was done manually using the chip tool.