### PR TITLE
[doc] Add example of 'chip-cert gen-cd' command.

### DIFF
--- a/.github/.wordlist.txt
+++ b/.github/.wordlist.txt
@@ -253,6 +253,7 @@ ClusterTestGeneration
 cmake
 CMakeLists
 CMD
+CMS
 CMSIS
 CMVH
 cn

--- a/src/tools/chip-cert/README.md
+++ b/src/tools/chip-cert/README.md
@@ -8,6 +8,7 @@
     -   [Directory Structure](#directory-structure)
         -   [<code>/src/tools/chip-cert</code>](#srctoolschip-cert)
     -   [Usage Examples](#usage-examples)
+        -   [Building](#building)
     -   [Operational Certificates Usage Examples](#operational-certificates-usage-examples)
         -   [Attestation Certificates Usage Examples](#attestation-certificates-usage-examples)
     -   [Command Reference](#command-reference)
@@ -21,6 +22,7 @@
         -   [gen-att-cert](#gen-att-cert)
         -   [validate-att-cert](#validate-att-cert)
         -   [gen-cd](#gen-cd)
+            -   [gen-cd example](#gen-cd-example)
         -   [version](#version)
 
 ## Introduction
@@ -55,6 +57,18 @@ Specify '--help' option for detail instructions on usage of each command:
 
 ```
 ./chip-cert gen-cert --help
+```
+
+### Building
+
+The `chip-cert` tool will be built when `gn_build.sh` is run. To build just the
+`chip-cert` tool locally:
+
+```
+. ./scripts/activate.sh
+gn gen out/host
+ninja -C out/host chip-cert
+./out/host/chip-cert help
 ```
 
 ## Operational Certificates Usage Examples
@@ -744,6 +758,24 @@ HELP OPTIONS
   -v, --version
        Print the version and then exit.
 ```
+
+#### gen-cd example
+
+An example of generating a Certificate Declaration (CD) follows:
+
+```
+./chip-cert gen-cd -C credentials/test/certification-declaration/Chip-Test-CD-Signing-Cert.pem -K credentials/test/certification-declaration/Chip-Test-CD-Signing-Key.pem --out cd.bin -f 1 -V FFF1 -p 8000 -d 0016 -c "ZIG0000000000000000" -l 0 -i 0 -n 0001 -t 0
+```
+
+The binary output of the CMS signed CD is written to `cd.bin`.
+
+-   Replace -V FFF1 with your VID in uppercase hex with zero padding
+-   Replace -p 8000 with your PID in uppercase hex with zero padding
+-   Replace -d 0016 with your primary device type in uppercase hex with zero
+    padding
+
+NOTE: `dac-origin-vendor-id` and `dac-origin-product-id` are not included in
+this example.
 
 ### version
 


### PR DESCRIPTION
#### Issue Being Resolved
Fix #22517
`chip-cert` documentation doesn't add example of `gen-cd`.

#### Change overview
Add example and how to build just `chip-cert` locally.