### PR TITLE
[SVE2] Add timer compensation in level control cluster

### DIFF
--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -73,10 +73,10 @@ static constexpr size_t kLevelControlStateTableSize =
 
 struct CallbackScheduleState
 {
-    System::Clock::Timestamp idealTimestamp;    // The ideal time-stamp for the next callback to be scheduled.
-    System::Clock::Milliseconds32 runTime;      // The duration of the previous scheduled callback function.
-                                                // e.g. running time of emberAfLevelControlClusterServerTickCallback
-                                                // when called consecutively
+    System::Clock::Timestamp idealTimestamp; // The ideal time-stamp for the next callback to be scheduled.
+    System::Clock::Milliseconds32 runTime;   // The duration of the previous scheduled callback function.
+                                             // e.g. running time of emberAfLevelControlClusterServerTickCallback
+                                             // when called consecutively
 };
 
 typedef struct
@@ -132,7 +132,7 @@ static uint32_t computeCallbackWaitTimeMs(CallbackScheduleState & callbackSchedu
     const auto currentTime = System::SystemClock().GetMonotonicTimestamp();
 
     // Subsequent call
-    if(callbackSchedule.runTime)
+    if (callbackSchedule.runTime)
     {
         // Check whether the previous scheduled callback was late and whether its running time
         // is smaller than the desired delay
@@ -731,7 +731,7 @@ static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId
 
     state->storedLevel = storedLevel;
 
-    state->callbackSchedule.runTime       = System::Clock::Milliseconds32(0);
+    state->callbackSchedule.runTime = System::Clock::Milliseconds32(0);
 
     // The setup was successful, so mark the new state as active and return.
     schedule(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
@@ -859,7 +859,7 @@ static void moveHandler(EndpointId endpoint, CommandId commandId, uint8_t moveMo
     // storedLevel is not used for Move commands.
     state->storedLevel = INVALID_STORED_LEVEL;
 
-    state->callbackSchedule.runTime       = System::Clock::Milliseconds32(0);
+    state->callbackSchedule.runTime = System::Clock::Milliseconds32(0);
 
     // The setup was successful, so mark the new state as active and return.
     schedule(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));
@@ -987,7 +987,7 @@ static void stepHandler(EndpointId endpoint, CommandId commandId, uint8_t stepMo
     // storedLevel is not used for Step commands
     state->storedLevel = INVALID_STORED_LEVEL;
 
-    state->callbackSchedule.runTime       = System::Clock::Milliseconds32(0);
+    state->callbackSchedule.runTime = System::Clock::Milliseconds32(0);
 
     // The setup was successful, so mark the new state as active and return.
     schedule(endpoint, computeCallbackWaitTimeMs(state->callbackSchedule, state->eventDurationMs));

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -118,20 +118,20 @@ static void timerCallback(System::Layer *, void * callbackContext)
     emberAfLevelControlClusterServerTickCallback(static_cast<EndpointId>(reinterpret_cast<uintptr_t>(callbackContext)));
 }
 
-static uint32_t calculateNextTimestampMs(int32_t delayMs)
+static uint32_t calculateNextTimestampMs(uint32_t delayMs)
 {
-    int32_t waitTime, latency;
+    int32_t waitTime, latency, delay = (int32_t) delayMs;
     const chip::System::Clock::Timestamp currentTime = chip::System::SystemClock().GetMonotonicTimestamp();
 
     latency = (int32_t) currentTime.count() - (int32_t) nextTimestamp.count();
 
-    if (latency > delayMs)
+    if (latency > delay)
     {
         waitTime = 0;
     }
     else
     {
-        waitTime = delayMs - latency;
+        waitTime = delay - latency;
     }
 
     nextTimestamp += chip::System::Clock::Milliseconds32(delayMs);

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -71,11 +71,11 @@ static bool areStartUpLevelControlServerAttributesNonVolatile(EndpointId endpoin
 static constexpr size_t kLevelControlStateTableSize =
     EMBER_AF_LEVEL_CONTROL_CLUSTER_SERVER_ENDPOINT_COUNT + CHIP_DEVICE_CONFIG_DYNAMIC_ENDPOINT_COUNT;
 
-typedef struct
+struct CallbackScheduleState
 {
     System::Clock::Milliseconds32 prevDuration;  // The duration of the previous scheduled callback.
     System::Clock::Timestamp nextIdealTimestamp; // The ideal time stamp for the next callback to be scheduled.
-} CallbackScheduleState;
+};
 
 typedef struct
 {

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -73,8 +73,8 @@ static constexpr size_t kLevelControlStateTableSize =
 
 typedef struct
 {
-    System::Clock::Milliseconds32 prevDuration;     // The duration of the previous scheduled callback.
-    System::Clock::Timestamp nextIdealTimestamp;    // The ideal time stamp for the next callback to be scheduled.
+    System::Clock::Milliseconds32 prevDuration;  // The duration of the previous scheduled callback.
+    System::Clock::Timestamp nextIdealTimestamp; // The ideal time stamp for the next callback to be scheduled.
 } CallbackScheduleState;
 
 typedef struct
@@ -123,7 +123,7 @@ static void timerCallback(System::Layer *, void * callbackContext)
     emberAfLevelControlClusterServerTickCallback(static_cast<EndpointId>(reinterpret_cast<uintptr_t>(callbackContext)));
 }
 
-static uint32_t computeCallbackWaitTimeMs(CallbackScheduleState& callbackSchedule, uint32_t delayMs)
+static uint32_t computeCallbackWaitTimeMs(CallbackScheduleState & callbackSchedule, uint32_t delayMs)
 {
     auto delay             = System::Clock::Milliseconds32(delayMs);
     auto waitTime          = delay;

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -120,23 +120,23 @@ static void timerCallback(System::Layer *, void * callbackContext)
 
 static uint32_t calculateNextTimestampMs(int32_t delayMs)
 {
-	 int32_t waitTime, latency;
-	 const chip::System::Clock::Timestamp currentTime = chip::System::SystemClock().GetMonotonicTimestamp();
+    int32_t waitTime, latency;
+    const chip::System::Clock::Timestamp currentTime = chip::System::SystemClock().GetMonotonicTimestamp();
 
-	 latency = (int32_t)currentTime.count() - (int32_t)nextTimestamp.count();
+    latency = (int32_t) currentTime.count() - (int32_t) nextTimestamp.count();
 
-	 if(latency > delayMs)
-	 {
-		 waitTime = 0;
-	 }
-	 else
-	 {
-		 waitTime = delayMs - latency;
-	 }
+    if (latency > delayMs)
+    {
+        waitTime = 0;
+    }
+    else
+    {
+        waitTime = delayMs - latency;
+    }
 
-	 nextTimestamp += chip::System::Clock::Milliseconds32(delayMs);
+    nextTimestamp += chip::System::Clock::Milliseconds32(delayMs);
 
-	 return (uint32_t)waitTime;
+    return (uint32_t) waitTime;
 }
 
 static void schedule(EndpointId endpoint, uint32_t delayMs)

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -132,7 +132,7 @@ static uint32_t computeCallbackWaitTimeMs(CallbackScheduleState & callbackSchedu
     const auto currentTime = System::SystemClock().GetMonotonicTimestamp();
 
     // Subsequent call
-    if (callbackSchedule.runTime)
+    if (callbackSchedule.runTime.count())
     {
         // Check whether the previous scheduled callback was late and whether its running time
         // is smaller than the desired delay

--- a/src/app/clusters/level-control/level-control.cpp
+++ b/src/app/clusters/level-control/level-control.cpp
@@ -73,8 +73,8 @@ static constexpr size_t kLevelControlStateTableSize =
 
 typedef struct
 {
-	chip::System::Clock::Milliseconds32 prevCallbackDuration;
-	chip::System::Clock::Timestamp nextTimestamp;
+    chip::System::Clock::Milliseconds32 prevCallbackDuration;
+    chip::System::Clock::Timestamp nextTimestamp;
 } NextWaitTimeState;
 
 typedef struct
@@ -125,25 +125,24 @@ static void timerCallback(System::Layer *, void * callbackContext)
 
 static uint32_t calculateNextWaitTimeMs(NextWaitTimeState * nextwaitTimeState, uint32_t delayMs)
 {
-	chip::System::Clock::Timestamp latency;
-    auto delay = chip::System::Clock::Milliseconds32(delayMs);
-    auto waitTime = delay;
+    chip::System::Clock::Timestamp latency;
+    auto delay             = chip::System::Clock::Milliseconds32(delayMs);
+    auto waitTime          = delay;
     const auto currentTime = chip::System::SystemClock().GetMonotonicTimestamp();
 
-    if((currentTime > nextwaitTimeState->nextTimestamp) && (nextwaitTimeState->prevCallbackDuration < delay))
+    if ((currentTime > nextwaitTimeState->nextTimestamp) && (nextwaitTimeState->prevCallbackDuration < delay))
     {
-		latency = currentTime - nextwaitTimeState->nextTimestamp;
+        latency = currentTime - nextwaitTimeState->nextTimestamp;
 
-		if (latency >= delay)
-		{
-			waitTime = chip::System::Clock::Milliseconds32(0);
-		}
-		else
-		{
-			waitTime -= latency;
-		}
-
-	}
+        if (latency >= delay)
+        {
+            waitTime = chip::System::Clock::Milliseconds32(0);
+        }
+        else
+        {
+            waitTime -= latency;
+        }
+    }
 
     nextwaitTimeState->nextTimestamp += chip::System::Clock::Milliseconds32(delayMs);
     nextwaitTimeState->prevCallbackDuration = chip::System::Clock::Milliseconds32(0);
@@ -719,7 +718,7 @@ static EmberAfStatus moveToLevelHandler(EndpointId endpoint, CommandId commandId
 
     // The setup was successful, so mark the new state as active and return.
     state->nextWaitTimeState.prevCallbackDuration = chip::System::Clock::Milliseconds32(0);
-    state->nextWaitTimeState.nextTimestamp = chip::System::SystemClock().GetMonotonicTimestamp();
+    state->nextWaitTimeState.nextTimestamp        = chip::System::SystemClock().GetMonotonicTimestamp();
     schedule(endpoint, calculateNextWaitTimeMs(&state->nextWaitTimeState, state->eventDurationMs));
     status = EMBER_ZCL_STATUS_SUCCESS;
 
@@ -847,7 +846,7 @@ static void moveHandler(EndpointId endpoint, CommandId commandId, uint8_t moveMo
 
     // The setup was successful, so mark the new state as active and return.
     state->nextWaitTimeState.prevCallbackDuration = chip::System::Clock::Milliseconds32(0);
-    state->nextWaitTimeState.nextTimestamp = chip::System::SystemClock().GetMonotonicTimestamp();
+    state->nextWaitTimeState.nextTimestamp        = chip::System::SystemClock().GetMonotonicTimestamp();
     schedule(endpoint, calculateNextWaitTimeMs(&state->nextWaitTimeState, state->eventDurationMs));
     status = EMBER_ZCL_STATUS_SUCCESS;
 
@@ -975,7 +974,7 @@ static void stepHandler(EndpointId endpoint, CommandId commandId, uint8_t stepMo
 
     // The setup was successful, so mark the new state as active and return.
     state->nextWaitTimeState.prevCallbackDuration = chip::System::Clock::Milliseconds32(0);
-    state->nextWaitTimeState.nextTimestamp = chip::System::SystemClock().GetMonotonicTimestamp();
+    state->nextWaitTimeState.nextTimestamp        = chip::System::SystemClock().GetMonotonicTimestamp();
     schedule(endpoint, calculateNextWaitTimeMs(&state->nextWaitTimeState, state->eventDurationMs));
     status = EMBER_ZCL_STATUS_SUCCESS;
 


### PR DESCRIPTION
#### Problem

Level Control tests (such as TC-LVL-4.1) fail because current level doesn't increase at the rate specified by Move command. This is due to delays introduced by crypto operations in CASE establishment when read requests are sent to the DUT.

#### Change overview

This PR adds timer compensation in level control cluster.
Fixes #22299
Inspired by #21755

#### Testing

Tested TC-LVL-4.1 with TH and it passes

