### PR TITLE
Darwin API review fixes for MTRSetupPayload and MTROptionalQRCodeInfo

### DIFF
--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -61,7 +61,7 @@ CHIP_ERROR SetupPayloadParseCommand::Run()
     NSString * codeString = [NSString stringWithCString:mCode encoding:NSASCIIStringEncoding];
     NSError * error;
     MTRSetupPayload * payload;
-    payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:codeString error:&error];
+    payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:codeString error:&error];
     if (error) {
         LogNSError("Error: ", error);
         return CHIP_ERROR_INTERNAL;
@@ -78,37 +78,33 @@ CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
     NSLog(@"ProductID:     %@", payload.productID);
     NSLog(@"Custom flow:   %lu    (%@)", payload.commissioningFlow, CustomFlowString(payload.commissioningFlow));
     {
-        if (payload.rendezvousInformation == nil) {
+        if (payload.discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
             NSLog(@"Capabilities:  UNKNOWN");
         } else {
             NSMutableString * humanFlags = [[NSMutableString alloc] init];
 
-            auto value = [payload.rendezvousInformation unsignedLongValue];
-            if (value == MTRDiscoveryCapabilitiesNone) {
-                [humanFlags appendString:@"NONE"];
-            } else {
-                if (value & MTRDiscoveryCapabilitiesSoftAP) {
-                    [humanFlags appendString:@"SoftAP"];
+            auto value = payload.discoveryCapabilities;
+            if (value & MTRDiscoveryCapabilitiesSoftAP) {
+                [humanFlags appendString:@"SoftAP"];
+            }
+            if (value & MTRDiscoveryCapabilitiesBLE) {
+                if (!humanFlags) {
+                    [humanFlags appendString:@", "];
                 }
-                if (value & MTRDiscoveryCapabilitiesBLE) {
-                    if (!humanFlags) {
-                        [humanFlags appendString:@", "];
-                    }
-                    [humanFlags appendString:@"BLE"];
+                [humanFlags appendString:@"BLE"];
+            }
+            if (value & MTRDiscoveryCapabilitiesOnNetwork) {
+                if (!humanFlags) {
+                    [humanFlags appendString:@", "];
                 }
-                if (value & MTRDiscoveryCapabilitiesOnNetwork) {
-                    if (!humanFlags) {
-                        [humanFlags appendString:@", "];
-                    }
-                    [humanFlags appendString:@"ON NETWORK"];
-                }
+                [humanFlags appendString:@"ON NETWORK"];
             }
 
             NSLog(@"Capabilities:  0x%02lX (%@)", value, humanFlags);
         }
     }
     NSLog(@"Discriminator: %@", payload.discriminator);
-    NSLog(@"Passcode:      %@", payload.setUpPINCode);
+    NSLog(@"Passcode:      %@", payload.setupPasscode);
 
     if (payload.serialNumber) {
         NSLog(@"SerialNumber: %@", payload.serialNumber);
@@ -120,8 +116,8 @@ CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
         return CHIP_ERROR_INTERNAL;
     }
     for (const MTROptionalQRCodeInfo * info : optionalVendorData) {
-        bool isTypeString = [info.infoType isEqual:@(MTROptionalQRCodeInfoTypeString)];
-        bool isTypeInt32 = [info.infoType isEqual:@(MTROptionalQRCodeInfoTypeInt32)];
+        bool isTypeString = (info.infoType == MTROptionalQRCodeInfoTypeString);
+        bool isTypeInt32 = (info.infoType == MTROptionalQRCodeInfoTypeInt32);
         VerifyOrReturnError(isTypeString || isTypeInt32, CHIP_ERROR_INVALID_ARGUMENT);
 
         if (isTypeString) {

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Enumeration/EnumerateViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Enumeration/EnumerateViewController.m
@@ -133,7 +133,7 @@
             for (NSNumber * endpoint in endpointsInUse) {
                 MTRBaseClusterDescriptor * descriptorCluster =
                     [[MTRBaseClusterDescriptor alloc] initWithDevice:device endpoint:endpoint queue:dispatch_get_main_queue()];
-                [descriptorCluster readAttributeDeviceListWithCompletionHandler:^(
+                [descriptorCluster readAttributeDeviceTypeListWithCompletionHandler:^(
                     NSArray * _Nullable value, NSError * _Nullable error) {
                     if (error) {
                         NSString * resultLog = [[NSString alloc]

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -18,7 +18,6 @@
 #import <Foundation/Foundation.h>
 
 #import <Matter/MTRNOCChainIssuer.h>
-#import <Matter/MTROnboardingPayloadParser.h>
 
 @class MTRBaseDevice;
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -18,7 +18,7 @@
 
 #ifdef __cplusplus
 - (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;
-- (NSNumber *)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value;
+- (MTRDiscoveryCapabilities)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value;
 - (MTRCommissioningFlow)convertCommissioningFlow:(chip::CommissioningFlow)value;
 #endif
 

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -38,12 +38,10 @@
 #import <Matter/MTRDevicePairingDelegate.h>
 #import <Matter/MTRError.h>
 #import <Matter/MTRKeypair.h>
-#import <Matter/MTRManualSetupPayloadParser.h>
 #import <Matter/MTRNOCChainIssuer.h>
 #import <Matter/MTROTAHeaderParser.h>
 #import <Matter/MTROTAProviderDelegate.h>
 #import <Matter/MTRPersistentStorageDelegate.h>
-#import <Matter/MTRQRCodeSetupPayloadParser.h>
 #import <Matter/MTRSetupPayload.h>
 #import <Matter/MTRStructsObjc.h>
 #import <Matter/MTRThreadOperationalDataset.h>

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
@@ -18,9 +18,6 @@
  *    limitations under the License.
  */
 // module headers
-#import "MTRManualSetupPayloadParser.h"
-#import "MTROnboardingPayloadParser.h"
-#import "MTRQRCodeSetupPayloadParser.h"
 #import "MTRSetupPayload.h"
 
 // additional includes
@@ -38,87 +35,81 @@
 - (void)testOnboardingPayloadParser_Manual_NoError
 {
     NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" error:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"636108753500001000015" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertTrue(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 123456780);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertNil(payload.rendezvousInformation);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
 }
 
 - (void)testOnboardingPayloadParser_QRCode_NoError
 {
     NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"MT:R5L90MP500K64J00000"
-                                                                                       error:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:R5L90MP500K64J00000" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertNotNil(payload.rendezvousInformation);
-    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
 }
 
 - (void)testOnboardingPayloadParser_NFC_NoError
 {
     NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser
-        setupPayloadForOnboardingPayload:@"MT:R5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
-                                   error:&error];
+    MTRSetupPayload * payload =
+        [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:R5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
+                                                     error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertNotNil(payload.rendezvousInformation);
-    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
 }
 
 - (void)testManualParser
 {
     NSError * error;
-    MTRManualSetupPayloadParser * parser =
-        [[MTRManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:@"636108753500001000015"];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"636108753500001000015" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertTrue(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 123456780);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertNil(payload.rendezvousInformation);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
 }
 
 - (void)testManualParser_Error
 {
     NSError * error;
-    MTRManualSetupPayloadParser * parser = [[MTRManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:@""];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"" error:&error];
 
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, MTRErrorCodeInvalidStringLength);
@@ -127,9 +118,7 @@
 - (void)testQRCodeParser_Error
 {
     NSError * error;
-    MTRQRCodeSetupPayloadParser * parser =
-        [[MTRQRCodeSetupPayloadParser alloc] initWithBase38Representation:@"MT:R5L90MP500K64J0000."];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:R5L90MP500K64J0000." error:&error];
 
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, MTRErrorCodeInvalidArgument);
@@ -138,30 +127,27 @@
 - (void)testQRCodeParser
 {
     NSError * error;
-    MTRQRCodeSetupPayloadParser * parser =
-        [[MTRQRCodeSetupPayloadParser alloc] initWithBase38Representation:@"MT:R5L90MP500K64J00000"];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:R5L90MP500K64J00000" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertNotNil(payload.rendezvousInformation);
-    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
 }
 
 - (void)testQRCodeParserWithOptionalData
 {
     NSError * error;
-    MTRQRCodeSetupPayloadParser * parser = [[MTRQRCodeSetupPayloadParser alloc]
-        initWithBase38Representation:@"MT:R5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload =
+        [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:R5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
+                                                     error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
@@ -169,12 +155,11 @@
     XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
-    XCTAssertNotNil(payload.rendezvousInformation);
-    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
     XCTAssertTrue([payload.serialNumber isEqualToString:@"123456789"]);
 
     NSArray<MTROptionalQRCodeInfo *> * vendorOptionalInfo = [payload getAllOptionalVendorData:&error];
@@ -182,13 +167,31 @@
     XCTAssertEqual([vendorOptionalInfo count], 2);
     for (MTROptionalQRCodeInfo * info in vendorOptionalInfo) {
         if (info.tag.intValue == 130) {
-            XCTAssertEqual(info.infoType.intValue, MTROptionalQRCodeInfoTypeString);
+            XCTAssertEqual(info.infoType, MTROptionalQRCodeInfoTypeString);
             XCTAssertTrue([info.stringValue isEqualToString:@"myData"]);
         } else if (info.tag.intValue == 131) {
-            XCTAssertEqual(info.infoType.intValue, MTROptionalQRCodeInfoTypeInt32);
+            XCTAssertEqual(info.infoType, MTROptionalQRCodeInfoTypeInt32);
             XCTAssertEqual(info.integerValue.intValue, 12);
         }
     }
+}
+
+- (void)testQRCodeWithNoCapabilities
+{
+    NSError * error;
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L9000000K64J00000" error:&error];
+
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertFalse(payload.hasShortDiscriminator);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesOnNetwork);
 }
 
 @end

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -118,13 +118,13 @@
 		AF1CB8702874B04C00865A96 /* MTROTAProviderDelegateBridge.h in Headers */ = {isa = PBXBuildFile; fileRef = AF1CB86F2874B04C00865A96 /* MTROTAProviderDelegateBridge.h */; };
 		AF5F90FF2878D351005503FA /* MTROTAProviderDelegateBridge.mm in Sources */ = {isa = PBXBuildFile; fileRef = AF5F90FE2878D351005503FA /* MTROTAProviderDelegateBridge.mm */; };
 		B20252972459E34F00F97062 /* Matter.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B202528D2459E34F00F97062 /* Matter.framework */; };
-		B289D4212639C0D300D4E314 /* MTROnboardingPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B289D41F2639C0D300D4E314 /* MTROnboardingPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B289D4212639C0D300D4E314 /* MTROnboardingPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B289D41F2639C0D300D4E314 /* MTROnboardingPayloadParser.h */; };
 		B289D4222639C0D300D4E314 /* MTROnboardingPayloadParser.m in Sources */ = {isa = PBXBuildFile; fileRef = B289D4202639C0D300D4E314 /* MTROnboardingPayloadParser.m */; };
 		B2E0D7B1245B0B5C003C5B48 /* Matter.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7A8245B0B5C003C5B48 /* Matter.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		B2E0D7B2245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7A9245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B2E0D7B2245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7A9245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h */; };
 		B2E0D7B3245B0B5C003C5B48 /* MTRError.mm in Sources */ = {isa = PBXBuildFile; fileRef = B2E0D7AA245B0B5C003C5B48 /* MTRError.mm */; };
 		B2E0D7B4245B0B5C003C5B48 /* MTRError_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7AB245B0B5C003C5B48 /* MTRError_Internal.h */; };
-		B2E0D7B5245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7AC245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B2E0D7B5245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7AC245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.h */; };
 		B2E0D7B6245B0B5C003C5B48 /* MTRManualSetupPayloadParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = B2E0D7AD245B0B5C003C5B48 /* MTRManualSetupPayloadParser.mm */; };
 		B2E0D7B7245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.mm in Sources */ = {isa = PBXBuildFile; fileRef = B2E0D7AE245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.mm */; };
 		B2E0D7B8245B0B5C003C5B48 /* MTRSetupPayload.h in Headers */ = {isa = PBXBuildFile; fileRef = B2E0D7AF245B0B5C003C5B48 /* MTRSetupPayload.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -511,7 +511,6 @@
 				515C1C70284F9FFB00A48F0C /* MTRMemory.h in Headers */,
 				7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */,
 				D4772A46285AE98400383630 /* MTRClusterConstants.h in Headers */,
-				B289D4212639C0D300D4E314 /* MTROnboardingPayloadParser.h in Headers */,
 				513DDB862761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h in Headers */,
 				2CB7163F252F731E0026E2BB /* MTRDevicePairingDelegate.h in Headers */,
 				88EBF8CE27FABDD500686BC1 /* MTRDeviceAttestationDelegate.h in Headers */,
@@ -522,10 +521,12 @@
 				754F3DF427FBB94B00E60580 /* MTREventTLVValueDecoder_Internal.h in Headers */,
 				3CF134AF289D90FF0017A19E /* MTRNOCChainIssuer.h in Headers */,
 				3CF134AB289D8DF70017A19E /* MTRAttestationInfo.h in Headers */,
-				B2E0D7B2245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h in Headers */,
 				3CF134A7289D8ADA0017A19E /* MTRCSRInfo.h in Headers */,
 				B2E0D7B1245B0B5C003C5B48 /* Matter.h in Headers */,
 				7596A84428762729004DAE0E /* MTRDevice.h in Headers */,
+				B2E0D7B5245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.h in Headers */,
+				B2E0D7B2245B0B5C003C5B48 /* MTRManualSetupPayloadParser.h in Headers */,
+				B289D4212639C0D300D4E314 /* MTROnboardingPayloadParser.h in Headers */,
 				B2E0D7B8245B0B5C003C5B48 /* MTRSetupPayload.h in Headers */,
 				7596A84D287782EF004DAE0E /* MTRAsyncCallbackWorkQueue_Internal.h in Headers */,
 				7596A83E28751220004DAE0E /* MTRBaseClusters_internal.h in Headers */,
@@ -543,7 +544,6 @@
 				5129BCFD26A9EE3300122DDF /* MTRError.h in Headers */,
 				2C8C8FC1253E0C2100797F05 /* MTRPersistentStorageDelegate.h in Headers */,
 				AF1CB8702874B04C00865A96 /* MTROTAProviderDelegateBridge.h in Headers */,
-				B2E0D7B5245B0B5C003C5B48 /* MTRQRCodeSetupPayloadParser.h in Headers */,
 				1EC4CE6425CC276600D7304F /* MTRBaseClusters.h in Headers */,
 				2C5EEEF6268A85C400CAE3D3 /* MTRDeviceConnectionBridge.h in Headers */,
 				2C8C8FC0253E0C2100797F05 /* MTRPersistentStorageDelegateBridge.h in Headers */,


### PR DESCRIPTION
* Rename MTRDiscoveryCapabilitiesNone to MTRDiscoveryCapabilitiesUnknown to indicate capabilities unknown (e.g. manual setup code).
* In MTROptionalQRCodeInfo mark integerValue and stringValue as nullable and document they are mutually exclusive.
* In MTROptionalQRCodeInfo switch infoType to MTROptionalQRCodeInfoType, not NSNumber.
* Change rendezvousInformation to just be a MTRDiscoveryCapabilities value, not nullable NSNumber, with MTRDiscoveryCapabilitiesNone meaning unknown. When parsing QR code, if the value ends up as 0, reset it to MTRDiscoveryCapabilitiesOnNetwork.
* Rename setUpPINCode to setupPasscode.
* Mark serialNumber as nullable.
* Add setupPayloadWithOnboardingPayload class method on MTRSetupPayload.
* Stop exposing the various payload parser APIs from the framework; consumers should use setupPayloadWithOnboardingPayload.

Addresses part of https://github.com/project-chip/connectedhomeip/issues/22420

#### Issue Being Resolved
* Fixes #22543
* Fixes #22539

#### Change overview
See above.
