### PR TITLE
Fix platform mdns build error

### DIFF
--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -76,7 +76,7 @@ jobs:
               timeout-minutes: 10
               run: |
                   ./scripts/run_in_build_env.sh \
-                  "./scripts/build/build_examples.py --no-log-timestamps --target address-resolve-tool-platform-mdns-ipv6only build"
+                  "./scripts/build/build_examples.py --no-log-timestamps --target linux-x64-address-resolve-tool-platform-mdns-ipv6only build"
             - name: Build example Standalone Echo Client
               timeout-minutes: 10
               run: |

--- a/.github/workflows/examples-linux-standalone.yaml
+++ b/.github/workflows/examples-linux-standalone.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     linux_standalone:
         name: Linux Standalone
-        timeout-minutes: 70
+        timeout-minutes: 90
 
         env:
             BUILD_TYPE: gn_linux
@@ -72,6 +72,11 @@ jobs:
               run: |
                   ./scripts/run_in_build_env.sh \
                   "./scripts/build/build_examples.py --no-log-timestamps --target-glob '*-chip-cert' build"
+            - name: Build minmdns example with platform dns
+              timeout-minutes: 10
+              run: |
+                  ./scripts/run_in_build_env.sh \
+                  "./scripts/build/build_examples.py --no-log-timestamps --target address-resolve-tool-platform-mdns-ipv6only build"
             - name: Build example Standalone Echo Client
               timeout-minutes: 10
               run: |

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -616,7 +616,7 @@ void MdnsAvahi::HandleBrowse(AvahiServiceBrowser * browser, AvahiIfIndex interfa
     switch (event)
     {
     case AVAHI_BROWSER_FAILURE:
-        context->mCallback(context->mContext, nullptr, 0, CHIP_ERROR_INTERNAL);
+        context->mCallback(context->mContext, nullptr, 0, true, CHIP_ERROR_INTERNAL);
         avahi_service_browser_free(browser);
         chip::Platform::Delete(context);
         break;


### PR DESCRIPTION
#### Issue Being Resolved
Fixes #22556

#### Change overview
Added missing argument in callback on error (callback is 'final browse'). 
Also added test by additional compilation in linux-standalone so that compiling platformmdns on linux does not regress.