### PR TITLE
Allow java applications to set timeouts for commands

### DIFF
--- a/src/controller/CHIPCluster.h
+++ b/src/controller/CHIPCluster.h
@@ -62,6 +62,12 @@ public:
     // TODO: remove when we start using InvokeCommand everywhere
     void SetCommandTimeout(Optional<System::Clock::Timeout> timeout) { mTimeout = timeout; }
 
+    /**
+     * Returns the current command timeout set via SetCommandTimeout, or an
+     * empty optional if no timeout has been set.
+     */
+    Optional<System::Clock::Timeout> GetCommandTimeout() { return mTimeout; }
+
     ClusterId GetClusterId() const { return mClusterId; }
 
     /*

--- a/src/controller/java/BaseCHIPCluster-JNI.cpp
+++ b/src/controller/java/BaseCHIPCluster-JNI.cpp
@@ -1,5 +1,6 @@
 #include <controller/CHIPCluster.h>
 #include <jni.h>
+#include <lib/support/JniReferences.h>
 #include <platform/PlatformManager.h>
 
 #define JNI_METHOD(RETURN, CLASS_NAME, METHOD_NAME)                                                                                \
@@ -12,5 +13,48 @@ JNI_METHOD(void, BaseChipCluster, deleteCluster)(JNIEnv * env, jobject self, jlo
     if (cluster != nullptr)
     {
         delete cluster;
+    }
+}
+
+JNI_METHOD(jobject, BaseChipCluster, getCommandTimeout)
+(JNIEnv * env, jobject self, jlong clusterPtr)
+{
+    chip::DeviceLayer::StackLock lock;
+    chip::Controller::ClusterBase * cluster = reinterpret_cast<chip::Controller::ClusterBase *>(clusterPtr);
+
+    chip::Optional<chip::System::Clock::Timeout> timeout = cluster->GetCommandTimeout();
+    if (!timeout.HasValue())
+    {
+        jobject emptyOptional = nullptr;
+        chip::JniReferences::GetInstance().CreateOptional(nullptr, emptyOptional);
+        return emptyOptional;
+    }
+
+    jobject timeoutOptional = nullptr;
+    jobject timeoutBoxed    = nullptr;
+    jlong timeoutPrimitive  = static_cast<jlong>(timeout.Value().count());
+    chip::JniReferences::GetInstance().CreateBoxedObject("java/lang/Long", "(J)V", timeoutPrimitive, timeoutBoxed);
+    chip::JniReferences::GetInstance().CreateOptional(timeoutBoxed, timeoutOptional);
+    return timeoutOptional;
+}
+
+JNI_METHOD(void, BaseChipCluster, setCommandTimeout)
+(JNIEnv * env, jobject self, jlong clusterPtr, jobject timeoutOptional)
+{
+    chip::DeviceLayer::StackLock lock;
+    chip::Controller::ClusterBase * cluster = reinterpret_cast<chip::Controller::ClusterBase *>(clusterPtr);
+
+    jobject boxedLong = nullptr;
+    chip::JniReferences::GetInstance().GetOptionalValue(timeoutOptional, boxedLong);
+
+    if (boxedLong != nullptr)
+    {
+        jlong timeoutMillis = chip::JniReferences::GetInstance().LongToPrimitive(boxedLong);
+        cluster->SetCommandTimeout(chip::Optional<chip::System::Clock::Timeout>(
+            chip::System::Clock::Milliseconds32(static_cast<uint64_t>(timeoutMillis))));
+    }
+    else
+    {
+        cluster->SetCommandTimeout(chip::Optional<chip::System::Clock::Timeout>());
     }
 }

--- a/src/controller/java/BaseCHIPCluster-JNI.cpp
+++ b/src/controller/java/BaseCHIPCluster-JNI.cpp
@@ -50,8 +50,7 @@ JNI_METHOD(void, BaseChipCluster, setCommandTimeout)
     if (boxedLong != nullptr)
     {
         jlong timeoutMillis = chip::JniReferences::GetInstance().LongToPrimitive(boxedLong);
-        cluster->SetCommandTimeout(chip::Optional<chip::System::Clock::Timeout>(
-            chip::System::Clock::Milliseconds32(static_cast<uint64_t>(timeoutMillis))));
+        cluster->SetCommandTimeout(MakeOptional(chip::System::Clock::Milliseconds32(static_cast<uint64_t>(timeoutMillis))));
     }
     else
     {

--- a/src/controller/java/BaseCHIPCluster-JNI.cpp
+++ b/src/controller/java/BaseCHIPCluster-JNI.cpp
@@ -50,7 +50,7 @@ JNI_METHOD(void, BaseChipCluster, setCommandTimeout)
     if (boxedLong != nullptr)
     {
         jlong timeoutMillis = chip::JniReferences::GetInstance().LongToPrimitive(boxedLong);
-        cluster->SetCommandTimeout(MakeOptional(chip::System::Clock::Milliseconds32(static_cast<uint64_t>(timeoutMillis))));
+        cluster->SetCommandTimeout(chip::MakeOptional(chip::System::Clock::Milliseconds32(static_cast<uint64_t>(timeoutMillis))));
     }
     else
     {

--- a/src/controller/java/BaseCHIPCluster-JNI.cpp
+++ b/src/controller/java/BaseCHIPCluster-JNI.cpp
@@ -54,6 +54,6 @@ JNI_METHOD(void, BaseChipCluster, setCommandTimeout)
     }
     else
     {
-        cluster->SetCommandTimeout(chip::Optional<chip::System::Clock::Timeout>());
+        cluster->SetCommandTimeout(chip::NullOptional);
     }
 }

--- a/src/controller/java/templates/ChipClusters-java.zapt
+++ b/src/controller/java/templates/ChipClusters-java.zapt
@@ -68,6 +68,25 @@ public class ChipClusters {
       chipClusterPtr = initWithDevice(devicePtr, endpointId);
     }
 
+    /**
+     * Sets the timeout, in milliseconds, after which commands sent through this cluster will fail
+     * with a timeout (regardless of whether or not a response has been received). If set to an
+     * empty optional, the default timeout will be used.
+     */
+    public void setCommandTimeout(Optional<Long> timeoutMillis) {
+      setCommandTimeout(chipClusterPtr, timeoutMillis);
+    }
+
+    private native void setCommandTimeout(long clusterPtr, Optional<Long> timeoutMillis);
+
+    /** Returns the current timeout (in milliseconds) for commands sent through this cluster. */
+    public Optional<Long> getCommandTimeout() {
+      Optional<Long> timeout = getCommandTimeout(chipClusterPtr);
+      return timeout == null ? Optional.empty() : timeout;
+    }
+
+    private native Optional<Long> getCommandTimeout(long clusterPtr);
+
     public abstract long initWithDevice(long devicePtr, int endpointId);
 
     public native void deleteCluster(long chipClusterPtr);

--- a/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
+++ b/src/controller/java/zap-generated/chip/devicecontroller/ChipClusters.java
@@ -97,6 +97,25 @@ public class ChipClusters {
       chipClusterPtr = initWithDevice(devicePtr, endpointId);
     }
 
+    /**
+     * Sets the timeout, in milliseconds, after which commands sent through this cluster will fail
+     * with a timeout (regardless of whether or not a response has been received). If set to an
+     * empty optional, the default timeout will be used.
+     */
+    public void setCommandTimeout(Optional<Long> timeoutMillis) {
+      setCommandTimeout(chipClusterPtr, timeoutMillis);
+    }
+
+    private native void setCommandTimeout(long clusterPtr, Optional<Long> timeoutMillis);
+
+    /** Returns the current timeout (in milliseconds) for commands sent through this cluster. */
+    public Optional<Long> getCommandTimeout() {
+      Optional<Long> timeout = getCommandTimeout(chipClusterPtr);
+      return timeout == null ? Optional.empty() : timeout;
+    }
+
+    private native Optional<Long> getCommandTimeout(long clusterPtr);
+
     public abstract long initWithDevice(long devicePtr, int endpointId);
 
     public native void deleteCluster(long chipClusterPtr);


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22601 

#### Change overview
Adds a SetTimeout and GetTimeout commant to java.

SDK itself gains a `GetTimeout` which was missing before (for symmerty - if I can set, I should be able to get in most cases).
