### PR TITLE
Address testing feedback from opcert callbacks, and re-commissioning

### DIFF
--- a/examples/platform/linux/AppMain.cpp
+++ b/examples/platform/linux/AppMain.cpp
@@ -334,7 +334,8 @@ void ChipLinuxAppMainLoop()
 #if CHIP_DEVICE_CONFIG_ENABLE_BOTH_COMMISSIONER_AND_COMMISSIONEE
     ChipLogProgress(AppServer, "Starting commissioner");
     VerifyOrReturn(InitCommissioner(LinuxDeviceOptions::GetInstance().securedCommissionerPort + 10,
-                                    LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort) == CHIP_NO_ERROR);
+                                    LinuxDeviceOptions::GetInstance().unsecuredCommissionerPort,
+                                    LinuxDeviceOptions::GetInstance().commissionerFabricId) == CHIP_NO_ERROR);
     ChipLogProgress(AppServer, "Started commissioner");
 #if defined(ENABLE_CHIP_SHELL)
     Shell::RegisterControllerCommands();

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -76,7 +76,7 @@ using namespace chip::app::Clusters;
 using namespace ::chip::Messaging;
 using namespace ::chip::Controller;
 
-class MyServerStorageDelegate : public PersistentStorageDelegate
+class CustomServerStorageDelegate : public PersistentStorageDelegate
 {
     CHIP_ERROR SyncGetKeyValue(const char * key, void * buffer, uint16_t & size) override
     {
@@ -105,7 +105,7 @@ class MyServerStorageDelegate : public PersistentStorageDelegate
     }
 };
 
-class MyCommissionerCallback : public CommissionerCallback
+class CustomCommissionerCallback : public CommissionerCallback
 {
     void ReadyForCommissioning(uint32_t pincode, uint16_t longDiscriminator, PeerAddress peerAddress) override
     {
@@ -115,16 +115,15 @@ class MyCommissionerCallback : public CommissionerCallback
 
 AutoCommissioner gAutoCommissioner;
 
-class MyCredsIssuer : public ExampleOperationalCredentialsIssuer
+class CustomCredsIssuer : public ExampleOperationalCredentialsIssuer
 {
     CHIP_ERROR GenerateNOCChain(const ByteSpan & csrElements, const ByteSpan & csrNonce, const ByteSpan & attestationSignature,
                                 const ByteSpan & attestationChallenge, const ByteSpan & DAC, const ByteSpan & PAI,
                                 Callback::Callback<OnNOCChainGeneration> * onCompletion) override
     {
-        ChipLogError(Controller, "---------------------------MyCredsIssuer ");
         // add parsing here
         const ByteSpan & attestationElements = gAutoCommissioner.GetCommissioningParameters().GetAttestationElements().Value();
-        ChipLogError(Controller, "MyCredsIssuer attestationElements size %d", static_cast<int>(attestationElements.size()));
+        ChipLogError(Controller, "CustomCredsIssuer attestationElements size %d", static_cast<int>(attestationElements.size()));
 
         ByteSpan certificationDeclarationSpan;
         ByteSpan attestationNonceSpan;
@@ -150,9 +149,9 @@ class MyCredsIssuer : public ExampleOperationalCredentialsIssuer
 
 DeviceCommissioner gCommissioner;
 CommissionerDiscoveryController gCommissionerDiscoveryController;
-MyCommissionerCallback gCommissionerCallback;
-MyServerStorageDelegate gServerStorage;
-MyCredsIssuer gOpCredsIssuer;
+CustomCommissionerCallback gCommissionerCallback;
+CustomServerStorageDelegate gServerStorage;
+CustomCredsIssuer gOpCredsIssuer;
 NodeId gLocalId = kMaxOperationalNodeId;
 Credentials::GroupDataProviderImpl gGroupDataProvider;
 Credentials::PartialDACVerifier gPartialDACVerifier;

--- a/examples/platform/linux/CommissionerMain.cpp
+++ b/examples/platform/linux/CommissionerMain.cpp
@@ -183,6 +183,11 @@ CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, F
 
     params.defaultCommissioner = &gAutoCommissioner;
 
+    // assign prefered feature settings
+    CommissioningParameters commissioningParams = gAutoCommissioner.GetCommissioningParameters();
+    commissioningParams.SetCheckForMatchingFabric(true);
+    gAutoCommissioner.SetCommissioningParameters(commissioningParams);
+
     auto & factory = Controller::DeviceControllerFactory::GetInstance();
     ReturnErrorOnFailure(factory.Init(factoryParams));
     ReturnErrorOnFailure(factory.SetupCommissioner(params, gCommissioner));

--- a/examples/platform/linux/CommissionerMain.h
+++ b/examples/platform/linux/CommissionerMain.h
@@ -34,7 +34,7 @@ using chip::Transport::PeerAddress;
 CHIP_ERROR CommissionerPairOnNetwork(uint32_t pincode, uint16_t disc, PeerAddress address);
 CHIP_ERROR CommissionerPairUDC(uint32_t pincode, size_t index);
 
-CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort);
+CHIP_ERROR InitCommissioner(uint16_t commissionerPort, uint16_t udcListenPort, chip::FabricId fabricId);
 void ShutdownCommissioner();
 
 DeviceCommissioner * GetDeviceCommissioner();

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -72,6 +72,7 @@ enum
     kOptionCSRResponseAttestationSignatureInvalid       = 0x101d,
     kOptionCSRResponseCSRExistingKeyPair                = 0x101e,
     kDeviceOption_TestEventTriggerEnableKey             = 0x101f,
+    kCommissionerOption_FabricID                        = 0x1020,
 };
 
 constexpr unsigned kAppUsageLength = 64;
@@ -117,6 +118,7 @@ OptionDef sDeviceOptionDefs[] = {
     { "cert_error_attestation_signature_incorrect_type", kNoArgument, kOptionCSRResponseAttestationSignatureIncorrectType },
     { "cert_error_attestation_signature_invalid", kNoArgument, kOptionCSRResponseAttestationSignatureInvalid },
     { "enable-key", kArgumentRequired, kDeviceOption_TestEventTriggerEnableKey },
+    { "commissioner-fabric-id", kArgumentRequired, kCommissionerOption_FabricID },
     {}
 };
 
@@ -181,6 +183,9 @@ const char * sDeviceOptionHelp =
     "\n"
     "  --unsecured-commissioner-port <port>\n"
     "       A 16-bit unsigned integer specifying the port to use for unsecured commissioner messages (default is 5550).\n"
+    "\n"
+    "  --commissioner-fabric-id <fabricid>\n"
+    "       The fabric ID to be used when this device is a commissioner (default in code is 1).\n"
     "\n"
     "  --command <command-name>\n"
     "       A name for a command to execute during startup.\n"
@@ -458,6 +463,11 @@ bool HandleOption(const char * aProgram, OptionSet * aOptions, int aIdentifier, 
             retval = false;
         }
 
+        break;
+    }
+    case kCommissionerOption_FabricID: {
+        char * eptr;
+        LinuxDeviceOptions::GetInstance().commissionerFabricId = (chip::FabricId) strtoull(aValue, &eptr, 0);
         break;
     }
 

--- a/examples/platform/linux/Options.h
+++ b/examples/platform/linux/Options.h
@@ -60,6 +60,7 @@ struct LinuxDeviceOptions
     chip::Credentials::DeviceAttestationCredentialsProvider * dacProvider = nullptr;
     chip::CSRResponseOptions mCSRResponseOptions;
     uint8_t testEventTriggerEnableKey[16] = { 0 };
+    chip::FabricId commissionerFabricId   = chip::kUndefinedFabricId;
 
     static LinuxDeviceOptions & GetInstance();
 };

--- a/src/app/app-platform/ContentAppPlatform.cpp
+++ b/src/app/app-platform/ContentAppPlatform.cpp
@@ -527,6 +527,8 @@ constexpr ClusterId kClusterIdAudioOutput     = 0x050b;
 // constexpr ClusterId kClusterIdApplicationLauncher = 0x050c;
 // constexpr ClusterId kClusterIdAccountLogin        = 0x050e;
 
+// Add ACLs on this device for the given client,
+// and create bindings on the given client so that it knows what it has access to.
 CHIP_ERROR ContentAppPlatform::ManageClientAccess(Messaging::ExchangeManager & exchangeMgr, SessionHandle & sessionHandle,
                                                   uint16_t targetVendorId, NodeId localNodeId,
                                                   Controller::WriteResponseSuccessCallback successCb,
@@ -575,6 +577,13 @@ CHIP_ERROR ContentAppPlatform::ManageClientAccess(Messaging::ExchangeManager & e
      * We could have organized things differently, for example,
      * - a single ACL for (a) and (b) which is shared by many subjects
      * - a single ACL entry per subject for (c)
+     *
+     * We are also creating the following set of bindings on the remote device:
+     * a) Video Player endpoint
+     * b) Speaker endpoint
+     * c) selection of content app endpoints (0 to many)
+     * The purpose of the bindings is to inform the client of its access to
+     * nodeId and endpoints on the app platform.
      */
 
     ChipLogProgress(Controller, "Create video player endpoint ACL and binding");

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -138,6 +138,11 @@ public:
      *   Add ACLs on this device for the given client,
      *   and create bindings on the given client so that it knows what it has access to.
      *
+     * The default implementation follows the device library Video Player Architecture spec
+     * for a typical video player given assumptions like video player endpoint id is 1 and
+     * speaker endpoint id is 2. Some devices may need to override this implementation when
+     * these assumptions are not correct.
+     *
      * @param[in] exchangeMgr     Exchange manager to be used to get an exchange context.
      * @param[in] sessionHandle   Reference to an established session.
      * @param[in] targetVendorId  Vendor ID for the target device.

--- a/src/app/app-platform/ContentAppPlatform.h
+++ b/src/app/app-platform/ContentAppPlatform.h
@@ -155,6 +155,7 @@ protected:
     // requires vendorApp to be in the catalog of the platform
     ContentApp * LoadContentAppInternal(const CatalogVendorApp & vendorApp);
     ContentApp * GetContentAppInternal(const CatalogVendorApp & vendorApp);
+    CHIP_ERROR GetACLEntryIndex(size_t * foundIndex, FabricIndex fabricIndex, NodeId subjectNodeId);
 
     static const int kNoCurrentEndpointId = 0;
     EndpointId mCurrentAppEndpointId      = kNoCurrentEndpointId;

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -328,9 +328,6 @@ void OnPlatformEventHandler(const chip::DeviceLayer::ChipDeviceEvent * event, in
 
 } // anonymous namespace
 
-// As per specifications section 11.22.5.1. Constant RESP_MAX
-constexpr size_t kMaxRspLen = 900;
-
 class OpCredsFabricTableDelegate : public chip::FabricTable::Delegate
 {
 public:
@@ -961,7 +958,8 @@ bool emberAfOperationalCredentialsClusterAttestationRequestCallback(app::Command
     attestationElementsSpan = MutableByteSpan{ attestationElements.Get(), attestationElementsLen };
     err = Credentials::ConstructAttestationElements(certDeclSpan, attestationNonce, timestamp, kEmptyFirmwareInfo,
                                                     emptyVendorReserved, attestationElementsSpan);
-    VerifyOrExit((err == CHIP_NO_ERROR) && (attestationElementsSpan.size() <= kMaxRspLen), finalStatus = Status::Failure);
+    VerifyOrExit((err == CHIP_NO_ERROR) && (attestationElementsSpan.size() <= Credentials::kMaxRspLen),
+                 finalStatus = Status::Failure);
 
     // Append attestation challenge in the back of the reserved space for the signature
     memcpy(attestationElements.Get() + attestationElementsSpan.size(), attestationChallenge.data(), attestationChallenge.size());
@@ -1092,7 +1090,8 @@ bool emberAfOperationalCredentialsClusterCSRRequestCallback(app::CommandHandler 
 
         err = Credentials::ConstructNOCSRElements(ByteSpan{ csrSpan.data(), csrSpan.size() }, CSRNonce, kNoVendorReserved,
                                                   kNoVendorReserved, kNoVendorReserved, nocsrElementsSpan);
-        VerifyOrExit((err == CHIP_NO_ERROR) && (nocsrElementsSpan.size() <= kMaxRspLen), finalStatus = Status::Failure);
+        VerifyOrExit((err == CHIP_NO_ERROR) && (nocsrElementsSpan.size() <= Credentials::kMaxRspLen),
+                     finalStatus = Status::Failure);
 
         // Append attestation challenge in the back of the reserved space for the signature
         memcpy(nocsrElements.Get() + nocsrElementsSpan.size(), attestationChallenge.data(), attestationChallenge.size());

--- a/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
+++ b/src/app/clusters/operational-credentials-server/operational-credentials-server.cpp
@@ -958,8 +958,7 @@ bool emberAfOperationalCredentialsClusterAttestationRequestCallback(app::Command
     attestationElementsSpan = MutableByteSpan{ attestationElements.Get(), attestationElementsLen };
     err = Credentials::ConstructAttestationElements(certDeclSpan, attestationNonce, timestamp, kEmptyFirmwareInfo,
                                                     emptyVendorReserved, attestationElementsSpan);
-    VerifyOrExit((err == CHIP_NO_ERROR) && (attestationElementsSpan.size() <= Credentials::kMaxRspLen),
-                 finalStatus = Status::Failure);
+    VerifyOrExit(err == CHIP_NO_ERROR, finalStatus = Status::Failure);
 
     // Append attestation challenge in the back of the reserved space for the signature
     memcpy(attestationElements.Get() + attestationElementsSpan.size(), attestationChallenge.data(), attestationChallenge.size());
@@ -1090,8 +1089,7 @@ bool emberAfOperationalCredentialsClusterCSRRequestCallback(app::CommandHandler 
 
         err = Credentials::ConstructNOCSRElements(ByteSpan{ csrSpan.data(), csrSpan.size() }, CSRNonce, kNoVendorReserved,
                                                   kNoVendorReserved, kNoVendorReserved, nocsrElementsSpan);
-        VerifyOrExit((err == CHIP_NO_ERROR) && (nocsrElementsSpan.size() <= Credentials::kMaxRspLen),
-                     finalStatus = Status::Failure);
+        VerifyOrExit(err == CHIP_NO_ERROR, finalStatus = Status::Failure);
 
         // Append attestation challenge in the back of the reserved space for the signature
         memcpy(nocsrElements.Get() + nocsrElementsSpan.size(), attestationChallenge.data(), attestationChallenge.size());

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -513,8 +513,12 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             {
                 memcpy(mAttestationElements, report.Get<AttestationResponse>().attestationElements.data(),
                        report.Get<AttestationResponse>().attestationElements.size());
+                mAttestationElementsLen = static_cast<uint16_t>(report.Get<AttestationResponse>().attestationElements.size());
                 mParams.SetAttestationElements(
                     ByteSpan(mAttestationElements, report.Get<AttestationResponse>().attestationElements.size()));
+                ChipLogError(Controller, "AutoCommissioner setting attestationElements buffer size %d/%d",
+                             static_cast<int>(report.Get<AttestationResponse>().attestationElements.size()),
+                             static_cast<int>(mParams.GetAttestationElements().Value().size()));
             }
 
             if (report.Get<AttestationResponse>().signature.size() > kAttestationSignatureLength)
@@ -530,12 +534,13 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             {
                 memcpy(mAttestationSignature, report.Get<AttestationResponse>().signature.data(),
                        report.Get<AttestationResponse>().signature.size());
+                mAttestationSignatureLen = static_cast<uint16_t>(report.Get<AttestationResponse>().signature.size());
                 mParams.SetAttestationSignature(
                     ByteSpan(mAttestationSignature, report.Get<AttestationResponse>().signature.size()));
             }
             // ? These don't need to be deep copied to local memory because they are used in this one step then never again.
             // mParams.SetAttestationElements(report.Get<AttestationResponse>().attestationElements)
-            //     .SetAttestationSignature(report.Get<AttestationResponse>().signature);
+            //    .SetAttestationSignature(report.Get<AttestationResponse>().signature);
 
             // TODO: Does this need to be done at runtime? Seems like this could be done earlier and we wouldn't need to hold a
             // reference to the operational credential delegate here

--- a/src/controller/AutoCommissioner.cpp
+++ b/src/controller/AutoCommissioner.cpp
@@ -522,9 +522,9 @@ CHIP_ERROR AutoCommissioner::CommissioningStepFinished(CHIP_ERROR err, Commissio
             memcpy(mAttestationElements, elements.data(), elements.size());
             mAttestationElementsLen = static_cast<uint16_t>(elements.size());
             mParams.SetAttestationElements(ByteSpan(mAttestationElements, elements.size()));
-            ChipLogError(Controller, "AutoCommissioner setting attestationElements buffer size %u/%u",
-                         static_cast<unsigned>(elements.size()),
-                         static_cast<unsigned>(mParams.GetAttestationElements().Value().size()));
+            ChipLogDetail(Controller, "AutoCommissioner setting attestationElements buffer size %u/%u",
+                          static_cast<unsigned>(elements.size()),
+                          static_cast<unsigned>(mParams.GetAttestationElements().Value().size()));
 
             if (signature.size() > sizeof(mAttestationSignature))
             {

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -38,6 +38,7 @@ public:
     void SetOperationalCredentialsDelegate(OperationalCredentialsDelegate * operationalCredentialsDelegate) override;
 
     CHIP_ERROR StartCommissioning(DeviceCommissioner * commissioner, CommissioneeDeviceProxy * proxy) override;
+    void StopCommissioning() { mStopCommissioning = true; };
 
     CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningDelegate::CommissioningReport report) override;
 
@@ -69,6 +70,8 @@ private:
     Optional<System::Clock::Timeout> GetCommandTimeout(DeviceProxy * device, CommissioningStage stage) const;
     EndpointId GetEndpoint(const CommissioningStage & stage) const;
     CommissioningStage GetNextCommissioningStageInternal(CommissioningStage currentStage, CHIP_ERROR & lastErr);
+
+    bool mStopCommissioning = false;
 
     DeviceCommissioner * mCommissioner                               = nullptr;
     CommissioneeDeviceProxy * mCommissioneeDeviceProxy               = nullptr;

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -23,6 +23,9 @@
 namespace chip {
 namespace Controller {
 
+constexpr size_t kAttestationElementsLength  = 900;
+constexpr size_t kAttestationSignatureLength = 64;
+
 class DeviceCommissioner;
 
 class AutoCommissioner : public CommissioningDelegate
@@ -86,6 +89,9 @@ private:
     uint8_t mCSRNonce[kCSRNonceLength];
     uint8_t mNOCertBuffer[Credentials::kMaxCHIPCertLength];
     uint8_t mICACertBuffer[Credentials::kMaxCHIPCertLength];
+
+    uint8_t mAttestationElements[kAttestationElementsLength];
+    uint8_t mAttestationSignature[kAttestationSignatureLength];
 };
 } // namespace Controller
 } // namespace chip

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -42,7 +42,7 @@ public:
 
     ByteSpan GetAttestationElements() const { return ByteSpan(mAttestationElements, mAttestationElementsLen); }
     ByteSpan GetAttestationSignature() const { return ByteSpan(mAttestationSignature, mAttestationSignatureLen); }
-    ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce, sizeof(mAttestationNonce)); }
+    ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce); }
 
 protected:
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -41,6 +41,10 @@ public:
 
     CHIP_ERROR CommissioningStepFinished(CHIP_ERROR err, CommissioningDelegate::CommissioningReport report) override;
 
+    ByteSpan GetAttestationElements() const { return ByteSpan(mAttestationElements, mAttestationElementsLen); }
+    ByteSpan GetAttestationSignature() const { return ByteSpan(mAttestationSignature, mAttestationSignatureLen); }
+    ByteSpan GetAttestationNonce() const { return ByteSpan(mAttestationNonce, sizeof(mAttestationNonce)); }
+
 protected:
     CommissioningStage GetNextCommissioningStage(CommissioningStage currentStage, CHIP_ERROR & lastErr);
     DeviceCommissioner * GetCommissioner() { return mCommissioner; }
@@ -90,7 +94,9 @@ private:
     uint8_t mNOCertBuffer[Credentials::kMaxCHIPCertLength];
     uint8_t mICACertBuffer[Credentials::kMaxCHIPCertLength];
 
+    uint16_t mAttestationElementsLen = 0;
     uint8_t mAttestationElements[kAttestationElementsLength];
+    uint16_t mAttestationSignatureLen = 0;
     uint8_t mAttestationSignature[kAttestationSignatureLength];
 };
 } // namespace Controller

--- a/src/controller/AutoCommissioner.h
+++ b/src/controller/AutoCommissioner.h
@@ -18,13 +18,11 @@
 #pragma once
 #include <controller/CommissioneeDeviceProxy.h>
 #include <controller/CommissioningDelegate.h>
+#include <credentials/DeviceAttestationConstructor.h>
 #include <protocols/secure_channel/RendezvousParameters.h>
 
 namespace chip {
 namespace Controller {
-
-constexpr size_t kAttestationElementsLength  = 900;
-constexpr size_t kAttestationSignatureLength = 64;
 
 class DeviceCommissioner;
 
@@ -98,9 +96,9 @@ private:
     uint8_t mICACertBuffer[Credentials::kMaxCHIPCertLength];
 
     uint16_t mAttestationElementsLen = 0;
-    uint8_t mAttestationElements[kAttestationElementsLength];
+    uint8_t mAttestationElements[Credentials::kMaxRspLen];
     uint16_t mAttestationSignatureLen = 0;
-    uint8_t mAttestationSignature[kAttestationSignatureLength];
+    uint8_t mAttestationSignature[Crypto::kMax_ECDSA_Signature_Length];
 };
 } // namespace Controller
 } // namespace chip

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1734,6 +1734,9 @@ void DeviceCommissioner::OnDone(app::ReadClient *)
         }
     });
 
+    // Try to parse as much as we can here before returning, even if this is an error.
+    return_err = err == CHIP_NO_ERROR ? return_err : err;
+
     err = mAttributeCache->ForEachAttribute(
         app::Clusters::OperationalCredentials::Id, [this, &info](const app::ConcreteAttributePath & path) {
             if (path.mAttributeId != app::Clusters::OperationalCredentials::Attributes::Fabrics::Id)
@@ -1742,6 +1745,9 @@ void DeviceCommissioner::OnDone(app::ReadClient *)
                 return CHIP_NO_ERROR;
             }
 
+            // this code is checking if the device is already on the commissioner's fabric.
+            // if a matching fabric is found, then remember the nodeId so that the commissioner
+            // can cancel commissioning (before it fails in AddNoc) and know it's nodeId.
             switch (path.mAttributeId)
             {
             case app::Clusters::OperationalCredentials::Attributes::Fabrics::Id: {

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1737,54 +1737,52 @@ void DeviceCommissioner::OnDone(app::ReadClient *)
     // Try to parse as much as we can here before returning, even if this is an error.
     return_err = (err == CHIP_NO_ERROR) ? return_err : err;
 
-    err =
-        mAttributeCache->ForEachAttribute(OperationalCredentials::Id, [this, &info](const app::ConcreteAttributePath & path) {
-            // this code is checking if the device is already on the commissioner's fabric.
-            // if a matching fabric is found, then remember the nodeId so that the commissioner
-            // can, if it decides to, cancel commissioning (before it fails in AddNoc) and know
-            // the device's nodeId on its fabric.
-            switch (path.mAttributeId)
+    err = mAttributeCache->ForEachAttribute(OperationalCredentials::Id, [this, &info](const app::ConcreteAttributePath & path) {
+        // this code is checking if the device is already on the commissioner's fabric.
+        // if a matching fabric is found, then remember the nodeId so that the commissioner
+        // can, if it decides to, cancel commissioning (before it fails in AddNoc) and know
+        // the device's nodeId on its fabric.
+        switch (path.mAttributeId)
+        {
+        case OperationalCredentials::Attributes::Fabrics::Id: {
+            OperationalCredentials::Attributes::Fabrics::TypeInfo::DecodableType fabrics;
+            ReturnErrorOnFailure(this->mAttributeCache->Get<OperationalCredentials::Attributes::Fabrics::TypeInfo>(path, fabrics));
+            auto iter = fabrics.begin();
+            while (iter.Next())
             {
-            case OperationalCredentials::Attributes::Fabrics::Id: {
-                OperationalCredentials::Attributes::Fabrics::TypeInfo::DecodableType fabrics;
-                ReturnErrorOnFailure(
-                    this->mAttributeCache->Get<OperationalCredentials::Attributes::Fabrics::TypeInfo>(path, fabrics));
-                auto iter = fabrics.begin();
-                while (iter.Next())
+                auto & fabricDescriptor = iter.GetValue();
+                ChipLogProgress(AppServer,
+                                "DeviceCommissioner::OnDone - fabric.vendorId=0x%04X fabric.fabricId=0x" ChipLogFormatX64
+                                " fabric.nodeId=0x" ChipLogFormatX64,
+                                fabricDescriptor.vendorId, ChipLogValueX64(fabricDescriptor.fabricId),
+                                ChipLogValueX64(fabricDescriptor.nodeId));
+                // need to add check for root public key
+                if (GetFabricId() == fabricDescriptor.fabricId)
                 {
-                    auto & fabricDescriptor = iter.GetValue();
-                    ChipLogProgress(AppServer,
-                                    "DeviceCommissioner::OnDone - fabric.vendorId=0x%04X fabric.fabricId=0x" ChipLogFormatX64
-                                    " fabric.nodeId=0x" ChipLogFormatX64,
-                                    fabricDescriptor.vendorId, ChipLogValueX64(fabricDescriptor.fabricId),
-                                    ChipLogValueX64(fabricDescriptor.nodeId));
-                    // need to add check for root public key
-                    if (GetFabricId() == fabricDescriptor.fabricId)
-                    {
-                        ChipLogProgress(AppServer, "DeviceCommissioner::OnDone - found a matching fabric id");
-                        chip::ByteSpan rootKeySpan = fabricDescriptor.rootPublicKey;
-                        P256PublicKeySpan rootPubKeySpan(rootKeySpan.data());
-                        Crypto::P256PublicKey deviceRootPublicKey(rootPubKeySpan);
+                    ChipLogProgress(AppServer, "DeviceCommissioner::OnDone - found a matching fabric id");
+                    chip::ByteSpan rootKeySpan = fabricDescriptor.rootPublicKey;
+                    P256PublicKeySpan rootPubKeySpan(rootKeySpan.data());
+                    Crypto::P256PublicKey deviceRootPublicKey(rootPubKeySpan);
 
-                        Crypto::P256PublicKey commissionerRootPublicKey;
-                        if (CHIP_NO_ERROR != GetRootPublicKey(commissionerRootPublicKey))
-                        {
-                            ChipLogError(AppServer, "DeviceCommissioner::OnDone - error reading commissioner root public key");
-                        }
-                        else if (commissionerRootPublicKey.Matches(deviceRootPublicKey))
-                        {
-                            ChipLogProgress(AppServer, "DeviceCommissioner::OnDone - fabric root keys match");
-                            info.nodeId = fabricDescriptor.nodeId;
-                        }
+                    Crypto::P256PublicKey commissionerRootPublicKey;
+                    if (CHIP_NO_ERROR != GetRootPublicKey(commissionerRootPublicKey))
+                    {
+                        ChipLogError(AppServer, "DeviceCommissioner::OnDone - error reading commissioner root public key");
+                    }
+                    else if (commissionerRootPublicKey.Matches(deviceRootPublicKey))
+                    {
+                        ChipLogProgress(AppServer, "DeviceCommissioner::OnDone - fabric root keys match");
+                        info.nodeId = fabricDescriptor.nodeId;
                     }
                 }
+            }
 
-                return CHIP_NO_ERROR;
-            }
-            default:
-                return CHIP_NO_ERROR;
-            }
-        });
+            return CHIP_NO_ERROR;
+        }
+        default:
+            return CHIP_NO_ERROR;
+        }
+    });
 
     // Try to parse as much as we can here before returning, even if this is an error.
     return_err = err == CHIP_NO_ERROR ? return_err : err;

--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -1735,7 +1735,7 @@ void DeviceCommissioner::OnDone(app::ReadClient *)
     });
 
     // Try to parse as much as we can here before returning, even if this is an error.
-    return_err = err == CHIP_NO_ERROR ? return_err : err;
+    return_err = (err == CHIP_NO_ERROR) ? return_err : err;
 
     err = mAttributeCache->ForEachAttribute(
         app::Clusters::OperationalCredentials::Id, [this, &info](const app::ConcreteAttributePath & path) {

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -399,10 +399,10 @@ public:
     // Check for matching fabric on target device by reading fabric list and looking for a
     // fabricId and RootCert match. If a match is detected, then use GetNodeId() to
     // access the nodeId for the device on the matching fabric.
-    Optional<bool> GetCheckForMatchingFabric() const { return mCheckForMatchingFabric; }
+    bool GetCheckForMatchingFabric() const { return mCheckForMatchingFabric; }
     CommissioningParameters & SetCheckForMatchingFabric(bool checkForMatchingFabric)
     {
-        mCheckForMatchingFabric = MakeOptional(checkForMatchingFabric);
+        mCheckForMatchingFabric = checkForMatchingFabric;
         return *this;
     }
 
@@ -437,7 +437,7 @@ private:
     Optional<bool> mAttemptWiFiNetworkScan;
     Optional<bool> mAttemptThreadNetworkScan; // This automatically gets set to false when a ThreadOperationalDataset is set
     Optional<bool> mSkipCommissioningComplete;
-    Optional<bool> mCheckForMatchingFabric;
+    bool mCheckForMatchingFabric = false;
 };
 
 struct RequestedCertificate

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -177,13 +177,11 @@ public:
     // Attestation elements from the node. These are obtained from node in response to the AttestationRequest command. In the
     // AutoCommissioner, this is automatically set from the report from the kSendAttestationRequest stage.
     // This must be set before calling PerformCommissioningStep for the kAttestationVerification step.
-    // Warning: data is not deep copied to local memory and can only be read during PerformCommissioningStep.
     const Optional<ByteSpan> GetAttestationElements() const { return mAttestationElements; }
 
     // Attestation signature from the node. This is obtained from node in response to the AttestationRequest command. In the
     // AutoCommissioner, this is automatically set from the report from the kSendAttestationRequest stage.
     // This must be set before calling PerformCommissioningStep for the kAttestationVerification step.
-    // Warning: data is not deep copied to local memory and can only be read during PerformCommissioningStep.
     const Optional<ByteSpan> GetAttestationSignature() const { return mAttestationSignature; }
 
     // Product attestation intermediate certificate from the node. This is obtained from the node in response to the

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -396,6 +396,16 @@ public:
         return *this;
     }
 
+    // Check for matching fabric on target device by reading fabric list and looking for a
+    // fabricId and RootCert match. If a match is detected, then use GetNodeId() to
+    // access the nodeId for the device on the matching fabric.
+    Optional<bool> GetCheckForMatchingFabric() const { return mCheckForMatchingFabric; }
+    CommissioningParameters & SetCheckForMatchingFabric(bool checkForMatchingFabric)
+    {
+        mCheckForMatchingFabric = MakeOptional(checkForMatchingFabric);
+        return *this;
+    }
+
 private:
     // Items that can be set by the commissioner
     Optional<uint16_t> mFailsafeTimerSeconds;
@@ -427,6 +437,7 @@ private:
     Optional<bool> mAttemptWiFiNetworkScan;
     Optional<bool> mAttemptThreadNetworkScan; // This automatically gets set to false when a ThreadOperationalDataset is set
     Optional<bool> mSkipCommissioningComplete;
+    Optional<bool> mCheckForMatchingFabric;
 };
 
 struct RequestedCertificate

--- a/src/controller/CommissioningDelegate.h
+++ b/src/controller/CommissioningDelegate.h
@@ -177,11 +177,13 @@ public:
     // Attestation elements from the node. These are obtained from node in response to the AttestationRequest command. In the
     // AutoCommissioner, this is automatically set from the report from the kSendAttestationRequest stage.
     // This must be set before calling PerformCommissioningStep for the kAttestationVerification step.
+    // Warning: data is not deep copied to local memory and can only be read during PerformCommissioningStep.
     const Optional<ByteSpan> GetAttestationElements() const { return mAttestationElements; }
 
     // Attestation signature from the node. This is obtained from node in response to the AttestationRequest command. In the
     // AutoCommissioner, this is automatically set from the report from the kSendAttestationRequest stage.
     // This must be set before calling PerformCommissioningStep for the kAttestationVerification step.
+    // Warning: data is not deep copied to local memory and can only be read during PerformCommissioningStep.
     const Optional<ByteSpan> GetAttestationSignature() const { return mAttestationSignature; }
 
     // Product attestation intermediate certificate from the node. This is obtained from the node in response to the
@@ -195,6 +197,10 @@ public:
     // stage.
     // This must be set before calling PerformCommissioningStep for the kAttestationVerification step.
     const Optional<ByteSpan> GetDAC() const { return mDAC; }
+
+    // Node ID when a matching fabric is found in the Node Operational Credentials cluster.
+    // In the AutoCommissioner, this is set from kReadCommissioningInfo stage.
+    const Optional<NodeId> GetRemoteNodeId() const { return mRemoteNodeId; }
 
     // Node vendor ID from the basic information cluster. In the AutoCommissioner, this is automatically set from report from the
     // kReadCommissioningInfo stage.
@@ -328,6 +334,11 @@ public:
         mDAC = MakeOptional(dac);
         return *this;
     }
+    CommissioningParameters & SetRemoteNodeId(NodeId id)
+    {
+        mRemoteNodeId = MakeOptional(id);
+        return *this;
+    }
     CommissioningParameters & SetRemoteVendorId(VendorId id)
     {
         mRemoteVendorId = MakeOptional(id);
@@ -407,6 +418,7 @@ private:
     Optional<ByteSpan> mAttestationSignature;
     Optional<ByteSpan> mPAI;
     Optional<ByteSpan> mDAC;
+    Optional<NodeId> mRemoteNodeId;
     Optional<VendorId> mRemoteVendorId;
     Optional<uint16_t> mRemoteProductId;
     Optional<app::Clusters::GeneralCommissioning::RegulatoryLocationType> mDefaultRegulatoryLocation;
@@ -491,6 +503,7 @@ struct ReadCommissioningInfo
     NetworkClusters network;
     BasicClusterInfo basic;
     GeneralCommissioningInfo general;
+    NodeId nodeId = kUndefinedNodeId;
 };
 
 struct AttestationErrorInfo

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -221,17 +221,19 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
     JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), attestationChallenge.size(),
                                                javaAttestationChallenge);
 
-    const ByteSpan & attestationElements = mAutoCommissioner->GetCommissioningParameters().GetAttestationElements().Value();
+    const ByteSpan & attestationElements = mAutoCommissioner->GetAttestationElements();
     jbyteArray javaAttestationElements;
     JniReferences::GetInstance().N2J_ByteArray(env, attestationElements.data(), attestationElements.size(),
                                                javaAttestationElements);
+    // new log message below
+    ChipLogError(Controller, "AndroidOpCredsIssuer attestationElements size %d/%d", static_cast<int>(attestationElements.size()),
+                 static_cast<int>(env->GetArrayLength(javaAttestationElements)));
 
-    const ByteSpan & attestationNonce = mAutoCommissioner->GetCommissioningParameters().GetAttestationNonce().Value();
+    const ByteSpan & attestationNonce = mAutoCommissioner->GetAttestationNonce();
     jbyteArray javaAttestationNonce;
     JniReferences::GetInstance().N2J_ByteArray(env, attestationNonce.data(), attestationNonce.size(), javaAttestationNonce);
 
-    const ByteSpan & attestationElementsSignature =
-        mAutoCommissioner->GetCommissioningParameters().GetAttestationSignature().Value();
+    const ByteSpan & attestationElementsSignature = mAutoCommissioner->GetAttestationSignature();
     jbyteArray javaAttestationElementsSignature;
     JniReferences::GetInstance().N2J_ByteArray(env, attestationElementsSignature.data(), attestationElementsSignature.size(),
                                                javaAttestationElementsSignature);

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -159,7 +159,9 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
     jmethodID method;
     CHIP_ERROR err = CHIP_NO_ERROR;
     JNIEnv * env   = JniReferences::GetInstance().GetEnvForCurrentThread();
-    err = JniReferences::GetInstance().FindMethod(env, mJavaObjectRef, "onNOCChainGenerationNeeded", "([B[B[B[B[B[B[B[B[B)V",
+
+    err = JniReferences::GetInstance().FindMethod(env, mJavaObjectRef, "onNOCChainGenerationNeeded",
+                                                  "(Lchip/devicecontroller/CSRInfo;Lchip/devicecontroller/AttestationInfo;)V",
                                                   &method);
     if (err != CHIP_NO_ERROR)
     {

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -225,9 +225,8 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
     jbyteArray javaAttestationElements;
     JniReferences::GetInstance().N2J_ByteArray(env, attestationElements.data(), attestationElements.size(),
                                                javaAttestationElements);
-    // new log message below
-    ChipLogError(Controller, "AndroidOpCredsIssuer attestationElements size %d/%d", static_cast<int>(attestationElements.size()),
-                 static_cast<int>(env->GetArrayLength(javaAttestationElements)));
+    ChipLogProgress(Controller, "AndroidOpCredsIssuer attestationElements size %d/%d", static_cast<int>(attestationElements.size()),
+                    static_cast<int>(env->GetArrayLength(javaAttestationElements)));
 
     const ByteSpan & attestationNonce = mAutoCommissioner->GetAttestationNonce();
     jbyteArray javaAttestationNonce;

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -225,8 +225,6 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
     jbyteArray javaAttestationElements;
     JniReferences::GetInstance().N2J_ByteArray(env, attestationElements.data(), attestationElements.size(),
                                                javaAttestationElements);
-    ChipLogProgress(Controller, "AndroidOpCredsIssuer attestationElements size %d/%d", static_cast<int>(attestationElements.size()),
-                    static_cast<int>(env->GetArrayLength(javaAttestationElements)));
 
     const ByteSpan & attestationNonce = mAutoCommissioner->GetAttestationNonce();
     jbyteArray javaAttestationNonce;

--- a/src/credentials/DeviceAttestationConstructor.cpp
+++ b/src/credentials/DeviceAttestationConstructor.cpp
@@ -183,6 +183,8 @@ CHIP_ERROR ConstructAttestationElements(const ByteSpan & certificationDeclaratio
     ReturnErrorOnFailure(tlvWriter.Finalize());
     attestationElements = attestationElements.SubSpan(0, tlvWriter.GetLengthWritten());
 
+    VerifyOrReturnError(attestationElements.size() <= Credentials::kMaxRspLen, CHIP_ERROR_MESSAGE_TOO_LONG);
+
     return CHIP_NO_ERROR;
 }
 
@@ -217,6 +219,8 @@ CHIP_ERROR ConstructNOCSRElements(const ByteSpan & csr, const ByteSpan & csrNonc
     ReturnErrorOnFailure(tlvWriter.EndContainer(outerContainerType));
     ReturnErrorOnFailure(tlvWriter.Finalize());
     nocsrElements = nocsrElements.SubSpan(0, tlvWriter.GetLengthWritten());
+
+    VerifyOrReturnError(nocsrElements.size() <= Credentials::kMaxRspLen, CHIP_ERROR_MESSAGE_TOO_LONG);
 
     return CHIP_NO_ERROR;
 }

--- a/src/credentials/DeviceAttestationConstructor.h
+++ b/src/credentials/DeviceAttestationConstructor.h
@@ -23,6 +23,9 @@
 namespace chip {
 namespace Credentials {
 
+// As per specifications section 11.22.5.1. Constant RESP_MAX
+constexpr size_t kMaxRspLen = 900;
+
 // CSRNonce and AttestationNonce need to be this size
 constexpr size_t kExpectedAttestationNonceSize = 32;
 


### PR DESCRIPTION
#### Problem
* Bugs found during testing of new external opcert signing - https://github.com/project-chip/connectedhomeip/issues/22419
* Bug when attempting to commission an already commissioned device - https://github.com/project-chip/connectedhomeip/issues/22421

#### Change overview
* Fix typo on JNI callback lookup
* Persist attestation elements and signature so they are available during opcert signing
* Read fabric list during attribute read step of commissioning and persist the nodeId if the device is already on the commissioners fabric.
* Add code in tv-app and content-app platform to handle the already-on-fabric case
* Fixes #22419
* Fixes #22421

#### Testing
* Tested on Android
* Tested on linux tv-casting-app and tv-app