### PR TITLE
[python] Add the switch to disable server interactions

### DIFF
--- a/src/controller/python/ChipDeviceController-ScriptBinding.cpp
+++ b/src/controller/python/ChipDeviceController-ScriptBinding.cpp
@@ -111,7 +111,8 @@ chip::NodeId kDefaultLocalDeviceId = chip::kTestControllerNodeId;
 chip::NodeId kRemoteDeviceId       = chip::kTestDeviceNodeId;
 
 extern "C" {
-ChipError::StorageType pychip_DeviceController_StackInit(Controller::Python::StorageAdapter * storageAdapter);
+ChipError::StorageType pychip_DeviceController_StackInit(Controller::Python::StorageAdapter * storageAdapter,
+                                                         bool enableServerInteractions);
 ChipError::StorageType pychip_DeviceController_StackShutdown();
 
 ChipError::StorageType pychip_DeviceController_NewDeviceController(chip::Controller::DeviceCommissioner ** outDevCtrl,
@@ -228,7 +229,8 @@ void pychip_Storage_ShutdownAdapter(chip::Controller::Python::StorageAdapter * s
     delete storageAdapter;
 }
 
-ChipError::StorageType pychip_DeviceController_StackInit(Controller::Python::StorageAdapter * storageAdapter)
+ChipError::StorageType pychip_DeviceController_StackInit(Controller::Python::StorageAdapter * storageAdapter,
+                                                         bool enableServerInteractions)
 {
     VerifyOrDie(storageAdapter != nullptr);
 
@@ -243,7 +245,7 @@ ChipError::StorageType pychip_DeviceController_StackInit(Controller::Python::Sto
     ReturnErrorOnFailure(sPersistentStorageOpCertStore.Init(storageAdapter).AsInteger());
     factoryParams.opCertStore = &sPersistentStorageOpCertStore;
 
-    factoryParams.enableServerInteractions = true;
+    factoryParams.enableServerInteractions = enableServerInteractions;
 
     // Hack needed due to the fact that DnsSd server uses the CommissionableDataProvider even
     // when never starting commissionable advertising. This will not be used but prevents

--- a/src/controller/python/OpCredsBinding.cpp
+++ b/src/controller/python/OpCredsBinding.cpp
@@ -324,7 +324,8 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
                                                          chip::Controller::DeviceCommissioner ** outDevCtrl, FabricId fabricId,
                                                          chip::NodeId nodeId, chip::VendorId adminVendorId,
                                                          const char * paaTrustStorePath, bool useTestCommissioner,
-                                                         CASEAuthTag * caseAuthTags, uint32_t caseAuthTagLen)
+                                                         bool enableServerInteractions, CASEAuthTag * caseAuthTags,
+                                                         uint32_t caseAuthTagLen)
 {
     ChipLogDetail(Controller, "Creating New Device Controller");
 
@@ -381,7 +382,7 @@ ChipError::StorageType pychip_OpCreds_AllocateController(OpCredsContext * contex
     initParams.controllerRCAC                 = rcacSpan;
     initParams.controllerICAC                 = icacSpan;
     initParams.controllerNOC                  = nocSpan;
-    initParams.enableServerInteractions       = true;
+    initParams.enableServerInteractions       = enableServerInteractions;
     initParams.controllerVendorId             = adminVendorId;
     initParams.permitMultiControllerFabrics   = true;
 

--- a/src/controller/python/chip/ChipDeviceCtrl.py
+++ b/src/controller/python/chip/ChipDeviceCtrl.py
@@ -218,12 +218,13 @@ class ChipDeviceController():
             c_catTags[i] = item
 
         self._dmLib.pychip_OpCreds_AllocateController.argtypes = [c_void_p, POINTER(
-            c_void_p), c_uint64, c_uint64, c_uint16, c_char_p, c_bool, POINTER(c_uint32), c_uint32]
+            c_void_p), c_uint64, c_uint64, c_uint16, c_char_p, c_bool, c_bool, POINTER(c_uint32), c_uint32]
         self._dmLib.pychip_OpCreds_AllocateController.restype = c_uint32
 
+        # TODO(erjiaqing@): Figure out how to control enableServerInteractions for a single device controller (node)
         res = self._ChipStack.Call(
             lambda: self._dmLib.pychip_OpCreds_AllocateController(c_void_p(
-                opCredsContext), pointer(devCtrl), fabricId, nodeId, adminVendorId, c_char_p(None if len(paaTrustStorePath) == 0 else str.encode(paaTrustStorePath)), useTestCommissioner, c_catTags, len(catTags))
+                opCredsContext), pointer(devCtrl), fabricId, nodeId, adminVendorId, c_char_p(None if len(paaTrustStorePath) == 0 else str.encode(paaTrustStorePath)), useTestCommissioner, self._ChipStack.enableServerInteractions, c_catTags, len(catTags))
         )
 
         if res != 0:

--- a/src/controller/python/chip/ChipReplStartup.py
+++ b/src/controller/python/chip/ChipReplStartup.py
@@ -94,7 +94,7 @@ args = parser.parse_args()
 chip.native.Init()
 
 ReplInit(args.debug)
-chipStack = ChipStack(persistentStoragePath=args.storagepath)
+chipStack = ChipStack(persistentStoragePath=args.storagepath, enableServerInteractions=False)
 certificateAuthorityManager = chip.CertificateAuthority.CertificateAuthorityManager(chipStack, chipStack.GetStorageManager())
 
 certificateAuthorityManager.LoadAuthoritiesFromStorage()

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -177,7 +177,7 @@ _ChipThreadTaskRunnerFunct = CFUNCTYPE(None, py_object)
 
 @_singleton
 class ChipStack(object):
-    def __init__(self, persistentStoragePath: str, installDefaultLogHandler=True, bluetoothAdapter=None):
+    def __init__(self, persistentStoragePath: str, installDefaultLogHandler=True, bluetoothAdapter=None, enableServerInteractions=True):
         builtins.enableDebugMode = False
 
         self.networkLock = Lock()
@@ -190,6 +190,7 @@ class ChipStack(object):
         self.commissioningEventRes = None
         self._activeLogFunct = None
         self.addModulePrefixToLogMessage = True
+        self._enableServerInteractions = enableServerInteractions
 
         #
         # Locate and load the chip shared library.
@@ -266,7 +267,8 @@ class ChipStack(object):
         self._persistentStorage = PersistentStorage(persistentStoragePath)
 
         # Initialize the chip stack.
-        res = self._ChipStackLib.pychip_DeviceController_StackInit(self._persistentStorage.GetSdkStorageObject())
+        res = self._ChipStackLib.pychip_DeviceController_StackInit(
+            self._persistentStorage.GetSdkStorageObject(), enableServerInteractions)
         if res != 0:
             raise self.ErrorToException(res)
 
@@ -278,6 +280,10 @@ class ChipStack(object):
 
     def GetStorageManager(self):
         return self._persistentStorage
+
+    @property
+    def enableServerInteractions(self):
+        return self._enableServerInteractions
 
     @property
     def defaultLogFunct(self):
@@ -440,7 +446,7 @@ class ChipStack(object):
             self._ChipStackLib = chip.native.GetLibraryHandle()
             self._chipDLLPath = chip.native.FindNativeLibraryPath()
 
-            self._ChipStackLib.pychip_DeviceController_StackInit.argtypes = [c_void_p]
+            self._ChipStackLib.pychip_DeviceController_StackInit.argtypes = [c_void_p, c_bool]
             self._ChipStackLib.pychip_DeviceController_StackInit.restype = c_uint32
             self._ChipStackLib.pychip_DeviceController_StackShutdown.argtypes = []
             self._ChipStackLib.pychip_DeviceController_StackShutdown.restype = c_uint32


### PR DESCRIPTION
#### Problem
Commissioning with Python script on raspberry pi might fail due to failure of BLE connection establishment.

This is an issue of Raspberry Pi's BT & WiFI CoEx.

#### Change overview

This PR adds a switch to disable server interactions, which will reduce mdns traffic on WiFi interface.

#### Testing

Manaully tested with Raspberry Pi