### PR TITLE
Fix bug in SubscribeEvent function that results in compilation failure

### DIFF
--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -366,7 +366,7 @@ public:
             }
         };
 
-        auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb]() {
+        auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb](const app::ReadClient & readClient) {
             if (subscriptionEstablishedCb != nullptr)
             {
                 subscriptionEstablishedCb(context);


### PR DESCRIPTION
#### Problem
Fix bug in SubscribeEvent function.

Fixes #22467

#### Change overview
Fix bug in SubscribeEvent function that results in compilation failure
There is a bug in the SubscribeEvent function in CHIPCluster.h: https://github.com/project-chip/connectedhomeip/blob/342ba68745610b4bee23112ac56e0681d3e72067/src/controller/CHIPCluster.h#L348
While trying to use this function I get the following compilation error:
vendor/csa-iot/connectedhomeip/src/controller/CHIPCluster.h:384:16: error: no matching function for call to 'SubscribeEvent'
        return Controller::SubscribeEvent<DecodableType>(&mExchangeManager, mSession.Get().Value(), mEndpoint, onReportCb,

By changing this line of code https://github.com/project-chip/connectedhomeip/blob/342ba68745610b4bee23112ac56e0681d3e72067/src/controller/CHIPCluster.h#L369
to
auto onSubscriptionEstablishedCb = [context, subscriptionEstablishedCb](const app::ReadClient & readClient)
compilation is successful

#### Testing
How was this tested? (at least one bullet point required)
* If no testing is required, why not? Not tested since this function is not currently used by any example. Compilation was successful with local setup that uses this function.
