### PR TITLE
Increaes CHIP_CONFIG_LAMBDA_EVENT_SIZE from 16 to 24

### DIFF
--- a/src/lib/core/CHIPConfig.h
+++ b/src/lib/core/CHIPConfig.h
@@ -896,7 +896,7 @@ extern const char CHIP_NON_PRODUCTION_MARKER[];
  * @brief The maximum size of the lambda which can be post into system event queue.
  */
 #ifndef CHIP_CONFIG_LAMBDA_EVENT_SIZE
-#define CHIP_CONFIG_LAMBDA_EVENT_SIZE (16)
+#define CHIP_CONFIG_LAMBDA_EVENT_SIZE (24)
 #endif
 
 /**


### PR DESCRIPTION
#### Problem
lambda event sizes are limited and 16 is ever so slightly too small. E.g. ScheduleWork would benefit from a bit more space.

Increasing size seems to be reasonable because chip event data is already 24 bytes at a minimum because InternetConnectivityChange has a size of 2 enums + a 16-byte object.

This facilitates work towards #22377 

#### Change overview
Change CHIP_CONFIG_LAMBDA_EVENT_SIZE to the new value.

#### Testing
N/A - CI should validate. This is generally a safe change (the extra space is not used by any current lambda).
