### PR TITLE
Fix android full build in CI

### DIFF
--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -45,16 +45,12 @@ jobs:
               with:
                   action: actions/checkout@v3
                   with: |
-                      submodules: true
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
             - uses: actions/checkout@v3
               if: ${{ env.ACT }}
               name: Checkout (ACT for local build)
-              with:
-                  submodules: true
-                  token: ${{ github.token }}
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --shallow --platform android
             - name: Bootstrap

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -40,6 +40,7 @@ jobs:
 
         steps:
             - uses: Wandalen/wretry.action@v1.0.15
+              if: ${{ !env.ACT }}
               name: Checkout
               with:
                   action: actions/checkout@v3
@@ -48,6 +49,12 @@ jobs:
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            - uses: actions/checkout@v3
+              if: ${{ env.ACT }}
+              name: Checkout (ACT for local build)
+              with:
+                  submodules: true
+                  token: ${{ github.token }}
             - name: Checkout submodules
               run: scripts/checkout_submodules.py --shallow --platform android
             - name: Bootstrap

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -48,6 +48,12 @@ jobs:
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            # To use act like:
+            #   act -j full_android
+            #
+            # Note you likely still need to have non submodules setup for the
+            # local machine, like:
+            #   git submodule deinit --all
             - uses: actions/checkout@v3
               if: ${{ env.ACT }}
               name: Checkout (ACT for local build)

--- a/.github/workflows/full-android.yaml
+++ b/.github/workflows/full-android.yaml
@@ -61,16 +61,38 @@ jobs:
                   path: |
                       .environment/gn_out/.ninja_log
                       .environment/pigweed-venv/*.log
-            - name: Build Android CHIPTool and CHIPTest (ARM)
+            - name: Build Android arm-chip-tool
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-arm-*' build"
+                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm-chip-tool build"
             - name: Clean out build output
               run: rm -rf ./out
-            - name: Build Android CHIPTool and CHIPTest (ARM64)
+            - name: Build Android arm-tv-casting-app
               run: |
                   ./scripts/run_in_build_env.sh \
-                    "./scripts/build/build_examples.py --no-log-timestamps --target-glob 'android-arm64-*' build"
+                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm-tv-casting-app build"
+            - name: Clean out build output
+              run: rm -rf ./out
+            - name: Build Android arm-tv-server
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm-tv-server build"
+            - name: Clean out build output
+              run: rm -rf ./out
+            - name: Build Android arm64-tv-casting-app
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm64-tv-casting-app build"
+            - name: Clean out build output
+              run: rm -rf ./out
+            - name: Build Android arm64-tv-server
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm64-tv-server build"
+            - name: Build Android arm64-chip-tool
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                    "./scripts/build/build_examples.py --no-log-timestamps --target android-arm64-chip-tool build"
             - name: Run Android build rule tests
               run: |
                   ./scripts/run_in_build_env.sh \

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -21,6 +21,7 @@
  *
  */
 
+#include <errno.h>
 #include <inttypes.h>
 
 #include <messaging/ReliableMessageMgr.h>


### PR DESCRIPTION
#### Issue Being Resolved

Fixes #22485

#### Change overview
CI was running out of space, so some builds were never tested. Changes contains:
  - split out builds instead of 'all apps' we build each app individually and clear output after that
  - added conditional checkout/retry for usage with `act` so that these builds can locally be tested
  - removed `submodules: true` option from checkout, since we use checkout_submodules
  - fixed an undeclared ENOBUFS when compiling for android (act complained about this)

Overall now `act -j full_android` passed for me.