### PR TITLE
[nrfconnect] Fix BDX transfer restart

### DIFF
--- a/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.cpp
@@ -71,7 +71,7 @@ CHIP_ERROR OTAImageProcessorImpl::PrepareDownloadImpl()
         writer.image_id = image_id;
         writer.open     = [](int id, size_t size) { return dfu_target_init(DFU_TARGET_IMAGE_TYPE_MCUBOOT, id, size, nullptr); };
         writer.write    = [](const uint8_t * chunk, size_t chunk_size) { return dfu_target_write(chunk, chunk_size); };
-        writer.close    = [](bool success) { return dfu_target_done(success); };
+        writer.close    = [](bool success) { return success ? dfu_target_done(success) : dfu_target_reset(); };
 
         ReturnErrorOnFailure(System::MapErrorZephyr(dfu_multi_image_register_writer(&writer)));
     };

--- a/src/platform/nrfconnect/OTAImageProcessorImpl.h
+++ b/src/platform/nrfconnect/OTAImageProcessorImpl.h
@@ -56,7 +56,7 @@ public:
     bool IsFirstImageRun() override;
     CHIP_ERROR ConfirmCurrentImage() override;
 
-private:
+protected:
     CHIP_ERROR PrepareDownloadImpl();
     CHIP_ERROR ProcessHeader(ByteSpan & aBlock);
 


### PR DESCRIPTION
#### Problem
When OTA is interrupted in the middle of a BDX transfer and the transfer is then re-initiated after the 5-minute idle timeout, it may fail with the following error:

<err> dfu_target_stream: stream_flash_buffered_write error -12
<inf> dfu_target_mcuboot: MCUBoot image upgrade aborted.


#### Change overview
Use `dfu_target_reset` in error conditions which should force releasing all the associated resources.
Make `OTAImageProcessorImpl` members protected to allow customers for adding a custom behaviour.
Fixes #22400.

#### Testing
Killed OTA provider in the middle of a transfer, waited 10 minutes and started it again, verified OTA completes succesfully.
