### PR TITLE
Fix android compilation: missing cast when formatting value in string

### DIFF
--- a/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
@@ -367,7 +367,7 @@ JNI_METHOD(jstring, OnExecuteCommand)(JNIEnv * env, jobject, jobjectArray string
     // Fill in argv
     for (int i = 0; i < argc; i++)
     {
-        jstring string = (jstring) (env->GetObjectArrayElement(stringArray, i));
+        jstring string = (jstring)(env->GetObjectArrayElement(stringArray, i));
         argv[i]        = (char *) env->GetStringUTFChars(string, 0);
     }
 
@@ -378,7 +378,7 @@ JNI_METHOD(jstring, OnExecuteCommand)(JNIEnv * env, jobject, jobjectArray string
     for (int i = 0; i < argc; i++)
     {
         ChipLogProgress(DeviceLayer, " Value=%s ", argv[i]);
-        jstring string = (jstring) (env->GetObjectArrayElement(stringArray, i));
+        jstring string = (jstring)(env->GetObjectArrayElement(stringArray, i));
         env->ReleaseStringUTFChars(string, argv[i]);
     }
 

--- a/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
+++ b/examples/tv-app/android/java/AppPlatformShellCommands-JNI.cpp
@@ -48,7 +48,7 @@ static CHIP_ERROR pairApp(bool printHeader, size_t index)
     if (printHeader)
     {
         char str[64];
-        sprintf(str, "udc-commission %ld\r\n", (long) index);
+        sprintf(str, "udc-commission %ld\r\n", static_cast<long>(index));
         strcat(response, str);
     }
 
@@ -57,7 +57,7 @@ static CHIP_ERROR pairApp(bool printHeader, size_t index)
     if (state == nullptr)
     {
         char str[64];
-        sprintf(str, "udc client[%d] null \r\n", index);
+        sprintf(str, "udc client[%ld] null \r\n", static_cast<long>(index));
         strcat(response, str);
     }
     else
@@ -367,7 +367,7 @@ JNI_METHOD(jstring, OnExecuteCommand)(JNIEnv * env, jobject, jobjectArray string
     // Fill in argv
     for (int i = 0; i < argc; i++)
     {
-        jstring string = (jstring)(env->GetObjectArrayElement(stringArray, i));
+        jstring string = (jstring) (env->GetObjectArrayElement(stringArray, i));
         argv[i]        = (char *) env->GetStringUTFChars(string, 0);
     }
 
@@ -378,7 +378,7 @@ JNI_METHOD(jstring, OnExecuteCommand)(JNIEnv * env, jobject, jobjectArray string
     for (int i = 0; i < argc; i++)
     {
         ChipLogProgress(DeviceLayer, " Value=%s ", argv[i]);
-        jstring string = (jstring)(env->GetObjectArrayElement(stringArray, i));
+        jstring string = (jstring) (env->GetObjectArrayElement(stringArray, i));
         env->ReleaseStringUTFChars(string, argv[i]);
     }
 


### PR DESCRIPTION
#### Problem
Failure in tv-app build: invalid cast for %d

#### Change overview
Fixes builds, this seems to be the only remaining build failure for cloudbuild 'all' build.

#### Testing
Ran locally (tool a very long time)

```
./scripts/build/build_examples.py --enable-flashbundle --target-glob '*' --skip-target-glob '{imx-*,tizen-*,*-androidstudio-*,*-tests*,*-chip-test}' build --create-archives /workspace/artifacts/
```