### PR TITLE
[nrfconnect] Fixed handling lock/unlock door lock commands

### DIFF
--- a/examples/lock-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lock-app/nrfconnect/main/AppTask.cpp
@@ -504,10 +504,7 @@ void AppTask::LockStateChanged(BoltLockManager::State state, BoltLockManager::Op
         break;
     }
 
-    if (source != BoltLockManager::OperationSource::kRemote)
-    {
-        sAppTask.UpdateClusterState(state, source);
-    }
+    sAppTask.UpdateClusterState(state, source);
 }
 
 void AppTask::PostEvent(AppEvent * aEvent)

--- a/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lock-app/nrfconnect/main/ZclCallbacks.cpp
@@ -77,12 +77,28 @@ bool emberAfPluginDoorLockSetCredential(EndpointId endpointId, uint16_t credenti
 
 bool emberAfPluginDoorLockOnDoorLockCommand(EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
-    return BoltLockMgr().ValidatePIN(pinCode, err);
+    bool result = BoltLockMgr().ValidatePIN(pinCode, err);
+
+    /* Handle changing attribute state on command reception */
+    if (result)
+    {
+        BoltLockMgr().Lock(BoltLockManager::OperationSource::kRemote);
+    }
+
+    return result;
 }
 
 bool emberAfPluginDoorLockOnDoorUnlockCommand(EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
-    return BoltLockMgr().ValidatePIN(pinCode, err);
+    bool result = BoltLockMgr().ValidatePIN(pinCode, err);
+
+    /* Handle changing attribute state on command reception */
+    if (result)
+    {
+        BoltLockMgr().Unlock(BoltLockManager::OperationSource::kRemote);
+    }
+
+    return result;
 }
 
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)


### PR DESCRIPTION
#### Problem
Some time ago setting lock state attribute was removed from the door lock cluster code, so basically now it doesn't work in
nrfconnect example, as application was relying on the cluster code.

#### Change overview
Added handling attribute state in the application.

#### Testing
Did manual testing to prove the fix works.
