### PR TITLE
Remove `KeyError` encountered on unknown attributes

### DIFF
--- a/src/controller/python/chip/clusters/attribute.cpp
+++ b/src/controller/python/chip/clusters/attribute.cpp
@@ -135,10 +135,7 @@ public:
         {
             version = aPath.mDataVersion.Value();
         }
-        else
-        {
-            ChipLogError(DataManagement, "expect aPath has valid mDataVersion");
-        }
+
         gOnReadAttributeDataCallback(mAppContext, version, aPath.mEndpointId, aPath.mClusterId, aPath.mAttributeId,
                                      to_underlying(aStatus.mStatus), buffer.get(), size);
     }


### PR DESCRIPTION
* fixes #22595

This removes the `KeyError` exception that is thrown when the Python cluster cache encounters an attribute that it doesn't have schema for. This occurs for some of the extended attributes in the test cluster that are not actually defined in schema.

This ensures that we don't abruptly terminate attribute processing when running tests against the all clusters app.

Also removes a bunch of over-zealous prints that serve to confuse and distract than they are helpful.
# Testing

Ran against all-clusters-app, ensured warnings and exceptions are no longer thrown.