### PR TITLE
[build] [linux] Fix missing include pthread.h.

### DIFF
--- a/examples/platform/linux/NamedPipeCommands.h
+++ b/examples/platform/linux/NamedPipeCommands.h
@@ -19,6 +19,7 @@
 #pragma once
 
 #include <lib/core/CHIPError.h>
+#include <pthread.h>
 #include <string>
 
 class NamedPipeCommandDelegate


### PR DESCRIPTION
#### Problem
issue #22503 
Compile errors exhibited related to `pthread_create` not being declared:

```
In file included from ../../examples/platform/linux/NamedPipeCommands.cpp:22:
../../examples/platform/linux/NamedPipeCommands.cpp: In member function ‘CHIP_ERROR NamedPipeCommands::Start(std::string&, NamedPipeCommandDelegate*)’:
../../examples/platform/linux/NamedPipeCommands.cpp:41:9: error: ‘pthread_create’ was not declared in this scope; did you mean ‘pthread_t’?
   41 |         pthread_create(&mChipEventCommandListener, nullptr, EventCommandListenerTask, reinterpret_cast<void *>(this)) == 0,
      |         ^~~~~~~~~~~~~~
```

#### Change overview
Add `#include <pthread.h>` to resolve issue.

#### Testing
Fixes repeatable build issue locally.
CI