### PR TITLE
Add `LogBufferAsHex` utility

### DIFF
--- a/src/lib/support/BytesToHex.cpp
+++ b/src/lib/support/BytesToHex.cpp
@@ -201,5 +201,36 @@ size_t UppercaseHexToUint16(const char * src_hex, const size_t src_size, uint16_
     return decoded_size;
 }
 
+void LogBufferAsHex(const char * label, const ByteSpan & span)
+{
+    constexpr size_t kBytesPerLine = 32u;
+
+    size_t remaining = span.size();
+    if (remaining == 0)
+    {
+        ChipLogProgress(Support, "%s>>>", ((label != nullptr) ? label : ""));
+        return;
+    }
+
+    const uint8_t * cursor = span.data();
+    while (remaining > 0u)
+    {
+        size_t chunk_size = (remaining < kBytesPerLine) ? remaining : kBytesPerLine;
+        char hex_buf[(kBytesPerLine * 2) + 1];
+
+        CHIP_ERROR err = BytesToUppercaseHexString(cursor, chunk_size, &hex_buf[0], sizeof(hex_buf));
+        if (err != CHIP_NO_ERROR)
+        {
+            ChipLogProgress(Support, "Failed to dump hex %" CHIP_ERROR_FORMAT, err.Format());
+            return;
+        }
+
+        ChipLogProgress(Support, "%s>>>%s", ((label != nullptr) ? label : ""), hex_buf);
+
+        cursor += chunk_size;
+        remaining -= chunk_size;
+    }
+}
+
 } // namespace Encoding
 } // namespace chip

--- a/src/lib/support/BytesToHex.h
+++ b/src/lib/support/BytesToHex.h
@@ -19,6 +19,7 @@
 
 #include <lib/core/CHIPError.h>
 #include <lib/support/BitFlags.h>
+#include <lib/support/Span.h>
 
 #include <stdint.h>
 #include <stdlib.h>
@@ -134,6 +135,33 @@ inline CHIP_ERROR BytesToLowercaseHexString(const uint8_t * src_bytes, size_t sr
 {
     return BytesToHex(src_bytes, src_size, dest_hex_str, dest_size_max, HexFlags::kNullTerminate);
 }
+
+/**
+ * @brief Dumps a binary buffer to log as hexadecimal
+ *
+ * Output is 32 bytes per line of uppercase hex, prepended with a given label.
+ *
+ * This function is useful to dump binary buffers such as certificates
+ * which may need to be extracted from logs during debugging.
+ *
+ * Format is organized to allow easy extraction by searching the regex
+ * `LABEL>>>[0-9A-F]+$` where LABEL is the `label` argument passed.
+ *
+ * Format looks like:
+ *
+ * ```
+ * label>>>A54A39294B28886E8BFC15B44105A3FD22745225983A753E6BB82DA7C62493BF
+ * label>>>02C3ED03D41B6F7874E7E887321DE7B4872CEB9F080B6ECE14A8ABFA260573A3
+ * label>>>8D759C
+ * ```
+ *
+ * If buffer is empty, at least one line with the `LABEL>>>` will be logged,
+ * with no data.
+ *
+ * @param label - label to prepend. If nullptr, no label will be prepended
+ * @param span - Span over buffer that needs to be dumped.
+ */
+void LogBufferAsHex(const char * label, const ByteSpan & span);
 
 /**
  * Convert a buffer of hexadecimal characters to bytes. Supports both lowercase


### PR DESCRIPTION
#### Problem
- During recent testing, it was found many participants were doing ad-hoc logging code for buffers, due to the lack of a hex dump capability. This is especially important to debug certificate issues and cryptographic algorithms.

#### Issue Being Resolved
Fixes #22136

#### Change overview

- Adds a `LogBufferAsHex` utility that can dump large binary buffer to log in a compact and recoverable format, using hexadecimal representation.
- Memory usage is only stack, and very minimal.
- Method bypasses limits imposed by single long log lines

#### Testing Done
- Added a full unit test suite for the behavior, validating the log format expected.
