### PR TITLE
Address API review issues in MTRDeviceController.

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/clusters/ModelCommandBridge.mm
@@ -25,31 +25,15 @@ using namespace ::chip;
 
 CHIP_ERROR ModelCommand::RunCommand()
 {
-    dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip-tool.command", DISPATCH_QUEUE_SERIAL);
-
     MTRDeviceController * commissioner = CurrentCommissioner();
     ChipLogProgress(chipTool, "Sending command to node 0x" ChipLogFormatX64, ChipLogValueX64(mNodeId));
-    [commissioner getBaseDevice:mNodeId
-                          queue:callbackQueue
-                     completion:^(MTRBaseDevice * _Nullable device, NSError * _Nullable error) {
-                         if (error != nil) {
-                             SetCommandExitStatus(error, "Error getting connected device");
-                             return;
-                         }
+    auto * device = [MTRBaseDevice deviceWithNodeID:@(mNodeId) controller:commissioner];
+    CHIP_ERROR err = SendCommand(device, mEndPointId);
 
-                         CHIP_ERROR err;
-                         if (device == nil) {
-                             err = CHIP_ERROR_INTERNAL;
-                         } else {
-                             err = SendCommand(device, mEndPointId);
-                         }
-
-                         if (err != CHIP_NO_ERROR) {
-                             ChipLogError(chipTool, "Error: %s", chip::ErrorStr(err));
-                             SetCommandExitStatus(err);
-                             return;
-                         }
-                     }];
+    if (err != CHIP_NO_ERROR) {
+        ChipLogError(chipTool, "Error: %s", chip::ErrorStr(err));
+        return err;
+    }
     return CHIP_NO_ERROR;
 }
 

--- a/examples/darwin-framework-tool/commands/pairing/Commands.h
+++ b/examples/darwin-framework-tool/commands/pairing/Commands.h
@@ -41,12 +41,6 @@ public:
     PairCodeThread() : PairingCommandBridge("code-thread", PairingMode::Code, PairingNetworkType::Thread) {}
 };
 
-class PairWithIPAddress : public PairingCommandBridge
-{
-public:
-    PairWithIPAddress() : PairingCommandBridge("ethernet", PairingMode::Ethernet, PairingNetworkType::Ethernet) {}
-};
-
 class PairBleWiFi : public PairingCommandBridge
 {
 public:
@@ -70,10 +64,13 @@ void registerCommandsPairing(Commands & commands)
     const char * clusterName = "Pairing";
 
     commands_list clusterCommands = {
-        make_unique<PairCode>(),     make_unique<PairWithIPAddress>(),
-        make_unique<PairCodeWifi>(), make_unique<PairCodeThread>(),
-        make_unique<PairBleWiFi>(),  make_unique<PairBleThread>(),
-        make_unique<Unpair>(),       make_unique<OpenCommissioningWindowCommand>(),
+        make_unique<PairCode>(),
+        make_unique<PairCodeWifi>(),
+        make_unique<PairCodeThread>(),
+        make_unique<PairBleWiFi>(),
+        make_unique<PairBleThread>(),
+        make_unique<Unpair>(),
+        make_unique<OpenCommissioningWindowCommand>(),
     };
 
     commands.Register(clusterName, clusterCommands);

--- a/examples/darwin-framework-tool/commands/pairing/OpenCommissioningWindowCommand.mm
+++ b/examples/darwin-framework-tool/commands/pairing/OpenCommissioningWindowCommand.mm
@@ -25,7 +25,7 @@ CHIP_ERROR OpenCommissioningWindowCommand::RunCommand()
 {
     mWorkQueue = dispatch_queue_create("com.chip.open_commissioning_window", DISPATCH_QUEUE_SERIAL);
     auto * controller = CurrentCommissioner();
-    auto * device = [[MTRBaseDevice alloc] initWithNodeID:@(mNodeId) controller:controller];
+    auto * device = [MTRBaseDevice deviceWithNodeID:@(mNodeId) controller:controller];
 
     auto * self = this;
     if (mCommissioningWindowOption == 0) {

--- a/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/pairing/PairingCommandBridge.h
@@ -24,7 +24,6 @@ enum class PairingMode
 {
     None,
     Code,
-    Ethernet,
     Ble,
 };
 
@@ -64,12 +63,6 @@ public:
         case PairingMode::Code:
             AddArgument("payload", &mOnboardingPayload);
             break;
-        case PairingMode::Ethernet:
-            AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
-            AddArgument("discriminator", 0, 4096, &mDiscriminator);
-            AddArgument("device-remote-ip", &ipAddress);
-            AddArgument("device-remote-port", 0, UINT16_MAX, &mRemotePort);
-            break;
         case PairingMode::Ble:
             AddArgument("setup-pin-code", 0, 134217727, &mSetupPINCode);
             AddArgument("discriminator", 0, 4096, &mDiscriminator);
@@ -84,7 +77,6 @@ public:
 private:
     void PairWithCode(NSError * __autoreleasing * error);
     void PairWithPayload(NSError * __autoreleasing * error);
-    void PairWithIPAddress(NSError * __autoreleasing * error);
     void Unpair();
     void SetUpPairingDelegate();
 
@@ -94,9 +86,7 @@ private:
     chip::ByteSpan mSSID;
     chip::ByteSpan mPassword;
     chip::NodeId mNodeId;
-    uint16_t mRemotePort;
     uint16_t mDiscriminator;
     uint32_t mSetupPINCode;
     char * mOnboardingPayload;
-    char * ipAddress;
 };

--- a/examples/darwin-framework-tool/commands/pairing/PairingDelegateBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/PairingDelegateBridge.mm
@@ -54,7 +54,7 @@
     ChipLogProgress(chipTool, "Pairing Success");
     ChipLogProgress(chipTool, "PASE establishment successful");
     NSError * commissionError;
-    [_commissioner commissionDevice:_deviceID commissioningParams:_params error:&commissionError];
+    [_commissioner commissionNodeWithID:@(_deviceID) commissioningParams:_params error:&commissionError];
     if (commissionError != nil) {
         _commandBridge->SetCommandExitStatus(commissionError);
         return;

--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -168,7 +168,9 @@ public:
         }
 
         mConnectedDevices[identity] = [MTRBaseDevice deviceWithNodeID:@(value.nodeId) controller:controller];
-        NextTest();
+        dispatch_async(mCallbackQueue, ^{
+            NextTest();
+        });
         return CHIP_NO_ERROR;
     }
 

--- a/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/tests/TestCommandBridge.h
@@ -156,9 +156,10 @@ public:
 
         SetIdentity(identity);
 
-        // Invalidate our existing CASE session; otherwise getConnectedDevice
-        // will just hand it right back to us without establishing a new CASE
-        // session when a reboot is done on the server.
+        // Invalidate our existing CASE session; otherwise trying to work with
+        // our device will just reuse it without establishing a new CASE
+        // session when a reboot is done on the server, and then our next
+        // interaction will time out.
         if (value.expireExistingSession.ValueOr(true)) {
             if (GetDevice(identity) != nil) {
                 [GetDevice(identity) invalidateCASESession];
@@ -166,17 +167,8 @@ public:
             }
         }
 
-        [controller getBaseDevice:value.nodeId
-                            queue:mCallbackQueue
-                       completion:^(MTRBaseDevice * _Nullable device, NSError * _Nullable error) {
-                           if (error != nil) {
-                               SetCommandExitStatus(error);
-                               return;
-                           }
-
-                           mConnectedDevices[identity] = device;
-                           NextTest();
-                       }];
+        mConnectedDevices[identity] = [MTRBaseDevice deviceWithNodeID:@(value.nodeId) controller:controller];
+        NextTest();
         return CHIP_NO_ERROR;
     }
 
@@ -197,7 +189,11 @@ public:
                                                          length:value.payload.size()
                                                        encoding:NSUTF8StringEncoding];
         NSError * err;
-        BOOL ok = [controller pairDevice:value.nodeId onboardingPayload:payloadStr error:&err];
+        auto * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:payloadStr error:&err];
+        if (err != nil) {
+            return MTRErrorToCHIPErrorCode(err);
+        }
+        BOOL ok = [controller setupCommissioningSessionWithPayload:payload newNodeID:@(value.nodeId) error:&err];
         if (ok == YES) {
             return CHIP_NO_ERROR;
         }
@@ -234,7 +230,9 @@ public:
         VerifyOrReturn(commissioner != nil, Exit("No current commissioner"));
 
         NSError * commissionError = nil;
-        [commissioner commissionDevice:nodeId commissioningParams:[[MTRCommissioningParameters alloc] init] error:&commissionError];
+        [commissioner commissionNodeWithID:@(nodeId)
+                       commissioningParams:[[MTRCommissioningParameters alloc] init]
+                                     error:&commissionError];
         CHIP_ERROR err = MTRErrorToCHIPErrorCode(commissionError);
         if (err != CHIP_NO_ERROR) {
             Exit("Failed to kick off commissioning", err);

--- a/scripts/tests/chiptest/lsan-mac-suppressions.txt
+++ b/scripts/tests/chiptest/lsan-mac-suppressions.txt
@@ -19,16 +19,5 @@ leak:drbg_bytes
 # TODO: OpenSSL ERR_get_state seems to leak.
 leak:ERR_get_state
 
-# TODO: BLE initialization allocates some UUIDs and strings that seem to leak.
-leak:[BleConnection initWithDiscriminator:]
-leak:[CBXpcConnection initWithDelegate:queue:options:sessionType:]
-
-# TODO: Figure out how we are managing to leak NSData while using ARC!
-leak:[CHIPToolKeypair signMessageECDSA_RAW:]
-
-# TODO: Figure out how we are managing to leak NSData while using ARC, though
-# this may just be a leak deep inside the CFPreferences stuff somewhere.
-leak:[CHIPToolPersistentStorageDelegate storageDataForKey:]
-
 # TODO: https://github.com/project-chip/connectedhomeip/issues/22333
 leak:[MTRBaseCluster* subscribeAttribute*WithParams:subscriptionEstablished:reportHandler:]

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.h
@@ -25,6 +25,8 @@ extern NSString * const kNetworkSSIDDefaultsKey;
 extern NSString * const kNetworkPasswordDefaultsKey;
 extern NSString * const kFabricIdKey;
 
+typedef void (^DeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NSError * _Nullable error);
+
 MTRDeviceController * _Nullable InitializeMTR(void);
 MTRDeviceController * _Nullable MTRRestartController(MTRDeviceController * controller);
 id _Nullable MTRGetDomainValueForKey(NSString * domain, NSString * key);
@@ -36,8 +38,8 @@ uint64_t MTRGetLastPairedDeviceId(void);
 void MTRSetNextAvailableDeviceID(uint64_t id);
 void MTRSetDevicePaired(uint64_t id, BOOL paired);
 BOOL MTRIsDevicePaired(uint64_t id);
-BOOL MTRGetConnectedDevice(MTRDeviceConnectionCallback completionHandler);
-BOOL MTRGetConnectedDeviceWithID(uint64_t deviceId, MTRDeviceConnectionCallback completionHandler);
+BOOL MTRGetConnectedDevice(DeviceConnectionCallback completionHandler);
+BOOL MTRGetConnectedDeviceWithID(uint64_t deviceId, DeviceConnectionCallback completionHandler);
 void MTRUnpairDeviceWithID(uint64_t deviceId);
 MTRBaseDevice * _Nullable MTRGetDeviceBeingCommissioned(void);
 

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -126,12 +126,12 @@ extern NSString * const MTRArrayValueType;
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * Initialize the device object with the given node id and controller.  This
+ * Create a device object with the given node id and controller.  This
  * will always succeed, even if there is no such node id on the controller's
  * fabric, but attempts to actually use the MTRBaseDevice will fail
  * (asynchronously) in that case.
  */
-- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
++ (instancetype)deviceWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
 
 /**
  * Subscribe to receive attribute reports for everything (all endpoints, all

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -251,6 +251,13 @@ static void CauseReadClientFailure(uint64_t deviceId, dispatch_queue_t queue, vo
     return self;
 }
 
++ (instancetype)deviceWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller
+{
+    // Indirect through the controller to give it a chance to create an
+    // MTRBaseDeviceOverXPC instead of just an MTRBaseDevice.
+    return [controller baseDeviceForNodeID:nodeID];
+}
+
 - (chip::DeviceProxy * _Nullable)paseDevice
 {
     return _cppPASEDevice;

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -59,6 +59,14 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
+/**
+ * Initialize the device object with the given node id and controller.  This
+ * will always succeed, even if there is no such node id on the controller's
+ * fabric, but attempts to actually use the MTRBaseDevice will fail
+ * (asynchronously) in that case.
+ */
+- (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
+
 @end
 
 @interface MTRAttributePath ()

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.m
@@ -123,10 +123,7 @@ static void SetupXPCQueue(void)
 
 - (MTRBaseDevice *)baseDeviceForNodeID:(NSNumber *)nodeID
 {
-    return [[MTRDeviceOverXPC alloc] initWithControllerID:self.controllerID
-                                               controller:self
-                                                 deviceID:nodeID
-                                            xpcConnection:self.xpcConnection];
+    return [[MTRDeviceOverXPC alloc] initWithControllerOverXPC:self deviceID:nodeID xpcConnection:self.xpcConnection];
 }
 
 - (instancetype)initWithControllerID:(id)controllerID

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.m
@@ -46,65 +46,54 @@ static void SetupXPCQueue(void)
                                                        connectBlock:xpcConnectBlock];
 }
 
-- (BOOL)pairDevice:(uint64_t)deviceID
-     discriminator:(uint16_t)discriminator
-      setupPINCode:(uint32_t)setupPINCode
-             error:(NSError * __autoreleasing *)error
+- (BOOL)setupCommissioningSessionWithPayload:(MTRSetupPayload *)payload
+                                   newNodeID:(NSNumber *)newNodeID
+                                       error:(NSError * __autoreleasing *)error
 {
-    MTR_LOG_ERROR("MTRDevice doesn't support pairDevice over XPC");
+    MTR_LOG_ERROR("MTRDeviceController doesn't support setupCommissioningSessionWithPayload over XPC");
+    if (error != nil) {
+        *error = [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil];
+    }
     return NO;
 }
 
-- (BOOL)pairDevice:(uint64_t)deviceID
-           address:(NSString *)address
-              port:(uint16_t)port
-     discriminator:(uint16_t)discriminator
-      setupPINCode:(uint32_t)setupPINCode
-             error:(NSError * __autoreleasing *)error
+- (BOOL)commissionNodeWithID:(NSNumber *)nodeID
+         commissioningParams:(MTRCommissioningParameters *)commissioningParams
+                       error:(NSError * __autoreleasing *)error;
 {
-    MTR_LOG_ERROR("MTRDevice doesn't support pairDevice over XPC");
+    MTR_LOG_ERROR("MTRDeviceController doesn't support commissionNodeWithID over XPC");
+    if (error != nil) {
+        *error = [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil];
+    }
     return NO;
 }
 
-- (BOOL)pairDevice:(uint64_t)deviceID onboardingPayload:(NSString *)onboardingPayload error:(NSError * __autoreleasing *)error
+- (BOOL)cancelCommissioningForNodeID:(NSNumber *)nodeID error:(NSError * __autoreleasing *)error
 {
-    MTR_LOG_ERROR("MTRDevice doesn't support pairDevice over XPC");
+    MTR_LOG_ERROR("MTRDeviceController doesn't support cancelCommissioningForNodeID over XPC");
+    if (error != nil) {
+        *error = [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil];
+    }
     return NO;
 }
 
-- (BOOL)commissionDevice:(uint64_t)deviceID
-     commissioningParams:(MTRCommissioningParameters *)commissioningParams
-                   error:(NSError * __autoreleasing *)error
+- (nullable MTRBaseDevice *)deviceBeingCommissionedWithNodeID:(NSNumber *)nodeID error:(NSError * __autoreleasing *)error
 {
-    MTR_LOG_ERROR("MTRDevice doesn't support pairDevice over XPC");
-    return NO;
-}
-
-- (void)setListenPort:(uint16_t)port
-{
-    MTR_LOG_ERROR("MTRDevice doesn't support setListenPort over XPC");
-}
-
-- (BOOL)stopDevicePairing:(uint64_t)deviceID error:(NSError * __autoreleasing *)error
-{
-    MTR_LOG_ERROR("MTRDevice doesn't support stopDevicePairing over XPC");
-    return NO;
-}
-
-- (nullable MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceID error:(NSError * __autoreleasing *)error
-{
-    MTR_LOG_ERROR("MTRDevice doesn't support getDeviceBeingCommissioned over XPC");
+    MTR_LOG_ERROR("MTRDeviceController doesn't support deviceBeingCommissionedWithNodeID over XPC");
+    if (error != nil) {
+        *error = [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidState userInfo:nil];
+    }
     return nil;
 }
 
-- (BOOL)getBaseDevice:(uint64_t)deviceID queue:(dispatch_queue_t)queue completion:(MTRDeviceConnectionCallback)completion
+- (void)fetchControllerIdWithQueue:(dispatch_queue_t)queue completion:(MTRFetchControllerIDCompletion)completion
 {
     dispatch_async(_workQueue, ^{
         dispatch_group_t group = dispatch_group_create();
         if (!self.controllerID) {
             dispatch_group_enter(group);
             [self.xpcConnection getProxyHandleWithCompletion:^(
-                dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
+                dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
                 if (handle) {
                     [handle.proxy getAnyDeviceControllerWithCompletion:^(id _Nullable controller, NSError * _Nullable error) {
                         if (error) {
@@ -124,16 +113,20 @@ static void SetupXPCQueue(void)
         }
         dispatch_group_notify(group, queue, ^{
             if (self.controllerID) {
-                MTRDeviceOverXPC * device = [[MTRDeviceOverXPC alloc] initWithController:self.controllerID
-                                                                                deviceID:@(deviceID)
-                                                                           xpcConnection:self.xpcConnection];
-                completion(device, nil);
+                completion(self.controllerID, nil);
             } else {
                 completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
             }
         });
     });
-    return YES;
+}
+
+- (MTRBaseDevice *)baseDeviceForNodeID:(NSNumber *)nodeID
+{
+    return [[MTRDeviceOverXPC alloc] initWithControllerID:self.controllerID
+                                               controller:self
+                                                 deviceID:nodeID
+                                            xpcConnection:self.xpcConnection];
 }
 
 - (instancetype)initWithControllerID:(id)controllerID

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
@@ -20,12 +20,17 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+typedef void (^MTRFetchControllerIDCompletion)(id _Nullable controllerID, NSError * _Nullable error);
+
 @interface MTRDeviceControllerOverXPC ()
 
 @property (nonatomic, readwrite, strong) id<NSCopying> _Nullable controllerID;
 @property (nonatomic, readonly, strong) dispatch_queue_t workQueue;
 @property (nonatomic, readonly, strong) MTRDeviceControllerXPCConnection * xpcConnection;
 
+// Guarantees that completion is called with either a non-nil controllerID or a
+// non-nil error.
+- (void)fetchControllerIdWithQueue:(dispatch_queue_t)queue completion:(MTRFetchControllerIDCompletion)completion;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -140,6 +140,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)asyncDispatchToMatterQueue:(void (^)(chip::Controller::DeviceCommissioner *))block
                       errorHandler:(void (^)(NSError *))erroHandler;
 
+/**
+ * Get an MTRBaseDevice for the given node id.  This exists to allow subclasses
+ * of MTRDeviceController (e.g. MTRDeviceControllerOverXPC) to override what
+ * sort of MTRBaseDevice they return.
+ */
+- (MTRBaseDevice *)baseDeviceForNodeID:(NSNumber *)nodeID;
+
 #pragma mark - Device-specific data and SDK access
 // DeviceController will act as a central repository for this opaque dictionary that MTRDevice manages
 - (MTRDevice *)deviceForNodeID:(NSNumber *)nodeID;

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
@@ -28,10 +28,9 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-- (instancetype)initWithControllerID:(id<NSCopying> _Nullable)controllerID
-                          controller:(MTRDeviceControllerOverXPC *)controller
-                            deviceID:(NSNumber *)deviceID
-                       xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection;
+- (instancetype)initWithControllerOverXPC:(MTRDeviceControllerOverXPC *)controllerOverXPC
+                                 deviceID:(NSNumber *)deviceID
+                            xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
@@ -19,6 +19,8 @@
 #import "MTRCluster.h" // For MTRSubscriptionEstablishedHandler
 #import "MTRDeviceControllerXPCConnection.h"
 
+@class MTRDeviceControllerOverXPC;
+
 NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceOverXPC : MTRBaseDevice
@@ -26,9 +28,10 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
 
-- (instancetype)initWithController:(id<NSCopying>)controller
-                          deviceID:(NSNumber *)deviceID
-                     xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection;
+- (instancetype)initWithControllerID:(id<NSCopying> _Nullable)controllerID
+                          controller:(MTRDeviceControllerOverXPC *)controller
+                            deviceID:(NSNumber *)deviceID
+                       xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
@@ -20,6 +20,7 @@
 #import "MTRAttributeCacheContainer+XPC.h"
 #import "MTRCluster.h"
 #import "MTRDeviceController+XPC.h"
+#import "MTRDeviceControllerOverXPC_Internal.h"
 #import "MTRDeviceControllerXPCConnection.h"
 #import "MTRError.h"
 #import "MTRLogging.h"
@@ -28,7 +29,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceOverXPC ()
 
-@property (nonatomic, strong, readonly) id<NSCopying> controller;
+@property (nonatomic, strong, readonly, nullable) id<NSCopying> controllerID;
+@property (nonatomic, strong, readonly) MTRDeviceControllerOverXPC * controller;
 @property (nonatomic, readonly) NSNumber * nodeID;
 @property (nonatomic, strong, readonly) MTRDeviceControllerXPCConnection * xpcConnection;
 
@@ -36,10 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MTRDeviceOverXPC
 
-- (instancetype)initWithController:(id<NSCopying>)controller
-                          deviceID:(NSNumber *)deviceID
-                     xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
+- (instancetype)initWithControllerID:(id<NSCopying> _Nullable)controllerID
+                          controller:(MTRDeviceControllerOverXPC *)controller
+                            deviceID:(NSNumber *)deviceID
+                       xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
 {
+    _controllerID = controllerID;
     _controller = controller;
     _nodeID = deviceID;
     _xpcConnection = xpcConnection;
@@ -57,13 +61,14 @@ NS_ASSUME_NONNULL_BEGIN
 {
     MTR_LOG_DEBUG("Subscribing all attributes... Note that attributeReportHandler, eventReportHandler, and resubscriptionScheduled "
                   "are not supported.");
-    if (attributeCacheContainer) {
-        [attributeCacheContainer setXPCConnection:_xpcConnection controllerID:self.controller deviceID:self.nodeID];
-    }
-    [_xpcConnection
-        getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
+    __auto_type workBlock = ^{
+        if (attributeCacheContainer) {
+            [attributeCacheContainer setXPCConnection:self->_xpcConnection controllerID:self.controllerID deviceID:self.nodeID];
+        }
+        [self->_xpcConnection getProxyHandleWithCompletion:^(
+            dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
-                [handle.proxy subscribeWithController:self.controller
+                [handle.proxy subscribeWithController:self.controllerID
                                                nodeID:self.nodeID
                                                params:[MTRDeviceController encodeXPCSubscribeParams:params]
                                           shouldCache:(attributeCacheContainer != nil)
@@ -85,6 +90,23 @@ NS_ASSUME_NONNULL_BEGIN
                 });
             }
         }];
+    };
+
+    if (self.controllerID != nil) {
+        workBlock();
+    } else {
+        [self.controller fetchControllerIdWithQueue:queue
+                                         completion:^(id _Nullable controllerID, NSError * _Nullable error) {
+                                             if (error != nil) {
+                                                 // We're already running on the right queue.
+                                                 errorHandler(error);
+                                                 return;
+                                             }
+
+                                             self->_controllerID = controllerID;
+                                             workBlock();
+                                         }];
+    }
 }
 
 - (void)readAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
@@ -95,10 +117,11 @@ NS_ASSUME_NONNULL_BEGIN
                              completion:(MTRDeviceResponseHandler)completion
 {
     MTR_LOG_DEBUG("Reading attribute ...");
-    [_xpcConnection
-        getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
+    __auto_type workBlock = ^{
+        [self->_xpcConnection getProxyHandleWithCompletion:^(
+            dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
-                [handle.proxy readAttributeWithController:self.controller
+                [handle.proxy readAttributeWithController:self.controllerID
                                                    nodeID:self.nodeID
                                                endpointID:endpointID
                                                 clusterID:clusterID
@@ -121,6 +144,23 @@ NS_ASSUME_NONNULL_BEGIN
                 });
             }
         }];
+    };
+
+    if (self.controllerID != nil) {
+        workBlock();
+    } else {
+        [self.controller fetchControllerIdWithQueue:queue
+                                         completion:^(id _Nullable controllerID, NSError * _Nullable error) {
+                                             if (error != nil) {
+                                                 // We're already running on the right queue.
+                                                 completion(nil, error);
+                                                 return;
+                                             }
+
+                                             self->_controllerID = controllerID;
+                                             workBlock();
+                                         }];
+    }
 }
 
 - (void)writeAttributeWithEndpointID:(NSNumber *)endpointID
@@ -132,10 +172,11 @@ NS_ASSUME_NONNULL_BEGIN
                           completion:(MTRDeviceResponseHandler)completion
 {
     MTR_LOG_DEBUG("Writing attribute ...");
-    [_xpcConnection
-        getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
+    __auto_type workBlock = ^{
+        [self->_xpcConnection getProxyHandleWithCompletion:^(
+            dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
-                [handle.proxy writeAttributeWithController:self.controller
+                [handle.proxy writeAttributeWithController:self.controllerID
                                                     nodeID:self.nodeID
                                                 endpointID:endpointID
                                                  clusterID:clusterID
@@ -159,6 +200,23 @@ NS_ASSUME_NONNULL_BEGIN
                 });
             }
         }];
+    };
+
+    if (self.controllerID != nil) {
+        workBlock();
+    } else {
+        [self.controller fetchControllerIdWithQueue:queue
+                                         completion:^(id _Nullable controllerID, NSError * _Nullable error) {
+                                             if (error != nil) {
+                                                 // We're already running on the right queue.
+                                                 completion(nil, error);
+                                                 return;
+                                             }
+
+                                             self->_controllerID = controllerID;
+                                             workBlock();
+                                         }];
+    }
 }
 
 - (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
@@ -170,10 +228,11 @@ NS_ASSUME_NONNULL_BEGIN
                          completion:(MTRDeviceResponseHandler)completion
 {
     MTR_LOG_DEBUG("Invoking command ...");
-    [_xpcConnection
-        getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
+    __auto_type workBlock = ^{
+        [self->_xpcConnection getProxyHandleWithCompletion:^(
+            dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
-                [handle.proxy invokeCommandWithController:self.controller
+                [handle.proxy invokeCommandWithController:self.controllerID
                                                    nodeID:self.nodeID
                                                endpointID:endpointID
                                                 clusterID:clusterID
@@ -197,6 +256,23 @@ NS_ASSUME_NONNULL_BEGIN
                 });
             }
         }];
+    };
+
+    if (self.controllerID != nil) {
+        workBlock();
+    } else {
+        [self.controller fetchControllerIdWithQueue:queue
+                                         completion:^(id _Nullable controllerID, NSError * _Nullable error) {
+                                             if (error != nil) {
+                                                 // We're already running on the right queue.
+                                                 completion(nil, error);
+                                                 return;
+                                             }
+
+                                             self->_controllerID = controllerID;
+                                             workBlock();
+                                         }];
+    }
 }
 
 - (void)subscribeAttributePathWithEndpointID:(NSNumber * _Nullable)endpointID
@@ -208,78 +284,118 @@ NS_ASSUME_NONNULL_BEGIN
                      subscriptionEstablished:(void (^_Nullable)(void))subscriptionEstablishedHandler
 {
     MTR_LOG_DEBUG("Subscribing attribute ...");
-    [_xpcConnection getProxyHandleWithCompletion:^(
-        dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
-        if (handle) {
-            MTR_LOG_DEBUG("Setup report handler");
-            [self.xpcConnection
-                registerReportHandlerWithController:self.controller
-                                             nodeID:self.nodeID
-                                            handler:^(id _Nullable values, NSError * _Nullable error) {
-                                                if (values && ![values isKindOfClass:[NSArray class]]) {
-                                                    MTR_LOG_ERROR("Unsupported report format");
-                                                    return;
-                                                }
-                                                if (!values) {
-                                                    MTR_LOG_DEBUG("Error report received");
-                                                    dispatch_async(queue, ^{
-                                                        reportHandler(values, error);
-                                                    });
-                                                    return;
-                                                }
-                                                __auto_type decodedValues = [MTRDeviceController decodeXPCResponseValues:values];
-                                                NSMutableArray<NSDictionary<NSString *, id> *> * filteredValues =
-                                                    [NSMutableArray arrayWithCapacity:[decodedValues count]];
-                                                for (NSDictionary<NSString *, id> * decodedValue in decodedValues) {
-                                                    MTRAttributePath * attributePath = decodedValue[MTRAttributePathKey];
-                                                    if ((endpointID == nil || [attributePath.endpoint isEqualToNumber:endpointID])
-                                                        && (clusterID == nil || [attributePath.cluster isEqualToNumber:clusterID])
-                                                        && (attributeID == nil ||
-                                                            [attributePath.attribute isEqualToNumber:attributeID])) {
-                                                        [filteredValues addObject:decodedValue];
+    __auto_type workBlock = ^{
+        [self->_xpcConnection getProxyHandleWithCompletion:^(
+            dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
+            if (handle) {
+                MTR_LOG_DEBUG("Setup report handler");
+                [self.xpcConnection
+                    registerReportHandlerWithController:self.controllerID
+                                                 nodeID:self.nodeID
+                                                handler:^(id _Nullable values, NSError * _Nullable error) {
+                                                    if (values && ![values isKindOfClass:[NSArray class]]) {
+                                                        MTR_LOG_ERROR("Unsupported report format");
+                                                        return;
                                                     }
-                                                }
-                                                if ([filteredValues count] > 0) {
-                                                    MTR_LOG_DEBUG("Report received");
-                                                    dispatch_async(queue, ^{
-                                                        reportHandler(filteredValues, error);
-                                                    });
-                                                }
+                                                    if (!values) {
+                                                        MTR_LOG_DEBUG("Error report received");
+                                                        dispatch_async(queue, ^{
+                                                            reportHandler(values, error);
+                                                        });
+                                                        return;
+                                                    }
+                                                    __auto_type decodedValues =
+                                                        [MTRDeviceController decodeXPCResponseValues:values];
+                                                    NSMutableArray<NSDictionary<NSString *, id> *> * filteredValues =
+                                                        [NSMutableArray arrayWithCapacity:[decodedValues count]];
+                                                    for (NSDictionary<NSString *, id> * decodedValue in decodedValues) {
+                                                        MTRAttributePath * attributePath = decodedValue[MTRAttributePathKey];
+                                                        if ((endpointID == nil ||
+                                                                [attributePath.endpoint isEqualToNumber:endpointID])
+                                                            && (clusterID == nil ||
+                                                                [attributePath.cluster isEqualToNumber:clusterID])
+                                                            && (attributeID == nil ||
+                                                                [attributePath.attribute isEqualToNumber:attributeID])) {
+                                                            [filteredValues addObject:decodedValue];
+                                                        }
+                                                    }
+                                                    if ([filteredValues count] > 0) {
+                                                        MTR_LOG_DEBUG("Report received");
+                                                        dispatch_async(queue, ^{
+                                                            reportHandler(filteredValues, error);
+                                                        });
+                                                    }
+                                                }];
+
+                [handle.proxy subscribeAttributeWithController:self.controllerID
+                                                        nodeID:self.nodeID
+                                                    endpointID:endpointID
+                                                     clusterID:clusterID
+                                                   attributeID:attributeID
+                                                        params:[MTRDeviceController encodeXPCSubscribeParams:params]
+                                            establishedHandler:^{
+                                                dispatch_async(queue, ^{
+                                                    MTR_LOG_DEBUG("Subscription established");
+                                                    subscriptionEstablishedHandler();
+                                                    // The following captures the proxy handle in the closure so that the handle
+                                                    // won't be released prior to block call.
+                                                    __auto_type handleRetainer = handle;
+                                                    (void) handleRetainer;
+                                                });
                                             }];
-            [handle.proxy subscribeAttributeWithController:self.controller
-                                                    nodeID:self.nodeID
-                                                endpointID:endpointID
-                                                 clusterID:clusterID
-                                               attributeID:attributeID
-                                                    params:[MTRDeviceController encodeXPCSubscribeParams:params]
-                                        establishedHandler:^{
-                                            dispatch_async(queue, ^{
-                                                MTR_LOG_DEBUG("Subscription established");
-                                                subscriptionEstablishedHandler();
-                                                // The following captures the proxy handle in the closure so that the handle
-                                                // won't be released prior to block call.
-                                                __auto_type handleRetainer = handle;
-                                                (void) handleRetainer;
-                                            });
-                                        }];
-        } else {
-            dispatch_async(queue, ^{
-                MTR_LOG_ERROR("Failed to obtain XPC connection to subscribe to attribute");
-                subscriptionEstablishedHandler();
-                reportHandler(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
-            });
-        }
-    }];
+            } else {
+                dispatch_async(queue, ^{
+                    MTR_LOG_ERROR("Failed to obtain XPC connection to subscribe to attribute");
+                    subscriptionEstablishedHandler();
+                    reportHandler(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
+                });
+            }
+        }];
+    };
+
+    if (self.controllerID != nil) {
+        workBlock();
+    } else {
+        [self.controller fetchControllerIdWithQueue:queue
+                                         completion:^(id _Nullable controllerID, NSError * _Nullable error) {
+                                             if (error != nil) {
+                                                 // We're already running on the right queue.
+                                                 reportHandler(nil, error);
+                                                 return;
+                                             }
+
+                                             self->_controllerID = controllerID;
+                                             workBlock();
+                                         }];
+    }
 }
 
 - (void)deregisterReportHandlersWithQueue:(dispatch_queue_t)queue completion:(void (^)(void))completion
 {
     MTR_LOG_DEBUG("Deregistering report handlers");
-    [_xpcConnection deregisterReportHandlersWithController:self.controller
-                                                    nodeID:self.nodeID
-                                                completion:^{
-                                                    dispatch_async(queue, completion);
-                                                }];
+    __auto_type workBlock = ^{
+        [self->_xpcConnection deregisterReportHandlersWithController:self.controllerID
+                                                              nodeID:self.nodeID
+                                                          completion:^{
+                                                              dispatch_async(queue, completion);
+                                                          }];
+    };
+
+    if (self.controllerID != nil) {
+        workBlock();
+    } else {
+        [self.controller fetchControllerIdWithQueue:queue
+                                         completion:^(id _Nullable controllerID, NSError * _Nullable error) {
+                                             if (error != nil) {
+                                                 // We're already running on the right queue.
+                                                 completion();
+                                                 return;
+                                             }
+
+                                             self->_controllerID = controllerID;
+                                             workBlock();
+                                         }];
+    }
 }
 
 - (void)openCommissioningWindowWithSetupPasscode:(NSNumber *)setupPasscode

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
@@ -38,13 +38,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 @implementation MTRDeviceOverXPC
 
-- (instancetype)initWithControllerID:(id<NSCopying> _Nullable)controllerID
-                          controller:(MTRDeviceControllerOverXPC *)controller
-                            deviceID:(NSNumber *)deviceID
-                       xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
+- (instancetype)initWithControllerOverXPC:(MTRDeviceControllerOverXPC *)controllerOverXPC
+                                 deviceID:(NSNumber *)deviceID
+                            xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
 {
-    _controllerID = controllerID;
-    _controller = controller;
+    _controllerID = controllerOverXPC.controllerID;
+    _controller = controllerOverXPC;
     _nodeID = deviceID;
     _xpcConnection = xpcConnection;
     return self;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -92,8 +92,26 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) { MTROptionalQRCodeInfoTy
 + (MTRSetupPayload * _Nullable)setupPayloadWithOnboardingPayload:(NSString *)onboardingPayload
                                                            error:(NSError * __autoreleasing *)error;
 
+/**
+ * Initialize an MTRSetupPayload with the given passcode and discriminator.
+ * This will pre-set version, product id, and vendor id to 0.
+ */
+- (instancetype)initWithSetupPasscode:(NSNumber *)setupPasscode discriminator:(NSNumber *)discriminator;
+
 /** Get 11 digit manual entry code from the setup payload. */
 - (NSString * _Nullable)manualEntryCode;
+
+/**
+ * Get a QR code from the setup payload.
+ *
+ * Returns nil on failure (e.g. if the setup payload does not have all the
+ * information a QR code needs).
+ */
+- (NSString * _Nullable)qrCodeString;
+
+// A setup payload must have a passcode and a discriminator at the very least.
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -17,7 +17,7 @@
 @interface MTRSetupPayload ()
 
 #ifdef __cplusplus
-- (id)initWithSetupPayload:(chip::SetupPayload)setupPayload;
+- (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload;
 - (MTRDiscoveryCapabilities)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value;
 - (MTRCommissioningFlow)convertCommissioningFlow:(chip::CommissioningFlow)value;
 #endif

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -238,11 +238,6 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
 
     XCTAssertFalse([controller isRunning]);
-    XCTAssertFalse([controller getBaseDevice:1234
-                                       queue:dispatch_get_main_queue()
-                                  completion:^(MTRBaseDevice * _Nullable chipDevice, NSError * _Nullable error) {
-                                      XCTAssertEqual(error.code, MTRErrorCodeInvalidState);
-                                  }]);
 
     [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -170,7 +170,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
     (void) controller;
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
+        __auto_type device = [MTRBaseDevice deviceWithNodeID:nodeID controller:sharedController];
         [device readAttributePathWithEndpointID:endpointID
                                       clusterID:clusterID
                                     attributeID:attributeID
@@ -198,7 +198,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
     (void) controller;
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
+        __auto_type device = [MTRBaseDevice deviceWithNodeID:nodeID controller:sharedController];
         [device
             writeAttributeWithEndpointID:endpointID
                                clusterID:clusterID
@@ -227,7 +227,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
     (void) controller;
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
+        __auto_type device = [MTRBaseDevice deviceWithNodeID:nodeID controller:sharedController];
         [device
             invokeCommandWithEndpointID:endpointID
                               clusterID:clusterID
@@ -254,7 +254,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 {
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
+        __auto_type device = [MTRBaseDevice deviceWithNodeID:nodeID controller:sharedController];
         [device subscribeAttributePathWithEndpointID:endpointID
                                            clusterID:clusterID
                                          attributeID:attributeID
@@ -286,7 +286,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 {
     __auto_type sharedController = sController;
     if (sharedController) {
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
+        __auto_type device = [MTRBaseDevice deviceWithNodeID:nodeID controller:sharedController];
         [device deregisterReportHandlersWithQueue:dispatch_get_main_queue() completion:completion];
     } else {
         NSLog(@"Failed to get shared controller");
@@ -307,7 +307,7 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
             attributeCacheContainer = [[MTRAttributeCacheContainer alloc] init];
         }
 
-        __auto_type device = [[MTRBaseDevice alloc] initWithNodeID:nodeID controller:sharedController];
+        __auto_type device = [MTRBaseDevice deviceWithNodeID:nodeID controller:sharedController];
         NSMutableArray * established = [NSMutableArray arrayWithCapacity:1];
         [established addObject:@NO];
         [device subscribeWithQueue:dispatch_get_main_queue()
@@ -367,13 +367,10 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
 @end
 
 static const uint16_t kPairingTimeoutInSeconds = 10;
-static const uint16_t kCASESetupTimeoutInSeconds = 30;
 static const uint16_t kTimeoutInSeconds = 3;
 static const uint64_t kDeviceId = 0x12344321;
-static const uint32_t kSetupPINCode = 20202021;
-static const uint16_t kRemotePort = 5540;
+static NSString * kOnboardingPayload = @"MT:-24J0AFN00KA0648G00";
 static const uint16_t kLocalPort = 5541;
-static NSString * kAddress = @"::1";
 
 // This test suite reuses a device object to speed up the test process for CI.
 // The following global variable holds the reference to the device object.
@@ -405,7 +402,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
 {
     XCTAssertEqual(error.code, 0);
     NSError * commissionError = nil;
-    [sController commissionDevice:kDeviceId commissioningParams:[[MTRCommissioningParameters alloc] init] error:&commissionError];
+    [sController commissionNodeWithID:@(kDeviceId)
+                  commissioningParams:[[MTRCommissioningParameters alloc] init]
+                                error:&commissionError];
     XCTAssertNil(commissionError);
 
     // Keep waiting for onCommissioningComplete
@@ -480,20 +479,14 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
     [controller setPairingDelegate:pairing queue:callbackQueue];
 
-    [controller pairDevice:kDeviceId address:kAddress port:kRemotePort setupPINCode:kSetupPINCode error:&error];
-    XCTAssertEqual(error.code, 0);
+    __auto_type * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:kOnboardingPayload error:&error];
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    [controller setupCommissioningSessionWithPayload:payload newNodeID:@(kDeviceId) error:&error];
+    XCTAssertNil(error);
 
     [self waitForExpectationsWithTimeout:kPairingTimeoutInSeconds handler:nil];
-
-    __block XCTestExpectation * connectionExpectation = [self expectationWithDescription:@"CASE established"];
-    [controller getBaseDevice:kDeviceId
-                        queue:dispatch_get_main_queue()
-                   completion:^(MTRBaseDevice * _Nullable device, NSError * _Nullable error) {
-                       XCTAssertEqual(error.code, 0);
-                       [connectionExpectation fulfill];
-                       connectionExpectation = nil;
-                   }];
-    [self waitForExpectationsWithTimeout:kCASESetupTimeoutInSeconds handler:nil];
 
     mSampleListener = [[MTRXPCListenerSample alloc] init];
     [mSampleListener start];
@@ -517,9 +510,6 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
 - (void)waitForCommissionee
 {
-    XCTestExpectation * expectation = [self expectationWithDescription:@"Wait for the commissioned device to be retrieved"];
-
-    dispatch_queue_t queue = dispatch_get_main_queue();
     __auto_type remoteController = [MTRDeviceController
         sharedControllerWithID:MTRDeviceControllerId
                xpcConnectBlock:^NSXPCConnection * _Nonnull {
@@ -529,13 +519,6 @@ static MTRBaseDevice * GetConnectedDevice(void)
                    NSLog(@"Listener is not active");
                    return nil;
                }];
-    [remoteController getBaseDevice:kDeviceId
-                              queue:queue
-                         completion:^(MTRBaseDevice * _Nullable device, NSError * _Nullable error) {
-                             mConnectedDevice = device;
-                             [expectation fulfill];
-                         }];
-    [self waitForExpectationsWithTimeout:kTimeoutInSeconds handler:nil];
     mDeviceController = remoteController;
 }
 
@@ -890,11 +873,13 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Set up expectation for report
     XCTestExpectation * errorReportExpectation = [self expectationWithDescription:@"receive OnOff attribute report"];
     globalReportHandler = ^(id _Nullable values, NSError * _Nullable error) {
+        // Because our subscription has no existent paths, it gets an
+        // InvalidAction response, which is EMBER_ZCL_STATUS_MALFORMED_COMMAND.
         XCTAssertNil(values);
         // Error is copied over XPC and hence cannot use MTRErrorTestUtils utility which checks against a local domain string
         // object.
         XCTAssertTrue([error.domain isEqualToString:MTRInteractionErrorDomain]);
-        XCTAssertEqual(error.code, EMBER_ZCL_STATUS_UNSUPPORTED_ENDPOINT);
+        XCTAssertEqual(error.code, EMBER_ZCL_STATUS_MALFORMED_COMMAND);
         [errorReportExpectation fulfill];
     };
 
@@ -902,6 +887,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     dispatch_queue_t queue = dispatch_get_main_queue();
 
     __auto_type * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(2) maxInterval:@(10)];
+    params.autoResubscribe = NO;
     [device subscribeAttributePathWithEndpointID:@10000
         clusterID:@6
         attributeID:@0

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -519,6 +519,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
                    NSLog(@"Listener is not active");
                    return nil;
                }];
+    mConnectedDevice = [MTRBaseDevice deviceWithNodeID:@(kDeviceId) controller:remoteController];
     mDeviceController = remoteController;
 }
 


### PR DESCRIPTION
* Make MTRBaseDevice creation synchronous.  This requires updates to MTRBaseDeviceOverXPC to do the possible async getting of the controller id it needs during its async operations, not when getting the device object.
* Rename "pairDevice" to "setupCommissioningSessionWithPayload", fix its signature, improve documentation.
* Rename "commissionDevice" to "commissionNodeWithID".
* Rename "stopDevicePairing" to "cancelCommissioningForNodeID" and document.
* Rename "getDeviceBeingCommissioned" to "getDeviceBeingCommissionedWithNodeID".
* Various documentation improvements.
* Add a way to generate a QR code from an MTRSetupPayload to allow correct recovery of long discriminators in setupCommissioningSessionWithPayload.

Addresses part of https://github.com/project-chip/connectedhomeip/issues/22420

#### Issue Being Resolved
* Fixes #22533

#### Change overview
See above.
