### PR TITLE
[privacy] Don't enable privacy when privacy is not supported.

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -166,7 +166,6 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         packetHeader.SetDestinationGroupId(groupSession->GetGroupId());
         packetHeader.SetMessageCounter(mGroupClientCounter.GetCounter(isControlMsg));
         mGroupClientCounter.IncrementCounter(isControlMsg);
-        packetHeader.SetFlags(Header::SecFlagValues::kPrivacyFlag);
         packetHeader.SetSessionType(Header::SessionType::kGroupSession);
         NodeId sourceNodeId = fabric->GetNodeId();
         packetHeader.SetSourceNodeId(sourceNodeId);

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -203,14 +203,14 @@ public:
     {
         // Check is based on spec 4.11.2
         return (IsGroupSession() && GetSourceNodeId().HasValue() && GetDestinationGroupId().HasValue() &&
-                !IsSecureSessionControlMsg() && HasPrivacyFlag());
+                !IsSecureSessionControlMsg());
     }
 
     bool IsValidMCSPMsg() const
     {
         // Check is based on spec 4.9.2.4
         return (IsGroupSession() && GetSourceNodeId().HasValue() && GetDestinationNodeId().HasValue() &&
-                IsSecureSessionControlMsg() && HasPrivacyFlag());
+                IsSecureSessionControlMsg());
     }
 
     bool IsEncrypted() const { return !((mSessionId == kMsgUnicastSessionIdUnsecured) && IsUnicastSession()); }

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -151,7 +151,6 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
 
     header.ClearDestinationNodeId();
     header.SetSessionType(Header::SessionType::kGroupSession);
-    header.SetFlags(Header::SecFlagValues::kPrivacyFlag);
     header.SetSecureSessionControlMsg(false);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
@@ -165,7 +164,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.IsValidGroupMsg());
 
     // Verify MCSP state
-    header.ClearDestinationGroupId().SetDestinationNodeId(42).SetFlags(Header::SecFlagValues::kPrivacyFlag);
+    header.ClearDestinationGroupId().SetDestinationNodeId(42);
     header.SetSecureSessionControlMsg(true);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
@@ -174,7 +173,6 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(42ull));
     NL_TEST_ASSERT(inSuite, !header.GetDestinationGroupId().HasValue());
-    NL_TEST_ASSERT(inSuite, header.HasPrivacyFlag());
     NL_TEST_ASSERT(inSuite, header.IsValidMCSPMsg());
 }
 


### PR DESCRIPTION
#### Problem
The SDK is setting the privacy flag from Group and MCSP messages even though support for privacy isn't enabled yet.
Fix #22426

#### Change overview
Correctly set privacy flag to reflect whether privacy is actually enabled on a message.

#### Testing
CI

#### Interoperability
This change will break interoperability of group messages between 1.0 and SVE2 + prior.
SVE2 + prior are erroneously sending group messages with privacy flag set but not applying any privacy.  This behavior does not match the spec.