### PR TITLE
Python: Add TestOnlyCommissionableDataProvider to pychip_server_native_init()

### DIFF
--- a/examples/lighting-app/python/lighting.py
+++ b/examples/lighting-app/python/lighting.py
@@ -177,7 +177,6 @@ def attributeChangeCallback(
     endpoint: int,
     clusterId: int,
     attributeId: int,
-    manufacturerCode: int,
     xx_type: int,
     size: int,
     value: bytes,

--- a/scripts/build_python_device.sh
+++ b/scripts/build_python_device.sh
@@ -104,7 +104,7 @@ gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args="chip_detail_logging=$chip_deta
 if [ "$enable_pybindings" == true ]; then
     ninja -v -C "$OUTPUT_ROOT" pycontroller
 else
-    ninja -v -C "$OUTPUT_ROOT" chip-library
+    ninja -v -C "$OUTPUT_ROOT" chip-core
 fi
 
 # Create a virtual environment that has access to the built python tools
@@ -115,7 +115,7 @@ virtualenv --clear "$ENVIRONMENT_ROOT"
 if [ "$enable_pybindings" == true ]; then
     WHEEL=("$OUTPUT_ROOT"/pybindings/pycontroller/pychip-*.whl)
 else
-    WHEEL=("$OUTPUT_ROOT"/controller/python/chip_library*.whl)
+    WHEEL=("$OUTPUT_ROOT"/controller/python/chip_core*.whl)
 fi
 
 source "$ENVIRONMENT_ROOT"/bin/activate

--- a/src/controller/python/chip/server/ServerInit.cpp
+++ b/src/controller/python/chip/server/ServerInit.cpp
@@ -19,6 +19,7 @@
 
 #include <platform/CHIPDeviceLayer.h>
 #include <platform/PlatformManager.h>
+#include <platform/TestOnlyCommissionableDataProvider.h>
 
 #include <app/server/OnboardingCodesUtil.h>
 #include <app/server/Server.h>
@@ -137,6 +138,9 @@ void pychip_server_native_init()
     {
         ChipLogError(DeviceLayer, "Failed to initialize CHIP stack: platform init failed: %s", chip::ErrorStr(err));
     }
+
+    static chip::DeviceLayer::TestOnlyCommissionableDataProvider TestOnlyCommissionableDataProvider;
+    chip::DeviceLayer::SetCommissionableDataProvider(&TestOnlyCommissionableDataProvider);
 
     ConfigurationMgr().LogDeviceConfig();
 

--- a/src/controller/python/chip/server/ServerInit.cpp
+++ b/src/controller/python/chip/server/ServerInit.cpp
@@ -30,6 +30,8 @@
 #include <setup_payload/QRCodeSetupPayloadGenerator.h>
 #include <setup_payload/SetupPayload.h>
 
+#include <credentials/examples/DeviceAttestationCredsExample.h>
+
 // #include <support/CHIPMem.h>
 // #include <support/ErrorStr.h>
 
@@ -181,7 +183,7 @@ void pychip_server_native_init()
     chip::Server::GetInstance().Init(initParams);
 
     // Initialize device attestation config
-    // SetDeviceAttestationCredentialsProvider(Examples::GetExampleDACProvider());
+    SetDeviceAttestationCredentialsProvider(chip::Credentials::Examples::GetExampleDACProvider());
 
     result   = pthread_create(&sPlatformMainThread, nullptr, PlatformMainLoop, nullptr);
     tmpErrno = errno;

--- a/src/controller/python/chip/server/ServerInit.cpp
+++ b/src/controller/python/chip/server/ServerInit.cpp
@@ -101,8 +101,8 @@ static bool EnsureWiFiIsStarted()
 }
 #endif
 
-using PostAttributeChangeCallback = void (*)(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId,
-                                             uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value);
+using PostAttributeChangeCallback = void (*)(EndpointId endpoint, ClusterId clusterId, AttributeId attributeId, uint8_t type,
+                                             uint16_t size, uint8_t * value);
 
 class PythonServerDelegate // : public ServerDelegate
 {
@@ -197,14 +197,15 @@ void pychip_server_native_init()
 }
 }
 
-void emberAfPostAttributeChangeCallback(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId,
-                                        uint16_t manufacturerCode, uint8_t type, uint16_t size, uint8_t * value)
+void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
+                                       uint8_t * value)
 {
     // ChipLogProgress(NotSpecified, "emberAfPostAttributeChangeCallback()");
     if (gPythonServerDelegate.mPostAttributeChangeCallback != nullptr)
     {
         // ChipLogProgress(NotSpecified, "callback %p", gPythonServerDelegate.mPostAttributeChangeCallback);
-        gPythonServerDelegate.mPostAttributeChangeCallback(endpoint, clusterId, attributeId, manufacturerCode, type, size, value);
+        gPythonServerDelegate.mPostAttributeChangeCallback(attributePath.mEndpointId, attributePath.mClusterId,
+                                                           attributePath.mAttributeId, type, size, value);
     }
     else
     {

--- a/src/controller/python/chip/server/types.py
+++ b/src/controller/python/chip/server/types.py
@@ -8,7 +8,5 @@ PostAttributeChangeCallback = CFUNCTYPE(
     c_uint16,
     c_uint8,
     c_uint16,
-    c_uint8,
-    c_uint16,
     c_char_p,
 )


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #21969

#### Change overview
This change adds a `LinuxCommissionableDataProvider` to the Python chip server similar to [`examples/platform/linux/AppMain.cpp`](https://github.com/project-chip/connectedhomeip/blob/master/examples/platform/linux/AppMain.cpp#L181-L183) to prevent issue #21969. It also includes the changes from PR #22494 as they are needed to build.

Note: There is most likely a more eloquent platform independent way to do this, but wanted to get the discussion going.

cc/ @mrjerryjohns 
