### PR TITLE
Replace "Id" with "ID" in Darwin APIs.

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -74,9 +74,9 @@ public:
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
 
         while (repeatCount--) {
-            [device invokeCommandWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
-                                      clusterId:[NSNumber numberWithUnsignedInteger:clusterId]
-                                      commandId:[NSNumber numberWithUnsignedInteger:commandId]
+            [device invokeCommandWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+                                      clusterID:[NSNumber numberWithUnsignedInteger:clusterId]
+                                      commandID:[NSNumber numberWithUnsignedInteger:commandId]
                                   commandFields:commandFields
                              timedInvokeTimeout:mTimedInteractionTimeoutMs.HasValue()
                                  ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]

--- a/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
@@ -56,9 +56,9 @@ public:
         MTRReadParams * params = [[MTRReadParams alloc] init];
         params.fabricFiltered = mFabricFiltered.HasValue() ? [NSNumber numberWithBool:mFabricFiltered.Value()] : nil;
         [device
-            readAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
-                              clusterId:[NSNumber numberWithUnsignedInteger:mClusterId]
-                            attributeId:[NSNumber numberWithUnsignedInteger:mAttributeId]
+            readAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+                              clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
+                            attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
                                  params:params
                             clientQueue:callbackQueue
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
@@ -129,9 +129,9 @@ public:
             = mKeepSubscriptions.HasValue() ? [NSNumber numberWithBool:mKeepSubscriptions.Value()] : nil;
         params.autoResubscribe = mAutoResubscribe.HasValue() ? [NSNumber numberWithBool:mAutoResubscribe.Value()] : nil;
 
-        [device subscribeAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
-            clusterId:[NSNumber numberWithUnsignedInteger:mClusterId]
-            attributeId:[NSNumber numberWithUnsignedInteger:mAttributeId]
+        [device subscribeAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+            clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
+            attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
             minInterval:[NSNumber numberWithUnsignedInteger:mMinInterval]
             maxInterval:[NSNumber numberWithUnsignedInteger:mMaxInterval]
             params:params

--- a/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
@@ -74,9 +74,9 @@ public:
     {
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
         [device
-            writeAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
-                               clusterId:[NSNumber numberWithUnsignedInteger:clusterId]
-                             attributeId:[NSNumber numberWithUnsignedInteger:attributeId]
+            writeAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+                               clusterID:[NSNumber numberWithUnsignedInteger:clusterId]
+                             attributeID:[NSNumber numberWithUnsignedInteger:attributeId]
                                    value:value
                        timedWriteTimeout:mTimedInteractionTimeoutMs.HasValue()
                            ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -139,7 +139,7 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
     constexpr const char * identities[] = { kIdentityAlpha, kIdentityBeta, kIdentityGamma };
     for (size_t i = 0; i < ArraySize(identities); ++i) {
         auto controllerParams = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:gNocSigner
-                                                                                        fabricId:@(i + 1)
+                                                                                        fabricID:@(i + 1)
                                                                                              ipk:ipk];
 
         // We're not sure whether we're creating a new fabric or using an
@@ -147,7 +147,7 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
         auto controller = [factory startControllerOnExistingFabric:controllerParams];
         if (controller == nil) {
             // Maybe we didn't have this fabric yet.
-            controllerParams.vendorId = @(chip::VendorId::TestVendor1);
+            controllerParams.vendorID = @(chip::VendorId::TestVendor1);
             controller = [factory startControllerOnNewFabric:controllerParams];
         }
         if (controller == nil) {
@@ -201,7 +201,7 @@ void CHIPCommandBridge::RestartCommissioners()
     constexpr const char * identities[] = { kIdentityAlpha, kIdentityBeta, kIdentityGamma };
     for (size_t i = 0; i < ArraySize(identities); ++i) {
         auto controllerParams = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:gNocSigner
-                                                                                        fabricId:@(i + 1)
+                                                                                        fabricID:@(i + 1)
                                                                                              ipk:ipk];
 
         auto controller = [factory startControllerOnExistingFabric:controllerParams];

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -87,8 +87,8 @@ MTRDeviceController * InitializeMTR(void)
             return;
         }
 
-        __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:keys fabricId:@(1) ipk:keys.ipk];
-        params.vendorId = @(kTestVendorId);
+        __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:keys fabricID:@(1) ipk:keys.ipk];
+        params.vendorID = @(kTestVendorId);
 
         // We're not sure whether we have a fabric configured already; try as if
         // we did, and if not fall back to creating a new one.
@@ -113,7 +113,7 @@ MTRDeviceController * MTRRestartController(MTRDeviceController * controller)
     [controller shutdown];
 
     NSLog(@"Starting up the stack");
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:keys fabricId:@(1) ipk:keys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:keys fabricID:@(1) ipk:keys.ipk];
 
     sController = [[MTRControllerFactory sharedInstance] startControllerOnExistingFabric:params];
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Bindings/BindingsViewController.m
@@ -119,7 +119,7 @@
 - (void)_clearTextFields
 {
     MTRDeviceController * chipController = InitializeMTR();
-    _nodeIDTextField.text = [NSString stringWithFormat:@"%@", chipController.controllerNodeId];
+    _nodeIDTextField.text = [NSString stringWithFormat:@"%@", chipController.controllerNodeID];
     _endpointIDTextField.text = @"1";
     _groupIDTextField.text = @"0";
     _clusterIDTextField.text = @"";

--- a/src/darwin/Framework/CHIP/MTRAttributeCacheContainer+XPC.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeCacheContainer+XPC.h
@@ -23,8 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRAttributeCacheContainer (XPC)
 - (void)setXPCConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
-            controllerId:(id<NSCopying>)controllerId
-                deviceId:(NSNumber *)deviceId;
+            controllerID:(id<NSCopying>)controllerID
+                deviceID:(NSNumber *)deviceID;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRAttributeCacheContainer.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeCacheContainer.h
@@ -29,17 +29,17 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Reads an attribute with specific attribute path
  *
- * @param endpointId  endpoint ID of the attribute
- * @param clusterId  cluster ID of the attribute
- * @param attributeId  attribute ID of the attribute
+ * @param endpointID  endpoint ID of the attribute
+ * @param clusterID  cluster ID of the attribute
+ * @param attributeID  attribute ID of the attribute
  * @param clientQueue  client queue to dispatch the completion handler through
  * @param completion  block to receive the result.
  *                   "values" received by the block will have the same format of object as the one received by completion block
- *                   of CHIPDevice readAttributeWithEndpointId:clusterId:attributeId:clientQueue:completion method.
+ *                   of CHIPDevice readAttributeWithEndpointID:clusterID:attributeID:clientQueue:completion method.
  */
-- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion;
 

--- a/src/darwin/Framework/CHIP/MTRAttributeCacheContainer_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeCacheContainer_Internal.h
@@ -27,9 +27,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRAttributeCacheContainer ()
 
 @property (atomic, readwrite, nullable) chip::app::ClusterStateCache * cppAttributeCache;
-@property (nonatomic, readwrite, copy) NSNumber * deviceId;
+@property (nonatomic, readwrite, copy) NSNumber * deviceID;
 @property (nonatomic, readwrite, weak, nullable) MTRDeviceControllerXPCConnection * xpcConnection;
-@property (nonatomic, readwrite, strong, nullable) id<NSCopying> xpcControllerId;
+@property (nonatomic, readwrite, strong, nullable) id<NSCopying> xpcControllerID;
 @property (atomic, readwrite) BOOL shouldUseXPC;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -184,9 +184,9 @@ extern NSString * const MTRArrayValueType;
 /**
  * Read attribute in a designated attribute path
  */
-- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                              params:(MTRReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion;
@@ -202,11 +202,11 @@ extern NSString * const MTRArrayValueType;
  * @param completion  response handler will receive either values or error.
  *
  *                    Received values are an NSArray object with response-value element as described in
- *                    readAttributeWithEndpointId:clusterId:attributeId:clientQueue:completion:.
+ *                    readAttributeWithEndpointID:clusterID:attributeID:clientQueue:completion:.
  */
-- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+- (void)writeAttributeWithEndpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                          clientQueue:(dispatch_queue_t)clientQueue
@@ -224,9 +224,9 @@ extern NSString * const MTRArrayValueType;
  *
  * @param completion  response handler will receive either values or error.
  */
-- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+- (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                       commandFields:(id)commandFields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                         clientQueue:(dispatch_queue_t)clientQueue
@@ -235,9 +235,9 @@ extern NSString * const MTRArrayValueType;
 /**
  * Subscribe an attribute in a designated attribute path
  */
-- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(MTRSubscribeParams * _Nullable)params
@@ -281,9 +281,9 @@ extern NSString * const MTRArrayValueType;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * attribute;
 
-+ (instancetype)attributePathWithEndpointId:(NSNumber *)endpoint
-                                  clusterId:(NSNumber *)clusterId
-                                attributeId:(NSNumber *)attributeId;
++ (instancetype)attributePathWithEndpointID:(NSNumber *)endpointID
+                                  clusterID:(NSNumber *)clusterID
+                                attributeID:(NSNumber *)attributeID;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
@@ -294,7 +294,7 @@ extern NSString * const MTRArrayValueType;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * event;
 
-+ (instancetype)eventPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId eventId:(NSNumber *)eventId;
++ (instancetype)eventPathWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID eventID:(NSNumber *)eventID;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
@@ -305,7 +305,7 @@ extern NSString * const MTRArrayValueType;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * command;
 
-+ (instancetype)commandPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId commandId:(NSNumber *)commandId;
++ (instancetype)commandPathWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID commandID:(NSNumber *)commandID;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -86,7 +86,7 @@ class MTRDataValueDictionaryCallbackBridge;
 @interface MTRReadClientContainer : NSObject
 @property (nonatomic, readwrite) app::ReadClient * readClientPtr;
 @property (nonatomic, readwrite) app::AttributePathParams * pathParams;
-@property (nonatomic, readwrite) uint64_t deviceId;
+@property (nonatomic, readwrite) uint64_t deviceID;
 - (void)onDone;
 @end
 
@@ -202,7 +202,7 @@ static void CauseReadClientFailure(uint64_t deviceId, dispatch_queue_t queue, vo
         Platform::Delete(_pathParams);
         _pathParams = nullptr;
     }
-    PurgeCompletedReadClientContainers(_deviceId);
+    PurgeCompletedReadClientContainers(_deviceID);
 }
 
 - (void)dealloc
@@ -771,16 +771,16 @@ private:
     Platform::UniquePtr<app::ReadClient> mReadClient;
 };
 
-- (void)readAttributeWithEndpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                        attributeId:(NSNumber *)attributeId
+- (void)readAttributeWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                        attributeID:(NSNumber *)attributeID
                              params:(MTRReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
 {
-    endpointId = (endpointId == nil) ? nil : [endpointId copy];
-    clusterId = (clusterId == nil) ? nil : [clusterId copy];
-    attributeId = (attributeId == nil) ? nil : [attributeId copy];
+    endpointID = (endpointID == nil) ? nil : [endpointID copy];
+    clusterID = (clusterID == nil) ? nil : [clusterID copy];
+    attributeID = (attributeID == nil) ? nil : [attributeID copy];
     params = (params == nil) ? nil : [params copy];
     new MTRDataValueDictionaryCallbackBridge(clientQueue, self, completion,
         ^(ExchangeManager & exchangeManager, const SessionHandle & session, chip::Callback::Cancelable * success,
@@ -816,14 +816,14 @@ private:
             };
 
             app::AttributePathParams attributePath;
-            if (endpointId) {
-                attributePath.mEndpointId = static_cast<chip::EndpointId>([endpointId unsignedShortValue]);
+            if (endpointID) {
+                attributePath.mEndpointId = static_cast<chip::EndpointId>([endpointID unsignedShortValue]);
             }
-            if (clusterId) {
-                attributePath.mClusterId = static_cast<chip::ClusterId>([clusterId unsignedLongValue]);
+            if (clusterID) {
+                attributePath.mClusterId = static_cast<chip::ClusterId>([clusterID unsignedLongValue]);
             }
-            if (attributeId) {
-                attributePath.mAttributeId = static_cast<chip::AttributeId>([attributeId unsignedLongValue]);
+            if (attributeID) {
+                attributePath.mAttributeId = static_cast<chip::AttributeId>([attributeID unsignedLongValue]);
             }
             app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
             CHIP_ERROR err = CHIP_NO_ERROR;
@@ -880,9 +880,9 @@ private:
         });
 }
 
-- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+- (void)writeAttributeWithEndpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                          clientQueue:(dispatch_queue_t)clientQueue
@@ -941,9 +941,9 @@ private:
                   };
 
             return chip::Controller::WriteAttribute<MTRDataValueDictionaryDecodableType>(session,
-                static_cast<chip::EndpointId>([endpointId unsignedShortValue]),
-                static_cast<chip::ClusterId>([clusterId unsignedLongValue]),
-                static_cast<chip::AttributeId>([attributeId unsignedLongValue]), MTRDataValueDictionaryDecodableType(value),
+                static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+                static_cast<chip::ClusterId>([clusterID unsignedLongValue]),
+                static_cast<chip::AttributeId>([attributeID unsignedLongValue]), MTRDataValueDictionaryDecodableType(value),
                 onSuccessCb, onFailureCb, (timeoutMs == nil) ? NullOptional : Optional<uint16_t>([timeoutMs unsignedShortValue]),
                 onDoneCb, NullOptional);
         });
@@ -1020,17 +1020,17 @@ exit:
     }
 }
 
-- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+- (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                       commandFields:(id)commandFields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
 {
-    endpointId = (endpointId == nil) ? nil : [endpointId copy];
-    clusterId = (clusterId == nil) ? nil : [clusterId copy];
-    commandId = (commandId == nil) ? nil : [commandId copy];
+    endpointID = (endpointID == nil) ? nil : [endpointID copy];
+    clusterID = (clusterID == nil) ? nil : [clusterID copy];
+    commandID = (commandID == nil) ? nil : [commandID copy];
     // TODO: This is not going to deep-copy the NSArray instances in
     // commandFields.  We need to do something smarter here.
     commandFields = (commandFields == nil) ? nil : [commandFields copy];
@@ -1068,9 +1068,9 @@ exit:
                 }
             };
 
-            app::CommandPathParams commandPath = { static_cast<chip::EndpointId>([endpointId unsignedShortValue]), 0,
-                static_cast<chip::ClusterId>([clusterId unsignedLongValue]),
-                static_cast<chip::CommandId>([commandId unsignedLongValue]), (app::CommandPathFlags::kEndpointIdValid) };
+            app::CommandPathParams commandPath = { static_cast<chip::EndpointId>([endpointID unsignedShortValue]), 0,
+                static_cast<chip::ClusterId>([clusterID unsignedLongValue]),
+                static_cast<chip::CommandId>([commandID unsignedLongValue]), (app::CommandPathFlags::kEndpointIdValid) };
 
             auto decoder = chip::Platform::MakeUnique<NSObjectCommandCallback>(
                 commandPath.mClusterId, commandPath.mCommandId, onSuccessCb, onFailureCb);
@@ -1114,9 +1114,9 @@ exit:
         });
 }
 
-- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(MTRSubscribeParams * _Nullable)params
@@ -1133,9 +1133,9 @@ exit:
     }
 
     // Copy params before going async.
-    endpointId = (endpointId == nil) ? nil : [endpointId copy];
-    clusterId = (clusterId == nil) ? nil : [clusterId copy];
-    attributeId = (attributeId == nil) ? nil : [attributeId copy];
+    endpointID = (endpointID == nil) ? nil : [endpointID copy];
+    clusterID = (clusterID == nil) ? nil : [clusterID copy];
+    attributeID = (attributeID == nil) ? nil : [attributeID copy];
     minInterval = (minInterval == nil) ? nil : [minInterval copy];
     maxInterval = (maxInterval == nil) ? nil : [maxInterval copy];
     params = (params == nil) ? nil : [params copy];
@@ -1191,16 +1191,16 @@ exit:
             };
 
             MTRReadClientContainer * container = [[MTRReadClientContainer alloc] init];
-            container.deviceId = [self deviceID];
+            container.deviceID = [self deviceID];
             container.pathParams = Platform::New<app::AttributePathParams>();
-            if (endpointId) {
-                container.pathParams->mEndpointId = static_cast<chip::EndpointId>([endpointId unsignedShortValue]);
+            if (endpointID) {
+                container.pathParams->mEndpointId = static_cast<chip::EndpointId>([endpointID unsignedShortValue]);
             }
-            if (clusterId) {
-                container.pathParams->mClusterId = static_cast<chip::ClusterId>([clusterId unsignedLongValue]);
+            if (clusterID) {
+                container.pathParams->mClusterId = static_cast<chip::ClusterId>([clusterID unsignedLongValue]);
             }
-            if (attributeId) {
-                container.pathParams->mAttributeId = static_cast<chip::AttributeId>([attributeId unsignedLongValue]);
+            if (attributeID) {
+                container.pathParams->mAttributeId = static_cast<chip::AttributeId>([attributeID unsignedLongValue]);
             }
 
             app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
@@ -1249,7 +1249,7 @@ exit:
 
             // Read clients will be purged when deregistered.
             container.readClientPtr = readClient;
-            AddReadClientContainer(container.deviceId, container);
+            AddReadClientContainer(container.deviceID, container);
             callback.release();
         }];
 }
@@ -1468,11 +1468,13 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
                      (uint32_t) _attribute.unsignedLongValue];
 }
 
-+ (instancetype)attributePathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId attributeId:(NSNumber *)attributeId
++ (instancetype)attributePathWithEndpointID:(NSNumber *)endpointID
+                                  clusterID:(NSNumber *)clusterID
+                                attributeID:(NSNumber *)attributeID
 {
-    ConcreteDataAttributePath path(static_cast<chip::EndpointId>([endpoint unsignedShortValue]),
-        static_cast<chip::ClusterId>([clusterId unsignedLongValue]),
-        static_cast<chip::AttributeId>([attributeId unsignedLongValue]));
+    ConcreteDataAttributePath path(static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+        static_cast<chip::ClusterId>([clusterID unsignedLongValue]),
+        static_cast<chip::AttributeId>([attributeID unsignedLongValue]));
 
     return [[MTRAttributePath alloc] initWithPath:path];
 }
@@ -1498,7 +1500,7 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return [MTRAttributePath attributePathWithEndpointId:_endpoint clusterId:_cluster attributeId:_attribute];
+    return [MTRAttributePath attributePathWithEndpointID:_endpoint clusterID:_cluster attributeID:_attribute];
 }
 @end
 
@@ -1513,10 +1515,10 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
     return self;
 }
 
-+ (instancetype)eventPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId eventId:(NSNumber *)eventId
++ (instancetype)eventPathWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID eventID:(NSNumber *)eventID
 {
-    ConcreteEventPath path(static_cast<chip::EndpointId>([endpoint unsignedShortValue]),
-        static_cast<chip::ClusterId>([clusterId unsignedLongValue]), static_cast<chip::EventId>([eventId unsignedLongValue]));
+    ConcreteEventPath path(static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+        static_cast<chip::ClusterId>([clusterID unsignedLongValue]), static_cast<chip::EventId>([eventID unsignedLongValue]));
 
     return [[MTREventPath alloc] initWithPath:path];
 }
@@ -1533,10 +1535,10 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
     return self;
 }
 
-+ (instancetype)commandPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId commandId:(NSNumber *)commandId
++ (instancetype)commandPathWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID commandID:(NSNumber *)commandID
 {
-    ConcreteCommandPath path(static_cast<chip::EndpointId>([endpoint unsignedShortValue]),
-        static_cast<chip::ClusterId>([clusterId unsignedLongValue]), static_cast<chip::CommandId>([commandId unsignedLongValue]));
+    ConcreteCommandPath path(static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+        static_cast<chip::ClusterId>([clusterID unsignedLongValue]), static_cast<chip::CommandId>([commandID unsignedLongValue]));
 
     return [[MTRCommandPath alloc] initWithPath:path];
 }

--- a/src/darwin/Framework/CHIP/MTRCertificates.h
+++ b/src/darwin/Framework/CHIP/MTRCertificates.h
@@ -30,28 +30,28 @@ NS_ASSUME_NONNULL_BEGIN
  * Generate a root (self-signed) X.509 DER encoded certificate that has the
  * right fields to be a valid Matter root certificate.
  *
- * If issuerId is nil, a random issuer id is generated.  Otherwise the provided
+ * If issuerID is nil, a random issuer id is generated.  Otherwise the provided
  * issuer id is used.
  *
- * If fabricId is not nil, it will be included in the subject DN of the
+ * If fabricID is not nil, it will be included in the subject DN of the
  * certificate.  In this case it must be a valid Matter fabric id.
  *
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
 + (nullable NSData *)generateRootCertificate:(id<MTRKeypair>)keypair
-                                    issuerId:(nullable NSNumber *)issuerId
-                                    fabricId:(nullable NSNumber *)fabricId
+                                    issuerID:(nullable NSNumber *)issuerID
+                                    fabricID:(nullable NSNumber *)fabricID
                                        error:(NSError * __autoreleasing _Nullable * _Nullable)error;
 
 /**
  * Generate an intermediate X.509 DER encoded certificate that has the
  * right fields to be a valid Matter intermediate certificate.
  *
- * If issuerId is nil, a random issuer id is generated.  Otherwise the provided
+ * If issuerID is nil, a random issuer id is generated.  Otherwise the provided
  * issuer id is used.
  *
- * If fabricId is not nil, it will be included in the subject DN of the
+ * If fabricID is not nil, it will be included in the subject DN of the
  * certificate.  In this case it must be a valid Matter fabric id.
  *
  * On failure returns nil and if "error" is not null sets *error to the relevant
@@ -60,8 +60,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
                                      rootCertificate:(NSData *)rootCertificate
                                intermediatePublicKey:(SecKeyRef)intermediatePublicKey
-                                            issuerId:(nullable NSNumber *)issuerId
-                                            fabricId:(nullable NSNumber *)fabricId
+                                            issuerID:(nullable NSNumber *)issuerID
+                                            fabricID:(nullable NSNumber *)fabricID
                                                error:(NSError * __autoreleasing _Nullable * _Nullable)error;
 
 /**
@@ -71,11 +71,11 @@ NS_ASSUME_NONNULL_BEGIN
  * signingKeypair and signingCertificate are the root or intermediate that is
  * signing the operational certificate.
  *
- * nodeId and fabricId are expected to be 64-bit unsigned integers.
+ * nodeID and fabricID are expected to be 64-bit unsigned integers.
  *
- * nodeId must be a valid Matter operational node id.
+ * nodeID must be a valid Matter operational node id.
  *
- * fabricId must be a valid Matter fabric id.
+ * fabricID must be a valid Matter fabric id.
  *
  * caseAuthenticatedTags may be nil to indicate no CASE Authenticated Tags
  * should be used.  If caseAuthenticatedTags is not nil, it must have length at
@@ -88,8 +88,8 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
                                  signingCertificate:(NSData *)signingCertificate
                                operationalPublicKey:(SecKeyRef)operationalPublicKey
-                                           fabricId:(NSNumber *)fabricId
-                                             nodeId:(NSNumber *)nodeId
+                                           fabricID:(NSNumber *)fabricID
+                                             nodeID:(NSNumber *)nodeID
                               caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error;
 

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -32,8 +32,8 @@ using namespace chip::Credentials;
 @implementation MTRCertificates
 
 + (nullable NSData *)generateRootCertificate:(id<MTRKeypair>)keypair
-                                    issuerId:(nullable NSNumber *)issuerId
-                                    fabricId:(nullable NSNumber *)fabricId
+                                    issuerID:(nullable NSNumber *)issuerID
+                                    fabricID:(nullable NSNumber *)fabricID
                                        error:(NSError * __autoreleasing *)error
 {
     NSLog(@"Generating root certificate");
@@ -41,7 +41,7 @@ using namespace chip::Credentials;
     [MTRMemory ensureInit];
 
     NSData * rootCert = nil;
-    CHIP_ERROR err = MTROperationalCredentialsDelegate::GenerateRootCertificate(keypair, issuerId, fabricId, &rootCert);
+    CHIP_ERROR err = MTROperationalCredentialsDelegate::GenerateRootCertificate(keypair, issuerID, fabricID, &rootCert);
     if (error) {
         *error = [MTRError errorForCHIPErrorCode:err];
     }
@@ -56,8 +56,8 @@ using namespace chip::Credentials;
 + (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
                                      rootCertificate:(NSData *)rootCertificate
                                intermediatePublicKey:(SecKeyRef)intermediatePublicKey
-                                            issuerId:(nullable NSNumber *)issuerId
-                                            fabricId:(nullable NSNumber *)fabricId
+                                            issuerID:(nullable NSNumber *)issuerID
+                                            fabricID:(nullable NSNumber *)fabricID
                                                error:(NSError * __autoreleasing *)error
 {
     NSLog(@"Generating intermediate certificate");
@@ -66,7 +66,7 @@ using namespace chip::Credentials;
 
     NSData * intermediate = nil;
     CHIP_ERROR err = MTROperationalCredentialsDelegate::GenerateIntermediateCertificate(
-        rootKeypair, rootCertificate, intermediatePublicKey, issuerId, fabricId, &intermediate);
+        rootKeypair, rootCertificate, intermediatePublicKey, issuerID, fabricID, &intermediate);
     if (error) {
         *error = [MTRError errorForCHIPErrorCode:err];
     }
@@ -81,8 +81,8 @@ using namespace chip::Credentials;
 + (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
                                  signingCertificate:(NSData *)signingCertificate
                                operationalPublicKey:(SecKeyRef)operationalPublicKey
-                                           fabricId:(NSNumber *)fabricId
-                                             nodeId:(NSNumber *)nodeId
+                                           fabricID:(NSNumber *)fabricID
+                                             nodeID:(NSNumber *)nodeID
                               caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
@@ -92,7 +92,7 @@ using namespace chip::Credentials;
 
     NSData * opcert = nil;
     CHIP_ERROR err = MTROperationalCredentialsDelegate::GenerateOperationalCertificate(
-        signingKeypair, signingCertificate, operationalPublicKey, fabricId, nodeId, caseAuthenticatedTags, &opcert);
+        signingKeypair, signingCertificate, operationalPublicKey, fabricID, nodeID, caseAuthenticatedTags, &opcert);
     if (error) {
         *error = [MTRError errorForCHIPErrorCode:err];
     }

--- a/src/darwin/Framework/CHIP/MTRControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRControllerFactory.mm
@@ -416,7 +416,7 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
         return nil;
     }
 
-    if (startupParams.vendorId == nil) {
+    if (startupParams.vendorID == nil) {
         MTR_LOG_ERROR("Must provide vendor id when starting controller on new fabric");
         return nil;
     }
@@ -526,7 +526,7 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
         }
     }
 
-    *fabric = fabricTable.FindFabric(pubKey, [params.fabricId unsignedLongLongValue]);
+    *fabric = fabricTable.FindFabric(pubKey, [params.fabricID unsignedLongLongValue]);
     return YES;
 }
 

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -372,9 +372,9 @@ private:
         MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:@(self.nodeID) controller:self.deviceController];
 
         [baseDevice
-            readAttributeWithEndpointId:endpointID
-                              clusterId:clusterID
-                            attributeId:attributeID
+            readAttributeWithEndpointID:endpointID
+                              clusterID:clusterID
+                            attributeID:attributeID
                                  params:params
                             clientQueue:self.queue
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
@@ -396,9 +396,9 @@ private:
     [_asyncCallbackWorkQueue enqueueWorkItem:workItem];
 
     // Return current known / expected value right away
-    MTRAttributePath * attributePath = [MTRAttributePath attributePathWithEndpointId:endpointID
-                                                                           clusterId:clusterID
-                                                                         attributeId:attributeID];
+    MTRAttributePath * attributePath = [MTRAttributePath attributePathWithEndpointID:endpointID
+                                                                           clusterID:clusterID
+                                                                         attributeID:attributeID];
     NSDictionary<NSString *, id> * attributeValueToReturn = [self _attributeValueDictionaryForAttributePath:attributePath];
 
     return attributeValueToReturn;
@@ -414,9 +414,9 @@ private:
     // Start the asynchronous operation
     MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:@(self.nodeID) controller:self.deviceController];
     [baseDevice
-        writeAttributeWithEndpointId:endpointID
-                           clusterId:clusterID
-                         attributeId:attributeID
+        writeAttributeWithEndpointID:endpointID
+                           clusterID:clusterID
+                         attributeID:attributeID
                                value:value
                    timedWriteTimeout:timeout
                          clientQueue:self.queue
@@ -427,9 +427,9 @@ private:
                           }];
 
     // Commit change into expected value cache
-    MTRAttributePath * attributePath = [MTRAttributePath attributePathWithEndpointId:endpointID
-                                                                           clusterId:clusterID
-                                                                         attributeId:attributeID];
+    MTRAttributePath * attributePath = [MTRAttributePath attributePathWithEndpointID:endpointID
+                                                                           clusterID:clusterID
+                                                                         attributeID:attributeID];
     NSDictionary * newExpectedValueDictionary = @{ MTRAttributePathKey : attributePath, MTRDataKey : value };
 
     [self setExpectedValues:@[ newExpectedValueDictionary ] expectedValueInterval:expectedValueInterval];
@@ -448,9 +448,9 @@ private:
     // Perform this operation
     MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:@(self.nodeID) controller:self.deviceController];
     [baseDevice
-        invokeCommandWithEndpointId:endpointID
-                          clusterId:clusterID
-                          commandId:commandID
+        invokeCommandWithEndpointID:endpointID
+                          clusterID:clusterID
+                          commandID:commandID
                       commandFields:commandFields
                  timedInvokeTimeout:timeout
                         clientQueue:self.queue

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.h
@@ -36,11 +36,11 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
 /**
  * Returns a shared device controller proxy for the controller object over XPC connection.
  *
- * @param controllerId    an implementation specific id in case multiple shared device controllers are available over XPC connection
+ * @param controllerID    an implementation specific id in case multiple shared device controllers are available over XPC connection
  * @param xpcConnectBlock block to connect to an XPC listener serving the shared device controllers in an implementation specific
  * way
  */
-+ (MTRDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
++ (MTRDeviceController *)sharedControllerWithID:(id<NSCopying> _Nullable)controllerID
                                 xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock;
 
 /**
@@ -82,9 +82,9 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
 @protocol MTRDeviceControllerServerProtocol <NSObject>
 
 /**
- * Gets device controller ID corresponding to a specific fabric Id
+ * Gets device controller ID corresponding to a specific fabric ID
  */
-- (void)getDeviceControllerWithFabricId:(NSNumber *)fabricId completion:(MTRDeviceControllerGetterHandler)completion;
+- (void)getDeviceControllerWithFabricID:(NSNumber *)fabricID completion:(MTRDeviceControllerGetterHandler)completion;
 
 /**
  * Gets any available device controller ID
@@ -95,10 +95,10 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
  * Requests reading attribute
  */
 - (void)readAttributeWithController:(id _Nullable)controller
-                             nodeId:(NSNumber *)nodeId
-                         endpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+                             nodeID:(NSNumber *)nodeID
+                         endpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                              params:(NSDictionary<NSString *, id> * _Nullable)params
                          completion:(MTRValuesHandler)completion;
 
@@ -106,10 +106,10 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
  * Requests writing attribute
  */
 - (void)writeAttributeWithController:(id _Nullable)controller
-                              nodeId:(NSNumber *)nodeId
-                          endpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+                              nodeID:(NSNumber *)nodeID
+                          endpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                           completion:(MTRValuesHandler)completion;
@@ -118,10 +118,10 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
  * Requests invoking command
  */
 - (void)invokeCommandWithController:(id _Nullable)controller
-                             nodeId:(NSNumber *)nodeId
-                         endpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+                             nodeID:(NSNumber *)nodeID
+                         endpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                              fields:(id)fields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                          completion:(MTRValuesHandler)completion;
@@ -130,10 +130,10 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
  * Requests subscribing attribute
  */
 - (void)subscribeAttributeWithController:(id _Nullable)controller
-                                  nodeId:(NSNumber *)nodeId
-                              endpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+                                  nodeID:(NSNumber *)nodeID
+                              endpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(NSDictionary<NSString *, id> * _Nullable)params
@@ -142,13 +142,13 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
 /**
  * Requests to stop reporting
  */
-- (void)stopReportsWithController:(id _Nullable)controller nodeId:(NSNumber *)nodeId completion:(dispatch_block_t)completion;
+- (void)stopReportsWithController:(id _Nullable)controller nodeID:(NSNumber *)nodeID completion:(dispatch_block_t)completion;
 
 /**
  * Requests subscription of all attributes.
  */
 - (void)subscribeWithController:(id _Nullable)controller
-                         nodeId:(NSNumber *)nodeId
+                         nodeID:(NSNumber *)nodeID
                     minInterval:(NSNumber *)minInterval
                     maxInterval:(NSNumber *)maxInterval
                          params:(NSDictionary<NSString *, id> * _Nullable)params
@@ -159,10 +159,10 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
  * Requests reading attribute cache
  */
 - (void)readAttributeCacheWithController:(id _Nullable)controller
-                                  nodeId:(NSNumber *)nodeId
-                              endpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+                                  nodeID:(NSNumber *)nodeID
+                              endpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                               completion:(MTRValuesHandler)completion;
 
 @end
@@ -176,7 +176,7 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
  * Handles a report received by a device controller
  */
 - (void)handleReportWithController:(id _Nullable)controller
-                            nodeId:(NSNumber *)nodeId
+                            nodeID:(NSNumber *)nodeID
                             values:(id _Nullable)values
                              error:(NSError * _Nullable)error;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.m
@@ -48,7 +48,7 @@ static MTRAttributePath * _Nullable decodeAttributePath(NSArray * _Nullable path
     if (pathArray == nil || [pathArray count] != 3) {
         return nil;
     }
-    return [MTRAttributePath attributePathWithEndpointId:pathArray[0] clusterId:pathArray[1] attributeId:pathArray[2]];
+    return [MTRAttributePath attributePathWithEndpointID:pathArray[0] clusterID:pathArray[1] attributeID:pathArray[2]];
 }
 
 static MTRCommandPath * _Nullable decodeCommandPath(NSArray * _Nullable pathArray)
@@ -56,7 +56,7 @@ static MTRCommandPath * _Nullable decodeCommandPath(NSArray * _Nullable pathArra
     if (pathArray == nil || [pathArray count] != 3) {
         return nil;
     }
-    return [MTRCommandPath commandPathWithEndpointId:pathArray[0] clusterId:pathArray[1] commandId:pathArray[2]];
+    return [MTRCommandPath commandPathWithEndpointID:pathArray[0] clusterID:pathArray[1] commandID:pathArray[2]];
 }
 
 static void decodeReadParams(NSDictionary<NSString *, id> * inParams, MTRReadParams * outParams)
@@ -66,10 +66,10 @@ static void decodeReadParams(NSDictionary<NSString *, id> * inParams, MTRReadPar
 
 @implementation MTRDeviceController (XPC)
 
-+ (MTRDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
++ (MTRDeviceController *)sharedControllerWithID:(id<NSCopying> _Nullable)controllerID
                                 xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock
 {
-    return [MTRDeviceControllerOverXPC sharedControllerWithId:controllerId xpcConnectBlock:xpcConnectBlock];
+    return [MTRDeviceControllerOverXPC sharedControllerWithID:controllerID xpcConnectBlock:xpcConnectBlock];
 }
 
 + (NSArray<NSDictionary<NSString *, id> *> * _Nullable)encodeXPCResponseValues:

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -34,10 +34,10 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 @property (readonly, nonatomic) BOOL isRunning;
 
 /**
- * Return the Node Id assigned to the controller.  Will return nil if the
+ * Return the Node ID assigned to the controller.  Will return nil if the
  * controller is not running (and hence does not know its node id).
  */
-@property (readonly, nonatomic, nullable) NSNumber * controllerNodeId;
+@property (readonly, nonatomic, nullable) NSNumber * controllerNodeID;
 
 /**
  * Start pairing for a device with the given ID, using the provided setup PIN
@@ -83,7 +83,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
  * after that point if it wants to commission the device.
  */
 - (BOOL)pairDevice:(uint64_t)deviceID onboardingPayload:(NSString *)onboardingPayload error:(NSError * __autoreleasing *)error;
-- (BOOL)commissionDevice:(uint64_t)deviceId
+- (BOOL)commissionDevice:(uint64_t)deviceID
      commissioningParams:(MTRCommissioningParameters *)commissioningParams
                    error:(NSError * __autoreleasing *)error;
 
@@ -93,7 +93,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 
 - (BOOL)stopDevicePairing:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 
-- (nullable MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error;
+- (nullable MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceID error:(NSError * __autoreleasing *)error;
 - (BOOL)getBaseDevice:(uint64_t)deviceID
                 queue:(dispatch_queue_t)queue
     completionHandler:(MTRDeviceConnectionCallback)completionHandler;
@@ -133,7 +133,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
  * Attempts to retrieve the attestation challenge for a commissionee with the given Device ID.
  * Returns nil if given Device ID does not match an active commissionee, or if a Secure Session is not availale.
  */
-- (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId;
+- (nullable NSData *)fetchAttestationChallengeForDeviceID:(uint64_t)deviceID;
 
 /**
  * Compute a PASE verifier and passcode ID for the desired setup pincode.

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -196,13 +196,13 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
             return;
         }
 
-        if (startupParams.vendorId == nil || [startupParams.vendorId unsignedShortValue] == chip::VendorId::Common) {
+        if (startupParams.vendorID == nil || [startupParams.vendorID unsignedShortValue] == chip::VendorId::Common) {
             // Shouldn't be using the "standard" vendor ID for actual devices.
-            MTR_LOG_ERROR("%@ is not a valid vendorId to initialize a device controller with", startupParams.vendorId);
+            MTR_LOG_ERROR("%@ is not a valid vendorID to initialize a device controller with", startupParams.vendorID);
             return;
         }
 
-        if (startupParams.operationalCertificate == nil && startupParams.nodeId == nil) {
+        if (startupParams.operationalCertificate == nil && startupParams.nodeID == nil) {
             MTR_LOG_ERROR("Can't start a controller if we don't know what node id it is");
             return;
         }
@@ -273,8 +273,8 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
             chip::MutableByteSpan noc(nocBuffer);
 
             if (commissionerParams.operationalKeypair != nullptr) {
-                errorCode = _operationalCredentialsDelegate->GenerateNOC([startupParams.nodeId unsignedLongLongValue],
-                    [startupParams.fabricId unsignedLongLongValue], chip::kUndefinedCATs,
+                errorCode = _operationalCredentialsDelegate->GenerateNOC([startupParams.nodeID unsignedLongLongValue],
+                    [startupParams.fabricID unsignedLongLongValue], chip::kUndefinedCATs,
                     commissionerParams.operationalKeypair->Pubkey(), noc);
 
                 if ([self checkForStartError:errorCode logMsg:kErrorGenerateNOC]) {
@@ -295,8 +295,8 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
                     return;
                 }
 
-                errorCode = _operationalCredentialsDelegate->GenerateNOC([startupParams.nodeId unsignedLongLongValue],
-                    [startupParams.fabricId unsignedLongLongValue], chip::kUndefinedCATs, pubKey, noc);
+                errorCode = _operationalCredentialsDelegate->GenerateNOC([startupParams.nodeID unsignedLongLongValue],
+                    [startupParams.fabricID unsignedLongLongValue], chip::kUndefinedCATs, pubKey, noc);
 
                 if ([self checkForStartError:errorCode logMsg:kErrorGenerateNOC]) {
                     return;
@@ -304,7 +304,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
             }
             commissionerParams.controllerNOC = noc;
         }
-        commissionerParams.controllerVendorId = static_cast<chip::VendorId>([startupParams.vendorId unsignedShortValue]);
+        commissionerParams.controllerVendorId = static_cast<chip::VendorId>([startupParams.vendorID unsignedShortValue]);
         commissionerParams.deviceAttestationVerifier = _factory.deviceAttestationVerifier;
 
         auto & factory = chip::Controller::DeviceControllerFactory::GetInstance();
@@ -339,7 +339,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     return commissionerInitialized;
 }
 
-- (NSNumber *)controllerNodeId
+- (NSNumber *)controllerNodeID
 {
     if (![self isRunning]) {
         MTR_LOG_ERROR("A controller has no node id if it has not been started");
@@ -426,7 +426,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     return success;
 }
 
-- (BOOL)commissionDevice:(uint64_t)deviceId
+- (BOOL)commissionDevice:(uint64_t)deviceID
      commissioningParams:(MTRCommissioningParameters *)commissioningParams
                    error:(NSError * __autoreleasing *)error
 {
@@ -473,8 +473,8 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
             params.SetDeviceAttestationDelegate(_deviceAttestationDelegateBridge);
         }
 
-        _operationalCredentialsDelegate->SetDeviceID(deviceId);
-        auto errorCode = self.cppCommissioner->Commission(deviceId, params);
+        _operationalCredentialsDelegate->SetDeviceID(deviceID);
+        auto errorCode = self.cppCommissioner->Commission(deviceID, params);
         success = ![self checkForError:errorCode logMsg:kErrorPairDevice error:error];
     });
     return success;
@@ -518,7 +518,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     return success;
 }
 
-- (MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error
+- (MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceID error:(NSError * __autoreleasing *)error
 {
     VerifyOrReturnValue([self checkIsRunning:error], nil);
 
@@ -528,7 +528,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     dispatch_sync(_chipWorkQueue, ^{
         VerifyOrReturn([self checkIsRunning:error]);
 
-        auto errorCode = self->_cppCommissioner->GetDeviceBeingCommissioned(deviceId, &deviceProxy);
+        auto errorCode = self->_cppCommissioner->GetDeviceBeingCommissioned(deviceID, &deviceProxy);
         success = ![self checkForError:errorCode logMsg:kErrorStopPairing error:error];
     });
     VerifyOrReturnValue(success, nil);
@@ -636,7 +636,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     return AsData(serializedBytes);
 }
 
-- (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId
+- (nullable NSData *)fetchAttestationChallengeForDeviceID:(uint64_t)deviceID
 {
     VerifyOrReturnValue([self checkIsRunning], nil);
 
@@ -645,7 +645,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
         VerifyOrReturn([self checkIsRunning]);
 
         chip::CommissioneeDeviceProxy * deviceProxy;
-        auto errorCode = self.cppCommissioner->GetDeviceBeingCommissioned(deviceId, &deviceProxy);
+        auto errorCode = self.cppCommissioner->GetDeviceBeingCommissioned(deviceID, &deviceProxy);
         auto success = ![self checkForError:errorCode logMsg:kErrorGetCommissionee error:nil];
         VerifyOrReturn(success);
 
@@ -727,12 +727,12 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
     return NO;
 }
 
-- (BOOL)_deviceBeingCommissionedOverBLE:(uint64_t)deviceId
+- (BOOL)_deviceBeingCommissionedOverBLE:(uint64_t)deviceID
 {
     VerifyOrReturnValue([self checkIsRunning], NO);
 
     chip::CommissioneeDeviceProxy * deviceProxy;
-    auto errorCode = self->_cppCommissioner->GetDeviceBeingCommissioned(deviceId, &deviceProxy);
+    auto errorCode = self->_cppCommissioner->GetDeviceBeingCommissioned(deviceID, &deviceProxy);
     VerifyOrReturnValue(errorCode == CHIP_NO_ERROR, NO);
 
     return deviceProxy->GetDeviceTransportType() == chip::Transport::Type::kBle;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.h
@@ -32,7 +32,7 @@ typedef NSXPCConnection * _Nonnull (^MTRXPCConnectBlock)(void);
  * Returns a shared remote device controller associated with an implementation specific id and implementation specific way to
  * connect to an XPC listener.
  */
-+ (MTRDeviceControllerOverXPC *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
++ (MTRDeviceControllerOverXPC *)sharedControllerWithID:(id<NSCopying> _Nullable)controllerID
                                        xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.m
@@ -37,11 +37,11 @@ static void SetupXPCQueue(void)
 
 @implementation MTRDeviceControllerOverXPC
 
-+ (MTRDeviceControllerOverXPC *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
++ (MTRDeviceControllerOverXPC *)sharedControllerWithID:(id<NSCopying> _Nullable)controllerID
                                        xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock
 {
     SetupXPCQueue();
-    return [[MTRDeviceControllerOverXPC alloc] initWithControllerId:controllerId
+    return [[MTRDeviceControllerOverXPC alloc] initWithControllerID:controllerID
                                                           workQueue:globalWorkQueue
                                                        connectBlock:xpcConnectBlock];
 }
@@ -72,7 +72,7 @@ static void SetupXPCQueue(void)
     return NO;
 }
 
-- (BOOL)commissionDevice:(uint64_t)deviceId
+- (BOOL)commissionDevice:(uint64_t)deviceID
      commissioningParams:(MTRCommissioningParameters *)commissioningParams
                    error:(NSError * __autoreleasing *)error
 {
@@ -91,7 +91,7 @@ static void SetupXPCQueue(void)
     return NO;
 }
 
-- (nullable MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error
+- (nullable MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceID error:(NSError * __autoreleasing *)error
 {
     MTR_LOG_ERROR("MTRDevice doesn't support getDeviceBeingCommissioned over XPC");
     return nil;
@@ -103,7 +103,7 @@ static void SetupXPCQueue(void)
 {
     dispatch_async(_workQueue, ^{
         dispatch_group_t group = dispatch_group_create();
-        if (!self.controllerId) {
+        if (!self.controllerID) {
             dispatch_group_enter(group);
             [self.xpcConnection getProxyHandleWithCompletion:^(
                 dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
@@ -112,7 +112,7 @@ static void SetupXPCQueue(void)
                         if (error) {
                             MTR_LOG_ERROR("Failed to fetch any shared remote controller");
                         } else {
-                            self.controllerId = controller;
+                            self.controllerID = controller;
                         }
                         dispatch_group_leave(group);
                         __auto_type handleRetainer = handle;
@@ -125,9 +125,9 @@ static void SetupXPCQueue(void)
             }];
         }
         dispatch_group_notify(group, queue, ^{
-            if (self.controllerId) {
-                MTRDeviceOverXPC * device = [[MTRDeviceOverXPC alloc] initWithController:self.controllerId
-                                                                                deviceId:@(deviceID)
+            if (self.controllerID) {
+                MTRDeviceOverXPC * device = [[MTRDeviceOverXPC alloc] initWithController:self.controllerID
+                                                                                deviceID:@(deviceID)
                                                                            xpcConnection:self.xpcConnection];
                 completionHandler(device, nil);
             } else {
@@ -138,22 +138,22 @@ static void SetupXPCQueue(void)
     return YES;
 }
 
-- (instancetype)initWithControllerId:(id)controllerId
+- (instancetype)initWithControllerID:(id)controllerID
                            workQueue:(dispatch_queue_t)queue
                        xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
 {
-    _controllerId = controllerId;
+    _controllerID = controllerID;
     _workQueue = queue;
     _xpcConnection = xpcConnection;
     return self;
 }
 
 // This is interface for unit testing
-- (instancetype)initWithControllerId:(id)controllerId
+- (instancetype)initWithControllerID:(id)controllerID
                            workQueue:(dispatch_queue_t)queue
                         connectBlock:(MTRXPCConnectBlock)connectBlock
 {
-    return [self initWithControllerId:controllerId
+    return [self initWithControllerID:controllerID
                             workQueue:queue
                         xpcConnection:[MTRDeviceControllerXPCConnection connectionWithWorkQueue:queue connectBlock:connectBlock]];
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceControllerOverXPC ()
 
-@property (nonatomic, readwrite, strong) id<NSCopying> _Nullable controllerId;
+@property (nonatomic, readwrite, strong) id<NSCopying> _Nullable controllerID;
 @property (nonatomic, readonly, strong) dispatch_queue_t workQueue;
 @property (nonatomic, readonly, strong) MTRDeviceControllerXPCConnection * xpcConnection;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -42,7 +42,7 @@ NS_ASSUME_NONNULL_BEGIN
  *   key of the nocSigner keypair, since in this case we are not using an
  *   intermediate certificate.
  */
-@property (nonatomic, copy, readonly) NSNumber * fabricId;
+@property (nonatomic, copy, readonly) NSNumber * fabricID;
 /**
  * IPK to use for the controller's fabric.  Allowed to change from the last time
  * a controller was started on this fabric if a new IPK has been distributed to
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  * * Will override existing value if not nil. Otherwise existing value will be
  *   used.
  */
-@property (nonatomic, copy, nullable) NSNumber * vendorId;
+@property (nonatomic, copy, nullable) NSNumber * vendorID;
 
 /**
  * Node id for this controller.
@@ -75,27 +75,27 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * If not nil, must be a valid Matter operational node id.
  *
- * If operationalCertificate is nil, nodeId and operationalKeypair are used to
+ * If operationalCertificate is nil, nodeID and operationalKeypair are used to
  * determine an operational certificate, as follows:
  *
  * * When creating a new fabric:
  *
- * ** nodeId is allowed to be nil to indicate that a random node id should be
+ * ** nodeID is allowed to be nil to indicate that a random node id should be
  *    generated.
  *
  * * When using an existing fabric:
  *
- * ** nodeId is allowed to be nil to indicate that the existing operational node
+ * ** nodeID is allowed to be nil to indicate that the existing operational node
  *    id should be used.  The existing operational keys will also be used,
  *    unless operationalKeypair is provided.
  *
- * ** If nodeId is not nil, a new operational certificate will be generated for
+ * ** If nodeID is not nil, a new operational certificate will be generated for
  *    the provided node id (even if that matches the existing node id), using
  *    either the operationalKeypair if that is provided or a new randomly
  *    generated operational key.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * nodeId;
+@property (nonatomic, copy, nullable) NSNumber * nodeID;
 
 // TODO: Add something here for CATs?
 
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
  * * May be nil if nocSigner is not nil and an intermediate CA is not being
  *   used.  In that case the nocSigner keypair, which is the keypair for the
  *   root certificate, will be used to generate and sign a root certificate,
- *   with a random issuer id.  In this case, the fabricId will be included in
+ *   with a random issuer id.  In this case, the fabricID will be included in
  *   the root certificate's subject DN.
  *
  * When using an existing fabric:
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
  * operationalKeypair must not be nil.
  *
  * If nil, an operational certificate will be determined as described in the
- * documentation for nodeId.
+ * documentation for nodeID.
  */
 @property (nonatomic, copy, readonly, nullable) NSData * operationalCertificate;
 
@@ -182,7 +182,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If not nil, and if operationalCertificate is nil, a new operational
  * certificate will be generated for the given operationalKeypair.  The node id
  * will for that certificated will be determined as described in the
- * documentation for nodeId.
+ * documentation for nodeID.
  */
 @property (nonatomic, strong, nullable) id<MTRKeypair> operationalKeypair;
 
@@ -192,11 +192,11 @@ NS_ASSUME_NONNULL_BEGIN
  * Prepare to initialize a controller given a keypair to use for signing
  * operational certificates.
  *
- * fabricId must be set to a valid (i.e. nonzero) value.
+ * fabricID must be set to a valid (i.e. nonzero) value.
  *
  * ipk must be 16 bytes in length
  */
-- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricId:(NSNumber *)fabricId ipk:(NSData *)ipk;
+- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricID:(NSNumber *)fabricID ipk:(NSData *)ipk;
 
 /**
  * Prepare to initialize a controller with a complete operational certificate

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -30,19 +30,19 @@ using namespace chip;
 
 @implementation MTRDeviceControllerStartupParams
 
-- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricId:(NSNumber *)fabricId ipk:(NSData *)ipk
+- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricID:(NSNumber *)fabricID ipk:(NSData *)ipk
 {
     if (!(self = [super init])) {
         return nil;
     }
 
-    if (!IsValidFabricId([fabricId unsignedLongLongValue])) {
-        MTR_LOG_ERROR("%llu is not a valid fabric id to initialize a device controller with", [fabricId unsignedLongLongValue]);
+    if (!IsValidFabricId([fabricID unsignedLongLongValue])) {
+        MTR_LOG_ERROR("%llu is not a valid fabric id to initialize a device controller with", [fabricID unsignedLongLongValue]);
         return nil;
     }
 
     _nocSigner = nocSigner;
-    _fabricId = [fabricId copy];
+    _fabricID = [fabricID copy];
     _ipk = [ipk copy];
 
     return self;
@@ -75,7 +75,7 @@ using namespace chip;
             MTR_LOG_ERROR("Unable to extract fabric id from operational certificate: %s", ErrorStr(err));
             return nil;
         }
-        _fabricId = @(fabricId);
+        _fabricID = @(fabricId);
     }
 
     _operationalKeypair = operationalKeypair;
@@ -94,10 +94,10 @@ using namespace chip;
     }
 
     _nocSigner = params.nocSigner;
-    _fabricId = params.fabricId;
+    _fabricID = params.fabricID;
     _ipk = params.ipk;
-    _vendorId = params.vendorId;
-    _nodeId = params.nodeId;
+    _vendorID = params.vendorID;
+    _nodeID = params.nodeID;
     _rootCertificate = params.rootCertificate;
     _intermediateCertificate = params.intermediateCertificate;
     _operationalCertificate = params.operationalCertificate;
@@ -136,8 +136,8 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
         return nil;
     }
 
-    if (self.operationalCertificate != nil && self.nodeId != nil) {
-        MTR_LOG_ERROR("nodeId must be nil if operationalCertificate is not nil");
+    if (self.operationalCertificate != nil && self.nodeID != nil) {
+        MTR_LOG_ERROR("nodeID must be nil if operationalCertificate is not nil");
         return nil;
     }
 
@@ -169,19 +169,19 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
         return nil;
     }
 
-    if (self.operationalCertificate == nil && self.nodeId == nil) {
+    if (self.operationalCertificate == nil && self.nodeID == nil) {
         // Just avoid setting the top bit, to avoid issues with node
         // ids outside the operational range.
         uint64_t nodeId = arc4random();
         nodeId = (nodeId << 31) | (arc4random() >> 1);
-        self.nodeId = @(nodeId);
+        self.nodeID = @(nodeId);
     }
 
     if (self.rootCertificate == nil) {
         NSError * error;
         self.rootCertificate = [MTRCertificates generateRootCertificate:self.nocSigner
-                                                               issuerId:nil
-                                                               fabricId:self.fabricId
+                                                               issuerID:nil
+                                                               fabricID:self.fabricID
                                                                   error:&error];
         if (error != nil || self.rootCertificate == nil) {
             MTR_LOG_ERROR("Failed to generate root certificate: %@", error);
@@ -206,13 +206,13 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 
     const FabricInfo * fabric = fabricTable->FindFabricWithIndex(fabricIndex);
 
-    if (self.vendorId == nil) {
-        self.vendorId = @(fabric->GetVendorId());
+    if (self.vendorID == nil) {
+        self.vendorID = @(fabric->GetVendorId());
     }
 
     BOOL usingExistingNOC = NO;
-    if (self.operationalCertificate == nil && self.nodeId == nil) {
-        self.nodeId = @(fabric->GetNodeId());
+    if (self.operationalCertificate == nil && self.nodeID == nil) {
+        self.nodeID = @(fabric->GetNodeId());
 
         if (self.operationalKeypair == nil) {
             uint8_t nocBuf[Credentials::kMaxCHIPCertLength];

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -83,7 +83,7 @@ NS_ASSUME_NONNULL_BEGIN
                              keystore:(chip::Crypto::OperationalKeystore *)keystore
                                params:(MTRDeviceControllerStartupParams *)params;
 
-- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricId:(NSNumber *)fabricId ipk:(NSData *)ipk NS_UNAVAILABLE;
+- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricID:(NSNumber *)fabricID ipk:(NSData *)ipk NS_UNAVAILABLE;
 - (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
                     operationalCertificate:(NSData *)operationalCertificate
                    intermediateCertificate:(nullable NSData *)intermediateCertificate

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
@@ -49,10 +49,10 @@ typedef void (^MTRGetProxyHandleHandler)(dispatch_queue_t queue, MTRDeviceContro
 
 - (void)getProxyHandleWithCompletion:(MTRGetProxyHandleHandler)completion;
 - (void)registerReportHandlerWithController:(id<NSCopying>)controller
-                                     nodeId:(NSNumber *)nodeId
+                                     nodeID:(NSNumber *)nodeID
                                     handler:(MTRXPCReportHandler)handler;
 - (void)deregisterReportHandlersWithController:(id<NSCopying>)controller
-                                        nodeId:(NSNumber *)nodeId
+                                        nodeID:(NSNumber *)nodeID
                                     completion:(dispatch_block_t)completion;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.m
@@ -118,7 +118,7 @@
     });
 }
 
-- (void)registerReportHandlerWithController:(id<NSCopying>)controller nodeId:(NSNumber *)nodeId handler:(MTRXPCReportHandler)handler
+- (void)registerReportHandlerWithController:(id<NSCopying>)controller nodeID:(NSNumber *)nodeID handler:(MTRXPCReportHandler)handler
 {
     dispatch_async(_workQueue, ^{
         BOOL shouldRetainProxyForReport = ([self.reportRegistry count] == 0);
@@ -127,10 +127,10 @@
             controllerDictionary = [[NSMutableDictionary alloc] init];
             [self.reportRegistry setObject:controllerDictionary forKey:controller];
         }
-        NSMutableArray * nodeArray = controllerDictionary[nodeId];
+        NSMutableArray * nodeArray = controllerDictionary[nodeID];
         if (!nodeArray) {
             nodeArray = [[NSMutableArray alloc] init];
-            [controllerDictionary setObject:nodeArray forKey:nodeId];
+            [controllerDictionary setObject:nodeArray forKey:nodeID];
         }
         [nodeArray addObject:handler];
         if (shouldRetainProxyForReport) {
@@ -140,7 +140,7 @@
 }
 
 - (void)deregisterReportHandlersWithController:(id<NSCopying>)controller
-                                        nodeId:(NSNumber *)nodeId
+                                        nodeID:(NSNumber *)nodeID
                                     completion:(dispatch_block_t)completion
 {
     dispatch_async(_workQueue, ^{
@@ -150,12 +150,12 @@
                 completion();
                 return;
             }
-            NSMutableArray * nodeArray = controllerDictionary[nodeId];
+            NSMutableArray * nodeArray = controllerDictionary[nodeID];
             if (!nodeArray) {
                 completion();
                 return;
             }
-            [controllerDictionary removeObjectForKey:nodeId];
+            [controllerDictionary removeObjectForKey:nodeID];
             if ([controllerDictionary count] == 0) {
                 // Dereference proxy retainer for reports so that XPC connection may be invalidated if no longer used.
                 self.proxyRetainerForReports = nil;
@@ -167,7 +167,7 @@
                 if (handle) {
                     MTR_LOG_DEBUG("CHIP XPC connection requests to stop reports");
                     [handle.proxy stopReportsWithController:controller
-                                                     nodeId:nodeId
+                                                     nodeID:nodeID
                                                  completion:^{
                                                      __auto_type handleRetainer = handle;
                                                      (void) handleRetainer;
@@ -182,7 +182,7 @@
 }
 
 - (void)handleReportWithController:(id)controller
-                            nodeId:(NSNumber *)nodeId
+                            nodeID:(NSNumber *)nodeID
                             values:(id _Nullable)values
                              error:(NSError * _Nullable)error
 {
@@ -191,7 +191,7 @@
         if (!controllerDictionary) {
             return;
         }
-        NSMutableArray * nodeArray = controllerDictionary[nodeId];
+        NSMutableArray * nodeArray = controllerDictionary[nodeID];
         if (!nodeArray) {
             return;
         }

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
     subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler NS_UNAVAILABLE;
 
 - (instancetype)initWithController:(id<NSCopying>)controller
-                          deviceId:(NSNumber *)deviceId
+                          deviceID:(NSNumber *)deviceID
                      xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceOverXPC ()
 
 @property (nonatomic, strong, readonly) id<NSCopying> controller;
-@property (nonatomic, readonly) NSNumber * nodeId;
+@property (nonatomic, readonly) NSNumber * nodeID;
 @property (nonatomic, strong, readonly) MTRDeviceControllerXPCConnection * xpcConnection;
 
 @end
@@ -37,11 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation MTRDeviceOverXPC
 
 - (instancetype)initWithController:(id<NSCopying>)controller
-                          deviceId:(NSNumber *)deviceId
+                          deviceID:(NSNumber *)deviceID
                      xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
 {
     _controller = controller;
-    _nodeId = deviceId;
+    _nodeID = deviceID;
     _xpcConnection = xpcConnection;
     return self;
 }
@@ -60,13 +60,13 @@ NS_ASSUME_NONNULL_BEGIN
     MTR_LOG_DEBUG("Subscribing all attributes... Note that attributeReportHandler, eventReportHandler, and resubscriptionScheduled "
                   "are not supported.");
     if (attributeCacheContainer) {
-        [attributeCacheContainer setXPCConnection:_xpcConnection controllerId:self.controller deviceId:self.nodeId];
+        [attributeCacheContainer setXPCConnection:_xpcConnection controllerID:self.controller deviceID:self.nodeID];
     }
     [_xpcConnection
         getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
                 [handle.proxy subscribeWithController:self.controller
-                                               nodeId:self.nodeId
+                                               nodeID:self.nodeID
                                           minInterval:minInterval
                                           maxInterval:maxInterval
                                                params:[MTRDeviceController encodeXPCSubscribeParams:params]
@@ -91,9 +91,9 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                              params:(MTRReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
@@ -103,10 +103,10 @@ NS_ASSUME_NONNULL_BEGIN
         getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
                 [handle.proxy readAttributeWithController:self.controller
-                                                   nodeId:self.nodeId
-                                               endpointId:endpointId
-                                                clusterId:clusterId
-                                              attributeId:attributeId
+                                                   nodeID:self.nodeID
+                                               endpointID:endpointID
+                                                clusterID:clusterID
+                                              attributeID:attributeID
                                                    params:[MTRDeviceController encodeXPCReadParams:params]
                                                completion:^(id _Nullable values, NSError * _Nullable error) {
                                                    dispatch_async(clientQueue, ^{
@@ -127,9 +127,9 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+- (void)writeAttributeWithEndpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                          clientQueue:(dispatch_queue_t)clientQueue
@@ -140,10 +140,10 @@ NS_ASSUME_NONNULL_BEGIN
         getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
                 [handle.proxy writeAttributeWithController:self.controller
-                                                    nodeId:self.nodeId
-                                                endpointId:endpointId
-                                                 clusterId:clusterId
-                                               attributeId:attributeId
+                                                    nodeID:self.nodeID
+                                                endpointID:endpointID
+                                                 clusterID:clusterID
+                                               attributeID:attributeID
                                                      value:value
                                          timedWriteTimeout:timeoutMs
                                                 completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -165,9 +165,9 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+- (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                       commandFields:(id)commandFields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                         clientQueue:(dispatch_queue_t)clientQueue
@@ -178,10 +178,10 @@ NS_ASSUME_NONNULL_BEGIN
         getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
                 [handle.proxy invokeCommandWithController:self.controller
-                                                   nodeId:self.nodeId
-                                               endpointId:endpointId
-                                                clusterId:clusterId
-                                                commandId:commandId
+                                                   nodeID:self.nodeID
+                                               endpointID:endpointID
+                                                clusterID:clusterID
+                                                commandID:commandID
                                                    fields:commandFields
                                        timedInvokeTimeout:timeoutMs
                                                completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -203,9 +203,9 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(MTRSubscribeParams * _Nullable)params
@@ -220,7 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
             MTR_LOG_DEBUG("Setup report handler");
             [self.xpcConnection
                 registerReportHandlerWithController:self.controller
-                                             nodeId:self.nodeId
+                                             nodeID:self.nodeID
                                             handler:^(id _Nullable values, NSError * _Nullable error) {
                                                 if (values && ![values isKindOfClass:[NSArray class]]) {
                                                     MTR_LOG_ERROR("Unsupported report format");
@@ -238,10 +238,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                     [NSMutableArray arrayWithCapacity:[decodedValues count]];
                                                 for (NSDictionary<NSString *, id> * decodedValue in decodedValues) {
                                                     MTRAttributePath * attributePath = decodedValue[MTRAttributePathKey];
-                                                    if ((endpointId == nil || [attributePath.endpoint isEqualToNumber:endpointId])
-                                                        && (clusterId == nil || [attributePath.cluster isEqualToNumber:clusterId])
-                                                        && (attributeId == nil ||
-                                                            [attributePath.attribute isEqualToNumber:attributeId])) {
+                                                    if ((endpointID == nil || [attributePath.endpoint isEqualToNumber:endpointID])
+                                                        && (clusterID == nil || [attributePath.cluster isEqualToNumber:clusterID])
+                                                        && (attributeID == nil ||
+                                                            [attributePath.attribute isEqualToNumber:attributeID])) {
                                                         [filteredValues addObject:decodedValue];
                                                     }
                                                 }
@@ -253,10 +253,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                 }
                                             }];
             [handle.proxy subscribeAttributeWithController:self.controller
-                                                    nodeId:self.nodeId
-                                                endpointId:endpointId
-                                                 clusterId:clusterId
-                                               attributeId:attributeId
+                                                    nodeID:self.nodeID
+                                                endpointID:endpointID
+                                                 clusterID:clusterID
+                                               attributeID:attributeID
                                                minInterval:minInterval
                                                maxInterval:maxInterval
                                                     params:[MTRDeviceController encodeXPCSubscribeParams:params]
@@ -284,7 +284,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     MTR_LOG_DEBUG("Deregistering report handlers");
     [_xpcConnection deregisterReportHandlersWithController:self.controller
-                                                    nodeId:self.nodeId
+                                                    nodeID:self.nodeID
                                                 completion:^{
                                                     dispatch_async(clientQueue, completion);
                                                 }];

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -32,7 +32,7 @@
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:testKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:testKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 }
 
@@ -41,7 +41,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -50,8 +50,8 @@
     __auto_type * intermediateCert = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                       rootCertificate:rootCert
                                                                 intermediatePublicKey:intermediateKeys.publicKey
-                                                                             issuerId:nil
-                                                                             fabricId:nil
+                                                                             issuerID:nil
+                                                                             fabricID:nil
                                                                                 error:nil];
     XCTAssertNotNil(intermediateCert);
 }
@@ -61,7 +61,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -76,8 +76,8 @@
     __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                                  signingCertificate:rootCert
                                                                operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricId:@1
-                                                                             nodeId:@1
+                                                                           fabricID:@1
+                                                                             nodeID:@1
                                                               caseAuthenticatedTags:cats
                                                                               error:nil];
     XCTAssertNotNil(operationalCert);
@@ -88,7 +88,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -97,8 +97,8 @@
     __auto_type * intermediateCert = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                       rootCertificate:rootCert
                                                                 intermediatePublicKey:intermediateKeys.publicKey
-                                                                             issuerId:nil
-                                                                             fabricId:nil
+                                                                             issuerID:nil
+                                                                             fabricID:nil
                                                                                 error:nil];
     XCTAssertNotNil(intermediateCert);
 
@@ -108,8 +108,8 @@
     __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:intermediateKeys
                                                                  signingCertificate:intermediateCert
                                                                operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricId:@1
-                                                                             nodeId:@1
+                                                                           fabricID:@1
+                                                                             nodeID:@1
                                                               caseAuthenticatedTags:nil
                                                                               error:nil];
     XCTAssertNotNil(operationalCert);
@@ -120,7 +120,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -153,8 +153,8 @@
     __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                                  signingCertificate:rootCert
                                                                operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricId:@1
-                                                                             nodeId:@1
+                                                                           fabricID:@1
+                                                                             nodeID:@1
                                                               caseAuthenticatedTags:nil
                                                                               error:nil];
     XCTAssertNotNil(operationalCert);
@@ -163,8 +163,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:longCats
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -173,8 +173,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:catsWithSameIdentifier
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -183,8 +183,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:catsWithDuplicatedCAT
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -193,8 +193,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:catsWithInvalidVersion
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -203,8 +203,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:operationalKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:nil
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -213,8 +213,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@0
-                                                               nodeId:@1
+                                                             fabricID:@0
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:nil
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -223,8 +223,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@0
+                                                             fabricID:@1
+                                                               nodeID:@0
                                                 caseAuthenticatedTags:nil
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -233,8 +233,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@(0xFFFFFFFFFFFFFFFFLLU)
+                                                             fabricID:@1
+                                                               nodeID:@(0xFFFFFFFFFFFFFFFFLLU)
                                                 caseAuthenticatedTags:nil
                                                                 error:nil];
     XCTAssertNil(operationalCert);

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -71,11 +71,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -93,7 +93,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([controller isRunning]);
 
     // now try to restart the controller without providing a vendor id.
-    params.vendorId = nil;
+    params.vendorID = nil;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
@@ -119,11 +119,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -148,11 +148,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertTrue([controller isRunning]);
@@ -181,11 +181,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertTrue([controller isRunning]);
     [controller shutdown];
@@ -199,11 +199,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     // Check that a new controller can be started on a different fabric too.
     __auto_type * params2 = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                    fabricId:@(2)
+                                                                                    fabricID:@(2)
                                                                                          ipk:testKeys.ipk];
     XCTAssertNotNil(params2);
 
-    params2.vendorId = @(kTestVendorId);
+    params2.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller3 = [factory startControllerOnNewFabric:params2];
     XCTAssertTrue([controller3 isRunning]);
@@ -239,11 +239,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertTrue([controller isRunning]);
@@ -274,11 +274,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -311,11 +311,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -347,11 +347,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(testKeys);
 
     __auto_type * params1 = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                    fabricId:@(1)
+                                                                                    fabricID:@(1)
                                                                                          ipk:testKeys.ipk];
     XCTAssertNotNil(params1);
 
-    params1.vendorId = @(kTestVendorId);
+    params1.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller1 = [factory startControllerOnNewFabric:params1];
     XCTAssertNotNil(controller1);
@@ -360,11 +360,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // Now try to start a new controller with the same root but a
     // different fabric id.
     __auto_type * params2 = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                    fabricId:@(2)
+                                                                                    fabricID:@(2)
                                                                                          ipk:testKeys.ipk];
     XCTAssertNotNil(params2);
 
-    params2.vendorId = @(kTestVendorId);
+    params2.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller2 = [factory startControllerOnNewFabric:params2];
     XCTAssertNotNil(controller2);
@@ -395,21 +395,21 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerId:@1 fabricId:@1 error:nil];
+    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root1);
 
-    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerId:@1 fabricId:@1 error:nil];
+    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root2);
 
-    __auto_type * root3 = [MTRCertificates generateRootCertificate:testKeys issuerId:@2 fabricId:@1 error:nil];
+    __auto_type * root3 = [MTRCertificates generateRootCertificate:testKeys issuerID:@2 fabricID:@1 error:nil];
     XCTAssertNotNil(root3);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root1;
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
@@ -426,7 +426,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -444,7 +444,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // operational certificate.  This should fail because our root of trust for
     // the fabric would change if we allowed this.
     params.rootCertificate = root3;
-    params.nodeId = nodeId;
+    params.nodeID = nodeId;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNil(controller);
 
@@ -465,18 +465,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerId:@1 fabricId:@1 error:nil];
+    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root1);
 
-    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerId:@1 fabricId:@2 error:nil];
+    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@2 error:nil];
     XCTAssertNotNil(root2);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Try to start controller when fabric id in root cert subject does not match provided fabric id.
     params.rootCertificate = root2;
@@ -526,15 +526,15 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * signerKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(signerKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:signerKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
 
     // Try to start controller when there is no ICA and root cert does not match signing key.
@@ -559,7 +559,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -568,17 +568,17 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Try to start controller when there is an ICA and the ICA cert does not match signing key.
     params.rootCertificate = root;
@@ -587,8 +587,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNil(controller);
 
     // Now start controller with the signing key matching the intermediate cert.
-    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys fabricId:@(1) ipk:rootKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys fabricID:@(1) ipk:rootKeys.ipk];
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate;
     controller = [factory startControllerOnNewFabric:params];
@@ -617,7 +617,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     // Invalid fabric ID.
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricId:@(0)
+                                                                                   fabricID:@(0)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNil(params);
 
@@ -639,12 +639,12 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(rootKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
     // Invalid vendor ID ("standard").
-    params.vendorId = @(0);
+    params.vendorID = @(0);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
@@ -667,17 +667,17 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(rootKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -686,7 +686,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -709,41 +709,41 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(rootKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Bring up with node id 17.
-    params.nodeId = @17;
+    params.nodeID = @17;
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @17);
+    XCTAssertEqualObjects([controller controllerNodeID], @17);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Bring up with a different node id (18).
-    params.nodeId = @18;
+    params.nodeID = @18;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @18);
+    XCTAssertEqualObjects([controller controllerNodeID], @18);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Verify the new node id has been stored.
-    params.nodeId = nil;
+    params.nodeID = nil;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @18);
+    XCTAssertEqualObjects([controller controllerNodeID], @18);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -766,29 +766,29 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(rootKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Try to bring up with node id 0.
-    params.nodeId = @0;
+    params.nodeID = @0;
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
 
     // Try to bring up with node id that is outside of the operational range.
-    params.nodeId = @(0xFFFFFFFF00000000ULL);
+    params.nodeID = @(0xFFFFFFFF00000000ULL);
     controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
 
     // Verify that we can indeed bring up a controller for this fabric, with a valid node id.
-    params.nodeId = @17;
+    params.nodeID = @17;
     controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @17);
+    XCTAssertEqualObjects([controller controllerNodeID], @17);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -811,7 +811,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -820,17 +820,17 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Create a new fabric without the ICA.
     params.rootCertificate = root;
@@ -838,21 +838,21 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but using the ICA.
-    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys fabricId:@(1) ipk:rootKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys fabricID:@(1) ipk:rootKeys.ipk];
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -875,7 +875,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -884,17 +884,17 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Create a new fabric without the ICA.
     params.rootCertificate = root;
@@ -903,20 +903,20 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but without using the ICA.
-    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys fabricId:@(1) ipk:rootKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys fabricID:@(1) ipk:rootKeys.ipk];
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -939,7 +939,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys1 = [[MTRTestKeys alloc] init];
@@ -948,8 +948,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate1 = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                    rootCertificate:root
                                                              intermediatePublicKey:intermediateKeys1.publicKey
-                                                                          issuerId:nil
-                                                                          fabricId:nil
+                                                                          issuerID:nil
+                                                                          fabricID:nil
                                                                              error:nil];
     XCTAssertNotNil(intermediate1);
 
@@ -959,17 +959,17 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate2 = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                    rootCertificate:root
                                                              intermediatePublicKey:intermediateKeys2.publicKey
-                                                                          issuerId:nil
-                                                                          fabricId:nil
+                                                                          issuerID:nil
+                                                                          fabricID:nil
                                                                              error:nil];
     XCTAssertNotNil(intermediate2);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys1
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Create a new fabric without the first ICA.
     params.rootCertificate = root;
@@ -978,21 +978,21 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but using the second ICA.
-    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys2 fabricId:@(1) ipk:rootKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys2 fabricID:@(1) ipk:rootKeys.ipk];
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate2;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1014,7 +1014,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -1023,17 +1023,17 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Pass in an intermediate but no root.  Should fail.
     params.intermediateCertificate = intermediate;
@@ -1057,7 +1057,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -1066,8 +1066,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
@@ -1077,8 +1077,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operational = [MTRCertificates generateOperationalCertificate:intermediateKeys
                                                              signingCertificate:intermediate
                                                            operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricId:@123
-                                                                         nodeId:@456
+                                                                       fabricID:@123
+                                                                         nodeID:@456
                                                           caseAuthenticatedTags:nil
                                                                           error:nil];
     XCTAssertNotNil(operational);
@@ -1090,13 +1090,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                             ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @456);
+    XCTAssertEqualObjects([controller controllerNodeID], @456);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1110,7 +1110,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @456);
+    XCTAssertEqualObjects([controller controllerNodeID], @456);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1132,7 +1132,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -1141,8 +1141,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operational = [MTRCertificates generateOperationalCertificate:rootKeys
                                                              signingCertificate:root
                                                            operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricId:@123
-                                                                         nodeId:@456
+                                                                       fabricID:@123
+                                                                         nodeID:@456
                                                           caseAuthenticatedTags:nil
                                                                           error:nil];
     XCTAssertNotNil(operational);
@@ -1154,13 +1154,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                             ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @456);
+    XCTAssertEqualObjects([controller controllerNodeID], @456);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1182,7 +1182,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:@111 error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:@111 error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -1191,8 +1191,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operational = [MTRCertificates generateOperationalCertificate:rootKeys
                                                              signingCertificate:root
                                                            operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricId:@123
-                                                                         nodeId:@456
+                                                                       fabricID:@123
+                                                                         nodeID:@456
                                                           caseAuthenticatedTags:nil
                                                                           error:nil];
     XCTAssertNotNil(operational);
@@ -1204,7 +1204,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                             ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
@@ -1226,7 +1226,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:@123 error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:@123 error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -1235,8 +1235,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:@111
+                                                                         issuerID:nil
+                                                                         fabricID:@111
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
@@ -1246,8 +1246,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operational = [MTRCertificates generateOperationalCertificate:intermediateKeys
                                                              signingCertificate:intermediate
                                                            operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricId:@123
-                                                                         nodeId:@456
+                                                                       fabricID:@123
+                                                                         nodeID:@456
                                                           caseAuthenticatedTags:nil
                                                                           error:nil];
     XCTAssertNotNil(operational);
@@ -1259,7 +1259,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                             ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
@@ -1285,18 +1285,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(operationalKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.operationalKeypair = operationalKeys;
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    __auto_type nodeId = [controller controllerNodeId];
+    __auto_type nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1315,7 +1315,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1330,7 +1330,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -158,9 +158,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -229,9 +229,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:nil
-                              clusterId:@29
-                            attributeId:@0
+    [device readAttributeWithEndpointID:nil
+                              clusterID:@29
+                            attributeID:@0
                                  params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -271,9 +271,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@17
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
                                    value:writeValue
                        timedWriteTimeout:nil
                              clientQueue:queue
@@ -319,9 +319,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
             @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
         ]
     };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@8
-                              commandId:@4
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@8
+                              commandID:@4
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -364,9 +364,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
         @"type" : @"Structure",
         @"value" : @[],
     };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:@10000
                             clientQueue:queue
@@ -407,9 +407,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@1
         maxInterval:@10
         params:nil
@@ -451,9 +451,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : [NSArray array] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -501,9 +501,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -549,9 +549,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     dispatch_queue_t queue = dispatch_get_main_queue();
 
     [device
-        readAttributeWithEndpointId:@0
-                          clusterId:@10000
-                        attributeId:@0
+        readAttributeWithEndpointID:@0
+                          clusterID:@10000
+                        attributeID:@0
                              params:nil
                         clientQueue:queue
                          completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -580,9 +580,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
     [device
-        writeAttributeWithEndpointId:@1
-                           clusterId:@8
-                         attributeId:@10000
+        writeAttributeWithEndpointID:@1
+                           clusterID:@8
+                         attributeID:@10000
                                value:writeValue
                    timedWriteTimeout:nil
                          clientQueue:queue
@@ -617,9 +617,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         ]
     };
     [device
-        invokeCommandWithEndpointId:@1
-                          clusterId:@8
-                          commandId:@40000
+        invokeCommandWithEndpointID:@1
+                          clusterID:@8
+                          commandID:@40000
                       commandFields:fields
                  timedInvokeTimeout:nil
                         clientQueue:queue
@@ -668,9 +668,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type * params = [[MTRSubscribeParams alloc] init];
     params.autoResubscribe = @(NO);
-    [device subscribeAttributeWithEndpointId:@10000
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@10000
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:params
@@ -705,9 +705,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:@1
-                              clusterId:@29
-                            attributeId:nil
+    [device readAttributeWithEndpointID:@1
+                              clusterID:@29
+                            attributeID:nil
                                  params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -886,9 +886,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using generic path...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:@1
-                          clusterId:@6
-                        attributeId:@0
+        readAttributeWithEndpointID:@1
+                          clusterID:@6
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -909,9 +909,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard endpoint...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:nil
-                          clusterId:@6
-                        attributeId:@0
+        readAttributeWithEndpointID:nil
+                          clusterID:@6
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -931,9 +931,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard cluster ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:@1
-                          clusterId:nil
-                        attributeId:@0
+        readAttributeWithEndpointID:@1
+                          clusterID:nil
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -952,9 +952,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard attribute ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:@1
-                          clusterId:@6
-                        attributeId:nil
+        readAttributeWithEndpointID:@1
+                          clusterID:@6
+                        attributeID:nil
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -974,9 +974,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard endpoint ID and cluster ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:nil
-                          clusterId:nil
-                        attributeId:@0
+        readAttributeWithEndpointID:nil
+                          clusterID:nil
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -1005,9 +1005,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@1
         maxInterval:@10
         params:nil
@@ -1049,9 +1049,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : [NSArray array] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1162,9 +1162,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     };
     // KeySetReadAllIndices in the Group Key Management has id 4 and a data response with id 5
     [device
-        invokeCommandWithEndpointId:@0
-                          clusterId:@(0x003F)
-                          commandId:@4
+        invokeCommandWithEndpointID:@0
+                          clusterID:@(0x003F)
+                          commandID:@4
                       commandFields:fields
                  timedInvokeTimeout:nil
                         clientQueue:queue
@@ -1228,9 +1228,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
 
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0xffffffff
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0xffffffff
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1272,9 +1272,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to set attribute state to a known state
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1302,9 +1302,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     commandExpectation = [self expectationWithDescription:@"command responded"];
     fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1351,9 +1351,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send command to trigger attribute change
     commandExpectation = [self expectationWithDescription:@"command responded"];
     fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -146,11 +146,11 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
     return self;
 }
 
-- (void)getDeviceControllerWithFabricId:(NSNumber *)fabricId
+- (void)getDeviceControllerWithFabricID:(NSNumber *)fabricID
                              completion:(void (^)(id _Nullable controller, NSError * _Nullable error))completion
 {
-    // We are using a shared local device controller and hence no disctinction per fabricId.
-    (void) fabricId;
+    // We are using a shared local device controller and hence no disctinction per fabricID.
+    (void) fabricID;
     completion(MTRDeviceControllerId, nil);
 }
 
@@ -160,21 +160,21 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 }
 
 - (void)readAttributeWithController:(id)controller
-                             nodeId:(NSNumber *)nodeId
-                         endpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+                             nodeID:(NSNumber *)nodeID
+                         endpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                              params:(NSDictionary<NSString *, id> * _Nullable)params
                          completion:(MTRValuesHandler)completion
 {
     (void) controller;
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeId controller:sharedController];
+        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
         [device
-            readAttributeWithEndpointId:endpointId
-                              clusterId:clusterId
-                            attributeId:attributeId
+            readAttributeWithEndpointID:endpointID
+                              clusterID:clusterID
+                            attributeID:attributeID
                                  params:[MTRDeviceController decodeXPCReadParams:params]
                             clientQueue:dispatch_get_main_queue()
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
@@ -187,10 +187,10 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 }
 
 - (void)writeAttributeWithController:(id)controller
-                              nodeId:(NSNumber *)nodeId
-                          endpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+                              nodeID:(NSNumber *)nodeID
+                          endpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber *)timeoutMs
                           completion:(MTRValuesHandler)completion
@@ -198,11 +198,11 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
     (void) controller;
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeId controller:sharedController];
+        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
         [device
-            writeAttributeWithEndpointId:endpointId
-                               clusterId:clusterId
-                             attributeId:attributeId
+            writeAttributeWithEndpointID:endpointID
+                               clusterID:clusterID
+                             attributeID:attributeID
                                    value:value
                        timedWriteTimeout:timeoutMs
                              clientQueue:dispatch_get_main_queue()
@@ -216,10 +216,10 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 }
 
 - (void)invokeCommandWithController:(id)controller
-                             nodeId:(NSNumber *)nodeId
-                         endpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+                             nodeID:(NSNumber *)nodeID
+                         endpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                              fields:(id)fields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                          completion:(MTRValuesHandler)completion
@@ -227,11 +227,11 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
     (void) controller;
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeId controller:sharedController];
+        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
         [device
-            invokeCommandWithEndpointId:endpointId
-                              clusterId:clusterId
-                              commandId:commandId
+            invokeCommandWithEndpointID:endpointID
+                              clusterID:clusterID
+                              commandID:commandID
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:dispatch_get_main_queue()
@@ -245,10 +245,10 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 }
 
 - (void)subscribeAttributeWithController:(id)controller
-                                  nodeId:(NSNumber *)nodeId
-                              endpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+                                  nodeID:(NSNumber *)nodeID
+                              endpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(NSDictionary<NSString *, id> * _Nullable)params
@@ -256,10 +256,10 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 {
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeId controller:sharedController];
-        [device subscribeAttributeWithEndpointId:endpointId
-                                       clusterId:clusterId
-                                     attributeId:attributeId
+        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
+        [device subscribeAttributeWithEndpointID:endpointID
+                                       clusterID:clusterID
+                                     attributeID:attributeID
                                      minInterval:minInterval
                                      maxInterval:maxInterval
                                           params:[MTRDeviceController decodeXPCSubscribeParams:params]
@@ -268,7 +268,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
                                        NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                                        [self.clientProxy
                                            handleReportWithController:controller
-                                                               nodeId:nodeId
+                                                               nodeID:nodeID
                                                                values:[MTRDeviceController encodeXPCResponseValues:values]
                                                                 error:error];
                                    }
@@ -278,7 +278,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
         establishedHandler();
         // Send an error report so that the client knows of the failure
         [self.clientProxy handleReportWithController:controller
-                                              nodeId:nodeId
+                                              nodeID:nodeID
                                               values:nil
                                                error:[NSError errorWithDomain:MTRErrorDomain
                                                                          code:MTRErrorCodeGeneralError
@@ -286,11 +286,11 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
     }
 }
 
-- (void)stopReportsWithController:(id _Nullable)controller nodeId:(NSNumber *)nodeId completion:(dispatch_block_t)completion
+- (void)stopReportsWithController:(id _Nullable)controller nodeID:(NSNumber *)nodeID completion:(dispatch_block_t)completion
 {
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeId controller:sharedController];
+        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
         [device deregisterReportHandlersWithClientQueue:dispatch_get_main_queue() completion:completion];
     } else {
         NSLog(@"Failed to get shared controller");
@@ -299,7 +299,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 }
 
 - (void)subscribeWithController:(id _Nullable)controller
-                         nodeId:(NSNumber *)nodeId
+                         nodeID:(NSNumber *)nodeID
                     minInterval:(NSNumber *)minInterval
                     maxInterval:(NSNumber *)maxInterval
                          params:(NSDictionary<NSString *, id> * _Nullable)params
@@ -313,7 +313,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
             attributeCacheContainer = [[MTRAttributeCacheContainer alloc] init];
         }
 
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeId controller:sharedController];
+        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
         NSMutableArray * established = [NSMutableArray arrayWithCapacity:1];
         [established addObject:@NO];
         [device subscribeWithQueue:dispatch_get_main_queue()
@@ -333,9 +333,9 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
                 }
             }
             subscriptionEstablished:^() {
-                NSLog(@"Attribute cache subscription succeeded for device %llu", [nodeId unsignedLongLongValue]);
+                NSLog(@"Attribute cache subscription succeeded for device %llu", [nodeID unsignedLongLongValue]);
                 if (attributeCacheContainer) {
-                    [self.attributeCacheDictionary setObject:attributeCacheContainer forKey:nodeId];
+                    [self.attributeCacheDictionary setObject:attributeCacheContainer forKey:nodeID];
                 }
                 if (![established[0] boolValue]) {
                     established[0] = @YES;
@@ -350,24 +350,24 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 }
 
 - (void)readAttributeCacheWithController:(id _Nullable)controller
-                                  nodeId:(NSNumber *)nodeId
-                              endpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+                                  nodeID:(NSNumber *)nodeID
+                              endpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                               completion:(MTRValuesHandler)completion
 {
-    MTRAttributeCacheContainer * attributeCacheContainer = _attributeCacheDictionary[nodeId];
+    MTRAttributeCacheContainer * attributeCacheContainer = _attributeCacheDictionary[nodeID];
     if (attributeCacheContainer) {
         [attributeCacheContainer
-            readAttributeWithEndpointId:endpointId
-                              clusterId:clusterId
-                            attributeId:attributeId
+            readAttributeWithEndpointID:endpointID
+                              clusterID:clusterID
+                            attributeID:attributeID
                             clientQueue:dispatch_get_main_queue()
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                                  completion([MTRDeviceController encodeXPCResponseValues:values], error);
                              }];
     } else {
-        NSLog(@"Attribute cache for node ID %llu was not setup", [nodeId unsignedLongLongValue]);
+        NSLog(@"Attribute cache for node ID %llu was not setup", [nodeID unsignedLongLongValue]);
         completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
     }
 }
@@ -472,9 +472,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
     XCTAssertNotNil(testKeys);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricId:@(1)
+                                                                                   fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -529,7 +529,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
     dispatch_queue_t queue = dispatch_get_main_queue();
     __auto_type remoteController = [MTRDeviceController
-        sharedControllerWithId:MTRDeviceControllerId
+        sharedControllerWithID:MTRDeviceControllerId
                xpcConnectBlock:^NSXPCConnection * _Nonnull {
                    if (mSampleListener.listenerEndpoint) {
                        return [[NSXPCConnection alloc] initWithListenerEndpoint:mSampleListener.listenerEndpoint];
@@ -567,9 +567,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:nil
-                              clusterId:@29
-                            attributeId:@0
+    [device readAttributeWithEndpointID:nil
+                              clusterID:@29
+                            attributeID:@0
                                  params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -609,9 +609,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@17
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
                                    value:writeValue
                        timedWriteTimeout:nil
                              clientQueue:queue
@@ -657,9 +657,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
             @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
         ]
     };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@8
-                              commandId:@4
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@8
+                              commandID:@4
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -700,9 +700,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -744,9 +744,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -791,9 +791,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:@0
-                              clusterId:@10000
-                            attributeId:@0
+    [device readAttributeWithEndpointID:@0
+                              clusterID:@10000
+                            attributeID:@0
                                  params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -824,9 +824,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@10000
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@10000
                                    value:writeValue
                        timedWriteTimeout:nil
                              clientQueue:queue
@@ -871,7 +871,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                             @"UnsignedInteger", @"type",
                                             [NSNumber numberWithUnsignedInteger:10], @"value", nil], @"value", nil],
                                           nil], @"value", nil];
-    [device invokeCommandWithEndpointId:@1 clusterId:@8 commandId:@40000 commandFields:fields clientQueue:queue
+    [device invokeCommandWithEndpointID:@1 clusterID:@8 commandID:@40000 commandFields:fields clientQueue:queue
             timedInvokeTimeout:nil
            completion:^(id _Nullable values, NSError * _Nullable error) {
                NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
@@ -910,9 +910,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device subscribeAttributeWithEndpointId:@10000
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@10000
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -949,9 +949,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     MTRReadParams * readParams = [[MTRReadParams alloc] init];
     readParams.fabricFiltered = @NO;
-    [device readAttributeWithEndpointId:nil
-                              clusterId:@29
-                            attributeId:@0
+    [device readAttributeWithEndpointID:nil
+                              clusterID:@29
+                            attributeID:@0
                                  params:readParams
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -999,9 +999,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1025,9 +1025,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Setup 2nd subscriber
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@8
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@8
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1052,9 +1052,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to clear attribute state
     XCTestExpectation * clearCommandExpectation = [self expectationWithDescription:@"Clearing command invoked"];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:@{ @"type" : @"Structure", @"value" : @[] }
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1121,9 +1121,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1178,9 +1178,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1206,9 +1206,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRSubscribeParams * myParams = [[MTRSubscribeParams alloc] init];
     myParams.keepPreviousSubscriptions = @NO;
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@8
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@8
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:myParams
@@ -1233,9 +1233,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to clear attribute state
     XCTestExpectation * clearCommandExpectation = [self expectationWithDescription:@"Clearing command invoked"];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:@{ @"type" : @"Structure", @"value" : @[] }
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1302,9 +1302,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1366,9 +1366,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1394,9 +1394,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
     MTRSubscribeParams * myParams = [[MTRSubscribeParams alloc] init];
     myParams.keepPreviousSubscriptions = @YES;
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@8
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@8
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:myParams
@@ -1421,9 +1421,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to clear attribute state
     XCTestExpectation * clearCommandExpectation = [self expectationWithDescription:@"Clearing command invoked"];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:@{ @"type" : @"Structure", @"value" : @[] }
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1488,9 +1488,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1537,9 +1537,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wrote LevelControl Brightness attribute"];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@17
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
                                    value:writeValue
                        timedWriteTimeout:nil
                              clientQueue:queue
@@ -1569,9 +1569,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:100], @"value", nil];
     expectation = [self expectationWithDescription:@"Requested timed write on LevelControl Brightness attribute"];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@17
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
                                    value:writeValue
                        timedWriteTimeout:@1000
                              clientQueue:queue
@@ -1601,9 +1601,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // subscribe, which should get the new value at the timeout
     expectation = [self expectationWithDescription:@"Subscribed"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error);
-    [device subscribeAttributeWithEndpointId:@1
-            clusterId:@8
-            attributeId:@17
+    [device subscribeAttributeWithEndpointID:@1
+            clusterID:@8
+            attributeID:@17
             minInterval:@2
             maxInterval:@10
             params:nil
@@ -1644,9 +1644,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Read back to see if the timed write has taken effect
     expectation = [self expectationWithDescription:@"Read LevelControl Brightness attribute after pause"];
-    [device readAttributeWithEndpointId:@1
-                              clusterId:@8
-                            attributeId:@17
+    [device readAttributeWithEndpointID:@1
+                              clusterID:@8
+                            attributeID:@17
                                  params:nil
                             clientQueue:queue
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
@@ -1683,9 +1683,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
             @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
         ]
     };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@8
-                              commandId:@4
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@8
+                              commandID:@4
                           commandFields:fields
                      timedInvokeTimeout:@1000
                             clientQueue:queue
@@ -1752,9 +1752,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Invoking clearing command...");
     expectation = [self expectationWithDescription:@"Clearing command invoked"];
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1783,9 +1783,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Invoking command to trigger report...");
     expectation = [self expectationWithDescription:@"Command invoked"];
     fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1815,9 +1815,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from attribute cache...");
     expectation = [self expectationWithDescription:@"Cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:@1
-                          clusterId:@6
-                        attributeId:@0
+        readAttributeWithEndpointID:@1
+                          clusterID:@6
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Cached attribute read: %@, error: %@", values, error);

--- a/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
@@ -79,7 +79,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 @interface MTRAttributeCacheContainer (Test)
 // Obsolete method is moved to this test suite to keep tests compatible
 - (void)subscribeWithDeviceController:(MTRDeviceController *)deviceController
-                             deviceId:(NSNumber *)deviceId
+                             deviceID:(NSNumber *)deviceID
                                params:(MTRSubscribeParams * _Nullable)params
                           clientQueue:(dispatch_queue_t)clientQueue
                            completion:(void (^)(NSError * _Nullable error))completion;
@@ -87,7 +87,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
 @implementation MTRAttributeCacheContainer (Test)
 - (void)subscribeWithDeviceController:(MTRDeviceController *)deviceController
-                             deviceId:(NSNumber *)deviceId
+                             deviceID:(NSNumber *)deviceID
                                params:(MTRSubscribeParams * _Nullable)params
                           clientQueue:clientQueue
                            completion:(void (^)(NSError * _Nullable error))completion
@@ -98,12 +98,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             completion(error);
         });
     };
-    [deviceController getBaseDevice:[deviceId unsignedLongLongValue]
+    [deviceController getBaseDevice:[deviceID unsignedLongLongValue]
                               queue:workQueue
                   completionHandler:^(MTRBaseDevice * _Nullable device, NSError * _Nullable error) {
                       if (error) {
                           NSLog(@"Error: Failed to get connected device (%llu) for attribute cache: %@",
-                              [deviceId unsignedLongLongValue], error);
+                              [deviceID unsignedLongLongValue], error);
                           completionHandler(error);
                           return;
                       }
@@ -126,7 +126,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }
                           }
                           subscriptionEstablished:^() {
-                              NSLog(@"Attribute cache subscription succeeded for device %llu", [deviceId unsignedLongLongValue]);
+                              NSLog(@"Attribute cache subscription succeeded for device %llu", [deviceID unsignedLongLongValue]);
                               if (![established[0] boolValue]) {
                                   established[0] = @YES;
                                   completionHandler(nil);
@@ -195,12 +195,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     return YES;
 }
 
-- (void)getDeviceControllerWithFabricId:(NSNumber *)fabricId
+- (void)getDeviceControllerWithFabricID:(NSNumber *)fabricID
                              completion:(void (^)(id _Nullable controller, NSError * _Nullable error))completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleGetAnySharedRemoteControllerWithFabricId);
-        self.handleGetAnySharedRemoteControllerWithFabricId(fabricId, completion);
+        self.handleGetAnySharedRemoteControllerWithFabricId(fabricID, completion);
     });
 }
 
@@ -213,55 +213,55 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 }
 
 - (void)readAttributeWithController:(id)controller
-                             nodeId:(NSNumber *)nodeId
-                         endpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+                             nodeID:(NSNumber *)nodeID
+                         endpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                              params:(NSDictionary<NSString *, id> * _Nullable)params
                          completion:(MTRValuesHandler)completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleReadAttribute);
         self.handleReadAttribute(
-            controller, nodeId, endpointId, clusterId, attributeId, [MTRDeviceController decodeXPCReadParams:params], completion);
+            controller, nodeID, endpointID, clusterID, attributeID, [MTRDeviceController decodeXPCReadParams:params], completion);
     });
 }
 
 - (void)writeAttributeWithController:(id)controller
-                              nodeId:(NSNumber *)nodeId
-                          endpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+                              nodeID:(NSNumber *)nodeID
+                          endpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                           completion:(MTRValuesHandler)completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleWriteAttribute);
-        self.handleWriteAttribute(controller, nodeId, endpointId, clusterId, attributeId, value, timeoutMs, completion);
+        self.handleWriteAttribute(controller, nodeID, endpointID, clusterID, attributeID, value, timeoutMs, completion);
     });
 }
 
 - (void)invokeCommandWithController:(id)controller
-                             nodeId:(NSNumber *)nodeId
-                         endpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+                             nodeID:(NSNumber *)nodeID
+                         endpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                              fields:(id)fields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                          completion:(MTRValuesHandler)completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleInvokeCommand);
-        self.handleInvokeCommand(controller, nodeId, endpointId, clusterId, commandId, fields, timeoutMs, completion);
+        self.handleInvokeCommand(controller, nodeID, endpointID, clusterID, commandID, fields, timeoutMs, completion);
     });
 }
 
 - (void)subscribeAttributeWithController:(id)controller
-                                  nodeId:(NSNumber *)nodeId
-                              endpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+                                  nodeID:(NSNumber *)nodeID
+                              endpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(NSDictionary<NSString *, id> * _Nullable)params
@@ -269,21 +269,21 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleSubscribeAttribute);
-        self.handleSubscribeAttribute(controller, nodeId, endpointId, clusterId, attributeId, minInterval, maxInterval,
+        self.handleSubscribeAttribute(controller, nodeID, endpointID, clusterID, attributeID, minInterval, maxInterval,
             [MTRDeviceController decodeXPCSubscribeParams:params], establishedHandler);
     });
 }
 
-- (void)stopReportsWithController:(id)controller nodeId:(NSNumber *)nodeId completion:(dispatch_block_t)completion
+- (void)stopReportsWithController:(id)controller nodeID:(NSNumber *)nodeID completion:(dispatch_block_t)completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleStopReports);
-        self.handleStopReports(controller, nodeId, completion);
+        self.handleStopReports(controller, nodeID, completion);
     });
 }
 
 - (void)subscribeWithController:(id _Nullable)controller
-                         nodeId:(NSNumber *)nodeId
+                         nodeID:(NSNumber *)nodeID
                     minInterval:(NSNumber *)minInterval
                     maxInterval:(NSNumber *)maxInterval
                          params:(NSDictionary<NSString *, id> * _Nullable)params
@@ -292,21 +292,21 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleSubscribeAll);
-        self.handleSubscribeAll(controller, nodeId, minInterval, maxInterval, [MTRDeviceController decodeXPCSubscribeParams:params],
+        self.handleSubscribeAll(controller, nodeID, minInterval, maxInterval, [MTRDeviceController decodeXPCSubscribeParams:params],
             shouldCache, completion);
     });
 }
 
 - (void)readAttributeCacheWithController:(id _Nullable)controller
-                                  nodeId:(NSNumber *)nodeId
-                              endpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+                                  nodeID:(NSNumber *)nodeID
+                              endpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                               completion:(MTRValuesHandler)completion
 {
     dispatch_async(dispatch_get_main_queue(), ^{
         XCTAssertNotNil(self.handleReadAttributeCache);
-        self.handleReadAttributeCache(controller, nodeId, endpointId, clusterId, attributeId, completion);
+        self.handleReadAttributeCache(controller, nodeID, endpointID, clusterID, attributeID, completion);
     });
 }
 
@@ -321,7 +321,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     [_xpcListener resume];
     _controllerUUID = [[NSUUID UUID] UUIDString];
     _remoteDeviceController =
-        [MTRDeviceController sharedControllerWithId:_controllerUUID
+        [MTRDeviceController sharedControllerWithID:_controllerUUID
                                     xpcConnectBlock:^NSXPCConnection * {
                                         return [[NSXPCConnection alloc] initWithListenerEndpoint:self.xpcListener.endpoint];
                                     }];
@@ -342,9 +342,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myClusterId = @200;
     NSNumber * myAttributeId = @300;
     NSArray * myValues = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
 
@@ -371,9 +371,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Reading...");
-                             [device readAttributeWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                     attributeId:myAttributeId
+                             [device readAttributeWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                     attributeID:myAttributeId
                                                           params:nil
                                                      clientQueue:dispatch_get_main_queue()
                                                       completion:^(id _Nullable value, NSError * _Nullable error) {
@@ -401,9 +401,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myClusterId = @200;
     NSNumber * myAttributeId = @300;
     NSArray * myValues = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     MTRReadParams * myParams = [[MTRReadParams alloc] init];
@@ -433,9 +433,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Reading...");
-                             [device readAttributeWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                     attributeId:myAttributeId
+                             [device readAttributeWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                     attributeID:myAttributeId
                                                           params:myParams
                                                      clientQueue:dispatch_get_main_queue()
                                                       completion:^(id _Nullable value, NSError * _Nullable error) {
@@ -486,9 +486,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Reading...");
-                             [device readAttributeWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                     attributeId:myAttributeId
+                             [device readAttributeWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                     attributeID:myAttributeId
                                                           params:nil
                                                      clientQueue:dispatch_get_main_queue()
                                                       completion:^(id _Nullable value, NSError * _Nullable error) {
@@ -517,9 +517,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSDictionary * myValue =
         [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
     NSArray * myResults = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId]
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId]
     } ];
 
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -545,9 +545,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Writing...");
-                             [device writeAttributeWithEndpointId:myEndpointId
-                                                        clusterId:myClusterId
-                                                      attributeId:myAttributeId
+                             [device writeAttributeWithEndpointID:myEndpointId
+                                                        clusterID:myClusterId
+                                                      attributeID:myAttributeId
                                                             value:myValue
                                                 timedWriteTimeout:nil
                                                       clientQueue:dispatch_get_main_queue()
@@ -579,9 +579,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
     NSNumber * myTimedWriteTimeout = @1234;
     NSArray * myResults = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId]
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId]
     } ];
 
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -608,9 +608,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Writing...");
-                             [device writeAttributeWithEndpointId:myEndpointId
-                                                        clusterId:myClusterId
-                                                      attributeId:myAttributeId
+                             [device writeAttributeWithEndpointID:myEndpointId
+                                                        clusterID:myClusterId
+                                                      attributeID:myAttributeId
                                                             value:myValue
                                                 timedWriteTimeout:myTimedWriteTimeout
                                                       clientQueue:dispatch_get_main_queue()
@@ -664,9 +664,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Writing...");
-                             [device writeAttributeWithEndpointId:myEndpointId
-                                                        clusterId:myClusterId
-                                                      attributeId:myAttributeId
+                             [device writeAttributeWithEndpointID:myEndpointId
+                                                        clusterID:myClusterId
+                                                      attributeID:myAttributeId
                                                             value:myValue
                                                 timedWriteTimeout:nil
                                                       clientQueue:dispatch_get_main_queue()
@@ -698,7 +698,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                                                    [NSNumber numberWithFloat:1.0], @"value", nil]],
                                             @"value", nil];
     NSArray * myResults = @[
-        @{ @"commandPath" : [MTRCommandPath commandPathWithEndpointId:myEndpointId clusterId:myClusterId commandId:myCommandId] }
+        @{ @"commandPath" : [MTRCommandPath commandPathWithEndpointID:myEndpointId clusterID:myClusterId commandID:myCommandId] }
     ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
@@ -724,9 +724,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Invoking command...");
-                             [device invokeCommandWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                       commandId:myCommandId
+                             [device invokeCommandWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                       commandID:myCommandId
                                                    commandFields:myFields
                                               timedInvokeTimeout:nil
                                                      clientQueue:dispatch_get_main_queue()
@@ -760,7 +760,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                                                    [NSNumber numberWithFloat:1.0], @"value", nil]],
                                             @"value", nil];
     NSArray * myResults = @[
-        @{ @"commandPath" : [MTRCommandPath commandPathWithEndpointId:myEndpointId clusterId:myClusterId commandId:myCommandId] }
+        @{ @"commandPath" : [MTRCommandPath commandPathWithEndpointID:myEndpointId clusterID:myClusterId commandID:myCommandId] }
     ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
@@ -787,9 +787,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Invoking command...");
-                             [device invokeCommandWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                       commandId:myCommandId
+                             [device invokeCommandWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                       commandID:myCommandId
                                                    commandFields:myFields
                                               timedInvokeTimeout:myTimedInvokeTimeout
                                                      clientQueue:dispatch_get_main_queue()
@@ -846,9 +846,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Invoking command...");
-                             [device invokeCommandWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                       commandId:myCommandId
+                             [device invokeCommandWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                       commandID:myCommandId
                                                    commandFields:myFields
                                               timedInvokeTimeout:nil
                                                      clientQueue:dispatch_get_main_queue()
@@ -878,9 +878,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -912,9 +912,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -936,7 +936,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -946,13 +946,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -996,9 +996,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     myParams.fabricFiltered = @NO;
     myParams.keepPreviousSubscriptions = @NO;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1032,9 +1032,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:myParams
@@ -1056,7 +1056,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1066,13 +1066,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1147,9 +1147,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1170,7 +1170,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     // Inject badly formatted report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
-    [clientObject handleReportWithController:uuid nodeId:@(myNodeId) values:myReport error:nil];
+    [clientObject handleReportWithController:uuid nodeID:@(myNodeId) values:myReport error:nil];
 
     // Wait for report, which isn't expected.
     [self waitForExpectations:[NSArray arrayWithObject:reportExpectation] timeout:kNegativeTimeoutInSeconds];
@@ -1178,13 +1178,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"Report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1226,9 +1226,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:@([myEndpointId unsignedShortValue] + 1)
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:@([myEndpointId unsignedShortValue] + 1)
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1261,9 +1261,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1285,7 +1285,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1295,13 +1295,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1342,9 +1342,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:@([myClusterId unsignedLongValue] + 1)
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:@([myClusterId unsignedLongValue] + 1)
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1377,9 +1377,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1401,7 +1401,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1411,13 +1411,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1458,9 +1458,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:@([myAttributeId unsignedLongValue] + 1)],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:@([myAttributeId unsignedLongValue] + 1)],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1493,9 +1493,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1517,7 +1517,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1527,13 +1527,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1574,9 +1574,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1609,9 +1609,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1633,7 +1633,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId + 1)
+                                      nodeID:@(myNodeId + 1)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1643,13 +1643,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1690,9 +1690,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1724,9 +1724,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:nil
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:nil
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1748,7 +1748,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1758,13 +1758,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1805,9 +1805,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1839,9 +1839,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:nil
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:nil
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1863,7 +1863,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1873,13 +1873,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1920,9 +1920,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1954,9 +1954,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:nil
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:nil
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1978,7 +1978,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject report
     id<MTRDeviceControllerClientProtocol> clientObject = _xpcConnection.remoteObjectProxy;
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -1988,13 +1988,13 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
-                                      nodeId:@(myNodeId)
+                                      nodeID:@(myNodeId)
                                       values:[MTRDeviceController encodeXPCResponseValues:myReport]
                                        error:nil];
 
@@ -2080,9 +2080,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                 XCTAssertNotNil(device);
                 XCTAssertNil(error);
                 NSLog(@"Device acquired. Subscribing...");
-                [device subscribeAttributeWithEndpointId:myEndpointId
-                    clusterId:myClusterId
-                    attributeId:myAttributeId
+                [device subscribeAttributeWithEndpointID:myEndpointId
+                    clusterID:myClusterId
+                    attributeID:myAttributeId
                     minInterval:myMinInterval
                     maxInterval:myMaxInterval
                     params:nil
@@ -2112,15 +2112,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
         myReports = @[
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[0]
-                                                                       clusterId:clusterIds[0]
-                                                                     attributeId:attributeIds[0]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[0]
+                                                                       clusterID:clusterIds[0]
+                                                                     attributeID:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:123456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[1]
-                                                                       clusterId:clusterIds[1]
-                                                                     attributeId:attributeIds[1]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[1]
+                                                                       clusterID:clusterIds[1]
+                                                                     attributeID:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:123457 + count * 100] }
             } ]
         ];
@@ -2128,7 +2128,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             NSUInteger nodeId = nodeIds[i];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [clientObject handleReportWithController:uuid
-                                                  nodeId:@(nodeId)
+                                                  nodeID:@(nodeId)
                                                   values:[MTRDeviceController encodeXPCResponseValues:myReports[i]]
                                                    error:nil];
             });
@@ -2170,15 +2170,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         reportExpectations[0].inverted = YES;
         myReports = @[
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[0]
-                                                                       clusterId:clusterIds[0]
-                                                                     attributeId:attributeIds[0]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[0]
+                                                                       clusterID:clusterIds[0]
+                                                                     attributeID:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[1]
-                                                                       clusterId:clusterIds[1]
-                                                                     attributeId:attributeIds[1]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[1]
+                                                                       clusterID:clusterIds[1]
+                                                                     attributeID:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223457 + count * 100] }
             } ]
         ];
@@ -2186,7 +2186,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             NSUInteger nodeId = nodeIds[i];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [clientObject handleReportWithController:uuid
-                                                  nodeId:@(nodeId)
+                                                  nodeID:@(nodeId)
                                                   values:[MTRDeviceController encodeXPCResponseValues:myReports[i]]
                                                    error:nil];
             });
@@ -2232,15 +2232,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         reportExpectations[1].inverted = YES;
         myReports = @[
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[0]
-                                                                       clusterId:clusterIds[0]
-                                                                     attributeId:attributeIds[0]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[0]
+                                                                       clusterID:clusterIds[0]
+                                                                     attributeID:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[1]
-                                                                       clusterId:clusterIds[1]
-                                                                     attributeId:attributeIds[1]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[1]
+                                                                       clusterID:clusterIds[1]
+                                                                     attributeID:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223457 + count * 100] }
             } ]
         ];
@@ -2248,7 +2248,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             NSUInteger nodeId = nodeIds[i];
             dispatch_async(dispatch_get_main_queue(), ^{
                 [clientObject handleReportWithController:uuid
-                                                  nodeId:@(nodeId)
+                                                  nodeID:@(nodeId)
                                                   values:[MTRDeviceController encodeXPCResponseValues:myReports[i]]
                                                    error:nil];
             });
@@ -2263,7 +2263,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     uint64_t myNodeId = 9876543210;
 
     __auto_type unspecifiedRemoteDeviceController =
-        [MTRDeviceController sharedControllerWithId:nil
+        [MTRDeviceController sharedControllerWithID:nil
                                     xpcConnectBlock:^NSXPCConnection * {
                                         return [[NSXPCConnection alloc] initWithListenerEndpoint:self.xpcListener.endpoint];
                                     }];
@@ -2308,7 +2308,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2346,7 +2346,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:myParams
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2380,7 +2380,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2400,9 +2400,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myClusterId = @200;
     NSNumber * myAttributeId = @300;
     NSArray * myValues = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
 
@@ -2434,7 +2434,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     };
 
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2446,9 +2446,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:myEndpointId
-                          clusterId:myClusterId
-                        attributeId:myAttributeId
+        readAttributeWithEndpointID:myEndpointId
+                          clusterID:myClusterId
+                        attributeID:myAttributeId
                         clientQueue:dispatch_get_main_queue()
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read cached value: %@", values);
@@ -2496,7 +2496,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     };
 
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2508,9 +2508,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:myEndpointId
-                          clusterId:myClusterId
-                        attributeId:myAttributeId
+        readAttributeWithEndpointID:myEndpointId
+                          clusterID:myClusterId
+                        attributeID:myAttributeId
                         clientQueue:dispatch_get_main_queue()
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read cached value: %@", values);
@@ -2531,7 +2531,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"Read response received"];
 
     // Test with a device controller which wouldn't connect to XPC listener successfully
-    __auto_type failingDeviceController = [MTRDeviceController sharedControllerWithId:_controllerUUID
+    __auto_type failingDeviceController = [MTRDeviceController sharedControllerWithID:_controllerUUID
                                                                       xpcConnectBlock:^NSXPCConnection * {
                                                                           return nil;
                                                                       }];
@@ -2542,9 +2542,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Reading...");
-                             [device readAttributeWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                     attributeId:myAttributeId
+                             [device readAttributeWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                     attributeID:myAttributeId
                                                           params:nil
                                                      clientQueue:dispatch_get_main_queue()
                                                       completion:^(id _Nullable value, NSError * _Nullable error) {


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/22528

Addresses part of https://github.com/project-chip/connectedhomeip/issues/22420

#### Issue Being Resolved
* Fixes #22528

#### Change overview
Renames selectors to have "ID" instead of "Id".
