### PR TITLE
Check the onboarding payload code type in MTROnboardingPayloadParser

### DIFF
--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -61,13 +61,7 @@ CHIP_ERROR SetupPayloadParseCommand::Run()
     NSString * codeString = [NSString stringWithCString:mCode encoding:NSASCIIStringEncoding];
     NSError * error;
     MTRSetupPayload * payload;
-    MTROnboardingPayloadType codeType;
-    if (IsQRCode(codeString)) {
-        codeType = MTROnboardingPayloadTypeQRCode;
-    } else {
-        codeType = MTROnboardingPayloadTypeManualCode;
-    }
-    payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:codeString ofType:codeType error:&error];
+    payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:codeString error:&error];
     if (error) {
         LogNSError("Error: ", error);
         return CHIP_ERROR_INTERNAL;

--- a/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.h
@@ -30,7 +30,6 @@ typedef NS_ENUM(NSUInteger, MTROnboardingPayloadType) {
 @interface MTROnboardingPayloadParser : NSObject
 
 + (nullable MTRSetupPayload *)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
-                                                        ofType:(MTROnboardingPayloadType)type
                                                          error:(NSError * __autoreleasing *)error;
 
 @end

--- a/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.m
+++ b/src/darwin/Framework/CHIP/MTROnboardingPayloadParser.m
@@ -22,17 +22,23 @@
 
 @implementation MTROnboardingPayloadParser
 
++ (bool)isQRCode:(NSString *)codeString
+{
+    return [codeString hasPrefix:@"MT:"];
+}
+
 + (nullable MTRSetupPayload *)setupPayloadForOnboardingPayload:(NSString *)onboardingPayload
-                                                        ofType:(MTROnboardingPayloadType)type
                                                          error:(NSError * __autoreleasing *)error
 {
     MTRSetupPayload * payload;
+    // MTROnboardingPayloadTypeNFC is of type QR code and handled same as QR code
+    MTROnboardingPayloadType type =
+        [self isQRCode:onboardingPayload] ? MTROnboardingPayloadTypeQRCode : MTROnboardingPayloadTypeManualCode;
     switch (type) {
     case MTROnboardingPayloadTypeManualCode:
         payload = [self setupPayloadForManualCodeOnboardingPayload:onboardingPayload error:error];
         break;
     case MTROnboardingPayloadTypeQRCode:
-    case MTROnboardingPayloadTypeNFC:
         payload = [self setupPayloadForQRCodeOnboardingPayload:onboardingPayload error:error];
         break;
     default:

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
@@ -38,9 +38,7 @@
 - (void)testOnboardingPayloadParser_Manual_NoError
 {
     NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015"
-                                                                                      ofType:MTROnboardingPayloadTypeManualCode
-                                                                                       error:&error];
+    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
@@ -55,33 +53,10 @@
     XCTAssertNil(payload.rendezvousInformation);
 }
 
-- (void)testOnboardingPayloadParser_Manual_WrongType
-{
-    NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015"
-                                                                                      ofType:MTROnboardingPayloadTypeQRCode
-                                                                                       error:&error];
-
-    XCTAssertNil(payload);
-    XCTAssertEqual(error.code, MTRErrorCodeInvalidArgument);
-}
-
-- (void)testOnboardingPayloadParser_Admin_WrongType
-{
-    NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015"
-                                                                                      ofType:MTROnboardingPayloadTypeQRCode
-                                                                                       error:&error];
-
-    XCTAssertNil(payload);
-    XCTAssertEqual(error.code, MTRErrorCodeInvalidArgument);
-}
-
 - (void)testOnboardingPayloadParser_QRCode_NoError
 {
     NSError * error;
     MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"MT:R5L90MP500K64J00000"
-                                                                                      ofType:MTROnboardingPayloadTypeQRCode
                                                                                        error:&error];
 
     XCTAssertNotNil(payload);
@@ -103,7 +78,6 @@
     NSError * error;
     MTRSetupPayload * payload = [MTROnboardingPayloadParser
         setupPayloadForOnboardingPayload:@"MT:R5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
-                                  ofType:MTROnboardingPayloadTypeNFC
                                    error:&error];
 
     XCTAssertNotNil(payload);
@@ -118,18 +92,6 @@
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
     XCTAssertNotNil(payload.rendezvousInformation);
     XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
-}
-
-- (void)testOnboardingPayloadParser_NFC_WrongType
-{
-    NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser
-        setupPayloadForOnboardingPayload:@"MT:R5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
-                                  ofType:MTROnboardingPayloadTypeManualCode
-                                   error:&error];
-
-    XCTAssertNil(payload);
-    XCTAssertEqual(error.code, MTRErrorCodeIntegrityCheckFailed);
 }
 
 - (void)testManualParser


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Fixes #20311 

#### Change overview
Do not pass code type to setupPayloadForOnboardingPayload. Instead just get the code type from the payload itself.

#### Testing
How was this tested? (at least one bullet point required)
Built darwin framework
