### PR TITLE
[darwin] Update DnssdHostNameRegistrar to use the network framework i…

### DIFF
--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -32,3 +32,26 @@ leak:[CHIPToolPersistentStorageDelegate storageDataForKey:]
 
 # TODO: https://github.com/project-chip/connectedhomeip/issues/22333
 leak:[MTRBaseCluster* subscribeAttribute*WithParams:subscriptionEstablished:reportHandler:]
+
+#TODO: Figure out why nw_path_monitor_create leaks. The leak can be reproduce using:
+# -- testFile.cpp
+#
+##include <Network/Network.h>
+#
+#int main(int argc, char **argv) {
+#  auto monitor = nw_path_monitor_create();
+#  nw_release(monitor);
+#  return 0;
+#}
+#
+# -- testFile.mm (with -fobj-arc)
+##include <Network/Network.h>
+#
+#int main(int argc, char **argv) {
+#  __auto_type monitor = nw_path_monitor_create();
+#  return 0;
+#}
+leak:nw_path_monitor_create
+
+# TODO: See the previous comment about nw_path_monitor_create, since it also applies to nw_path_monitor_start
+leak:nw_path_monitor_start

--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -33,7 +33,7 @@ leak:[CHIPToolPersistentStorageDelegate storageDataForKey:]
 # TODO: https://github.com/project-chip/connectedhomeip/issues/22333
 leak:[MTRBaseCluster* subscribeAttribute*WithParams:subscriptionEstablished:reportHandler:]
 
-#TODO: Figure out why nw_path_monitor_create leaks. The leak can be reproduce using:
+#TODO: Figure out why nw_path_monitor_create leaks. The leak can be reproduced using:
 # -- testFile.cpp
 #
 ##include <Network/Network.h>

--- a/src/platform/Darwin/BUILD.gn
+++ b/src/platform/Darwin/BUILD.gn
@@ -24,6 +24,7 @@ config("darwin_config") {
     "CoreFoundation.framework",
     "CoreBluetooth.framework",
     "Foundation.framework",
+    "Network.framework",
   ]
 
   if (current_os == "mac") {

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -272,23 +272,10 @@ void RegisterContext::DispatchSuccess()
 {
     std::string typeWithoutSubTypes = GetFullTypeWithoutSubTypes(mType);
     callback(context, typeWithoutSubTypes.c_str(), mInstanceName.c_str(), CHIP_NO_ERROR);
-}
 
-RegisterRecordContext::RegisterRecordContext(RegisterContext * context)
-{
-    type             = ContextType::RegisterRecord;
-    mRegisterContext = context;
-}
-
-void RegisterRecordContext::DispatchFailure(DNSServiceErrorType err)
-{
-    mRegisterContext->Finalize(err);
-    MdnsContexts::GetInstance().Remove(this);
-}
-
-void RegisterRecordContext::DispatchSuccess()
-{
-    mRegisterContext->Finalize();
+    // Once a service has been properly published it is normally unreachable because the hostname has not been yet
+    // registered against the dns daemon. Register the records mapping the hostname to our IP.
+    mHostNameRegistrar.Register();
 }
 
 BrowseContext::BrowseContext(void * cbContext, DnssdBrowseCallback cb, DnssdServiceProtocol cbContextProtocol)

--- a/src/platform/Darwin/DnssdContexts.cpp
+++ b/src/platform/Darwin/DnssdContexts.cpp
@@ -273,7 +273,7 @@ void RegisterContext::DispatchSuccess()
     std::string typeWithoutSubTypes = GetFullTypeWithoutSubTypes(mType);
     callback(context, typeWithoutSubTypes.c_str(), mInstanceName.c_str(), CHIP_NO_ERROR);
 
-    // Once a service has been properly published it is normally unreachable because the hostname has not been yet
+    // Once a service has been properly published it is normally unreachable because the hostname has not yet been
     // registered against the dns daemon. Register the records mapping the hostname to our IP.
     mHostNameRegistrar.Register();
 }

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -32,7 +32,6 @@ namespace Dnssd {
 enum class ContextType
 {
     Register,
-    RegisterRecord,
     Browse,
     Resolve,
 };
@@ -99,23 +98,12 @@ struct RegisterContext : public GenericContext
     HostNameRegistrar mHostNameRegistrar;
 
     RegisterContext(const char * sType, const char * instanceName, DnssdPublishCallback cb, void * cbContext);
-    virtual ~RegisterContext() {}
+    virtual ~RegisterContext() { mHostNameRegistrar.Unregister(); }
 
     void DispatchFailure(DNSServiceErrorType err) override;
     void DispatchSuccess() override;
 
     bool matches(const char * sType) { return mType.compare(sType) == 0; }
-};
-
-struct RegisterRecordContext : public GenericContext
-{
-    RegisterContext * mRegisterContext;
-
-    RegisterRecordContext(RegisterContext * context);
-    virtual ~RegisterRecordContext(){};
-
-    void DispatchFailure(DNSServiceErrorType err) override;
-    void DispatchSuccess() override;
 };
 
 struct BrowseContext : public GenericContext


### PR DESCRIPTION
…n order to react to interface changes

#### Issue Being Resolved
* Fixes #22011

#### Change overview
* This PR updates darwin dnssd code to monitor interface changes and register the device hostname against the dns daemon if needed.
* Add a lot of logging for the interface monitoring in order to make it easier to debug what is happening
* The logic behind registering a service has changed a little bit. Now it is considered a success to publish the service, even if the dns hostname has not been registered yet. This is because the interface may change and there is no way with the current API to tell the system if something goes wrong (like all the interfaces are down...).
