### PR TITLE
[EFR32] Fix thermostat app build

### DIFF
--- a/examples/platform/efr32/BaseApplication.cpp
+++ b/examples/platform/efr32/BaseApplication.cpp
@@ -156,7 +156,7 @@ CHIP_ERROR BaseApplication::Init(Identify * identifyObj)
 
     if (identifyObj == nullptr)
     {
-        EFR32_LOG("funct timer create failed");
+        EFR32_LOG("Invalid Identify Object!");
         appError(CHIP_ERROR_INVALID_ARGUMENT);
     }
 

--- a/examples/thermostat/efr32/args.gni
+++ b/examples/thermostat/efr32/args.gni
@@ -24,3 +24,6 @@ pw_log_BACKEND = "${chip_root}/src/lib/support/pw_log_chip"
 pw_assert_BACKEND = "$dir_pw_assert_log:check_backend"
 chip_enable_openthread = true
 pw_rpc_CONFIG = "$dir_pw_rpc:disable_global_mutex"
+
+openthread_external_platform =
+    "${chip_root}/third_party/openthread/platforms/efr32:libopenthread-efr32"

--- a/examples/thermostat/efr32/src/AppTask.cpp
+++ b/examples/thermostat/efr32/src/AppTask.cpp
@@ -140,6 +140,10 @@ CHIP_ERROR AppTask::Init()
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
 
+#ifdef DISPLAY_ENABLED
+    GetLCD().Init((uint8_t *) "Thermostat-App");
+#endif
+
     err = BaseApplication::Init(&gIdentify);
     if (err != CHIP_NO_ERROR)
     {


### PR DESCRIPTION
#### Problem
Thermostat example build was broken

#### Change overview
Fix thermostat build
- Add missing variable for openthread lib
- Add LCD init call

#### Testing
Manual tests with EFR32 MG24 and the thermostat example
