### PR TITLE
Enable schema check on debug ios builds.

### DIFF
--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -21,8 +21,8 @@ import("common_flags.gni")
 declare_args() {
   # Enable strict schema checks.
   chip_enable_schema_check =
-      is_debug &&
-      (current_os == "linux" || current_os == "mac" || current_os == "android")
+      is_debug && (current_os == "linux" || current_os == "mac" ||
+                   current_os == "ios" || current_os == "android")
 
   # Logging verbosity control for Access Control implementation
   #


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22509

#### Change overview
Enable payload logging via schema check on iOS too, not just MacOS.
