### PR TITLE
[darwin-framework-tool] Add a shortcut (CTL('_')) to stop the stack w…

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -95,6 +95,8 @@ protected:
 
     static std::set<CHIPCommandBridge *> sDeferredCleanups;
 
+    void StopCommissioners();
+
     void RestartCommissioners();
 
 private:

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -136,11 +136,16 @@ MTRDeviceController * CHIPCommandBridge::CurrentCommissioner() { return mCurrent
 
 MTRDeviceController * CHIPCommandBridge::GetCommissioner(const char * identity) { return mControllers[identity]; }
 
-void CHIPCommandBridge::RestartCommissioners()
+void CHIPCommandBridge::StopCommissioners()
 {
     for (auto & pair : mControllers) {
         [pair.second shutdown];
     }
+}
+
+void CHIPCommandBridge::RestartCommissioners()
+{
+    StopCommissioners();
 
     auto factory = [MTRControllerFactory sharedInstance];
     NSData * ipk = [gNocSigner getIPK];
@@ -159,9 +164,7 @@ void CHIPCommandBridge::RestartCommissioners()
 void CHIPCommandBridge::ShutdownCommissioner()
 {
     ChipLogProgress(chipTool, "Shutting down controller");
-    for (auto & pair : mControllers) {
-        [pair.second shutdown];
-    }
+    StopCommissioners();
     mControllers.clear();
     mCurrentController = nil;
 

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -47,6 +47,22 @@ public:
     chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(0); }
 };
 
+class StopCommand : public CHIPCommandBridge {
+public:
+    StopCommand()
+        : CHIPCommandBridge("stop")
+    {
+    }
+
+    CHIP_ERROR RunCommand() override
+    {
+        StopCommissioners();
+        return CHIP_NO_ERROR;
+    }
+
+    chip::System::Clock::Timeout GetWaitDuration() const override { return chip::System::Clock::Seconds16(0); }
+};
+
 void ClearLine()
 {
     printf("\r\x1B[0J"); // Move cursor to the beginning of the line and clear from cursor to end of the screen
@@ -85,6 +101,13 @@ el_status_t RestartFunction()
     return CSstay;
 }
 
+el_status_t StopFunction()
+{
+    StopCommand cmd;
+    cmd.RunCommand();
+    return CSstay;
+}
+
 CHIP_ERROR InteractiveStartCommand::RunCommand()
 {
     read_history(kInteractiveModeHistoryFilePath);
@@ -94,6 +117,7 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
     chip::Logging::SetLogRedirectCallback(LoggingCallback);
 
     el_bind_key(CTL('^'), RestartFunction);
+    el_bind_key(CTL('_'), StopFunction);
 
     char * command = nullptr;
     while (YES) {


### PR DESCRIPTION
…hile in interactive mode

#### Problem

This PR is similar to #22268. But instead of adding a shortcut to restart the Matter stack, it adds one to stop the Matter stack with the possibility to do a restart afterward (using `Ctrl + ^`).

It is sometimes helpful to found/debug some crashes that does not happens when quickly restarting the stack. For example the second step of #22320 shows that a quick restart was not able to get the crash since some actions are a little bit delayed by some dispatch queues but won't crash if the stack is restarted too quickly.

So the reason for this PR is to not have to manually hack the restart method ;) 

I'm arguing for v1.0 for the same reason than #22268 in the sense that it does not affect anything from the core SDK and may help to find some bugs related to the stack shutdown.

#### Change overview
* Add a new option in interactive mode for the darwin-framework-tool in order to stop the stack. Using a shortcut to make it fast.

#### Testing
I have only tested that the stack is correctly turned off when pressing `Ctrl + _` and that it does restart when starting `Ctrl + ^`.
