### PR TITLE
[EFR32] Fix examples build as sleepy end device

### DIFF
--- a/examples/platform/efr32/BaseApplication.h
+++ b/examples/platform/efr32/BaseApplication.h
@@ -101,13 +101,13 @@ public:
     /**
      * @brief Function called to start the LED light timer
      */
-    void StartStatusLEDTimer(void);
+    static void StartStatusLEDTimer(void);
 
     /**
      * @brief Function to stop LED light timer
      *        Turns off Status LED before stopping timer
      */
-    void StopStatusLEDTimer(void);
+    static void StopStatusLEDTimer(void);
 
     enum Function_t
     {


### PR DESCRIPTION
#### Problem
Examples built as Sleepy end device fail to build with error
```
../../../examples/light-switch-app/efr32/third_party/connectedhomeip/examples/platform/efr32/BaseApplication.cpp:262:29: error: cannot call member function 'void BaseApplication::StartStatusLEDTimer()' without object
  262 |         StartStatusLEDTimer();
```

#### Change overview
Set `StartStatusLEDTimer` and `StopStatusLEDTimer` as public static as they are called by static members of the base application class for SED examples but are also called outside the context of the class.

#### Testing
Build efr32 examples as sleepy end device (--sed)
