### PR TITLE
Cherrypick: Platform fixes for CC13x2_26x2 (#22502)

### DIFF
--- a/src/platform/cc13x2_26x2/BLEManagerImpl.h
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.h
@@ -327,6 +327,7 @@ private:
     static void advCallback(uint32_t event, void * pBuf, uintptr_t arg);
     static void ClockHandler(uintptr_t arg);
     static void AdvTimeoutHandler(uintptr_t arg);
+    static void FastAdvTimeoutHandler(uintptr_t arg);
     static void CHIPoBLEProfile_charValueChangeCB(uint8_t paramId, uint16_t len, uint16_t connHandle);
     static void PasscodeCb(uint8_t * pDeviceAddr, uint16_t connHandle, uint8_t uiInputs, uint8_t uiOutputs, uint32_t numComparison);
     static void PairStateCb(uint16_t connHandle, uint8_t state, uint8_t status);

--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.cpp
@@ -68,6 +68,10 @@ const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_Spake2pSalt          
                                                                              .itemID   = 0x000b } };
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_Spake2pVerifier       = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,
                                                                                  .itemID   = 0x000c } };
+const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_BootCount             = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,
+                                                                           .itemID   = 0x000d } };
+const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_TotalOperationalHours = { { .systemID = kCC13X2_26X2ChipFactory_Sysid,
+                                                                                       .itemID   = 0x000f } };
 
 // Keys stored in the Chip-config namespace
 const CC13X2_26X2Config::Key CC13X2_26X2Config::kConfigKey_ServiceConfig      = { { .systemID = kCC13X2_26X2ChipConfig_Sysid,

--- a/src/platform/cc13x2_26x2/CC13X2_26X2Config.h
+++ b/src/platform/cc13x2_26x2/CC13X2_26X2Config.h
@@ -68,6 +68,8 @@ public:
     static const Key kConfigKey_Spake2pIterationCount;
     static const Key kConfigKey_Spake2pSalt;
     static const Key kConfigKey_Spake2pVerifier;
+    static const Key kConfigKey_BootCount;
+    static const Key kConfigKey_TotalOperationalHours;
 
     static CHIP_ERROR Init(void);
 

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.cpp
@@ -66,7 +66,10 @@ CHIP_ERROR ConfigurationManagerImpl::Init()
 
     // Initialize the generic implementation base class.
     err = Internal::GenericConfigurationManagerImpl<CC13X2_26X2Config>::Init();
+    SuccessOrExit(err);
 
+    IncreaseBootCount();
+exit:
     return err;
 }
 
@@ -79,6 +82,46 @@ bool ConfigurationManagerImpl::CanFactoryReset()
 void ConfigurationManagerImpl::InitiateFactoryReset()
 {
     PlatformMgr().ScheduleWork(DoFactoryReset);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetRebootCount(uint32_t & rebootCount)
+{
+    return ReadConfigValue(CC13X2_26X2Config::kConfigKey_BootCount, rebootCount);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::IncreaseBootCount(void)
+{
+    CHIP_ERROR ret;
+    uint32_t bootCount = 0;
+
+    ret = ReadConfigValue(CC13X2_26X2Config::kConfigKey_BootCount, bootCount);
+
+    if (CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND == ret || CHIP_NO_ERROR == ret)
+    {
+        ret = WriteConfigValue(CC13X2_26X2Config::kConfigKey_BootCount, bootCount + 1);
+    }
+
+    return ret;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetTotalOperationalHours(uint32_t & totalOperationalHours)
+{
+    CHIP_ERROR ret;
+
+    ret = ReadConfigValue(CC13X2_26X2Config::kConfigKey_TotalOperationalHours, totalOperationalHours);
+
+    if (CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND == ret)
+    {
+        totalOperationalHours = 0;
+        return CHIP_NO_ERROR;
+    }
+
+    return ret;
+}
+
+CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOperationalHours)
+{
+    return WriteConfigValue(CC13X2_26X2Config::kConfigKey_TotalOperationalHours, totalOperationalHours);
 }
 
 CHIP_ERROR ConfigurationManagerImpl::ReadPersistedStorageValue(::chip::Platform::PersistedStorage::Key key, uint32_t & value)

--- a/src/platform/cc13x2_26x2/ConfigurationManagerImpl.h
+++ b/src/platform/cc13x2_26x2/ConfigurationManagerImpl.h
@@ -39,6 +39,11 @@ public:
     // This returns an instance of this class.
     static ConfigurationManagerImpl & GetDefaultInstance();
 
+    CHIP_ERROR GetRebootCount(uint32_t & rebootCount);
+    CHIP_ERROR IncreaseBootCount(void);
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours);
+    CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours);
+
 private:
     // ===== Members that implement the ConfigurationManager public interface.
 

--- a/src/platform/cc13x2_26x2/DiagnosticDataProviderImpl.h
+++ b/src/platform/cc13x2_26x2/DiagnosticDataProviderImpl.h
@@ -35,11 +35,19 @@ class DiagnosticDataProviderImpl : public DiagnosticDataProvider
 public:
     static DiagnosticDataProviderImpl & GetDefaultInstance();
 
-    // ===== Methods that implement the PlatformManager abstract interface.
+    CHIP_ERROR GetRebootCount(uint16_t & rebootCount) override;
+    CHIP_ERROR GetBootReason(BootReasonType & bootReason) override;
+    CHIP_ERROR GetUpTime(uint64_t & upTime) override;
+    CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
     CHIP_ERROR GetCurrentHeapFree(uint64_t & currentHeapFree) override;
     CHIP_ERROR GetCurrentHeapUsed(uint64_t & currentHeapUsed) override;
     CHIP_ERROR GetThreadMetrics(ThreadMetrics ** threadMetricsOut) override;
     void ReleaseThreadMetrics(ThreadMetrics * threadMetrics) override;
+    CHIP_ERROR GetActiveHardwareFaults(GeneralFaults<kMaxHardwareFaults> & hardwareFaults) override;
+    CHIP_ERROR GetActiveRadioFaults(GeneralFaults<kMaxRadioFaults> & radioFaults) override;
+    CHIP_ERROR GetActiveNetworkFaults(GeneralFaults<kMaxNetworkFaults> & networkFaults) override;
+    CHIP_ERROR GetNetworkInterfaces(NetworkInterface ** netifpp) override;
+    void ReleaseNetworkInterfaces(NetworkInterface * netifp) override;
 };
 
 /**

--- a/src/platform/cc13x2_26x2/OTAImageProcessorImpl.h
+++ b/src/platform/cc13x2_26x2/OTAImageProcessorImpl.h
@@ -36,7 +36,7 @@ public:
     CHIP_ERROR Abort() override;
     CHIP_ERROR ProcessBlock(ByteSpan & block) override;
     bool IsFirstImageRun() override;
-    CHIP_ERROR ConfirmCurrentImage() override { return CHIP_NO_ERROR; }
+    CHIP_ERROR ConfirmCurrentImage() override;
 
     void SetOTADownloader(OTADownloader * downloader) { mDownloader = downloader; }
 

--- a/src/platform/cc13x2_26x2/PlatformManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/PlatformManagerImpl.cpp
@@ -146,5 +146,30 @@ exit:
     return err;
 }
 
+void PlatformManagerImpl::_Shutdown()
+{
+    uint64_t upTime = 0;
+
+    if (GetDiagnosticDataProvider().GetUpTime(upTime) == CHIP_NO_ERROR)
+    {
+        uint32_t totalOperationalHours = 0;
+
+        if (ConfigurationMgr().GetTotalOperationalHours(totalOperationalHours) == CHIP_NO_ERROR)
+        {
+            ConfigurationMgr().StoreTotalOperationalHours(totalOperationalHours + static_cast<uint32_t>(upTime / 3600));
+        }
+        else
+        {
+            ChipLogError(DeviceLayer, "Failed to get total operational hours of the Node");
+        }
+    }
+    else
+    {
+        ChipLogError(DeviceLayer, "Failed to get current uptime since the Node’s last reboot");
+    }
+
+    Internal::GenericPlatformManagerImpl_FreeRTOS<PlatformManagerImpl>::_Shutdown();
+}
+
 } // namespace DeviceLayer
 } // namespace chip

--- a/src/platform/cc13x2_26x2/PlatformManagerImpl.h
+++ b/src/platform/cc13x2_26x2/PlatformManagerImpl.h
@@ -47,18 +47,21 @@ class PlatformManagerImpl final : public PlatformManager, public Internal::Gener
 public:
     // ===== Platform-specific members that may be accessed directly by the application.
 
-    /* none so far */
+    System::Clock::Timestamp GetStartTime() { return mStartTime; }
 
 private:
     // ===== Methods that implement the PlatformManager abstract interface.
 
     CHIP_ERROR _InitChipStack(void);
+    void _Shutdown(void);
 
     // ===== Members for internal use by the following friends.
 
     friend PlatformManager & PlatformMgr(void);
     friend PlatformManagerImpl & PlatformMgrImpl(void);
     friend class Internal::BLEManagerImpl;
+
+    System::Clock::Timestamp mStartTime = System::Clock::kZero;
 
     static PlatformManagerImpl sInstance;
 

--- a/src/platform/cc13x2_26x2/ThreadStackManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/ThreadStackManagerImpl.cpp
@@ -158,6 +158,16 @@ void ThreadStackManagerImpl::_ProcMessage(otInstance * aInstance)
     }
 }
 
+void ThreadStackManagerImpl::GetExtAddress(otExtAddress & aExtAddr)
+{
+    const otExtAddress * extAddr;
+    LockThreadStack();
+    extAddr = otLinkGetExtendedAddress(OTInstance());
+    UnlockThreadStack();
+
+    memcpy(aExtAddr.m8, extAddr->m8, OT_EXT_ADDRESS_SIZE);
+}
+
 } // namespace DeviceLayer
 } // namespace chip
 

--- a/src/platform/cc13x2_26x2/ThreadStackManagerImpl.h
+++ b/src/platform/cc13x2_26x2/ThreadStackManagerImpl.h
@@ -95,6 +95,7 @@ public:
     CHIP_ERROR InitThreadStack(otInstance * otInst);
     void _SendProcMessage(procQueueMsg & procMsg);
     void _ProcMessage(otInstance * aInstance);
+    void GetExtAddress(otExtAddress & aExtAddr);
 
 private:
     // ===== Methods that implement the ThreadStackManager abstract interface.

--- a/src/platform/cc13x2_26x2/crypto/aes_alt.c
+++ b/src/platform/cc13x2_26x2/crypto/aes_alt.c
@@ -25,7 +25,6 @@
 
 #include "ti_drivers_config.h"
 
-#include <ti/devices/DeviceFamily.h>
 #include <ti/drivers/AESECB.h>
 #include <ti/drivers/cryptoutils/cryptokey/CryptoKeyPlaintext.h>
 


### PR DESCRIPTION
* Add timer for fast advertisment

Issue found in SVE#2 for TC-DD-2.1.

* add reboot reason

Added boot count and reboot reason to the configuration manager. Found in SVE#2 TC-DGGEN-2.1.

* fix incorrect log

* update interface total size

Add the total image size to the mParams for OTA to allow for download tracking. Found in SVE#2 TC-SU-4.1.

* clang-format

* move reboot reason

Implement the correct GetRebootReason.

* update to use only one timer

* Restyled by clang-format

* add additional diagnostic functions

* Restyled by clang-format

Co-authored-by: Restyled.io <commits@restyled.io>

#### Issue Being Resolved
* Fixes #12345 (exactly like this, so this PR is associated with an issue)

#### Change overview
What's in this PR
