### PR TITLE
[SVE][TC-CADMIN-1.9] SetUpCodePairer won't start another PASE if discover-once option is enabled.

### DIFF
--- a/examples/chip-tool/commands/pairing/PairingCommand.h
+++ b/examples/chip-tool/commands/pairing/PairingCommand.h
@@ -145,7 +145,7 @@ public:
 
     /////////// DeviceDiscoveryDelegate Interface /////////
     void OnDiscoveredDevice(const chip::Dnssd::DiscoveredNodeData & nodeData) override;
-    bool IsDiscoverOnce() { return mDiscoverOnce.ValueOr(false); }
+    bool IsDiscoverOnce() override { return mDiscoverOnce.ValueOr(false); };
 
 private:
     CHIP_ERROR RunInternal(NodeId remoteId);

--- a/src/controller/DevicePairingDelegate.h
+++ b/src/controller/DevicePairingDelegate.h
@@ -109,6 +109,12 @@ public:
      * in order to resume the commissioning process.
      */
     virtual void OnScanNetworksFailure(CHIP_ERROR error) {}
+
+    /**
+     * @brief
+     *  Called to check if the discover-once option is enabled.
+     */
+    virtual bool IsDiscoverOnce() { return false; }
 };
 
 } // namespace Controller

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -448,6 +448,9 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
         return;
     }
 
+    if (pairingDelegate != nullptr && pairingDelegate->IsDiscoverOnce())
+        return;
+
     // We failed to establish PASE.  Try the next thing we have discovered, if
     // any.
     if (TryNextRendezvousParameters())

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -448,16 +448,16 @@ void SetUpCodePairer::OnPairingComplete(CHIP_ERROR error)
         return;
     }
 
-    if (pairingDelegate != nullptr && pairingDelegate->IsDiscoverOnce())
-        return;
-
-    // We failed to establish PASE.  Try the next thing we have discovered, if
-    // any.
-    if (TryNextRendezvousParameters())
+    if (pairingDelegate == nullptr || !pairingDelegate->IsDiscoverOnce())
     {
-        // Keep waiting until that finishes.  Don't call OnPairingComplete yet.
-        mLastPASEError = error;
-        return;
+        // We failed to establish PASE.  Try the next thing we have discovered, if
+        // any.
+        if (TryNextRendezvousParameters())
+        {
+            // Keep waiting until that finishes.  Don't call OnPairingComplete yet.
+            mLastPASEError = error;
+            return;
+        }
     }
 
     if (pairingDelegate != nullptr)


### PR DESCRIPTION
#### Problem
Fixes #22547

We use `chip-tool pairing code {node-id} {setup-payload} --timeout 30 --commissioner-name beta --discover-once true` command 20 times to make the DUT close the commission window for TC-CADMIN-1.9.

Even if the user enabled the discover-once option, chip-tool sends another PBKDF param request after the first PASE attempt failed and then shutdowns itself. This additional PBKDF param request is not expected.

The 2nd PBKDF param request sent from chip-tool causes the DUT to wait for spake2p msg1 after it sent PBKDF param response. The waiting timeout for spake2p msg1 is around 50 seconds.

The 50-second timeout causes a problem that we cannot finish 20 times attempts in the period of the maximum open commissioning window for TC-CADMIN-1.9. (50*20=1000 > 900 seconds)

#### Change overview
SetUpCodePairer::OnPairingComplete would try to start another PASE if the previous PASE failed. But if the user adds the discover-once option to PairingCommand, SetUpCodePairer should do only a single PASE to the first discovered device.

#### Testing
TC-CADMIN-1.9