### PR TITLE
Add paa-trust-store-path CLI arg in darwin framework tool

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.h
@@ -28,13 +28,19 @@
 #pragma once
 
 constexpr const char kIdentityAlpha[] = "alpha";
-constexpr const char kIdentityBeta[]  = "beta";
+constexpr const char kIdentityBeta[] = "beta";
 constexpr const char kIdentityGamma[] = "gamma";
 
-class CHIPCommandBridge : public Command
-{
+class CHIPCommandBridge : public Command {
 public:
-    CHIPCommandBridge(const char * commandName) : Command(commandName) { AddArgument("commissioner-name", &mCommissionerName); }
+    CHIPCommandBridge(const char * commandName)
+        : Command(commandName)
+    {
+        AddArgument("commissioner-name", &mCommissionerName);
+        AddArgument("paa-trust-store-path", &mPaaTrustStorePath,
+            "Path to directory holding PAA certificate information.  Can be absolute or relative to the current working "
+            "directory.");
+    }
 
     /////////// Command Interface /////////
     CHIP_ERROR Run() override;
@@ -100,8 +106,8 @@ protected:
     void RestartCommissioners();
 
 private:
-    CHIP_ERROR InitializeCommissioner(std::string key, chip::FabricId fabricId,
-                                      const chip::Credentials::AttestationTrustStore * trustStore);
+    CHIP_ERROR InitializeCommissioner(
+        std::string key, chip::FabricId fabricId, const chip::Credentials::AttestationTrustStore * trustStore);
     void ShutdownCommissioner();
     uint16_t CurrentCommissionerIndex();
 
@@ -113,6 +119,8 @@ private:
     CHIP_ERROR MaybeSetUpStack();
     void MaybeTearDownStack();
 
+    CHIP_ERROR GetPAACertsFromFolder(NSArray<NSData *> * __autoreleasing * paaCertsResult);
+
     // Our three controllers: alpha, beta, gamma.
     static std::map<std::string, MTRDeviceController *> mControllers;
 
@@ -122,6 +130,7 @@ private:
     std::condition_variable cvWaitingForResponse;
     std::mutex cvWaitingForResponseMutex;
     chip::Optional<char *> mCommissionerName;
-    bool mWaitingForResponse{ true };
+    bool mWaitingForResponse { true };
     static dispatch_queue_t mOTAProviderCallbackQueue;
+    chip::Optional<char *> mPaaTrustStorePath;
 };

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -32,6 +32,7 @@ std::set<CHIPCommandBridge *> CHIPCommandBridge::sDeferredCleanups;
 std::map<std::string, MTRDeviceController *> CHIPCommandBridge::mControllers;
 dispatch_queue_t CHIPCommandBridge::mOTAProviderCallbackQueue;
 OTAProviderDelegate * CHIPCommandBridge::mOTADelegate;
+constexpr const char * kTrustStorePathVariable = "PAA_TRUST_STORE_PATH";
 
 CHIPToolKeypair * gNocSigner = [[CHIPToolKeypair alloc] init];
 
@@ -57,6 +58,48 @@ CHIP_ERROR CHIPCommandBridge::Run()
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR CHIPCommandBridge::GetPAACertsFromFolder(NSArray<NSData *> * __autoreleasing * paaCertsResult)
+{
+    NSMutableArray * paaCerts = [[NSMutableArray alloc] init];
+
+    if (!mPaaTrustStorePath.HasValue()) {
+        char * const trust_store_path = getenv(kTrustStorePathVariable);
+        if (trust_store_path != nullptr) {
+            mPaaTrustStorePath.SetValue(trust_store_path);
+        }
+    }
+    if (mPaaTrustStorePath.HasValue()) {
+        NSError * error;
+        NSString * paaStorePath = [NSString stringWithCString:mPaaTrustStorePath.Value() encoding:NSUTF8StringEncoding];
+        NSArray * derFolder = [[NSFileManager defaultManager] contentsOfDirectoryAtPath:paaStorePath error:&error];
+        if (error) {
+            NSLog(@"Error: %@", error);
+            return CHIP_ERROR_INTERNAL;
+        }
+
+        NSArray * derFiles = [derFolder filteredArrayUsingPredicate:[NSPredicate predicateWithFormat:@"self ENDSWITH '.der'"]];
+        if ([derFiles count] == 0) {
+            NSLog(@"Unable to find DER cert files");
+            return CHIP_ERROR_INTERNAL;
+        }
+        for (id derFile in derFiles) {
+            NSString * certPath = [NSString stringWithFormat:@"%@/%@", paaStorePath, derFile];
+            NSData * fileData = [NSData dataWithContentsOfFile:certPath];
+            if (fileData) {
+                [paaCerts addObject:fileData];
+            }
+        }
+    } else {
+        return CHIP_NO_ERROR;
+    }
+    if ([paaCerts count] == 0) {
+        NSLog(@"Unable to find PAA certs");
+        return CHIP_ERROR_INTERNAL;
+    }
+    *paaCertsResult = paaCerts;
+    return CHIP_NO_ERROR;
+}
+
 CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
 {
     if (IsInteractive()) {
@@ -78,6 +121,11 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
     params.port = @(kListenPort);
     params.startServer = YES;
     params.otaProviderDelegate = mOTADelegate;
+    NSArray<NSData *> * paaCertResults;
+    ReturnLogErrorOnFailure(GetPAACertsFromFolder(&paaCertResults));
+    if ([paaCertResults count] > 0) {
+        params.paaCerts = paaCertResults;
+    }
 
     if ([factory startup:params] == NO) {
         ChipLogError(chipTool, "Controller factory startup failed");


### PR DESCRIPTION
#### Problem
* Fixes #22350

#### Change overview
- Adds paa-trust-store-path optional param to darwin-framework-tool

#### Testing
- Ran with optional param and successfully paired.
- Ran without optional param to make sure pairing still works with test device.
- Ran on folder without PAA DER cert files to validate it fails.
- Ran on folder with PAA DER cert files that do not correspond to test accessory.