### PR TITLE
Remove a leak when quit() is used in interactive mode, the buffer hol…

### DIFF
--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -81,6 +81,11 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
         }
     }
 
+    if (command != nullptr)
+    {
+        free(command);
+    }
+
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;
 }

--- a/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
+++ b/examples/chip-tool/commands/interactive/InteractiveCommands.cpp
@@ -84,6 +84,7 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
     if (command != nullptr)
     {
         free(command);
+        command = nullptr;
     }
 
     SetCommandExitStatus(CHIP_NO_ERROR);

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -129,6 +129,7 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
 
     if (command != nullptr) {
         free(command);
+        command = nullptr;
     }
 
     SetCommandExitStatus(CHIP_NO_ERROR);

--- a/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
+++ b/examples/darwin-framework-tool/commands/interactive/InteractiveCommands.mm
@@ -127,6 +127,10 @@ CHIP_ERROR InteractiveStartCommand::RunCommand()
         }
     }
 
+    if (command != nullptr) {
+        free(command);
+    }
+
     SetCommandExitStatus(CHIP_NO_ERROR);
     return CHIP_NO_ERROR;
 }


### PR DESCRIPTION
…ding the command not beeing freed

#### Problem

When in interactive mode with `chip-tool` or the `darwin-framework-tool` the buffer holding the command "quit()" is not freed.

```
leaks -atExit -- ./out/debug/standalone/darwin-framework-tool interactive start
quit()
```

That is not really a big deal for the SDK but it is annoying as it shows up as a leak when using tools to find leaks..
```
1 (16 bytes) ROOT LEAK: 0x7fd6da6ed230 [16]  length: 6  "quit()"
```

#### Change overview
 * Free the buffer...
 
#### Testing
The leak does not show up anymore with this PR.