### PR TITLE
Remove androidstudio builds from build-all integrations in cloudbuild…

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -28,7 +28,7 @@ steps:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
               --target-glob '*' --skip-target-glob
-              '{imx-*,tizen-*,*-tests*,*-chip-test}' build --create-archives
+              '{imx-*,tizen-*,*-androidstudio-*,*-tests*,*-chip-test}' build --create-archives
               /workspace/artifacts/
       id: CompileAll
       waitFor:


### PR DESCRIPTION
…. non-studio builds should be sufficient

#### Problem
Androidstudio builds cannot compile:

```
CMakeFiles/src__crypto_cryptopal_mbedtls.dir/workspace/src/crypto/CHIPCryptoPALmbedTLS.cpp.o -c /workspace/src/crypto/CHIPCryptoPALmbedTLS.cpp
Step #2 - "CompileAll": 2022-09-02 15:19:09 WARNING   In file included from /workspace/src/crypto/CHIPCryptoPALmbedTLS.cpp:23:
Step #2 - "CompileAll": 2022-09-02 15:19:09 WARNING   /workspace/src/crypto/CHIPCryptoPAL.h:26:10: fatal error: 'crypto/CryptoBuildConfig.h' file not found
Step #2 - "CompileAll": 2022-09-02 15:19:09 WARNING   #include <crypto/CryptoBuildConfig.h>
Step #2 - "CompileAll": 2022-09-02 15:19:09 WARNING 
```


#### Change overview
Glob-out the android studio builds. Non-studio builds suffice.

#### Testing
N/A - integration only.
Locally tested that androidstudio builds fail, but non-androidstudio succeeds (for chip-tool)