### PR TITLE
Remove now-unnecessary leak suppression.

### DIFF
--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -23,10 +23,6 @@ leak:ERR_get_state
 leak:[BleConnection initWithDiscriminator:]
 leak:[CBXpcConnection initWithDelegate:queue:options:sessionType:]
 
-# TODO: ClusterBase::SubscribeAttribute creates a subscription that cannot
-# actually be shut down in any way.
-leak:ClusterBase::SubscribeAttribute
-
 # TODO: Figure out how we are managing to leak NSData while using ARC!
 leak:[CHIPToolKeypair signMessageECDSA_RAW:]
 


### PR DESCRIPTION
This leak got fixed in https://github.com/project-chip/connectedhomeip/pull/22323

#### Problem
Leak suppression for LSan that we don't need anymore.

#### Change overview
Remove it, so if something re-introduces the leak we will catch it.

#### Testing
Should pass CI.