### PR TITLE
[darwin][leak] (80 bytes) ROOT LEAK: <OS_dispatch_semaphore 0x7fd6db928c60> [80] when pressing Ctrl + ^ in interactive mode

### DIFF
--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -52,8 +52,6 @@ CHIP_ERROR PlatformManagerImpl::_InitChipStack()
     SuccessOrExit(err);
 #endif // CHIP_DISABLE_PLATFORM_KVS
 
-    mRunLoopSem = dispatch_semaphore_create(0);
-
     // Ensure there is a dispatch queue available
     static_cast<System::LayerSocketsLoop &>(DeviceLayer::SystemLayer()).SetDispatchQueue(GetWorkQueue());
 
@@ -127,7 +125,10 @@ void PlatformManagerImpl::_RunEventLoop()
     // Block on the semaphore till we're signalled to stop by
     // _StopEventLoopTask()
     //
+    mRunLoopSem = dispatch_semaphore_create(0);
     dispatch_semaphore_wait(mRunLoopSem, DISPATCH_TIME_FOREVER);
+    dispatch_release(mRunLoopSem);
+    mRunLoopSem = nullptr;
 }
 
 void PlatformManagerImpl::_Shutdown()


### PR DESCRIPTION
#### Problem

When restarting the Matter stack the dispatch semaphore that is used by `RunEventLoop` is leaking.

The steps to reproduce are the following:
```
leaks -atExit -- ./out/debug/standalone/darwin-framework-tool interactive start
#once in interative mode, press Ctrl+^
quit()
```

#### Change overview
 * Allocate it when needed, and release it when appropriate

Asking to land in v1.0 since this is a leak.