### PR TITLE
Fix event min filtering

### DIFF
--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -118,6 +118,7 @@ void EventManagement::Init(Messaging::ExchangeManager * apExchangeManager, uint3
 
     mpEventNumberCounter = apEventNumberCounter;
     mLastEventNumber     = mpEventNumberCounter->GetValue();
+    mCurrentEventEpoch   = mpEventNumberCounter->GetValue();
 
     mpEventBuffer = apCircularEventBuffer;
     mState        = EventManagementStates::Idle;
@@ -642,7 +643,7 @@ CHIP_ERROR EventManagement::FetchEventsSince(TLVWriter & aWriter, const ObjectLi
     const bool recurse = false;
     TLVReader reader;
     CircularEventBufferWrapper bufWrapper;
-    EventLoadOutContext context(aWriter, PriorityLevel::Invalid, aEventMin);
+    EventLoadOutContext context(aWriter, PriorityLevel::Invalid, aEventMin + mCurrentEventEpoch);
 
     context.mSubjectDescriptor     = aSubjectDescriptor;
     context.mpInterestedEventPaths = apEventPathList;

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -510,8 +510,8 @@ private:
     MonotonicallyIncreasingCounter<EventNumber> * mpEventNumberCounter = nullptr;
 
     EventNumber mCurrentEventEpoch = 0;
-    EventNumber mLastEventNumber = 0; ///< Last event Number vended
-    Timestamp mLastEventTimestamp;    ///< The timestamp of the last event in this buffer
+    EventNumber mLastEventNumber   = 0; ///< Last event Number vended
+    Timestamp mLastEventTimestamp;      ///< The timestamp of the last event in this buffer
 };
 } // namespace app
 } // namespace chip

--- a/src/app/EventManagement.h
+++ b/src/app/EventManagement.h
@@ -509,6 +509,7 @@ private:
     // The counter we're going to use for event numbers.
     MonotonicallyIncreasingCounter<EventNumber> * mpEventNumberCounter = nullptr;
 
+    EventNumber mCurrentEventEpoch = 0;
     EventNumber mLastEventNumber = 0; ///< Last event Number vended
     Timestamp mLastEventTimestamp;    ///< The timestamp of the last event in this buffer
 };


### PR DESCRIPTION
#### Issue Being Resolved
Event min filtering doesn't take into account the current event epoch.
`./chip-tool basic subscribe-event-by-id 0x000 100 1000 1 0  --event-min 2` works the first time after a successful commissioning (right after a reset to factory defaults) and filters out the StartUp event. But after a reset it won't work anymore because the epoch was updated and now events start from `0x10000`.

#### Change overview
Add current event epoch in event min filtering.

#### Tested
With `./chip-tool basic subscribe-event-by-id 0x000 100 1000 1 0  --event-min 2` through multiple resets with and without the fix.
