### PR TITLE
Fix --commissioner-nodeid handling in interactive mode.

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/commands/common/CHIPCommand.cpp
+++ b/examples/tv-casting-app/tv-casting-common/commands/common/CHIPCommand.cpp
@@ -86,12 +86,13 @@ void CHIPCommand::StopWaiting()
 
 chip::Controller::DeviceCommissioner & CHIPCommand::CurrentCommissioner()
 {
-    auto item = mCommissioners.find(GetIdentity());
+    CommissionerIdentity identity{ GetIdentity(), chip::kUndefinedNodeId };
+    auto item = mCommissioners.find(identity);
     return *item->second;
 }
 
 constexpr chip::FabricId kIdentityOtherFabricId = 4;
-std::map<std::string, std::unique_ptr<chip::Controller::DeviceCommissioner>> CHIPCommand::mCommissioners;
+std::map<CHIPCommand::CommissionerIdentity, std::unique_ptr<chip::Controller::DeviceCommissioner>> CHIPCommand::mCommissioners;
 
 std::string CHIPCommand::GetIdentity()
 {


### PR DESCRIPTION
1. Instead of keying commissioners by just name in chip-tool, key them by the (name, commissioner-node-id) pair.

2. Allow multiple commissioners for the same fabric (as long as they have different node ids).

#### Issue Being Resolved
* Fixes #22454

#### Change overview
See above.

Tested both the steps from #22454 and `onoff toggle 1 1` followed by `onoff toggle 1 1 --commissioner-nodeid 25`: before this PR that last command succeeds, whereas after it correctly fails with an `UNSUPPORTED_ACCCESS`.
