### PR TITLE
[Android/JAVA]add IM isFabricFiltered and keepSubscriptions flag for read/subscribe API

### DIFF
--- a/src/android/CHIPTool/app/src/main/res/layout/read_dialog.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/read_dialog.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="wrap_content"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+  <TextView
+      android:id="@+id/titleText"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/read_dialog_title_text"
+      android:textSize="22sp"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toTopOf="parent" />
+
+  <EditText
+      android:id="@+id/isFabricFilteredEd"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:hint="@string/read_dialog_is_fabric_filtered_hint"
+      android:inputType="text"
+      android:textSize="16sp"
+      android:layout_marginBottom="8dp"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/isFabricFilteredEd"
+      app:layout_constraintBottom_toTopOf="@+id/subscribeBtn"/>
+
+  <Button
+      android:id="@+id/readBtn"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:text="@string/read_dialog_read_btn_text"
+      app:layout_constraintBottom_toBottomOf="parent"
+      app:layout_constraintEnd_toEndOf="parent" />
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/src/android/CHIPTool/app/src/main/res/layout/subscribe_dialog.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/subscribe_dialog.xml
@@ -36,6 +36,30 @@
       app:layout_constraintTop_toBottomOf="@id/minIntervalEd"
       app:layout_constraintBottom_toTopOf="@+id/subscribeBtn"/>
 
+  <EditText
+      android:id="@+id/keepSubscriptionsEd"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:hint="@string/subscribe_dialog_keep_subscriptions_hint"
+      android:inputType="text"
+      android:textSize="16sp"
+      android:layout_marginBottom="8dp"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/keepSubscriptionsEd"
+      app:layout_constraintBottom_toTopOf="@+id/subscribeBtn"/>
+
+  <EditText
+      android:id="@+id/isFabricFilteredEd"
+      android:layout_width="wrap_content"
+      android:layout_height="wrap_content"
+      android:hint="@string/subscribe_dialog_is_fabric_filtered_hint"
+      android:inputType="text"
+      android:textSize="16sp"
+      android:layout_marginBottom="8dp"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintTop_toBottomOf="@id/isFabricFilteredEd"
+      app:layout_constraintBottom_toTopOf="@+id/subscribeBtn"/>
+
   <Button
       android:id="@+id/subscribeBtn"
       android:layout_width="wrap_content"

--- a/src/android/CHIPTool/app/src/main/res/layout/wildcard_fragment.xml
+++ b/src/android/CHIPTool/app/src/main/res/layout/wildcard_fragment.xml
@@ -91,6 +91,7 @@
       android:layout_margin="16dp"
       android:inputType="number"
       android:hint="@string/wildcard_help_label"/>
+
   <Button
       android:id="@+id/readBtn"
       android:layout_width="wrap_content"

--- a/src/android/CHIPTool/app/src/main/res/values/strings.xml
+++ b/src/android/CHIPTool/app/src/main/res/values/strings.xml
@@ -133,10 +133,16 @@
     <string name="basic_cluster_reachable_text">Reachable</string>
     <string name="basic_cluster_cluster_revision_text">ClusterRevision</string>
 
+    <string name="read_dialog_title_text">Read</string>
+    <string name="read_dialog_read_btn_text">Read</string>
+    <string name="read_dialog_is_fabric_filtered_hint">is Fabric Filtered (bool)</string>
+
     <string name="subscribe_dialog_title_text">Subscribe</string>
     <string name="subscribe_dialog_subscribe_btn_text">Subscribe</string>
     <string name="subscribe_dialog_min_interval_hint">Minimum interval (seconds)</string>
     <string name="subscribe_dialog_max_interval_hint">Maximum interval (seconds)</string>
+    <string name="subscribe_dialog_keep_subscriptions_hint">keep subscriptions (bool)</string>
+    <string name="subscribe_dialog_is_fabric_filtered_hint">is Fabric Filtered (bool)</string>
 
     <string name="endpoint_id_label">Endpoint ID</string>
     <string name="cluster_id_label">Cluster ID</string>

--- a/src/controller/java/AndroidCallbacks-JNI.cpp
+++ b/src/controller/java/AndroidCallbacks-JNI.cpp
@@ -40,10 +40,11 @@ JNI_METHOD(void, GetConnectedDeviceCallbackJni, deleteCallback)(JNIEnv * env, jo
 }
 
 JNI_METHOD(jlong, ReportCallbackJni, newCallback)
-(JNIEnv * env, jobject self, jobject subscriptionEstablishedCallbackJava, jobject reportCallbackJava)
+(JNIEnv * env, jobject self, jobject subscriptionEstablishedCallbackJava, jobject reportCallbackJava,
+ jobject resubscriptionAttemptCallbackJava)
 {
-    ReportCallback * reportCallback =
-        chip::Platform::New<ReportCallback>(self, subscriptionEstablishedCallbackJava, reportCallbackJava);
+    ReportCallback * reportCallback = chip::Platform::New<ReportCallback>(self, subscriptionEstablishedCallbackJava,
+                                                                          reportCallbackJava, resubscriptionAttemptCallbackJava);
     return reinterpret_cast<jlong>(reportCallback);
 }
 

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1043,9 +1043,9 @@ exit:
     return nullptr;
 }
 
-JNI_METHOD(void, subscribeToPath)
-(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jint minInterval,
- jint maxInterval)
+JNI_METHOD(void, subscribe)
+(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jobject eventPathList,
+ jint minInterval, jint maxInterval, jboolean keepSubscriptions, jboolean isFabricFiltered)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1060,12 +1060,20 @@ JNI_METHOD(void, subscribeToPath)
     std::vector<app::AttributePathParams> attributePathParamsList;
     err = ParseAttributePathList(attributePathList, attributePathParamsList);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error parsing Java attribute paths: %s", ErrorStr(err)));
+
+    std::vector<app::EventPathParams> eventPathParamsList;
+    err = ParseEventPathList(eventPathList, eventPathParamsList);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error parsing Java event paths: %s", ErrorStr(err)));
 
     app::ReadPrepareParams params(device->GetSecureSession().Value());
     params.mMinIntervalFloorSeconds     = minInterval;
     params.mMaxIntervalCeilingSeconds   = maxInterval;
     params.mpAttributePathParamsList    = attributePathParamsList.data();
     params.mAttributePathParamsListSize = attributePathParamsList.size();
+    params.mpEventPathParamsList        = eventPathParamsList.data();
+    params.mEventPathParamsListSize     = eventPathParamsList.size();
+    params.mKeepSubscriptions           = (keepSubscriptions != JNI_FALSE);
+    params.mIsFabricFiltered            = (isFabricFiltered != JNI_FALSE);
 
     auto callback = reinterpret_cast<ReportCallback *>(callbackHandle);
 
@@ -1086,8 +1094,9 @@ JNI_METHOD(void, subscribeToPath)
     callback->mReadClient = readClient;
 }
 
-JNI_METHOD(void, readPath)
-(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList)
+JNI_METHOD(void, read)
+(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject attributePathList, jobject eventPathList,
+ jboolean isFabricFiltered)
 {
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
@@ -1103,97 +1112,19 @@ JNI_METHOD(void, readPath)
     err = ParseAttributePathList(attributePathList, attributePathParamsList);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error parsing Java attribute paths: %s", ErrorStr(err)));
 
+    std::vector<app::EventPathParams> eventPathParamsList;
+    err = ParseEventPathList(eventPathList, eventPathParamsList);
+    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error parsing Java event paths: %s", ErrorStr(err)));
+
     app::ReadPrepareParams params(device->GetSecureSession().Value());
     params.mpAttributePathParamsList    = attributePathParamsList.data();
     params.mAttributePathParamsListSize = attributePathParamsList.size();
+    params.mpEventPathParamsList        = eventPathParamsList.data();
+    params.mEventPathParamsListSize     = eventPathParamsList.size();
+
+    params.mIsFabricFiltered = (isFabricFiltered != JNI_FALSE);
 
     auto callback = reinterpret_cast<ReportCallback *>(callbackHandle);
-
-    app::ReadClient * readClient =
-        Platform::New<app::ReadClient>(app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                       callback->mBufferedReadAdapter, app::ReadClient::InteractionType::Read);
-
-    err = readClient->SendRequest(params);
-    if (err != CHIP_NO_ERROR)
-    {
-        chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback->mReportCallbackRef, ErrorStr(err),
-                                                                                  err);
-        delete readClient;
-        delete callback;
-        return;
-    }
-
-    callback->mReadClient = readClient;
-}
-
-JNI_METHOD(void, subscribeToEventPath)
-(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject eventPathList, jint minInterval,
- jint maxInterval, jboolean keepSubscriptions, jboolean isFabricFiltered)
-{
-    chip::DeviceLayer::StackLock lock;
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    if (device == nullptr)
-    {
-        ChipLogError(Controller, "No device found");
-        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, CHIP_ERROR_INCORRECT_STATE);
-    }
-
-    std::vector<app::EventPathParams> eventPathParamsList;
-    err = ParseEventPathList(eventPathList, eventPathParamsList);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error parsing Java event paths: %s", ErrorStr(err)));
-
-    app::ReadPrepareParams params(device->GetSecureSession().Value());
-    params.mMinIntervalFloorSeconds   = minInterval;
-    params.mMaxIntervalCeilingSeconds = maxInterval;
-    params.mpEventPathParamsList      = eventPathParamsList.data();
-    params.mEventPathParamsListSize   = eventPathParamsList.size();
-    params.mKeepSubscriptions         = (keepSubscriptions != JNI_FALSE);
-    params.mIsFabricFiltered          = (isFabricFiltered != JNI_FALSE);
-
-    auto callback = reinterpret_cast<ReportEventCallback *>(callbackHandle);
-
-    app::ReadClient * readClient =
-        Platform::New<app::ReadClient>(app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                       callback->mBufferedReadAdapter, app::ReadClient::InteractionType::Subscribe);
-
-    err = readClient->SendAutoResubscribeRequest(std::move(params));
-    if (err != CHIP_NO_ERROR)
-    {
-        chip::AndroidClusterExceptions::GetInstance().ReturnIllegalStateException(env, callback->mReportCallbackRef, ErrorStr(err),
-                                                                                  err);
-        delete readClient;
-        delete callback;
-        return;
-    }
-
-    callback->mReadClient = readClient;
-}
-
-JNI_METHOD(void, readEventPath)
-(JNIEnv * env, jobject self, jlong handle, jlong callbackHandle, jlong devicePtr, jobject eventPathList)
-{
-    chip::DeviceLayer::StackLock lock;
-    CHIP_ERROR err = CHIP_NO_ERROR;
-
-    DeviceProxy * device = reinterpret_cast<DeviceProxy *>(devicePtr);
-    if (device == nullptr)
-    {
-        ChipLogError(Controller, "No device found");
-        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, CHIP_ERROR_INCORRECT_STATE);
-    }
-
-    std::vector<app::EventPathParams> eventPathParamsList;
-
-    err = ParseEventPathList(eventPathList, eventPathParamsList);
-    VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Error parsing Java event paths: %s", ErrorStr(err)));
-
-    app::ReadPrepareParams params(device->GetSecureSession().Value());
-    params.mpEventPathParamsList    = eventPathParamsList.data();
-    params.mEventPathParamsListSize = eventPathParamsList.size();
-
-    auto callback = reinterpret_cast<ReportEventCallback *>(callbackHandle);
 
     app::ReadClient * readClient =
         Platform::New<app::ReadClient>(app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -460,61 +460,62 @@ public class ChipDeviceController {
       int minInterval,
       int maxInterval) {
     ReportCallbackJni jniCallback =
-        new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback);
-    subscribeToPath(
+        new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
+    subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
         attributePaths,
+        null,
         minInterval,
-        maxInterval);
+        maxInterval,
+        false,
+        false);
   }
 
-  /** Read the given attribute path. */
-  public void readPath(
-      ReportCallback callback, long devicePtr, List<ChipAttributePath> attributePaths) {
-    ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback);
-    readPath(deviceControllerPtr, jniCallback.getCallbackHandle(), devicePtr, attributePaths);
-  }
-
-  /** Subscribe to the given event path. */
+  /** Subscribe to the given event path */
   public void subscribeToEventPath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
-      ResubscriptionAttemptCallback resubscriptionAttemptCallback,
-      ReportEventCallback reportCallback,
+      ReportCallback reportCallback,
       long devicePtr,
       List<ChipEventPath> eventPaths,
       int minInterval,
       int maxInterval) {
-    subscribeToEventPath(
-        subscriptionEstablishedCallback,
-        resubscriptionAttemptCallback,
-        reportCallback,
+    ReportCallbackJni jniCallback =
+        new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
+    subscribe(
+        deviceControllerPtr,
+        jniCallback.getCallbackHandle(),
         devicePtr,
+        null,
         eventPaths,
         minInterval,
         maxInterval,
         false,
-        true);
+        false);
   }
 
-  public void subscribeToEventPath(
+  /** Subscribe to the given attribute/event path with keepSubscriptions and isFabricFiltered. */
+  public void subscribeToPath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
       ResubscriptionAttemptCallback resubscriptionAttemptCallback,
-      ReportEventCallback reportCallback,
+      ReportCallback reportCallback,
       long devicePtr,
+      List<ChipAttributePath> attributePaths,
       List<ChipEventPath> eventPaths,
       int minInterval,
       int maxInterval,
       boolean keepSubscriptions,
       boolean isFabricFiltered) {
-    ReportEventCallbackJni jniCallback =
-        new ReportEventCallbackJni(
-            subscriptionEstablishedCallback, reportCallback, resubscriptionAttemptCallback);
-    subscribeToEventPath(
+    // TODO: pass resubscriptionAttemptCallback to ReportCallbackJni since jni layer is not ready
+    // for auto-resubscribe
+    ReportCallbackJni jniCallback =
+        new ReportCallbackJni(subscriptionEstablishedCallback, reportCallback, null);
+    subscribe(
         deviceControllerPtr,
         jniCallback.getCallbackHandle(),
         devicePtr,
+        attributePaths,
         eventPaths,
         minInterval,
         maxInterval,
@@ -522,11 +523,41 @@ public class ChipDeviceController {
         isFabricFiltered);
   }
 
+  /** Read the given attribute path. */
+  public void readPath(
+      ReportCallback callback, long devicePtr, List<ChipAttributePath> attributePaths) {
+    ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
+    read(
+        deviceControllerPtr,
+        jniCallback.getCallbackHandle(),
+        devicePtr,
+        attributePaths,
+        null,
+        true);
+  }
+
   /** Read the given event path. */
   public void readEventPath(
-      ReportEventCallback callback, long devicePtr, List<ChipEventPath> eventPaths) {
-    ReportEventCallbackJni jniCallback = new ReportEventCallbackJni(null, callback, null);
-    readEventPath(deviceControllerPtr, jniCallback.getCallbackHandle(), devicePtr, eventPaths);
+      ReportCallback callback, long devicePtr, List<ChipEventPath> eventPaths) {
+    ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
+    read(deviceControllerPtr, jniCallback.getCallbackHandle(), devicePtr, null, eventPaths, true);
+  }
+
+  /** Read the given attribute/event path with isFabricFiltered flag. */
+  public void readPath(
+      ReportCallback callback,
+      long devicePtr,
+      List<ChipAttributePath> attributePaths,
+      List<ChipEventPath> eventPaths,
+      boolean isFabricFiltered) {
+    ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
+    read(
+        deviceControllerPtr,
+        jniCallback.getCallbackHandle(),
+        devicePtr,
+        attributePaths,
+        eventPaths,
+        isFabricFiltered);
   }
 
   /**
@@ -557,35 +588,24 @@ public class ChipDeviceController {
   private native PaseVerifierParams computePaseVerifier(
       long deviceControllerPtr, long devicePtr, long setupPincode, long iterations, byte[] salt);
 
-  private native void subscribeToPath(
+  private native void subscribe(
       long deviceControllerPtr,
       long callbackHandle,
       long devicePtr,
       List<ChipAttributePath> attributePaths,
-      int minInterval,
-      int maxInterval);
-
-  public native void readPath(
-      long deviceControllerPtr,
-      long callbackHandle,
-      long devicePtr,
-      List<ChipAttributePath> attributePaths);
-
-  private native void subscribeToEventPath(
-      long deviceControllerPtr,
-      long callbackHandle,
-      long devicePtr,
       List<ChipEventPath> eventPaths,
       int minInterval,
       int maxInterval,
       boolean keepSubscriptions,
       boolean isFabricFiltered);
 
-  public native void readEventPath(
+  private native void read(
       long deviceControllerPtr,
       long callbackHandle,
       long devicePtr,
-      List<ChipEventPath> eventPaths);
+      List<ChipAttributePath> attributePaths,
+      List<ChipEventPath> eventPaths,
+      boolean isFabricFiltered);
 
   private native long newDeviceController(ControllerParams params);
 

--- a/src/controller/java/src/chip/devicecontroller/ReportCallback.java
+++ b/src/controller/java/src/chip/devicecontroller/ReportCallback.java
@@ -18,11 +18,12 @@
 package chip.devicecontroller;
 
 import chip.devicecontroller.model.ChipAttributePath;
+import chip.devicecontroller.model.ChipEventPath;
 import chip.devicecontroller.model.NodeState;
 
 /** An interface for receiving read/subscribe CHIP reports. */
 public interface ReportCallback {
-  void onError(ChipAttributePath attributePath, Exception e);
+  void onError(ChipAttributePath attributePath, ChipEventPath eventPath, Exception e);
 
   void onReport(NodeState nodeState);
 

--- a/src/controller/java/src/chip/devicecontroller/ReportCallbackJni.java
+++ b/src/controller/java/src/chip/devicecontroller/ReportCallbackJni.java
@@ -22,15 +22,19 @@ import androidx.annotation.Nullable;
 /** JNI wrapper callback class for {@link ReportCallback}. */
 public class ReportCallbackJni {
   @Nullable private SubscriptionEstablishedCallback wrappedSubscriptionEstablishedCallback;
+  @Nullable private ResubscriptionAttemptCallback wrappedResubscriptionAttemptCallback;
   private ReportCallback wrappedReportCallback;
   private long callbackHandle;
 
   public ReportCallbackJni(
       @Nullable SubscriptionEstablishedCallback subscriptionEstablishedCallback,
-      ReportCallback reportCallback) {
+      ReportCallback reportCallback,
+      ResubscriptionAttemptCallback resubscriptionAttemptCallback) {
     this.wrappedSubscriptionEstablishedCallback = subscriptionEstablishedCallback;
     this.wrappedReportCallback = reportCallback;
-    this.callbackHandle = newCallback(subscriptionEstablishedCallback, reportCallback);
+    this.wrappedResubscriptionAttemptCallback = resubscriptionAttemptCallback;
+    this.callbackHandle =
+        newCallback(subscriptionEstablishedCallback, reportCallback, resubscriptionAttemptCallback);
   }
 
   long getCallbackHandle() {
@@ -39,7 +43,8 @@ public class ReportCallbackJni {
 
   private native long newCallback(
       @Nullable SubscriptionEstablishedCallback subscriptionEstablishedCallback,
-      ReportCallback wrappedCallback);
+      ReportCallback wrappedCallback,
+      @Nullable ResubscriptionAttemptCallback resubscriptionAttemptCallback);
 
   private native void deleteCallback(long callbackHandle);
 


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #18686 

#### Change overview
Add IM isFabricFiltered and keepSubscriptions flag for read/subscribe API, fix across jni, java, kotlin, android chip-tool.
Disable auto-resubscribe since controller jni is using std::vector, we cannot move the memory to readclient.
