### PR TITLE
OTA: Fix linux BlockEOF with data length zero

### DIFF
--- a/src/platform/Linux/OTAImageProcessorImpl.cpp
+++ b/src/platform/Linux/OTAImageProcessorImpl.cpp
@@ -68,11 +68,6 @@ CHIP_ERROR OTAImageProcessorImpl::ProcessBlock(ByteSpan & block)
         return CHIP_ERROR_INTERNAL;
     }
 
-    if ((block.data() == nullptr) || block.empty())
-    {
-        return CHIP_ERROR_INVALID_ARGUMENT;
-    }
-
     // Store block data for HandleProcessBlock to access
     CHIP_ERROR err = SetBlock(block);
     if (err != CHIP_NO_ERROR)


### PR DESCRIPTION
#### Problem
Fixes issue #22308 where linux currently doesn't support BlockEOF of data length zero. 

#### Change overview
Remove this check, it is checked immediately after in SetBlock: https://github.com/project-chip/connectedhomeip/blob/master/src/platform/Linux/OTAImageProcessorImpl.cpp#L244
But at this point the block is released correctly and it does not return an error.

#### Testing
Did an ota which finished with a BlockEOF with data length zero and confirmed it finished. 
