### PR TITLE
Remove upload of entire out dir for linux - it is too large

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -112,14 +112,19 @@ jobs:
                   path: /tmp/cores/
                   # Cores are big; don't hold on to them too long.
                   retention-days: 5
-            - name: Uploading objdir for debugging
-              uses: actions/upload-artifact@v2
-              if: ${{ failure() && !env.ACT }}
-              with:
-                  name: crash-objdir-linux-gcc-debug
-                  path: out/
-                  # objdirs are big; don't hold on to them too long.
-                  retention-days: 5
+            # OBJDIR on linux is > 10K files and takes more than 50 minutes to upload, usually
+            # having the job timeout.
+            #
+            # If re-enabling, some subset of this should be picked
+            #
+            # - name: Uploading objdir for debugging
+            #   uses: actions/upload-artifact@v2
+            #   if: ${{ failure() && !env.ACT }}
+            #   with:
+            #       name: crash-objdir-linux-gcc-debug
+            #       path: out/
+            #       # objdirs are big; don't hold on to them too long.
+            #       retention-days: 5
     build_linux:
         name: Build on Linux (fake, gcc_release, clang, simulated)
         timeout-minutes: 150
@@ -240,7 +245,7 @@ jobs:
                   # Cores are big; don't hold on to them too long.
                   retention-days: 5
             # OBJDIR on linux is > 10K files and takes more than 50 minutes to upload, usually
-            # having the job timeout. 
+            # having the job timeout.
             #
             # If re-enabling, some subset of this should be picked
             #


### PR DESCRIPTION
#### Problem
Timing out on builds, like https://github.com/project-chip/connectedhomeip/runs/8137393997?check_suite_focus=true

Uploading the entire out directory (expecting 100s of MB) including a python venv is not practical. If we enable this, we need some curated subset (like elf files in test and maybe map files).

#### Change overview
Disable upload on failure for linux

#### Testing
N/A - CI will run and this is a comment-out only. if CI runs we are fine.