### PR TITLE
Fix the naming of the "get the attestation challenge" Darwin function.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -137,10 +137,10 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 /**
  * Return the attestation challenge for the secure session of the device being commissioned.
  *
- * Attempts to retrieve the generated attestation challenge from a commissionee with the given Device ID.
+ * Attempts to retrieve the attestation challenge for a commissionee with the given Device ID.
  * Returns nil if given Device ID does not match an active commissionee, or if a Secure Session is not availale.
  */
-- (nullable NSData *)generateAttestationChallengeForDeviceId:(uint64_t)deviceId;
+- (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId;
 
 /**
  * Compute a PASE verifier and passcode ID for the desired setup pincode.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -719,7 +719,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     return result;
 }
 
-- (nullable NSData *)generateAttestationChallengeForDeviceId:(uint64_t)deviceId
+- (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId
 {
     VerifyOrReturnValue([self checkIsRunning], nil);
 


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/22296

#### Problem
Function name talks about "generating" a challenge, but it's not actually being generated.

#### Change overview
Fix naming.

#### Testing
Just a rename.