### PR TITLE
Add a new use-only-on-network-discovery optional option to pairing code and pairing code-paseonly

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -81,6 +81,7 @@ public:
         case PairingMode::CodePaseOnly:
             AddArgument("payload", &mOnboardingPayload);
             AddArgument("discover-once", 0, 1, &mDiscoverOnce);
+            AddArgument("use-only-onnetwork-discovery", 0, 1, &mUseOnlyOnNetworkDiscovery);
             break;
         case PairingMode::Ble:
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
@@ -163,6 +164,7 @@ private:
     NodeId mNodeId;
     chip::Optional<uint16_t> mTimeout;
     chip::Optional<bool> mDiscoverOnce;
+    chip::Optional<bool> mUseOnlyOnNetworkDiscovery;
     uint16_t mRemotePort;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;

--- a/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
+++ b/src/app/tests/suites/commands/commissioner/CommissionerCommands.cpp
@@ -32,7 +32,11 @@ CommissionerCommands::PairWithCode(const char * identity,
     memset(code, '\0', sizeof(code));
     memcpy(code, value.payload.data(), value.payload.size());
     ChipLogError(chipTool, "Pairing Code is %s", code);
-    return GetCommissioner(identity).PairDevice(value.nodeId, code);
+
+    // To reduce the scanning latency in some setups, and since the primary use for PairWithCode is to commission a device to
+    // another commissioner, assume that the commissionable device is available on the network.
+    chip::Controller::DiscoveryType discoveryType = chip::Controller::DiscoveryType::kDiscoveryNetworkOnly;
+    return GetCommissioner(identity).PairDevice(value.nodeId, code, discoveryType);
 }
 
 CHIP_ERROR CommissionerCommands::Unpair(const char * identity,

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -573,7 +573,8 @@ CHIP_ERROR DeviceCommissioner::GetDeviceBeingCommissioned(NodeId deviceId, Commi
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, const CommissioningParameters & params)
+CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, const CommissioningParameters & params,
+                                          DiscoveryType discoveryType)
 {
     MATTER_TRACE_EVENT_SCOPE("PairDevice", "DeviceCommissioner");
     if (mDefaultCommissioner == nullptr)
@@ -583,21 +584,13 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * se
     }
     ReturnErrorOnFailure(mDefaultCommissioner->SetCommissioningParameters(params));
 
-    auto threadCredentials = params.GetThreadOperationalDataset();
-    auto wiFiCredentials   = params.GetWiFiCredentials();
-    bool hasCredentials    = threadCredentials.HasValue() || wiFiCredentials.HasValue();
-
-    // If there is no network credentials, we assume that the pairing command as been issued to pair with a
-    // device that is already on the network.
-    auto pairerBehaviour = hasCredentials ? SetupCodePairerBehaviour::kCommission : SetupCodePairerBehaviour::kCommissionOnNetwork;
-
-    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, pairerBehaviour);
+    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType);
 }
 
-CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode)
+CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType)
 {
     MATTER_TRACE_EVENT_SCOPE("PairDevice", "DeviceCommissioner");
-    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission);
+    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kCommission, discoveryType);
 }
 
 CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParameters & params)
@@ -615,10 +608,10 @@ CHIP_ERROR DeviceCommissioner::PairDevice(NodeId remoteDeviceId, RendezvousParam
     return Commission(remoteDeviceId, commissioningParams);
 }
 
-CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode)
+CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType)
 {
     MATTER_TRACE_EVENT_SCOPE("EstablishPASEConnection", "DeviceCommissioner");
-    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kPaseOnly);
+    return mSetUpCodePairer.PairDevice(remoteDeviceId, setUpCode, SetupCodePairerBehaviour::kPaseOnly, discoveryType);
 }
 
 CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, RendezvousParameters & params)

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -403,9 +403,11 @@ public:
      *
      * @param[in] remoteDeviceId        The remote device Id.
      * @param[in] setUpCode             The setup code for connecting to the device
+     * @param[in] discoveryType         The network discovery type, defaults to DiscoveryType::kAll.
      */
-    CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode);
-    CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode, const CommissioningParameters & CommissioningParameters);
+    CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode, DiscoveryType discoveryType = DiscoveryType::kAll);
+    CHIP_ERROR PairDevice(NodeId remoteDeviceId, const char * setUpCode, const CommissioningParameters & CommissioningParameters,
+                          DiscoveryType discoveryType = DiscoveryType::kAll);
 
     /**
      * @brief
@@ -466,8 +468,10 @@ public:
      *
      * @param[in] remoteDeviceId        The remote device Id.
      * @param[in] setUpCode             The setup code for connecting to the device
+     * @param[in] discoveryType         The network discovery type, defaults to DiscoveryType::kAll.
      */
-    CHIP_ERROR EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode);
+    CHIP_ERROR EstablishPASEConnection(NodeId remoteDeviceId, const char * setUpCode,
+                                       DiscoveryType discoveryType = DiscoveryType::kAll);
 
     /**
      * @brief

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -36,12 +36,14 @@ constexpr uint32_t kDeviceDiscoveredTimeout = CHIP_CONFIG_SETUP_CODE_PAIRER_DISC
 namespace chip {
 namespace Controller {
 
-CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, SetupCodePairerBehaviour commission)
+CHIP_ERROR SetUpCodePairer::PairDevice(NodeId remoteId, const char * setUpCode, SetupCodePairerBehaviour commission,
+                                       DiscoveryType discoveryType)
 {
     VerifyOrReturnError(mSystemLayer != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     SetupPayload payload;
     mConnectionType = commission;
+    mDiscoveryType  = discoveryType;
 
     bool isQRCode = strncmp(setUpCode, kQRCodePrefix, strlen(kQRCodePrefix)) == 0;
     if (isQRCode)
@@ -73,7 +75,7 @@ CHIP_ERROR SetUpCodePairer::Connect(SetupPayload & payload)
 
     bool searchOverAll = !payload.rendezvousInformation.HasValue();
 
-    if (mConnectionType != SetupCodePairerBehaviour::kCommissionOnNetwork)
+    if (mDiscoveryType == DiscoveryType::kAll)
     {
         if (searchOverAll || payload.rendezvousInformation.Value().Has(RendezvousInformationFlag::kBLE))
         {
@@ -229,8 +231,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
         ExpectPASEEstablishment();
 
         CHIP_ERROR err;
-        if (mConnectionType == SetupCodePairerBehaviour::kCommission ||
-            mConnectionType == SetupCodePairerBehaviour::kCommissionOnNetwork)
+        if (mConnectionType == SetupCodePairerBehaviour::kCommission)
         {
             err = mCommissioner->PairDevice(mRemoteId, params);
         }

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -51,8 +51,13 @@ class DeviceCommissioner;
 enum class SetupCodePairerBehaviour : uint8_t
 {
     kCommission,
-    kCommissionOnNetwork,
     kPaseOnly,
+};
+
+enum class DiscoveryType : uint8_t
+{
+    kDiscoveryNetworkOnly,
+    kAll,
 };
 
 class DLL_EXPORT SetUpCodePairer : public DevicePairingDelegate
@@ -62,7 +67,8 @@ public:
     virtual ~SetUpCodePairer() {}
 
     CHIP_ERROR PairDevice(chip::NodeId remoteId, const char * setUpCode,
-                          SetupCodePairerBehaviour connectionType = SetupCodePairerBehaviour::kCommission);
+                          SetupCodePairerBehaviour connectionType = SetupCodePairerBehaviour::kCommission,
+                          DiscoveryType discoveryType             = DiscoveryType::kAll);
 
     // Called by the DeviceCommissioner to notify that we have discovered a new device.
     void NotifyCommissionableDeviceDiscovered(const chip::Dnssd::DiscoveredNodeData & nodeData);
@@ -152,6 +158,7 @@ private:
     chip::NodeId mRemoteId;
     uint32_t mSetUpPINCode                   = 0;
     SetupCodePairerBehaviour mConnectionType = SetupCodePairerBehaviour::kCommission;
+    DiscoveryType mDiscoveryType             = DiscoveryType::kAll;
 
     // While we are trying to pair, we intercept the DevicePairingDelegate
     // notifications from mCommissioner.  We want to make sure we send them on


### PR DESCRIPTION
#### Problem

https://github.com/project-chip/connectedhomeip/pull/22104 changed things so we do only on-network discovery if we don't have network credentials at commissioning start.

The problem is that is has generated #22195 which break some commissioning flow from some vendors. So instead of trying to be "smart", this PR is adding an explicit option to `chip-tool` to only perform on-network discovery.

It should not creates any SDK behaviour changes since by default this flag is off and the only consumer that can turn it on at the moment is `chip-tool`. The original issue that #22104 was trying to fix is an issue that happens in lab-like environment when there is a certain amount of devices that where making scanning very slow...

v1.0 justification is that this PR is trying to solve the initial problem than #22104 was trying to solve in a way that does not break things. This is purely for cert test purposes and should not introduce any regression into the SDK as the toggle is explicit this time.

#### Change overview
* Add an explicit option to force `on-network` discovery and skipping other networks

#### Testing
```
# with a chip-tool build that has BLE enabled
$ ./out/debug/standalone/chip-tool pairing code 0x12344321 MT:-24J042C00KA0648G00 --use-only-onnetwork-discovery 1
```
