### PR TITLE
Fix handling of errors in Darwin framework OTA delegate bridge.

### DIFF
--- a/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
+++ b/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
@@ -46,17 +46,11 @@ constexpr uint8_t kUpdateTokenLen = 32;
                 completionHandler:(void (^_Nonnull)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
                                       NSError * _Nullable error))completionHandler
 {
-    NSError * error;
-
     auto isBDXProtocolSupported =
         [params.protocolsSupported containsObject:@(MTROtaSoftwareUpdateProviderOTADownloadProtocolBDXSynchronous)];
     if (!isBDXProtocolSupported) {
         _selectedCandidate.status = @(MTROtaSoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported);
-        error =
-            [[NSError alloc] initWithDomain:@"OTAProviderDomain"
-                                       code:MTRErrorCodeGeneralError
-                                   userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Protocol is not supported.", nil) }];
-        completionHandler(_selectedCandidate, error);
+        completionHandler(_selectedCandidate, nil);
         return;
     }
 
@@ -64,10 +58,7 @@ constexpr uint8_t kUpdateTokenLen = 32;
     if (!hasCandidate) {
         NSLog(@"Unable to select OTA Image.");
         _selectedCandidate.status = @(MTROtaSoftwareUpdateProviderOTAQueryStatusNotAvailable);
-        error = [[NSError alloc]
-            initWithDomain:@"OTAProviderDomain"
-                      code:MTRErrorCodeInvalidState
-                  userInfo:@{ NSLocalizedDescriptionKey : NSLocalizedString(@"Unable to select Candidate.", nil) }];
+        completionHandler(_selectedCandidate, nil);
         return;
     }
 
@@ -78,7 +69,7 @@ constexpr uint8_t kUpdateTokenLen = 32;
         _selectedCandidate.userConsentNeeded
             = (_userConsentState == OTAProviderUserUnknown || _userConsentState == OTAProviderUserDenied) ? @(1) : @(0);
         NSLog(@"User Consent Needed: %@", _selectedCandidate.userConsentNeeded);
-        completionHandler(_selectedCandidate, error);
+        completionHandler(_selectedCandidate, nil);
         return;
     }
 
@@ -101,7 +92,7 @@ constexpr uint8_t kUpdateTokenLen = 32;
         break;
     }
     _selectedCandidate.status = @(_queryImageStatus);
-    completionHandler(_selectedCandidate, error);
+    completionHandler(_selectedCandidate, nil);
 }
 
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber * _Nonnull)nodeID

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
@@ -31,6 +31,10 @@ NS_ASSUME_NONNULL_BEGIN
  * Notify the delegate when the query image command is received from some node.
  * The controller identifies the fabric the node is on, and the nodeID
  * identifies the node within that fabric.
+ *
+ * If completionHandler is passed a non-nil error, that will be converted into
+ * an error response to the client.  Otherwise it must have a non-nil data,
+ * which will be returned to the client.
  */
 - (void)handleQueryImageForNodeID:(NSNumber *)nodeID
                        controller:(MTRDeviceController *)controller
@@ -42,6 +46,10 @@ NS_ASSUME_NONNULL_BEGIN
  * Notify the delegate when the apply update request command is received from
  * some node.  The controller identifies the fabric the node is on, and the
  * nodeID identifies the node within that fabric.
+ *
+ * If completionHandler is passed a non-nil error, that will be converted into
+ * an error response to the client.  Otherwise it must have a non-nil data,
+ * which will be returned to the client.
  */
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber *)nodeID
                                controller:(MTRDeviceController *)controller
@@ -53,6 +61,9 @@ NS_ASSUME_NONNULL_BEGIN
  * Notify the delegate when the notify update applied command is received from
  * some node.  The controller identifies the fabric the node is on, and the
  * nodeID identifies the node within that fabric.
+ *
+ * If completionHandler is passed a non-nil error, that will be converted into
+ * an error response to the client.  Otherwise a success response will be sent.
  */
 - (void)handleNotifyUpdateAppliedForNodeID:(NSNumber *)nodeID
                                 controller:(MTRDeviceController *)controller

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -378,6 +378,60 @@ bool GetPeerNodeInfo(CommandHandler * commandHandler, const ConcreteCommandPath 
     *outNodeId = desc.subject;
     return true;
 }
+
+// Ensures we have a usable CommandHandler and do not have an error.
+//
+// When this function returns non-null, it's safe to go ahead and use the return
+// value to send a response.
+//
+// When this function returns null, the CommandHandler::Handle should not be
+// used anymore.
+CommandHandler * _Nullable EnsureValidState(
+    CommandHandler::Handle & handle, const ConcreteCommandPath & cachedCommandPath, const char * prefix, NSError * _Nullable error)
+{
+    CommandHandler * handler = handle.Get();
+    if (handler == nullptr) {
+        ChipLogError(Controller, "%s: no CommandHandler to send response", prefix);
+        return nullptr;
+    }
+
+    if (error != nil) {
+        auto * desc = [error description];
+        auto err = [MTRError errorToCHIPErrorCode:error];
+        ChipLogError(Controller, "%s: application returned error: '%s', sending error: '%s'", prefix,
+            [desc cStringUsingEncoding:NSUTF8StringEncoding], chip::ErrorStr(err));
+
+        handler->AddStatus(cachedCommandPath, StatusIB(err).mStatus);
+        handle.Release();
+        return nullptr;
+    }
+
+    return handler;
+}
+
+// Ensures we have a usable CommandHandler and that our args don't involve any
+// errors, for the case when we have data to send back.
+//
+// When this function returns non-null, it's safe to go ahead and use whatever
+// object "data" points to to add a response to the command.
+//
+// When this function returns null, the CommandHandler::Handle should not be
+// used anymore.
+CommandHandler * _Nullable EnsureValidState(CommandHandler::Handle & handle, const ConcreteCommandPath & cachedCommandPath,
+    const char * prefix, NSObject * _Nullable data, NSError * _Nullable error)
+{
+    CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, prefix, error);
+    VerifyOrReturnValue(handler != nullptr, nullptr);
+
+    if (data == nil) {
+        ChipLogError(Controller, "%s: no data to send as a response", prefix);
+        handler->AddStatus(cachedCommandPath, Protocols::InteractionModel::Status::Failure);
+        handle.Release();
+        return nullptr;
+    }
+
+    return handler;
+}
 } // anonymous namespace
 
 void MTROTAProviderDelegateBridge::HandleQueryImage(
@@ -403,8 +457,11 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
     auto completionHandler = ^(
         MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error) {
         dispatch_async(mWorkQueue, ^{
-            CommandHandler * handler = handle.Get();
+            CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, "QueryImage", data, error);
             VerifyOrReturn(handler != nullptr);
+
+            ChipLogDetail(Controller, "QueryImage: application responded with: %s",
+                [[data description] cStringUsingEncoding:NSUTF8StringEncoding]);
 
             Commands::QueryImageResponse::Type response;
             ConvertFromQueryImageResponseParms(data, response);
@@ -472,8 +529,11 @@ void MTROTAProviderDelegateBridge::HandleApplyUpdateRequest(CommandHandler * com
     auto completionHandler
         = ^(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error) {
               dispatch_async(mWorkQueue, ^{
-                  CommandHandler * handler = handle.Get();
+                  CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, "ApplyUpdateRequest", data, error);
                   VerifyOrReturn(handler != nullptr);
+
+                  ChipLogDetail(Controller, "ApplyUpdateRequest: application responded with: %s",
+                      [[data description] cStringUsingEncoding:NSUTF8StringEncoding]);
 
                   Commands::ApplyUpdateResponse::Type response;
                   ConvertFromApplyUpdateRequestResponseParms(data, response);
@@ -509,7 +569,7 @@ void MTROTAProviderDelegateBridge::HandleNotifyUpdateApplied(CommandHandler * co
 
     auto completionHandler = ^(NSError * _Nullable error) {
         dispatch_async(mWorkQueue, ^{
-            CommandHandler * handler = handle.Get();
+            CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, "NotifyUpdateApplied", error);
             VerifyOrReturn(handler != nullptr);
 
             handler->AddStatus(cachedCommandPath, Protocols::InteractionModel::Status::Success);


### PR DESCRIPTION
This allows the framework consumer to return an error that will be sent as an error status to the OTA provider client.

Fixes https://github.com/project-chip/connectedhomeip/issues/20653

#### Problem
The callbacks have an `NSError *` argument that is not used in a sane way.

#### Change overview
1. Stop passing in a non-nil NSError from darwin-framework-tool.
2. Convert non-nil NSError into an error status response to the server

#### Testing
1. Modified `handleQueryImageForNodeID` in darwin-framework-tool to pass in a non-null error in the "no OTA image" case allocated like so:
    ```
        auto * error = [[NSError alloc] initWithDomain:MTRInteractionErrorDomain
                                                  code:MTRInteractionErrorCodeFailsafeRequired
                                              userInfo:nil];
    ```
2. Ran the ota-requestor app.
3. Ran darwin-framework-tool in interactive mode, commissioned the ota-requestor app as node id `17`, and ran:
    ```
    otasoftwareupdaterequestor announce-ota-provider ${FRAMEWORK_TOOL_NODE_ID} 0xfff1 0 0 17 0
    ```
4. Observed that the ota-requestor app logged:
    ```
    CHIP: [SWU] Received QueryImage failure response: IM Error 0x000005CA: General error: 0xca (FAILSAFE_REQUIRED)
    ```