### PR TITLE
[nrfconnect] fix the crash during CASE session resumption

### DIFF
--- a/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
+++ b/examples/light-switch-app/nrfconnect/main/BindingHandler.cpp
@@ -35,18 +35,13 @@ void BindingHandler::Init()
     DeviceLayer::PlatformMgr().ScheduleWork(InitInternal);
 }
 
-void BindingHandler::OnInvokeCommandFailure(DeviceProxy * aDevice, BindingData & aBindingData, CHIP_ERROR aError)
+void BindingHandler::OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERROR aError)
 {
     CHIP_ERROR error;
 
     if (aError == CHIP_ERROR_TIMEOUT && !BindingHandler::GetInstance().mCaseSessionRecovered)
     {
         LOG_INF("Response timeout for invoked command, trying to recover CASE session.");
-        if (!aDevice)
-            return;
-
-        // Release current CASE session.
-        aDevice->Disconnect();
 
         // Set flag to not try recover session multiple times.
         BindingHandler::GetInstance().mCaseSessionRecovered = true;
@@ -85,9 +80,7 @@ void BindingHandler::OnOffProcessCommand(CommandId aCommandId, const EmberBindin
             BindingHandler::GetInstance().mCaseSessionRecovered = false;
     };
 
-    auto onFailure = [aDevice, dataRef = *data](CHIP_ERROR aError) mutable {
-        BindingHandler::OnInvokeCommandFailure(aDevice, dataRef, aError);
-    };
+    auto onFailure = [dataRef = *data](CHIP_ERROR aError) mutable { BindingHandler::OnInvokeCommandFailure(dataRef, aError); };
 
     if (aDevice)
     {
@@ -162,9 +155,7 @@ void BindingHandler::LevelControlProcessCommand(CommandId aCommandId, const Embe
             BindingHandler::GetInstance().mCaseSessionRecovered = false;
     };
 
-    auto onFailure = [aDevice, dataRef = *data](CHIP_ERROR aError) mutable {
-        BindingHandler::OnInvokeCommandFailure(aDevice, dataRef, aError);
-    };
+    auto onFailure = [dataRef = *data](CHIP_ERROR aError) mutable { BindingHandler::OnInvokeCommandFailure(dataRef, aError); };
 
     CHIP_ERROR ret = CHIP_NO_ERROR;
 

--- a/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
+++ b/examples/light-switch-app/nrfconnect/main/include/BindingHandler.h
@@ -42,7 +42,7 @@ public:
     bool IsGroupBound();
 
     static void SwitchWorkerHandler(intptr_t);
-    static void OnInvokeCommandFailure(chip::DeviceProxy * aDevice, BindingData & aBindingData, CHIP_ERROR aError);
+    static void OnInvokeCommandFailure(BindingData & aBindingData, CHIP_ERROR aError);
 
     static BindingHandler & GetInstance()
     {


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22621

#### Change overview
Do not use DeviceProxy pointer in application callback (BindingHandler),
as this object instantiated as temporary object in the caller's code.

This is only application/platform related change.