### PR TITLE
Fix port logging in OnNewInterface.

### DIFF
--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -408,7 +408,7 @@ void ResolveContext::OnNewInterface(uint32_t interfaceId, const char * fullname,
     }
 #endif // CHIP_DETAIL_LOGGING
     ChipLogDetail(Discovery, "Mdns : %s hostname:%s fullname:%s interface: %" PRIu32 " port: %u TXT:\"%s\"", __func__,
-                  hostnameWithDomain, fullname, interfaceId, port, txtString.c_str());
+                  hostnameWithDomain, fullname, interfaceId, ntohs(port), txtString.c_str());
 
     InterfaceInfo interface;
     interface.service.mPort = ntohs(port);


### PR DESCRIPTION
The port is in network byte order, not native.

#### Problem
Wrong value logged.

#### Change overview
Log the right value.

#### Testing
Checked with chip-tool to make sure the logging matches what the server is doing.

For 1.0 triage: This is a platform-specific change that does not change behavior other than logging.