### PR TITLE
Update scripts build_coverage.sh for Ubuntu 22.04 LTS/macOS 10.15 and…

### DIFF
--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -18,8 +18,28 @@
 
 set -e
 
+_install_lcov() {
+    if ! lcov --version >/dev/null 2>&1; then
+        echo "lcov not installed. Installing..."
+        case "$(uname)" in
+            "Darwin")
+                brew install lcov
+                ;;
+            "Linux")
+                sudo apt-get update
+                sudo apt-get install -y lcov
+                ;;
+            *)
+                die
+                ;;
+        esac
+    fi
+}
+
+_install_lcov
+
 _normpath() {
-    python -c "import os.path; print(os.path.normpath('$@'))"
+    python3 -c "import os.path; print(os.path.normpath('$@'))"
 }
 
 CHIP_ROOT=$(_normpath "$(dirname "$0")/..")


### PR DESCRIPTION
… later versions

#### Issue Being Resolved
* Fixes #22567
#### Change overview
1. Install the dependent tools lcov if it is not installed on the current environment (Ubuntu or Mac)
2. using python3 instead of python to run coverage script
