### PR TITLE
[ColorControl] Enhanced commands should set EnhancedColorMode to 3

### DIFF
--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -1087,6 +1087,9 @@ bool ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, uint
     {
         colorHueTransitionState->initialEnhancedHue = currentHue;
         colorHueTransitionState->currentEnhancedHue = currentHue;
+        Attributes::ColorMode::Set(endpoint, CurrentHueandCurrentSaturation);
+        Attributes::EnhancedColorMode::Set(endpoint, EnhancedCurrentHueandCurrentSaturation);
+
         colorHueTransitionState->finalEnhancedHue   = hue;
     }
     else

--- a/src/app/clusters/color-control-server/color-control-server.cpp
+++ b/src/app/clusters/color-control-server/color-control-server.cpp
@@ -49,14 +49,6 @@ using namespace chip::app::Clusters::ColorControl;
  * Attributes Definition
  *********************************************************/
 
-enum EnhancedColorModeType
-{
-    CurrentHueandCurrentSaturation         = 0,
-    CurrentXandCurrentY                    = 1,
-    ColorTemperatureMireds                 = 2,
-    EnhancedCurrentHueandCurrentSaturation = 3,
-};
-
 ColorControlServer ColorControlServer::instance;
 
 /**********************************************************
@@ -184,6 +176,11 @@ void ColorControlServer::handleModeSwitch(EndpointId endpoint, uint8_t newColorM
     }
 
     Attributes::EnhancedColorMode::Set(endpoint, newColorMode);
+    if (newColorMode == ColorControlServer::ColorMode::COLOR_MODE_EHSV)
+    {
+        // Transpose COLOR_MODE_EHSV to COLOR_MODE_HSV after setting EnhancedColorMode
+        newColorMode = ColorControlServer::ColorMode::COLOR_MODE_HSV;
+    }
     Attributes::ColorMode::Set(endpoint, newColorMode);
 
     colorModeTransition = static_cast<uint8_t>((newColorMode << 4) + oldColorMode);
@@ -796,7 +793,14 @@ bool ColorControlServer::moveHueCommand(EndpointId endpoint, uint8_t moveMode, u
     }
 
     // Handle color mode transition, if necessary.
-    handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_HSV);
+    if (isEnhanced)
+    {
+        handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_EHSV);
+    }
+    else
+    {
+        handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_HSV);
+    }
 
     // now, kick off the state machine.
     initHueSat(endpoint, colorHueTransitionState, colorSaturationTransitionState);
@@ -963,7 +967,14 @@ bool ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, uin
     stopAllColorTransitions(endpoint);
 
     // Handle color mode transition, if necessary.
-    handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_HSV);
+    if (isEnhanced)
+    {
+        handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_EHSV);
+    }
+    else
+    {
+        handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_HSV);
+    }
 
     // now, kick off the state machine.
     initHueSat(endpoint, colorHueTransitionState, colorSaturationTransitionState);
@@ -973,8 +984,6 @@ bool ColorControlServer::moveToHueCommand(EndpointId endpoint, uint16_t hue, uin
     {
         Attributes::EnhancedCurrentHue::Get(endpoint, &(colorHueTransitionState->initialEnhancedHue));
         Attributes::EnhancedCurrentHue::Get(endpoint, &(colorHueTransitionState->currentEnhancedHue));
-        Attributes::ColorMode::Set(endpoint, CurrentHueandCurrentSaturation);
-        Attributes::EnhancedColorMode::Set(endpoint, EnhancedCurrentHueandCurrentSaturation);
 
         colorHueTransitionState->finalEnhancedHue = hue;
     }
@@ -1077,7 +1086,14 @@ bool ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, uint
     stopAllColorTransitions(endpoint);
 
     // Handle color mode transition, if necessary.
-    handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_HSV);
+    if (isEnhanced)
+    {
+        handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_EHSV);
+    }
+    else
+    {
+        handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_HSV);
+    }
 
     // now, kick off the state machine.
     initHueSat(endpoint, colorHueTransitionState, colorSaturationTransitionState);
@@ -1087,9 +1103,6 @@ bool ColorControlServer::moveToHueAndSaturationCommand(EndpointId endpoint, uint
     {
         colorHueTransitionState->initialEnhancedHue = currentHue;
         colorHueTransitionState->currentEnhancedHue = currentHue;
-        Attributes::ColorMode::Set(endpoint, CurrentHueandCurrentSaturation);
-        Attributes::EnhancedColorMode::Set(endpoint, EnhancedCurrentHueandCurrentSaturation);
-
         colorHueTransitionState->finalEnhancedHue   = hue;
     }
     else
@@ -1170,7 +1183,14 @@ bool ColorControlServer::stepHueCommand(EndpointId endpoint, uint8_t stepMode, u
     }
 
     // Handle color mode transition, if necessary.
-    handleModeSwitch(endpoint, COLOR_MODE_HSV);
+    if (isEnhanced)
+    {
+        handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_EHSV);
+    }
+    else
+    {
+        handleModeSwitch(endpoint, ColorControlServer::ColorMode::COLOR_MODE_HSV);
+    }
 
     // now, kick off the state machine.
     initHueSat(endpoint, colorHueTransitionState, colorSaturationTransitionState);

--- a/src/app/clusters/color-control-server/color-control-server.h
+++ b/src/app/clusters/color-control-server/color-control-server.h
@@ -91,7 +91,8 @@ public:
     {
         COLOR_MODE_HSV         = 0x00,
         COLOR_MODE_CIE_XY      = 0x01,
-        COLOR_MODE_TEMPERATURE = 0x02
+        COLOR_MODE_TEMPERATURE = 0x02,
+        COLOR_MODE_EHSV        = 0x03
     };
 
     enum Conversion


### PR DESCRIPTION
#### Issue Being Resolved
- From spec, enhancedcolormode should be set to 3 for enhanced commands
- Currently not set properly
- Fixes #22617

#### Change overview
- Add new entry `COLOR_MODE_EHSV = 0x03` in ColorMode enum
- Call `handleModeSwitch(endpoint, COLOR_MODE_EHSV)` for all commands that are enhanced
- `handleModeSwitch` will set EnhancedColorMode to 3 if command is enhanced and set ColorMode to 0

#### Testing
- Tested with Ameba platform
- ./chip-tool colorcontrol enhanced-move-to-hue-and-saturation  16000 80 200 0 0 1 1
- ./chip-tool colorcontrol read enhanced-color-mode 1 1
- enhanced-color-mode should be 3
