### PR TITLE
Fix incorrect feature check to align with spec

### DIFF
--- a/src/app/clusters/window-covering-server/window-covering-server.cpp
+++ b/src/app/clusters/window-covering-server/window-covering-server.cpp
@@ -689,11 +689,11 @@ bool emberAfWindowCoveringClusterUpOrOpenCallback(app::CommandHandler * commandO
         return true;
     }
 
-    if (HasFeature(endpoint, Feature::kLift))
+    if (HasFeature(endpoint, Feature::kPositionAwareLift))
     {
         Attributes::TargetPositionLiftPercent100ths::Set(endpoint, WC_PERCENT100THS_MIN_OPEN);
     }
-    if (HasFeature(endpoint, Feature::kTilt))
+    if (HasFeature(endpoint, Feature::kPositionAwareTilt))
     {
         Attributes::TargetPositionTiltPercent100ths::Set(endpoint, WC_PERCENT100THS_MIN_OPEN);
     }
@@ -719,11 +719,11 @@ bool emberAfWindowCoveringClusterDownOrCloseCallback(app::CommandHandler * comma
         return true;
     }
 
-    if (HasFeature(endpoint, Feature::kLift))
+    if (HasFeature(endpoint, Feature::kPositionAwareLift))
     {
         Attributes::TargetPositionLiftPercent100ths::Set(endpoint, WC_PERCENT100THS_MAX_CLOSED);
     }
-    if (HasFeature(endpoint, Feature::kTilt))
+    if (HasFeature(endpoint, Feature::kPositionAwareTilt))
     {
         Attributes::TargetPositionTiltPercent100ths::Set(endpoint, WC_PERCENT100THS_MAX_CLOSED);
     }


### PR DESCRIPTION
#### Problem
What is being fixed?  Examples:
* Current implementation of UpOrOpen and DownOrClose is not aligned with spec, according to spec:

* Upon receipt of UpOrOpen command, if Position Aware feature is supported:
TargetPositionLiftPercent100ths attribute SHALL be set to 0.00%.
TargetPositionTiltPercent100ths attribute SHALL be set to 0.00%. 

* Upon receipt of DownOrClose command, if Position Aware feature is supported:
TargetPositionLiftPercent100ths attribute SHALL be set to 100.00%.
TargetPositionTiltPercent100ths attribute SHALL be set to 100.00%.

https://github.com/CHIP-Specifications/connectedhomeip-spec/blob/master/src/app_clusters/WindowCovering.adoc#features

#### Change overview
Fix incorrect feature check to align with spec

#### Testing
How was this tested? (at least one bullet point required)
* confirm the  UpOrOpen and DownOrClose commands can be executed successfully.
```
yufengwang@yufengwang:~/connectedhomeip/out/debug/standalone$ ./chip-tool windowcovering down-or-close 12344321 1
....
[1662502041.986683][2058737:2058742] CHIP:EM: Removed CHIP MessageCounter:2650576 from RetransTable on exchange 64514i
[1662502041.986702][2058737:2058742] CHIP:DMG: ICR moving to [ResponseRe]
[1662502041.986732][2058737:2058742] CHIP:DMG: InvokeResponseMessage =
[1662502041.986746][2058737:2058742] CHIP:DMG: {
[1662502041.986759][2058737:2058742] CHIP:DMG: 	suppressResponse = false, 
[1662502041.986772][2058737:2058742] CHIP:DMG: 	InvokeResponseIBs =
[1662502041.986791][2058737:2058742] CHIP:DMG: 	[
[1662502041.986803][2058737:2058742] CHIP:DMG: 		InvokeResponseIB =
[1662502041.986821][2058737:2058742] CHIP:DMG: 		{
[1662502041.986834][2058737:2058742] CHIP:DMG: 			CommandStatusIB =
[1662502041.986848][2058737:2058742] CHIP:DMG: 			{
[1662502041.986861][2058737:2058742] CHIP:DMG: 				CommandPathIB =
[1662502041.986876][2058737:2058742] CHIP:DMG: 				{
[1662502041.986890][2058737:2058742] CHIP:DMG: 					EndpointId = 0x1,
[1662502041.986905][2058737:2058742] CHIP:DMG: 					ClusterId = 0x102,
[1662502041.986919][2058737:2058742] CHIP:DMG: 					CommandId = 0x1,
[1662502041.986932][2058737:2058742] CHIP:DMG: 				},
[1662502041.986951][2058737:2058742] CHIP:DMG: 				
[1662502041.986964][2058737:2058742] CHIP:DMG: 				StatusIB =
[1662502041.986979][2058737:2058742] CHIP:DMG: 				{
[1662502041.986993][2058737:2058742] CHIP:DMG: 					status = 0x00 (SUCCESS),
[1662502041.987007][2058737:2058742] CHIP:DMG: 				},
[1662502041.987021][2058737:2058742] CHIP:DMG: 				
[1662502041.987033][2058737:2058742] CHIP:DMG: 			},
[1662502041.987050][2058737:2058742] CHIP:DMG: 			
[1662502041.987062][2058737:2058742] CHIP:DMG: 		},
[1662502041.987080][2058737:2058742] CHIP:DMG: 		
[1662502041.987091][2058737:2058742] CHIP:DMG: 	],
[1662502041.987109][2058737:2058742] CHIP:DMG: 	
[1662502041.987121][2058737:2058742] CHIP:DMG: 	InteractionModelRevision = 1
[1662502041.987132][2058737:2058742] CHIP:DMG: },
[1662502041.987176][2058737:2058742] CHIP:DMG: Received Command Response Status for Endpoint=1 Cluster=0x0000_0102 Command=0x0000_0001 Status=0x0
```


