### PR TITLE
[ESP32] Erase the chip-counters namespace when doing factory reset

### DIFF
--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -353,6 +353,13 @@ void ConfigurationManagerImpl::DoFactoryReset(intptr_t arg)
         ChipLogError(DeviceLayer, "ClearNamespace(ChipConfig) failed: %s", chip::ErrorStr(err));
     }
 
+    // Erase all values in the chip-counters NVS namespace.
+    err = ESP32Config::ClearNamespace(ESP32Config::kConfigNamespace_ChipCounters);
+    if (err != CHIP_NO_ERROR)
+    {
+        ChipLogError(DeviceLayer, "ClearNamespace(ChipCounters) failed: %s", chip::ErrorStr(err));
+    }
+
     // Restore WiFi persistent settings to default values.
 #if CHIP_DEVICE_CONFIG_ENABLE_WIFI
     esp_err_t error = esp_wifi_restore();


### PR DESCRIPTION
#### Problem
Fixes #22449
The chip-counters namespace is not cleared when doing factory-reset.

#### Change overview
Add `ClearNamespace` for chip-counters namespace in factory-reset function.

#### Testing
Tested on ESP32, and the reboot count was reset to 0 after factoryreset.