### PR TITLE
[ESP32] - Make sure that BLE indications are sent sequentially

### DIFF
--- a/src/platform/ESP32/nimble/BLEManagerImpl.cpp
+++ b/src/platform/ESP32/nimble/BLEManagerImpl.cpp
@@ -833,7 +833,7 @@ CHIP_ERROR BLEManagerImpl::HandleTXComplete(struct ble_gap_event * gapEvent)
                     gapEvent->notify_tx.conn_handle, gapEvent->notify_tx.status);
 
     // Signal the BLE Layer that the outstanding indication is complete.
-    if (gapEvent->notify_tx.status == 0 || gapEvent->notify_tx.status == BLE_HS_EDONE)
+    if (gapEvent->notify_tx.status == BLE_HS_EDONE)
     {
         // Post an event to the Chip queue to process the indicate confirmation.
         ChipDeviceEvent event;
@@ -1012,8 +1012,11 @@ int BLEManagerImpl::ble_svr_gap_event(struct ble_gap_event * event, void * arg)
         break;
 
     case BLE_GAP_EVENT_NOTIFY_TX:
-        err = sInstance.HandleTXComplete(event);
-        SuccessOrExit(err);
+        if (event->notify_tx.status != 0)
+        {
+            err = sInstance.HandleTXComplete(event);
+            SuccessOrExit(err);
+        }
         break;
 
     case BLE_GAP_EVENT_MTU:


### PR DESCRIPTION
The next indication is sent only after the previous one is acked

#### Problem
* Fixes #22444

@yufengwangca As per our offline discussion, please try it for your automated test issue reported in #22416 

#### Change overview
A status of 0 indicates that the indication is sent from the BLE host. Ideally, we should move to the next step when the status received is BLE_HS_EDONE which indicates the indication ack is received. For any other status value, give an appropriate error.

In short, handle all the status values except for 0.

#### Testing
* BLE based commissioning successful