### PR TITLE
Fix the Network information does not restore back if failsafe is set …

### DIFF
--- a/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
+++ b/src/platform/OpenThread/GenericNetworkCommissioningThreadDriver.cpp
@@ -119,9 +119,9 @@ Status GenericThreadDriver::AddOrUpdateNetwork(ByteSpan operationalDataset, Muta
     // Staging network not commissioned yet (active) or we are updating the dataset with same Extended Pan ID.
     VerifyOrReturnError(!mStagingNetwork.IsCommissioned() || MatchesNetworkId(mStagingNetwork, newExtpanid) == Status::kSuccess,
                         Status::kBoundsExceeded);
+    mStagingNetwork = newDataset;
     VerifyOrReturnError(BackupConfiguration() == CHIP_NO_ERROR, Status::kUnknownError);
 
-    mStagingNetwork = newDataset;
     return Status::kSuccess;
 }
 


### PR DESCRIPTION
#### Problem
It put a void dataset to the storage at the beginning while commissioning TH and DUT on Thread setup.
After executing "./chip-tool generalcommissioning arm-fail-safe 0 0 1 0" and "./chip-tool networkcommissioning read networks 1 0", it got the void dataset from the storage.

#### Change overview
Change the order of mStagingNetwork to avoid this issue.

#### Testing
TC-CNET-4.10
