### PR TITLE
[nrfconnect] Reduce MCUBoot parititon size on nRF53

### DIFF
--- a/examples/all-clusters-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/all-clusters-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/all-clusters-minimal-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/all-clusters-minimal-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/light-switch-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/light-switch-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/lighting-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/lighting-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/lock-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/lock-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/pump-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/pump-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/pump-controller-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/pump-controller-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:

--- a/examples/window-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
+++ b/examples/window-app/nrfconnect/configuration/nrf5340dk_nrf5340_cpuapp/pm_static_dfu.yml
@@ -1,27 +1,27 @@
 mcuboot:
     address: 0x0
-    size: 0xC000
+    size: 0x8000
     region: flash_primary
 mcuboot_pad:
-    address: 0xC000
+    address: 0x8000
     size: 0x200
 app:
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 mcuboot_primary:
     orig_span: &id001
         - mcuboot_pad
         - app
     span: *id001
-    address: 0xC000
-    size: 0xef000
+    address: 0x8000
+    size: 0xf3000
     region: flash_primary
 mcuboot_primary_app:
     orig_span: &id002
         - app
     span: *id002
-    address: 0xC200
-    size: 0xeee00
+    address: 0x8200
+    size: 0xf2e00
 factory_data:
     address: 0xfb000
     size: 0x1000
@@ -37,17 +37,17 @@ mcuboot_primary_1:
     region: ram_flash
 mcuboot_secondary:
     address: 0x0
-    size: 0xef000
+    size: 0xf3000
     device: MX25R64
     region: external_flash
 mcuboot_secondary_1:
-    address: 0xef000
+    address: 0xf3000
     size: 0x40000
     device: MX25R64
     region: external_flash
 external_flash:
-    address: 0x12f000
-    size: 0x6D1000
+    address: 0x133000
+    size: 0x6CD000
     device: MX25R64
     region: external_flash
 pcd_sram:


### PR DESCRIPTION
#### Problem
The current MCUBoot partition size of 48kB on nRF53 SoCs seems to be needlessly large.

#### Change overview
 Reduce MCUBoot parititon by 16kB to leave more flash space for applications.

#### Testing
CI tested, smoke tested a single example on hardware.
