### PR TITLE
Add a Darwin framework notification when subscription drops.

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
@@ -211,6 +211,9 @@ public:
             }
             subscriptionEstablished:^() {
                 mSubscriptionEstablished = YES;
+            }
+            resubscriptionScheduled:^(NSError * error, NSNumber * resubscriptionDelay) {
+                NSLog(@"Subscription dropped with error %@.  Resubscription in %@ms", error, resubscriptionDelay);
             }];
 
         return CHIP_NO_ERROR;

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -250,8 +250,9 @@ static TemperatureSensorViewController * _Nullable sCurrentController = nil;
                     errorHandler:^(NSError * error) {
                         NSLog(@"Status: update reportAttributeMeasuredValue completed with error %@", [error description]);
                     }
-                    subscriptionEstablished:^ {
-                    }];
+                    subscriptionEstablished:^{
+                    }
+                    resubscriptionScheduled:nil];
             } else {
                 NSLog(@"Status: Failed to establish a connection with the device");
             }

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -77,6 +77,16 @@ typedef void (^MTRDeviceResponseHandler)(NSArray<NSDictionary<NSString *, id> *>
 typedef void (^MTRDeviceReportHandler)(NSArray * values);
 typedef void (^MTRDeviceErrorHandler)(NSError * error);
 
+/**
+ * Handler for subscribeWithQueue: resubscription scheduling notifications.
+ * This will be called when subscription loss is detected.
+ *
+ * @param error An error indicating the reason the subscription has been lost.
+ * @param resubscriptionDelay A delay, in milliseconds, before the next
+ *        automatic resubscription will be attempted.
+ */
+typedef void (^MTRDeviceResubscriptionScheduledHandler)(NSError * error, NSNumber * resubscriptionDelay);
+
 extern NSString * const MTRAttributePathKey;
 extern NSString * const MTRCommandPathKey;
 extern NSString * const MTREventPathKey;
@@ -126,15 +136,23 @@ extern NSString * const MTRArrayValueType;
  * instances.  Errors for specific paths, not the whole subscription, will be
  * reported via those objects.
  *
- * errorHandler will be called any time there is an error for the
- * entire subscription (with a non-nil "error"), and terminate the subscription.
+ * errorHandler will be called any time there is an error for the entire
+ * subscription (with a non-nil "error"), and terminate the subscription.  This
+ * will generally not be invoked if auto-resubscription is enabled, unless there
+ * is a fatal error during a resubscription attempt.
  *
  * Both report handlers are not supported over XPC at the moment.
  *
- * subscriptionEstablished block, if not nil, will be called once the
+ * The subscriptionEstablished block, if not nil, will be called once the
  * subscription is established.  This will be _after_ the first (priming) call
  * to both report handlers.  Note that if the MTRSubscribeParams are set to
  * automatically resubscribe this can end up being called more than once.
+ *
+ * The resubscriptionScheduled block, if not nil, will be called if
+ * auto-resubscription is enabled, subscription loss is detected, and a
+ * resubscription is scheduled.  This can be called multiple times in a row
+ * without an intervening subscriptionEstablished call if the resubscription
+ * attempts fail.
  */
 - (void)subscribeWithQueue:(dispatch_queue_t)queue
                 minInterval:(uint16_t)minInterval
@@ -144,7 +162,8 @@ extern NSString * const MTRArrayValueType;
      attributeReportHandler:(MTRDeviceReportHandler _Nullable)attributeReportHandler
          eventReportHandler:(MTRDeviceReportHandler _Nullable)eventReportHandler
                errorHandler:(MTRDeviceErrorHandler)errorHandler
-    subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler;
+    subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler
+    resubscriptionScheduled:(MTRDeviceResubscriptionScheduledHandler _Nullable)resubscriptionScheduledHandler;
 
 /**
  * Read attribute in a designated attribute path

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -57,8 +57,8 @@ public:
         , mAttributeReportCallback(attributeReportCallback)
         , mEventReportCallback(eventReportCallback)
         , mErrorCallback(errorCallback)
-        , mSubscriptionEstablishedHandler(subscriptionEstablishedHandler)
         , mResubscriptionCallback(resubscriptionCallback)
+        , mSubscriptionEstablishedHandler(subscriptionEstablishedHandler)
         , mBufferedReadAdapter(*this)
         , mOnDoneHandler(onDoneHandler)
     {
@@ -123,8 +123,8 @@ private:
     // We set mErrorCallback to nil when queueing error reports, so we
     // make sure to only report one error.
     ErrorCallback _Nullable mErrorCallback = nil;
-    SubscriptionEstablishedHandler _Nullable mSubscriptionEstablishedHandler = nil;
     MTRDeviceResubscriptionScheduledHandler _Nullable mResubscriptionCallback = nil;
+    SubscriptionEstablishedHandler _Nullable mSubscriptionEstablishedHandler = nil;
     chip::app::BufferedReadCallback mBufferedReadAdapter;
 
     // Our lifetime management is a little complicated.  On errors that don't

--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #import "Foundation/Foundation.h"
+#import "MTRBaseDevice.h"
 
 #include <app/BufferedReadCallback.h>
 #include <app/ClusterStateCache.h>
@@ -43,7 +44,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^DataReportCallback)(NSArray * value);
 typedef void (^ErrorCallback)(NSError * error);
-typedef void (^ResubscriptionCallback)(void);
 typedef void (^SubscriptionEstablishedHandler)(void);
 typedef void (^OnDoneHandler)(void);
 
@@ -51,7 +51,7 @@ class MTRBaseSubscriptionCallback : public chip::app::ClusterStateCache::Callbac
 public:
     MTRBaseSubscriptionCallback(dispatch_queue_t queue, DataReportCallback attributeReportCallback,
         DataReportCallback eventReportCallback, ErrorCallback errorCallback,
-        ResubscriptionCallback _Nullable resubscriptionCallback,
+        MTRDeviceResubscriptionScheduledHandler _Nullable resubscriptionCallback,
         SubscriptionEstablishedHandler _Nullable subscriptionEstablishedHandler, OnDoneHandler _Nullable onDoneHandler)
         : mQueue(queue)
         , mAttributeReportCallback(attributeReportCallback)
@@ -124,7 +124,7 @@ private:
     // make sure to only report one error.
     ErrorCallback _Nullable mErrorCallback = nil;
     SubscriptionEstablishedHandler _Nullable mSubscriptionEstablishedHandler = nil;
-    ResubscriptionCallback _Nullable mResubscriptionCallback = nil;
+    MTRDeviceResubscriptionScheduledHandler _Nullable mResubscriptionCallback = nil;
     chip::app::BufferedReadCallback mBufferedReadAdapter;
 
     // Our lifetime management is a little complicated.  On errors that don't

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -102,8 +102,8 @@ namespace {
 class SubscriptionCallback final : public MTRBaseSubscriptionCallback {
 public:
     SubscriptionCallback(dispatch_queue_t queue, DataReportCallback attributeReportCallback, DataReportCallback eventReportCallback,
-        ErrorCallback errorCallback, SubscriptionEstablishedHandler subscriptionEstablishedHandler,
-        MTRDeviceResubscriptionScheduledHandler resubscriptionCallback, OnDoneHandler onDoneHandler)
+        ErrorCallback errorCallback, MTRDeviceResubscriptionScheduledHandler resubscriptionCallback,
+        SubscriptionEstablishedHandler subscriptionEstablishedHandler, OnDoneHandler onDoneHandler)
         : MTRBaseSubscriptionCallback(queue, attributeReportCallback, eventReportCallback, errorCallback, resubscriptionCallback,
             subscriptionEstablishedHandler, onDoneHandler)
     {
@@ -327,13 +327,13 @@ private:
                                    // OnError
                                    [self _handleSubscriptionError:error];
                                },
-                               ^(void) {
-                                   // OnSubscriptionEstablished
-                                   [self _handleSubscriptionEstablished];
-                               },
                                ^(NSError * error, NSNumber * resubscriptionDelay) {
                                    // OnResubscriptionNeeded
                                    [self _handleResubscriptionNeeded];
+                               },
+                               ^(void) {
+                                   // OnSubscriptionEstablished
+                                   [self _handleSubscriptionEstablished];
                                },
                                ^(void) {
                                    // OnDone

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -103,7 +103,7 @@ class SubscriptionCallback final : public MTRBaseSubscriptionCallback {
 public:
     SubscriptionCallback(dispatch_queue_t queue, DataReportCallback attributeReportCallback, DataReportCallback eventReportCallback,
         ErrorCallback errorCallback, SubscriptionEstablishedHandler subscriptionEstablishedHandler,
-        ResubscriptionCallback resubscriptionCallback, OnDoneHandler onDoneHandler)
+        MTRDeviceResubscriptionScheduledHandler resubscriptionCallback, OnDoneHandler onDoneHandler)
         : MTRBaseSubscriptionCallback(queue, attributeReportCallback, eventReportCallback, errorCallback, resubscriptionCallback,
             subscriptionEstablishedHandler, onDoneHandler)
     {
@@ -331,7 +331,7 @@ private:
                                    // OnSubscriptionEstablished
                                    [self _handleSubscriptionEstablished];
                                },
-                               ^(void) {
+                               ^(NSError * error, NSNumber * resubscriptionDelay) {
                                    // OnResubscriptionNeeded
                                    [self _handleResubscriptionNeeded];
                                },

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
@@ -54,9 +54,11 @@ NS_ASSUME_NONNULL_BEGIN
      attributeReportHandler:(nullable void (^)(NSArray * value))attributeReportHandler
          eventReportHandler:(nullable void (^)(NSArray * value))eventReportHandler
                errorHandler:(void (^)(NSError * error))errorHandler
-    subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler;
+    subscriptionEstablished:(nullable void (^)(void))subscriptionEstablishedHandler
+    resubscriptionScheduled:(MTRDeviceResubscriptionScheduledHandler _Nullable)resubscriptionScheduledHandler
 {
-    MTR_LOG_DEBUG("Subscribing all attributes... Note that reportHandler is not supported.");
+    MTR_LOG_DEBUG("Subscribing all attributes... Note that attributeReportHandler, eventReportHandler, and resubscriptionScheduled "
+                  "are not supported.");
     if (attributeCacheContainer) {
         [attributeCacheContainer setXPCConnection:_xpcConnection controllerId:self.controller deviceId:self.nodeId];
     }

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -776,7 +776,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         }
         subscriptionEstablished:^() {
             [subscribeExpectation fulfill];
-        }];
+        }
+        resubscriptionScheduled:nil];
     [self waitForExpectations:@[ subscribeExpectation ] timeout:60];
 
     // Invoke command to set the attribute to a known state

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -395,7 +395,8 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
                                       established[0] = @YES;
                                       completion(nil);
                                   }
-                              }];
+                              }
+                              resubscriptionScheduled:nil];
                       }];
     } else {
         NSLog(@"Failed to get shared controller");
@@ -1794,7 +1795,8 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         subscriptionEstablished:^() {
             NSLog(@"Attribute cache subscribed attributes");
             [expectation fulfill];
-        }];
+        }
+        resubscriptionScheduled:nil];
     // Wait for subscription establishment. This can take very long to collect initial reports.
     NSLog(@"Waiting for initial report...");
     [self waitForExpectations:@[ expectation ] timeout:120];

--- a/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
@@ -130,7 +130,8 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                   established[0] = @YES;
                                   completionHandler(nil);
                               }
-                          }];
+                          }
+                          resubscriptionScheduled:nil];
                   }];
 }
 @end


### PR DESCRIPTION
Tells the API consumer the reason for the drop and how long we will wait before resubscribing.

Fixes https://github.com/project-chip/connectedhomeip/issues/21613

#### Problem
No way to find out about subscription loss when using auto-resubscribe.

#### Change overview
Add a way to find out.

#### Testing
Tested using darwin-framework-tool `any subscribe-all-events`.  Killed the server app, observed messages like:
```
2022-09-01 17:12:51.445 darwin-framework-tool[60339:16774123] Subscription dropped with error Error Domain=MTRErrorDomain Code=9 "Transaction timed out." UserInfo={NSLocalizedDescription=Transaction timed out., underlyingError=<MTRErrorHolder: 0x60300006aed0>}.  Resubscription in 0ms

2022-09-01 17:13:46.653 darwin-framework-tool[60339:16774709] Subscription dropped with error Error Domain=MTRErrorDomain Code=9 "Transaction timed out." UserInfo={NSLocalizedDescription=Transaction timed out., underlyingError=<MTRErrorHolder: 0x60300006a0c0>}.  Resubscription in 4025ms

2022-09-01 17:14:48.641 darwin-framework-tool[60339:16775798] Subscription dropped with error Error Domain=MTRErrorDomain Code=9 "Transaction timed out." UserInfo={NSLocalizedDescription=Transaction timed out., underlyingError=<MTRErrorHolder: 0x60300006a450>}.  Resubscription in 3444ms
```
etc.