### PR TITLE
Fix Android Tests in CI

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -23,7 +23,7 @@ concurrency:
     cancel-in-progress: true
 
 jobs:
-    android:
+    full_android:
         name: Run
         timeout-minutes: 75
 

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -39,15 +39,12 @@ jobs:
                 - "/tmp/log_output:/tmp/test_logs"
 
         steps:
-            - uses: Wandalen/wretry.action@v1.0.15
-              name: Checkout
+            - uses: actions/checkout@v3
               with:
-                  action: actions/checkout@v3
-                  with: |
-                      submodules: true
-                      token: ${{ github.token }}
-                  attempt_limit: 3
-                  attempt_delay: 2000
+                  submodules: true
+                  token: ${{ github.token }}
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform android
             - name: Bootstrap
               timeout-minutes: 10
               run: scripts/build/gn_bootstrap.sh
@@ -59,8 +56,6 @@ jobs:
                   path: |
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
-            - name: Checkout submodules
-              run: scripts/checkout_submodules.py --shallow --platform android
             - name: Build Android CHIPTool and CHIPTest (ARM)
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -39,10 +39,15 @@ jobs:
                 - "/tmp/log_output:/tmp/test_logs"
 
         steps:
-            - uses: actions/checkout@v3
+            - uses: Wandalen/wretry.action@v1.0.15
+              name: Checkout
               with:
-                  submodules: true
-                  token: ${{ github.token }}
+                  action: actions/checkout@v3
+                  with: |
+                      submodules: true
+                      token: ${{ github.token }}
+                  attempt_limit: 3
+                  attempt_delay: 2000
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --shallow --platform android
             - name: Bootstrap

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -59,6 +59,8 @@ jobs:
                   path: |
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform android
             - name: Build Android CHIPTool and CHIPTest (ARM)
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -15,6 +15,7 @@
 name: Smoke test - Android
 
 on:
+    push:
     pull_request:
     workflow_dispatch:
 

--- a/.github/workflows/smoketest-android.yaml
+++ b/.github/workflows/smoketest-android.yaml
@@ -15,7 +15,6 @@
 name: Smoke test - Android
 
 on:
-    push:
     pull_request:
     workflow_dispatch:
 


### PR DESCRIPTION
Android CI was manually disabled.
When trying to re-enable it, it turns out it does not properly compile.

Fixes #22463