### PR TITLE
Issue 22318 - commissioner attestation delegate should be able to override success

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -793,8 +793,8 @@ CHIP_ERROR DeviceCommissioner::Commission(NodeId remoteDeviceId)
 }
 
 CHIP_ERROR
-DeviceCommissioner::ContinueCommissioningAfterDeviceAttestationFailure(DeviceProxy * device,
-                                                                       Credentials::AttestationVerificationResult attestationResult)
+DeviceCommissioner::ContinueCommissioningAfterDeviceAttestation(DeviceProxy * device,
+                                                                Credentials::AttestationVerificationResult attestationResult)
 {
     MATTER_TRACE_EVENT_SCOPE("continueCommissioningDevice", "DeviceCommissioner");
     if (device == nullptr || device != mDeviceBeingCommissioned)
@@ -990,7 +990,8 @@ void DeviceCommissioner::OnAttestationResponse(void * context,
     commissioner->CommissioningStageComplete(CHIP_NO_ERROR, report);
 }
 
-void DeviceCommissioner::OnDeviceAttestationInformationVerification(void * context, AttestationVerificationResult result)
+void DeviceCommissioner::OnDeviceAttestationInformationVerification(
+    void * context, const Credentials::DeviceAttestationVerifier::AttestationInfo & info, AttestationVerificationResult result)
 {
     MATTER_TRACE_EVENT_SCOPE("OnDeviceAttestationInformationVerification", "DeviceCommissioner");
     DeviceCommissioner * commissioner = reinterpret_cast<DeviceCommissioner *>(context);
@@ -1000,6 +1001,9 @@ void DeviceCommissioner::OnDeviceAttestationInformationVerification(void * conte
         ChipLogError(Controller, "Device attestation verification result received when we're not commissioning a device");
         return;
     }
+
+    auto & params = commissioner->mDefaultCommissioner->GetCommissioningParameters();
+    Credentials::DeviceAttestationDelegate * deviceAttestationDelegate = params.GetDeviceAttestationDelegate();
 
     if (result != AttestationVerificationResult::kSuccess)
     {
@@ -1021,14 +1025,11 @@ void DeviceCommissioner::OnDeviceAttestationInformationVerification(void * conte
         // Go look at AttestationVerificationResult enum in src/credentials/attestation_verifier/DeviceAttestationVerifier.h to
         // understand the errors.
 
-        auto & params = commissioner->mDefaultCommissioner->GetCommissioningParameters();
-        Credentials::DeviceAttestationDelegate * deviceAttestationDelegate = params.GetDeviceAttestationDelegate();
-
         // If a device attestation status delegate is installed, delegate handling of failure to the client and let them
         // decide on whether to proceed further or not.
         if (deviceAttestationDelegate)
         {
-            commissioner->ExtendArmFailSafeForFailedDeviceAttestation(result);
+            commissioner->ExtendArmFailSafeForDeviceAttestation(info, result);
         }
         else
         {
@@ -1037,15 +1038,22 @@ void DeviceCommissioner::OnDeviceAttestationInformationVerification(void * conte
     }
     else
     {
-        ChipLogProgress(Controller, "Successfully validated 'Attestation Information' command received from the device.");
-        commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
+        if (deviceAttestationDelegate && deviceAttestationDelegate->ShouldWaitAfterDeviceAttestation())
+        {
+            commissioner->ExtendArmFailSafeForDeviceAttestation(info, result);
+        }
+        else
+        {
+            ChipLogProgress(Controller, "Successfully validated 'Attestation Information' command received from the device.");
+            commissioner->CommissioningStageComplete(CHIP_NO_ERROR);
+        }
     }
 }
 
-void DeviceCommissioner::OnArmFailSafeExtendedForFailedDeviceAttestation(
+void DeviceCommissioner::OnArmFailSafeExtendedForDeviceAttestation(
     void * context, const GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data)
 {
-    // If this function starts using "data", need to fix ExtendArmFailSafeForFailedDeviceAttestation accordingly.
+    // If this function starts using "data", need to fix ExtendArmFailSafeForDeviceAttestation accordingly.
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
 
     if (!commissioner->mDeviceBeingCommissioned)
@@ -1058,8 +1066,9 @@ void DeviceCommissioner::OnArmFailSafeExtendedForFailedDeviceAttestation(
     if (deviceAttestationDelegate)
     {
         ChipLogProgress(Controller, "Device attestation failed, delegating error handling to client");
-        deviceAttestationDelegate->OnDeviceAttestationFailed(commissioner, commissioner->mDeviceBeingCommissioned,
-                                                             commissioner->mAttestationResult);
+        deviceAttestationDelegate->OnDeviceAttestationCompleted(commissioner, commissioner->mDeviceBeingCommissioned,
+                                                                *commissioner->mAttestationDeviceInfo,
+                                                                commissioner->mAttestationResult);
     }
     else
     {
@@ -1070,7 +1079,7 @@ void DeviceCommissioner::OnArmFailSafeExtendedForFailedDeviceAttestation(
     }
 }
 
-void DeviceCommissioner::OnFailedToExtendedArmFailSafeFailedDeviceAttestation(void * context, CHIP_ERROR error)
+void DeviceCommissioner::OnFailedToExtendedArmFailSafeDeviceAttestation(void * context, CHIP_ERROR error)
 {
     ChipLogProgress(Controller, "Failed to extend fail-safe timer to handle attestation failure %s", chip::ErrorStr(error));
     DeviceCommissioner * commissioner = static_cast<DeviceCommissioner *>(context);
@@ -1080,13 +1089,20 @@ void DeviceCommissioner::OnFailedToExtendedArmFailSafeFailedDeviceAttestation(vo
     commissioner->CommissioningStageComplete(CHIP_ERROR_INTERNAL, report);
 }
 
-void DeviceCommissioner::ExtendArmFailSafeForFailedDeviceAttestation(AttestationVerificationResult result)
+void DeviceCommissioner::ExtendArmFailSafeForDeviceAttestation(const Credentials::DeviceAttestationVerifier::AttestationInfo & info,
+                                                               Credentials::AttestationVerificationResult result)
 {
     mAttestationResult = result;
 
     auto & params                                                      = mDefaultCommissioner->GetCommissioningParameters();
     Credentials::DeviceAttestationDelegate * deviceAttestationDelegate = params.GetDeviceAttestationDelegate();
-    auto expiryLengthSeconds                                           = deviceAttestationDelegate->FailSafeExpiryTimeoutSecs();
+
+    if (deviceAttestationDelegate->ShouldWaitAfterDeviceAttestation())
+    {
+        mAttestationDeviceInfo = Platform::MakeUnique<Credentials::DeviceAttestationVerifier::AttestationDeviceInfo>(info);
+    }
+
+    auto expiryLengthSeconds = deviceAttestationDelegate->FailSafeExpiryTimeoutSecs();
     if (expiryLengthSeconds.HasValue())
     {
         GeneralCommissioning::Commands::ArmFailSafe::Type request;
@@ -1095,8 +1111,8 @@ void DeviceCommissioner::ExtendArmFailSafeForFailedDeviceAttestation(Attestation
         ChipLogProgress(Controller, "Changing fail-safe timer to %u seconds to handle DA failure", request.expiryLengthSeconds);
         // Per spec, anything we do with the fail-safe armed must not time out
         // in less than kMinimumCommissioningStepTimeout.
-        SendCommand<GeneralCommissioningCluster>(mDeviceBeingCommissioned, request, OnArmFailSafeExtendedForFailedDeviceAttestation,
-                                                 OnFailedToExtendedArmFailSafeFailedDeviceAttestation,
+        SendCommand<GeneralCommissioningCluster>(mDeviceBeingCommissioned, request, OnArmFailSafeExtendedForDeviceAttestation,
+                                                 OnFailedToExtendedArmFailSafeDeviceAttestation,
                                                  MakeOptional(kMinimumCommissioningStepTimeout));
     }
     else
@@ -1104,7 +1120,7 @@ void DeviceCommissioner::ExtendArmFailSafeForFailedDeviceAttestation(Attestation
         ChipLogProgress(Controller, "Proceeding without changing fail-safe timer value as delegate has not set it");
         // Callee does not use data argument.
         const GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType data;
-        OnArmFailSafeExtendedForFailedDeviceAttestation(this, data);
+        OnArmFailSafeExtendedForDeviceAttestation(this, data);
     }
 }
 
@@ -1471,6 +1487,7 @@ void OnBasicFailure(void * context, CHIP_ERROR error)
 void DeviceCommissioner::CleanupCommissioning(DeviceProxy * proxy, NodeId nodeId, const CompletionStatus & completionStatus)
 {
     commissioningCompletionStatus = completionStatus;
+
     if (completionStatus.err == CHIP_NO_ERROR)
     {
 

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1065,7 +1065,7 @@ void DeviceCommissioner::OnArmFailSafeExtendedForDeviceAttestation(
     Credentials::DeviceAttestationDelegate * deviceAttestationDelegate = params.GetDeviceAttestationDelegate();
     if (deviceAttestationDelegate)
     {
-        ChipLogProgress(Controller, "Device attestation failed, delegating error handling to client");
+        ChipLogProgress(Controller, "Device attestation completed, delegating continuation to client");
         deviceAttestationDelegate->OnDeviceAttestationCompleted(commissioner, commissioner->mDeviceBeingCommissioned,
                                                                 *commissioner->mAttestationDeviceInfo,
                                                                 commissioner->mAttestationResult);
@@ -1097,10 +1097,7 @@ void DeviceCommissioner::ExtendArmFailSafeForDeviceAttestation(const Credentials
     auto & params                                                      = mDefaultCommissioner->GetCommissioningParameters();
     Credentials::DeviceAttestationDelegate * deviceAttestationDelegate = params.GetDeviceAttestationDelegate();
 
-    if (deviceAttestationDelegate->ShouldWaitAfterDeviceAttestation())
-    {
-        mAttestationDeviceInfo = Platform::MakeUnique<Credentials::DeviceAttestationVerifier::AttestationDeviceInfo>(info);
-    }
+    mAttestationDeviceInfo = Platform::MakeUnique<Credentials::DeviceAttestationVerifier::AttestationDeviceInfo>(info);
 
     auto expiryLengthSeconds = deviceAttestationDelegate->FailSafeExpiryTimeoutSecs();
     if (expiryLengthSeconds.HasValue())

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -487,15 +487,14 @@ public:
     /**
      * @brief
      *   This function instructs the commissioner to proceed to the next stage of commissioning after
-     *   attestation failure is reported to an installed attestation delegate.
+     *   attestation is reported to an installed attestation delegate.
      *
      * @param[in] device                The device being commissioned.
      * @param[in] attestationResult     The attestation result to use instead of whatever the device
      *                                  attestation verifier came up with. May be a success or an error result.
      */
     CHIP_ERROR
-    ContinueCommissioningAfterDeviceAttestationFailure(DeviceProxy * device,
-                                                       Credentials::AttestationVerificationResult attestationResult);
+    ContinueCommissioningAfterDeviceAttestation(DeviceProxy * device, Credentials::AttestationVerificationResult attestationResult);
 
     CHIP_ERROR GetDeviceBeingCommissioned(NodeId deviceId, CommissioneeDeviceProxy ** device);
 
@@ -715,7 +714,9 @@ private:
     /* Callback when the previously sent CSR request results in failure */
     static void OnCSRFailureResponse(void * context, CHIP_ERROR error);
 
-    void ExtendArmFailSafeForFailedDeviceAttestation(Credentials::AttestationVerificationResult result);
+    void ClearAttestationDeviceInfo();
+    void ExtendArmFailSafeForDeviceAttestation(const Credentials::DeviceAttestationVerifier::AttestationInfo & info,
+                                               Credentials::AttestationVerificationResult result);
     static void OnCertificateChainFailureResponse(void * context, CHIP_ERROR error);
     static void OnCertificateChainResponse(
         void * context, const app::Clusters::OperationalCredentials::Commands::CertificateChainResponse::DecodableType & response);
@@ -754,7 +755,9 @@ private:
     static void OnDeviceConnectedFn(void * context, Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle);
     static void OnDeviceConnectionFailureFn(void * context, const ScopedNodeId & peerId, CHIP_ERROR error);
 
-    static void OnDeviceAttestationInformationVerification(void * context, Credentials::AttestationVerificationResult result);
+    static void OnDeviceAttestationInformationVerification(void * context,
+                                                           const Credentials::DeviceAttestationVerifier::AttestationInfo & info,
+                                                           Credentials::AttestationVerificationResult result);
 
     static void OnDeviceNOCChainGeneration(void * context, CHIP_ERROR status, const ByteSpan & noc, const ByteSpan & icac,
                                            const ByteSpan & rcac, Optional<AesCcm128KeySpan> ipk, Optional<NodeId> adminSubject);
@@ -779,9 +782,9 @@ private:
                                  const app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data);
     static void OnDisarmFailsafeFailure(void * context, CHIP_ERROR error);
     void DisarmDone();
-    static void OnArmFailSafeExtendedForFailedDeviceAttestation(
+    static void OnArmFailSafeExtendedForDeviceAttestation(
         void * context, const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType & data);
-    static void OnFailedToExtendedArmFailSafeFailedDeviceAttestation(void * context, CHIP_ERROR error);
+    static void OnFailedToExtendedArmFailSafeDeviceAttestation(void * context, CHIP_ERROR error);
 
     /**
      * @brief
@@ -860,7 +863,8 @@ private:
     chip::Callback::Callback<OnDeviceConnected> mOnDeviceConnectedCallback;
     chip::Callback::Callback<OnDeviceConnectionFailure> mOnDeviceConnectionFailureCallback;
 
-    chip::Callback::Callback<Credentials::OnAttestationInformationVerification> mDeviceAttestationInformationVerificationCallback;
+    chip::Callback::Callback<Credentials::DeviceAttestationVerifier::OnAttestationInformationVerification>
+        mDeviceAttestationInformationVerificationCallback;
 
     chip::Callback::Callback<OnNOCChainGeneration> mDeviceNOCChainCallback;
     SetUpCodePairer mSetUpCodePairer;
@@ -874,6 +878,7 @@ private:
     Platform::UniquePtr<app::ClusterStateCache> mAttributeCache;
     Platform::UniquePtr<app::ReadClient> mReadClient;
     Credentials::AttestationVerificationResult mAttestationResult;
+    Platform::UniquePtr<Credentials::DeviceAttestationVerifier::AttestationDeviceInfo> mAttestationDeviceInfo;
     Credentials::DeviceAttestationVerifier * mDeviceAttestationVerifier = nullptr;
 };
 

--- a/src/controller/CHIPDeviceController.h
+++ b/src/controller/CHIPDeviceController.h
@@ -714,7 +714,6 @@ private:
     /* Callback when the previously sent CSR request results in failure */
     static void OnCSRFailureResponse(void * context, CHIP_ERROR error);
 
-    void ClearAttestationDeviceInfo();
     void ExtendArmFailSafeForDeviceAttestation(const Credentials::DeviceAttestationVerifier::AttestationInfo & info,
                                                Credentials::AttestationVerificationResult result);
     static void OnCertificateChainFailureResponse(void * context, CHIP_ERROR error);

--- a/src/credentials/attestation_verifier/DacOnlyPartialAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DacOnlyPartialAttestationVerifier.cpp
@@ -148,7 +148,7 @@ void PartialDACVerifier::VerifyAttestationInformation(const DeviceAttestationVer
     }
 
 exit:
-    onCompletion->mCall(onCompletion->mContext, attestationError);
+    onCompletion->mCall(onCompletion->mContext, info, attestationError);
 }
 
 } // namespace Credentials

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
@@ -277,7 +277,7 @@ void DefaultDACVerifier::VerifyAttestationInformation(const DeviceAttestationVer
     }
 
 exit:
-    onCompletion->mCall(onCompletion->mContext, attestationError);
+    onCompletion->mCall(onCompletion->mContext, info, attestationError);
 }
 
 AttestationVerificationResult DefaultDACVerifier::ValidateCertificationDeclarationSignature(const ByteSpan & cmsEnvelopeBuffer,

--- a/src/credentials/attestation_verifier/DeviceAttestationDelegate.h
+++ b/src/credentials/attestation_verifier/DeviceAttestationDelegate.h
@@ -50,11 +50,8 @@ public:
      *   This method is invoked when device attestation fails for a device that is being commissioned. The client
      *   handling the failure has the option to continue commissioning or fail the operation.
      *
-     *   If ShouldWaitAfterDeviceAttestation returns false, then in the case attestationResult is successful, the
-     *   commissioner would finish commissioning the device after OnDeviceAttestationCompleted returns.
-     *
-     *   If ShouldWaitAfterDeviceAttestation returns true, then the commissioner will always wait for a
-     *   ContinueCommissioningAfterDeviceAttestation call after calling OnDeviceAttestationCompleted.
+     *   Optionally, when ShouldWaitAfterDeviceAttestation is overridden to return true, this method is also
+     *   invoked when device attestation succeeds.
      *
      *   @param deviceCommissioner The commissioner object that is commissioning the device
      *   @param device The proxy represent the device being commissioned

--- a/src/credentials/attestation_verifier/DeviceAttestationDelegate.h
+++ b/src/credentials/attestation_verifier/DeviceAttestationDelegate.h
@@ -48,14 +48,29 @@ public:
     /**
      * @brief
      *   This method is invoked when device attestation fails for a device that is being commissioned. The client
-     *   handling the failure has the option to continue commissionning or fail the operation.
+     *   handling the failure has the option to continue commissioning or fail the operation.
+     *
+     *   If ShouldWaitAfterDeviceAttestation returns false, then in the case attestationResult is successful, the
+     *   commissioner would finish commissioning the device after OnDeviceAttestationCompleted returns.
+     *
+     *   If ShouldWaitAfterDeviceAttestation returns true, then the commissioner will always wait for a
+     *   ContinueCommissioningAfterDeviceAttestation call after calling OnDeviceAttestationCompleted.
      *
      *   @param deviceCommissioner The commissioner object that is commissioning the device
      *   @param device The proxy represent the device being commissioned
+     *   @param info The structure holding device info for additional verification by the application
      *   @param attestationResult The failure code for the device attestation validation operation
      */
-    virtual void OnDeviceAttestationFailed(Controller::DeviceCommissioner * deviceCommissioner, DeviceProxy * device,
-                                           AttestationVerificationResult attestationResult) = 0;
+    virtual void OnDeviceAttestationCompleted(Controller::DeviceCommissioner * deviceCommissioner, DeviceProxy * device,
+                                              const DeviceAttestationVerifier::AttestationDeviceInfo & info,
+                                              AttestationVerificationResult attestationResult) = 0;
+
+    /**
+     * @brief
+     *   Override this method to return whether the attestation delegate wants the commissioner to wait for a
+     *   ContinueCommissioningAfterDeviceAttestation call in the case attestationResult is successful.
+     */
+    virtual bool ShouldWaitAfterDeviceAttestation() { return false; }
 };
 
 } // namespace Credentials

--- a/src/credentials/attestation_verifier/DeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DeviceAttestationVerifier.cpp
@@ -116,8 +116,10 @@ void SetDeviceAttestationVerifier(DeviceAttestationVerifier * verifier)
 static inline Platform::ScopedMemoryBufferWithSize<uint8_t> CopyByteSpanHelper(const ByteSpan & span_to_copy)
 {
     Platform::ScopedMemoryBufferWithSize<uint8_t> bufferCopy;
-    bufferCopy.Alloc(span_to_copy.size());
-    memcpy(bufferCopy.Get(), span_to_copy.data(), span_to_copy.size());
+    if (bufferCopy.Alloc(span_to_copy.size()))
+    {
+        memcpy(bufferCopy.Get(), span_to_copy.data(), span_to_copy.size());
+    }
     return bufferCopy;
 }
 

--- a/src/credentials/attestation_verifier/DeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DeviceAttestationVerifier.cpp
@@ -16,7 +16,9 @@
  */
 #include "DeviceAttestationVerifier.h"
 
+#include <credentials/DeviceAttestationConstructor.h>
 #include <crypto/CHIPCryptoPAL.h>
+#include <lib/support/CHIPMem.h>
 
 using namespace chip::Crypto;
 
@@ -109,6 +111,31 @@ void SetDeviceAttestationVerifier(DeviceAttestationVerifier * verifier)
     }
 
     gDacVerifier = verifier;
+}
+
+static inline Platform::ScopedMemoryBufferWithSize<uint8_t> CopyByteSpanHelper(const ByteSpan & span_to_copy)
+{
+    Platform::ScopedMemoryBufferWithSize<uint8_t> bufferCopy;
+    bufferCopy.Alloc(span_to_copy.size());
+    memcpy(bufferCopy.Get(), span_to_copy.data(), span_to_copy.size());
+    return bufferCopy;
+}
+
+DeviceAttestationVerifier::AttestationDeviceInfo::AttestationDeviceInfo(const AttestationInfo & attestationInfo) :
+    mPaiDerBuffer(CopyByteSpanHelper(attestationInfo.paiDerBuffer)), mDacDerBuffer(CopyByteSpanHelper(attestationInfo.dacDerBuffer))
+{
+    ByteSpan certificationDeclarationSpan;
+    ByteSpan attestationNonceSpan;
+    uint32_t timestampDeconstructed;
+    ByteSpan firmwareInfoSpan;
+    DeviceAttestationVendorReservedDeconstructor vendorReserved;
+
+    if (DeconstructAttestationElements(attestationInfo.attestationElementsBuffer, certificationDeclarationSpan,
+                                       attestationNonceSpan, timestampDeconstructed, firmwareInfoSpan,
+                                       vendorReserved) == CHIP_NO_ERROR)
+    {
+        mCdBuffer = CopyByteSpanHelper(certificationDeclarationSpan);
+    }
 }
 
 } // namespace Credentials

--- a/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
+++ b/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
@@ -124,7 +124,7 @@ public:
     virtual ~AttestationTrustStore() = default;
 
     // Not copyable
-    AttestationTrustStore(const AttestationTrustStore &)             = delete;
+    AttestationTrustStore(const AttestationTrustStore &) = delete;
     AttestationTrustStore & operator=(const AttestationTrustStore &) = delete;
 
     /**
@@ -197,7 +197,7 @@ public:
     virtual ~DeviceAttestationVerifier() = default;
 
     // Not copyable
-    DeviceAttestationVerifier(const DeviceAttestationVerifier &)             = delete;
+    DeviceAttestationVerifier(const DeviceAttestationVerifier &) = delete;
     DeviceAttestationVerifier & operator=(const DeviceAttestationVerifier &) = delete;
 
     struct AttestationInfo

--- a/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
+++ b/src/credentials/attestation_verifier/DeviceAttestationVerifier.h
@@ -20,6 +20,7 @@
 #include <lib/core/CHIPCallback.h>
 #include <lib/core/CHIPError.h>
 #include <lib/core/CHIPVendorIdentifiers.hpp>
+#include <lib/support/ScopedBuffer.h>
 #include <lib/support/Span.h>
 
 namespace chip {
@@ -108,8 +109,6 @@ struct DeviceInfoForAttestation
     uint8_t paaSKID[Crypto::kSubjectKeyIdentifierLength] = { 0 };
 };
 
-typedef void (*OnAttestationInformationVerification)(void * context, AttestationVerificationResult result);
-
 /**
  * @brief Helper utility to model a basic trust store usable for device attestation verifiers.
  *
@@ -125,7 +124,7 @@ public:
     virtual ~AttestationTrustStore() = default;
 
     // Not copyable
-    AttestationTrustStore(const AttestationTrustStore &) = delete;
+    AttestationTrustStore(const AttestationTrustStore &)             = delete;
     AttestationTrustStore & operator=(const AttestationTrustStore &) = delete;
 
     /**
@@ -198,7 +197,7 @@ public:
     virtual ~DeviceAttestationVerifier() = default;
 
     // Not copyable
-    DeviceAttestationVerifier(const DeviceAttestationVerifier &) = delete;
+    DeviceAttestationVerifier(const DeviceAttestationVerifier &)             = delete;
     DeviceAttestationVerifier & operator=(const DeviceAttestationVerifier &) = delete;
 
     struct AttestationInfo
@@ -221,6 +220,43 @@ public:
         VendorId vendorId;
         uint16_t productId;
     };
+
+    // Copies the bytes passed to it, and holds the PAI, DAC, and CD for additional verification step
+    class AttestationDeviceInfo
+    {
+    public:
+        AttestationDeviceInfo(const AttestationInfo & attestationInfo);
+        AttestationDeviceInfo(const ByteSpan & attestationElementsBuffer, const ByteSpan paiDerBuffer, const ByteSpan dacDerBuffer);
+
+        ~AttestationDeviceInfo() = default;
+
+        // Returns buffer containing the PAI certificate from device in DER format.
+        const ByteSpan paiDerBuffer() const { return ByteSpan(mPaiDerBuffer.Get(), mPaiDerBuffer.AllocatedSize()); }
+
+        // Returns buffer containing the DAC certificate from device in DER format.
+        const ByteSpan dacDerBuffer() const { return ByteSpan(mDacDerBuffer.Get(), mDacDerBuffer.AllocatedSize()); }
+
+        // Returns optional buffer containing the certificate declaration from device.
+        const Optional<ByteSpan> cdBuffer() const
+        {
+            if (mCdBuffer.Get())
+            {
+                return MakeOptional(ByteSpan(mDacDerBuffer.Get(), mDacDerBuffer.AllocatedSize()));
+            }
+            else
+            {
+                return Optional<ByteSpan>();
+            }
+        }
+
+    private:
+        Platform::ScopedMemoryBufferWithSize<uint8_t> mPaiDerBuffer;
+        Platform::ScopedMemoryBufferWithSize<uint8_t> mDacDerBuffer;
+        Platform::ScopedMemoryBufferWithSize<uint8_t> mCdBuffer;
+    };
+
+    typedef void (*OnAttestationInformationVerification)(void * context, const AttestationInfo & info,
+                                                         AttestationVerificationResult result);
 
     /**
      * @brief Verify an attestation information payload against a DAC/PAI chain.

--- a/src/credentials/tests/TestDeviceAttestationCredentials.cpp
+++ b/src/credentials/tests/TestDeviceAttestationCredentials.cpp
@@ -148,7 +148,8 @@ static void TestDACProvidersExample_Signature(nlTestSuite * inSuite, void * inCo
     NL_TEST_ASSERT(inSuite, err == CHIP_NO_ERROR);
 }
 
-static void OnAttestationInformationVerificationCallback(void * context, AttestationVerificationResult result)
+static void OnAttestationInformationVerificationCallback(void * context, const DeviceAttestationVerifier::AttestationInfo & info,
+                                                         AttestationVerificationResult result)
 {
     AttestationVerificationResult * pResult = reinterpret_cast<AttestationVerificationResult *>(context);
     *pResult                                = result;
@@ -205,7 +206,7 @@ static void TestDACVerifierExample_AttestationInfoVerification(nlTestSuite * inS
     NL_TEST_ASSERT(inSuite, default_verifier == example_dac_verifier);
 
     attestationResult = AttestationVerificationResult::kNotImplemented;
-    Callback::Callback<OnAttestationInformationVerification> attestationInformationVerificationCallback(
+    Callback::Callback<DeviceAttestationVerifier::OnAttestationInformationVerification> attestationInformationVerificationCallback(
         OnAttestationInformationVerificationCallback, &attestationResult);
 
     Credentials::DeviceAttestationVerifier::AttestationInfo info(

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
@@ -37,6 +37,16 @@ NS_ASSUME_NONNULL_BEGIN
 @protocol MTRDeviceAttestationDelegate <NSObject>
 @optional
 /**
+ * Only one of the following delegate callbacks should be implemented.
+ *
+ * If -deviceAttestation:failedForDevice:error: is implemented, then it will be called when device
+ * attestation fails, and the client can decide to continue or stop the commissioning.
+ *
+ * If -deviceAttestation:completedForDevice:attestationDeviceInfo:error: is implemented, then it
+ * will always be called when device attestation completes.
+ */
+
+/**
  * Notify the delegate when device attestation completed with device info for additional verification. If
  * this callback is implemented, continueCommissioningDevice on MTRDeviceController is expected
  * to be called if commisioning should continue.
@@ -46,12 +56,12 @@ NS_ASSUME_NONNULL_BEGIN
  * @param controller Controller corresponding to the commissioning process
  * @param device Handle of device being commissioned
  * @param attestationDeviceInfo Attestation information for the device
- * @param error NSError representing the error code for the failure
+ * @param error NSError representing the error code on attestation failure. Nil if success.
  */
 - (void)deviceAttestation:(MTRDeviceController *)controller
        completedForDevice:(void *)device
     attestationDeviceInfo:(MTRDeviceAttestationDeviceInfo *)attestationDeviceInfo
-                    error:(NSError * _Nonnull)error;
+                    error:(NSError * _Nullable)error;
 
 /**
  * Notify the delegate when device attestation fails

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.h
@@ -21,12 +21,38 @@ NS_ASSUME_NONNULL_BEGIN
 
 @class MTRDeviceController;
 
+@interface MTRDeviceAttestationDeviceInfo : NSObject
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@property (nonatomic, readonly) NSData * dacCertificate;
+@property (nonatomic, readonly) NSData * dacPAICertificate;
+@property (nonatomic, readonly, nullable) NSData * certificateDeclaration;
+@end
+
 /**
  * The protocol definition for the MTRDeviceAttestationDelegate
  *
  * All delegate methods will be called on the callers queue.
  */
 @protocol MTRDeviceAttestationDelegate <NSObject>
+@optional
+/**
+ * Notify the delegate when device attestation completed with device info for additional verification. If
+ * this callback is implemented, continueCommissioningDevice on MTRDeviceController is expected
+ * to be called if commisioning should continue.
+ *
+ * This allows the delegate to stop commissioning after examining the device info (DAC, PAI, CD).
+ *
+ * @param controller Controller corresponding to the commissioning process
+ * @param device Handle of device being commissioned
+ * @param attestationDeviceInfo Attestation information for the device
+ * @param error NSError representing the error code for the failure
+ */
+- (void)deviceAttestation:(MTRDeviceController *)controller
+       completedForDevice:(void *)device
+    attestationDeviceInfo:(MTRDeviceAttestationDeviceInfo *)attestationDeviceInfo
+                    error:(NSError * _Nonnull)error;
+
 /**
  * Notify the delegate when device attestation fails
  *

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate.mm
@@ -1,0 +1,33 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+#import <MTRDeviceAttestationDelegate_Internal.h>
+
+@implementation MTRDeviceAttestationDeviceInfo
+- (instancetype)initWithDACCertificate:(NSData *)dacCertificate
+                     dacPAICertificate:(NSData *)dacPAICertificate
+                certificateDeclaration:(NSData *)certificateDeclaration
+{
+    if (self = [super init]) {
+        _dacCertificate = [dacCertificate copy];
+        _dacPAICertificate = [dacPAICertificate copy];
+        _certificateDeclaration = [certificateDeclaration copy];
+    }
+    return self;
+}
+@end

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
@@ -29,12 +29,13 @@ class MTRDeviceAttestationDelegateBridge : public chip::Credentials::DeviceAttes
 public:
     MTRDeviceAttestationDelegateBridge(MTRDeviceController * deviceController,
         id<MTRDeviceAttestationDelegate> deviceAttestationDelegate, dispatch_queue_t queue,
-        chip::Optional<uint16_t> expiryTimeoutSecs)
+        chip::Optional<uint16_t> expiryTimeoutSecs, bool shouldWaitAfterDeviceAttestation = false)
         : mResult(chip::Credentials::AttestationVerificationResult::kSuccess)
         , mDeviceController(deviceController)
         , mDeviceAttestationDelegate(deviceAttestationDelegate)
         , mQueue(queue)
         , mExpiryTimeoutSecs(expiryTimeoutSecs)
+        , mShouldWaitAfterDeviceAttestation(shouldWaitAfterDeviceAttestation)
     {
     }
 
@@ -42,8 +43,11 @@ public:
 
     chip::Optional<uint16_t> FailSafeExpiryTimeoutSecs() const override { return mExpiryTimeoutSecs; }
 
-    void OnDeviceAttestationFailed(chip::Controller::DeviceCommissioner * deviceCommissioner, chip::DeviceProxy * device,
+    void OnDeviceAttestationCompleted(chip::Controller::DeviceCommissioner * deviceCommissioner, chip::DeviceProxy * device,
+        const chip::Credentials::DeviceAttestationVerifier::AttestationDeviceInfo & info,
         chip::Credentials::AttestationVerificationResult attestationResult) override;
+
+    bool ShouldWaitAfterDeviceAttestation() override { return mShouldWaitAfterDeviceAttestation; }
 
     chip::Credentials::AttestationVerificationResult attestationVerificationResult() const { return mResult; }
 
@@ -53,6 +57,7 @@ private:
     id<MTRDeviceAttestationDelegate> mDeviceAttestationDelegate;
     dispatch_queue_t mQueue;
     chip::Optional<uint16_t> mExpiryTimeoutSecs;
+    bool mShouldWaitAfterDeviceAttestation;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.h
@@ -57,7 +57,7 @@ private:
     id<MTRDeviceAttestationDelegate> mDeviceAttestationDelegate;
     dispatch_queue_t mQueue;
     chip::Optional<uint16_t> mExpiryTimeoutSecs;
-    bool mShouldWaitAfterDeviceAttestation;
+    const bool mShouldWaitAfterDeviceAttestation;
 };
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegateBridge.mm
@@ -25,7 +25,7 @@ void MTRDeviceAttestationDelegateBridge::OnDeviceAttestationCompleted(chip::Cont
     chip::Credentials::AttestationVerificationResult attestationResult)
 {
     dispatch_async(mQueue, ^{
-        NSLog(@"MTRDeviceAttestationDelegateBridge::OnDeviceAttestationFailed failed with result: %hu", attestationResult);
+        NSLog(@"MTRDeviceAttestationDelegateBridge::OnDeviceAttestationFailed completed with result: %hu", attestationResult);
 
         mResult = attestationResult;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceAttestationDelegate_Internal.h
@@ -1,0 +1,28 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <MTRDeviceAttestationDelegate.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@interface MTRDeviceAttestationDeviceInfo ()
+- (instancetype)initWithDACCertificate:(NSData *)dacCertificate
+                     dacPAICertificate:(NSData *)dacPAICertificate
+                certificateDeclaration:(NSData *)certificateDeclaration;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -460,7 +460,8 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
                     = chip::MakeOptional(static_cast<uint16_t>([commissioningParams.failSafeExpiryTimeoutSecs unsignedIntValue]));
             }
             BOOL shouldWaitAfterDeviceAttestation = NO;
-            if ([commissioningParams.deviceAttestationDelegate respondsToSelector:@selector(deviceAttestation:completedForDevice:attestationDeviceInfo:error:)]) {
+            if ([commissioningParams.deviceAttestationDelegate
+                    respondsToSelector:@selector(deviceAttestation:completedForDevice:attestationDeviceInfo:error:)]) {
                 shouldWaitAfterDeviceAttestation = YES;
             }
             _deviceAttestationDelegateBridge = new MTRDeviceAttestationDelegateBridge(

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -459,8 +459,12 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
                 timeoutSecs
                     = chip::MakeOptional(static_cast<uint16_t>([commissioningParams.failSafeExpiryTimeoutSecs unsignedIntValue]));
             }
+            BOOL shouldWaitAfterDeviceAttestation = NO;
+            if ([commissioningParams.deviceAttestationDelegate respondsToSelector:@selector(deviceAttestation:completedForDevice:attestationDeviceInfo:error:)]) {
+                shouldWaitAfterDeviceAttestation = YES;
+            }
             _deviceAttestationDelegateBridge = new MTRDeviceAttestationDelegateBridge(
-                self, commissioningParams.deviceAttestationDelegate, _chipWorkQueue, timeoutSecs);
+                self, commissioningParams.deviceAttestationDelegate, _chipWorkQueue, timeoutSecs, shouldWaitAfterDeviceAttestation);
             params.SetDeviceAttestationDelegate(_deviceAttestationDelegateBridge);
         }
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -486,7 +486,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
             : chip::Credentials::AttestationVerificationResult::kSuccess;
 
         auto deviceProxy = static_cast<chip::DeviceProxy *>(device);
-        auto errorCode = self.cppCommissioner->ContinueCommissioningAfterDeviceAttestationFailure(deviceProxy,
+        auto errorCode = self.cppCommissioner->ContinueCommissioningAfterDeviceAttestation(deviceProxy,
             ignoreAttestationFailure ? chip::Credentials::AttestationVerificationResult::kSuccess : lastAttestationResult);
         success = ![self checkForError:errorCode logMsg:kErrorPairDevice error:error];
     });

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -83,6 +83,8 @@
 		5ACDDD7D27CD16D200EFD68A /* MTRAttributeCacheContainer.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5ACDDD7C27CD16D200EFD68A /* MTRAttributeCacheContainer.mm */; };
 		5ACDDD7E27CD3F3A00EFD68A /* MTRAttributeCacheContainer_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5ACDDD7B27CD14AF00EFD68A /* MTRAttributeCacheContainer_Internal.h */; };
 		5AE6D4E427A99041001F2493 /* MTRDeviceTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */; };
+		7534F12828BFF20300390851 /* MTRDeviceAttestationDelegate.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7534F12628BFF20300390851 /* MTRDeviceAttestationDelegate.mm */; };
+		7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7534F12728BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h */; };
 		754F3DF427FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 754F3DF327FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h */; };
 		7560FD1C27FBBD3F005E85B3 /* MTREventTLVValueDecoder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 7560FD1B27FBBD3F005E85B3 /* MTREventTLVValueDecoder.mm */; };
 		7596A83E28751220004DAE0E /* MTRBaseClusters_internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 7596A83D28751220004DAE0E /* MTRBaseClusters_internal.h */; };
@@ -221,6 +223,8 @@
 		5ACDDD7B27CD14AF00EFD68A /* MTRAttributeCacheContainer_Internal.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRAttributeCacheContainer_Internal.h; sourceTree = "<group>"; };
 		5ACDDD7C27CD16D200EFD68A /* MTRAttributeCacheContainer.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRAttributeCacheContainer.mm; sourceTree = "<group>"; };
 		5AE6D4E327A99041001F2493 /* MTRDeviceTests.m */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.objc; path = MTRDeviceTests.m; sourceTree = "<group>"; };
+		7534F12628BFF20300390851 /* MTRDeviceAttestationDelegate.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceAttestationDelegate.mm; sourceTree = "<group>"; };
+		7534F12728BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceAttestationDelegate_Internal.h; sourceTree = "<group>"; };
 		754F3DF327FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTREventTLVValueDecoder_Internal.h; sourceTree = "<group>"; };
 		7560FD1B27FBBD3F005E85B3 /* MTREventTLVValueDecoder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MTREventTLVValueDecoder.mm; path = "zap-generated/MTREventTLVValueDecoder.mm"; sourceTree = "<group>"; };
 		7596A83D28751220004DAE0E /* MTRBaseClusters_internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MTRBaseClusters_internal.h; path = "zap-generated/MTRBaseClusters_internal.h"; sourceTree = "<group>"; };
@@ -359,6 +363,8 @@
 				27A53C1527FBC6920053F131 /* MTRAttestationTrustStoreBridge.h */,
 				27A53C1627FBC6920053F131 /* MTRAttestationTrustStoreBridge.mm */,
 				88EBF8CB27FABDD500686BC1 /* MTRDeviceAttestationDelegate.h */,
+				7534F12728BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h */,
+				7534F12628BFF20300390851 /* MTRDeviceAttestationDelegate.mm */,
 				88EBF8CD27FABDD500686BC1 /* MTRDeviceAttestationDelegateBridge.h */,
 				88EBF8CC27FABDD500686BC1 /* MTRDeviceAttestationDelegateBridge.mm */,
 				513DDB852761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h */,
@@ -506,6 +512,7 @@
 				99D466E12798936D0089A18F /* MTRCommissioningParameters.h in Headers */,
 				5136661528067D550025EDAE /* MTRControllerFactory_Internal.h in Headers */,
 				515C1C70284F9FFB00A48F0C /* MTRMemory.h in Headers */,
+				7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */,
 				D4772A46285AE98400383630 /* MTRClusterConstants.h in Headers */,
 				B289D4212639C0D300D4E314 /* MTROnboardingPayloadParser.h in Headers */,
 				513DDB862761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h in Headers */,
@@ -687,6 +694,7 @@
 				5136661428067D550025EDAE /* MTRControllerFactory.mm in Sources */,
 				51B22C2A2740CB47008D5055 /* MTRCommandPayloadsObjc.mm in Sources */,
 				AF5F90FF2878D351005503FA /* MTROTAProviderDelegateBridge.mm in Sources */,
+				7534F12828BFF20300390851 /* MTRDeviceAttestationDelegate.mm in Sources */,
 				2C5EEEF7268A85C400CAE3D3 /* MTRDeviceConnectionBridge.mm in Sources */,
 				51B22C262740CB32008D5055 /* MTRStructsObjc.mm in Sources */,
 				2C222AD1255C620600E446B9 /* MTRBaseDevice.mm in Sources */,


### PR DESCRIPTION
#### Problem
Copying problem description from issue #22318:

The SDK currently allows an attestation delegate to override an attestation failure in response to user preference. The attestation delegate should also be able to override attestation success, in case application logic decides to stop commissioning a device.

For example, if the application keeps a more up-to-date revocation list, it can use that information to reject commissioning particular devices.

For this to work, the completion callback for the delegate should include DAC/PAI/CD for the device.

Edit for justification:
* why is this important
This is required for third party developers on iOS to verify device attestation.

* what is the sideffect if we decide to not accept this change into 1.0 branch or if we fail to finish its development?
Once commissioning starts, third party developers would not be able to reject attestation results, even if they have more verification information

/Edit

 #### Change overview
* Have `DeviceAttestationDelegate` add an optional override to use the new flow
* Add a new `AttestationDeviceInfo` object to hold a copy of the device information
* Have `DeviceCommissioner` check if the delegate uses the new flow, and always pass the device information
* Darwin: add an optional attestation completion callback for the objc delegate protocol

#### Testing
* Used darwin-framework-tool and verified the existing path still works
* Used chip-tool and verified existing path still works
* Tested locally with modified darwin-framework-tool that implements the new delegate callback