### PR TITLE
Fix redundant ReleaseObject casing issue post commissioning.

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -544,7 +544,6 @@ void DeviceCommissioner::ReleaseCommissioneeDevice(CommissioneeDeviceProxy * dev
         mSystemState->BleLayer()->CloseAllBleConnections();
     }
 #endif
-    mCommissioneeDevicePool.ReleaseObject(device);
     // Make sure that there will be no dangling pointer
     if (mDeviceInPASEEstablishment == device)
     {


### PR DESCRIPTION
#### Problem
The cleanup after commissioning was failing because of a redundant call to ReleaseObject probably introduced as a result of a merge.

#### Change overview
Remove the extra ReleaseObject

#### Testing
Manually using the tv-casting-app and the tv-app.