### PR TITLE
Idl lint in ci

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,11 +47,25 @@ jobs:
               if: ${{ env.ACT }}
               name: Checkout (ACT for local build)
 
+            # Bootstrap and checkout for internal scripts (like idl_lint)
+            # to run
+            - name: Checkout submodules
+              run: scripts/checkout_submodules.py --shallow --platform linux
+            - name: Bootstrap
+              timeout-minutes: 10
+              run: scripts/build/gn_bootstrap.sh
+
             - name: Check for matter lint errors
               if: always()
               run: |
                  for idl_file in $(find . -name '*.matter'); do
                      # TODO: all these conformance failures should be fixed
+                     #       Issues exist for most of them:
+                     #       https://github.com/project-chip/connectedhomeip/issues/19180
+                     #       https://github.com/project-chip/connectedhomeip/issues/19176
+                     #       https://github.com/project-chip/connectedhomeip/issues/19175
+                     #       https://github.com/project-chip/connectedhomeip/issues/19173
+                     #       https://github.com/project-chip/connectedhomeip/issues/19169
                      if [ "$idl_file" == './examples/window-app/common/window-app.matter' ]; then continue; fi
                      if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter']; then continue; fi
                      if [ "$idl_file" == './examples/placeholder/linux/apps/app1/config.matter']; then continue; fi

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,6 +29,7 @@ jobs:
 
         steps:
             - uses: Wandalen/wretry.action@v1.0.15
+              if: ${{ !env.ACT }}
               name: Checkout
               with:
                   action: actions/checkout@v3
@@ -36,6 +37,32 @@ jobs:
                       token: ${{ github.token }}
                   attempt_limit: 3
                   attempt_delay: 2000
+            # To use act like:
+            #   act -j full_android
+            #
+            # Note you likely still need to have non submodules setup for the
+            # local machine, like:
+            #   git submodule deinit --all
+            - uses: actions/checkout@v3
+              if: ${{ env.ACT }}
+              name: Checkout (ACT for local build)
+
+            - name: Check for matter lint errors
+              if: always()
+              run: |
+                 for idl_file in $(find . -name '*.matter'); do
+                     # TODO: all these conformance failures should be fixed
+                     if [ "$idl_file" == './examples/window-app/common/window-app.matter' ]; then continue; fi
+                     if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter']; then continue; fi
+                     if [ "$idl_file" == './examples/placeholder/linux/apps/app1/config.matter']; then continue; fi
+                     if [ "$idl_file" == './examples/placeholder/linux/apps/app2/config.matter']; then continue; fi
+                     if [ "$idl_file" == './examples/thermostat/thermostat-common/thermostat.matter']; then continue; fi
+                     if [ "$idl_file" == './examples/all-clusters-app/all-clusters-common/all-clusters-app.matter']; then continue; fi
+                     if [ "$idl_file" == './examples/lighting-app/lighting-common/lighting-app.matter']; then continue; fi
+                     if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter']; then continue; fi
+
+                     ./scripts/run_in_build_env.sh "./scripts/idl_lint.py --log-level warn $idl_file" >/dev/null || exit 1
+                 done
 
             - name: Check broken links
               # On-push disabled until the job can run fully green

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -70,13 +70,13 @@ jobs:
                      #       https://github.com/project-chip/connectedhomeip/issues/19173
                      #       https://github.com/project-chip/connectedhomeip/issues/19169
                      if [ "$idl_file" == './examples/window-app/common/window-app.matter' ]; then continue; fi
-                     if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter']; then continue; fi
-                     if [ "$idl_file" == './examples/placeholder/linux/apps/app1/config.matter']; then continue; fi
-                     if [ "$idl_file" == './examples/placeholder/linux/apps/app2/config.matter']; then continue; fi
-                     if [ "$idl_file" == './examples/thermostat/thermostat-common/thermostat.matter']; then continue; fi
-                     if [ "$idl_file" == './examples/all-clusters-app/all-clusters-common/all-clusters-app.matter']; then continue; fi
-                     if [ "$idl_file" == './examples/lighting-app/lighting-common/lighting-app.matter']; then continue; fi
-                     if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter']; then continue; fi
+                     if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
+                     if [ "$idl_file" == './examples/placeholder/linux/apps/app1/config.matter' ]; then continue; fi
+                     if [ "$idl_file" == './examples/placeholder/linux/apps/app2/config.matter' ]; then continue; fi
+                     if [ "$idl_file" == './examples/thermostat/thermostat-common/thermostat.matter' ]; then continue; fi
+                     if [ "$idl_file" == './examples/all-clusters-app/all-clusters-common/all-clusters-app.matter' ]; then continue; fi
+                     if [ "$idl_file" == './examples/lighting-app/lighting-common/lighting-app.matter' ]; then continue; fi
+                     if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
 
                      ./scripts/run_in_build_env.sh "./scripts/idl_lint.py --log-level warn $idl_file" >/dev/null || exit 1
                  done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -41,7 +41,7 @@ jobs:
                   attempt_limit: 3
                   attempt_delay: 2000
             # To use act like:
-            #   act -j full_android
+            #   act -j code-lints
             #
             # Note you likely still need to have non submodules setup for the
             # local machine, like:

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,14 +69,14 @@ jobs:
                      #       https://github.com/project-chip/connectedhomeip/issues/19175
                      #       https://github.com/project-chip/connectedhomeip/issues/19173
                      #       https://github.com/project-chip/connectedhomeip/issues/19169
-                     if [ "$idl_file" == './examples/window-app/common/window-app.matter' ]; then continue; fi
-                     if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
-                     if [ "$idl_file" == './examples/placeholder/linux/apps/app1/config.matter' ]; then continue; fi
-                     if [ "$idl_file" == './examples/placeholder/linux/apps/app2/config.matter' ]; then continue; fi
-                     if [ "$idl_file" == './examples/thermostat/thermostat-common/thermostat.matter' ]; then continue; fi
-                     if [ "$idl_file" == './examples/all-clusters-app/all-clusters-common/all-clusters-app.matter' ]; then continue; fi
-                     if [ "$idl_file" == './examples/lighting-app/lighting-common/lighting-app.matter' ]; then continue; fi
-                     if [ "$idl_file" == './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/window-app/common/window-app.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/placeholder/linux/apps/app1/config.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/placeholder/linux/apps/app2/config.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/thermostat/thermostat-common/thermostat.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/all-clusters-app/all-clusters-common/all-clusters-app.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/lighting-app/lighting-common/lighting-app.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
 
                      ./scripts/run_in_build_env.sh "./scripts/idl_lint.py --log-level warn $idl_file" >/dev/null || exit 1
                  done

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,6 +27,9 @@ jobs:
         runs-on: ubuntu-latest
         if: github.actor != 'restyled-io[bot]'
 
+        container:
+            image: connectedhomeip/chip-build:0.5.99
+
         steps:
             - uses: Wandalen/wretry.action@v1.0.15
               if: ${{ !env.ACT }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -69,14 +69,33 @@ jobs:
                      #       https://github.com/project-chip/connectedhomeip/issues/19175
                      #       https://github.com/project-chip/connectedhomeip/issues/19173
                      #       https://github.com/project-chip/connectedhomeip/issues/19169
-                     if [ "$idl_file" = './examples/window-app/common/window-app.matter' ]; then continue; fi
+                     #       https://github.com/project-chip/connectedhomeip/issues/22640
+                     if [ "$idl_file" = './examples/all-clusters-app/all-clusters-common/all-clusters-app.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/lighting-app/lighting-common/lighting-app.matter' ]; then continue; fi
                      if [ "$idl_file" = './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
                      if [ "$idl_file" = './examples/placeholder/linux/apps/app1/config.matter' ]; then continue; fi
                      if [ "$idl_file" = './examples/placeholder/linux/apps/app2/config.matter' ]; then continue; fi
                      if [ "$idl_file" = './examples/thermostat/thermostat-common/thermostat.matter' ]; then continue; fi
-                     if [ "$idl_file" = './examples/all-clusters-app/all-clusters-common/all-clusters-app.matter' ]; then continue; fi
-                     if [ "$idl_file" = './examples/lighting-app/lighting-common/lighting-app.matter' ]; then continue; fi
-                     if [ "$idl_file" = './examples/log-source-app/log-source-common/log-source-app.matter' ]; then continue; fi
+                     if [ "$idl_file" = './examples/window-app/common/window-app.matter' ]; then continue; fi
 
                      ./scripts/run_in_build_env.sh "./scripts/idl_lint.py --log-level warn $idl_file" >/dev/null || exit 1
                  done

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -1462,7 +1462,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.zap
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
@@ -1344,7 +1344,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.zap
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -1596,7 +1596,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.zap
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -1951,7 +1951,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.zap
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -1851,7 +1851,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.zap
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
@@ -1356,7 +1356,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.zap
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -1704,7 +1704,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.zap
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
@@ -1356,7 +1356,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.zap
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -1360,7 +1360,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.zap
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
@@ -1355,7 +1355,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.zap
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -1586,7 +1586,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.zap
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
@@ -1645,7 +1645,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.zap
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
@@ -1492,7 +1492,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.zap
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -1359,7 +1359,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.zap
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
@@ -1466,7 +1466,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.zap
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
@@ -1355,7 +1355,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.zap
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -1604,7 +1604,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.zap
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -1584,7 +1584,7 @@ endpoint 0 {
   }
 
   server cluster LocalizationConfiguration {
-    callback attribute supportedLocales default = en-US;
+    callback attribute supportedLocales;
     ram      attribute featureMap;
     ram      attribute clusterRevision default = 1;
   }

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.zap
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.zap
@@ -1768,7 +1768,7 @@
               "storageOption": "External",
               "singleton": 0,
               "bounded": 0,
-              "defaultValue": "en-US",
+              "defaultValue": "",
               "reportable": 1,
               "minInterval": 1,
               "maxInterval": 65534,

--- a/scripts/tools/check_includes.sh
+++ b/scripts/tools/check_includes.sh
@@ -16,4 +16,4 @@
 #
 
 git grep -n -E '^[[:space:]]*#[[:space:]]*include[[:space:]]*[<"]' src |
-    python "${0%.*}.py"
+    python3 "${0%.*}.py"


### PR DESCRIPTION
#### Issue Being Resolved
Closes #22634

#### Change overview
Run `scripts/idl_lint.py` over all matter files in the repo to not allow it to regress.

We have a list of known wrong examples that are skipped and marked the corresponding TODO and issue numbers for them to get fixed.

Fixes a 'default array value' that was present in all chef examples (defaults do not work for external values and all arrays are external)
