### PR TITLE
Issue 22325: Darwin: MTRSetupPayload should move NSSecureCoding confo…

### DIFF
--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -49,7 +49,7 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 @property (nonatomic, copy) NSString * stringValue;
 @end
 
-@interface MTRSetupPayload : NSObject
+@interface MTRSetupPayload : NSObject <NSSecureCoding>
 
 @property (nonatomic, copy) NSNumber * version;
 @property (nonatomic, copy) NSNumber * vendorID;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -14,7 +14,7 @@
 #import <setup_payload/SetupPayload.h>
 #endif
 
-@interface MTRSetupPayload () <NSSecureCoding>
+@interface MTRSetupPayload ()
 
 #ifdef __cplusplus
 - (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;


### PR DESCRIPTION
#### Problem
Copying from associated issue #22325:

To support serialization of MTRSetupPayload object for public use, the NSSecureCoding conformance should be moved from internal to public header.

#### Change overview
Move the NSSecureCoding conformance from the internal header to the public head.

#### Testing
* Compiled the darwin framework and found no issues. Moving obj-c protocol conformance from internal to public header should not affect function.