### PR TITLE
Allow null ICAC in `AndroidDeviceControllerWrapper::AllocateNew`

### DIFF
--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -247,8 +247,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     else
     {
         ChipLogProgress(Controller,
-                        "No existing credentials provided: generating ephemeral local NOC chain with OperationalCredentialsIssuer",
-                        static_cast<unsigned>(wrapper->Controller()->GetFabricIndex()));
+                        "No existing credentials provided: generating ephemeral local NOC chain with OperationalCredentialsIssuer");
 
         *errInfoOnFailure = ephemeralKey.Initialize();
         if (*errInfoOnFailure != CHIP_NO_ERROR)
@@ -293,7 +292,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     }
     ChipLogProgress(Controller, "Setting up group data for Fabric Index %u with Compressed Fabric ID:",
                     static_cast<unsigned>(wrapper->Controller()->GetFabricIndex()));
-    ChipLogByteSpan(Controller, compressedFabricIdSpan);
+    ChipLogByteSpan(Support, compressedFabricIdSpan);
 
     chip::ByteSpan ipkSpan;
     std::vector<uint8_t> ipkBuffer;

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -246,7 +246,8 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     }
     else
     {
-        ChipLogProgress(Controller, "No existing credentials provided: generating ephemeral local NOC chain with OperationalCredentialsIssuer",
+        ChipLogProgress(Controller,
+                        "No existing credentials provided: generating ephemeral local NOC chain with OperationalCredentialsIssuer",
                         static_cast<unsigned>(wrapper->Controller()->GetFabricIndex()));
 
         *errInfoOnFailure = ephemeralKey.Initialize();

--- a/src/controller/java/AndroidDeviceControllerWrapper.cpp
+++ b/src/controller/java/AndroidDeviceControllerWrapper.cpp
@@ -209,8 +209,7 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     // The lifetime of the ephemeralKey variable must be kept until SetupParams is saved.
     Crypto::P256Keypair ephemeralKey;
 
-    if (rootCertificate != nullptr && intermediateCertificate != nullptr && nodeOperationalCertificate != nullptr &&
-        keypairDelegate != nullptr)
+    if (rootCertificate != nullptr && nodeOperationalCertificate != nullptr && keypairDelegate != nullptr)
     {
         CHIPP256KeypairBridge * nativeKeypairBridge = wrapper->GetP256KeypairBridge();
         nativeKeypairBridge->SetDelegate(keypairDelegate);
@@ -224,20 +223,19 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
         setupParams.hasExternallyOwnedOperationalKeypair = true;
 
         JniByteArray jniRcac(env, rootCertificate);
-        JniByteArray jniIcac(env, intermediateCertificate);
         JniByteArray jniNoc(env, nodeOperationalCertificate);
 
         // Make copies of the cert that outlive the scope so that future factor init does not
         // cause loss of scope from the JNI refs going away. Also, this keeps the certs
         // handy for debugging commissioner init.
         wrapper->mRcacCertificate = std::vector<uint8_t>(jniRcac.byteSpan().begin(), jniRcac.byteSpan().end());
-        if (!jniIcac.byteSpan().empty())
+
+        // Intermediate cert could be missing. Let's only copy it if present
+        wrapper->mIcacCertificate.clear();
+        if (intermediateCertificate != nullptr)
         {
+            JniByteArray jniIcac(env, intermediateCertificate);
             wrapper->mIcacCertificate = std::vector<uint8_t>(jniIcac.byteSpan().begin(), jniIcac.byteSpan().end());
-        }
-        else
-        {
-            wrapper->mIcacCertificate.clear();
         }
 
         wrapper->mNocCertificate = std::vector<uint8_t>(jniNoc.byteSpan().begin(), jniNoc.byteSpan().end());
@@ -248,6 +246,9 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     }
     else
     {
+        ChipLogProgress(Controller, "No existing credentials provided: generating ephemeral local NOC chain with OperationalCredentialsIssuer",
+                        static_cast<unsigned>(wrapper->Controller()->GetFabricIndex()));
+
         *errInfoOnFailure = ephemeralKey.Initialize();
         if (*errInfoOnFailure != CHIP_NO_ERROR)
         {
@@ -289,9 +290,9 @@ AndroidDeviceControllerWrapper * AndroidDeviceControllerWrapper::AllocateNew(
     {
         return nullptr;
     }
-    ChipLogProgress(Support, "Setting up group data for Fabric Index %u with Compressed Fabric ID:",
+    ChipLogProgress(Controller, "Setting up group data for Fabric Index %u with Compressed Fabric ID:",
                     static_cast<unsigned>(wrapper->Controller()->GetFabricIndex()));
-    ChipLogByteSpan(Support, compressedFabricIdSpan);
+    ChipLogByteSpan(Controller, compressedFabricIdSpan);
 
     chip::ByteSpan ipkSpan;
     std::vector<uint8_t> ipkBuffer;


### PR DESCRIPTION
#### Problem
- Passing null for existing ICAC, when a NOC and RCAC were provided and desired to be used caused confusing behavior of NOC/RCAC being ignored and a completely different cert chain being generated.

Fixes #22455

#### Change overview
- Add code to just use empty internal ICAC when null is provided in Java
- Add log to tell users when an ephemeral NOC chain is generated.

#### Testing
- CI still passes
- Tested in unit/integration with our internal infrastructure that uses this API both with/without ICAC
