### PR TITLE
Fix documentation for chip-app1 commisioning.

### DIFF
--- a/docs/guides/simulated_device_linux.md
+++ b/docs/guides/simulated_device_linux.md
@@ -88,15 +88,12 @@ interact with it using chip-tool
 1. Follow the instruction to build chip-tool in the
    [chip-tool readme](../../examples/chip-tool).
 
-2. Run this command to initiate the pairing.
+2. Run this command to commission.
     ```
-    ./out/debug/standalone/chip-tool pairing ethernet 0x654321 20202021 3842 [IP ADDRESS of App] 5542
+    ./out/debug/standalone/chip-tool pairing code MT:-24J0AFN00KA0648G00
     ```
-3. Run this command to complete the commissioning.
-    ```
-    ./out/debug/standalone/chip-tool generalcommissioning commissioning-complete 0x654321 0
-    ```
-4. Most tests will start at this point and now an send cluster commands with
+    or whatever is listed on the "SetupQRCode:" line in the log output.
+3. Most tests will start at this point and now an send cluster commands with
    chip-tool as follow.
 
     ```

--- a/docs/guides/simulated_device_linux.md
+++ b/docs/guides/simulated_device_linux.md
@@ -90,7 +90,7 @@ interact with it using chip-tool
 
 2. Run this command to commission.
     ```
-    ./out/debug/standalone/chip-tool pairing code MT:-24J0AFN00KA0648G00
+    ./out/debug/standalone/chip-tool pairing code 0x654321 MT:-24J0AFN00KA0648G00
     ```
     or whatever is listed on the "SetupQRCode:" line in the log output.
 3. Most tests will start at this point and now an send cluster commands with


### PR DESCRIPTION
PR #15801 changed the port to 5543, but the documentation was not updated. Just
use "pairing code" to avoid problems like that.

Fixes https://github.com/project-chip/connectedhomeip/issues/22312

#### Problem
Wrong documentation.  Port is wrong, and the extra CommissioningComplete is not needed (and in fact would fail).

#### Change overview
Fix the docs.

