### PR TITLE
Correctly clean up VectorBool optional arguments in chip-tool.

### DIFF
--- a/examples/chip-tool/commands/common/Command.cpp
+++ b/examples/chip-tool/commands/common/Command.cpp
@@ -898,8 +898,7 @@ void Command::ResetArguments()
                 break;
             }
             case ArgumentType::VectorBool: {
-                auto vectorArgument = static_cast<std::vector<bool> *>(arg.value);
-                vectorArgument->clear();
+                ResetOptionalArg<std::vector<bool>>(arg);
                 break;
             }
             case ArgumentType::Vector16: {


### PR DESCRIPTION
We were not actually resetting the Optional (and in fact were operating on
totally the wrong type, and it's not clear why this was not crashing all the
time).

Fixes https://github.com/project-chip/connectedhomeip/issues/22406

#### Problem
End up with a "vector of booleans" argument that points to empty vector, when the expectation is no vector at all or a nonempty one.

#### Change overview
Fix cleanup of command args when a command is done to handle this type of argument correctly.

#### Testing
Used test steps in  https://github.com/project-chip/connectedhomeip/issues/22406 to verify the fix.

We should probably take this on the sve2 branch @woody-apple @andy31415 