### PR TITLE
Prevent Subscription to attributes with no access privilege and absence

### DIFF
--- a/src/app/InteractionModelEngine.h
+++ b/src/app/InteractionModelEngine.h
@@ -379,6 +379,21 @@ private:
     void OnResponseTimeout(Messaging::ExchangeContext * ec) override;
 
     /**
+     * This parses the attribute path list to ensure it is well formed. If so, for each path in the list, it will expand to a list
+     * of concrete paths and walk each path to check if it has privileges to read that attribute.
+     *
+     * If there is AT LEAST one "existent path" (as the spec calls it) that has sufficient privilege, aHasValidAttributePath
+     * will be set to true. Otherwise, it will be set to false.
+     *
+     * aRequestedAttributePathCount will be updated to reflect the number of attribute paths in the request.
+     *
+     *
+     */
+    static CHIP_ERROR ParseAttributePaths(const Access::SubjectDescriptor & aSubjectDescriptor,
+                                          AttributePathIBs::Parser & aAttributePathListParser, bool & aHasValidAttributePath,
+                                          size_t & aRequestedAttributePathCount);
+
+    /**
      * Called when Interaction Model receives a Read Request message.  Errors processing
      * the Read Request are handled entirely within this function.  If the
      * status returned is not Status::Success, the caller will send a status
@@ -616,6 +631,13 @@ Protocols::InteractionModel::Status ServerClusterCommandExists(const ConcreteCom
 CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescriptor, bool aIsFabricFiltered,
                                  const ConcreteReadAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports,
                                  AttributeValueEncoder::AttributeEncodeState * apEncoderState);
+
+/**
+ *  Check whether concrete attribute path is an "existent attribute path" in spec terms.
+ *  @param[in]    aPath                 The concrete path of the data being read.
+ *  @retval  boolean
+ */
+bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath);
 
 /**
  *  Get the registered attribute access override. nullptr when attribute access override is not found.

--- a/src/app/MessageDef/AttributePathIB.cpp
+++ b/src/app/MessageDef/AttributePathIB.cpp
@@ -227,6 +227,63 @@ CHIP_ERROR AttributePathIB::Parser::GetListIndex(ConcreteDataAttributePath & aAt
     return err;
 }
 
+CHIP_ERROR AttributePathIB::Parser::ParsePath(AttributePathParams & aAttribute) const
+{
+    CHIP_ERROR err = CHIP_NO_ERROR;
+
+    err = GetEndpoint(&(aAttribute.mEndpointId));
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aAttribute.HasWildcardEndpointId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    err = GetCluster(&aAttribute.mClusterId);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(IsValidClusterId(aAttribute.mClusterId), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    err = GetAttribute(&aAttribute.mAttributeId);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(IsValidAttributeId(aAttribute.mAttributeId), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    // A wildcard cluster requires that the attribute path either be
+    // wildcard or a global attribute.
+    VerifyOrReturnError(!aAttribute.HasWildcardClusterId() || aAttribute.HasWildcardAttributeId() ||
+                            IsGlobalAttribute(aAttribute.mAttributeId),
+                        CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    err = GetListIndex(&aAttribute.mListIndex);
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aAttribute.HasWildcardAttributeId() && !aAttribute.HasWildcardListIndex(),
+                            CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    return CHIP_NO_ERROR;
+}
+
 AttributePathIB::Builder & AttributePathIB::Builder::EnableTagCompression(const bool aEnableTagCompression)
 {
     // skip if error has already been set

--- a/src/app/MessageDef/AttributePathIB.h
+++ b/src/app/MessageDef/AttributePathIB.h
@@ -153,6 +153,14 @@ public:
     CHIP_ERROR GetListIndex(ConcreteDataAttributePath & aAttributePath) const;
 
     // TODO(#14934) Add a function to get ConcreteDataAttributePath from AttributePathIB::Parser directly.
+
+    /**
+     * @brief Parse the attribute path into an AttributePathParams object. As part of parsing,
+     * validity checks for each path item will be done as well.
+     *
+     * If any errors are encountered, an IM error of 'InvalidAction' will be returned.
+     */
+    CHIP_ERROR ParsePath(AttributePathParams & attribute) const;
 };
 
 class Builder : public ListBuilder

--- a/src/app/MessageDef/EventPathIB.cpp
+++ b/src/app/MessageDef/EventPathIB.cpp
@@ -26,6 +26,8 @@
 
 #include <app/AppConfig.h>
 
+#include <protocols/interaction_model/Constants.h>
+
 namespace chip {
 namespace app {
 #if CHIP_CONFIG_IM_ENABLE_SCHEMA_CHECK
@@ -169,6 +171,50 @@ CHIP_ERROR EventPathIB::Parser::GetEventPath(ConcreteEventPath * const apPath) c
 CHIP_ERROR EventPathIB::Parser::GetIsUrgent(bool * const apIsUrgent) const
 {
     return GetSimpleValue(to_underlying(Tag::kIsUrgent), TLV::kTLVType_Boolean, apIsUrgent);
+}
+
+CHIP_ERROR EventPathIB::Parser::ParsePath(EventPathParams & aEvent) const
+{
+    CHIP_ERROR err = GetEndpoint(&(aEvent.mEndpointId));
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aEvent.HasWildcardEndpointId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    err = GetCluster(&(aEvent.mClusterId));
+    if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aEvent.HasWildcardClusterId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    else if (err == CHIP_END_OF_TLV)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    err = GetEvent(&(aEvent.mEventId));
+    if (CHIP_END_OF_TLV == err)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    else if (err == CHIP_NO_ERROR)
+    {
+        VerifyOrReturnError(!aEvent.HasWildcardEventId(), CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    }
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(InvalidAction));
+
+    err = GetIsUrgent(&(aEvent.mIsUrgentEvent));
+    if (CHIP_END_OF_TLV == err)
+    {
+        err = CHIP_NO_ERROR;
+    }
+    VerifyOrReturnError(err == CHIP_NO_ERROR, CHIP_IM_GLOBAL_STATUS(InvalidAction));
+    return CHIP_NO_ERROR;
 }
 
 EventPathIB::Builder & EventPathIB::Builder::Node(const NodeId aNode)

--- a/src/app/MessageDef/EventPathIB.h
+++ b/src/app/MessageDef/EventPathIB.h
@@ -127,6 +127,14 @@ public:
      *          #CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB if the path from the reader is not a valid concrere event path.
      */
     CHIP_ERROR GetEventPath(ConcreteEventPath * const apPath) const;
+
+    /**
+     * @brief Parse the event path into an EventPathParams object. As part of parsing,
+     * validity checks for each path item will be done as well.
+     *
+     * If any errors are encountered, an IM error of 'InvalidAction' will be returned.
+     */
+    CHIP_ERROR ParsePath(EventPathParams & aEvent) const;
 };
 
 class Builder : public ListBuilder

--- a/src/app/ReadHandler.cpp
+++ b/src/app/ReadHandler.cpp
@@ -315,7 +315,7 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
     }
     else if (err == CHIP_NO_ERROR)
     {
-        ReturnErrorOnFailure(ProcessAttributePathList(attributePathListParser));
+        ReturnErrorOnFailure(ProcessAttributePaths(attributePathListParser));
         DataVersionFilterIBs::Parser dataVersionFilterListParser;
         err = readRequestParser.GetDataVersionFilters(&dataVersionFilterListParser);
         if (err == CHIP_END_OF_TLV)
@@ -363,75 +363,19 @@ CHIP_ERROR ReadHandler::ProcessReadRequest(System::PacketBufferHandle && aPayloa
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathIBs::Parser & aAttributePathListParser)
+CHIP_ERROR ReadHandler::ProcessAttributePaths(AttributePathIBs::Parser & aAttributePathListParser)
 {
     CHIP_ERROR err = CHIP_NO_ERROR;
     TLV::TLVReader reader;
     aAttributePathListParser.GetReader(&reader);
     while (CHIP_NO_ERROR == (err = reader.Next()))
     {
-        VerifyOrExit(TLV::AnonymousTag() == reader.GetTag(), err = CHIP_ERROR_INVALID_TLV_TAG);
+        VerifyOrReturnError(TLV::AnonymousTag() == reader.GetTag(), CHIP_ERROR_INVALID_TLV_TAG);
         AttributePathParams attribute;
         AttributePathIB::Parser path;
-        err = path.Init(reader);
-        SuccessOrExit(err);
-
-        err = path.GetEndpoint(&(attribute.mEndpointId));
-        if (err == CHIP_NO_ERROR)
-        {
-            VerifyOrExit(!attribute.HasWildcardEndpointId(), err = CHIP_IM_GLOBAL_STATUS(InvalidAction));
-        }
-        else if (err == CHIP_END_OF_TLV)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        SuccessOrExit(err);
-
-        ClusterId clusterId = kInvalidClusterId;
-        err                 = path.GetCluster(&clusterId);
-        if (err == CHIP_NO_ERROR)
-        {
-            VerifyOrExit(IsValidClusterId(clusterId), err = CHIP_IM_GLOBAL_STATUS(InvalidAction));
-            attribute.mClusterId = clusterId;
-        }
-        else if (err == CHIP_END_OF_TLV)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        SuccessOrExit(err);
-
-        AttributeId attributeId = kInvalidAttributeId;
-        err                     = path.GetAttribute(&attributeId);
-        if (CHIP_END_OF_TLV == err)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        else if (err == CHIP_NO_ERROR)
-        {
-            VerifyOrExit(IsValidAttributeId(attributeId), err = CHIP_IM_GLOBAL_STATUS(InvalidAction));
-            attribute.mAttributeId = attributeId;
-        }
-        SuccessOrExit(err);
-
-        // A wildcard cluster requires that the attribute path either be
-        // wildcard or a global attribute.
-        VerifyOrExit(!attribute.HasWildcardClusterId() || attribute.HasWildcardAttributeId() ||
-                         IsGlobalAttribute(attribute.mAttributeId),
-                     err = CHIP_IM_GLOBAL_STATUS(InvalidAction));
-
-        err = path.GetListIndex(&(attribute.mListIndex));
-        if (CHIP_NO_ERROR == err)
-        {
-            VerifyOrExit(!attribute.HasWildcardAttributeId() && !attribute.HasWildcardListIndex(),
-                         err = CHIP_IM_GLOBAL_STATUS(InvalidAction));
-        }
-        else if (CHIP_END_OF_TLV == err)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        SuccessOrExit(err);
-        err = InteractionModelEngine::GetInstance()->PushFrontAttributePathList(mpAttributePathList, attribute);
-        SuccessOrExit(err);
+        ReturnErrorOnFailure(path.Init(reader));
+        ReturnErrorOnFailure(path.ParsePath(attribute));
+        ReturnErrorOnFailure(InteractionModelEngine::GetInstance()->PushFrontAttributePathList(mpAttributePathList, attribute));
     }
     // if we have exhausted this container
     if (CHIP_END_OF_TLV == err)
@@ -440,8 +384,6 @@ CHIP_ERROR ReadHandler::ProcessAttributePathList(AttributePathIBs::Parser & aAtt
         mAttributePathExpandIterator = AttributePathExpandIterator(mpAttributePathList);
         err                          = CHIP_NO_ERROR;
     }
-
-exit:
     return err;
 }
 
@@ -487,47 +429,7 @@ CHIP_ERROR ReadHandler::ProcessEventPaths(EventPathIBs::Parser & aEventPathsPars
         EventPathParams event;
         EventPathIB::Parser path;
         ReturnErrorOnFailure(path.Init(reader));
-
-        err = path.GetEndpoint(&(event.mEndpointId));
-        if (err == CHIP_NO_ERROR)
-        {
-            VerifyOrReturnError(!event.HasWildcardEndpointId(), err = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB);
-        }
-        else if (err == CHIP_END_OF_TLV)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        ReturnErrorOnFailure(err);
-
-        err = path.GetCluster(&(event.mClusterId));
-        if (err == CHIP_NO_ERROR)
-        {
-            VerifyOrReturnError(!event.HasWildcardClusterId(), err = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB);
-        }
-        else if (err == CHIP_END_OF_TLV)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        ReturnErrorOnFailure(err);
-
-        err = path.GetEvent(&(event.mEventId));
-        if (CHIP_END_OF_TLV == err)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        else if (err == CHIP_NO_ERROR)
-        {
-            VerifyOrReturnError(!event.HasWildcardEventId(), err = CHIP_ERROR_IM_MALFORMED_EVENT_PATH_IB);
-        }
-        ReturnErrorOnFailure(err);
-
-        err = path.GetIsUrgent(&(event.mIsUrgentEvent));
-        if (CHIP_END_OF_TLV == err)
-        {
-            err = CHIP_NO_ERROR;
-        }
-        ReturnErrorOnFailure(err);
-
+        ReturnErrorOnFailure(path.ParsePath(event));
         ReturnErrorOnFailure(InteractionModelEngine::GetInstance()->PushFrontEventPathParamsList(mpEventPathList, event));
     }
 
@@ -667,7 +569,7 @@ CHIP_ERROR ReadHandler::ProcessSubscribeRequest(System::PacketBufferHandle && aP
     }
     else if (err == CHIP_NO_ERROR)
     {
-        ReturnErrorOnFailure(ProcessAttributePathList(attributePathListParser));
+        ReturnErrorOnFailure(ProcessAttributePaths(attributePathListParser));
         DataVersionFilterIBs::Parser dataVersionFilterListParser;
         err = subscribeRequestParser.GetDataVersionFilters(&dataVersionFilterListParser);
         if (err == CHIP_END_OF_TLV)

--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -362,7 +362,7 @@ private:
     CHIP_ERROR SendSubscribeResponse();
     CHIP_ERROR ProcessSubscribeRequest(System::PacketBufferHandle && aPayload);
     CHIP_ERROR ProcessReadRequest(System::PacketBufferHandle && aPayload);
-    CHIP_ERROR ProcessAttributePathList(AttributePathIBs::Parser & aAttributePathListParser);
+    CHIP_ERROR ProcessAttributePaths(AttributePathIBs::Parser & aAttributePathListParser);
     CHIP_ERROR ProcessEventPaths(EventPathIBs::Parser & aEventPathsParser);
     CHIP_ERROR ProcessEventFilters(EventFilterIBs::Parser & aEventFiltersParser);
     CHIP_ERROR OnStatusResponse(Messaging::ExchangeContext * apExchangeContext, System::PacketBufferHandle && aPayload,

--- a/src/app/tests/BUILD.gn
+++ b/src/app/tests/BUILD.gn
@@ -102,6 +102,8 @@ chip_test_suite("tests") {
     test_sources += [ "TestFailSafeContext.cpp" ]
   }
 
+  test_sources += [ "TestAclAttribute.cpp" ]
+
   #
   # On NRF platforms, the allocation of a large number of pbufs in this test
   # to exercise chunking causes it to run out of memory. For now, disable it there.

--- a/src/app/tests/TestAclAttribute.cpp
+++ b/src/app/tests/TestAclAttribute.cpp
@@ -1,0 +1,283 @@
+/*
+ *
+ *    Copyright (c) 2021 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "lib/support/CHIPMem.h"
+#include <access/examples/PermissiveAccessControlDelegate.h>
+#include <app/AttributeAccessInterface.h>
+#include <app/InteractionModelEngine.h>
+#include <app/MessageDef/AttributeReportIBs.h>
+#include <app/MessageDef/EventDataIB.h>
+#include <app/tests/AppTestContext.h>
+#include <app/util/basic-types.h>
+#include <app/util/mock/Constants.h>
+#include <app/util/mock/Functions.h>
+#include <lib/core/CHIPCore.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/core/CHIPTLVDebug.hpp>
+#include <lib/core/CHIPTLVUtilities.hpp>
+#include <lib/support/CHIPCounter.h>
+#include <lib/support/ErrorStr.h>
+#include <lib/support/UnitTestContext.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <messaging/ExchangeContext.h>
+#include <messaging/Flags.h>
+#include <nlunit-test.h>
+#include <protocols/interaction_model/Constants.h>
+
+#include <type_traits>
+
+namespace {
+using namespace chip;
+using namespace chip::Access;
+
+chip::ClusterId kTestClusterId        = 1;
+chip::ClusterId kTestDeniedClusterId1 = 1000;
+chip::ClusterId kTestDeniedClusterId2 = 3;
+chip::EndpointId kTestEndpointId      = 4;
+
+class TestAccessControlDelegate : public AccessControl::Delegate
+{
+public:
+    CHIP_ERROR Check(const SubjectDescriptor & subjectDescriptor, const chip::Access::RequestPath & requestPath,
+                     Privilege requestPrivilege) override
+    {
+        if (requestPath.cluster == kTestDeniedClusterId2)
+        {
+            return CHIP_ERROR_ACCESS_DENIED;
+        }
+        return CHIP_NO_ERROR;
+    }
+};
+
+AccessControl::Delegate * GetTestAccessControlDelegate()
+{
+    static TestAccessControlDelegate accessControlDelegate;
+    return &accessControlDelegate;
+}
+
+class TestDeviceTypeResolver : public AccessControl::DeviceTypeResolver
+{
+public:
+    bool IsDeviceTypeOnEndpoint(DeviceTypeId deviceType, EndpointId endpoint) override { return false; }
+} gDeviceTypeResolver;
+
+class TestAccessContext : public chip::Test::AppContext
+{
+public:
+    static int Initialize(void * context)
+    {
+        if (AppContext::Initialize(context) != SUCCESS)
+            return FAILURE;
+        Access::GetAccessControl().Finish();
+        Access::GetAccessControl().Init(GetTestAccessControlDelegate(), gDeviceTypeResolver);
+        return SUCCESS;
+    }
+
+    static int Finalize(void * context)
+    {
+        if (AppContext::Finalize(context) != SUCCESS)
+            return FAILURE;
+        return SUCCESS;
+    }
+
+private:
+    chip::MonotonicallyIncreasingCounter<chip::EventNumber> mEventCounter;
+};
+
+class MockInteractionModelApp : public chip::app::ReadClient::Callback
+{
+public:
+    void OnAttributeData(const chip::app::ConcreteDataAttributePath & aPath, chip::TLV::TLVReader * apData,
+                         const chip::app::StatusIB & status) override
+    {
+        mGotReport          = true;
+        mLastStatusReceived = status;
+    }
+
+    void OnError(CHIP_ERROR aError) override { mError = aError; }
+
+    void OnDone(chip::app::ReadClient *) override {}
+
+    void OnDeallocatePaths(chip::app::ReadPrepareParams && aReadPrepareParams) override
+    {
+        if (aReadPrepareParams.mpAttributePathParamsList != nullptr)
+        {
+            delete[] aReadPrepareParams.mpAttributePathParamsList;
+        }
+
+        if (aReadPrepareParams.mpDataVersionFilterList != nullptr)
+        {
+            delete[] aReadPrepareParams.mpDataVersionFilterList;
+        }
+    }
+
+    bool mGotReport = false;
+    chip::app::StatusIB mLastStatusReceived;
+    CHIP_ERROR mError = CHIP_NO_ERROR;
+};
+} // namespace
+
+namespace chip {
+namespace app {
+
+bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath)
+{
+    return aPath.mClusterId != kTestDeniedClusterId1;
+}
+
+class TestAclAttribute
+{
+public:
+    static void TestACLDeniedAttribute(nlTestSuite * apSuite, void * apContext);
+};
+
+// Read Client sends a malformed subscribe request, interaction model engine fails to parse the request and generates a status
+// report to client, and client is closed.
+void TestAclAttribute::TestACLDeniedAttribute(nlTestSuite * apSuite, void * apContext)
+{
+    TestAccessContext & ctx = *static_cast<TestAccessContext *>(apContext);
+    CHIP_ERROR err          = CHIP_NO_ERROR;
+
+    Messaging::ReliableMessageMgr * rm = ctx.GetExchangeManager().GetReliableMessageMgr();
+    NL_TEST_ASSERT(apSuite, rm->TestGetCountRetransTable() == 0);
+
+    MockInteractionModelApp delegate;
+    auto * engine = chip::app::InteractionModelEngine::GetInstance();
+    err           = engine->Init(&ctx.GetExchangeManager(), &ctx.GetFabricTable());
+    NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+    {
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Subscribe);
+
+        chip::app::AttributePathParams attributePathParams[2];
+        attributePathParams[0].mEndpointId  = kTestEndpointId;
+        attributePathParams[0].mClusterId   = kTestDeniedClusterId1;
+        attributePathParams[0].mAttributeId = 1;
+
+        attributePathParams[1].mEndpointId  = kTestEndpointId;
+        attributePathParams[1].mClusterId   = kTestDeniedClusterId1;
+        attributePathParams[1].mAttributeId = 2;
+
+        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+        readPrepareParams.mAttributePathParamsListSize = 2;
+
+        err = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, delegate.mError == CHIP_IM_GLOBAL_STATUS(InvalidAction));
+        NL_TEST_ASSERT(apSuite, !delegate.mGotReport);
+        delegate.mError     = CHIP_NO_ERROR;
+        delegate.mGotReport = false;
+    }
+
+    {
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Subscribe);
+
+        chip::app::AttributePathParams attributePathParams[2];
+
+        attributePathParams[0].mClusterId   = kTestDeniedClusterId2;
+        attributePathParams[0].mAttributeId = 1;
+
+        attributePathParams[1].mClusterId   = kTestDeniedClusterId2;
+        attributePathParams[1].mAttributeId = 2;
+
+        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+        readPrepareParams.mAttributePathParamsListSize = 2;
+
+        err = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, delegate.mError == CHIP_IM_GLOBAL_STATUS(InvalidAction));
+        NL_TEST_ASSERT(apSuite, !delegate.mGotReport);
+        delegate.mError     = CHIP_NO_ERROR;
+        delegate.mGotReport = false;
+    }
+
+    {
+        app::ReadClient readClient(chip::app::InteractionModelEngine::GetInstance(), &ctx.GetExchangeManager(), delegate,
+                                   chip::app::ReadClient::InteractionType::Subscribe);
+
+        chip::app::AttributePathParams attributePathParams[2];
+        attributePathParams[0].mEndpointId  = kTestEndpointId;
+        attributePathParams[0].mClusterId   = kTestDeniedClusterId1;
+        attributePathParams[0].mAttributeId = 1;
+
+        attributePathParams[1].mEndpointId  = kTestEndpointId;
+        attributePathParams[1].mClusterId   = kTestClusterId;
+        attributePathParams[1].mAttributeId = 2;
+
+        ReadPrepareParams readPrepareParams(ctx.GetSessionBobToAlice());
+        readPrepareParams.mpAttributePathParamsList    = attributePathParams;
+        readPrepareParams.mAttributePathParamsListSize = 2;
+
+        err = readClient.SendRequest(readPrepareParams);
+        NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
+
+        ctx.DrainAndServiceIO();
+        NL_TEST_ASSERT(apSuite, delegate.mError == CHIP_NO_ERROR);
+        NL_TEST_ASSERT(apSuite, delegate.mGotReport);
+        NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadHandlers(ReadHandler::InteractionType::Subscribe) == 1);
+        delegate.mError     = CHIP_NO_ERROR;
+        delegate.mGotReport = false;
+    }
+
+    NL_TEST_ASSERT(apSuite, engine->GetNumActiveReadClients() == 0);
+    engine->Shutdown();
+    NL_TEST_ASSERT(apSuite, ctx.GetExchangeManager().GetNumActiveExchanges() == 0);
+}
+} // namespace app
+} // namespace chip
+
+namespace {
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+
+// clang-format off
+const nlTest sTests[] =
+{
+    NL_TEST_DEF("TestACLDeniedAttribute", chip::app::TestAclAttribute::TestACLDeniedAttribute),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+// clang-format off
+nlTestSuite sSuite =
+{
+    "TestAclAttribute",
+    &sTests[0],
+    TestAccessContext::Initialize,
+    TestAccessContext::Finalize
+};
+// clang-format on
+
+} // namespace
+
+int TestAclAttribute()
+{
+    return chip::ExecuteTestsWithContext<TestAccessContext>(&sSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestAclAttribute)

--- a/src/app/tests/TestAclEvent.cpp
+++ b/src/app/tests/TestAclEvent.cpp
@@ -16,12 +16,6 @@
  *    limitations under the License.
  */
 
-/**
- *    @file
- *      This file implements unit tests for CHIP Interaction Model Read Interaction
- *
- */
-
 #include "lib/support/CHIPMem.h"
 #include <access/AccessControl.h>
 #include <app/AttributeAccessInterface.h>
@@ -55,7 +49,7 @@ uint8_t gDebugEventBuffer[128];
 uint8_t gInfoEventBuffer[128];
 uint8_t gCritEventBuffer[128];
 chip::app::CircularEventBuffer gCircularEventBuffer[3];
-chip::ClusterId kTestClusterId1    = 6;
+chip::ClusterId kTestClusterId1    = 100;
 chip::ClusterId kTestClusterId2    = 7;
 chip::EndpointId kTestEndpointId   = 1;
 chip::EventId kTestEventIdDebug    = 1;

--- a/src/app/tests/integration/chip_im_initiator.cpp
+++ b/src/app/tests/integration/chip_im_initiator.cpp
@@ -654,6 +654,11 @@ const EmberAfAttributeMetadata * GetAttributeMetadata(const ConcreteAttributePat
     return &stub;
 }
 
+bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath)
+{
+    return true;
+}
+
 CHIP_ERROR WriteSingleClusterData(const Access::SubjectDescriptor & aSubjectDescriptor, const ConcreteDataAttributePath & aPath,
                                   TLV::TLVReader & aReader, WriteHandler *)
 {

--- a/src/app/tests/integration/chip_im_responder.cpp
+++ b/src/app/tests/integration/chip_im_responder.cpp
@@ -122,6 +122,11 @@ CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescr
     return CHIP_NO_ERROR;
 }
 
+bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath)
+{
+    return true;
+}
+
 const EmberAfAttributeMetadata * GetAttributeMetadata(const ConcreteAttributePath & aConcreteClusterPath)
 {
     // Note: This test does not make use of the real attribute metadata.

--- a/src/app/util/ember-compatibility-functions.cpp
+++ b/src/app/util/ember-compatibility-functions.cpp
@@ -516,6 +516,18 @@ Protocols::InteractionModel::Status UnsupportedAttributeStatus(const ConcreteAtt
 
 } // anonymous namespace
 
+bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath)
+{
+    for (auto & attr : GlobalAttributesNotInMetadata)
+    {
+        if (attr == aPath.mAttributeId)
+        {
+            return (emberAfFindCluster(aPath.mEndpointId, aPath.mClusterId, CLUSTER_MASK_SERVER) != nullptr);
+        }
+    }
+    return (emberAfLocateAttributeMetadata(aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId) != nullptr);
+}
+
 CHIP_ERROR ReadSingleClusterData(const SubjectDescriptor & aSubjectDescriptor, bool aIsFabricFiltered,
                                  const ConcreteReadAttributePath & aPath, AttributeReportIBs::Builder & aAttributeReports,
                                  AttributeValueEncoder::AttributeEncodeState * apEncoderState)

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -1218,7 +1218,11 @@ exit:
             auto readClient = Platform::New<app::ReadClient>(
                 engine, exchangeManager, callback->GetBufferedCallback(), chip::app::ReadClient::InteractionType::Subscribe);
 
-            err = readClient->SendAutoResubscribeRequest(std::move(readParams));
+            if (params != nil && params.autoResubscribe != nil && ![params.autoResubscribe boolValue]) {
+                err = readClient->SendRequest(readParams);
+            } else {
+                err = readClient->SendAutoResubscribeRequest(std::move(readParams));
+            }
 
             if (err != CHIP_NO_ERROR) {
                 if (reportHandler) {
@@ -1227,6 +1231,8 @@ exit:
                     });
                 }
                 Platform::Delete(readClient);
+                Platform::Delete(container.pathParams);
+                container.pathParams = nullptr;
                 return;
             }
 

--- a/src/darwin/Framework/CHIP/MTRIMDispatch.mm
+++ b/src/darwin/Framework/CHIP/MTRIMDispatch.mm
@@ -121,6 +121,11 @@ namespace app {
         return aAttributeReports.EncodeAttributeStatus(aPath, StatusIB(status));
     }
 
+    bool ConcreteAttributePathExists(const ConcreteAttributePath & aPath)
+    {
+        return DetermineAttributeStatus(aPath, /* aIsWrite = */ false) == Status::UnsupportedAccess;
+    }
+
     Status ServerClusterCommandExists(const ConcreteCommandPath & aPath)
     {
         // TODO: Consider making this configurable for applications that are not


### PR DESCRIPTION
#### Problem
Reads and Subscribes from nodes with no access still get serviced to completion (which for subs mean that a subscription is established). This ends up stealing precious resources from nodes that do have access.

Fixes: issue #18485 

#### Change overview
Prevents reads/subs from moving past the processing stage to actual allocation of resources. A StatusResponse is returned immediately.

Caveat: This doesn't address lack of access for event paths. That will come separately. currently we don't have ways to expand wildcard event path and check if path exists, suggest to figure out this in post1.0. At this moment, subscription prevention with no access privilege and absence is the best effort we can go 

#### Testing
add unit test to validate empty attribute paths and event paths in subscribe request
add unit test to validate non-exist concrete attribute path and event paths in subscribe request
add unit test to validate acl-denied attribute path and event path in subscribe request
