### PR TITLE
[darwin] ROOT LEAK: <chip::DeviceLayer::Internal::Ble*DelegateImpl

### DIFF
--- a/src/platform/Darwin/BLEManagerImpl.cpp
+++ b/src/platform/Darwin/BLEManagerImpl.cpp
@@ -71,19 +71,19 @@ void BLEManagerImpl::_Shutdown()
 {
     if (mApplicationDelegate)
     {
-        delete (mApplicationDelegate);
+        delete mApplicationDelegate;
         mApplicationDelegate = nullptr;
     }
 
     if (mConnectionDelegate)
     {
-        delete (mConnectionDelegate);
+        delete mConnectionDelegate;
         mConnectionDelegate = nullptr;
     }
 
     if (mPlatformDelegate)
     {
-        delete (mPlatformDelegate);
+        delete mPlatformDelegate;
         mPlatformDelegate = nullptr;
     }
 }

--- a/src/platform/Darwin/BLEManagerImpl.cpp
+++ b/src/platform/Darwin/BLEManagerImpl.cpp
@@ -52,8 +52,40 @@ CHIP_ERROR BLEManagerImpl::_Init()
     BleApplicationDelegateImpl * appDelegate   = new BleApplicationDelegateImpl();
     BleConnectionDelegateImpl * connDelegate   = new BleConnectionDelegateImpl();
     BlePlatformDelegateImpl * platformDelegate = new BlePlatformDelegateImpl();
+
+    mApplicationDelegate = appDelegate;
+    mConnectionDelegate  = connDelegate;
+    mPlatformDelegate    = platformDelegate;
+
     err = BleLayer::Init(platformDelegate, connDelegate, appDelegate, &DeviceLayer::SystemLayer());
+
+    if (CHIP_NO_ERROR != err)
+    {
+        _Shutdown();
+    }
+
     return err;
+}
+
+void BLEManagerImpl::_Shutdown()
+{
+    if (mApplicationDelegate)
+    {
+        delete (mApplicationDelegate);
+        mApplicationDelegate = nullptr;
+    }
+
+    if (mConnectionDelegate)
+    {
+        delete (mConnectionDelegate);
+        mConnectionDelegate = nullptr;
+    }
+
+    if (mPlatformDelegate)
+    {
+        delete (mPlatformDelegate);
+        mPlatformDelegate = nullptr;
+    }
 }
 
 bool BLEManagerImpl::_IsAdvertisingEnabled(void)

--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -47,7 +47,7 @@ private:
     // ===== Members that implement the BLEManager internal interface.
 
     CHIP_ERROR _Init(void);
-    void _Shutdown() {}
+    void _Shutdown();
     bool _IsAdvertisingEnabled(void);
     CHIP_ERROR _SetAdvertisingEnabled(bool val);
     bool _IsAdvertising(void);
@@ -64,6 +64,10 @@ private:
     friend BLEManagerImpl & BLEMgrImpl(void);
 
     static BLEManagerImpl sInstance;
+
+    BleConnectionDelegate * mConnectionDelegate   = nullptr;
+    BlePlatformDelegate * mPlatformDelegate       = nullptr;
+    BleApplicationDelegate * mApplicationDelegate = nullptr;
 };
 
 /**


### PR DESCRIPTION
#### Problem

When restarting the Matter stack, the `BLEManagerImpl` leaks some delegates.

The steps to reproduce are the following:
```
leaks -atExit -- ./out/debug/standalone/darwin-framework-tool interactive start
#once in interative mode, press Ctrl+^
quit()
```

#### Change overview
* free the delegate objects

#### Testing
Can't see the leaks after that.