### PR TITLE
Treat an ERR_MEM on send as non-fatal on LwIP.

### DIFF
--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -419,9 +419,11 @@ void ReliableMessageMgr::RegisterSessionUpdateDelegate(SessionUpdateDelegate * s
 
 CHIP_ERROR ReliableMessageMgr::MapSendError(CHIP_ERROR error, uint16_t exchangeId, bool isInitiator)
 {
-    if (error == CHIP_ERROR_POSIX(ENOBUFS)
+    if (
 #if CHIP_SYSTEM_CONFIG_USE_LWIP
-        || error == System::MapErrorLwIP(ERR_MEM)
+        error == System::MapErrorLwIP(ERR_MEM)
+#else
+        error == CHIP_ERROR_POSIX(ENOBUFS)
 #endif // CHIP_SYSTEM_CONFIG_USE_LWIP
     )
     {

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -311,6 +311,7 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 
     auto * sessionManager = entry->ec->GetExchangeMgr()->GetSessionManager();
     CHIP_ERROR err        = sessionManager->SendPreparedMessage(entry->ec->GetSessionHandle(), entry->retainedBuf);
+    err                   = MapSendError(err, entry->ec->GetExchangeId(), entry->ec->IsInitiator());
 
     if (err == CHIP_NO_ERROR)
     {
@@ -414,6 +415,32 @@ void ReliableMessageMgr::StopTimer()
 void ReliableMessageMgr::RegisterSessionUpdateDelegate(SessionUpdateDelegate * sessionUpdateDelegate)
 {
     mSessionUpdateDelegate = sessionUpdateDelegate;
+}
+
+CHIP_ERROR ReliableMessageMgr::MapSendError(CHIP_ERROR error, uint16_t exchangeId, bool isInitiator)
+{
+    if (error == CHIP_ERROR_POSIX(ENOBUFS)
+#if CHIP_SYSTEM_CONFIG_USE_LWIP
+        || error == System::MapErrorLwIP(ERR_MEM)
+#endif // CHIP_SYSTEM_CONFIG_USE_LWIP
+    )
+    {
+        // sendmsg on BSD-based systems never blocks, no matter how the
+        // socket is configured, and will return ENOBUFS in situation in
+        // which Linux, for example, blocks.
+        //
+        // This is typically a transient situation, so we pretend like this
+        // packet drop happened somewhere on the network instead of inside
+        // sendmsg and will just resend it in the normal MRP way later.
+        //
+        // Similarly, on LwIP an ERR_MEM on send indicates a likely
+        // temporary lack of TX buffers.
+        ChipLogError(ExchangeManager, "Ignoring transient send error: %" CHIP_ERROR_FORMAT " on exchange " ChipLogFormatExchangeId,
+                     error.Format(), ChipLogValueExchangeId(exchangeId, isInitiator));
+        error = CHIP_NO_ERROR;
+    }
+
+    return error;
 }
 
 #if CHIP_CONFIG_TEST

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -182,6 +182,13 @@ public:
      */
     void RegisterSessionUpdateDelegate(SessionUpdateDelegate * sessionUpdateDelegate);
 
+    /**
+     * Map a send error code to the error code we should actually use for
+     * success checks.  This maps some error codes to CHIP_NO_ERROR as
+     * appropriate.
+     */
+    static CHIP_ERROR MapSendError(CHIP_ERROR error, uint16_t exchangeId, bool isInitiator);
+
 #if CHIP_CONFIG_TEST
     // Functions for testing
     int TestGetCountRetransTable();


### PR DESCRIPTION
That can be caused by a transient lack of TX buffers.  We should just
try again via MRP.

Fixes https://github.com/project-chip/connectedhomeip/issues/21671

#### Problem
Errors that should be transient end up being fatal.

#### Change overview
Treat ERR_MEM on send as a transient error when using LwIP.

#### Testing
Needs real-world testing.  I asked for some in https://github.com/project-chip/connectedhomeip/issues/21671 but no responses so far.