### PR TITLE
Get multicast lock when publishing services on android

### DIFF
--- a/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
+++ b/src/platform/android/java/chip/platform/NsdManagerServiceResolver.java
@@ -189,6 +189,9 @@ public class NsdManagerServiceResolver implements ServiceResolver {
                 "service " + serviceInfo.getServiceName() + "(" + this + ") onServiceUnregistered");
           }
         };
+    if (registrationListeners.size() == 0) {
+      multicastLock.acquire();
+    }
     registrationListeners.add(registrationListener);
 
     nsdManager.registerService(serviceInfo, NsdManager.PROTOCOL_DNS_SD, registrationListener);
@@ -198,6 +201,9 @@ public class NsdManagerServiceResolver implements ServiceResolver {
   @Override
   public void removeServices() {
     Log.d(TAG, "removeServices: ");
+    if (registrationListeners.size() > 0) {
+      multicastLock.release();
+    }
     for (NsdManager.RegistrationListener l : registrationListeners) {
       Log.i(TAG, "Remove " + l);
       nsdManager.unregisterService(l);


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22251

#### Change overview
Android 'publish' does not aquire a multicast lock, effectively disallowing the services from being seen on the network past any temporary "resolve" calls (which do aquire the lock).

Added aquire/release for the multicast lock when registering listeners.

1.0 justification: platform fix.
