### PR TITLE
Add more debug log to track CASE failure during commission

### DIFF
--- a/src/app/CASESessionManager.cpp
+++ b/src/app/CASESessionManager.cpp
@@ -90,6 +90,12 @@ void CASESessionManager::UpdatePeerAddress(ScopedNodeId peerId)
             return;
         }
     }
+    else
+    {
+        ChipLogDetail(CASESessionManager,
+                      "UpdatePeerAddress: Found existing OperationalSessionSetup instance for peerId[" ChipLogFormatX64 "]",
+                      ChipLogValueX64(peerId.GetNodeId()));
+    }
 
     session->PerformAddressUpdate();
 }

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -411,7 +411,7 @@ void OperationalSessionSetup::PerformAddressUpdate()
     CHIP_ERROR err = LookupPeerAddress();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "PerformAddressUpdate could not perform lookup");
+        ChipLogError(Controller, "Failed to lookup peer address: %" CHIP_ERROR_FORMAT, err.Format());
         DequeueConnectionCallbacks(err);
         // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
         return;

--- a/src/app/OperationalSessionSetup.cpp
+++ b/src/app/OperationalSessionSetup.cpp
@@ -411,7 +411,7 @@ void OperationalSessionSetup::PerformAddressUpdate()
     CHIP_ERROR err = LookupPeerAddress();
     if (err != CHIP_NO_ERROR)
     {
-        ChipLogError(Controller, "Failed to lookup peer address: %" CHIP_ERROR_FORMAT, err.Format());
+        ChipLogError(Controller, "Failed to look up peer address: %" CHIP_ERROR_FORMAT, err.Format());
         DequeueConnectionCallbacks(err);
         // Do not touch `this` instance anymore; it has been destroyed in DequeueConnectionCallbacks.
         return;

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -322,6 +322,7 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
             // After the first failure notify session manager to refresh device data
             if (entry->sendCount == 1 && mSessionUpdateDelegate != nullptr)
             {
+                ChipLogDetail(ExchangeManager, "Notify session manager to update peer address");
                 mSessionUpdateDelegate->UpdatePeerAddress(entry->ec->GetSessionHandle()->GetPeer());
             }
         }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Found random commission failure during automation test against esp32 target. It looks the reason of this failure if the esp32 was not able to send Sigma2 msg to the controller. We just know where it failed but don't know why. 

* We need to instrument more debug log to help us understand the failure reason.

#### Change overview
Add more debug log to track CASE failure during commission

#### Testing
How was this tested? (at least one bullet point required)
* Only debug log added, no logic change.
