### PR TITLE
[Debugging]fix cirque test via releasing extra storage

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -111,15 +111,7 @@ jobs:
                     --volume /tmp:/tmp \
                     -- sh -c '\
                        git config --global --add safe.directory "*" \
-                       && ./gn_build.sh \
-                          chip_build_tests=false \
-                          chip_enable_wifi=false \
-                          chip_im_force_fabric_quota_check=true \
-                          enable_default_builds=false \
-                          enable_host_gcc_build=true \
-                          enable_standalone_chip_tool_build=true \
-                          enable_linux_all_clusters_app_build=true \
-                          enable_linux_lighting_app_build=true \
+                       && scripts/build/gn_gen_cirque.sh
                       '
             - name: Run Tests
               timeout-minutes: 25

--- a/scripts/build/gn_gen_cirque.sh
+++ b/scripts/build/gn_gen_cirque.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+
+#
+# Copyright (c) 2022 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set -e
+
+CHIP_ROOT="$(dirname "$0")/../.."
+if [[ -z "${CHIP_ROOT_PATH}" ]]; then
+    CHIP_ROOT_PATH=""
+fi
+
+set -x
+
+env
+
+echo "Build: GN configure"
+
+gn --root="$CHIP_ROOT" gen --check --fail-on-unused-args "$CHIP_ROOT/out/debug" --args='target_os="all"'"chip_build_tests=false chip_enable_wifi=false chip_im_force_fabric_quota_check=true enable_default_builds=false enable_host_gcc_build=true enable_standalone_chip_tool_build=true enable_linux_all_clusters_app_build=true enable_linux_lighting_app_build=true"
+
+echo "Build: Ninja build"
+
+time ninja -C "$CHIP_ROOT/out/debug" all check

--- a/src/test_driver/linux-cirque/helper/CHIPTestBase.py
+++ b/src/test_driver/linux-cirque/helper/CHIPTestBase.py
@@ -140,7 +140,7 @@ class CHIPVirtualHome:
         for device_id in devices:
             # Wait for otbr-agent and CHIP server start
             self.assertTrue(self.wait_for_device_output(
-                device_id, "Border router agent started.", 10))
+                device_id, "Thread Border Router started on AIL", 10))
             self.assertTrue(self.wait_for_device_output(
                 device_id, "CHIP:SVR: Server Listening...", 15))
             # Clear default Thread network commissioning data


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22499 

#### Change overview
update binary generation instruction which would not need submodule all repos since this has been done previously. This update would also largely improve the ci running speed