### PR TITLE
[build] Fix #21255 - allow circular initialization of SimpleStateMachine test.

### DIFF
--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -62,6 +62,8 @@ chip_test_suite("tests") {
 
   cflags = [
     "-Wconversion",
+
+    # TODO(#21255): work-around for SimpleStateMachine constructor issue.
     "-Wno-error=uninitialized",
   ]
 

--- a/src/lib/support/tests/BUILD.gn
+++ b/src/lib/support/tests/BUILD.gn
@@ -60,7 +60,10 @@ chip_test_suite("tests") {
     test_sources += [ "TestCHIPArgParser.cpp" ]
   }
 
-  cflags = [ "-Wconversion" ]
+  cflags = [
+    "-Wconversion",
+    "-Wno-error=uninitialized",
+  ]
 
   public_deps = [
     "${chip_root}/src/credentials",


### PR DESCRIPTION
#### Problem
Fixes #21255 

#### Change overview
Allows circular initialization of `SimpleStateMachine` in `TestStateMachine`:

```
class SimpleStateMachine
{
public:
    Transitions mTransitions;
    chip::StateMachine::StateMachine<State, Event, Transitions> mStateMachine;

    SimpleStateMachine() : mTransitions(mStateMachine), mStateMachine(mTransitions) {}
    /// ^^^ Note uninitialized circular construction above ^^^
    ~SimpleStateMachine() {}
};
```

#### Testing
Fixes repeatable build issue locally.
CI.