### PR TITLE
Fix timer cancellation to be reliable in LayerImplSelect.

### DIFF
--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -300,8 +300,8 @@ private:
 
     // Helper for MultipleReadHelper that does not spin the event loop, so we
     // don't end up with nested event loops.
-    static void MultipleReadHelperGuts(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount, uint32_t & aNumSuccessCalls,
-                                       uint32_t & aNumFailureCalls);
+    static void MultipleReadHelperInternal(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount,
+                                           uint32_t & aNumSuccessCalls, uint32_t & aNumFailureCalls);
 
     // Establish the given number of subscriptions, then issue the given number
     // of reads in parallel and wait for them all to succeed.
@@ -2514,7 +2514,7 @@ void TestReadInteraction::SubscribeThenReadHelper(nlTestSuite * apSuite, TestCon
         numSubscriptionEstablishedCalls++;
         if (numSubscriptionEstablishedCalls == aSubscribeCount)
         {
-            MultipleReadHelperGuts(apSuite, aCtx, aReadCount, numReadSuccessCalls, numReadFailureCalls);
+            MultipleReadHelperInternal(apSuite, aCtx, aReadCount, numReadSuccessCalls, numReadFailureCalls);
         }
     };
 
@@ -2536,8 +2536,8 @@ void TestReadInteraction::SubscribeThenReadHelper(nlTestSuite * apSuite, TestCon
 
 // The guts of MultipleReadHelper which take references to the success/failure
 // counts to modify and assume the consumer will be spinning the event loop.
-void TestReadInteraction::MultipleReadHelperGuts(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount,
-                                                 uint32_t & aNumSuccessCalls, uint32_t & aNumFailureCalls)
+void TestReadInteraction::MultipleReadHelperInternal(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount,
+                                                     uint32_t & aNumSuccessCalls, uint32_t & aNumFailureCalls)
 {
     NL_TEST_ASSERT(apSuite, aNumSuccessCalls == 0);
     NL_TEST_ASSERT(apSuite, aNumFailureCalls == 0);
@@ -2573,7 +2573,7 @@ void TestReadInteraction::MultipleReadHelper(nlTestSuite * apSuite, TestContext 
     uint32_t numSuccessCalls = 0;
     uint32_t numFailureCalls = 0;
 
-    MultipleReadHelperGuts(apSuite, aCtx, aReadCount, numSuccessCalls, numFailureCalls);
+    MultipleReadHelperInternal(apSuite, aCtx, aReadCount, numSuccessCalls, numFailureCalls);
 
     aCtx.DrainAndServiceIO();
 

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -298,6 +298,11 @@ private:
     // succeed.
     static void MultipleReadHelper(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount);
 
+    // Helper for MultipleReadHelper that does not spin the event loop, so we
+    // don't end up with nested event loops.
+    static void MultipleReadHelperGuts(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount, uint32_t & aNumSuccessCalls,
+                                       uint32_t & aNumFailureCalls);
+
     // Establish the given number of subscriptions, then issue the given number
     // of reads in parallel and wait for them all to succeed.
     static void SubscribeThenReadHelper(nlTestSuite * apSuite, TestContext & aCtx, size_t aSubscribeCount, size_t aReadCount);
@@ -2484,6 +2489,9 @@ void TestReadInteraction::SubscribeThenReadHelper(nlTestSuite * apSuite, TestCon
     uint32_t numSuccessCalls                 = 0;
     uint32_t numSubscriptionEstablishedCalls = 0;
 
+    uint32_t numReadSuccessCalls = 0;
+    uint32_t numReadFailureCalls = 0;
+
     responseDirective = kSendDataResponse;
 
     // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
@@ -2501,12 +2509,12 @@ void TestReadInteraction::SubscribeThenReadHelper(nlTestSuite * apSuite, TestCon
         NL_TEST_ASSERT(apSuite, false);
     };
 
-    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite, &aCtx, aSubscribeCount,
-                                        aReadCount](const app::ReadClient & readClient) {
+    auto onSubscriptionEstablishedCb = [&numSubscriptionEstablishedCalls, &apSuite, &aCtx, aSubscribeCount, aReadCount,
+                                        &numReadSuccessCalls, &numReadFailureCalls](const app::ReadClient & readClient) {
         numSubscriptionEstablishedCalls++;
         if (numSubscriptionEstablishedCalls == aSubscribeCount)
         {
-            MultipleReadHelper(apSuite, aCtx, aReadCount);
+            MultipleReadHelperGuts(apSuite, aCtx, aReadCount, numReadSuccessCalls, numReadFailureCalls);
         }
     };
 
@@ -2522,40 +2530,50 @@ void TestReadInteraction::SubscribeThenReadHelper(nlTestSuite * apSuite, TestCon
 
     NL_TEST_ASSERT(apSuite, numSuccessCalls == aSubscribeCount);
     NL_TEST_ASSERT(apSuite, numSubscriptionEstablishedCalls == aSubscribeCount);
+    NL_TEST_ASSERT(apSuite, numReadSuccessCalls == aReadCount);
+    NL_TEST_ASSERT(apSuite, numReadFailureCalls == 0);
 }
 
-void TestReadInteraction::MultipleReadHelper(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount)
+// The guts of MultipleReadHelper which take references to the success/failure
+// counts to modify and assume the consumer will be spinning the event loop.
+void TestReadInteraction::MultipleReadHelperGuts(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount,
+                                                 uint32_t & aNumSuccessCalls, uint32_t & aNumFailureCalls)
 {
-    auto sessionHandle       = aCtx.GetSessionBobToAlice();
-    uint32_t numSuccessCalls = 0;
-    uint32_t numFailureCalls = 0;
+    NL_TEST_ASSERT(apSuite, aNumSuccessCalls == 0);
+    NL_TEST_ASSERT(apSuite, aNumFailureCalls == 0);
+
+    auto sessionHandle = aCtx.GetSessionBobToAlice();
 
     responseDirective = kSendDataResponse;
 
     uint16_t firstExpectedResponse = totalReadCount + 1;
 
-    // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise, it's
-    // not safe to do so.
-    auto onFailureCb = [&apSuite, &numFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
-        numFailureCalls++;
+    auto onFailureCb = [apSuite, &aNumFailureCalls](const app::ConcreteDataAttributePath * attributePath, CHIP_ERROR aError) {
+        aNumFailureCalls++;
 
         NL_TEST_ASSERT(apSuite, attributePath == nullptr);
     };
 
     for (size_t i = 0; i < aReadCount; ++i)
     {
-        // Passing of stack variables by reference is only safe because of synchronous completion of the interaction. Otherwise,
-        // it's not safe to do so.
-        auto onSuccessCb = [&numSuccessCalls, &apSuite, firstExpectedResponse,
+        auto onSuccessCb = [&aNumSuccessCalls, apSuite, firstExpectedResponse,
                             i](const app::ConcreteDataAttributePath & attributePath, const auto & dataResponse) {
             NL_TEST_ASSERT(apSuite, dataResponse == firstExpectedResponse + i);
-            numSuccessCalls++;
+            aNumSuccessCalls++;
         };
 
         NL_TEST_ASSERT(apSuite,
                        Controller::ReadAttribute<TestCluster::Attributes::Int16u::TypeInfo>(
                            &aCtx.GetExchangeManager(), sessionHandle, kTestEndpointId, onSuccessCb, onFailureCb) == CHIP_NO_ERROR);
     }
+}
+
+void TestReadInteraction::MultipleReadHelper(nlTestSuite * apSuite, TestContext & aCtx, size_t aReadCount)
+{
+    uint32_t numSuccessCalls = 0;
+    uint32_t numFailureCalls = 0;
+
+    MultipleReadHelperGuts(apSuite, aCtx, aReadCount, numSuccessCalls, numFailureCalls);
 
     aCtx.DrainAndServiceIO();
 

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -172,6 +172,10 @@ void LayerImplSelect::CancelTimer(TimerCompleteCallback onComplete, void * appSt
     TimerList::Node * timer = mTimerList.Remove(onComplete, appState);
     if (timer == nullptr)
     {
+        // The timer was not in our "will fire in the future" list, but it might
+        // be in the "we're about to fire these" chunk we already grabbed from
+        // that list.  Check for it there too, and if found there we still want
+        // to cancel it.
         timer = mExpiredTimers.Remove(onComplete, appState);
     }
     VerifyOrReturn(timer != nullptr);

--- a/src/system/SystemLayerImplSelect.cpp
+++ b/src/system/SystemLayerImplSelect.cpp
@@ -170,6 +170,10 @@ void LayerImplSelect::CancelTimer(TimerCompleteCallback onComplete, void * appSt
     VerifyOrReturn(mLayerState.IsInitialized());
 
     TimerList::Node * timer = mTimerList.Remove(onComplete, appState);
+    if (timer == nullptr)
+    {
+        timer = mExpiredTimers.Remove(onComplete, appState);
+    }
     VerifyOrReturn(timer != nullptr);
 
 #if CHIP_SYSTEM_CONFIG_USE_DISPATCH
@@ -199,8 +203,31 @@ CHIP_ERROR LayerImplSelect::ScheduleWork(TimerCompleteCallback onComplete, void 
     }
 #endif // CHIP_SYSTEM_CONFIG_USE_DISPATCH
 
-    CancelTimer(onComplete, appState);
-
+    // Ideally we would not use a timer here at all, but if we try to just
+    // ScheduleLambda the lambda needs to capture the following:
+    // 1) onComplete
+    // 2) appState
+    // 3) The `this` pointer, because onComplete needs to be passed a pointer to
+    //    the System::Layer.
+    //
+    // On a 64-bit system that's 24 bytes, but lambdas passed to ScheduleLambda
+    // are capped at CHIP_CONFIG_LAMBDA_EVENT_SIZE which is 16 bytes.
+    //
+    // So for now use a timer as a poor-man's closure that captures `this` and
+    // onComplete and appState in a single pointer, so we fit inside the size
+    // limit.
+    //
+    // TODO: We could do something here where we compile-time condition on the
+    // sizes of things and use a direct ScheduleLambda if it would fit and this
+    // setup otherwise.
+    //
+    // TODO: But also, unit tests seem to do SystemLayer::ScheduleWork without
+    // actually running a useful event loop (in the PlatformManager sense),
+    // which breaks if we use ScheduleLambda here, since that does rely on the
+    // PlatformManager event loop. So for now, keep scheduling an expires-ASAP
+    // timer, but just make sure we don't cancel existing timers with the same
+    // callback and appState, so ScheduleWork invocations don't stomp on each
+    // other.
     TimerList::Node * timer = mTimerPool.Create(*this, SystemClock().GetMonotonicTimestamp(), onComplete, appState);
     VerifyOrReturnError(timer != nullptr, CHIP_ERROR_NO_MEMORY);
 
@@ -469,9 +496,10 @@ void LayerImplSelect::HandleEvents()
 
     // Obtain the list of currently expired timers. Any new timers added by timer callback are NOT handled on this pass,
     // since that could result in infinite handling of new timers blocking any other progress.
-    TimerList expiredTimers = mTimerList.ExtractEarlier(Clock::Timeout(1) + SystemClock().GetMonotonicTimestamp());
+    VerifyOrDieWithMsg(mExpiredTimers.Empty(), DeviceLayer, "Re-entry into HandleEvents from a timer callback?");
+    mExpiredTimers          = mTimerList.ExtractEarlier(Clock::Timeout(1) + SystemClock().GetMonotonicTimestamp());
     TimerList::Node * timer = nullptr;
-    while ((timer = expiredTimers.PopEarliest()) != nullptr)
+    while ((timer = mExpiredTimers.PopEarliest()) != nullptr)
     {
         mTimerPool.Invoke(timer);
     }

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -101,6 +101,9 @@ protected:
 
     TimerPool<TimerList::Node> mTimerPool;
     TimerList mTimerList;
+    // List of expired times being processed right now.  Stored in a member so
+    // we can cancel them.
+    TimerList mExpiredTimers;
     timeval mNextTimeout;
 
     // Members for select loop

--- a/src/system/SystemLayerImplSelect.h
+++ b/src/system/SystemLayerImplSelect.h
@@ -101,7 +101,7 @@ protected:
 
     TimerPool<TimerList::Node> mTimerPool;
     TimerList mTimerList;
-    // List of expired times being processed right now.  Stored in a member so
+    // List of expired timers being processed right now.  Stored in a member so
     // we can cancel them.
     TimerList mExpiredTimers;
     timeval mNextTimeout;

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -26,11 +26,14 @@ chip_test_suite("tests") {
     "TestSystemErrorStr.cpp",
     "TestSystemPacketBuffer.cpp",
     "TestSystemScheduleLambda.cpp",
-    "TestSystemScheduleWork.cpp",
     "TestSystemTimer.cpp",
     "TestSystemWakeEvent.cpp",
     "TestTimeSource.cpp",
   ]
+
+  if (chip_device_platform != "esp32") {
+    test_sources += [ "TestSystemScheduleWork.cpp" ]
+  }
 
   cflags = [ "-Wconversion" ]
 

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -31,7 +31,7 @@ chip_test_suite("tests") {
     "TestTimeSource.cpp",
   ]
 
-  if (chip_device_platform != "esp32") {
+  if (chip_device_platform != "esp32" && chip_device_platform != "fake") {
     test_sources += [ "TestSystemScheduleWork.cpp" ]
   }
 

--- a/src/system/tests/BUILD.gn
+++ b/src/system/tests/BUILD.gn
@@ -26,6 +26,7 @@ chip_test_suite("tests") {
     "TestSystemErrorStr.cpp",
     "TestSystemPacketBuffer.cpp",
     "TestSystemScheduleLambda.cpp",
+    "TestSystemScheduleWork.cpp",
     "TestSystemTimer.cpp",
     "TestSystemWakeEvent.cpp",
     "TestTimeSource.cpp",

--- a/src/system/tests/TestSystemClock.cpp
+++ b/src/system/tests/TestSystemClock.cpp
@@ -118,7 +118,7 @@ static const nlTest sTests[] =
 int TestSystemClock(void)
 {
     nlTestSuite theSuite = {
-        "chip-timesource", &sTests[0], nullptr /* setup */, nullptr /* teardown */
+        "chip-systemclock", &sTests[0], nullptr /* setup */, nullptr /* teardown */
     };
 
     // Run test suit againt one context.

--- a/src/system/tests/TestSystemScheduleWork.cpp
+++ b/src/system/tests/TestSystemScheduleWork.cpp
@@ -1,0 +1,94 @@
+/*
+ *    Copyright (c) 2021 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <system/SystemConfig.h>
+
+#include <lib/support/CodeUtils.h>
+#include <lib/support/ErrorStr.h>
+#include <lib/support/UnitTestRegistration.h>
+#include <nlunit-test.h>
+#include <platform/CHIPDeviceLayer.h>
+
+// Test input data.
+
+static void CheckScheduleLambda(nlTestSuite * inSuite, void * aContext)
+{
+    bool * called = new bool(false);
+    chip::DeviceLayer::SystemLayer().ScheduleLambda([called] {
+        *called = true;
+        chip::DeviceLayer::PlatformMgr().StopEventLoopTask();
+    });
+    chip::DeviceLayer::PlatformMgr().RunEventLoop();
+    NL_TEST_ASSERT(inSuite, *called);
+    delete called;
+}
+
+// Test Suite
+
+/**
+ *   Test Suite. It lists all the test functions.
+ */
+// clang-format off
+static const nlTest sTests[] =
+{
+    NL_TEST_DEF("System::TestScheduleLambda", CheckScheduleLambda),
+    NL_TEST_SENTINEL()
+};
+// clang-format on
+
+static int TestSetup(void * aContext);
+static int TestTeardown(void * aContext);
+
+// clang-format off
+static nlTestSuite kTheSuite =
+{
+    "chip-system-schedule-lambda",
+    &sTests[0],
+    TestSetup,
+    TestTeardown
+};
+// clang-format on
+
+/**
+ *  Set up the test suite.
+ */
+static int TestSetup(void * aContext)
+{
+    if (chip::DeviceLayer::PlatformMgr().InitChipStack() != CHIP_NO_ERROR)
+        return FAILURE;
+
+    return (SUCCESS);
+}
+
+/**
+ *  Tear down the test suite.
+ *  Free memory reserved at TestSetup.
+ */
+static int TestTeardown(void * aContext)
+{
+    chip::DeviceLayer::PlatformMgr().Shutdown();
+    return (SUCCESS);
+}
+
+int TestSystemScheduleLambda(void)
+{
+    // Run test suit againt one lContext.
+    nlTestRunner(&kTheSuite, nullptr);
+
+    return nlTestRunnerStats(&kTheSuite);
+}
+
+CHIP_REGISTER_TEST_SUITE(TestSystemScheduleLambda)

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -126,6 +126,15 @@ public:
     TestContext() : mGreedyTimer(GreedyTimer, this), mNumTimersHandled(0) {}
 };
 
+static TestContext * gCurrentTestContext = nullptr;
+
+class ScopedGlobalTestContext
+{
+public:
+    ScopedGlobalTestContext(TestContext * ctx) { gCurrentTestContext = ctx; }
+    ~ScopedGlobalTestContext() { gCurrentTestContext = nullptr; }
+};
+
 // Test input data.
 
 static volatile bool sOverflowTestDone;
@@ -204,7 +213,7 @@ static void CheckStarvation(nlTestSuite * inSuite, void * aContext)
     LayerEvents<LayerImpl>::ServiceEvents(lSys);
 }
 
-void CheckOrder(nlTestSuite * inSuite, void * aContext)
+static void CheckOrder(nlTestSuite * inSuite, void * aContext)
 {
     if (!LayerEvents<LayerImpl>::HasServiceEvents())
         return;
@@ -257,7 +266,7 @@ void CheckOrder(nlTestSuite * inSuite, void * aContext)
     Clock::Internal::SetSystemClockForTesting(savedClock);
 }
 
-void CheckCancellation(nlTestSuite * inSuite, void * aContext)
+static void CheckCancellation(nlTestSuite * inSuite, void * aContext)
 {
     if (!LayerEvents<LayerImpl>::HasServiceEvents())
         return;
@@ -319,6 +328,109 @@ void CheckCancellation(nlTestSuite * inSuite, void * aContext)
 
     Clock::Internal::SetSystemClockForTesting(savedClock);
 }
+
+namespace {
+
+namespace CancelTimerTest {
+
+// A bit lower than maximum system timers just in case, for systems that
+// have some form of limit
+constexpr unsigned kCancelTimerCount = CHIP_SYSTEM_CONFIG_NUM_TIMERS - 4;
+int gCallbackProcessed[kCancelTimerCount];
+
+/// Validates that gCallbackProcessed has valid values (0 or 1)
+void ValidateExecutedTimerCounts(nlTestSuite * suite)
+{
+    for (unsigned i = 0; i < kCancelTimerCount; i++)
+    {
+        NL_TEST_ASSERT(suite, (gCallbackProcessed[i] == 0) || (gCallbackProcessed[i] == 1));
+    }
+}
+
+unsigned ExecutedTimerCount()
+{
+    unsigned count = 0;
+    for (unsigned i = 0; i < kCancelTimerCount; i++)
+    {
+        if (gCallbackProcessed[i] != 0)
+        {
+            count++;
+        }
+    }
+    return count;
+}
+
+void Callback(Layer * layer, void * state)
+{
+    unsigned idx = static_cast<unsigned>(reinterpret_cast<uintptr_t>(state));
+    if (gCallbackProcessed[idx] != 0)
+    {
+        ChipLogError(Test, "UNEXPECTED EXECUTION at index %u", idx);
+    }
+
+    gCallbackProcessed[idx]++;
+
+    if (ExecutedTimerCount() == kCancelTimerCount / 2)
+    {
+        ChipLogProgress(Test, "Cancelling timers");
+        for (unsigned i = 0; i < kCancelTimerCount; i++)
+        {
+            if (gCallbackProcessed[i] != 0)
+            {
+                continue;
+            }
+            ChipLogProgress(Test, "Timer %u is being cancelled", i);
+            gCurrentTestContext->mLayer->CancelTimer(Callback, reinterpret_cast<void *>(static_cast<uintptr_t>(i)));
+            gCallbackProcessed[i]++; // pretend executed.
+        }
+    }
+}
+
+void Test(nlTestSuite * inSuite, void * aContext)
+{
+    // Validates that timers can cancel other timers. Generally the test will
+    // do the following:
+    //   - schedule several timers to start at the same time
+    //   - within each timers, after half of them have run, make one timer
+    //     cancel all the other ones
+    //   - assert that:
+    //       - timers will run if scheduled
+    //       - once cancelled, timers will NOT run (i.e. a timer can cancel
+    //         other timers, even if they are expiring at the same time)
+    memset(gCallbackProcessed, 0, sizeof(gCallbackProcessed));
+
+    TestContext & testContext = *static_cast<TestContext *>(aContext);
+    ScopedGlobalTestContext testScope(&testContext);
+
+    Layer & systemLayer       = *testContext.mLayer;
+    nlTestSuite * const suite = testContext.mTestSuite;
+
+    Clock::ClockBase * const savedClock = &SystemClock();
+    Clock::Internal::MockClock mockClock;
+    Clock::Internal::SetSystemClockForTesting(&mockClock);
+    using namespace Clock::Literals;
+
+    for (unsigned i = 0; i < kCancelTimerCount; i++)
+    {
+        NL_TEST_ASSERT(
+            suite, systemLayer.StartTimer(10_ms, Callback, reinterpret_cast<void *>(static_cast<uintptr_t>(i))) == CHIP_NO_ERROR);
+    }
+
+    LayerEvents<LayerImpl>::ServiceEvents(systemLayer);
+    ValidateExecutedTimerCounts(suite);
+    NL_TEST_ASSERT(suite, ExecutedTimerCount() == 0);
+
+    mockClock.AdvanceMonotonic(20_ms);
+    LayerEvents<LayerImpl>::ServiceEvents(systemLayer);
+
+    ValidateExecutedTimerCounts(suite);
+    NL_TEST_ASSERT(suite, ExecutedTimerCount() == kCancelTimerCount);
+
+    Clock::Internal::SetSystemClockForTesting(savedClock);
+}
+
+} // namespace CancelTimerTest
+} // namespace
 
 // Test the implementation helper classes TimerPool, TimerList, and TimerData.
 namespace chip {
@@ -481,6 +593,7 @@ static const nlTest sTests[] =
     NL_TEST_DEF("Timer::TestTimerOrder",           CheckOrder),
     NL_TEST_DEF("Timer::TestTimerCancellation",    CheckCancellation),
     NL_TEST_DEF("Timer::TestTimerPool",            chip::System::TestTimer::CheckTimerPool),
+    NL_TEST_DEF("Timer::TestCancelTimer",          CancelTimerTest::Test),
     NL_TEST_SENTINEL()
 };
 // clang-format on

--- a/src/system/tests/TestSystemTimer.cpp
+++ b/src/system/tests/TestSystemTimer.cpp
@@ -277,7 +277,7 @@ static void CheckCancellation(nlTestSuite * inSuite, void * aContext)
 
     struct TestState
     {
-        TestState(Layer & systemLayer) : systemLayer(systemLayer) {}
+        TestState(Layer & aSystemLayer) : mSystemLayer(aSystemLayer) {}
 
         void Record(char c)
         {
@@ -292,21 +292,21 @@ static void CheckCancellation(nlTestSuite * inSuite, void * aContext)
         {
             auto self = static_cast<TestState *>(state);
             self->Record('A');
-            self->systemLayer.CancelTimer(B, state);
-            self->systemLayer.CancelTimer(D, state);
+            self->mSystemLayer.CancelTimer(B, state);
+            self->mSystemLayer.CancelTimer(D, state);
         }
         static void B(Layer * layer, void * state) { static_cast<TestState *>(state)->Record('B'); }
         static void C(Layer * layer, void * state)
         {
             auto self = static_cast<TestState *>(state);
             self->Record('C');
-            self->systemLayer.CancelTimer(E, state);
+            self->mSystemLayer.CancelTimer(E, state);
         }
         static void D(Layer * layer, void * state) { static_cast<TestState *>(state)->Record('D'); }
         static void E(Layer * layer, void * state) { static_cast<TestState *>(state)->Record('E'); }
         char record[6] = { 0 };
 
-        Layer & systemLayer;
+        Layer & mSystemLayer;
     };
     TestState testState(systemLayer);
     NL_TEST_ASSERT(suite, testState.record[0] == 0);


### PR DESCRIPTION
To minimize risk, the changes here keep the "grab all the timers we
should fire, then fire them" setup instead of switching to the "fire
the timers one at a time" approach LayerImplFreeRTOS uses.

The fix consists of the following parts:

1) Store the list of timers to fire in a member, so we can cancel things from
   that list as needed.
2) To avoid canceling things scheduled by ScheduleWork, remove the CancelTimer
   call in ScheduleWork.  This does mean we now allow multiple timers for the
   same callback+appState in the timer list, if they were created by
   ScheduleWork, but that should be OK, since the only reason that pair needs to
   be unique is to allow cancellation and we never want to cancel the things
   ScheduleWork schedules.  As a followup we should stop using the timer list
   for ScheduleWork altogether and use ScheduleLambda like LayerImplFreeRTOS
   does, but that involves fixing the unit tests that call ScheduleWork without
   actually running the platfor manager event loop and expect it to work
   somehow.

TestRead was failing the sanity assert for not losing track of timers
to fire, because it was spinning a nested event loop.  The changes to
that test stop it from doing that.

Fixes https://github.com/project-chip/connectedhomeip/issues/19387
Fixes https://github.com/project-chip/connectedhomeip/issues/22160

#### Problem
Timer cancellation sometimes fails, leading to crashes.

#### Change overview
Fix timer cancellation to be reliable.

#### Testing
New unit tests added for canceling timers and ScheduleWork not canceling a previous ScheduleWork.