### PR TITLE
Pin dbus-python to correct version for arm64 build

### DIFF
--- a/scripts/constraints.txt
+++ b/scripts/constraints.txt
@@ -63,7 +63,7 @@ cryptography==3.4.7
     #   -r requirements.txt
 cxxfilt==0.2.2
     # via -r requirements.txt
-dbus-python==1.2.16 ; sys_platform == "linux"
+dbus-python==1.2.18 ; sys_platform == "linux"
     # via -r requirements.txt
 decorator==5.0.9
     # via ipython

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -16,7 +16,7 @@ requests>=2.24.0
 
 # device controller wheel package
 wheel
-dbus-python; sys_platform == 'linux'
+dbus-python==1.2.18; sys_platform == 'linux'
 pgi; sys_platform == 'linux'
 pyobjc-core; sys_platform == 'darwin'
 pyobjc-framework-cocoa; sys_platform == 'darwin'

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -298,7 +298,7 @@ chip_python_wheel_action("chip-core") {
     py_package_reqs += [ "pyobjc-framework-corebluetooth" ]
   } else if (current_os == "linux") {
     py_package_reqs += [
-      "dbus-python",
+      "dbus-python==1.2.18",
       "pygobject",
     ]
   }

--- a/src/pybindings/pycontroller/build-chip-wheel.py
+++ b/src/pybindings/pycontroller/build-chip-wheel.py
@@ -123,7 +123,7 @@ try:
         requiredPackages.append('pyobjc-framework-corebluetooth')
 
     if platform.system() == 'Linux':
-        requiredPackages.append('dbus-python')
+        requiredPackages.append('dbus-python==1.2.18')
         requiredPackages.append('pygobject')
 
     #


### PR DESCRIPTION
#### Issue Being Resolved
Fixes #22613
- dbus-python was updated on Sep 6 2022 to 1.3.0.
- This change caused issues with arm64 build of python controller

#### Change overview
- Pin version 1.2.18, which was tested to work and was the default before.

Testing done:
- Built successfully with prior version known to work
- Can run tests
