### PR TITLE
Address API review issues in MTRControllerFactory.

### DIFF
--- a/examples/darwin-framework-tool/main.mm
+++ b/examples/darwin-framework-tool/main.mm
@@ -30,13 +30,15 @@
 
 int main(int argc, const char * argv[])
 {
-    Commands commands;
-    registerCommandsPairing(commands);
-    registerCommandsInteractive(commands);
-    registerCommandsPayload(commands);
-    registerClusterOtaSoftwareUpdateProviderInteractive(commands);
-    registerCommandsStorage(commands);
-    registerCommandsTests(commands);
-    registerClusters(commands);
-    return commands.Run(argc, (char **) argv);
+    @autoreleasepool {
+        Commands commands;
+        registerCommandsPairing(commands);
+        registerCommandsInteractive(commands);
+        registerCommandsPayload(commands);
+        registerClusterOtaSoftwareUpdateProviderInteractive(commands);
+        registerCommandsStorage(commands);
+        registerCommandsTests(commands);
+        registerClusters(commands);
+        return commands.Run(argc, (char **) argv);
+    }
 }

--- a/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
+++ b/src/darwin/CHIPTool/CHIPTool/Framework Helpers/DefaultsUtils.m
@@ -76,9 +76,9 @@ MTRDeviceController * InitializeMTR(void)
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
         CHIPToolPersistentStorageDelegate * storage = [[CHIPToolPersistentStorageDelegate alloc] init];
-        __auto_type * factory = [MTRControllerFactory sharedInstance];
-        __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-        if (![factory startup:factoryParams]) {
+        __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
+        __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+        if (![factory startControllerFactory:factoryParams error:nil]) {
             return;
         }
 
@@ -87,14 +87,14 @@ MTRDeviceController * InitializeMTR(void)
             return;
         }
 
-        __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:keys fabricID:@(1) ipk:keys.ipk];
+        __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:keys.ipk fabricID:@(1) nocSigner:keys];
         params.vendorID = @(kTestVendorId);
 
         // We're not sure whether we have a fabric configured already; try as if
         // we did, and if not fall back to creating a new one.
-        sController = [factory startControllerOnExistingFabric:params];
+        sController = [factory createControllerOnExistingFabric:params error:nil];
         if (sController == nil) {
-            sController = [factory startControllerOnNewFabric:params];
+            sController = [factory createControllerOnNewFabric:params error:nil];
         }
     });
 
@@ -113,9 +113,9 @@ MTRDeviceController * MTRRestartController(MTRDeviceController * controller)
     [controller shutdown];
 
     NSLog(@"Starting up the stack");
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:keys fabricID:@(1) ipk:keys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:keys.ipk fabricID:@(1) nocSigner:keys];
 
-    sController = [[MTRControllerFactory sharedInstance] startControllerOnExistingFabric:params];
+    sController = [[MTRDeviceControllerFactory sharedInstance] createControllerOnExistingFabric:params error:nil];
 
     return sController;
 }

--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -54,7 +54,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign, readonly) chip::NodeId nodeID;
 
 /**
- * Controllers are created via the MTRControllerFactory object.
+ * Controllers are created via the MTRDeviceControllerFactory object.
  */
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -30,7 +30,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 
 @interface MTRDeviceController : NSObject
 
-@property (readonly, nonatomic) BOOL isRunning;
+@property (readonly, nonatomic, getter=isRunning) BOOL running;
 
 /**
  * Return the Node ID assigned to the controller.  Will return nil if the
@@ -96,7 +96,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 - (BOOL)getBaseDevice:(uint64_t)deviceID queue:(dispatch_queue_t)queue completion:(MTRDeviceConnectionCallback)completion;
 
 /**
- * Controllers are created via the MTRControllerFactory object.
+ * Controllers are created via the MTRDeviceControllerFactory object.
  */
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -20,7 +20,7 @@
 
 #import "MTRBaseDevice_Internal.h"
 #import "MTRCommissioningParameters.h"
-#import "MTRControllerFactory_Internal.h"
+#import "MTRDeviceControllerFactory_Internal.h"
 #import "MTRDeviceControllerStartupParams.h"
 #import "MTRDeviceControllerStartupParams_Internal.h"
 #import "MTRDevicePairingDelegateBridge.h"
@@ -86,14 +86,14 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
 @property (readonly) MTRP256KeypairBridge signingKeypairBridge;
 @property (readonly) MTRP256KeypairBridge operationalKeypairBridge;
 @property (readonly) MTRDeviceAttestationDelegateBridge * deviceAttestationDelegateBridge;
-@property (readonly) MTRControllerFactory * factory;
+@property (readonly) MTRDeviceControllerFactory * factory;
 @property (readonly) NSMutableDictionary * nodeIDToDeviceMap;
 @property (readonly) os_unfair_lock deviceMapLock; // protects nodeIDToDeviceMap
 @end
 
 @implementation MTRDeviceController
 
-- (instancetype)initWithFactory:(MTRControllerFactory *)factory queue:(dispatch_queue_t)queue
+- (instancetype)initWithFactory:(MTRDeviceControllerFactory *)factory queue:(dispatch_queue_t)queue
 {
     if (self = [super init]) {
         _chipWorkQueue = queue;
@@ -139,11 +139,10 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
 - (void)cleanupAfterStartup
 {
     [_factory controllerShuttingDown:self];
-    [self cleanup];
 }
 
 // Part of cleanupAfterStartup that has to interact with the Matter work queue
-// in a very specific way that only MTRControllerFactory knows about.
+// in a very specific way that only MTRDeviceControllerFactory knows about.
 - (void)shutDownCppController
 {
     if (_cppCommissioner) {
@@ -158,6 +157,11 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
             _operationalCredentialsDelegate->SetDeviceCommissioner(nullptr);
         }
     }
+}
+
+- (void)deinitFromFactory
+{
+    [self cleanup];
 }
 
 // Clean up any members we might have allocated.

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
 @class MTRDeviceController;
 @class MTRDeviceControllerStartupParams;
 
-@interface MTRControllerFactoryParams : NSObject
+@interface MTRDeviceControllerFactoryParams : NSObject
 /*
  * Storage delegate must be provided for correct functioning of Matter
  * controllers.  It is used to store persistent information for the fabrics the
@@ -66,44 +66,47 @@ NS_ASSUME_NONNULL_BEGIN
  * Whether to run a server capable of accepting incoming CASE
  * connections.  Defaults to NO.
  */
-@property (nonatomic, assign) BOOL startServer;
+@property (nonatomic, assign) BOOL shouldStartServer;
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithStorage:(id<MTRStorage>)storage;
 @end
 
-@interface MTRControllerFactory : NSObject
-
-@property (readonly, nonatomic) BOOL isRunning;
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
+@interface MTRDeviceControllerFactory : NSObject
 
 /**
- * Return the single MTRControllerFactory we support existing.  It starts off
+ * If true, the factory is in a state where it can create controllers:
+ * startControllerFactory has been called, but stopControllerFactory has not been called
+ * since then.
+ */
+@property (readonly, nonatomic, getter=isRunning) BOOL running;
+
+/**
+ * Return the single MTRDeviceControllerFactory we support existing.  It starts off
  * in a "not started" state.
  */
 + (instancetype)sharedInstance;
 
 /**
- * Start the controller factory. Repeated calls to startup without calls to
- * shutdown in between are NO-OPs. Use the isRunning property to check whether
- * the controller factory needs to be started up.
+ * Start the controller factory. Repeated calls to startControllerFactory
+ * without calls to stopControllerFactory in between are NO-OPs. Use the
+ * isRunning property to check whether the controller factory needs to be
+ * started up.
  *
  * @param[in] startupParams data needed to start up the controller factory.
  *
  * @return Whether startup succeded.
  */
-- (BOOL)startup:(MTRControllerFactoryParams *)startupParams;
+- (BOOL)startControllerFactory:(MTRDeviceControllerFactoryParams *)startupParams error:(NSError * __autoreleasing *)error;
 
 /**
- * Shut down the controller factory. This will shut down any outstanding
- * controllers as part of the factory shutdown.
+ * Stop the controller factory. This will shut down any outstanding
+ * controllers as part of the factory stopping.
  *
- * Repeated calls to shutdown without calls to startup in between are
- * NO-OPs.
+ * Repeated calls to stopControllerFactory without calls to
+ * startControllerFactory in between are NO-OPs.
  */
-- (void)shutdown;
+- (void)stopControllerFactory;
 
 /**
  * Create a MTRDeviceController on an existing fabric.  Returns nil on failure.
@@ -114,7 +117,8 @@ NS_ASSUME_NONNULL_BEGIN
  * The fabric is identified by the root public key and fabric id in
  * the startupParams.
  */
-- (MTRDeviceController * _Nullable)startControllerOnExistingFabric:(MTRDeviceControllerStartupParams *)startupParams;
+- (MTRDeviceController * _Nullable)createControllerOnExistingFabric:(MTRDeviceControllerStartupParams *)startupParams
+                                                              error:(NSError * __autoreleasing *)error;
 
 /**
  * Create a MTRDeviceController on a new fabric.  Returns nil on failure.
@@ -124,7 +128,11 @@ NS_ASSUME_NONNULL_BEGIN
  * The fabric is identified by the root public key and fabric id in
  * the startupParams.
  */
-- (MTRDeviceController * _Nullable)startControllerOnNewFabric:(MTRDeviceControllerStartupParams *)startupParams;
+- (MTRDeviceController * _Nullable)createControllerOnNewFabric:(MTRDeviceControllerStartupParams *)startupParams
+                                                         error:(NSError * __autoreleasing *)error;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory_Internal.h
@@ -15,13 +15,13 @@
  */
 
 /**
- * Parts of MTRControllerFactory that are not part of the framework API.
+ * Parts of MTRDeviceControllerFactory that are not part of the framework API.
  * Mostly for use from MTRDeviceController.
  */
 
 #import <Foundation/Foundation.h>
 
-#import "MTRControllerFactory.h"
+#import "MTRDeviceControllerFactory.h"
 
 #include <lib/core/DataModelTypes.h>
 
@@ -38,7 +38,7 @@ namespace Credentials {
 
 NS_ASSUME_NONNULL_BEGIN
 
-@interface MTRControllerFactory (InternalMethods)
+@interface MTRDeviceControllerFactory (InternalMethods)
 
 - (void)controllerShuttingDown:(MTRDeviceController *)controller;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -28,9 +28,10 @@ NS_ASSUME_NONNULL_BEGIN
  * if not using an intermediate CA, the intermediate CA's keypair otherwise.
  *
  * Allowed to be nil if this controller will not be issuing operational
- * certificates.  In that case, the MTRDeviceControllerStartupParams object
- * must be initialized using initWithOperationalKeypair (to provide the
- * operational credentials for the controller itself).
+ * certificates.  In that case, the MTRDeviceControllerStartupParams object must
+ * be initialized using
+ * initWithIPK:operationalKeypair:operationalCertificate:intermediateCertificate:rootCertificate:
+ * (to provide the operational credentials for the controller itself).
  */
 @property (nonatomic, copy, readonly, nullable) id<MTRKeypair> nocSigner;
 /**
@@ -98,8 +99,6 @@ NS_ASSUME_NONNULL_BEGIN
  *
  */
 @property (nonatomic, copy, nullable) NSNumber * nodeID;
-
-// TODO: Add something here for CATs?
 
 /**
  * Root certificate, in X.509 DER form, to use.
@@ -198,14 +197,14 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * ipk must be 16 bytes in length
  */
-- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricID:(NSNumber *)fabricID ipk:(NSData *)ipk;
+- (instancetype)initWithIPK:(NSData *)ipk fabricID:(NSNumber *)fabricID nocSigner:(id<MTRKeypair>)nocSigner;
 
 /**
  * Prepare to initialize a controller with a complete operational certificate
  * chain.  This initialization method should be used when none of the
  * certificate-signing private keys are available locally.
  *
- * The fabric id and node if to use will be derived from the provided
+ * The fabric id and node id to use will be derived from the provided
  * operationalCertificate.
  *
  * intermediateCertificate may be nil if operationalCertificate is signed by
@@ -213,11 +212,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * ipk must be 16 bytes in length.
  */
-- (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
-                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
-                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
-                                       ipk:(NSData *)ipk;
+- (instancetype)initWithIPK:(NSData *)ipk
+         operationalKeypair:(id<MTRKeypair>)operationalKeypair
+     operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
+    intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
+            rootCertificate:(MTRCertificateDERBytes *)rootCertificate;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -30,7 +30,7 @@ using namespace chip;
 
 @implementation MTRDeviceControllerStartupParams
 
-- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricID:(NSNumber *)fabricID ipk:(NSData *)ipk
+- (instancetype)initWithIPK:(NSData *)ipk fabricID:(NSNumber *)fabricID nocSigner:(id<MTRKeypair>)nocSigner
 {
     if (!(self = [super init])) {
         return nil;
@@ -48,11 +48,11 @@ using namespace chip;
     return self;
 }
 
-- (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
-                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
-                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
-                                       ipk:(NSData *)ipk
+- (instancetype)initWithIPK:(NSData *)ipk
+         operationalKeypair:(id<MTRKeypair>)operationalKeypair
+     operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
+    intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
+            rootCertificate:(MTRCertificateDERBytes *)rootCertificate
 {
     if (!(self = [super init])) {
         return nil;

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams_Internal.h
@@ -83,12 +83,12 @@ NS_ASSUME_NONNULL_BEGIN
                              keystore:(chip::Crypto::OperationalKeystore *)keystore
                                params:(MTRDeviceControllerStartupParams *)params;
 
-- (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricID:(NSNumber *)fabricID ipk:(NSData *)ipk NS_UNAVAILABLE;
-- (instancetype)initWithOperationalKeypair:(id<MTRKeypair>)operationalKeypair
-                    operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
-                   intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
-                           rootCertificate:(MTRCertificateDERBytes *)rootCertificate
-                                       ipk:(NSData *)ipk NS_UNAVAILABLE;
+- (instancetype)initWithIPK:(NSData *)ipk fabricID:(NSNumber *)fabricID nocSigner:(id<MTRKeypair>)nocSigner NS_UNAVAILABLE;
+- (instancetype)initWithIPK:(NSData *)ipk
+         operationalKeypair:(id<MTRKeypair>)operationalKeypair
+     operationalCertificate:(MTRCertificateDERBytes *)operationalCertificate
+    intermediateCertificate:(MTRCertificateDERBytes * _Nullable)intermediateCertificate
+            rootCertificate:(MTRCertificateDERBytes *)rootCertificate NS_UNAVAILABLE;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -16,7 +16,7 @@
 
 /**
  * Parts of MTRDeviceController that are not part of the framework API.  Mostly
- * for use from MTRControllerFactory.
+ * for use from MTRDeviceControllerFactory.
  */
 
 #import <Foundation/Foundation.h>
@@ -31,7 +31,7 @@
 #import "MTRDeviceController.h"
 
 @class MTRDeviceControllerStartupParamsInternal;
-@class MTRControllerFactory;
+@class MTRDeviceControllerFactory;
 @class MTRDevice;
 
 namespace chip {
@@ -46,17 +46,17 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceController (InternalMethods)
 
-#pragma mark - MTRControllerFactory methods
+#pragma mark - MTRDeviceControllerFactory methods
 
 /**
  * Start a new controller.  Returns whether startup succeeded.  If this fails,
  * it guarantees that it has called controllerShuttingDown on the
- * MTRControllerFactory.
+ * MTRDeviceControllerFactory.
  *
  * The return value will always match [controller isRunning] for this
  * controller.
  *
- * Only MTRControllerFactory should be calling this.
+ * Only MTRDeviceControllerFactory should be calling this.
  */
 - (BOOL)startup:(MTRDeviceControllerStartupParamsInternal *)startupParams;
 
@@ -69,9 +69,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Init a newly created controller.
  *
- * Only MTRControllerFactory should be calling this.
+ * Only MTRDeviceControllerFactory should be calling this.
  */
-- (instancetype)initWithFactory:(MTRControllerFactory *)factory queue:(dispatch_queue_t)queue;
+- (instancetype)initWithFactory:(MTRDeviceControllerFactory *)factory queue:(dispatch_queue_t)queue;
 
 /**
  * Check whether this controller is running on the given fabric, as represented
@@ -82,7 +82,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Might return failure, in which case we don't know whether it's running on the
  * given fabric.  Otherwise it will set *isRunning to the right boolean value.
  *
- * Only MTRControllerFactory should be calling this.
+ * Only MTRDeviceControllerFactory should be calling this.
  */
 - (CHIP_ERROR)isRunningOnFabric:(chip::FabricTable *)fabricTable
                     fabricIndex:(chip::FabricIndex)fabricIndex
@@ -92,9 +92,18 @@ NS_ASSUME_NONNULL_BEGIN
  * Shut down the underlying C++ controller.  Must be called on the Matter work
  * queue or after the Matter work queue has been shut down.
  *
- * Only MTRControllerFactory should be calling this.
+ * Only MTRDeviceControllerFactory should be calling this.
  */
 - (void)shutDownCppController;
+
+/**
+ * Notification that the MTRDeviceControllerFactory has finished shutting down
+ * this controller and will not be touching it anymore.  This is guaranteed to
+ * be called after initWithFactory succeeds.
+ *
+ * Only MTRDeviceControllerFactory should be calling this.
+ */
+- (void)deinitFromFactory;
 
 /**
  * Ensure we have a CASE session to the given node ID and then call the provided

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -16,7 +16,7 @@
  */
 
 #import "MTROTAProviderDelegateBridge.h"
-#import "MTRControllerFactory_Internal.h"
+#import "MTRDeviceControllerFactory_Internal.h"
 #import "NSDataSpanConversion.h"
 #import "NSStringSpanConversion.h"
 
@@ -149,7 +149,7 @@ private:
             });
         };
 
-        auto * controller = [[MTRControllerFactory sharedInstance] runningControllerForFabricIndex:mFabricIndex.Value()];
+        auto * controller = [[MTRDeviceControllerFactory sharedInstance] runningControllerForFabricIndex:mFabricIndex.Value()];
         VerifyOrReturnError(controller != nil, CHIP_ERROR_INCORRECT_STATE);
         auto nodeId = @(mNodeId.Value());
 
@@ -177,7 +177,7 @@ private:
             error = CHIP_ERROR_INTERNAL;
         }
 
-        auto * controller = [[MTRControllerFactory sharedInstance] runningControllerForFabricIndex:mFabricIndex.Value()];
+        auto * controller = [[MTRDeviceControllerFactory sharedInstance] runningControllerForFabricIndex:mFabricIndex.Value()];
         VerifyOrReturnError(controller != nil, CHIP_ERROR_INCORRECT_STATE);
         auto nodeId = @(mNodeId.Value());
 
@@ -227,7 +227,7 @@ private:
 
         // TODO Handle MaxLength
 
-        auto * controller = [[MTRControllerFactory sharedInstance] runningControllerForFabricIndex:mFabricIndex.Value()];
+        auto * controller = [[MTRDeviceControllerFactory sharedInstance] runningControllerForFabricIndex:mFabricIndex.Value()];
         VerifyOrReturnError(controller != nil, CHIP_ERROR_INCORRECT_STATE);
         auto nodeId = @(mNodeId.Value());
 
@@ -368,7 +368,7 @@ bool GetPeerNodeInfo(CommandHandler * commandHandler, const ConcreteCommandPath 
     }
 
     auto * controller =
-        [[MTRControllerFactory sharedInstance] runningControllerForFabricIndex:commandHandler->GetAccessingFabricIndex()];
+        [[MTRDeviceControllerFactory sharedInstance] runningControllerForFabricIndex:commandHandler->GetAccessingFabricIndex()];
     if (controller == nil) {
         commandHandler->AddStatus(commandPath, Status::Failure);
         return false;

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -29,11 +29,11 @@
 #import <Matter/MTRClusters.h>
 #import <Matter/MTRCommandPayloadsObjc.h>
 #import <Matter/MTRCommissioningParameters.h>
-#import <Matter/MTRControllerFactory.h>
 #import <Matter/MTRDevice.h>
 #import <Matter/MTRDeviceAttestationDelegate.h>
 #import <Matter/MTRDeviceController+XPC.h>
 #import <Matter/MTRDeviceController.h>
+#import <Matter/MTRDeviceControllerFactory.h>
 #import <Matter/MTRDeviceControllerStartupParams.h>
 #import <Matter/MTRDevicePairingDelegate.h>
 #import <Matter/MTRError.h>

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -37,47 +37,45 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
 - (void)testFactoryLifecycle
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
     XCTAssertFalse([factory isRunning]);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 
     // Now try to restart the factory.
-    XCTAssertTrue([factory startup:factoryParams]);
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerLifecycle
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -85,7 +83,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([controller isRunning]);
 
     // now try to restart the controller
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -94,158 +92,148 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     // now try to restart the controller without providing a vendor id.
     params.vendorID = nil;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testFactoryShutdownShutsDownController
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
     XCTAssertFalse([controller isRunning]);
 }
 
 - (void)testControllerMultipleShutdown
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertTrue([controller isRunning]);
     for (int i = 0; i < 5; i++) {
         [controller shutdown];
         XCTAssertFalse([controller isRunning]);
     }
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerWithOTAProviderDelegate
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * otaProvider = [[MTRTestOTAProvider alloc] init];
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
     factoryParams.otaProviderDelegate = otaProvider;
-    XCTAssertTrue([factory startup:factoryParams]);
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertTrue([controller isRunning]);
     [controller shutdown];
 
     // OTA Provider depends on the system state maintained by CHIPDeviceControllerFactory that is destroyed when
     // the controller count goes down to 0. Make sure that a new controller can still be started successfully onto the
     // same fabric.
-    MTRDeviceController * controller2 = [factory startControllerOnExistingFabric:params];
+    MTRDeviceController * controller2 = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertTrue([controller2 isRunning]);
     [controller2 shutdown];
 
     // Check that a new controller can be started on a different fabric too.
-    __auto_type * params2 = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                    fabricID:@(2)
-                                                                                         ipk:testKeys.ipk];
+    __auto_type * params2 = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(2) nocSigner:testKeys];
     XCTAssertNotNil(params2);
 
     params2.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller3 = [factory startControllerOnNewFabric:params2];
+    MTRDeviceController * controller3 = [factory createControllerOnNewFabric:params2 error:nil];
     XCTAssertTrue([controller3 isRunning]);
     [controller3 shutdown];
 
     // Stop the factory, start it up again and create a controller to ensure that no dead state from the previous
     // ota provider delegate is staying around.
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 
-    XCTAssertTrue([factory startup:factoryParams]);
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
-    MTRDeviceController * controller4 = [factory startControllerOnExistingFabric:params2];
+    MTRDeviceController * controller4 = [factory createControllerOnExistingFabric:params2 error:nil];
     XCTAssertTrue([controller4 isRunning]);
     [controller4 shutdown];
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerInvalidAccess
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertTrue([controller isRunning]);
     [controller shutdown];
 
@@ -256,31 +244,29 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                       XCTAssertEqual(error.code, MTRErrorCodeInvalidState);
                                   }]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerNewFabricMatchesOldFabric
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -289,88 +275,82 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     // now try to start a new controller on a new fabric but using the
     // same params; this should fail.
-    XCTAssertNil([factory startControllerOnNewFabric:params]);
+    XCTAssertNil([factory createControllerOnNewFabric:params error:nil]);
 
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerExistingFabricMatchesRunningController
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
     // Now try to start a new controller on the same fabric.  This should fail.
-    XCTAssertNil([factory startControllerOnExistingFabric:params]);
+    XCTAssertNil([factory createControllerOnExistingFabric:params error:nil]);
 
     XCTAssertTrue([controller isRunning]);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerStartControllersOnTwoFabricIds
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params1 = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                    fabricID:@(1)
-                                                                                         ipk:testKeys.ipk];
+    __auto_type * params1 = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params1);
 
     params1.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller1 = [factory startControllerOnNewFabric:params1];
+    MTRDeviceController * controller1 = [factory createControllerOnNewFabric:params1 error:nil];
     XCTAssertNotNil(controller1);
     XCTAssertTrue([controller1 isRunning]);
 
     // Now try to start a new controller with the same root but a
     // different fabric id.
-    __auto_type * params2 = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                    fabricID:@(2)
-                                                                                         ipk:testKeys.ipk];
+    __auto_type * params2 = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(2) nocSigner:testKeys];
     XCTAssertNotNil(params2);
 
     params2.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller2 = [factory startControllerOnNewFabric:params2];
+    MTRDeviceController * controller2 = [factory createControllerOnNewFabric:params2 error:nil];
     XCTAssertNotNil(controller2);
     XCTAssertTrue([controller2 isRunning]);
 
-    XCTAssertNil([factory startControllerOnExistingFabric:params2]);
+    XCTAssertNil([factory createControllerOnExistingFabric:params2 error:nil]);
 
     [controller1 shutdown];
     XCTAssertFalse([controller1 isRunning]);
@@ -378,18 +358,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller2 shutdown];
     XCTAssertFalse([controller2 isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerStartControllerSameFabricWrongSubject
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
@@ -404,15 +384,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * root3 = [MTRCertificates createRootCertificate:testKeys issuerID:@2 fabricID:@1 error:nil];
     XCTAssertNotNil(root3);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
     params.rootCertificate = root1;
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -422,7 +400,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // Now try to start a new controller on the same fabric with what should be
     // a compatible root certificate.
     params.rootCertificate = root2;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -436,7 +414,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // reasons, including our existing operational certificate not matching this
     // root.
     params.rootCertificate = root3;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNil(controller);
 
     // Now try to start a new controller on the same fabric but with a root
@@ -445,21 +423,21 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // the fabric would change if we allowed this.
     params.rootCertificate = root3;
     params.nodeID = nodeId;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNil(controller);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerFabricIdRootCertMismatch
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
@@ -471,21 +449,19 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * root2 = [MTRCertificates createRootCertificate:testKeys issuerID:@1 fabricID:@2 error:nil];
     XCTAssertNotNil(root2);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
     // Try to start controller when fabric id in root cert subject does not match provided fabric id.
     params.rootCertificate = root2;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
     // Start controller when the fabric ids do match.
     params.rootCertificate = root1;
-    controller = [factory startControllerOnNewFabric:params];
+    controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -493,7 +469,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([controller isRunning]);
 
     // Re-start controller on the new fabric.
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -503,21 +479,21 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // Now try to restart controller on the fabric, but with the wrong fabric id
     // in the root cert.
     params.rootCertificate = root2;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNil(controller);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerSignerDoesNotMatchRoot
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -529,9 +505,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * root = [MTRCertificates createRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:signerKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:signerKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
@@ -539,21 +513,21 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     // Try to start controller when there is no ICA and root cert does not match signing key.
     params.rootCertificate = root;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerSignerKeyWithIntermediate
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -573,9 +547,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                           error:nil];
     XCTAssertNotNil(intermediate);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:rootKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
@@ -583,97 +555,91 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // Try to start controller when there is an ICA and the ICA cert does not match signing key.
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
     // Now start controller with the signing key matching the intermediate cert.
-    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys fabricID:@(1) ipk:rootKeys.ipk];
+    params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:intermediateKeys];
     params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate;
-    controller = [factory startControllerOnNewFabric:params];
+    controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerStartupParamsInvalidFabric
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
     // Invalid fabric ID.
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricID:@(0)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(0) nocSigner:rootKeys];
     XCTAssertNil(params);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerStartupParamsInvalidVendor
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:rootKeys];
     XCTAssertNotNil(params);
 
     // Invalid vendor ID ("standard").
     params.vendorID = @(0);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerStartupNodeIdPreserved
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:rootKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -682,7 +648,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -691,33 +657,31 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerStartupNodeIdUsed
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:rootKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
     // Bring up with node id 17.
     params.nodeID = @17;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -728,7 +692,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     // Bring up with a different node id (18).
     params.nodeID = @18;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -739,7 +703,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     // Verify the new node id has been stored.
     params.nodeID = nil;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -748,43 +712,41 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerStartupNodeIdValidation
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:rootKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
     // Try to bring up with node id 0.
     params.nodeID = @0;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
     // Try to bring up with node id that is outside of the operational range.
     params.nodeID = @(0xFFFFFFFF00000000ULL);
-    controller = [factory startControllerOnNewFabric:params];
+    controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
     // Verify that we can indeed bring up a controller for this fabric, with a valid node id.
     params.nodeID = @17;
-    controller = [factory startControllerOnNewFabric:params];
+    controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -793,19 +755,19 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerRotateToICA
 {
     // Tests that we can switch a fabric from not using an ICA to using an ICA.
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -825,16 +787,14 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                           error:nil];
     XCTAssertNotNil(intermediate);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:rootKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
     // Create a new fabric without the ICA.
     params.rootCertificate = root;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -844,11 +804,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but using the ICA.
-    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys fabricID:@(1) ipk:rootKeys.ipk];
+    params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:intermediateKeys];
     params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -857,19 +817,19 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerRotateFromICA
 {
     // Tests that we can switch a fabric from using an ICA to not using an ICA.
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -889,9 +849,9 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                           error:nil];
     XCTAssertNotNil(intermediate);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk
+                                                                        fabricID:@(1)
+                                                                       nocSigner:intermediateKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
@@ -899,7 +859,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // Create a new fabric without the ICA.
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -909,10 +869,10 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but without using the ICA.
-    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys fabricID:@(1) ipk:rootKeys.ipk];
+    params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:rootKeys];
     params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -921,19 +881,19 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerRotateICA
 {
     // Tests that we can change the ICA being used for a fabric.
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -964,9 +924,9 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                            error:nil];
     XCTAssertNotNil(intermediate2);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys1
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk
+                                                                        fabricID:@(1)
+                                                                       nocSigner:intermediateKeys1];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
@@ -974,7 +934,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // Create a new fabric without the first ICA.
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate1;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -984,11 +944,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but using the second ICA.
-    params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys2 fabricID:@(1) ipk:rootKeys.ipk];
+    params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:intermediateKeys2];
     params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate2;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -997,18 +957,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerICAWithoutRoot
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -1028,30 +988,30 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                           error:nil];
     XCTAssertNotNil(intermediate);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk
+                                                                        fabricID:@(1)
+                                                                       nocSigner:intermediateKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
     // Pass in an intermediate but no root.  Should fail.
     params.intermediateCertificate = intermediate;
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerProvideFullCertChain
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -1083,16 +1043,16 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                         error:nil];
     XCTAssertNotNil(operational);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithOperationalKeypair:operationalKeys
-                                                                         operationalCertificate:operational
-                                                                        intermediateCertificate:intermediate
-                                                                                rootCertificate:root
-                                                                                            ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk
+                                                              operationalKeypair:operationalKeys
+                                                          operationalCertificate:operational
+                                                         intermediateCertificate:intermediate
+                                                                 rootCertificate:root];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -1102,11 +1062,11 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([controller isRunning]);
 
     // Trying to bring up another new fabric with the same root and NOC should fail.
-    controller = [factory startControllerOnNewFabric:params];
+    controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
     // Trying to bring up the same fabric should succeed.
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -1115,18 +1075,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerProvideCertChainNoICA
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -1147,16 +1107,16 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                         error:nil];
     XCTAssertNotNil(operational);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithOperationalKeypair:operationalKeys
-                                                                         operationalCertificate:operational
-                                                                        intermediateCertificate:nil
-                                                                                rootCertificate:root
-                                                                                            ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk
+                                                              operationalKeypair:operationalKeys
+                                                          operationalCertificate:operational
+                                                         intermediateCertificate:nil
+                                                                 rootCertificate:root];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -1165,18 +1125,18 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerCertChainFabricMismatchRoot
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -1197,30 +1157,30 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                         error:nil];
     XCTAssertNotNil(operational);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithOperationalKeypair:operationalKeys
-                                                                         operationalCertificate:operational
-                                                                        intermediateCertificate:nil
-                                                                                rootCertificate:root
-                                                                                            ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk
+                                                              operationalKeypair:operationalKeys
+                                                          operationalCertificate:operational
+                                                         intermediateCertificate:nil
+                                                                 rootCertificate:root];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerCertChainFabricMismatchIntermediate
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -1252,30 +1212,30 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                         error:nil];
     XCTAssertNotNil(operational);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithOperationalKeypair:operationalKeys
-                                                                         operationalCertificate:operational
-                                                                        intermediateCertificate:intermediate
-                                                                                rootCertificate:root
-                                                                                            ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk
+                                                              operationalKeypair:operationalKeys
+                                                          operationalCertificate:operational
+                                                         intermediateCertificate:intermediate
+                                                                 rootCertificate:root];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNil(controller);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 
 - (void)testControllerExternallyProvidedOperationalKey
 {
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
-    XCTAssertTrue([factory startup:factoryParams]);
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startControllerFactory:factoryParams error:nil]);
     XCTAssertTrue([factory isRunning]);
 
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
@@ -1284,15 +1244,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(operationalKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:rootKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:rootKeys.ipk fabricID:@(1) nocSigner:rootKeys];
     XCTAssertNotNil(params);
 
     params.vendorID = @(kTestVendorId);
     params.operationalKeypair = operationalKeys;
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -1305,13 +1263,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // keypair should now fail, because we won't know what operational keys to
     // use.
     params.operationalKeypair = nil;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNil(controller);
 
     // But bringing up the controller with provided operational keys should
     // work, and have the same node id.
     params.operationalKeypair = operationalKeys;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -1326,7 +1284,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(newOperationalKeys);
 
     params.operationalKeypair = newOperationalKeys;
-    controller = [factory startControllerOnExistingFabric:params];
+    controller = [factory createControllerOnExistingFabric:params error:nil];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
@@ -1335,7 +1293,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [factory shutdown];
+    [factory stopControllerFactory];
     XCTAssertFalse([factory isRunning]);
 }
 

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -144,25 +144,23 @@ static MTRBaseDevice * GetConnectedDevice(void)
 {
     XCTestExpectation * expectation = [self expectationWithDescription:@"Pairing Complete"];
 
-    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];
     XCTAssertNotNil(factory);
 
     __auto_type * storage = [[MTRTestStorage alloc] init];
-    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
+    __auto_type * factoryParams = [[MTRDeviceControllerFactoryParams alloc] initWithStorage:storage];
     factoryParams.port = @(kLocalPort);
 
-    BOOL ok = [factory startup:factoryParams];
+    BOOL ok = [factory startControllerFactory:factoryParams error:nil];
     XCTAssertTrue(ok);
 
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
-                                                                                   fabricID:@(1)
-                                                                                        ipk:testKeys.ipk];
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
     params.vendorID = @(kTestVendorId);
 
-    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    MTRDeviceController * controller = [factory createControllerOnNewFabric:params error:nil];
     XCTAssertNotNil(controller);
 
     sController = controller;
@@ -197,7 +195,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
-    [[MTRControllerFactory sharedInstance] shutdown];
+    [[MTRDeviceControllerFactory sharedInstance] stopControllerFactory];
 }
 
 - (void)waitForCommissionee

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -43,9 +43,9 @@
 		511913FC28C100EF009235E9 /* MTRBaseSubscriptionCallback.h in Headers */ = {isa = PBXBuildFile; fileRef = 511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */; };
 		5129BCFD26A9EE3300122DDF /* MTRError.h in Headers */ = {isa = PBXBuildFile; fileRef = 5129BCFC26A9EE3300122DDF /* MTRError.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		5136661328067D550025EDAE /* MTRDeviceController_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5136660F28067D540025EDAE /* MTRDeviceController_Internal.h */; };
-		5136661428067D550025EDAE /* MTRControllerFactory.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5136661028067D540025EDAE /* MTRControllerFactory.mm */; };
-		5136661528067D550025EDAE /* MTRControllerFactory_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5136661128067D540025EDAE /* MTRControllerFactory_Internal.h */; };
-		5136661628067D550025EDAE /* MTRControllerFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 5136661228067D550025EDAE /* MTRControllerFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		5136661428067D550025EDAE /* MTRDeviceControllerFactory.mm in Sources */ = {isa = PBXBuildFile; fileRef = 5136661028067D540025EDAE /* MTRDeviceControllerFactory.mm */; };
+		5136661528067D550025EDAE /* MTRDeviceControllerFactory_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 5136661128067D540025EDAE /* MTRDeviceControllerFactory_Internal.h */; };
+		5136661628067D550025EDAE /* MTRDeviceControllerFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 5136661228067D550025EDAE /* MTRDeviceControllerFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		513DDB862761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 513DDB852761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h */; };
 		513DDB8A2761F6F900DAA01A /* MTRAttributeTLVValueDecoder.mm in Sources */ = {isa = PBXBuildFile; fileRef = 513DDB892761F6F900DAA01A /* MTRAttributeTLVValueDecoder.mm */; };
 		51431AF927D2973E008A7943 /* MTRIMDispatch.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51431AF827D2973E008A7943 /* MTRIMDispatch.mm */; };
@@ -182,9 +182,9 @@
 		511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRBaseSubscriptionCallback.h; sourceTree = "<group>"; };
 		5129BCFC26A9EE3300122DDF /* MTRError.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = MTRError.h; sourceTree = "<group>"; };
 		5136660F28067D540025EDAE /* MTRDeviceController_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceController_Internal.h; sourceTree = "<group>"; };
-		5136661028067D540025EDAE /* MTRControllerFactory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRControllerFactory.mm; sourceTree = "<group>"; };
-		5136661128067D540025EDAE /* MTRControllerFactory_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRControllerFactory_Internal.h; sourceTree = "<group>"; };
-		5136661228067D550025EDAE /* MTRControllerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRControllerFactory.h; sourceTree = "<group>"; };
+		5136661028067D540025EDAE /* MTRDeviceControllerFactory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRDeviceControllerFactory.mm; sourceTree = "<group>"; };
+		5136661128067D540025EDAE /* MTRDeviceControllerFactory_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerFactory_Internal.h; sourceTree = "<group>"; };
+		5136661228067D550025EDAE /* MTRDeviceControllerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRDeviceControllerFactory.h; sourceTree = "<group>"; };
 		513DDB852761F69300DAA01A /* MTRAttributeTLVValueDecoder_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRAttributeTLVValueDecoder_Internal.h; sourceTree = "<group>"; };
 		513DDB892761F6F900DAA01A /* MTRAttributeTLVValueDecoder.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MTRAttributeTLVValueDecoder.mm; path = "zap-generated/MTRAttributeTLVValueDecoder.mm"; sourceTree = "<group>"; };
 		51431AF827D2973E008A7943 /* MTRIMDispatch.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRIMDispatch.mm; sourceTree = "<group>"; };
@@ -421,12 +421,12 @@
 				991DC0822475F45400C13860 /* MTRDeviceController.h */,
 				991DC0872475F47D00C13860 /* MTRDeviceController.mm */,
 				5136660F28067D540025EDAE /* MTRDeviceController_Internal.h */,
-				5136661128067D540025EDAE /* MTRControllerFactory_Internal.h */,
+				5136661128067D540025EDAE /* MTRDeviceControllerFactory_Internal.h */,
 				51E51FBD282AD37A00FC978D /* MTRDeviceControllerStartupParams_Internal.h */,
 				51E51FBC282AD37A00FC978D /* MTRDeviceControllerStartupParams.h */,
 				51E51FBE282AD37A00FC978D /* MTRDeviceControllerStartupParams.mm */,
-				5136661228067D550025EDAE /* MTRControllerFactory.h */,
-				5136661028067D540025EDAE /* MTRControllerFactory.mm */,
+				5136661228067D550025EDAE /* MTRDeviceControllerFactory.h */,
+				5136661028067D540025EDAE /* MTRDeviceControllerFactory.mm */,
 				5A7947E227C0101200434CF2 /* MTRDeviceController+XPC.h */,
 				517BF3EE282B62B800A8B7DB /* MTRCertificates.h */,
 				517BF3EF282B62B800A8B7DB /* MTRCertificates.mm */,
@@ -496,7 +496,7 @@
 			files = (
 				517BF3F0282B62B800A8B7DB /* MTRCertificates.h in Headers */,
 				51E51FBF282AD37A00FC978D /* MTRDeviceControllerStartupParams.h in Headers */,
-				5136661628067D550025EDAE /* MTRControllerFactory.h in Headers */,
+				5136661628067D550025EDAE /* MTRDeviceControllerFactory.h in Headers */,
 				7596A84B287636C1004DAE0E /* MTRDevice_Internal.h in Headers */,
 				5A6FEC9927B5C88900F25F42 /* MTRDeviceOverXPC.h in Headers */,
 				51B22C222740CB1D008D5055 /* MTRCommandPayloadsObjc.h in Headers */,
@@ -507,7 +507,7 @@
 				2C1B027B2641DB4E00780EF1 /* MTROperationalCredentialsDelegate.h in Headers */,
 				7596A85728788557004DAE0E /* MTRClusters.h in Headers */,
 				99D466E12798936D0089A18F /* MTRCommissioningParameters.h in Headers */,
-				5136661528067D550025EDAE /* MTRControllerFactory_Internal.h in Headers */,
+				5136661528067D550025EDAE /* MTRDeviceControllerFactory_Internal.h in Headers */,
 				515C1C70284F9FFB00A48F0C /* MTRMemory.h in Headers */,
 				7534F12928BFF20300390851 /* MTRDeviceAttestationDelegate_Internal.h in Headers */,
 				D4772A46285AE98400383630 /* MTRClusterConstants.h in Headers */,
@@ -687,7 +687,7 @@
 				515C1C6F284F9FFB00A48F0C /* MTRMemory.mm in Sources */,
 				27A53C1827FBC6920053F131 /* MTRAttestationTrustStoreBridge.mm in Sources */,
 				998F287126D56940001846C6 /* MTRP256KeypairBridge.mm in Sources */,
-				5136661428067D550025EDAE /* MTRControllerFactory.mm in Sources */,
+				5136661428067D550025EDAE /* MTRDeviceControllerFactory.mm in Sources */,
 				51B22C2A2740CB47008D5055 /* MTRCommandPayloadsObjc.mm in Sources */,
 				AF5F90FF2878D351005503FA /* MTROTAProviderDelegateBridge.mm in Sources */,
 				7534F12828BFF20300390851 /* MTRDeviceAttestationDelegate.mm in Sources */,


### PR DESCRIPTION
* Rename to MTRDeviceControllerFactory.
* Change the startup params startServer to shouldStartServer.
* Change the startup params init signatures to be more aligned.
* Change isRunning to running.
* Rename startup to startControllerFactory and add NSError outparam.
* Rename shutdown to stopControllerFactory
* Rename startControllerOnExistingFabric to createControllerOnExistingFabric and add NSError outparam.
* Rename startControllerOnNewFabric to createControllerOnNewFabric and add NSError outparam.

Addresses part of https://github.com/project-chip/connectedhomeip/issues/22420

#### Issue Being Resolved
* Fixes #22594

#### Change overview
See above.
