### PR TITLE
Only do address updates for CASE delivery failures.

### DIFF
--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -411,7 +411,7 @@ void OperationalSessionSetup::PerformAddressUpdate()
     CHIP_ERROR err = LookupPeerAddress();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "PerformAddressUpdate could not perform lookup");
+        ChipLogError(Controller, "PerformAddressUpdate could not perform lookup: %" CHIP_ERROR_FORMAT, err.Format());
         DequeueConnectionCallbacks(err);
         // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
         return;

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -411,7 +411,7 @@ void OperationalSessionSetup::PerformAddressUpdate()
     CHIP_ERROR err = LookupPeerAddress();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "PerformAddressUpdate could not perform lookup: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(Controller, "Failed to look up peer address: %" CHIP_ERROR_FORMAT, err.Format());
         DequeueConnectionCallbacks(err);
         // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
         return;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -320,7 +320,8 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
         if (exchangeMgr)
         {
             // After the first failure notify session manager to refresh device data
-            if (entry->sendCount == 1 && mSessionUpdateDelegate != nullptr)
+            if (entry->sendCount == 1 && mSessionUpdateDelegate != nullptr && entry->ec->GetSessionHandle()->IsSecureSession() &&
+                entry->ec->GetSessionHandle()->AsSecureSession()->IsCASESession())
             {
                 mSessionUpdateDelegate->UpdatePeerAddress(entry->ec->GetSessionHandle()->GetPeer());
             }


### PR DESCRIPTION
When the handling of "failed to send message, so update the IP for this peer"
moved out of DeviceCommissioner, we stopped checking whether the session is a
CASE session.  Go back to checking that again.

Fixes https://github.com/project-chip/connectedhomeip/issues/22326

#### Problem
See #22326.

#### Change overview
Check that we're dealing with a CASE session before we try to find a new IP for it.

#### Testing
Tried doing a CASE handshake with a device that was not responding; observed that we don't try to re-resolve for the failed-delivery handshake messages (which are happening on an unauthenticated session, not a CASE session).