### PR TITLE
Groups Cluster: AddGroup bugfix.

### DIFF
--- a/src/app/clusters/groups-server/groups-server.cpp
+++ b/src/app/clusters/groups-server/groups-server.cpp
@@ -90,17 +90,16 @@ static bool KeyExists(FabricIndex fabricIndex, GroupId groupId)
 
     auto it    = provider->IterateGroupKeys(fabricIndex);
     bool found = false;
-    while (it->Next(entry) && !found)
+    while (!found && it->Next(entry))
     {
-        found = (entry.group_id == groupId);
+        if (entry.group_id == groupId)
+        {
+            GroupDataProvider::KeySet keys;
+            found = (CHIP_NO_ERROR == provider->GetKeySet(fabricIndex, entry.keyset_id, keys));
+        }
     }
     it->Release();
 
-    if (found)
-    {
-        GroupDataProvider::KeySet keys;
-        found = (CHIP_NO_ERROR == provider->GetKeySet(fabricIndex, entry.keyset_id, keys));
-    }
     return found;
 }
 


### PR DESCRIPTION
#### Problem
TC-G-2.2 fails due to an error in the AddGroup implementation. In src/app/clusters/groups-server/groups-server.cpp, the expression:
```
while (it->Next(entry) && !found)
```
Causes the entry to change before exiting the loop, so the value of `entry` is no longer the matching entry. Instead, the expression should be:
```
while (!found && it->Next(entry))
```

#### Change overview
Loop changed to correct the error, and make the logic clearer.

#### Testing
Groups, and Group Key Management tests executed correctly.
