### PR TITLE
Make sure we create semaphore before we try to use it.

### DIFF
--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -119,13 +119,14 @@ CHIP_ERROR PlatformManagerImpl::_StopEventLoopTask()
 
 void PlatformManagerImpl::_RunEventLoop()
 {
+    mRunLoopSem = dispatch_semaphore_create(0);
+
     _StartEventLoopTask();
 
     //
     // Block on the semaphore till we're signalled to stop by
     // _StopEventLoopTask()
     //
-    mRunLoopSem = dispatch_semaphore_create(0);
     dispatch_semaphore_wait(mRunLoopSem, DISPATCH_TIME_FOREVER);
     dispatch_release(mRunLoopSem);
     mRunLoopSem = nullptr;


### PR DESCRIPTION
The semaphore will get signaled by the event loop we spin up.  We
should make sure it exists before we spin up that event loop.

#### Problem
Crashes in CI running tests that shut down the event loop soon after starting it.

#### Change overview
Fix those crashes.

#### Testing
Did 8 test runs without this PR and 8 test runs with.  Of the 8 without, 4 failed with the crashes.  Of the 8 with, none did.  The chance of that happening randomly is < 1%.