### PR TITLE
Disable imx builds from cloudbuild all-build

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -28,7 +28,7 @@ steps:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
               --target-glob '*' --skip-target-glob
-              '{tizen-*,*-tests*,*-chip-test}' build --create-archives
+              '{imx-*,tizen-*,*-tests*,*-chip-test}' build --create-archives
               /workspace/artifacts/
       id: CompileAll
       waitFor:


### PR DESCRIPTION
#### Problem

Bad IMX SDK path in vscode image prevents vscode image from building imx binaries (see #22365)


#### Change overview
Disable IMX builds from cloudbuild.

#### Testing
N/A (cloudbuild CI will validate, this cannot be tested by github ci)