### PR TITLE
[Darwin] Update templates to preserve acronyms (e.g ACL) in APIs

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -73,6 +73,7 @@ exclude:
     - "examples/chef/sample_app_util/test_files/*.yaml"
     - "examples/chef/zzz_generated/**/*"
     - "src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.mm" # https://github.com/project-chip/connectedhomeip/issues/20236
+    - "src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h" # https://github.com/project-chip/connectedhomeip/issues/20236
 
 
 changed_paths:

--- a/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
+++ b/examples/all-clusters-app/all-clusters-common/all-clusters-app.matter
@@ -636,18 +636,18 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
@@ -724,7 +724,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -1002,33 +1002,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -1042,7 +1042,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -1086,7 +1086,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -1188,7 +1188,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1613,7 +1613,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
+++ b/examples/all-clusters-minimal-app/all-clusters-common/all-clusters-minimal-app.matter
@@ -571,18 +571,18 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
@@ -659,7 +659,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -931,33 +931,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -971,7 +971,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -1015,7 +1015,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -1111,7 +1111,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1458,7 +1458,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {
@@ -2922,11 +2922,11 @@ server cluster AccountLogin = 1294 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct GetSetupPINRequest {
-    CHAR_STRING tempAccountIdentifier = 0;
+    CHAR_STRING<100> tempAccountIdentifier = 0;
   }
 
   request struct LoginRequest {
-    CHAR_STRING tempAccountIdentifier = 0;
+    CHAR_STRING<100> tempAccountIdentifier = 0;
     CHAR_STRING setupPIN = 1;
   }
 

--- a/examples/bridge-app/bridge-common/bridge-app.matter
+++ b/examples/bridge-app/bridge-common/bridge-app.matter
@@ -695,33 +695,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -735,7 +735,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -779,7 +779,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -881,7 +881,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1306,7 +1306,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/noip_rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -526,30 +526,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -625,7 +625,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -750,7 +750,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -849,7 +849,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1271,7 +1271,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
+++ b/examples/chef/devices/rootnode_contactsensor_lFAGG1bfRO.matter
@@ -271,30 +271,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -370,7 +370,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -545,33 +545,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -585,7 +585,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -629,7 +629,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -728,7 +728,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1150,7 +1150,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
+++ b/examples/chef/devices/rootnode_dimmablelight_bCwGYSDpoe.matter
@@ -526,30 +526,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -625,7 +625,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -800,33 +800,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -840,7 +840,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -884,7 +884,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -983,7 +983,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1405,7 +1405,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
+++ b/examples/chef/devices/rootnode_doorlock_aNKYAreMXE.matter
@@ -493,30 +493,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -592,7 +592,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -767,33 +767,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -807,7 +807,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -851,7 +851,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -950,7 +950,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1372,7 +1372,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
+++ b/examples/chef/devices/rootnode_extendedcolorlight_8lcaaYJVAa.matter
@@ -526,30 +526,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -625,7 +625,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -800,33 +800,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -840,7 +840,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -884,7 +884,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -983,7 +983,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1405,7 +1405,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
+++ b/examples/chef/devices/rootnode_flowsensor_1zVxHedlaV.matter
@@ -284,30 +284,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -383,7 +383,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -558,33 +558,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -598,7 +598,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -642,7 +642,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -741,7 +741,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1163,7 +1163,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
+++ b/examples/chef/devices/rootnode_heatingcoolingunit_ncdGai1E5a.matter
@@ -519,30 +519,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -618,7 +618,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -793,33 +793,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -833,7 +833,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -877,7 +877,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -976,7 +976,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1398,7 +1398,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
+++ b/examples/chef/devices/rootnode_humiditysensor_Xyj4gda6Hb.matter
@@ -284,30 +284,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -383,7 +383,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -558,33 +558,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -598,7 +598,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -642,7 +642,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -741,7 +741,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1163,7 +1163,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
+++ b/examples/chef/devices/rootnode_lightsensor_lZQycTFcJK.matter
@@ -284,30 +284,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -383,7 +383,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -558,33 +558,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -598,7 +598,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -642,7 +642,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -741,7 +741,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1163,7 +1163,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
+++ b/examples/chef/devices/rootnode_occupancysensor_iHyVgifZuo.matter
@@ -284,30 +284,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -383,7 +383,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -558,33 +558,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -598,7 +598,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -642,7 +642,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -741,7 +741,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1163,7 +1163,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
+++ b/examples/chef/devices/rootnode_onofflight_bbs1b7IaOV.matter
@@ -526,30 +526,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -625,7 +625,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -800,33 +800,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -840,7 +840,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -884,7 +884,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -983,7 +983,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1405,7 +1405,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
+++ b/examples/chef/devices/rootnode_onofflightswitch_FsPlMr090Q.matter
@@ -585,30 +585,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -684,7 +684,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -859,33 +859,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -899,7 +899,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -943,7 +943,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -1042,7 +1042,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1464,7 +1464,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
+++ b/examples/chef/devices/rootnode_onoffpluginunit_Wtf8ss5EBY.matter
@@ -432,30 +432,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -531,7 +531,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -706,33 +706,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -746,7 +746,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -790,7 +790,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -889,7 +889,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1311,7 +1311,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
+++ b/examples/chef/devices/rootnode_pressuresensor_s0qC9wLH4k.matter
@@ -284,30 +284,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -383,7 +383,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -558,33 +558,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -598,7 +598,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -642,7 +642,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -741,7 +741,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1163,7 +1163,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
+++ b/examples/chef/devices/rootnode_speaker_RpzeXdimqA.matter
@@ -406,30 +406,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -505,7 +505,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -680,33 +680,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -720,7 +720,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -764,7 +764,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -863,7 +863,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1285,7 +1285,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
+++ b/examples/chef/devices/rootnode_temperaturesensor_Qy1zkNW7c3.matter
@@ -284,30 +284,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -383,7 +383,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -558,33 +558,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -598,7 +598,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -642,7 +642,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -741,7 +741,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1163,7 +1163,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
+++ b/examples/chef/devices/rootnode_thermostat_bm3fb8dhYi.matter
@@ -382,30 +382,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -481,7 +481,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -656,33 +656,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -696,7 +696,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -740,7 +740,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -839,7 +839,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1261,7 +1261,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
+++ b/examples/chef/devices/rootnode_windowcovering_RLCxaGi9Yx.matter
@@ -382,30 +382,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -481,7 +481,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -656,33 +656,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -696,7 +696,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -740,7 +740,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -839,7 +839,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1261,7 +1261,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.h
+++ b/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.h
@@ -24,7 +24,7 @@ typedef NS_ENUM(uint8_t, UserConsentState) {
     OTAProviderUserUnknown = 0x03,
 };
 
-@interface DeviceSoftwareVersionModelData : MTROtaSoftwareUpdateProviderClusterQueryImageParams
+@interface DeviceSoftwareVersionModelData : MTROTASoftwareUpdateProviderClusterQueryImageParams
 @property BOOL softwareVersionValid;
 @property (strong, nonatomic, nullable) NSNumber * cDVersionNumber;
 @property (strong, nonatomic, nullable) NSNumber * minApplicableSoftwareVersion;
@@ -32,7 +32,7 @@ typedef NS_ENUM(uint8_t, UserConsentState) {
 @property (strong, nonatomic, nullable) NSString * otaURL;
 @end
 
-@interface DeviceSoftwareVersionModel : MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams
+@interface DeviceSoftwareVersionModel : MTROTASoftwareUpdateProviderClusterQueryImageResponseParams
 @property (strong, nonatomic, nullable) DeviceSoftwareVersionModelData * deviceModelData;
 - (NSComparisonResult)CompareSoftwareVersions:(DeviceSoftwareVersionModel * _Nullable)otherObject;
 @end
@@ -40,28 +40,28 @@ typedef NS_ENUM(uint8_t, UserConsentState) {
 @interface OTAProviderDelegate : NSObject <MTROTAProviderDelegate>
 - (void)handleQueryImageForNodeID:(NSNumber * _Nonnull)nodeID
                        controller:(MTRDeviceController * _Nonnull)controller
-                           params:(MTROtaSoftwareUpdateProviderClusterQueryImageParams * _Nonnull)params
-                       completion:(void (^_Nonnull)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
+                           params:(MTROTASoftwareUpdateProviderClusterQueryImageParams * _Nonnull)params
+                       completion:(void (^_Nonnull)(MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
                                       NSError * _Nullable error))completion;
 
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber * _Nonnull)nodeID
                                controller:(MTRDeviceController * _Nonnull)controller
-                                   params:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams * _Nonnull)params
+                                   params:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams * _Nonnull)params
                                completion:
-                                   (void (^_Nonnull)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                                   (void (^_Nonnull)(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion;
 
 - (void)handleNotifyUpdateAppliedForNodeID:(NSNumber * _Nonnull)nodeID
                                 controller:(MTRDeviceController * _Nonnull)controller
-                                    params:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams * _Nonnull)params
+                                    params:(MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams * _Nonnull)params
                                 completion:(MTRStatusCompletion _Nonnull)completion;
 
 @property (strong, nonatomic, nullable) NSArray<DeviceSoftwareVersionModel *> * candidates;
 @property (strong, nonatomic, nullable) DeviceSoftwareVersionModel * selectedCandidate;
 @property (strong, nonatomic, nullable) NSNumber * nodeID;
-@property (nonatomic, readwrite) MTROtaSoftwareUpdateProviderOTAQueryStatus queryImageStatus;
+@property (nonatomic, readwrite) MTROTASoftwareUpdateProviderOTAQueryStatus queryImageStatus;
 @property (nonatomic, readwrite) UserConsentState userConsentState;
-@property (nonatomic, readwrite) MTROtaSoftwareUpdateProviderOTAApplyUpdateAction action;
+@property (nonatomic, readwrite) MTROTASoftwareUpdateProviderOTAApplyUpdateAction action;
 @property (nonatomic, readwrite, nullable) NSNumber * delayedActionTime;
 @property (nonatomic, readwrite, nullable) NSNumber * timedInvokeTimeoutMs;
 @property (nonatomic, readwrite, nullable) NSNumber * userConsentNeeded;

--- a/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
+++ b/examples/darwin-framework-tool/commands/provider/OTAProviderDelegate.mm
@@ -35,26 +35,26 @@ constexpr uint8_t kUpdateTokenLen = 32;
 {
     if (self = [super init]) {
         _selectedCandidate = [[DeviceSoftwareVersionModel alloc] init];
-        _action = MTROtaSoftwareUpdateProviderOTAApplyUpdateActionProceed;
+        _action = MTROTASoftwareUpdateProviderOTAApplyUpdateActionProceed;
         _userConsentState = OTAProviderUserUnknown;
         _delayedActionTime = nil;
         _timedInvokeTimeoutMs = nil;
         _userConsentNeeded = nil;
-        _queryImageStatus = MTROtaSoftwareUpdateProviderOTAQueryStatusNotAvailable;
+        _queryImageStatus = MTROTASoftwareUpdateProviderOTAQueryStatusNotAvailable;
     }
     return self;
 }
 
 - (void)handleQueryImageForNodeID:(NSNumber * _Nonnull)nodeID
                        controller:(MTRDeviceController * _Nonnull)controller
-                           params:(MTROtaSoftwareUpdateProviderClusterQueryImageParams * _Nonnull)params
-                       completion:(void (^_Nonnull)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
+                           params:(MTROTASoftwareUpdateProviderClusterQueryImageParams * _Nonnull)params
+                       completion:(void (^_Nonnull)(MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
                                       NSError * _Nullable error))completion
 {
     auto isBDXProtocolSupported =
-        [params.protocolsSupported containsObject:@(MTROtaSoftwareUpdateProviderOTADownloadProtocolBDXSynchronous)];
+        [params.protocolsSupported containsObject:@(MTROTASoftwareUpdateProviderOTADownloadProtocolBDXSynchronous)];
     if (!isBDXProtocolSupported) {
-        _selectedCandidate.status = @(MTROtaSoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported);
+        _selectedCandidate.status = @(MTROTASoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported);
         completion(_selectedCandidate, nil);
         return;
     }
@@ -62,7 +62,7 @@ constexpr uint8_t kUpdateTokenLen = 32;
     auto hasCandidate = [self SelectOTACandidate:params.vendorId rPID:params.productId rSV:params.softwareVersion];
     if (!hasCandidate) {
         NSLog(@"Unable to select OTA Image.");
-        _selectedCandidate.status = @(MTROtaSoftwareUpdateProviderOTAQueryStatusNotAvailable);
+        _selectedCandidate.status = @(MTROTASoftwareUpdateProviderOTAQueryStatusNotAvailable);
         completion(_selectedCandidate, nil);
         return;
     }
@@ -80,13 +80,13 @@ constexpr uint8_t kUpdateTokenLen = 32;
 
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber * _Nonnull)nodeID
                                controller:(MTRDeviceController * _Nonnull)controller
-                                   params:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams * _Nonnull)params
+                                   params:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams * _Nonnull)params
                                completion:
-                                   (void (^_Nonnull)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                                   (void (^_Nonnull)(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion
 {
-    MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * applyUpdateResponseParams =
-        [[MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams alloc] init];
+    MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * applyUpdateResponseParams =
+        [[MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams alloc] init];
     applyUpdateResponseParams.action = @(_action);
     if (_delayedActionTime) {
         applyUpdateResponseParams.delayedActionTime = _delayedActionTime;
@@ -100,7 +100,7 @@ constexpr uint8_t kUpdateTokenLen = 32;
 
 - (void)handleNotifyUpdateAppliedForNodeID:(NSNumber * _Nonnull)nodeID
                                 controller:(MTRDeviceController * _Nonnull)controller
-                                    params:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams * _Nonnull)params
+                                    params:(MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams * _Nonnull)params
                                 completion:(MTRStatusCompletion _Nonnull)completion
 {
     completion(nil);

--- a/examples/darwin-framework-tool/commands/provider/OTASoftwareUpdateInteractive.mm
+++ b/examples/darwin-framework-tool/commands/provider/OTASoftwareUpdateInteractive.mm
@@ -161,14 +161,14 @@ CHIP_ERROR OTASoftwareUpdateBase::SetActionReplyStatus(uint16_t action)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     if (action == 0) {
-        mOTADelegate.action = MTROtaSoftwareUpdateProviderOTAApplyUpdateActionProceed;
-        ChipLogDetail(chipTool, "Successfully set action to: MTROtaSoftwareUpdateProviderOTAApplyUpdateActionProceed");
+        mOTADelegate.action = MTROTASoftwareUpdateProviderOTAApplyUpdateActionProceed;
+        ChipLogDetail(chipTool, "Successfully set action to: MTROTASoftwareUpdateProviderOTAApplyUpdateActionProceed");
     } else if (action == 1) {
-        mOTADelegate.action = MTROtaSoftwareUpdateProviderOTAApplyUpdateActionAwaitNextAction;
-        ChipLogDetail(chipTool, "Successfully set action to: MTROtaSoftwareUpdateProviderOTAApplyUpdateActionAwaitNextAction");
+        mOTADelegate.action = MTROTASoftwareUpdateProviderOTAApplyUpdateActionAwaitNextAction;
+        ChipLogDetail(chipTool, "Successfully set action to: MTROTASoftwareUpdateProviderOTAApplyUpdateActionAwaitNextAction");
     } else if (action == 2) {
-        mOTADelegate.action = MTROtaSoftwareUpdateProviderOTAApplyUpdateActionDiscontinue;
-        ChipLogDetail(chipTool, "Successfully set action to: MTROtaSoftwareUpdateProviderOTAApplyUpdateActionDiscontinue");
+        mOTADelegate.action = MTROTASoftwareUpdateProviderOTAApplyUpdateActionDiscontinue;
+        ChipLogDetail(chipTool, "Successfully set action to: MTROTASoftwareUpdateProviderOTAApplyUpdateActionDiscontinue");
     } else {
         ChipLogError(chipTool, "Only accepts the following: 0 (Proceed), 1 (Await Next Action), 2 (Discontinue)");
         error = CHIP_ERROR_INTERNAL;
@@ -179,18 +179,18 @@ CHIP_ERROR OTASoftwareUpdateBase::SetReplyStatus(uint16_t status)
 {
     CHIP_ERROR error = CHIP_NO_ERROR;
     if (status == 0) {
-        mOTADelegate.queryImageStatus = MTROtaSoftwareUpdateProviderOTAQueryStatusUpdateAvailable;
-        ChipLogDetail(chipTool, "Successfully set status to: MTROtaSoftwareUpdateProviderOTAQueryStatusUpdateAvailable");
+        mOTADelegate.queryImageStatus = MTROTASoftwareUpdateProviderOTAQueryStatusUpdateAvailable;
+        ChipLogDetail(chipTool, "Successfully set status to: MTROTASoftwareUpdateProviderOTAQueryStatusUpdateAvailable");
     } else if (status == 1) {
-        mOTADelegate.queryImageStatus = MTROtaSoftwareUpdateProviderOTAQueryStatusBusy;
-        ChipLogDetail(chipTool, "Successfully set status to: MTROtaSoftwareUpdateProviderOTAQueryStatusBusy");
+        mOTADelegate.queryImageStatus = MTROTASoftwareUpdateProviderOTAQueryStatusBusy;
+        ChipLogDetail(chipTool, "Successfully set status to: MTROTASoftwareUpdateProviderOTAQueryStatusBusy");
     } else if (status == 2) {
-        mOTADelegate.queryImageStatus = MTROtaSoftwareUpdateProviderOTAQueryStatusNotAvailable;
-        ChipLogDetail(chipTool, "Successfully set status to: MTROtaSoftwareUpdateProviderOTAQueryStatusNotAvailable");
+        mOTADelegate.queryImageStatus = MTROTASoftwareUpdateProviderOTAQueryStatusNotAvailable;
+        ChipLogDetail(chipTool, "Successfully set status to: MTROTASoftwareUpdateProviderOTAQueryStatusNotAvailable");
     } else if (status == 4) {
-        mOTADelegate.queryImageStatus = MTROtaSoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported;
+        mOTADelegate.queryImageStatus = MTROTASoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported;
         ChipLogDetail(
-            chipTool, "Successfully set status to: MTROtaSoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported");
+            chipTool, "Successfully set status to: MTROTASoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported");
     } else {
         ChipLogError(chipTool, "Only accepts the following: 0 (Available), 1 (Busy), 2 (Not Available), 3 (Not Supported)");
         error = CHIP_ERROR_INTERNAL;

--- a/examples/darwin-framework-tool/templates/commands.zapt
+++ b/examples/darwin-framework-tool/templates/commands.zapt
@@ -46,8 +46,8 @@ public:
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) command ({{asHex code 8}}) on endpoint %u", endpointId);
 
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        MTRBaseCluster{{asUpperCamelCase clusterName}} * cluster = [[MTRBaseCluster{{asUpperCamelCase clusterName}} alloc] initWithDevice:device endpoint:@(endpointId) queue:callbackQueue];
-        __auto_type * params = [[MTR{{asUpperCamelCase clusterName}}Cluster{{asUpperCamelCase name}}Params alloc] init];
+        __auto_type * cluster = [[MTRBaseCluster{{asUpperCamelCase clusterName preserveAcronyms=true}} alloc] initWithDevice:device endpoint:@(endpointId) queue:callbackQueue];
+        __auto_type * params = [[MTR{{asUpperCamelCase clusterName preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params alloc] init];
         params.timedInvokeTimeoutMs = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
         {{#chip_cluster_command_arguments}}
         {{>decodable_value target=(concat "params." (asStructPropertyName label)) source=(concat "mRequest." (asLowerCamelCase label)) cluster=parent.clusterName type=type depth=0}}
@@ -58,7 +58,7 @@ public:
         {
             [cluster {{asLowerCamelCase name}}WithParams:params completion:
             {{#if hasSpecificResponse}}
-                ^(MTR{{asUpperCamelCase clusterName}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable values, NSError * _Nullable error) {
+                ^(MTR{{asUpperCamelCase clusterName preserveAcronyms=true}}Cluster{{asUpperCamelCase responseName}}Params * _Nullable values, NSError * _Nullable error) {
                     NSLog(@"Values: %@", values);
             {{else}}
                 ^(NSError * _Nullable error) {
@@ -90,7 +90,8 @@ private:
 {{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-{{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
+{{#*inline "cluster"}}Cluster{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 
 /*
  * Attribute {{asUpperCamelCase name}}
@@ -111,23 +112,23 @@ public:
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) ReadAttribute ({{asHex code 8}}) on endpoint %u", endpointId);
 
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        MTRBaseCluster{{asUpperCamelCase parent.name}} * cluster = [[MTRBaseCluster{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:@(endpointId) queue:callbackQueue];
+        __auto_type * cluster = [[MTRBase{{>cluster}} alloc] initWithDevice:device endpoint:@(endpointId) queue:callbackQueue];
         {{#if_is_fabric_scoped_struct type}}
-        MTRReadParams * params = [[MTRReadParams alloc] init];
+        __auto_type * params = [[MTRReadParams alloc] init];
         if (mFabricFiltered.HasValue()) {
           params.fabricFiltered = mFabricFiltered.Value();
         }
         {{/if_is_fabric_scoped_struct}}
-        [cluster readAttribute{{asUpperCamelCase name}}With
+        [cluster read{{>attribute}}With
         {{~#if_is_fabric_scoped_struct type~}}
         Params:params completion:
         {{~else~}}
         Completion:
         {{~/if_is_fabric_scoped_struct~}}
         ^({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error) {
-        NSLog(@"{{asUpperCamelCase parent.name}}.{{asUpperCamelCase name}} response %@", [value description]);
+        NSLog(@"{{asUpperCamelCase parent.name preserveAcronyms=true}}.{{asUpperCamelCase name preserveAcronyms=true}} response %@", [value description]);
         if (error != nil) {
-          LogNSError("{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} read Error", error);
+          LogNSError("{{asUpperCamelCase parent.name preserveAcronyms=true}} {{asUpperCamelCase name preserveAcronyms=true}} read Error", error);
         }
         SetCommandExitStatus(error);
          }];
@@ -163,8 +164,8 @@ public:
     {
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) WriteAttribute ({{asHex code 8}}) on endpoint %u", endpointId);
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        MTRBaseCluster{{asUpperCamelCase parent.name}} * cluster = [[MTRBaseCluster{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:@(endpointId) queue:callbackQueue];
-        MTRWriteParams * params = [[MTRWriteParams alloc] init];
+        __auto_type * cluster = [[MTRBase{{>cluster}} alloc] initWithDevice:device endpoint:@(endpointId) queue:callbackQueue];
+        __auto_type * params = [[MTRWriteParams alloc] init];
         params.timedWriteTimeout = mTimedInteractionTimeoutMs.HasValue() ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()] : nil;
         params.dataVersion = mDataVersion.HasValue() ? [NSNumber numberWithUnsignedInt:mDataVersion.Value()] : nil;
         {{#if_chip_complex}}
@@ -178,9 +179,9 @@ public:
         {{asObjectiveCType type parent.name}} value = [NSNumber numberWith{{asObjectiveCNumberType "" type false}}:mValue];
         {{/if_chip_complex}}
 
-        [cluster writeAttribute{{asUpperCamelCase name}}WithValue:value params:params completion:^(NSError * _Nullable error) {
+        [cluster write{{>attribute}}WithValue:value params:params completion:^(NSError * _Nullable error) {
             if (error != nil) {
-              LogNSError("{{asUpperCamelCase parent.name}} {{asUpperCamelCase name}} write Error", error);
+              LogNSError("{{asUpperCamelCase parent.name preserveAcronyms=true}} {{asUpperCamelCase name preserveAcronyms=true}} write Error", error);
             }
             SetCommandExitStatus(error);
             }];
@@ -217,8 +218,8 @@ public:
     {
         ChipLogProgress(chipTool, "Sending cluster ({{asHex parent.code 8}}) ReportAttribute ({{asHex code 8}}) on endpoint %u", endpointId);
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
-        MTRBaseCluster{{asUpperCamelCase parent.name}} * cluster = [[MTRBaseCluster{{asUpperCamelCase parent.name}} alloc] initWithDevice:device endpoint:@(endpointId) queue:callbackQueue];
-        MTRSubscribeParams * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(mMinInterval) maxInterval:@(mMaxInterval)];
+        __auto_type * cluster = [[MTRBase{{>cluster}} alloc] initWithDevice:device endpoint:@(endpointId) queue:callbackQueue];
+        __auto_type * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(mMinInterval) maxInterval:@(mMaxInterval)];
         if (mKeepSubscriptions.HasValue()) {
           params.keepPreviousSubscriptions = mKeepSubscriptions.Value();
         }
@@ -228,7 +229,7 @@ public:
         [cluster subscribe{{>attribute}}WithParams:params
                                 subscriptionEstablished:^(){ mSubscriptionEstablished=YES; }
                                 reportHandler:^({{asObjectiveCClass type parent.name}} * _Nullable value, NSError * _Nullable error) {
-        NSLog(@"{{asUpperCamelCase parent.name}}.{{asUpperCamelCase name}} response %@", [value description]);
+        NSLog(@"{{asUpperCamelCase parent.name preserveAcronyms=true}}.{{asUpperCamelCase name preserveAcronyms=true}} response %@", [value description]);
         SetCommandExitStatus(error);
          }];
 

--- a/examples/darwin-framework-tool/templates/tests/partials/test_cluster.zapt
+++ b/examples/darwin-framework-tool/templates/tests/partials/test_cluster.zapt
@@ -126,6 +126,8 @@ class {{filename}}: public TestCommandBridge
     {{#*inline "testCommand"}}Test{{asUpperCamelCase label}}_{{index}}{{/inline}}
     CHIP_ERROR {{>testCommand}}()
     {
+        {{#*inline "cluster"}}{{asUpperCamelCase cluster preserveAcronyms=true}}{{/inline}}
+        {{#*inline "attribute"}}{{asUpperCamelCase attribute preserveAcronyms=true}}{{/inline}}
         {{#if (isTestOnlyCluster cluster)}}
         {{asEncodableType}} value;
         {{#chip_tests_item_parameters}}
@@ -134,19 +136,19 @@ class {{filename}}: public TestCommandBridge
         return {{command}}("{{identity}}", value);
         {{else}}
         MTRBaseDevice * device = GetDevice("{{identity}}");
-        MTRBaseCluster{{asUpperCamelCase cluster}} * cluster = [[MTRBaseCluster{{asUpperCamelCase cluster}} alloc] initWithDevice:device endpoint:@({{endpoint}}) queue:mCallbackQueue];
+        __auto_type * cluster = [[MTRBaseCluster{{>cluster}} alloc] initWithDevice:device endpoint:@({{endpoint}}) queue:mCallbackQueue];
         VerifyOrReturnError(cluster != nil, CHIP_ERROR_INCORRECT_STATE);
 
         {{#if isCommand}}
           {{#if commandObject.arguments.length}}
-            __auto_type * params = [[MTR{{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase command}}Params alloc] init];
+            __auto_type * params = [[MTR{{>cluster}}Cluster{{asUpperCamelCase command preserveAcronyms=true}}Params alloc] init];
           {{/if}}
           {{#chip_tests_item_parameters}}
             {{>test_value target=(concat "params." (asStructPropertyName label)) definedValue=definedValue cluster=parent.cluster depth=0}}
           {{/chip_tests_item_parameters}}
           [cluster {{asLowerCamelCase command}}With{{#if commandObject.arguments.length}}Params:params completion{{else}}Completion{{/if}}:
           {{#if commandObject.hasSpecificResponse}}
-            ^(MTR{{asUpperCamelCase cluster}}Cluster{{asUpperCamelCase commandObject.responseName}}Params * _Nullable values, NSError * _Nullable err) {
+            ^(MTR{{>cluster}}Cluster{{asUpperCamelCase commandObject.responseName}}Params * _Nullable values, NSError * _Nullable err) {
           {{else}}
             ^(NSError * _Nullable err) {
           {{/if}}
@@ -154,9 +156,9 @@ class {{filename}}: public TestCommandBridge
           {{#chip_tests_item_parameters}}
             {{asObjectiveCBasicType type}} {{asLowerCamelCase name}}Argument = {{asTypedLiteral definedValue type}};
           {{/chip_tests_item_parameters}}
-          MTRSubscribeParams * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(minIntervalArgument) maxInterval:@(maxIntervalArgument)];
-          [cluster subscribeAttribute{{asUpperCamelCase attribute}}WithParams:params
-                                                                   subscriptionEstablished:^{
+          __auto_type * params = [[MTRSubscribeParams alloc] initWithMinInterval:@(minIntervalArgument) maxInterval:@(maxIntervalArgument)];
+          [cluster subscribeAttribute{{>attribute}}WithParams:params
+                                      subscriptionEstablished:^{
               VerifyOrReturn(testSendCluster{{parent.filename}}_{{waitForReport.index}}_{{asUpperCamelCase waitForReport.command}}_Fulfilled, SetCommandExitStatus(CHIP_ERROR_INCORRECT_STATE));
               NextTest();
           }
@@ -165,10 +167,10 @@ class {{filename}}: public TestCommandBridge
           {{> subscribeDataCallback }} = ^({{asObjectiveCClass attributeObject.type cluster forceList=attributeObject.isArray}} * _Nullable value, NSError * _Nullable err) {
         {{else if isReadAttribute}}
         {{#if_is_fabric_scoped_struct attributeObject.type}}
-        MTRReadParams * params = [[MTRReadParams alloc] init];
+        __auto_type * params = [[MTRReadParams alloc] init];
         params.fabricFiltered = {{fabricFiltered}};
         {{/if_is_fabric_scoped_struct}}
-        [cluster readAttribute{{asUpperCamelCase attribute}}With
+        [cluster readAttribute{{>attribute}}With
         {{~#if_is_fabric_scoped_struct attributeObject.type~}}
         Params:params completion:
         {{~else~}}
@@ -180,7 +182,7 @@ class {{filename}}: public TestCommandBridge
             id {{asLowerCamelCase name}}Argument;
             {{>test_value target=(concat (asLowerCamelCase name) "Argument") definedValue=definedValue cluster=parent.cluster depth=0}}
           {{/chip_tests_item_parameters}}
-          [cluster writeAttribute{{asUpperCamelCase attribute}}WithValue:{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}} completion:^(NSError * _Nullable err) {
+          [cluster writeAttribute{{>attribute}}WithValue:{{#chip_tests_item_parameters}}{{asLowerCamelCase name}}Argument{{/chip_tests_item_parameters}} completion:^(NSError * _Nullable err) {
         {{/if}}
             NSLog(@"{{label}} Error: %@", err);
 

--- a/examples/light-switch-app/light-switch-common/light-switch-app.matter
+++ b/examples/light-switch-app/light-switch-common/light-switch-app.matter
@@ -469,30 +469,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -568,7 +568,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -745,33 +745,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -785,7 +785,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -829,7 +829,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -928,7 +928,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1355,7 +1355,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/lighting-app/lighting-common/lighting-app.matter
+++ b/examples/lighting-app/lighting-common/lighting-app.matter
@@ -420,30 +420,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -519,7 +519,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -696,33 +696,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -736,7 +736,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -780,7 +780,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -879,7 +879,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1301,7 +1301,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/lock-app/lock-common/lock-app.matter
+++ b/examples/lock-app/lock-common/lock-app.matter
@@ -302,30 +302,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -401,7 +401,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -662,33 +662,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -702,7 +702,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -746,7 +746,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -845,7 +845,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1232,7 +1232,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/log-source-app/log-source-common/log-source-app.matter
+++ b/examples/log-source-app/log-source-common/log-source-app.matter
@@ -187,33 +187,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -227,7 +227,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -295,7 +295,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   response struct RetrieveLogsResponse = 1 {
@@ -360,7 +360,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
+++ b/examples/ota-provider-app/ota-provider-common/ota-provider-app.matter
@@ -213,30 +213,30 @@ server cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -419,33 +419,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -459,7 +459,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -570,7 +570,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -678,7 +678,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
+++ b/examples/ota-requestor-app/ota-requestor-common/ota-requestor-app.matter
@@ -325,30 +325,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -424,7 +424,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -601,33 +601,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -641,7 +641,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -752,7 +752,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -860,7 +860,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/placeholder/linux/apps/app1/config.matter
+++ b/examples/placeholder/linux/apps/app1/config.matter
@@ -842,33 +842,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -882,7 +882,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -993,7 +993,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1297,7 +1297,7 @@ client cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {
@@ -1376,7 +1376,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/placeholder/linux/apps/app2/config.matter
+++ b/examples/placeholder/linux/apps/app2/config.matter
@@ -842,33 +842,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -882,7 +882,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -993,7 +993,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1297,7 +1297,7 @@ client cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {
@@ -1376,7 +1376,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/pump-app/pump-common/pump-app.matter
+++ b/examples/pump-app/pump-common/pump-app.matter
@@ -352,30 +352,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -454,7 +454,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -602,27 +602,27 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -636,7 +636,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -743,7 +743,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -972,7 +972,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
+++ b/examples/pump-controller-app/pump-controller-common/pump-controller-app.matter
@@ -256,30 +256,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -358,7 +358,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -506,27 +506,27 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -540,7 +540,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -647,7 +647,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -876,7 +876,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
+++ b/examples/temperature-measurement-app/esp32/main/temperature-measurement.matter
@@ -317,28 +317,28 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -352,7 +352,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -395,7 +395,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -494,7 +494,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -708,7 +708,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/thermostat/thermostat-common/thermostat.matter
+++ b/examples/thermostat/thermostat-common/thermostat.matter
@@ -413,30 +413,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -512,7 +512,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -705,33 +705,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -745,7 +745,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -789,7 +789,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -888,7 +888,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1267,7 +1267,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/examples/tv-app/tv-common/tv-app.matter
+++ b/examples/tv-app/tv-common/tv-app.matter
@@ -330,30 +330,30 @@ server cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -611,33 +611,33 @@ client cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -651,7 +651,7 @@ client cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -745,33 +745,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -785,7 +785,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -829,7 +829,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -928,7 +928,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1304,7 +1304,7 @@ client cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {
@@ -1409,7 +1409,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {
@@ -2103,11 +2103,11 @@ server cluster AccountLogin = 1294 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct GetSetupPINRequest {
-    CHAR_STRING tempAccountIdentifier = 0;
+    CHAR_STRING<100> tempAccountIdentifier = 0;
   }
 
   request struct LoginRequest {
-    CHAR_STRING tempAccountIdentifier = 0;
+    CHAR_STRING<100> tempAccountIdentifier = 0;
     CHAR_STRING setupPIN = 1;
   }
 

--- a/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
+++ b/examples/tv-casting-app/tv-casting-common/tv-casting-app.matter
@@ -690,30 +690,30 @@ server cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -912,33 +912,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -952,7 +952,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -996,7 +996,7 @@ server cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   command RetrieveLogsRequest(RetrieveLogsRequestRequest): RetrieveLogsResponse = 0;
@@ -1095,7 +1095,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1513,7 +1513,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {
@@ -2112,11 +2112,11 @@ client cluster AccountLogin = 1294 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct GetSetupPINRequest {
-    CHAR_STRING tempAccountIdentifier = 0;
+    CHAR_STRING<100> tempAccountIdentifier = 0;
   }
 
   request struct LoginRequest {
-    CHAR_STRING tempAccountIdentifier = 0;
+    CHAR_STRING<100> tempAccountIdentifier = 0;
     CHAR_STRING setupPIN = 1;
   }
 

--- a/examples/window-app/common/window-app.matter
+++ b/examples/window-app/common/window-app.matter
@@ -386,30 +386,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -485,7 +485,7 @@ server cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -771,33 +771,33 @@ server cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -811,7 +811,7 @@ server cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -925,7 +925,7 @@ server cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1314,7 +1314,7 @@ server cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {

--- a/src/app/tests/suites/certification/Test_TC_DGWIFI_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_DGWIFI_2_1.yaml
@@ -35,7 +35,7 @@ tests:
     - label: "TH reads BSSID attribute from DUT"
       PICS: DGWIFI.S.A0000
       command: "readAttribute"
-      attribute: "BSSID"
+      attribute: "bssid"
       response:
           constraints:
               type: octet_string
@@ -72,7 +72,7 @@ tests:
     - label: "Reads RSSI attribute constraints"
       PICS: DGWIFI.S.A0004
       command: "readAttribute"
-      attribute: "RSSI"
+      attribute: "rssi"
       response:
           constraints:
               type: int8s

--- a/src/controller/data_model/controller-clusters.matter
+++ b/src/controller/data_model/controller-clusters.matter
@@ -752,30 +752,30 @@ client cluster OtaSoftwareUpdateProvider = 41 {
     INT32U softwareVersion = 2;
     OTADownloadProtocol protocolsSupported[] = 3;
     optional INT16U hardwareVersion = 4;
-    optional CHAR_STRING location = 5;
+    optional CHAR_STRING<2> location = 5;
     optional BOOLEAN requestorCanConsent = 6;
-    optional OCTET_STRING metadataForProvider = 7;
+    optional OCTET_STRING<512> metadataForProvider = 7;
   }
 
   request struct ApplyUpdateRequestRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U newVersion = 1;
   }
 
   request struct NotifyUpdateAppliedRequest {
-    OCTET_STRING updateToken = 0;
+    OCTET_STRING<32> updateToken = 0;
     INT32U softwareVersion = 1;
   }
 
   response struct QueryImageResponse = 1 {
     OTAQueryStatus status = 0;
     optional INT32U delayedActionTime = 1;
-    optional CHAR_STRING imageURI = 2;
+    optional CHAR_STRING<256> imageURI = 2;
     optional INT32U softwareVersion = 3;
-    optional CHAR_STRING softwareVersionString = 4;
-    optional OCTET_STRING updateToken = 5;
+    optional CHAR_STRING<64> softwareVersionString = 4;
+    optional OCTET_STRING<32> updateToken = 5;
     optional BOOLEAN userConsentNeeded = 6;
-    optional OCTET_STRING metadataForRequestor = 7;
+    optional OCTET_STRING<512> metadataForRequestor = 7;
   }
 
   response struct ApplyUpdateResponse = 3 {
@@ -852,7 +852,7 @@ client cluster OtaSoftwareUpdateRequestor = 42 {
     node_id providerNodeId = 0;
     vendor_id vendorId = 1;
     OTAAnnouncementReason announcementReason = 2;
-    optional OCTET_STRING metadataForNode = 3;
+    optional OCTET_STRING<512> metadataForNode = 3;
     endpoint_no endpoint = 4;
   }
 
@@ -1168,33 +1168,33 @@ client cluster NetworkCommissioning = 49 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct ScanNetworksRequest {
-    optional nullable OCTET_STRING ssid = 0;
+    optional nullable OCTET_STRING<32> ssid = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct AddOrUpdateWiFiNetworkRequest {
-    OCTET_STRING ssid = 0;
-    OCTET_STRING credentials = 1;
+    OCTET_STRING<32> ssid = 0;
+    OCTET_STRING<64> credentials = 1;
     optional INT64U breadcrumb = 2;
   }
 
   request struct AddOrUpdateThreadNetworkRequest {
-    OCTET_STRING operationalDataset = 0;
+    OCTET_STRING<254> operationalDataset = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct RemoveNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ConnectNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     optional INT64U breadcrumb = 1;
   }
 
   request struct ReorderNetworkRequest {
-    OCTET_STRING networkID = 0;
+    OCTET_STRING<32> networkID = 0;
     INT8U networkIndex = 1;
     optional INT64U breadcrumb = 2;
   }
@@ -1208,7 +1208,7 @@ client cluster NetworkCommissioning = 49 {
 
   response struct NetworkConfigResponse = 5 {
     NetworkCommissioningStatus networkingStatus = 0;
-    optional CHAR_STRING debugText = 1;
+    optional CHAR_STRING<512> debugText = 1;
     optional INT8U networkIndex = 2;
   }
 
@@ -1255,7 +1255,7 @@ client cluster DiagnosticLogs = 50 {
   request struct RetrieveLogsRequestRequest {
     LogsIntent intent = 0;
     LogsTransferProtocol requestedProtocol = 1;
-    OCTET_STRING transferFileDesignator = 2;
+    OCTET_STRING<32> transferFileDesignator = 2;
   }
 
   response struct RetrieveLogsResponse = 1 {
@@ -1364,7 +1364,7 @@ client cluster GeneralDiagnostics = 51 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct TestEventTriggerRequest {
-    OCTET_STRING enableKey = 0;
+    OCTET_STRING<16> enableKey = 0;
     INT64U eventTrigger = 1;
   }
 
@@ -1847,7 +1847,7 @@ client cluster OperationalCredentials = 62 {
   }
 
   request struct UpdateFabricLabelRequest {
-    CHAR_STRING label = 0;
+    CHAR_STRING<32> label = 0;
   }
 
   request struct RemoveFabricRequest {
@@ -4039,11 +4039,11 @@ client cluster AccountLogin = 1294 {
   readonly attribute int16u clusterRevision = 65533;
 
   request struct GetSetupPINRequest {
-    CHAR_STRING tempAccountIdentifier = 0;
+    CHAR_STRING<100> tempAccountIdentifier = 0;
   }
 
   request struct LoginRequest {
-    CHAR_STRING tempAccountIdentifier = 0;
+    CHAR_STRING<100> tempAccountIdentifier = 0;
     CHAR_STRING setupPIN = 1;
   }
 

--- a/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
+++ b/src/darwin/CHIPTool/CHIPTool/View Controllers/Temperature Sensor/TemperatureSensorViewController.m
@@ -232,9 +232,9 @@ static TemperatureSensorViewController * _Nullable sCurrentController = nil;
                             return;
                         for (MTRAttributeReport * report in reports) {
                             // These should be exposed by the SDK
-                            if ([report.path.cluster isEqualToNumber:@(MTRClusterTemperatureMeasurementID)] &&
+                            if ([report.path.cluster isEqualToNumber:@(MTRClusterIDTypeTemperatureMeasurementID)] &&
                                 [report.path.attribute
-                                    isEqualToNumber:@(MTRClusterTemperatureMeasurementAttributeMeasuredValueID)]) {
+                                    isEqualToNumber:@(MTRAttributeIDTypeClusterTemperatureMeasurementAttributeMeasuredValueID)]) {
                                 if (report.error != nil) {
                                     NSLog(@"Error reading temperature: %@", report.error);
                                 } else {

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegate.h
@@ -21,10 +21,10 @@
 NS_ASSUME_NONNULL_BEGIN
 
 typedef void (^MTRQueryImageCompletionHandler)(
-    MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error);
+    MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error);
 
 typedef void (^MTRApplyUpdateRequestCompletionHandler)(
-    MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error);
+    MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error);
 
 typedef void (^MTRBDXQueryCompletionHandler)(NSData * _Nullable data, BOOL isEOF);
 
@@ -46,7 +46,7 @@ typedef void (^MTRBDXQueryCompletionHandler)(NSData * _Nullable data, BOOL isEOF
  */
 - (void)handleQueryImageForNodeID:(NSNumber *)nodeID
                        controller:(MTRDeviceController *)controller
-                           params:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
+                           params:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params
                        completion:(MTRQueryImageCompletionHandler)completion;
 
 /**
@@ -60,7 +60,7 @@ typedef void (^MTRBDXQueryCompletionHandler)(NSData * _Nullable data, BOOL isEOF
  */
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber *)nodeID
                                controller:(MTRDeviceController *)controller
-                                   params:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
+                                   params:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
                                completion:(MTRApplyUpdateRequestCompletionHandler)completion;
 
 /**
@@ -73,7 +73,7 @@ typedef void (^MTRBDXQueryCompletionHandler)(NSData * _Nullable data, BOOL isEOF
  */
 - (void)handleNotifyUpdateAppliedForNodeID:(NSNumber *)nodeID
                                 controller:(MTRDeviceController *)controller
-                                    params:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
+                                    params:(MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                                 completion:(MTRStatusCompletion)completion;
 
 /**

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.h
@@ -45,19 +45,19 @@ public:
 private:
     static CHIP_ERROR ConvertToQueryImageParams(
         const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImage::DecodableType & commandData,
-        MTROtaSoftwareUpdateProviderClusterQueryImageParams * commandParams);
+        MTROTASoftwareUpdateProviderClusterQueryImageParams * commandParams);
     static void ConvertFromQueryImageResponseParms(
-        const MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * responseParams,
+        const MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * responseParams,
         chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::Type & response);
     static void ConvertToApplyUpdateRequestParams(
         const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateRequest::DecodableType & commandData,
-        MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams * commandParams);
+        MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams * commandParams);
     static void ConvertFromApplyUpdateRequestResponseParms(
-        const MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * responseParams,
+        const MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * responseParams,
         chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::Type & response);
     static void ConvertToNotifyUpdateAppliedParams(
         const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::NotifyUpdateApplied::DecodableType & commandData,
-        MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams * commandParams);
+        MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams * commandParams);
 
     _Nullable id<MTROTAProviderDelegate> mDelegate;
     dispatch_queue_t mWorkQueue;

--- a/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTROTAProviderDelegateBridge.mm
@@ -443,7 +443,7 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
         return;
     }
 
-    auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterQueryImageParams alloc] init];
+    auto * commandParams = [[MTROTASoftwareUpdateProviderClusterQueryImageParams alloc] init];
     CHIP_ERROR err = ConvertToQueryImageParams(commandData, commandParams);
     if (err != CHIP_NO_ERROR) {
         commandObj->AddStatus(commandPath, Protocols::InteractionModel::Status::InvalidCommand);
@@ -455,7 +455,7 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
     __block ConcreteCommandPath cachedCommandPath(commandPath.mEndpointId, commandPath.mClusterId, commandPath.mCommandId);
 
     auto completionHandler = ^(
-        MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error) {
+        MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error) {
         dispatch_async(mWorkQueue, ^{
             CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, "QueryImage", data, error);
             VerifyOrReturn(handler != nullptr);
@@ -466,9 +466,9 @@ void MTROTAProviderDelegateBridge::HandleQueryImage(
             Commands::QueryImageResponse::Type response;
             ConvertFromQueryImageResponseParms(data, response);
 
-            auto hasUpdate = [data.status isEqual:@(MTROtaSoftwareUpdateProviderOTAQueryStatusUpdateAvailable)];
+            auto hasUpdate = [data.status isEqual:@(MTROTASoftwareUpdateProviderOTAQueryStatusUpdateAvailable)];
             auto isBDXProtocolSupported =
-                [commandParams.protocolsSupported containsObject:@(MTROtaSoftwareUpdateProviderOTADownloadProtocolBDXSynchronous)];
+                [commandParams.protocolsSupported containsObject:@(MTROTASoftwareUpdateProviderOTADownloadProtocolBDXSynchronous)];
 
             if (hasUpdate && isBDXProtocolSupported) {
                 auto fabricIndex = handler->GetSubjectDescriptor().fabricIndex;
@@ -527,7 +527,7 @@ void MTROTAProviderDelegateBridge::HandleApplyUpdateRequest(CommandHandler * com
     __block ConcreteCommandPath cachedCommandPath(commandPath.mEndpointId, commandPath.mClusterId, commandPath.mCommandId);
 
     auto completionHandler
-        = ^(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error) {
+        = ^(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error) {
               dispatch_async(mWorkQueue, ^{
                   CommandHandler * handler = EnsureValidState(handle, cachedCommandPath, "ApplyUpdateRequest", data, error);
                   VerifyOrReturn(handler != nullptr);
@@ -542,7 +542,7 @@ void MTROTAProviderDelegateBridge::HandleApplyUpdateRequest(CommandHandler * com
               });
           };
 
-    auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
+    auto * commandParams = [[MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
     ConvertToApplyUpdateRequestParams(commandData, commandParams);
 
     auto strongDelegate = mDelegate;
@@ -577,7 +577,7 @@ void MTROTAProviderDelegateBridge::HandleNotifyUpdateApplied(CommandHandler * co
         });
     };
 
-    auto * commandParams = [[MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
+    auto * commandParams = [[MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
     ConvertToNotifyUpdateAppliedParams(commandData, commandParams);
 
     auto strongDelegate = mDelegate;
@@ -590,7 +590,7 @@ void MTROTAProviderDelegateBridge::HandleNotifyUpdateApplied(CommandHandler * co
 }
 
 CHIP_ERROR MTROTAProviderDelegateBridge::ConvertToQueryImageParams(
-    const Commands::QueryImage::DecodableType & commandData, MTROtaSoftwareUpdateProviderClusterQueryImageParams * commandParams)
+    const Commands::QueryImage::DecodableType & commandData, MTROTASoftwareUpdateProviderClusterQueryImageParams * commandParams)
 {
     commandParams.vendorId = [NSNumber numberWithUnsignedShort:commandData.vendorId];
     commandParams.productId = [NSNumber numberWithUnsignedShort:commandData.productId];
@@ -623,7 +623,7 @@ CHIP_ERROR MTROTAProviderDelegateBridge::ConvertToQueryImageParams(
 }
 
 void MTROTAProviderDelegateBridge::ConvertFromQueryImageResponseParms(
-    const MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * responseParams,
+    const MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * responseParams,
     Commands::QueryImageResponse::Type & response)
 {
     response.status = static_cast<OTAQueryStatus>([responseParams.status intValue]);
@@ -659,14 +659,14 @@ void MTROTAProviderDelegateBridge::ConvertFromQueryImageResponseParms(
 
 void MTROTAProviderDelegateBridge::ConvertToApplyUpdateRequestParams(
     const Commands::ApplyUpdateRequest::DecodableType & commandData,
-    MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams * commandParams)
+    MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams * commandParams)
 {
     commandParams.updateToken = AsData(commandData.updateToken);
     commandParams.newVersion = [NSNumber numberWithUnsignedLong:commandData.newVersion];
 }
 
 void MTROTAProviderDelegateBridge::ConvertFromApplyUpdateRequestResponseParms(
-    const MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * responseParams,
+    const MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * responseParams,
     Commands::ApplyUpdateResponse::Type & response)
 {
     response.action = static_cast<OTAApplyUpdateAction>([responseParams.action intValue]);
@@ -675,7 +675,7 @@ void MTROTAProviderDelegateBridge::ConvertFromApplyUpdateRequestResponseParms(
 
 void MTROTAProviderDelegateBridge::ConvertToNotifyUpdateAppliedParams(
     const Commands::NotifyUpdateApplied::DecodableType & commandData,
-    MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams * commandParams)
+    MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams * commandParams)
 {
     commandParams.updateToken = AsData(commandData.updateToken);
     commandParams.softwareVersion = [NSNumber numberWithUnsignedLong:commandData.softwareVersion];

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters-src.zapt
@@ -23,7 +23,7 @@ using chip::SessionHandle;
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
 {{#chip_client_clusters includeAll=true}}
-@implementation MTRBaseCluster{{asUpperCamelCase name}}
+@implementation MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
 - (instancetype)initWithDevice:(MTRBaseDevice *)device endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue
 {
@@ -41,14 +41,16 @@ using chip::SessionHandle;
 }
 
 {{#chip_cluster_commands}}
-{{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}{{else}}CommandSuccess{{/if}}{{/inline}}
+{{#*inline "cluster"}}{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline}}
+{{#*inline "command"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
+{{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{>cluster}}Cluster{{asUpperCamelCase responseName preserveAcronyms=true}}{{else}}CommandSuccess{{/if}}{{/inline}}
 {{#unless (hasArguments)}}
 - (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion
 {
   [self {{asLowerCamelCase name}}WithParams:nil completion:completion];
 }
 {{/unless}}
-- (void){{asLowerCamelCase name}}WithParams: (MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion
+- (void){{asLowerCamelCase name}}WithParams: (MTR{{>cluster}}Cluster{{>command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion
 {
     // Make a copy of params before we go async.
     params = [params copy];
@@ -103,7 +105,7 @@ using chip::SessionHandle;
 {{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-{{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (void)read{{>attribute}}With
 {{~#if_is_fabric_scoped_struct type~}}
   Params:(MTRReadParams * _Nullable)params completion:
@@ -116,7 +118,7 @@ using chip::SessionHandle;
     // Make a copy of params before we go async.
     params = [params copy];
     {{/if_is_fabric_scoped_struct~}}
-    new MTR{{>attribute_data_callback_name}}CallbackBridge(self.callbackQueue,
+    new MTR{{~>attribute_data_callback_name~}}CallbackBridge(self.callbackQueue,
       self.device,
       {{! This treats completion as taking an id for the data.  This is
           not great from a type-safety perspective, of course. }}

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -14,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster {{name}}
- *    {{description}}
+ *
+ * {{description}}
  */
 @interface MTRBaseCluster{{asUpperCamelCase name}} : MTRCluster
 
@@ -23,6 +24,12 @@ NS_ASSUME_NONNULL_BEGIN
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
 {{#chip_cluster_commands}}
+
+/**
+ * Command {{name}}
+ *
+ * {{description}}
+ */
 - (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion;
 {{#unless (hasArguments)}}
 - (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion;

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -17,7 +17,7 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * {{description}}
  */
-@interface MTRBaseCluster{{asUpperCamelCase name}} : MTRCluster
+@interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
                                 endpoint:(NSNumber *)endpoint
@@ -30,14 +30,16 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * {{description}}
  */
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion;
+{{~#*inline "cluster"}}{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "command"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{>cluster}}Cluster{{>command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion;
 {{#unless (hasArguments)}}
 - (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion;
 {{/unless}}
 {{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-{{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (void)read{{>attribute}}With
 {{~#if_is_fabric_scoped_struct type~}}
   Params:(MTRReadParams * _Nullable)params completion:

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters_internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters_internal.zapt
@@ -9,7 +9,7 @@
 
 {{#chip_client_clusters includeAll=true}}
 
-@interface MTRBaseCluster{{asUpperCamelCase name}} ()
+@interface MTRBaseCluster{{asUpperCamelCase name preserveAcronyms=true}} ()
 @property (nonatomic, strong, readonly) MTRBaseDevice * device;
 @property (nonatomic, assign, readonly) chip::EndpointId endpoint;
 @end

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge-src.zapt
@@ -40,13 +40,13 @@
 {{#chip_client_clusters includeAll=true}}
 {{#chip_server_cluster_attributes}}
 {{#if isArray}}
-{{#>MTRCallbackBridge ns=parent.name                                }}{{asUpperCamelCase ../../name}}{{asUpperCamelCase ../name}}ListAttributeCallback{{/MTRCallbackBridge}}
+{{#>MTRCallbackBridge ns=parent.name                                }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}ListAttributeCallback{{/MTRCallbackBridge}}
 {{else}}
   {{#if_is_struct type}}
-  {{#>MTRCallbackBridge ns=parent.name                              }}{{asUpperCamelCase ../../name}}{{asUpperCamelCase ../name}}StructAttributeCallback{{/MTRCallbackBridge}}
+  {{#>MTRCallbackBridge ns=parent.name                              }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}StructAttributeCallback{{/MTRCallbackBridge}}
   {{/if_is_struct}}
   {{#if_is_strongly_typed_bitmap type}}
-  {{#>MTRCallbackBridge ns=parent.name                              }}{{asUpperCamelCase ../../name}}{{asUpperCamelCase ../name}}AttributeCallback{{/MTRCallbackBridge}}
+  {{#>MTRCallbackBridge ns=parent.name                              }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
   {{/if_is_strongly_typed_bitmap}}
 {{/if}}
 {{/chip_server_cluster_attributes}}
@@ -54,13 +54,13 @@
 
 {{#chip_client_clusters includeAll=true}}
 {{#chip_cluster_responses}}
-{{#>MTRCallbackBridge partial-type="Command"                        }}{{asUpperCamelCase ../../name}}Cluster{{asUpperCamelCase ../name}}Callback{{/MTRCallbackBridge}}
+{{#>MTRCallbackBridge partial-type="Command"                        }}{{asUpperCamelCase ../../name preserveAcronyms=true}}Cluster{{asUpperCamelCase ../name preserveAcronyms=true}}Callback{{/MTRCallbackBridge}}
 {{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
-{{#>MTRCallbackBridge type=(asType label) isNullable=false ns=parent.name}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallback{{/MTRCallbackBridge}}
-{{#>MTRCallbackBridge type=(asType label) isNullable=true  ns=parent.name}}Nullable{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallback{{/MTRCallbackBridge}}
+{{#>MTRCallbackBridge type=(asType label) isNullable=false ns=parent.name}}{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
+{{#>MTRCallbackBridge type=(asType label) isNullable=true  ns=parent.name}}Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
 {{/zcl_enums}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRCallbackBridge_internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCallbackBridge_internal.zapt
@@ -16,27 +16,27 @@ typedef void (*NullableVendorIdAttributeCallback)(void *, const chip::app::DataM
 
 {{#chip_client_clusters includeAll=true}}
 {{#chip_cluster_responses}}
-typedef void (*{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}CallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType &);
+typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}CallbackType)(void *, const chip::app::Clusters::{{asUpperCamelCase parent.name}}::Commands::{{asUpperCamelCase name}}::DecodableType &);
 {{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
-typedef void (*{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallback)(void *, chip::app::Clusters::{{asUpperCamelCase parent.name}}::{{asType label}});
-typedef void (*Nullable{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallback)(void *, const chip::app::DataModel::Nullable<chip::app::Clusters::{{asUpperCamelCase parent.name}}::{{asType label}}> &);
+typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback)(void *, chip::app::Clusters::{{asUpperCamelCase parent.name}}::{{asType label}});
+typedef void (*Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback)(void *, const chip::app::DataModel::Nullable<chip::app::Clusters::{{asUpperCamelCase parent.name}}::{{asType label}}> &);
 {{/zcl_enums}}
 {{/zcl_clusters}}
 
 {{#chip_client_clusters includeAll=true}}
 {{#chip_server_cluster_attributes}}
 {{#if isArray}}
-typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}ListAttributeCallback)(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} data);
+typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}ListAttributeCallback)(void * context, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true}} data);
 {{else}}
 {{#if_is_struct type}}
-typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}StructAttributeCallback)(void *, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true forceNotOptional=true}});
+typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}StructAttributeCallback)(void *, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true forceNotOptional=true}});
 {{/if_is_struct}}
 {{#if_is_strongly_typed_bitmap type}}
-typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}AttributeCallback)(void *, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true forceNotOptional=true}});
+typedef void (*{{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback)(void *, {{zapTypeToDecodableClusterObjectType type ns=parent.name isArgument=true forceNotOptional=true}});
 {{/if_is_strongly_typed_bitmap}}
 {{/if}}
 {{/chip_server_cluster_attributes}}
@@ -76,13 +76,13 @@ typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Attribut
 {{#chip_client_clusters includeAll=true}}
 {{#chip_server_cluster_attributes}}
 {{#if isArray}}
-{{#>MTRCallbackBridge header="1" ns=parent.name                                }}{{asUpperCamelCase ../../name}}{{asUpperCamelCase ../name}}ListAttributeCallback{{/MTRCallbackBridge}}
+{{#>MTRCallbackBridge header="1" ns=parent.name                                }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}ListAttributeCallback{{/MTRCallbackBridge}}
 {{else}}
   {{#if_is_struct type}}
-  {{#>MTRCallbackBridge header="1" ns=parent.name                              }}{{asUpperCamelCase ../../name}}{{asUpperCamelCase ../name}}StructAttributeCallback{{/MTRCallbackBridge}}
+  {{#>MTRCallbackBridge header="1" ns=parent.name                              }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}StructAttributeCallback{{/MTRCallbackBridge}}
   {{/if_is_struct}}
   {{#if_is_strongly_typed_bitmap type}}
-  {{#>MTRCallbackBridge header="1" ns=parent.name                              }}{{asUpperCamelCase ../../name}}{{asUpperCamelCase ../name}}AttributeCallback{{/MTRCallbackBridge}}
+  {{#>MTRCallbackBridge header="1" ns=parent.name                              }}{{asUpperCamelCase ../../name preserveAcronyms=true}}{{asUpperCamelCase ../name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
   {{/if_is_strongly_typed_bitmap}}
 {{/if}}
 {{/chip_server_cluster_attributes}}
@@ -90,13 +90,13 @@ typedef void (*{{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Attribut
 
 {{#chip_client_clusters includeAll=true}}
 {{#chip_cluster_responses}}
-{{#>MTRCallbackBridge header="1" partial-type="Command"                        }}{{asUpperCamelCase ../../name}}Cluster{{asUpperCamelCase ../name}}Callback{{/MTRCallbackBridge}}
+{{#>MTRCallbackBridge header="1" partial-type="Command"                        }}{{asUpperCamelCase ../../name preserveAcronyms=true}}Cluster{{asUpperCamelCase ../name preserveAcronyms=true}}Callback{{/MTRCallbackBridge}}
 {{/chip_cluster_responses}}
 {{/chip_client_clusters}}
 
 {{#zcl_clusters}}
 {{#zcl_enums}}
-{{#>MTRCallbackBridge header="1" type=(asType label) isNullable=false ns=parent.name}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallback{{/MTRCallbackBridge}}
-{{#>MTRCallbackBridge header="1" type=(asType label) isNullable=true  ns=parent.name}}Nullable{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}AttributeCallback{{/MTRCallbackBridge}}
+{{#>MTRCallbackBridge header="1" type=(asType label) isNullable=false ns=parent.name}}{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
+{{#>MTRCallbackBridge header="1" type=(asType label) isNullable=true  ns=parent.name}}Nullable{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}AttributeCallback{{/MTRCallbackBridge}}
 {{/zcl_enums}}
 {{/zcl_clusters}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusterConstants.zapt
@@ -7,7 +7,8 @@
 
 typedef NS_ENUM(uint32_t, MTRClusterIDType) {
 {{#zcl_clusters}}
-MTRClusterIDType{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode code}},
+{{~#*inline "cluster"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
+MTRClusterIDType{{>cluster}}ID = {{asMEI manufacturerCode code}},
 {{/zcl_clusters}}
 };
 
@@ -16,20 +17,23 @@ MTRClusterIDType{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode code}},
 typedef NS_ENUM(uint32_t, MTRAttributeIDType) {
 // Global attributes
 {{#zcl_attributes_server}}
+{{~#*inline "attribute"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
 {{#unless clusterRef}}
-MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode code}},
+MTRAttributeIDTypeGlobalAttribute{{>attribute}}ID = {{asMEI manufacturerCode code}},
 {{/unless}}
 {{/zcl_attributes_server}}
 
 {{#zcl_clusters}}
 {{#zcl_attributes_server}}
+{{~#*inline "cluster"}}{{asUpperCamelCase parent.label preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "attribute"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
 {{#first}}
-// Cluster {{asUpperCamelCase parent.label}} attributes
+// Cluster {{>cluster}} attributes
 {{/first}}
 {{#if clusterRef}}
-MTRAttributeIDTypeCluster{{asUpperCamelCase parent.label}}Attribute{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode code}},
+MTRAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID = {{asMEI manufacturerCode code}},
 {{else}}
-MTRAttributeIDTypeCluster{{asUpperCamelCase parent.label}}Attribute{{asUpperCamelCase label}}ID = MTRAttributeIDTypeGlobalAttribute{{asUpperCamelCase label}}ID,
+MTRAttributeIDTypeCluster{{>cluster}}Attribute{{>attribute}}ID = MTRAttributeIDTypeGlobalAttribute{{>attribute}}ID,
 {{/if}}
 {{#last}}
 
@@ -43,10 +47,12 @@ MTRAttributeIDTypeCluster{{asUpperCamelCase parent.label}}Attribute{{asUpperCame
 typedef NS_ENUM(uint32_t, MTRCommandIDType) {
 {{#zcl_clusters}}
 {{#zcl_commands}}
+{{~#*inline "cluster"}}{{asUpperCamelCase parent.label preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "command"}}{{asUpperCamelCase label preserveAcronyms=true}}{{/inline~}}
 {{#first}}
-// Cluster {{asUpperCamelCase parent.label}} commands
+// Cluster {{>cluster}} commands
 {{/first}}
-MTRCommandIDTypeCluster{{asUpperCamelCase parent.label}}Command{{asUpperCamelCase label}}ID = {{asMEI manufacturerCode code}},
+MTRCommandIDTypeCluster{{>cluster}}Command{{>command}}ID = {{asMEI manufacturerCode code}},
 {{#last}}
 
 {{/last}}
@@ -59,10 +65,12 @@ MTRCommandIDTypeCluster{{asUpperCamelCase parent.label}}Command{{asUpperCamelCas
 typedef NS_ENUM(uint32_t, MTREventIDType) {
 {{#zcl_clusters}}
 {{#zcl_events}}
+{{~#*inline "cluster"}}{{asUpperCamelCase parent.label preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "event"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
 {{#first}}
-// Cluster {{asUpperCamelCase parent.label}} events
+// Cluster {{>cluster}} events
 {{/first}}
-MTREventIDTypeCluster{{asUpperCamelCase parent.label}}Event{{asUpperCamelCase name}}ID = {{asMEI manufacturerCode code}},
+MTREventIDTypeCluster{{>cluster}}Event{{>event}}ID = {{asMEI manufacturerCode code}},
 {{#last}}
 
 {{/last}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters-src.zapt
@@ -25,7 +25,7 @@ using chip::SessionHandle;
 
 // NOLINTBEGIN(clang-analyzer-cplusplus.NewDeleteLeaks): Linter is unable to locate the delete on these objects.
 {{#chip_client_clusters includeAll=true}}
-@implementation MTRCluster{{asUpperCamelCase name}}
+@implementation MTRCluster{{asUpperCamelCase name preserveAcronyms=true}}
 
 - (instancetype)initWithDevice:(MTRDevice *)device endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue
 {
@@ -43,14 +43,15 @@ using chip::SessionHandle;
 }
 
 {{#chip_cluster_commands}}
-{{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase responseName}}{{else}}CommandSuccess{{/if}}{{/inline}}
+{{#*inline "cluster"}}{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline}}
+{{#*inline "callbackName"}}{{#if hasSpecificResponse}}{{>cluster}}Cluster{{asUpperCamelCase responseName preserveAcronyms=true}}{{else}}CommandSuccess{{/if}}{{/inline}}
 {{#unless (hasArguments)}}
 - (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion
 {
   [self {{asLowerCamelCase name}}WithParams:nil expectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs completion:completion];
 }
 {{/unless}}
-- (void){{asLowerCamelCase name}}WithParams: (MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion
+- (void){{asLowerCamelCase name}}WithParams: (MTR{{>cluster}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion
 {
     // Make a copy of params before we go async.
     params = [params copy];
@@ -108,9 +109,10 @@ using chip::SessionHandle;
 {{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-{{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
+{{#*inline "cluster"}}{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (NSDictionary<NSString *, id> *)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params {
-    return [self.device readAttributeWithEndpointID:@(_endpoint) clusterID:@(MTRClusterIDType{{asUpperCamelCase parent.name}}ID) attributeID:@(MTRAttributeIDTypeCluster{{asUpperCamelCase parent.name}}Attribute{{asUpperCamelCase name}}ID) params:params];
+    return [self.device readAttributeWithEndpointID:@(_endpoint) clusterID:@(MTRClusterIDType{{>cluster}}ID) attributeID:@(MTRAttributeIDTypeCluster{{>cluster}}{{>attribute}}ID) params:params];
 }
 
 {{#if isWritableAttribute}}
@@ -128,7 +130,7 @@ using chip::SessionHandle;
     }
     {{/if}}
 
-    [self.device writeAttributeWithEndpointID:@(_endpoint) clusterID:@(MTRClusterIDType{{asUpperCamelCase parent.name}}ID) attributeID:@(MTRAttributeIDTypeCluster{{asUpperCamelCase parent.name}}Attribute{{asUpperCamelCase name}}ID) value:dataValueDictionary expectedValueInterval:expectedValueIntervalMs timedWriteTimeout:timedWriteTimeout];
+    [self.device writeAttributeWithEndpointID:@(_endpoint) clusterID:@(MTRClusterIDType{{>cluster}}ID) attributeID:@(MTRAttributeIDTypeCluster{{>cluster}}{{>attribute}}ID) value:dataValueDictionary expectedValueInterval:expectedValueIntervalMs timedWriteTimeout:timedWriteTimeout];
 }
 
 {{/if}}

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -18,21 +18,23 @@ NS_ASSUME_NONNULL_BEGIN
  * Cluster {{name}}
  *    {{description}}
  */
-@interface MTRCluster{{asUpperCamelCase name}} : MTRCluster
+@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRDevice *)device
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
 {{#chip_cluster_commands}}
-- (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion;
+{{~#*inline "cluster"}}{{asUpperCamelCase parent.name preserveAcronyms=true}}{{/inline~}}
+{{~#*inline "command"}}{{asUpperCamelCase name preserveAcronyms=true}}{{/inline~}}
+- (void){{asLowerCamelCase name}}WithParams:(MTR{{>cluster}}Cluster{{>command}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion;
 {{#unless (hasArguments)}}
 - (void){{asLowerCamelCase name}}WithExpectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues expectedValueInterval:(NSNumber *)expectedValueIntervalMs completion:({{>command_completion_type command=.}})completion;
 {{/unless}}
 {{/chip_cluster_commands}}
 
 {{#chip_server_cluster_attributes}}
-{{#*inline "attribute"}}Attribute{{asUpperCamelCase name}}{{/inline}}
+{{#*inline "attribute"}}Attribute{{asUpperCamelCase name preserveAcronyms=true}}{{/inline}}
 - (NSDictionary<NSString *, id> *)read{{>attribute}}WithParams:(MTRReadParams * _Nullable)params;
 {{#if isWritableAttribute}}
 - (void)write{{>attribute}}WithValue:(NSDictionary<NSString *, id> *)dataValueDictionary expectedValueInterval:(NSNumber *)expectedValueIntervalMs;

--- a/src/darwin/Framework/CHIP/templates/MTRClusters_internal.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters_internal.zapt
@@ -10,7 +10,7 @@
 
 {{#chip_client_clusters includeAll=true}}
 
-@interface MTRCluster{{asUpperCamelCase name}} ()
+@interface MTRCluster{{asUpperCamelCase name preserveAcronyms=true}} ()
 @property (nonatomic, readonly) uint16_t endpoint;
 @property (nonatomic, readonly) MTRDevice *device;
 @end

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc-src.zapt
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_commands}}
-@implementation MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params
+@implementation MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params
 - (instancetype)init
 {
   if (self = [super init]) {
@@ -21,7 +21,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 {
-  auto other = [[MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params alloc] init];
+  auto other = [[MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params alloc] init];
 
   {{#zcl_command_arguments}}
   other.{{asStructPropertyName label}} = self.{{asStructPropertyName label}};

--- a/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRCommandPayloadsObjc.zapt
@@ -7,7 +7,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_commands}}
-@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params : NSObject <NSCopying>
+@interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params : NSObject <NSCopying>
 {{#zcl_command_arguments}}
 
 {{! Override the getter name because some of our properties start with things

--- a/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTREventTLVValueDecoder-src.zapt
@@ -38,7 +38,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event *value = [MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event new];
+            __auto_type *value = [MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event new];
 
             {{#zcl_event_fields}}
             do {

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc-src.zapt
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_structs}}
-@implementation MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}
+@implementation MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}
 - (instancetype)init
 {
   if (self = [super init]) {
@@ -19,7 +19,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone
 {
-  auto other = [[MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}} alloc] init];
+  auto other = [[MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}} alloc] init];
 
   {{#zcl_struct_items}}
   other.{{asStructPropertyName label}} = self.{{asStructPropertyName label}};
@@ -39,7 +39,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_structs}}
 
 {{#zcl_events}}
-@implementation MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event
+@implementation MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event
 - (instancetype)init
 {
   if (self = [super init]) {
@@ -52,7 +52,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone
 {
-  auto other = [[MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event alloc] init];
+  auto other = [[MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event alloc] init];
 
   {{#zcl_event_fields}}
   other.{{asStructPropertyName name}} = self.{{asStructPropertyName name}};

--- a/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRStructsObjc.zapt
@@ -6,7 +6,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 {{#zcl_clusters}}
 {{#zcl_structs}}
-@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}} : NSObject <NSCopying>
+@interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}} : NSObject <NSCopying>
 {{! Override the getter name because some of our properties start with things
     like "new" or "init" }}
 {{#zcl_struct_items}}
@@ -20,7 +20,7 @@ NS_ASSUME_NONNULL_BEGIN
 {{/zcl_structs}}
 
 {{#zcl_events}}
-@interface MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Event : NSObject <NSCopying>
+@interface MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Event : NSObject <NSCopying>
 {{#zcl_event_fields}}
 @property (nonatomic, copy{{#unless (isStrEqual (asGetterName name) (asStructPropertyName name))}}, getter={{asGetterName name}}{{/unless}}) {{asObjectiveCType type parent.parent.name}} {{asStructPropertyName name}};
 {{/zcl_event_fields}}

--- a/src/darwin/Framework/CHIP/templates/partials/MTRCallbackBridge.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/MTRCallbackBridge.zapt
@@ -84,7 +84,7 @@ void MTR{{> @partial-block}}Bridge::OnSuccessFn(void * context
       {{#if (isStrEqual partial-type "Status")}}
       DispatchSuccess(context, nil);
       {{else if (isStrEqual partial-type "Command")}}
-      auto * response = [MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params new];
+      auto * response = [MTR{{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase name preserveAcronyms=true}}Params new];
       {{#chip_cluster_response_arguments}}
       {
         {{>decode_value target=(concat "response." (asStructPropertyName label)) source=(concat "data." (asLowerCamelCase label)) cluster=parent.parent.name errorCode="OnFailureFn(context, err); return;" depth=0}}

--- a/src/darwin/Framework/CHIP/templates/partials/attribute_data_callback_name.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/attribute_data_callback_name.zapt
@@ -1,22 +1,22 @@
 {{~#if isArray~}}
-  {{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}List
+  {{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}List
 {{~else~}}
   {{~#if_is_struct type~}}
     {{~! Structs are not used as types of attributes much, so it's
          less code to generate the callbacks on a per-attribute basis
          than a per-struct-type basis. ~}}
-    {{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}Struct
+    {{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}Struct
   {{~else if_is_strongly_typed_bitmap type~}}
-      {{asUpperCamelCase parent.name}}{{asUpperCamelCase name}}
+      {{asUpperCamelCase parent.name preserveAcronyms=true}}{{asUpperCamelCase name preserveAcronyms=true}}
   {{~else~}}
     {{~#if isNullable}}Nullable{{/if~}}
     {{~#if (isStrEqual (asUpperCamelCase type) (asUpperCamelCase "vendor_id"))~}}
       VendorId
     {{~else if_is_strongly_typed_chip_enum type~}}
-        {{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase type}}
+        {{asUpperCamelCase parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase type preserveAcronyms=true}}
     {{~else~}}
       {{chipCallback.name}}
     {{~/if~}}
   {{~/if_is_struct~}}
 {{~/if~}}
-Attribute
+Attribute{{~"remove_extra_spaces"~}}

--- a/src/darwin/Framework/CHIP/templates/partials/command_completion_type.zapt
+++ b/src/darwin/Framework/CHIP/templates/partials/command_completion_type.zapt
@@ -1,5 +1,5 @@
 {{#if command.hasSpecificResponse}}
-void (^)(MTR{{asUpperCamelCase command.parent.name}}Cluster{{asUpperCamelCase command.responseName}}Params * _Nullable data, NSError * _Nullable error)
+void (^)(MTR{{asUpperCamelCase command.parent.name preserveAcronyms=true}}Cluster{{asUpperCamelCase command.responseName}}Params * _Nullable data, NSError * _Nullable error)
 {{else}}
 MTRStatusCompletion
 {{/if}}

--- a/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRAttributeTLVValueDecoder.mm
@@ -2538,8 +2538,8 @@ id MTRDecodeAttributeValue(const ConcreteAttributePath & aPath, TLV::TLVReader &
                 auto iter_0 = cppValue.begin();
                 while (iter_0.Next()) {
                     auto & entry_0 = iter_0.GetValue();
-                    MTROtaSoftwareUpdateRequestorClusterProviderLocation * newElement_0;
-                    newElement_0 = [MTROtaSoftwareUpdateRequestorClusterProviderLocation new];
+                    MTROTASoftwareUpdateRequestorClusterProviderLocation * newElement_0;
+                    newElement_0 = [MTROTASoftwareUpdateRequestorClusterProviderLocation new];
                     newElement_0.providerNodeID = [NSNumber numberWithUnsignedLongLong:entry_0.providerNodeID];
                     newElement_0.endpoint = [NSNumber numberWithUnsignedShort:entry_0.endpoint];
                     newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Identify
  *
+ * Attributes and commands for putting a device into Identification mode (e.g. flashing a light).
  */
 @interface MTRBaseClusterIdentify : MTRCluster
 
@@ -34,8 +35,19 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)identifyWithParams:(MTRIdentifyClusterIdentifyParams *)params completion:(MTRStatusCompletion)completion;
-- (void)triggerEffectWithParams:(MTRIdentifyClusterTriggerEffectParams *)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command Identify
+ *
+ * Command description for Identify
+ */
+-(void) identifyWithParams : (MTRIdentifyClusterIdentifyParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command TriggerEffect
+ *
+ * Command description for TriggerEffect
+ */
+-(void) triggerEffectWithParams : (MTRIdentifyClusterTriggerEffectParams *) params completion : (MTRStatusCompletion) completion;
 
 - (void)readAttributeIdentifyTimeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 - (void)writeAttributeIdentifyTimeWithValue:(NSNumber * _Nonnull)value completion:(MTRStatusCompletion)completion;
@@ -145,6 +157,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Groups
  *
+ * Attributes and commands for group configuration and manipulation.
  */
 @interface MTRBaseClusterGroups : MTRCluster
 
@@ -152,22 +165,54 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)addGroupWithParams:(MTRGroupsClusterAddGroupParams *)params
-                completion:(void (^)(MTRGroupsClusterAddGroupResponseParams * _Nullable data, NSError * _Nullable error))completion;
-- (void)viewGroupWithParams:(MTRGroupsClusterViewGroupParams *)params
-                 completion:
-                     (void (^)(MTRGroupsClusterViewGroupResponseParams * _Nullable data, NSError * _Nullable error))completion;
-- (void)getGroupMembershipWithParams:(MTRGroupsClusterGetGroupMembershipParams *)params
-                          completion:(void (^)(MTRGroupsClusterGetGroupMembershipResponseParams * _Nullable data,
-                                         NSError * _Nullable error))completion;
-- (void)removeGroupWithParams:(MTRGroupsClusterRemoveGroupParams *)params
-                   completion:
-                       (void (^)(MTRGroupsClusterRemoveGroupResponseParams * _Nullable data, NSError * _Nullable error))completion;
-- (void)removeAllGroupsWithParams:(MTRGroupsClusterRemoveAllGroupsParams * _Nullable)params
-                       completion:(MTRStatusCompletion)completion;
+/**
+ * Command AddGroup
+ *
+ * Command description for AddGroup
+ */
+-(void) addGroupWithParams : (MTRGroupsClusterAddGroupParams *) params completion
+    : (void (^)(MTRGroupsClusterAddGroupResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ViewGroup
+ *
+ * Command description for ViewGroup
+ */
+-(void) viewGroupWithParams : (MTRGroupsClusterViewGroupParams *) params completion
+    : (void (^)(MTRGroupsClusterViewGroupResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command GetGroupMembership
+ *
+ * Command description for GetGroupMembership
+ */
+-(void) getGroupMembershipWithParams : (MTRGroupsClusterGetGroupMembershipParams *) params completion
+    : (void (^)(MTRGroupsClusterGetGroupMembershipResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command RemoveGroup
+ *
+ * Command description for RemoveGroup
+ */
+-(void) removeGroupWithParams : (MTRGroupsClusterRemoveGroupParams *) params completion
+    : (void (^)(MTRGroupsClusterRemoveGroupResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command RemoveAllGroups
+ *
+ * Command description for RemoveAllGroups
+ */
+-(void) removeAllGroupsWithParams : (MTRGroupsClusterRemoveAllGroupsParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)removeAllGroupsWithCompletion:(MTRStatusCompletion)completion;
-- (void)addGroupIfIdentifyingWithParams:(MTRGroupsClusterAddGroupIfIdentifyingParams *)params
-                             completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command AddGroupIfIdentifying
+ *
+ * Command description for AddGroupIfIdentifying
+ */
+-(void) addGroupIfIdentifyingWithParams : (MTRGroupsClusterAddGroupIfIdentifyingParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeNameSupportWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -260,6 +305,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Scenes
  *
+ * Attributes and commands for scene configuration and manipulation.
  */
 @interface MTRBaseClusterScenes : MTRCluster
 
@@ -267,33 +313,88 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)addSceneWithParams:(MTRScenesClusterAddSceneParams *)params
-                completion:(void (^)(MTRScenesClusterAddSceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
-- (void)viewSceneWithParams:(MTRScenesClusterViewSceneParams *)params
-                 completion:
-                     (void (^)(MTRScenesClusterViewSceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
-- (void)removeSceneWithParams:(MTRScenesClusterRemoveSceneParams *)params
-                   completion:
-                       (void (^)(MTRScenesClusterRemoveSceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
-- (void)removeAllScenesWithParams:(MTRScenesClusterRemoveAllScenesParams *)params
-                       completion:(void (^)(MTRScenesClusterRemoveAllScenesResponseParams * _Nullable data,
-                                      NSError * _Nullable error))completion;
-- (void)storeSceneWithParams:(MTRScenesClusterStoreSceneParams *)params
-                  completion:
-                      (void (^)(MTRScenesClusterStoreSceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
-- (void)recallSceneWithParams:(MTRScenesClusterRecallSceneParams *)params completion:(MTRStatusCompletion)completion;
-- (void)getSceneMembershipWithParams:(MTRScenesClusterGetSceneMembershipParams *)params
-                          completion:(void (^)(MTRScenesClusterGetSceneMembershipResponseParams * _Nullable data,
-                                         NSError * _Nullable error))completion;
-- (void)enhancedAddSceneWithParams:(MTRScenesClusterEnhancedAddSceneParams *)params
-                        completion:(void (^)(MTRScenesClusterEnhancedAddSceneResponseParams * _Nullable data,
-                                       NSError * _Nullable error))completion;
-- (void)enhancedViewSceneWithParams:(MTRScenesClusterEnhancedViewSceneParams *)params
-                         completion:(void (^)(MTRScenesClusterEnhancedViewSceneResponseParams * _Nullable data,
-                                        NSError * _Nullable error))completion;
-- (void)copySceneWithParams:(MTRScenesClusterCopySceneParams *)params
-                 completion:
-                     (void (^)(MTRScenesClusterCopySceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
+/**
+ * Command AddScene
+ *
+ * Add a scene to the scene table. Extension field sets are supported, and are inputed as '{"ClusterID": VALUE,
+ * "AttributeValueList":[{"AttributeId": VALUE, "AttributeValue": VALUE}]}'
+ */
+-(void) addSceneWithParams : (MTRScenesClusterAddSceneParams *) params completion
+    : (void (^)(MTRScenesClusterAddSceneResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ViewScene
+ *
+ * Retrieves the requested scene entry from its Scene table.
+ */
+-(void) viewSceneWithParams : (MTRScenesClusterViewSceneParams *) params completion
+    : (void (^)(MTRScenesClusterViewSceneResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command RemoveScene
+ *
+ * Removes the requested scene entry, corresponding to the value of the GroupID field, from its Scene Table
+ */
+-(void) removeSceneWithParams : (MTRScenesClusterRemoveSceneParams *) params completion
+    : (void (^)(MTRScenesClusterRemoveSceneResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command RemoveAllScenes
+ *
+ * Remove all scenes, corresponding to the value of the GroupID field, from its Scene Table
+ */
+-(void) removeAllScenesWithParams : (MTRScenesClusterRemoveAllScenesParams *) params completion
+    : (void (^)(MTRScenesClusterRemoveAllScenesResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command StoreScene
+ *
+ * Adds the scene entry into its Scene Table along with all extension field sets corresponding to the current state of other
+ * clusters on the same endpoint
+ */
+-(void) storeSceneWithParams : (MTRScenesClusterStoreSceneParams *) params completion
+    : (void (^)(MTRScenesClusterStoreSceneResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command RecallScene
+ *
+ * Set the attributes and corresponding state for each other cluster implemented on the endpoint accordingly to the resquested scene
+ * entry in the Scene Table
+ */
+-(void) recallSceneWithParams : (MTRScenesClusterRecallSceneParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command GetSceneMembership
+ *
+ * Get an unused scene identifier when no commissioning tool is in the network, or for a commissioning tool to get the used scene
+ * identifiers within a certain group
+ */
+-(void) getSceneMembershipWithParams : (MTRScenesClusterGetSceneMembershipParams *) params completion
+    : (void (^)(MTRScenesClusterGetSceneMembershipResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command EnhancedAddScene
+ *
+ * Allows a scene to be added using a finer scene transition time than the AddScene command.
+ */
+-(void) enhancedAddSceneWithParams : (MTRScenesClusterEnhancedAddSceneParams *) params completion
+    : (void (^)(MTRScenesClusterEnhancedAddSceneResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command EnhancedViewScene
+ *
+ * Allows a scene to be retrieved using a finer scene transition time than the ViewScene command
+ */
+-(void) enhancedViewSceneWithParams : (MTRScenesClusterEnhancedViewSceneParams *) params completion
+    : (void (^)(MTRScenesClusterEnhancedViewSceneResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command CopyScene
+ *
+ * Allows a client to efficiently copy scenes from one group/scene identifier pair to another group/scene identifier pair.
+ */
+-(void) copySceneWithParams : (MTRScenesClusterCopySceneParams *) params completion
+    : (void (^)(MTRScenesClusterCopySceneResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeSceneCountWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -452,6 +553,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster On/Off
  *
+ * Attributes and commands for switching devices between 'On' and 'Off' states.
  */
 @interface MTRBaseClusterOnOff : MTRCluster
 
@@ -459,17 +561,60 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)offWithParams:(MTROnOffClusterOffParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command Off
+ *
+ * On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is recommended that it
+ * is used for power off or similar functions. On receipt of the Off command, the OnTime attribute SHALL be set to 0.
+ */
+-(void) offWithParams : (MTROnOffClusterOffParams * _Nullable) params completion : (MTRStatusCompletion) completion;
 - (void)offWithCompletion:(MTRStatusCompletion)completion;
-- (void)onWithParams:(MTROnOffClusterOnParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command On
+ *
+ * On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is recommended that it is
+ * used for power on or similar functions. On receipt of the On command, if the value of the OnTime attribute is equal to 0, the
+ * device SHALL set the OffWaitTime attribute to 0.
+ */
+-(void) onWithParams : (MTROnOffClusterOnParams * _Nullable) params completion : (MTRStatusCompletion) completion;
 - (void)onWithCompletion:(MTRStatusCompletion)completion;
-- (void)toggleWithParams:(MTROnOffClusterToggleParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command Toggle
+ *
+ * On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise, if it is in its ‘On’
+ * state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value of the OnOff attribute is equal to FALSE and
+ * if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. If the value of the
+ * OnOff attribute is equal to TRUE, the OnTime attribute SHALL be set to 0.
+ */
+-(void) toggleWithParams : (MTROnOffClusterToggleParams * _Nullable) params completion : (MTRStatusCompletion) completion;
 - (void)toggleWithCompletion:(MTRStatusCompletion)completion;
-- (void)offWithEffectWithParams:(MTROnOffClusterOffWithEffectParams *)params completion:(MTRStatusCompletion)completion;
-- (void)onWithRecallGlobalSceneWithParams:(MTROnOffClusterOnWithRecallGlobalSceneParams * _Nullable)params
-                               completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command OffWithEffect
+ *
+ * The OffWithEffect command allows devices to be turned off using enhanced ways of fading.
+ */
+-(void) offWithEffectWithParams : (MTROnOffClusterOffWithEffectParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command OnWithRecallGlobalScene
+ *
+ * The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.
+ */
+-(void) onWithRecallGlobalSceneWithParams : (MTROnOffClusterOnWithRecallGlobalSceneParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)onWithRecallGlobalSceneWithCompletion:(MTRStatusCompletion)completion;
-- (void)onWithTimedOffWithParams:(MTROnOffClusterOnWithTimedOffParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command OnWithTimedOff
+ *
+ * The OnWithTimedOff command allows devices to be turned on for a specific duration with a guarded off duration so that SHOULD the
+ * device be subsequently switched off, further OnWithTimedOff commands, received during this time, are prevented from turning the
+ * devices back on.
+ */
+-(void) onWithTimedOffWithParams : (MTROnOffClusterOnWithTimedOffParams *) params completion : (MTRStatusCompletion) completion;
 
 - (void)readAttributeOnOffWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -628,6 +773,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster On/off Switch Configuration
  *
+ * Attributes and commands for configuring On/Off switching devices.
  */
 @interface MTRBaseClusterOnOffSwitchConfiguration : MTRCluster
 
@@ -743,6 +889,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Level Control
  *
+ * Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'
  */
 @interface MTRBaseClusterLevelControl : MTRCluster
 
@@ -750,17 +897,74 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)moveToLevelWithParams:(MTRLevelControlClusterMoveToLevelParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveWithParams:(MTRLevelControlClusterMoveParams *)params completion:(MTRStatusCompletion)completion;
-- (void)stepWithParams:(MTRLevelControlClusterStepParams *)params completion:(MTRStatusCompletion)completion;
-- (void)stopWithParams:(MTRLevelControlClusterStopParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveToLevelWithOnOffWithParams:(MTRLevelControlClusterMoveToLevelWithOnOffParams *)params
-                            completion:(MTRStatusCompletion)completion;
-- (void)moveWithOnOffWithParams:(MTRLevelControlClusterMoveWithOnOffParams *)params completion:(MTRStatusCompletion)completion;
-- (void)stepWithOnOffWithParams:(MTRLevelControlClusterStepWithOnOffParams *)params completion:(MTRStatusCompletion)completion;
-- (void)stopWithOnOffWithParams:(MTRLevelControlClusterStopWithOnOffParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveToClosestFrequencyWithParams:(MTRLevelControlClusterMoveToClosestFrequencyParams *)params
-                              completion:(MTRStatusCompletion)completion;
+/**
+ * Command MoveToLevel
+ *
+ * Command description for MoveToLevel
+ */
+-(void) moveToLevelWithParams : (MTRLevelControlClusterMoveToLevelParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command Move
+ *
+ * Command description for Move
+ */
+-(void) moveWithParams : (MTRLevelControlClusterMoveParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command Step
+ *
+ * Command description for Step
+ */
+-(void) stepWithParams : (MTRLevelControlClusterStepParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command Stop
+ *
+ * Command description for Stop
+ */
+-(void) stopWithParams : (MTRLevelControlClusterStopParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveToLevelWithOnOff
+ *
+ * Command description for MoveToLevelWithOnOff
+ */
+-(void) moveToLevelWithOnOffWithParams : (MTRLevelControlClusterMoveToLevelWithOnOffParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveWithOnOff
+ *
+ * Command description for MoveWithOnOff
+ */
+-(void) moveWithOnOffWithParams : (MTRLevelControlClusterMoveWithOnOffParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command StepWithOnOff
+ *
+ * Command description for StepWithOnOff
+ */
+-(void) stepWithOnOffWithParams : (MTRLevelControlClusterStepWithOnOffParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command StopWithOnOff
+ *
+ * Command description for StopWithOnOff
+ */
+-(void) stopWithOnOffWithParams : (MTRLevelControlClusterStopWithOnOffParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveToClosestFrequency
+ *
+ * Change the currrent frequency to the provided one, or a close
+        approximation if the exact provided one is not possible.
+ */
+-(void) moveToClosestFrequencyWithParams : (MTRLevelControlClusterMoveToClosestFrequencyParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeCurrentLevelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -1059,6 +1263,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Binary Input (Basic)
  *
+ * An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
  */
 @interface MTRBaseClusterBinaryInputBasic : MTRCluster
 
@@ -1286,6 +1491,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Descriptor
  *
+ * The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints
+ * and clusters.
  */
 @interface MTRBaseClusterDescriptor : MTRCluster
 
@@ -1423,6 +1630,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Binding
  *
+ * The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
  */
 @interface MTRBaseClusterBinding : MTRCluster
 
@@ -1526,6 +1734,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Access Control
  *
+ * The Access Control Cluster exposes a data model view of a
+      Node's Access Control List (ACL), which codifies the rules used to manage
+      and enforce Access Control for the Node's endpoints and their associated
+      cluster instances.
  */
 @interface MTRBaseClusterAccessControl : MTRCluster
 
@@ -1533,20 +1745,20 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)readAttributeAclWithParams:(MTRReadParams * _Nullable)params
+- (void)readAttributeACLWithParams:(MTRReadParams * _Nullable)params
                         completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
-- (void)writeAttributeAclWithValue:(NSArray * _Nonnull)value completion:(MTRStatusCompletion)completion;
-- (void)writeAttributeAclWithValue:(NSArray * _Nonnull)value
+- (void)writeAttributeACLWithValue:(NSArray * _Nonnull)value completion:(MTRStatusCompletion)completion;
+- (void)writeAttributeACLWithValue:(NSArray * _Nonnull)value
                             params:(MTRWriteParams * _Nullable)params
                         completion:(MTRStatusCompletion)completion;
 /**
  * This API does not support setting autoResubscribe to NO in the
  * MTRSubscribeParams.
  */
-- (void)subscribeAttributeAclWithParams:(MTRSubscribeParams *)params
+- (void)subscribeAttributeACLWithParams:(MTRSubscribeParams *)params
                 subscriptionEstablished:(MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                           reportHandler:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))reportHandler;
-+ (void)readAttributeAclWithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer
++ (void)readAttributeACLWithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer
                                      endpoint:(NSNumber *)endpoint
                                         queue:(dispatch_queue_t)queue
                                    completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -1698,6 +1910,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Actions
  *
+ * This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
  */
 @interface MTRBaseClusterActions : MTRCluster
 
@@ -1705,23 +1918,95 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)instantActionWithParams:(MTRActionsClusterInstantActionParams *)params completion:(MTRStatusCompletion)completion;
-- (void)instantActionWithTransitionWithParams:(MTRActionsClusterInstantActionWithTransitionParams *)params
-                                   completion:(MTRStatusCompletion)completion;
-- (void)startActionWithParams:(MTRActionsClusterStartActionParams *)params completion:(MTRStatusCompletion)completion;
-- (void)startActionWithDurationWithParams:(MTRActionsClusterStartActionWithDurationParams *)params
-                               completion:(MTRStatusCompletion)completion;
-- (void)stopActionWithParams:(MTRActionsClusterStopActionParams *)params completion:(MTRStatusCompletion)completion;
-- (void)pauseActionWithParams:(MTRActionsClusterPauseActionParams *)params completion:(MTRStatusCompletion)completion;
-- (void)pauseActionWithDurationWithParams:(MTRActionsClusterPauseActionWithDurationParams *)params
-                               completion:(MTRStatusCompletion)completion;
-- (void)resumeActionWithParams:(MTRActionsClusterResumeActionParams *)params completion:(MTRStatusCompletion)completion;
-- (void)enableActionWithParams:(MTRActionsClusterEnableActionParams *)params completion:(MTRStatusCompletion)completion;
-- (void)enableActionWithDurationWithParams:(MTRActionsClusterEnableActionWithDurationParams *)params
-                                completion:(MTRStatusCompletion)completion;
-- (void)disableActionWithParams:(MTRActionsClusterDisableActionParams *)params completion:(MTRStatusCompletion)completion;
-- (void)disableActionWithDurationWithParams:(MTRActionsClusterDisableActionWithDurationParams *)params
-                                 completion:(MTRStatusCompletion)completion;
+/**
+ * Command InstantAction
+ *
+ * This command triggers an action (state change) on the involved endpoints.
+ */
+-(void) instantActionWithParams : (MTRActionsClusterInstantActionParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command InstantActionWithTransition
+ *
+ * This command triggers an action (state change) on the involved endpoints, with a specified time to transition from the current
+ * state to the new state.
+ */
+-(void) instantActionWithTransitionWithParams : (MTRActionsClusterInstantActionWithTransitionParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command StartAction
+ *
+ * This command triggers the commencement of an action on the involved endpoints.
+ */
+-(void) startActionWithParams : (MTRActionsClusterStartActionParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command StartActionWithDuration
+ *
+ * This command triggers the commencement of an action (with a duration) on the involved endpoints.
+ */
+-(void) startActionWithDurationWithParams : (MTRActionsClusterStartActionWithDurationParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command StopAction
+ *
+ * This command stops the ongoing action on the involved endpoints.
+ */
+-(void) stopActionWithParams : (MTRActionsClusterStopActionParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command PauseAction
+ *
+ * This command pauses an ongoing action.
+ */
+-(void) pauseActionWithParams : (MTRActionsClusterPauseActionParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command PauseActionWithDuration
+ *
+ * This command pauses an ongoing action with a duration.
+ */
+-(void) pauseActionWithDurationWithParams : (MTRActionsClusterPauseActionWithDurationParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command ResumeAction
+ *
+ * This command resumes a previously paused action.
+ */
+-(void) resumeActionWithParams : (MTRActionsClusterResumeActionParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command EnableAction
+ *
+ * This command enables a certain action or automation.
+ */
+-(void) enableActionWithParams : (MTRActionsClusterEnableActionParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command EnableActionWithDuration
+ *
+ * This command enables a certain action or automation with a duration.
+ */
+-(void) enableActionWithDurationWithParams : (MTRActionsClusterEnableActionWithDurationParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command DisableAction
+ *
+ * This command disables a certain action or automation.
+ */
+-(void) disableActionWithParams : (MTRActionsClusterDisableActionParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command DisableActionWithDuration
+ *
+ * This command disables a certain action or automation with a duration.
+ */
+-(void) disableActionWithDurationWithParams : (MTRActionsClusterDisableActionWithDurationParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeActionListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -1840,6 +2125,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Basic
  *
+ * This cluster provides attributes and events for determining basic information about Nodes, which supports both
+      Commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
+      which apply to the whole Node. Also allows setting user device information such as location.
  */
 @interface MTRBaseClusterBasic : MTRCluster
 
@@ -1847,8 +2135,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)mfgSpecificPingWithParams:(MTRBasicClusterMfgSpecificPingParams * _Nullable)params
-                       completion:(MTRStatusCompletion)completion;
+/**
+ * Command MfgSpecificPing
+ *
+ *
+ */
+-(void) mfgSpecificPingWithParams : (MTRBasicClusterMfgSpecificPingParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)mfgSpecificPingWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeDataModelRevisionWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -2218,21 +2511,39 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster OTA Software Update Provider
  *
+ * Provides an interface for providing OTA software updates
  */
-@interface MTRBaseClusterOtaSoftwareUpdateProvider : MTRCluster
+@interface MTRBaseClusterOTASoftwareUpdateProvider : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)queryImageWithParams:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
-                  completion:(void (^)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
-                                 NSError * _Nullable error))completion;
-- (void)applyUpdateRequestWithParams:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
-                          completion:(void (^)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
-                                         NSError * _Nullable error))completion;
-- (void)notifyUpdateAppliedWithParams:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
-                           completion:(MTRStatusCompletion)completion;
+/**
+ * Command QueryImage
+ *
+ * Determine availability of a new Software Image
+ */
+-(void) queryImageWithParams : (MTROTASoftwareUpdateProviderClusterQueryImageParams *) params completion
+    : (void (^)(
+          MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ApplyUpdateRequest
+ *
+ * Determine next action to take for a downloaded Software Image
+ */
+-(void) applyUpdateRequestWithParams : (MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams *) params completion
+    : (void (^)(
+          MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command NotifyUpdateApplied
+ *
+ * Notify OTA Provider that an update was applied
+ */
+-(void) notifyUpdateAppliedWithParams : (MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -2312,15 +2623,21 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster OTA Software Update Requestor
  *
+ * Provides an interface for downloading and applying OTA software updates
  */
-@interface MTRBaseClusterOtaSoftwareUpdateRequestor : MTRCluster
+@interface MTRBaseClusterOTASoftwareUpdateRequestor : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)announceOtaProviderWithParams:(MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
-                           completion:(MTRStatusCompletion)completion;
+/**
+ * Command AnnounceOtaProvider
+ *
+ * Announce the presence of an OTA Provider
+ */
+-(void) announceOtaProviderWithParams : (MTROTASoftwareUpdateRequestorClusterAnnounceOtaProviderParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeDefaultOtaProvidersWithParams:(MTRReadParams * _Nullable)params
                                         completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -2462,6 +2779,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Localization Configuration
  *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing common languages, units of measurements, and numerical formatting
+      standards. As such, Nodes that visually or audibly convey information need a mechanism by which
+      they can be configured to use a user’s preferred language, units, etc
  */
 @interface MTRBaseClusterLocalizationConfiguration : MTRCluster
 
@@ -2578,6 +2899,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Time Format Localization
  *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
+      or audibly convey time information need a mechanism by which they can be configured to use a
+      user’s preferred format.
  */
 @interface MTRBaseClusterTimeFormatLocalization : MTRCluster
 
@@ -2715,6 +3040,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Unit Localization
  *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing preferences for the units in which values are conveyed in communication to a
+      user. As such, Nodes that visually or audibly convey measurable values to the user need a
+      mechanism by which they can be configured to use a user’s preferred unit.
  */
 @interface MTRBaseClusterUnitLocalization : MTRCluster
 
@@ -2818,6 +3147,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Power Source Configuration
  *
+ * This cluster is used to describe the configuration and capabilities of a Device's power system.
  */
 @interface MTRBaseClusterPowerSourceConfiguration : MTRCluster
 
@@ -2916,6 +3246,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Power Source
  *
+ * This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the Node.
  */
 @interface MTRBaseClusterPowerSource : MTRCluster
 
@@ -3448,6 +3779,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster General Commissioning
  *
+ * This cluster is used to manage global aspects of the Commissioning flow.
  */
 @interface MTRBaseClusterGeneralCommissioning : MTRCluster
 
@@ -3455,16 +3787,32 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)armFailSafeWithParams:(MTRGeneralCommissioningClusterArmFailSafeParams *)params
-                   completion:(void (^)(MTRGeneralCommissioningClusterArmFailSafeResponseParams * _Nullable data,
-                                  NSError * _Nullable error))completion;
-- (void)setRegulatoryConfigWithParams:(MTRGeneralCommissioningClusterSetRegulatoryConfigParams *)params
-                           completion:(void (^)(MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams * _Nullable data,
-                                          NSError * _Nullable error))completion;
-- (void)commissioningCompleteWithParams:(MTRGeneralCommissioningClusterCommissioningCompleteParams * _Nullable)params
-                             completion:
-                                 (void (^)(MTRGeneralCommissioningClusterCommissioningCompleteResponseParams * _Nullable data,
-                                     NSError * _Nullable error))completion;
+/**
+ * Command ArmFailSafe
+ *
+ * Arm the persistent fail-safe timer with an expiry time of now + ExpiryLengthSeconds using device clock
+ */
+-(void) armFailSafeWithParams : (MTRGeneralCommissioningClusterArmFailSafeParams *) params completion
+    : (void (^)(MTRGeneralCommissioningClusterArmFailSafeResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command SetRegulatoryConfig
+ *
+ * Set the regulatory configuration to be used during commissioning
+ */
+-(void) setRegulatoryConfigWithParams : (MTRGeneralCommissioningClusterSetRegulatoryConfigParams *) params completion
+    : (void (^)(
+          MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command CommissioningComplete
+ *
+ * Signals the Server that the Client has successfully completed all steps of Commissioning/Recofiguration needed during fail-safe
+ * period.
+ */
+-(void) commissioningCompleteWithParams : (MTRGeneralCommissioningClusterCommissioningCompleteParams * _Nullable) params completion
+    : (void (^)(MTRGeneralCommissioningClusterCommissioningCompleteResponseParams * _Nullable data,
+          NSError * _Nullable error)) completion;
 - (void)commissioningCompleteWithCompletion:(void (^)(
                                                 MTRGeneralCommissioningClusterCommissioningCompleteResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completion;
@@ -3630,6 +3978,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Network Commissioning
  *
+ * Functionality to configure, enable, disable network credentials and access on a Matter device.
  */
 @interface MTRBaseClusterNetworkCommissioning : MTRCluster
 
@@ -3637,24 +3986,53 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)scanNetworksWithParams:(MTRNetworkCommissioningClusterScanNetworksParams * _Nullable)params
-                    completion:(void (^)(MTRNetworkCommissioningClusterScanNetworksResponseParams * _Nullable data,
-                                   NSError * _Nullable error))completion;
-- (void)addOrUpdateWiFiNetworkWithParams:(MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams *)params
-                              completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
-                                             NSError * _Nullable error))completion;
-- (void)addOrUpdateThreadNetworkWithParams:(MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams *)params
-                                completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
-                                               NSError * _Nullable error))completion;
-- (void)removeNetworkWithParams:(MTRNetworkCommissioningClusterRemoveNetworkParams *)params
-                     completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
-                                    NSError * _Nullable error))completion;
-- (void)connectNetworkWithParams:(MTRNetworkCommissioningClusterConnectNetworkParams *)params
-                      completion:(void (^)(MTRNetworkCommissioningClusterConnectNetworkResponseParams * _Nullable data,
-                                     NSError * _Nullable error))completion;
-- (void)reorderNetworkWithParams:(MTRNetworkCommissioningClusterReorderNetworkParams *)params
-                      completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
-                                     NSError * _Nullable error))completion;
+/**
+ * Command ScanNetworks
+ *
+ * Detemine the set of networks the device sees as available.
+ */
+-(void) scanNetworksWithParams : (MTRNetworkCommissioningClusterScanNetworksParams * _Nullable) params completion
+    : (void (^)(MTRNetworkCommissioningClusterScanNetworksResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command AddOrUpdateWiFiNetwork
+ *
+ * Add or update the credentials for a given Wi-Fi network.
+ */
+-(void) addOrUpdateWiFiNetworkWithParams : (MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams *) params completion
+    : (void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command AddOrUpdateThreadNetwork
+ *
+ * Add or update the credentials for a given Thread network.
+ */
+-(void) addOrUpdateThreadNetworkWithParams : (MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams *) params completion
+    : (void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command RemoveNetwork
+ *
+ * Remove the definition of a given network (including its credentials).
+ */
+-(void) removeNetworkWithParams : (MTRNetworkCommissioningClusterRemoveNetworkParams *) params completion
+    : (void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ConnectNetwork
+ *
+ * Connect to the specified network, using previously-defined credentials.
+ */
+-(void) connectNetworkWithParams : (MTRNetworkCommissioningClusterConnectNetworkParams *) params completion
+    : (void (^)(MTRNetworkCommissioningClusterConnectNetworkResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ReorderNetwork
+ *
+ * Modify the order in which networks will be presented in the Networks attribute.
+ */
+-(void) reorderNetworkWithParams : (MTRNetworkCommissioningClusterReorderNetworkParams *) params completion
+    : (void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeMaxNetworksWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -3853,6 +4231,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Diagnostic Logs
  *
+ * The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
  */
 @interface MTRBaseClusterDiagnosticLogs : MTRCluster
 
@@ -3860,9 +4239,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)retrieveLogsRequestWithParams:(MTRDiagnosticLogsClusterRetrieveLogsRequestParams *)params
-                           completion:(void (^)(MTRDiagnosticLogsClusterRetrieveLogsResponseParams * _Nullable data,
-                                          NSError * _Nullable error))completion;
+/**
+ * Command RetrieveLogsRequest
+ *
+ * Retrieving diagnostic logs from a Node
+ */
+-(void) retrieveLogsRequestWithParams : (MTRDiagnosticLogsClusterRetrieveLogsRequestParams *) params completion
+    : (void (^)(MTRDiagnosticLogsClusterRetrieveLogsResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -3942,6 +4325,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster General Diagnostics
  *
+ * The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics
+ * metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterGeneralDiagnostics : MTRCluster
 
@@ -3949,8 +4334,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)testEventTriggerWithParams:(MTRGeneralDiagnosticsClusterTestEventTriggerParams *)params
-                        completion:(MTRStatusCompletion)completion;
+/**
+ * Command TestEventTrigger
+ *
+ * Provide a means for certification tests to trigger some test-plan-specific events
+ */
+-(void) testEventTriggerWithParams : (MTRGeneralDiagnosticsClusterTestEventTriggerParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeNetworkInterfacesWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -4159,6 +4549,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Software Diagnostics
  *
+ * The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterSoftwareDiagnostics : MTRCluster
 
@@ -4166,8 +4558,14 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)resetWatermarksWithParams:(MTRSoftwareDiagnosticsClusterResetWatermarksParams * _Nullable)params
-                       completion:(MTRStatusCompletion)completion;
+/**
+ * Command ResetWatermarks
+ *
+ * Reception of this command SHALL reset the values: The StackFreeMinimum field of the ThreadMetrics attribute,
+ * CurrentHeapHighWaterMark attribute.
+ */
+-(void) resetWatermarksWithParams : (MTRSoftwareDiagnosticsClusterResetWatermarksParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)resetWatermarksWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeThreadMetricsWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -4305,6 +4703,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Thread Network Diagnostics
  *
+ * The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems
  */
 @interface MTRBaseClusterThreadNetworkDiagnostics : MTRCluster
 
@@ -4312,8 +4712,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)resetCountsWithParams:(MTRThreadNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
-                   completion:(MTRStatusCompletion)completion;
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the OverrunCount attributes to 0
+ */
+-(void) resetCountsWithParams : (MTRThreadNetworkDiagnosticsClusterResetCountsParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeChannelWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -5297,6 +5702,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster WiFi Network Diagnostics
  *
+ * The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterWiFiNetworkDiagnostics : MTRCluster
 
@@ -5304,8 +5711,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)resetCountsWithParams:(MTRWiFiNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
-                   completion:(MTRStatusCompletion)completion;
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the Breacon and Packet related count attributes to 0
+ */
+-(void) resetCountsWithParams : (MTRWiFiNetworkDiagnosticsClusterResetCountsParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeBssidWithCompletion:(void (^)(NSData * _Nullable value, NSError * _Nullable error))completion;
@@ -5567,6 +5979,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Ethernet Network Diagnostics
  *
+ * The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
+ * to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterEthernetNetworkDiagnostics : MTRCluster
 
@@ -5574,8 +5988,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)resetCountsWithParams:(MTREthernetNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
-                   completion:(MTRStatusCompletion)completion;
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the attributes: PacketRxCount, PacketTxCount, TxErrCount, CollisionCount, OverrunCount to 0
+ */
+-(void) resetCountsWithParams : (MTREthernetNetworkDiagnosticsClusterResetCountsParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributePHYRateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -5775,6 +6194,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Bridged Device Basic
  *
+ * This Cluster serves two purposes towards a Node communicating with a Bridge: indicate that the functionality on
+          the Endpoint where it is placed (and its Parts) is bridged from a non-CHIP technology; and provide a centralized
+          collection of attributes that the Node MAY collect to aid in conveying information regarding the Bridged Device to a user,
+          such as the vendor name, the model name, or user-assigned name.
  */
 @interface MTRBaseClusterBridgedDeviceBasic : MTRCluster
 
@@ -6069,6 +6492,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Switch
  *
+ * This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
+Two types of switch devices are supported: latching switch (e.g. rocker switch) and momentary switch (e.g. push button),
+distinguished with their feature flags. Interactions with the switch device are exposed as attributes (for the latching switch) and
+as events (for both types of switches). An interested party MAY subscribe to these attributes/events and thus be informed of the
+interactions, and can perform actions based on this, for example by sending commands to perform an action such as controlling a
+light or a window shade.
  */
 @interface MTRBaseClusterSwitch : MTRCluster
 
@@ -6196,6 +6625,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster AdministratorCommissioning
  *
+ * Commands to trigger a Node to allow a new Administrator to commission it.
  */
 @interface MTRBaseClusterAdministratorCommissioning : MTRCluster
 
@@ -6203,12 +6633,34 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)openCommissioningWindowWithParams:(MTRAdministratorCommissioningClusterOpenCommissioningWindowParams *)params
-                               completion:(MTRStatusCompletion)completion;
-- (void)openBasicCommissioningWindowWithParams:(MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams *)params
-                                    completion:(MTRStatusCompletion)completion;
-- (void)revokeCommissioningWithParams:(MTRAdministratorCommissioningClusterRevokeCommissioningParams * _Nullable)params
-                           completion:(MTRStatusCompletion)completion;
+/**
+ * Command OpenCommissioningWindow
+ *
+ * This command is used by a current Administrator to instruct a Node to go into commissioning mode using enhanced commissioning
+ * method.
+ */
+-(void) openCommissioningWindowWithParams : (MTRAdministratorCommissioningClusterOpenCommissioningWindowParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command OpenBasicCommissioningWindow
+ *
+ * This command is used by a current Administrator to instruct a Node to go into commissioning mode using basic commissioning
+ * method, if the node supports it.
+ */
+-(void) openBasicCommissioningWindowWithParams
+    : (MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command RevokeCommissioning
+ *
+ * This command is used by a current Administrator to instruct a Node to revoke any active Open Commissioning Window or Open Basic
+ * Commissioning Window command.
+ */
+-(void) revokeCommissioningWithParams
+    : (MTRAdministratorCommissioningClusterRevokeCommissioningParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)revokeCommissioningWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeWindowStatusWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -6329,6 +6781,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Operational Credentials
  *
+ * This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated
+ * Fabrics.
  */
 @interface MTRBaseClusterOperationalCredentials : MTRCluster
 
@@ -6336,29 +6790,71 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)attestationRequestWithParams:(MTROperationalCredentialsClusterAttestationRequestParams *)params
-                          completion:(void (^)(MTROperationalCredentialsClusterAttestationResponseParams * _Nullable data,
-                                         NSError * _Nullable error))completion;
-- (void)certificateChainRequestWithParams:(MTROperationalCredentialsClusterCertificateChainRequestParams *)params
-                               completion:(void (^)(MTROperationalCredentialsClusterCertificateChainResponseParams * _Nullable data,
-                                              NSError * _Nullable error))completion;
-- (void)CSRRequestWithParams:(MTROperationalCredentialsClusterCSRRequestParams *)params
-                  completion:(void (^)(MTROperationalCredentialsClusterCSRResponseParams * _Nullable data,
-                                 NSError * _Nullable error))completion;
-- (void)addNOCWithParams:(MTROperationalCredentialsClusterAddNOCParams *)params
-              completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
-                             NSError * _Nullable error))completion;
-- (void)updateNOCWithParams:(MTROperationalCredentialsClusterUpdateNOCParams *)params
-                 completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
-                                NSError * _Nullable error))completion;
-- (void)updateFabricLabelWithParams:(MTROperationalCredentialsClusterUpdateFabricLabelParams *)params
-                         completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
-                                        NSError * _Nullable error))completion;
-- (void)removeFabricWithParams:(MTROperationalCredentialsClusterRemoveFabricParams *)params
-                    completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
-                                   NSError * _Nullable error))completion;
-- (void)addTrustedRootCertificateWithParams:(MTROperationalCredentialsClusterAddTrustedRootCertificateParams *)params
-                                 completion:(MTRStatusCompletion)completion;
+/**
+ * Command AttestationRequest
+ *
+ * Sender is requesting attestation information from the receiver.
+ */
+-(void) attestationRequestWithParams : (MTROperationalCredentialsClusterAttestationRequestParams *) params completion
+    : (void (^)(MTROperationalCredentialsClusterAttestationResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command CertificateChainRequest
+ *
+ * Sender is requesting a device attestation certificate from the receiver.
+ */
+-(void) certificateChainRequestWithParams : (MTROperationalCredentialsClusterCertificateChainRequestParams *) params completion
+    : (void (^)(
+          MTROperationalCredentialsClusterCertificateChainResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command CSRRequest
+ *
+ * Sender is requesting a certificate signing request (CSR) from the receiver.
+ */
+-(void) CSRRequestWithParams : (MTROperationalCredentialsClusterCSRRequestParams *) params completion
+    : (void (^)(MTROperationalCredentialsClusterCSRResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command AddNOC
+ *
+ * Sender is requesting to add the new node operational certificates.
+ */
+-(void) addNOCWithParams : (MTROperationalCredentialsClusterAddNOCParams *) params completion
+    : (void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command UpdateNOC
+ *
+ * Sender is requesting to update the node operational certificates.
+ */
+-(void) updateNOCWithParams : (MTROperationalCredentialsClusterUpdateNOCParams *) params completion
+    : (void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command UpdateFabricLabel
+ *
+ * This command SHALL be used by an Administrative Node to set the user-visible Label field for a given Fabric, as reflected by
+ * entries in the Fabrics attribute.
+ */
+-(void) updateFabricLabelWithParams : (MTROperationalCredentialsClusterUpdateFabricLabelParams *) params completion
+    : (void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command RemoveFabric
+ *
+ * This command is used by Administrative Nodes to remove a given fabric index and delete all associated fabric-scoped data.
+ */
+-(void) removeFabricWithParams : (MTROperationalCredentialsClusterRemoveFabricParams *) params completion
+    : (void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command AddTrustedRootCertificate
+ *
+ * This command SHALL add a Trusted Root CA Certificate, provided as its CHIP Certificate representation.
+ */
+-(void) addTrustedRootCertificateWithParams : (MTROperationalCredentialsClusterAddTrustedRootCertificateParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeNOCsWithParams:(MTRReadParams * _Nullable)params
                          completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -6526,6 +7022,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Group Key Management
  *
+ * The Group Key Management Cluster is the mechanism by which group keys are managed.
  */
 @interface MTRBaseClusterGroupKeyManagement : MTRCluster
 
@@ -6533,14 +7030,38 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)keySetWriteWithParams:(MTRGroupKeyManagementClusterKeySetWriteParams *)params completion:(MTRStatusCompletion)completion;
-- (void)keySetReadWithParams:(MTRGroupKeyManagementClusterKeySetReadParams *)params
-                  completion:(void (^)(MTRGroupKeyManagementClusterKeySetReadResponseParams * _Nullable data,
-                                 NSError * _Nullable error))completion;
-- (void)keySetRemoveWithParams:(MTRGroupKeyManagementClusterKeySetRemoveParams *)params completion:(MTRStatusCompletion)completion;
-- (void)keySetReadAllIndicesWithParams:(MTRGroupKeyManagementClusterKeySetReadAllIndicesParams *)params
-                            completion:(void (^)(MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams * _Nullable data,
-                                           NSError * _Nullable error))completion;
+/**
+ * Command KeySetWrite
+ *
+ * Revoke a Root Key from a Group
+ */
+-(void) keySetWriteWithParams : (MTRGroupKeyManagementClusterKeySetWriteParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command KeySetRead
+ *
+ * Revoke a Root Key from a Group
+ */
+-(void) keySetReadWithParams : (MTRGroupKeyManagementClusterKeySetReadParams *) params completion
+    : (void (^)(MTRGroupKeyManagementClusterKeySetReadResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command KeySetRemove
+ *
+ * Revoke a Root Key from a Group
+ */
+-(void) keySetRemoveWithParams : (MTRGroupKeyManagementClusterKeySetRemoveParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command KeySetReadAllIndices
+ *
+ * Return the list of Group Key Sets associated with the accessing fabric
+ */
+-(void) keySetReadAllIndicesWithParams : (MTRGroupKeyManagementClusterKeySetReadAllIndicesParams *) params completion
+    : (void (^)(
+          MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeGroupKeyMapWithParams:(MTRReadParams * _Nullable)params
                                 completion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -6683,6 +7204,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Fixed Label
  *
+ * The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
+labels.
  */
 @interface MTRBaseClusterFixedLabel : MTRCluster
 
@@ -6781,6 +7304,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster User Label
  *
+ * The User Label Cluster provides a feature to tag an endpoint with zero or more labels.
  */
 @interface MTRBaseClusterUserLabel : MTRCluster
 
@@ -6883,6 +7407,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Boolean State
  *
+ * This cluster provides an interface to a boolean state called StateValue.
  */
 @interface MTRBaseClusterBooleanState : MTRCluster
 
@@ -6981,6 +7506,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Mode Select
  *
+ * Attributes and commands for selecting a mode from a list of supported options.
  */
 @interface MTRBaseClusterModeSelect : MTRCluster
 
@@ -6988,7 +7514,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)changeToModeWithParams:(MTRModeSelectClusterChangeToModeParams *)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command ChangeToMode
+ *
+ * On receipt of this command, if the NewMode field matches the Mode field in an entry of the SupportedModes list, the server SHALL
+ * set the CurrentMode attribute to the NewMode value, otherwise, the server SHALL respond with an INVALID_COMMAND status response.
+ */
+-(void) changeToModeWithParams : (MTRModeSelectClusterChangeToModeParams *) params completion : (MTRStatusCompletion) completion;
 
 - (void)readAttributeDescriptionWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -7156,6 +7688,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Door Lock
  *
+ * An interface to a generic way to secure a door
  */
 @interface MTRBaseClusterDoorLock : MTRCluster
 
@@ -7163,41 +7696,146 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)lockDoorWithParams:(MTRDoorLockClusterLockDoorParams * _Nullable)params completion:(MTRStatusCompletion)completion;
-- (void)unlockDoorWithParams:(MTRDoorLockClusterUnlockDoorParams * _Nullable)params completion:(MTRStatusCompletion)completion;
-- (void)unlockWithTimeoutWithParams:(MTRDoorLockClusterUnlockWithTimeoutParams *)params completion:(MTRStatusCompletion)completion;
-- (void)setWeekDayScheduleWithParams:(MTRDoorLockClusterSetWeekDayScheduleParams *)params
-                          completion:(MTRStatusCompletion)completion;
-- (void)getWeekDayScheduleWithParams:(MTRDoorLockClusterGetWeekDayScheduleParams *)params
-                          completion:(void (^)(MTRDoorLockClusterGetWeekDayScheduleResponseParams * _Nullable data,
-                                         NSError * _Nullable error))completion;
-- (void)clearWeekDayScheduleWithParams:(MTRDoorLockClusterClearWeekDayScheduleParams *)params
-                            completion:(MTRStatusCompletion)completion;
-- (void)setYearDayScheduleWithParams:(MTRDoorLockClusterSetYearDayScheduleParams *)params
-                          completion:(MTRStatusCompletion)completion;
-- (void)getYearDayScheduleWithParams:(MTRDoorLockClusterGetYearDayScheduleParams *)params
-                          completion:(void (^)(MTRDoorLockClusterGetYearDayScheduleResponseParams * _Nullable data,
-                                         NSError * _Nullable error))completion;
-- (void)clearYearDayScheduleWithParams:(MTRDoorLockClusterClearYearDayScheduleParams *)params
-                            completion:(MTRStatusCompletion)completion;
-- (void)setHolidayScheduleWithParams:(MTRDoorLockClusterSetHolidayScheduleParams *)params
-                          completion:(MTRStatusCompletion)completion;
-- (void)getHolidayScheduleWithParams:(MTRDoorLockClusterGetHolidayScheduleParams *)params
-                          completion:(void (^)(MTRDoorLockClusterGetHolidayScheduleResponseParams * _Nullable data,
-                                         NSError * _Nullable error))completion;
-- (void)clearHolidayScheduleWithParams:(MTRDoorLockClusterClearHolidayScheduleParams *)params
-                            completion:(MTRStatusCompletion)completion;
-- (void)setUserWithParams:(MTRDoorLockClusterSetUserParams *)params completion:(MTRStatusCompletion)completion;
-- (void)getUserWithParams:(MTRDoorLockClusterGetUserParams *)params
-               completion:(void (^)(MTRDoorLockClusterGetUserResponseParams * _Nullable data, NSError * _Nullable error))completion;
-- (void)clearUserWithParams:(MTRDoorLockClusterClearUserParams *)params completion:(MTRStatusCompletion)completion;
-- (void)setCredentialWithParams:(MTRDoorLockClusterSetCredentialParams *)params
-                     completion:(void (^)(MTRDoorLockClusterSetCredentialResponseParams * _Nullable data,
-                                    NSError * _Nullable error))completion;
-- (void)getCredentialStatusWithParams:(MTRDoorLockClusterGetCredentialStatusParams *)params
-                           completion:(void (^)(MTRDoorLockClusterGetCredentialStatusResponseParams * _Nullable data,
-                                          NSError * _Nullable error))completion;
-- (void)clearCredentialWithParams:(MTRDoorLockClusterClearCredentialParams *)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command LockDoor
+ *
+ * This command causes the lock device to lock the door.
+ */
+-(void) lockDoorWithParams : (MTRDoorLockClusterLockDoorParams * _Nullable) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command UnlockDoor
+ *
+ * This command causes the lock device to unlock the door.
+ */
+-(void) unlockDoorWithParams : (MTRDoorLockClusterUnlockDoorParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command UnlockWithTimeout
+ *
+ * This command causes the lock device to unlock the door with a timeout parameter.
+ */
+-(void) unlockWithTimeoutWithParams : (MTRDoorLockClusterUnlockWithTimeoutParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command SetWeekDaySchedule
+ *
+ * Set a weekly repeating schedule for a specified user.
+ */
+-(void) setWeekDayScheduleWithParams : (MTRDoorLockClusterSetWeekDayScheduleParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command GetWeekDaySchedule
+ *
+ * Retrieve the specific weekly schedule for the specific user.
+ */
+-(void) getWeekDayScheduleWithParams : (MTRDoorLockClusterGetWeekDayScheduleParams *) params completion
+    : (void (^)(MTRDoorLockClusterGetWeekDayScheduleResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ClearWeekDaySchedule
+ *
+ * Clear the specific weekly schedule or all weekly schedules for the specific user.
+ */
+-(void) clearWeekDayScheduleWithParams : (MTRDoorLockClusterClearWeekDayScheduleParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command SetYearDaySchedule
+ *
+ * Set a time-specific schedule ID for a specified user.
+ */
+-(void) setYearDayScheduleWithParams : (MTRDoorLockClusterSetYearDayScheduleParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command GetYearDaySchedule
+ *
+ * Returns the year day schedule data for the specified schedule and user indexes.
+ */
+-(void) getYearDayScheduleWithParams : (MTRDoorLockClusterGetYearDayScheduleParams *) params completion
+    : (void (^)(MTRDoorLockClusterGetYearDayScheduleResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ClearYearDaySchedule
+ *
+ * Clears the specific year day schedule or all year day schedules for the specific user.
+ */
+-(void) clearYearDayScheduleWithParams : (MTRDoorLockClusterClearYearDayScheduleParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command SetHolidaySchedule
+ *
+ * Set the holiday Schedule by specifying local start time and local end time with respect to any Lock Operating Mode.
+ */
+-(void) setHolidayScheduleWithParams : (MTRDoorLockClusterSetHolidayScheduleParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command GetHolidaySchedule
+ *
+ * Get the holiday schedule for the specified index.
+ */
+-(void) getHolidayScheduleWithParams : (MTRDoorLockClusterGetHolidayScheduleParams *) params completion
+    : (void (^)(MTRDoorLockClusterGetHolidayScheduleResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ClearHolidaySchedule
+ *
+ * Clears the holiday schedule or all holiday schedules.
+ */
+-(void) clearHolidayScheduleWithParams : (MTRDoorLockClusterClearHolidayScheduleParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command SetUser
+ *
+ * Set User into the lock.
+ */
+-(void) setUserWithParams : (MTRDoorLockClusterSetUserParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command GetUser
+ *
+ * Retrieve User.
+ */
+-(void) getUserWithParams : (MTRDoorLockClusterGetUserParams *) params completion
+    : (void (^)(MTRDoorLockClusterGetUserResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ClearUser
+ *
+ * Clears a User or all Users.
+ */
+-(void) clearUserWithParams : (MTRDoorLockClusterClearUserParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command SetCredential
+ *
+ * Set a credential (e.g. PIN, RFID, Fingerprint, etc.) into the lock for a new user, existing user, or ProgrammingUser.
+ */
+-(void) setCredentialWithParams : (MTRDoorLockClusterSetCredentialParams *) params completion
+    : (void (^)(MTRDoorLockClusterSetCredentialResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command GetCredentialStatus
+ *
+ * Retrieve the status of a particular credential (e.g. PIN, RFID, Fingerprint, etc.) by index.
+ */
+-(void) getCredentialStatusWithParams : (MTRDoorLockClusterGetCredentialStatusParams *) params completion
+    : (void (^)(MTRDoorLockClusterGetCredentialStatusResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ClearCredential
+ *
+ * Clear one, one type, or all credentials except ProgrammingPIN credential.
+ */
+-(void) clearCredentialWithParams : (MTRDoorLockClusterClearCredentialParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeLockStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -7895,6 +8533,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Window Covering
  *
+ * Provides an interface for controlling and adjusting automatic window coverings.
  */
 @interface MTRBaseClusterWindowCovering : MTRCluster
 
@@ -7902,20 +8541,64 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)upOrOpenWithParams:(MTRWindowCoveringClusterUpOrOpenParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command UpOrOpen
+ *
+ * Moves window covering to InstalledOpenLimitLift and InstalledOpenLimitTilt
+ */
+-(void) upOrOpenWithParams : (MTRWindowCoveringClusterUpOrOpenParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)upOrOpenWithCompletion:(MTRStatusCompletion)completion;
-- (void)downOrCloseWithParams:(MTRWindowCoveringClusterDownOrCloseParams * _Nullable)params
-                   completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command DownOrClose
+ *
+ * Moves window covering to InstalledClosedLimitLift and InstalledCloseLimitTilt
+ */
+-(void) downOrCloseWithParams : (MTRWindowCoveringClusterDownOrCloseParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)downOrCloseWithCompletion:(MTRStatusCompletion)completion;
-- (void)stopMotionWithParams:(MTRWindowCoveringClusterStopMotionParams * _Nullable)params
-                  completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StopMotion
+ *
+ * Stop any adjusting of window covering
+ */
+-(void) stopMotionWithParams : (MTRWindowCoveringClusterStopMotionParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)stopMotionWithCompletion:(MTRStatusCompletion)completion;
-- (void)goToLiftValueWithParams:(MTRWindowCoveringClusterGoToLiftValueParams *)params completion:(MTRStatusCompletion)completion;
-- (void)goToLiftPercentageWithParams:(MTRWindowCoveringClusterGoToLiftPercentageParams *)params
-                          completion:(MTRStatusCompletion)completion;
-- (void)goToTiltValueWithParams:(MTRWindowCoveringClusterGoToTiltValueParams *)params completion:(MTRStatusCompletion)completion;
-- (void)goToTiltPercentageWithParams:(MTRWindowCoveringClusterGoToTiltPercentageParams *)params
-                          completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GoToLiftValue
+ *
+ * Go to lift value specified
+ */
+-(void) goToLiftValueWithParams : (MTRWindowCoveringClusterGoToLiftValueParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command GoToLiftPercentage
+ *
+ * Go to lift percentage specified
+ */
+-(void) goToLiftPercentageWithParams : (MTRWindowCoveringClusterGoToLiftPercentageParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command GoToTiltValue
+ *
+ * Go to tilt value specified
+ */
+-(void) goToTiltValueWithParams : (MTRWindowCoveringClusterGoToTiltValueParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command GoToTiltPercentage
+ *
+ * Go to tilt percentage specified
+ */
+-(void) goToTiltPercentageWithParams : (MTRWindowCoveringClusterGoToTiltPercentageParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -8344,6 +9027,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Barrier Control
  *
+ * This cluster provides control of a barrier (garage door).
  */
 @interface MTRBaseClusterBarrierControl : MTRCluster
 
@@ -8351,10 +9035,21 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)barrierControlGoToPercentWithParams:(MTRBarrierControlClusterBarrierControlGoToPercentParams *)params
-                                 completion:(MTRStatusCompletion)completion;
-- (void)barrierControlStopWithParams:(MTRBarrierControlClusterBarrierControlStopParams * _Nullable)params
-                          completion:(MTRStatusCompletion)completion;
+/**
+ * Command BarrierControlGoToPercent
+ *
+ * Command to instruct a barrier to go to a percent open state.
+ */
+-(void) barrierControlGoToPercentWithParams : (MTRBarrierControlClusterBarrierControlGoToPercentParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command BarrierControlStop
+ *
+ * Command that instructs the barrier to stop moving.
+ */
+-(void) barrierControlStopWithParams : (MTRBarrierControlClusterBarrierControlStopParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)barrierControlStopWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeBarrierMovingStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -8610,6 +9305,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Pump Configuration and Control
  *
+ * An interface for configuring and controlling pumps.
  */
 @interface MTRBaseClusterPumpConfigurationAndControl : MTRCluster
 
@@ -9024,6 +9720,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Thermostat
  *
+ * An interface for configuring and controlling the functionality of a thermostat.
  */
 @interface MTRBaseClusterThermostat : MTRCluster
 
@@ -9031,15 +9728,37 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)setpointRaiseLowerWithParams:(MTRThermostatClusterSetpointRaiseLowerParams *)params
-                          completion:(MTRStatusCompletion)completion;
-- (void)setWeeklyScheduleWithParams:(MTRThermostatClusterSetWeeklyScheduleParams *)params
-                         completion:(MTRStatusCompletion)completion;
-- (void)getWeeklyScheduleWithParams:(MTRThermostatClusterGetWeeklyScheduleParams *)params
-                         completion:(void (^)(MTRThermostatClusterGetWeeklyScheduleResponseParams * _Nullable data,
-                                        NSError * _Nullable error))completion;
-- (void)clearWeeklyScheduleWithParams:(MTRThermostatClusterClearWeeklyScheduleParams * _Nullable)params
-                           completion:(MTRStatusCompletion)completion;
+/**
+ * Command SetpointRaiseLower
+ *
+ * Command description for SetpointRaiseLower
+ */
+-(void) setpointRaiseLowerWithParams : (MTRThermostatClusterSetpointRaiseLowerParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command SetWeeklySchedule
+ *
+ * Command description for SetWeeklySchedule
+ */
+-(void) setWeeklyScheduleWithParams : (MTRThermostatClusterSetWeeklyScheduleParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command GetWeeklySchedule
+ *
+ * Command description for GetWeeklySchedule
+ */
+-(void) getWeeklyScheduleWithParams : (MTRThermostatClusterGetWeeklyScheduleParams *) params completion
+    : (void (^)(MTRThermostatClusterGetWeeklyScheduleResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ClearWeeklySchedule
+ *
+ * The Clear Weekly Schedule command is used to clear the weekly schedule.
+ */
+-(void) clearWeeklyScheduleWithParams : (MTRThermostatClusterClearWeeklyScheduleParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)clearWeeklyScheduleWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeLocalTemperatureWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -9968,6 +10687,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Fan Control
  *
+ * An interface for controlling a fan in a heating/cooling system.
  */
 @interface MTRBaseClusterFanControl : MTRCluster
 
@@ -10223,6 +10943,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Thermostat User Interface Configuration
  *
+ * An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
  */
 @interface MTRBaseClusterThermostatUserInterfaceConfiguration : MTRCluster
 
@@ -10366,6 +11087,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Color Control
  *
+ * Attributes and commands for controlling the color properties of a color-capable light.
  */
 @interface MTRBaseClusterColorControl : MTRCluster
 
@@ -10373,32 +11095,149 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)moveToHueWithParams:(MTRColorControlClusterMoveToHueParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveHueWithParams:(MTRColorControlClusterMoveHueParams *)params completion:(MTRStatusCompletion)completion;
-- (void)stepHueWithParams:(MTRColorControlClusterStepHueParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveToSaturationWithParams:(MTRColorControlClusterMoveToSaturationParams *)params
-                        completion:(MTRStatusCompletion)completion;
-- (void)moveSaturationWithParams:(MTRColorControlClusterMoveSaturationParams *)params completion:(MTRStatusCompletion)completion;
-- (void)stepSaturationWithParams:(MTRColorControlClusterStepSaturationParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveToHueAndSaturationWithParams:(MTRColorControlClusterMoveToHueAndSaturationParams *)params
-                              completion:(MTRStatusCompletion)completion;
-- (void)moveToColorWithParams:(MTRColorControlClusterMoveToColorParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveColorWithParams:(MTRColorControlClusterMoveColorParams *)params completion:(MTRStatusCompletion)completion;
-- (void)stepColorWithParams:(MTRColorControlClusterStepColorParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveToColorTemperatureWithParams:(MTRColorControlClusterMoveToColorTemperatureParams *)params
-                              completion:(MTRStatusCompletion)completion;
-- (void)enhancedMoveToHueWithParams:(MTRColorControlClusterEnhancedMoveToHueParams *)params
-                         completion:(MTRStatusCompletion)completion;
-- (void)enhancedMoveHueWithParams:(MTRColorControlClusterEnhancedMoveHueParams *)params completion:(MTRStatusCompletion)completion;
-- (void)enhancedStepHueWithParams:(MTRColorControlClusterEnhancedStepHueParams *)params completion:(MTRStatusCompletion)completion;
-- (void)enhancedMoveToHueAndSaturationWithParams:(MTRColorControlClusterEnhancedMoveToHueAndSaturationParams *)params
-                                      completion:(MTRStatusCompletion)completion;
-- (void)colorLoopSetWithParams:(MTRColorControlClusterColorLoopSetParams *)params completion:(MTRStatusCompletion)completion;
-- (void)stopMoveStepWithParams:(MTRColorControlClusterStopMoveStepParams *)params completion:(MTRStatusCompletion)completion;
-- (void)moveColorTemperatureWithParams:(MTRColorControlClusterMoveColorTemperatureParams *)params
-                            completion:(MTRStatusCompletion)completion;
-- (void)stepColorTemperatureWithParams:(MTRColorControlClusterStepColorTemperatureParams *)params
-                            completion:(MTRStatusCompletion)completion;
+/**
+ * Command MoveToHue
+ *
+ * Move to specified hue.
+ */
+-(void) moveToHueWithParams : (MTRColorControlClusterMoveToHueParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveHue
+ *
+ * Move hue up or down at specified rate.
+ */
+-(void) moveHueWithParams : (MTRColorControlClusterMoveHueParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command StepHue
+ *
+ * Step hue up or down by specified size at specified rate.
+ */
+-(void) stepHueWithParams : (MTRColorControlClusterStepHueParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveToSaturation
+ *
+ * Move to specified saturation.
+ */
+-(void) moveToSaturationWithParams : (MTRColorControlClusterMoveToSaturationParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveSaturation
+ *
+ * Move saturation up or down at specified rate.
+ */
+-(void) moveSaturationWithParams : (MTRColorControlClusterMoveSaturationParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command StepSaturation
+ *
+ * Step saturation up or down by specified size at specified rate.
+ */
+-(void) stepSaturationWithParams : (MTRColorControlClusterStepSaturationParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveToHueAndSaturation
+ *
+ * Move to hue and saturation.
+ */
+-(void) moveToHueAndSaturationWithParams : (MTRColorControlClusterMoveToHueAndSaturationParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveToColor
+ *
+ * Move to specified color.
+ */
+-(void) moveToColorWithParams : (MTRColorControlClusterMoveToColorParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveColor
+ *
+ * Moves the color.
+ */
+-(void) moveColorWithParams : (MTRColorControlClusterMoveColorParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command StepColor
+ *
+ * Steps the lighting to a specific color.
+ */
+-(void) stepColorWithParams : (MTRColorControlClusterStepColorParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveToColorTemperature
+ *
+ * Move to a specific color temperature.
+ */
+-(void) moveToColorTemperatureWithParams : (MTRColorControlClusterMoveToColorTemperatureParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command EnhancedMoveToHue
+ *
+ * Command description for EnhancedMoveToHue
+ */
+-(void) enhancedMoveToHueWithParams : (MTRColorControlClusterEnhancedMoveToHueParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command EnhancedMoveHue
+ *
+ * Command description for EnhancedMoveHue
+ */
+-(void) enhancedMoveHueWithParams : (MTRColorControlClusterEnhancedMoveHueParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command EnhancedStepHue
+ *
+ * Command description for EnhancedStepHue
+ */
+-(void) enhancedStepHueWithParams : (MTRColorControlClusterEnhancedStepHueParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command EnhancedMoveToHueAndSaturation
+ *
+ * Command description for EnhancedMoveToHueAndSaturation
+ */
+-(void) enhancedMoveToHueAndSaturationWithParams : (MTRColorControlClusterEnhancedMoveToHueAndSaturationParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command ColorLoopSet
+ *
+ * Command description for ColorLoopSet
+ */
+-(void) colorLoopSetWithParams : (MTRColorControlClusterColorLoopSetParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command StopMoveStep
+ *
+ * Command description for StopMoveStep
+ */
+-(void) stopMoveStepWithParams : (MTRColorControlClusterStopMoveStepParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command MoveColorTemperature
+ *
+ * Command description for MoveColorTemperature
+ */
+-(void) moveColorTemperatureWithParams : (MTRColorControlClusterMoveColorTemperatureParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command StepColorTemperature
+ *
+ * Command description for StepColorTemperature
+ */
+-(void) stepColorTemperatureWithParams : (MTRColorControlClusterStepColorTemperatureParams *) params completion
+    : (MTRStatusCompletion) completion;
 
 - (void)readAttributeCurrentHueWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -11264,6 +12103,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Ballast Configuration
  *
+ * Attributes and commands for configuring a lighting ballast.
  */
 @interface MTRBaseClusterBallastConfiguration : MTRCluster
 
@@ -11584,6 +12424,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Illuminance Measurement
  *
+ * Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
  */
 @interface MTRBaseClusterIlluminanceMeasurement : MTRCluster
 
@@ -11737,6 +12578,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Temperature Measurement
  *
+ * Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
  */
 @interface MTRBaseClusterTemperatureMeasurement : MTRCluster
 
@@ -11876,6 +12718,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Pressure Measurement
  *
+ * Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.
  */
 @interface MTRBaseClusterPressureMeasurement : MTRCluster
 
@@ -12083,6 +12926,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Flow Measurement
  *
+ * Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
  */
 @interface MTRBaseClusterFlowMeasurement : MTRCluster
 
@@ -12222,6 +13066,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Relative Humidity Measurement
  *
+ * Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
  */
 @interface MTRBaseClusterRelativeHumidityMeasurement : MTRCluster
 
@@ -12361,6 +13206,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Occupancy Sensing
  *
+ * Attributes and commands for configuring occupancy sensing, and reporting occupancy status.
  */
 @interface MTRBaseClusterOccupancySensing : MTRCluster
 
@@ -12412,65 +13258,65 @@ NS_ASSUME_NONNULL_BEGIN
                                                          completion:(void (^)(NSNumber * _Nullable value,
                                                                         NSError * _Nullable error))completion;
 
-- (void)readAttributePirOccupiedToUnoccupiedDelayWithCompletion:(void (^)(NSNumber * _Nullable value,
+- (void)readAttributePIROccupiedToUnoccupiedDelayWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                     NSError * _Nullable error))completion;
-- (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value completion:(MTRStatusCompletion)completion;
-- (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value
+- (void)writeAttributePIROccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value completion:(MTRStatusCompletion)completion;
+- (void)writeAttributePIROccupiedToUnoccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion;
 /**
  * This API does not support setting autoResubscribe to NO in the
  * MTRSubscribeParams.
  */
-- (void)subscribeAttributePirOccupiedToUnoccupiedDelayWithParams:(MTRSubscribeParams *)params
+- (void)subscribeAttributePIROccupiedToUnoccupiedDelayWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                    reportHandler:(void (^)(NSNumber * _Nullable value,
                                                                      NSError * _Nullable error))reportHandler;
-+ (void)readAttributePirOccupiedToUnoccupiedDelayWithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer
++ (void)readAttributePIROccupiedToUnoccupiedDelayWithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer
                                                               endpoint:(NSNumber *)endpoint
                                                                  queue:(dispatch_queue_t)queue
                                                             completion:(void (^)(NSNumber * _Nullable value,
                                                                            NSError * _Nullable error))completion;
 
-- (void)readAttributePirUnoccupiedToOccupiedDelayWithCompletion:(void (^)(NSNumber * _Nullable value,
+- (void)readAttributePIRUnoccupiedToOccupiedDelayWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                     NSError * _Nullable error))completion;
-- (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value completion:(MTRStatusCompletion)completion;
-- (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value
+- (void)writeAttributePIRUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value completion:(MTRStatusCompletion)completion;
+- (void)writeAttributePIRUnoccupiedToOccupiedDelayWithValue:(NSNumber * _Nonnull)value
                                                      params:(MTRWriteParams * _Nullable)params
                                                  completion:(MTRStatusCompletion)completion;
 /**
  * This API does not support setting autoResubscribe to NO in the
  * MTRSubscribeParams.
  */
-- (void)subscribeAttributePirUnoccupiedToOccupiedDelayWithParams:(MTRSubscribeParams *)params
+- (void)subscribeAttributePIRUnoccupiedToOccupiedDelayWithParams:(MTRSubscribeParams *)params
                                          subscriptionEstablished:
                                              (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                    reportHandler:(void (^)(NSNumber * _Nullable value,
                                                                      NSError * _Nullable error))reportHandler;
-+ (void)readAttributePirUnoccupiedToOccupiedDelayWithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer
++ (void)readAttributePIRUnoccupiedToOccupiedDelayWithClusterStateCache:(MTRClusterStateCacheContainer *)clusterStateCacheContainer
                                                               endpoint:(NSNumber *)endpoint
                                                                  queue:(dispatch_queue_t)queue
                                                             completion:(void (^)(NSNumber * _Nullable value,
                                                                            NSError * _Nullable error))completion;
 
-- (void)readAttributePirUnoccupiedToOccupiedThresholdWithCompletion:(void (^)(NSNumber * _Nullable value,
+- (void)readAttributePIRUnoccupiedToOccupiedThresholdWithCompletion:(void (^)(NSNumber * _Nullable value,
                                                                         NSError * _Nullable error))completion;
-- (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
+- (void)writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
                                                      completion:(MTRStatusCompletion)completion;
-- (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
+- (void)writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:(NSNumber * _Nonnull)value
                                                          params:(MTRWriteParams * _Nullable)params
                                                      completion:(MTRStatusCompletion)completion;
 /**
  * This API does not support setting autoResubscribe to NO in the
  * MTRSubscribeParams.
  */
-- (void)subscribeAttributePirUnoccupiedToOccupiedThresholdWithParams:(MTRSubscribeParams *)params
+- (void)subscribeAttributePIRUnoccupiedToOccupiedThresholdWithParams:(MTRSubscribeParams *)params
                                              subscriptionEstablished:
                                                  (MTRSubscriptionEstablishedHandler _Nullable)subscriptionEstablished
                                                        reportHandler:(void (^)(NSNumber * _Nullable value,
                                                                          NSError * _Nullable error))reportHandler;
-+ (void)readAttributePirUnoccupiedToOccupiedThresholdWithClusterStateCache:
++ (void)readAttributePIRUnoccupiedToOccupiedThresholdWithClusterStateCache:
             (MTRClusterStateCacheContainer *)clusterStateCacheContainer
                                                                   endpoint:(NSNumber *)endpoint
                                                                      queue:(dispatch_queue_t)queue
@@ -12693,8 +13539,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Wake on LAN
  *
+ * This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
  */
-@interface MTRBaseClusterWakeOnLan : MTRCluster
+@interface MTRBaseClusterWakeOnLAN : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRBaseDevice *)device
                                 endpoint:(NSNumber *)endpoint
@@ -12791,6 +13638,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Channel
  *
+ * This cluster provides an interface for controlling the current Channel on a device.
  */
 @interface MTRBaseClusterChannel : MTRCluster
 
@@ -12798,12 +13646,31 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)changeChannelWithParams:(MTRChannelClusterChangeChannelParams *)params
-                     completion:(void (^)(MTRChannelClusterChangeChannelResponseParams * _Nullable data,
-                                    NSError * _Nullable error))completion;
-- (void)changeChannelByNumberWithParams:(MTRChannelClusterChangeChannelByNumberParams *)params
-                             completion:(MTRStatusCompletion)completion;
-- (void)skipChannelWithParams:(MTRChannelClusterSkipChannelParams *)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command ChangeChannel
+ *
+ * Change the channel on the media player to the channel case-insensitive exact matching the value passed as an argument.
+ */
+-(void) changeChannelWithParams : (MTRChannelClusterChangeChannelParams *) params completion
+    : (void (^)(MTRChannelClusterChangeChannelResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command ChangeChannelByNumber
+ *
+ * Change the channel on the media plaeyer to the channel with the given Number in the ChannelList attribute.
+ */
+-(void) changeChannelByNumberWithParams : (MTRChannelClusterChangeChannelByNumberParams *) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command SkipChannel
+ *
+ * This command provides channel up and channel down functionality, but allows channel index jumps of size Count. When the value of
+ * the increase or decrease is larger than the number of channels remaining in the given direction, then the behavior SHALL be to
+ * return to the beginning (or end) of the channel list and continue. For example, if the current channel is at index 0 and count
+ * value of -1 is given, then the current channel should change to the last channel.
+ */
+-(void) skipChannelWithParams : (MTRChannelClusterSkipChannelParams *) params completion : (MTRStatusCompletion) completion;
 
 - (void)readAttributeChannelListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -12928,6 +13795,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Target Navigator
  *
+ * This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
  */
 @interface MTRBaseClusterTargetNavigator : MTRCluster
 
@@ -12935,9 +13803,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)navigateTargetWithParams:(MTRTargetNavigatorClusterNavigateTargetParams *)params
-                      completion:(void (^)(MTRTargetNavigatorClusterNavigateTargetResponseParams * _Nullable data,
-                                     NSError * _Nullable error))completion;
+/**
+ * Command NavigateTarget
+ *
+ * Upon receipt, this SHALL navigation the UX to the target identified.
+ */
+-(void) navigateTargetWithParams : (MTRTargetNavigatorClusterNavigateTargetParams *) params completion
+    : (void (^)(MTRTargetNavigatorClusterNavigateTargetResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeTargetListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -13043,6 +13915,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Media Playback
  *
+ * This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or Speaker.
  */
 @interface MTRBaseClusterMediaPlayback : MTRCluster
 
@@ -13050,55 +13923,114 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)playWithParams:(MTRMediaPlaybackClusterPlayParams * _Nullable)params
-            completion:
-                (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
+/**
+ * Command Play
+ *
+ * Upon receipt, this SHALL play media.
+ */
+-(void) playWithParams : (MTRMediaPlaybackClusterPlayParams * _Nullable) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)playWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                NSError * _Nullable error))completion;
-- (void)pauseWithParams:(MTRMediaPlaybackClusterPauseParams * _Nullable)params
-             completion:
-                 (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command Pause
+ *
+ * Upon receipt, this SHALL pause media.
+ */
+-(void) pauseWithParams : (MTRMediaPlaybackClusterPauseParams * _Nullable) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)pauseWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion;
-- (void)stopPlaybackWithParams:(MTRMediaPlaybackClusterStopPlaybackParams * _Nullable)params
-                    completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
-                                   NSError * _Nullable error))completion;
+
+/**
+ * Command StopPlayback
+ *
+ * Upon receipt, this SHALL stop media. User experience is context-specific. This will often navigate the user back to the location
+ * where media was originally launched.
+ */
+-(void) stopPlaybackWithParams : (MTRMediaPlaybackClusterStopPlaybackParams * _Nullable) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)stopPlaybackWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion;
-- (void)startOverWithParams:(MTRMediaPlaybackClusterStartOverParams * _Nullable)params
-                 completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
-                                NSError * _Nullable error))completion;
+
+/**
+ * Command StartOver
+ *
+ * Upon receipt, this SHALL Start Over with the current media playback item.
+ */
+-(void) startOverWithParams : (MTRMediaPlaybackClusterStartOverParams * _Nullable) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)startOverWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion;
-- (void)previousWithParams:(MTRMediaPlaybackClusterPreviousParams * _Nullable)params
-                completion:
-                    (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command Previous
+ *
+ * Upon receipt, this SHALL cause the handler to be invoked for "Previous". User experience is context-specific. This will often Go
+ * back to the previous media playback item.
+ */
+-(void) previousWithParams : (MTRMediaPlaybackClusterPreviousParams * _Nullable) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)previousWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion;
-- (void)nextWithParams:(MTRMediaPlaybackClusterNextParams * _Nullable)params
-            completion:
-                (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command Next
+ *
+ * Upon receipt, this SHALL cause the handler to be invoked for "Next". User experience is context-specific. This will often Go
+ * forward to the next media playback item.
+ */
+-(void) nextWithParams : (MTRMediaPlaybackClusterNextParams * _Nullable) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)nextWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                NSError * _Nullable error))completion;
-- (void)rewindWithParams:(MTRMediaPlaybackClusterRewindParams * _Nullable)params
-              completion:
-                  (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command Rewind
+ *
+ * Upon receipt, this SHALL Rewind through media. Different Rewind speeds can be used on the TV based upon the number of sequential
+ * calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).
+ */
+-(void) rewindWithParams : (MTRMediaPlaybackClusterRewindParams * _Nullable) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)rewindWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion;
-- (void)fastForwardWithParams:(MTRMediaPlaybackClusterFastForwardParams * _Nullable)params
-                   completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
-                                  NSError * _Nullable error))completion;
+
+/**
+ * Command FastForward
+ *
+ * Upon receipt, this SHALL Advance through media. Different FF speeds can be used on the TV based upon the number of sequential
+ * calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).
+ */
+-(void) fastForwardWithParams : (MTRMediaPlaybackClusterFastForwardParams * _Nullable) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)fastForwardWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                       NSError * _Nullable error))completion;
-- (void)skipForwardWithParams:(MTRMediaPlaybackClusterSkipForwardParams *)params
-                   completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
-                                  NSError * _Nullable error))completion;
-- (void)skipBackwardWithParams:(MTRMediaPlaybackClusterSkipBackwardParams *)params
-                    completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
-                                   NSError * _Nullable error))completion;
-- (void)seekWithParams:(MTRMediaPlaybackClusterSeekParams *)params
-            completion:
-                (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command SkipForward
+ *
+ * Upon receipt, this SHALL Skip forward in the media by the given number of seconds, using the data as follows:
+ */
+-(void) skipForwardWithParams : (MTRMediaPlaybackClusterSkipForwardParams *) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command SkipBackward
+ *
+ * Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:
+ */
+-(void) skipBackwardWithParams : (MTRMediaPlaybackClusterSkipBackwardParams *) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command Seek
+ *
+ * Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:
+ */
+-(void) seekWithParams : (MTRMediaPlaybackClusterSeekParams *) params completion
+    : (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeCurrentStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -13273,6 +14205,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Media Input
  *
+ * This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
  */
 @interface MTRBaseClusterMediaInput : MTRCluster
 
@@ -13280,14 +14213,38 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)selectInputWithParams:(MTRMediaInputClusterSelectInputParams *)params completion:(MTRStatusCompletion)completion;
-- (void)showInputStatusWithParams:(MTRMediaInputClusterShowInputStatusParams * _Nullable)params
-                       completion:(MTRStatusCompletion)completion;
+/**
+ * Command SelectInput
+ *
+ * Upon receipt, this SHALL change the input on the media device to the input at a specific index in the Input List.
+ */
+-(void) selectInputWithParams : (MTRMediaInputClusterSelectInputParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command ShowInputStatus
+ *
+ * Upon receipt, this SHALL display the active status of the input list on screen.
+ */
+-(void) showInputStatusWithParams : (MTRMediaInputClusterShowInputStatusParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)showInputStatusWithCompletion:(MTRStatusCompletion)completion;
-- (void)hideInputStatusWithParams:(MTRMediaInputClusterHideInputStatusParams * _Nullable)params
-                       completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command HideInputStatus
+ *
+ * Upon receipt, this SHALL hide the input list from the screen.
+ */
+-(void) hideInputStatusWithParams : (MTRMediaInputClusterHideInputStatusParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)hideInputStatusWithCompletion:(MTRStatusCompletion)completion;
-- (void)renameInputWithParams:(MTRMediaInputClusterRenameInputParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command RenameInput
+ *
+ * Upon receipt, this SHALL rename the input at a specific index in the Input List. Updates to the input name SHALL appear in the TV
+ * settings menus.
+ */
+-(void) renameInputWithParams : (MTRMediaInputClusterRenameInputParams *) params completion : (MTRStatusCompletion) completion;
 
 - (void)readAttributeInputListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -13393,6 +14350,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Low Power
  *
+ * This cluster provides an interface for managing low power mode on a device.
  */
 @interface MTRBaseClusterLowPower : MTRCluster
 
@@ -13400,7 +14358,12 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)sleepWithParams:(MTRLowPowerClusterSleepParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command Sleep
+ *
+ * This command shall put the device into low power mode.
+ */
+-(void) sleepWithParams : (MTRLowPowerClusterSleepParams * _Nullable) params completion : (MTRStatusCompletion) completion;
 - (void)sleepWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -13481,6 +14444,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Keypad Input
  *
+ * This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
  */
 @interface MTRBaseClusterKeypadInput : MTRCluster
 
@@ -13488,9 +14452,13 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)sendKeyWithParams:(MTRKeypadInputClusterSendKeyParams *)params
-               completion:
-                   (void (^)(MTRKeypadInputClusterSendKeyResponseParams * _Nullable data, NSError * _Nullable error))completion;
+/**
+ * Command SendKey
+ *
+ * Upon receipt, this SHALL process a keycode as input to the media device.
+ */
+-(void) sendKeyWithParams : (MTRKeypadInputClusterSendKeyParams *) params completion
+    : (void (^)(MTRKeypadInputClusterSendKeyResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -13570,6 +14538,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Content Launcher
  *
+ * This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRBaseClusterContentLauncher : MTRCluster
 
@@ -13577,12 +14546,21 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)launchContentWithParams:(MTRContentLauncherClusterLaunchContentParams *)params
-                     completion:(void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data,
-                                    NSError * _Nullable error))completion;
-- (void)launchURLWithParams:(MTRContentLauncherClusterLaunchURLParams *)params
-                 completion:(void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data,
-                                NSError * _Nullable error))completion;
+/**
+ * Command LaunchContent
+ *
+ * Upon receipt, this SHALL launch the specified content with optional search criteria.
+ */
+-(void) launchContentWithParams : (MTRContentLauncherClusterLaunchContentParams *) params completion
+    : (void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command LaunchURL
+ *
+ * Upon receipt, this SHALL launch content from the specified URL.
+ */
+-(void) launchURLWithParams : (MTRContentLauncherClusterLaunchURLParams *) params completion
+    : (void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeAcceptHeaderWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -13695,6 +14673,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Audio Output
  *
+ * This cluster provides an interface for controlling the Output on a media device such as a TV.
  */
 @interface MTRBaseClusterAudioOutput : MTRCluster
 
@@ -13702,8 +14681,20 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)selectOutputWithParams:(MTRAudioOutputClusterSelectOutputParams *)params completion:(MTRStatusCompletion)completion;
-- (void)renameOutputWithParams:(MTRAudioOutputClusterRenameOutputParams *)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command SelectOutput
+ *
+ * Upon receipt, this SHALL change the output on the media device to the output at a specific index in the Output List.
+ */
+-(void) selectOutputWithParams : (MTRAudioOutputClusterSelectOutputParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command RenameOutput
+ *
+ * Upon receipt, this SHALL rename the output at a specific index in the Output List. Updates to the output name SHALL appear in the
+ * TV settings menus.
+ */
+-(void) renameOutputWithParams : (MTRAudioOutputClusterRenameOutputParams *) params completion : (MTRStatusCompletion) completion;
 
 - (void)readAttributeOutputListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -13809,6 +14800,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Application Launcher
  *
+ * This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRBaseClusterApplicationLauncher : MTRCluster
 
@@ -13816,15 +14808,32 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)launchAppWithParams:(MTRApplicationLauncherClusterLaunchAppParams *)params
-                 completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
-                                NSError * _Nullable error))completion;
-- (void)stopAppWithParams:(MTRApplicationLauncherClusterStopAppParams *)params
-               completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
-                              NSError * _Nullable error))completion;
-- (void)hideAppWithParams:(MTRApplicationLauncherClusterHideAppParams *)params
-               completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
-                              NSError * _Nullable error))completion;
+/**
+ * Command LaunchApp
+ *
+ * Upon receipt, this SHALL launch the specified app with optional data. The TV Device SHALL launch and bring to foreground the
+ * identified application in the command if the application is not already launched and in foreground. The TV Device SHALL update
+ * state attribute on the Application Basic cluster of the Endpoint corresponding to the launched application. This command returns
+ * a Launch Response.
+ */
+-(void) launchAppWithParams : (MTRApplicationLauncherClusterLaunchAppParams *) params completion
+    : (void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command StopApp
+ *
+ * Upon receipt on a Video Player endpoint this SHALL stop the specified application if it is running.
+ */
+-(void) stopAppWithParams : (MTRApplicationLauncherClusterStopAppParams *) params completion
+    : (void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command HideApp
+ *
+ * Upon receipt on a Video Player endpoint this SHALL hide the specified application if it is running and visible.
+ */
+-(void) hideAppWithParams : (MTRApplicationLauncherClusterHideAppParams *) params completion
+    : (void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeCatalogListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -13938,6 +14947,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Application Basic
  *
+ * This cluster provides information about an application running on a TV or media player device which is represented as an
+ * endpoint.
  */
 @interface MTRBaseClusterApplicationBasic : MTRCluster
 
@@ -14135,6 +15146,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Account Login
  *
+ * This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App running
+ * on a Video Player device, which is represented as an endpoint (see [TV Architecture]), can use this cluster to help make the user
+ * account on the Content App match the user account on the Client.
  */
 @interface MTRBaseClusterAccountLogin : MTRCluster
 
@@ -14142,11 +15156,32 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)getSetupPINWithParams:(MTRAccountLoginClusterGetSetupPINParams *)params
-                   completion:(void (^)(MTRAccountLoginClusterGetSetupPINResponseParams * _Nullable data,
-                                  NSError * _Nullable error))completion;
-- (void)loginWithParams:(MTRAccountLoginClusterLoginParams *)params completion:(MTRStatusCompletion)completion;
-- (void)logoutWithParams:(MTRAccountLoginClusterLogoutParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command GetSetupPIN
+ *
+ * Upon receipt, the Content App checks if the account associated with the client Temp Account Identifier Rotating ID is the same
+ * acount that is active on the given Content App. If the accounts are the same, then the Content App includes the Setup PIN in the
+ * GetSetupPIN Response.
+ */
+-(void) getSetupPINWithParams : (MTRAccountLoginClusterGetSetupPINParams *) params completion
+    : (void (^)(MTRAccountLoginClusterGetSetupPINResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command Login
+ *
+ * Upon receipt, the Content App checks if the account associated with the client’s Temp Account Identifier (Rotating ID) has a
+ * current active Setup PIN with the given value. If the Setup PIN is valid for the user account associated with the Temp Account
+ * Identifier, then the Content App MAY make that user account active.
+ */
+-(void) loginWithParams : (MTRAccountLoginClusterLoginParams *) params completion : (MTRStatusCompletion) completion;
+
+/**
+ * Command Logout
+ *
+ * The purpose of this command is to instruct the Content App to clear the current user account. This command SHOULD be used by
+ * clients of a Content App to indicate the end of a user session.
+ */
+-(void) logoutWithParams : (MTRAccountLoginClusterLogoutParams * _Nullable) params completion : (MTRStatusCompletion) completion;
 - (void)logoutWithCompletion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeGeneratedCommandListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -14227,6 +15262,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Electrical Measurement
  *
+ * Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to
+ * provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..
  */
 @interface MTRBaseClusterElectricalMeasurement : MTRCluster
 
@@ -14234,11 +15271,23 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)getProfileInfoCommandWithParams:(MTRElectricalMeasurementClusterGetProfileInfoCommandParams * _Nullable)params
-                             completion:(MTRStatusCompletion)completion;
+/**
+ * Command GetProfileInfoCommand
+ *
+ * A function which retrieves the power profiling information from the electrical measurement server.
+ */
+-(void) getProfileInfoCommandWithParams : (MTRElectricalMeasurementClusterGetProfileInfoCommandParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)getProfileInfoCommandWithCompletion:(MTRStatusCompletion)completion;
-- (void)getMeasurementProfileCommandWithParams:(MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams *)params
-                                    completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GetMeasurementProfileCommand
+ *
+ * A function which retrieves an electricity measurement profile from the electricity measurement server for a specific attribute Id
+ * requested.
+ */
+-(void) getMeasurementProfileCommandWithParams
+    : (MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams *) params completion : (MTRStatusCompletion) completion;
 
 - (void)readAttributeMeasurementTypeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 /**
@@ -16289,6 +17338,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Test Cluster
  *
+ * The Test Cluster is meant to validate the generated code
  */
 @interface MTRBaseClusterTestCluster : MTRCluster
 
@@ -16296,79 +17346,217 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)testWithParams:(MTRTestClusterClusterTestParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+/**
+ * Command Test
+ *
+ * Simple command without any parameters and without a specific response
+ */
+-(void) testWithParams : (MTRTestClusterClusterTestParams * _Nullable) params completion : (MTRStatusCompletion) completion;
 - (void)testWithCompletion:(MTRStatusCompletion)completion;
-- (void)testNotHandledWithParams:(MTRTestClusterClusterTestNotHandledParams * _Nullable)params
-                      completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TestNotHandled
+ *
+ * Simple command without any parameters and without a specific response not handled by the server
+ */
+-(void) testNotHandledWithParams : (MTRTestClusterClusterTestNotHandledParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)testNotHandledWithCompletion:(MTRStatusCompletion)completion;
-- (void)testSpecificWithParams:(MTRTestClusterClusterTestSpecificParams * _Nullable)params
-                    completion:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
-                                   NSError * _Nullable error))completion;
+
+/**
+ * Command TestSpecific
+ *
+ * Simple command without any parameters and with a specific response
+ */
+-(void) testSpecificWithParams : (MTRTestClusterClusterTestSpecificParams * _Nullable) params completion
+    : (void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 - (void)testSpecificWithCompletion:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion;
-- (void)testUnknownCommandWithParams:(MTRTestClusterClusterTestUnknownCommandParams * _Nullable)params
-                          completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TestUnknownCommand
+ *
+ * Simple command that should not be added to the server.
+ */
+-(void) testUnknownCommandWithParams : (MTRTestClusterClusterTestUnknownCommandParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)testUnknownCommandWithCompletion:(MTRStatusCompletion)completion;
-- (void)testAddArgumentsWithParams:(MTRTestClusterClusterTestAddArgumentsParams *)params
-                        completion:(void (^)(MTRTestClusterClusterTestAddArgumentsResponseParams * _Nullable data,
-                                       NSError * _Nullable error))completion;
-- (void)testSimpleArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleArgumentRequestParams *)params
-                                 completion:(void (^)(MTRTestClusterClusterTestSimpleArgumentResponseParams * _Nullable data,
-                                                NSError * _Nullable error))completion;
-- (void)testStructArrayArgumentRequestWithParams:(MTRTestClusterClusterTestStructArrayArgumentRequestParams *)params
-                                      completion:
-                                          (void (^)(MTRTestClusterClusterTestStructArrayArgumentResponseParams * _Nullable data,
-                                              NSError * _Nullable error))completion;
-- (void)testStructArgumentRequestWithParams:(MTRTestClusterClusterTestStructArgumentRequestParams *)params
-                                 completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
-                                                NSError * _Nullable error))completion;
-- (void)testNestedStructArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructArgumentRequestParams *)params
-                                       completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
-                                                      NSError * _Nullable error))completion;
-- (void)testListStructArgumentRequestWithParams:(MTRTestClusterClusterTestListStructArgumentRequestParams *)params
-                                     completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
-                                                    NSError * _Nullable error))completion;
-- (void)testListInt8UArgumentRequestWithParams:(MTRTestClusterClusterTestListInt8UArgumentRequestParams *)params
-                                    completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
-                                                   NSError * _Nullable error))completion;
-- (void)testNestedStructListArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructListArgumentRequestParams *)params
-                                           completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
-                                                          NSError * _Nullable error))completion;
-- (void)testListNestedStructListArgumentRequestWithParams:
-            (MTRTestClusterClusterTestListNestedStructListArgumentRequestParams *)params
-                                               completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
-                                                              NSError * _Nullable error))completion;
-- (void)testListInt8UReverseRequestWithParams:(MTRTestClusterClusterTestListInt8UReverseRequestParams *)params
-                                   completion:(void (^)(MTRTestClusterClusterTestListInt8UReverseResponseParams * _Nullable data,
-                                                  NSError * _Nullable error))completion;
-- (void)testEnumsRequestWithParams:(MTRTestClusterClusterTestEnumsRequestParams *)params
-                        completion:(void (^)(MTRTestClusterClusterTestEnumsResponseParams * _Nullable data,
-                                       NSError * _Nullable error))completion;
-- (void)testNullableOptionalRequestWithParams:(MTRTestClusterClusterTestNullableOptionalRequestParams * _Nullable)params
-                                   completion:(void (^)(MTRTestClusterClusterTestNullableOptionalResponseParams * _Nullable data,
-                                                  NSError * _Nullable error))completion;
-- (void)testComplexNullableOptionalRequestWithParams:(MTRTestClusterClusterTestComplexNullableOptionalRequestParams *)params
-                                          completion:
-                                              (void (^)(
-                                                  MTRTestClusterClusterTestComplexNullableOptionalResponseParams * _Nullable data,
-                                                  NSError * _Nullable error))completion;
-- (void)simpleStructEchoRequestWithParams:(MTRTestClusterClusterSimpleStructEchoRequestParams *)params
-                               completion:(void (^)(MTRTestClusterClusterSimpleStructResponseParams * _Nullable data,
-                                              NSError * _Nullable error))completion;
-- (void)timedInvokeRequestWithParams:(MTRTestClusterClusterTimedInvokeRequestParams * _Nullable)params
-                          completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TestAddArguments
+ *
+ * Command that takes two arguments and returns their sum.
+ */
+-(void) testAddArgumentsWithParams : (MTRTestClusterClusterTestAddArgumentsParams *) params completion
+    : (void (^)(MTRTestClusterClusterTestAddArgumentsResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestSimpleArgumentRequest
+ *
+ * Command that takes an argument which is bool
+ */
+-(void) testSimpleArgumentRequestWithParams : (MTRTestClusterClusterTestSimpleArgumentRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterTestSimpleArgumentResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestStructArrayArgumentRequest
+ *
+ * Command that takes various arguments that are arrays, including an array of structs which have a list member.
+ */
+-(void) testStructArrayArgumentRequestWithParams : (MTRTestClusterClusterTestStructArrayArgumentRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterTestStructArrayArgumentResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestStructArgumentRequest
+ *
+ * Command that takes an argument which is struct.  The response echoes the
+        'b' field of the single arg.
+ */
+-(void) testStructArgumentRequestWithParams : (MTRTestClusterClusterTestStructArgumentRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestNestedStructArgumentRequest
+ *
+ * Command that takes an argument which is nested struct.  The response
+        echoes the 'b' field of ar1.c.
+ */
+-(void) testNestedStructArgumentRequestWithParams : (MTRTestClusterClusterTestNestedStructArgumentRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestListStructArgumentRequest
+ *
+ * Command that takes an argument which is a list of structs.  The response
+        returns false if there is some struct in the list whose 'b' field is
+        false, and true otherwise (including if the list is empty).
+ */
+-(void) testListStructArgumentRequestWithParams : (MTRTestClusterClusterTestListStructArgumentRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestListInt8UArgumentRequest
+ *
+ * Command that takes an argument which is a list of INT8U.  The response
+        returns false if the list contains a 0 in it, true otherwise (including
+        if the list is empty).
+ */
+-(void) testListInt8UArgumentRequestWithParams : (MTRTestClusterClusterTestListInt8UArgumentRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestNestedStructListArgumentRequest
+ *
+ * Command that takes an argument which is a Nested Struct List.  The
+        response returns false if there is some struct in arg1 (either directly
+        in arg1.c or in the arg1.d list) whose 'b' field is false, and true
+        otherwise.
+ */
+-(void) testNestedStructListArgumentRequestWithParams
+    : (MTRTestClusterClusterTestNestedStructListArgumentRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestListNestedStructListArgumentRequest
+ *
+ * Command that takes an argument which is a list of Nested Struct List.
+        The response returns false if there is some struct in arg1 (either
+        directly in as the 'c' field of an entry 'd' list of an entry) whose 'b'
+        field is false, and true otherwise (including if the list is empty).
+ */
+-(void) testListNestedStructListArgumentRequestWithParams
+    : (MTRTestClusterClusterTestListNestedStructListArgumentRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestListInt8UReverseRequest
+ *
+ * Command that takes an argument which is a list of INT8U and expects a
+        response that reverses the list.
+ */
+-(void) testListInt8UReverseRequestWithParams : (MTRTestClusterClusterTestListInt8UReverseRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterTestListInt8UReverseResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestEnumsRequest
+ *
+ * Command that sends a vendor id and an enum.  The server is expected to
+        echo them back.
+ */
+-(void) testEnumsRequestWithParams : (MTRTestClusterClusterTestEnumsRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterTestEnumsResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestNullableOptionalRequest
+ *
+ * Command that takes an argument which is nullable and optional.  The
+        response returns a boolean indicating whether the argument was present,
+        if that's true a boolean indicating whether the argument was null, and
+        if that' false the argument it received.
+ */
+-(void) testNullableOptionalRequestWithParams
+    : (MTRTestClusterClusterTestNullableOptionalRequestParams * _Nullable) params completion
+    : (void (^)(MTRTestClusterClusterTestNullableOptionalResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestComplexNullableOptionalRequest
+ *
+ * Command that takes various arguments which can be nullable and/or optional.  The
+        response returns information about which things were received and what
+        their state was.
+ */
+-(void) testComplexNullableOptionalRequestWithParams
+    : (MTRTestClusterClusterTestComplexNullableOptionalRequestParams *) params completion
+    : (void (^)(
+          MTRTestClusterClusterTestComplexNullableOptionalResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command SimpleStructEchoRequest
+ *
+ * Command that takes an argument which is a struct.  The response echoes
+        the struct back.
+ */
+-(void) simpleStructEchoRequestWithParams : (MTRTestClusterClusterSimpleStructEchoRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterSimpleStructResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TimedInvokeRequest
+ *
+ * Command that just responds with a success status if the timed invoke
+        conditions are met.
+ */
+-(void) timedInvokeRequestWithParams : (MTRTestClusterClusterTimedInvokeRequestParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
 - (void)timedInvokeRequestWithCompletion:(MTRStatusCompletion)completion;
-- (void)testSimpleOptionalArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
-                                         completion:(MTRStatusCompletion)completion;
-- (void)testEmitTestEventRequestWithParams:(MTRTestClusterClusterTestEmitTestEventRequestParams *)params
-                                completion:(void (^)(MTRTestClusterClusterTestEmitTestEventResponseParams * _Nullable data,
-                                               NSError * _Nullable error))completion;
-- (void)
-    testEmitTestFabricScopedEventRequestWithParams:(MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams *)params
-                                        completion:
-                                            (void (^)(
-                                                MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data,
-                                                NSError * _Nullable error))completion;
+
+/**
+ * Command TestSimpleOptionalArgumentRequest
+ *
+ * Command that takes an optional argument which is bool. It responds with a success value if the optional is set to any value.
+ */
+-(void) testSimpleOptionalArgumentRequestWithParams
+    : (MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams * _Nullable) params completion
+    : (MTRStatusCompletion) completion;
+
+/**
+ * Command TestEmitTestEventRequest
+ *
+ * Command that takes identical arguments to the fields of the TestEvent and logs the TestEvent to the buffer.  Command returns an
+ * event ID as the response.
+ */
+-(void) testEmitTestEventRequestWithParams : (MTRTestClusterClusterTestEmitTestEventRequestParams *) params completion
+    : (void (^)(MTRTestClusterClusterTestEmitTestEventResponseParams * _Nullable data, NSError * _Nullable error)) completion;
+
+/**
+ * Command TestEmitTestFabricScopedEventRequest
+ *
+ * Command that takes identical arguments to the fields of the TestFabricScopedEvent and logs the TestFabricScopedEvent to the
+ * buffer.  Command returns an event ID as the response.
+ */
+-(void) testEmitTestFabricScopedEventRequestWithParams
+    : (MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams *) params completion
+    : (void (^)(
+          MTRTestClusterClusterTestEmitTestFabricScopedEventResponseParams * _Nullable data, NSError * _Nullable error)) completion;
 
 - (void)readAttributeBooleanWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
 - (void)writeAttributeBooleanWithValue:(NSNumber * _Nonnull)value completion:(MTRStatusCompletion)completion;
@@ -18046,50 +19234,50 @@ typedef NS_OPTIONS(uint16_t, MTRActionsCommandBits) {
     MTRActionsCommandBitsDisableActionWithDuration = 0x800,
 };
 
-typedef NS_ENUM(uint8_t, MTROtaSoftwareUpdateProviderOTAApplyUpdateAction) {
-    MTROtaSoftwareUpdateProviderOTAApplyUpdateActionProceed = 0x00,
-    MTROtaSoftwareUpdateProviderOTAApplyUpdateActionAwaitNextAction = 0x01,
-    MTROtaSoftwareUpdateProviderOTAApplyUpdateActionDiscontinue = 0x02,
+typedef NS_ENUM(uint8_t, MTROTASoftwareUpdateProviderOTAApplyUpdateAction) {
+    MTROTASoftwareUpdateProviderOTAApplyUpdateActionProceed = 0x00,
+    MTROTASoftwareUpdateProviderOTAApplyUpdateActionAwaitNextAction = 0x01,
+    MTROTASoftwareUpdateProviderOTAApplyUpdateActionDiscontinue = 0x02,
 };
 
-typedef NS_ENUM(uint8_t, MTROtaSoftwareUpdateProviderOTADownloadProtocol) {
-    MTROtaSoftwareUpdateProviderOTADownloadProtocolBDXSynchronous = 0x00,
-    MTROtaSoftwareUpdateProviderOTADownloadProtocolBDXAsynchronous = 0x01,
-    MTROtaSoftwareUpdateProviderOTADownloadProtocolHTTPS = 0x02,
-    MTROtaSoftwareUpdateProviderOTADownloadProtocolVendorSpecific = 0x03,
+typedef NS_ENUM(uint8_t, MTROTASoftwareUpdateProviderOTADownloadProtocol) {
+    MTROTASoftwareUpdateProviderOTADownloadProtocolBDXSynchronous = 0x00,
+    MTROTASoftwareUpdateProviderOTADownloadProtocolBDXAsynchronous = 0x01,
+    MTROTASoftwareUpdateProviderOTADownloadProtocolHTTPS = 0x02,
+    MTROTASoftwareUpdateProviderOTADownloadProtocolVendorSpecific = 0x03,
 };
 
-typedef NS_ENUM(uint8_t, MTROtaSoftwareUpdateProviderOTAQueryStatus) {
-    MTROtaSoftwareUpdateProviderOTAQueryStatusUpdateAvailable = 0x00,
-    MTROtaSoftwareUpdateProviderOTAQueryStatusBusy = 0x01,
-    MTROtaSoftwareUpdateProviderOTAQueryStatusNotAvailable = 0x02,
-    MTROtaSoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported = 0x03,
+typedef NS_ENUM(uint8_t, MTROTASoftwareUpdateProviderOTAQueryStatus) {
+    MTROTASoftwareUpdateProviderOTAQueryStatusUpdateAvailable = 0x00,
+    MTROTASoftwareUpdateProviderOTAQueryStatusBusy = 0x01,
+    MTROTASoftwareUpdateProviderOTAQueryStatusNotAvailable = 0x02,
+    MTROTASoftwareUpdateProviderOTAQueryStatusDownloadProtocolNotSupported = 0x03,
 };
 
-typedef NS_ENUM(uint8_t, MTROtaSoftwareUpdateRequestorOTAAnnouncementReason) {
-    MTROtaSoftwareUpdateRequestorOTAAnnouncementReasonSimpleAnnouncement = 0x00,
-    MTROtaSoftwareUpdateRequestorOTAAnnouncementReasonUpdateAvailable = 0x01,
-    MTROtaSoftwareUpdateRequestorOTAAnnouncementReasonUrgentUpdateAvailable = 0x02,
+typedef NS_ENUM(uint8_t, MTROTASoftwareUpdateRequestorOTAAnnouncementReason) {
+    MTROTASoftwareUpdateRequestorOTAAnnouncementReasonSimpleAnnouncement = 0x00,
+    MTROTASoftwareUpdateRequestorOTAAnnouncementReasonUpdateAvailable = 0x01,
+    MTROTASoftwareUpdateRequestorOTAAnnouncementReasonUrgentUpdateAvailable = 0x02,
 };
 
-typedef NS_ENUM(uint8_t, MTROtaSoftwareUpdateRequestorOTAChangeReason) {
-    MTROtaSoftwareUpdateRequestorOTAChangeReasonUnknown = 0x00,
-    MTROtaSoftwareUpdateRequestorOTAChangeReasonSuccess = 0x01,
-    MTROtaSoftwareUpdateRequestorOTAChangeReasonFailure = 0x02,
-    MTROtaSoftwareUpdateRequestorOTAChangeReasonTimeOut = 0x03,
-    MTROtaSoftwareUpdateRequestorOTAChangeReasonDelayByProvider = 0x04,
+typedef NS_ENUM(uint8_t, MTROTASoftwareUpdateRequestorOTAChangeReason) {
+    MTROTASoftwareUpdateRequestorOTAChangeReasonUnknown = 0x00,
+    MTROTASoftwareUpdateRequestorOTAChangeReasonSuccess = 0x01,
+    MTROTASoftwareUpdateRequestorOTAChangeReasonFailure = 0x02,
+    MTROTASoftwareUpdateRequestorOTAChangeReasonTimeOut = 0x03,
+    MTROTASoftwareUpdateRequestorOTAChangeReasonDelayByProvider = 0x04,
 };
 
-typedef NS_ENUM(uint8_t, MTROtaSoftwareUpdateRequestorOTAUpdateState) {
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateUnknown = 0x00,
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateIdle = 0x01,
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateQuerying = 0x02,
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateDelayedOnQuery = 0x03,
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateDownloading = 0x04,
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateApplying = 0x05,
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateDelayedOnApply = 0x06,
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateRollingBack = 0x07,
-    MTROtaSoftwareUpdateRequestorOTAUpdateStateDelayedOnUserConsent = 0x08,
+typedef NS_ENUM(uint8_t, MTROTASoftwareUpdateRequestorOTAUpdateState) {
+    MTROTASoftwareUpdateRequestorOTAUpdateStateUnknown = 0x00,
+    MTROTASoftwareUpdateRequestorOTAUpdateStateIdle = 0x01,
+    MTROTASoftwareUpdateRequestorOTAUpdateStateQuerying = 0x02,
+    MTROTASoftwareUpdateRequestorOTAUpdateStateDelayedOnQuery = 0x03,
+    MTROTASoftwareUpdateRequestorOTAUpdateStateDownloading = 0x04,
+    MTROTASoftwareUpdateRequestorOTAUpdateStateApplying = 0x05,
+    MTROTASoftwareUpdateRequestorOTAUpdateStateDelayedOnApply = 0x06,
+    MTROTASoftwareUpdateRequestorOTAUpdateStateRollingBack = 0x07,
+    MTROTASoftwareUpdateRequestorOTAUpdateStateDelayedOnUserConsent = 0x08,
 };
 
 typedef NS_ENUM(uint8_t, MTRTimeFormatLocalizationCalendarType) {

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters_internal.h
@@ -82,12 +82,12 @@
 @property (nonatomic, assign, readonly) chip::EndpointId endpoint;
 @end
 
-@interface MTRBaseClusterOtaSoftwareUpdateProvider ()
+@interface MTRBaseClusterOTASoftwareUpdateProvider ()
 @property (nonatomic, strong, readonly) MTRBaseDevice * device;
 @property (nonatomic, assign, readonly) chip::EndpointId endpoint;
 @end
 
-@interface MTRBaseClusterOtaSoftwareUpdateRequestor ()
+@interface MTRBaseClusterOTASoftwareUpdateRequestor ()
 @property (nonatomic, strong, readonly) MTRBaseDevice * device;
 @property (nonatomic, assign, readonly) chip::EndpointId endpoint;
 @end
@@ -277,7 +277,7 @@
 @property (nonatomic, assign, readonly) chip::EndpointId endpoint;
 @end
 
-@interface MTRBaseClusterWakeOnLan ()
+@interface MTRBaseClusterWakeOnLAN ()
 @property (nonatomic, strong, readonly) MTRBaseDevice * device;
 @property (nonatomic, assign, readonly) chip::EndpointId endpoint;
 @end

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge.mm
@@ -2004,7 +2004,7 @@ void MTRBindingAttributeListListAttributeCallbackSubscriptionBridge::OnSubscript
     }
 }
 
-void MTRAccessControlAclListAttributeCallbackBridge::OnSuccessFn(void * context,
+void MTRAccessControlACLListAttributeCallbackBridge::OnSuccessFn(void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::AccessControlEntry::DecodableType> &
         value)
 {
@@ -2086,9 +2086,9 @@ void MTRAccessControlAclListAttributeCallbackBridge::OnSuccessFn(void * context,
     DispatchSuccess(context, objCValue);
 };
 
-void MTRAccessControlAclListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRAccessControlACLListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<MTRAccessControlAclListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTRAccessControlACLListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -2627,7 +2627,7 @@ void MTRBasicAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptio
     }
 }
 
-void MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -2650,10 +2650,10 @@ void MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -2667,7 +2667,7 @@ void MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscr
     }
 }
 
-void MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -2690,10 +2690,10 @@ void MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge:
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -2707,7 +2707,7 @@ void MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscri
     }
 }
 
-void MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -2730,9 +2730,9 @@ void MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge::OnSuc
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -2746,7 +2746,7 @@ void MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionB
     }
 }
 
-void MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge::OnSuccessFn(void * context,
+void MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge::OnSuccessFn(void * context,
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::DecodableType> & value)
 {
@@ -2756,8 +2756,8 @@ void MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge
         auto iter_0 = value.begin();
         while (iter_0.Next()) {
             auto & entry_0 = iter_0.GetValue();
-            MTROtaSoftwareUpdateRequestorClusterProviderLocation * newElement_0;
-            newElement_0 = [MTROtaSoftwareUpdateRequestorClusterProviderLocation new];
+            MTROTASoftwareUpdateRequestorClusterProviderLocation * newElement_0;
+            newElement_0 = [MTROTASoftwareUpdateRequestorClusterProviderLocation new];
             newElement_0.providerNodeID = [NSNumber numberWithUnsignedLongLong:entry_0.providerNodeID];
             newElement_0.endpoint = [NSNumber numberWithUnsignedShort:entry_0.endpoint];
             newElement_0.fabricIndex = [NSNumber numberWithUnsignedChar:entry_0.fabricIndex];
@@ -2773,10 +2773,10 @@ void MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -2790,7 +2790,7 @@ void MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscr
     }
 }
 
-void MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -2813,10 +2813,10 @@ void MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridg
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -2830,7 +2830,7 @@ void MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubsc
     }
 }
 
-void MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -2853,10 +2853,10 @@ void MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -2870,7 +2870,7 @@ void MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscr
     }
 }
 
-void MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -2893,9 +2893,9 @@ void MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge::OnSu
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -8669,7 +8669,7 @@ void MTROccupancySensingAttributeListListAttributeCallbackSubscriptionBridge::On
     }
 }
 
-void MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
+void MTRWakeOnLANGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -8692,9 +8692,9 @@ void MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWakeOnLANGeneratedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTRWakeOnLANGeneratedCommandListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -8708,7 +8708,7 @@ void MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge::On
     }
 }
 
-void MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
+void MTRWakeOnLANAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -8731,9 +8731,9 @@ void MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWakeOnLANAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTRWakeOnLANAcceptedCommandListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -8747,7 +8747,7 @@ void MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge::OnS
     }
 }
 
-void MTRWakeOnLanAttributeListListAttributeCallbackBridge::OnSuccessFn(
+void MTRWakeOnLANAttributeListListAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value)
 {
     NSArray * _Nonnull objCValue;
@@ -8770,9 +8770,9 @@ void MTRWakeOnLanAttributeListListAttributeCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, objCValue);
 };
 
-void MTRWakeOnLanAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTRWakeOnLANAttributeListListAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<MTRWakeOnLanAttributeListListAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTRWakeOnLANAttributeListListAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -11956,10 +11956,10 @@ void MTRScenesClusterCopySceneResponseCallbackBridge::OnSuccessFn(
     DispatchSuccess(context, response);
 };
 
-void MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSuccessFn(
     void * context, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType & data)
 {
-    auto * response = [MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams new];
+    auto * response = [MTROTASoftwareUpdateProviderClusterQueryImageResponseParams new];
     {
         response.status = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.status)];
     }
@@ -12020,10 +12020,10 @@ void MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge::OnSucc
     DispatchSuccess(context, response);
 };
 
-void MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge::OnSuccessFn(
     void * context, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType & data)
 {
-    auto * response = [MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams new];
+    auto * response = [MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams new];
     {
         response.action = [NSNumber numberWithUnsignedChar:chip::to_underlying(data.action)];
     }
@@ -14198,7 +14198,7 @@ void MTRNullableActionsClusterEndpointListTypeEnumAttributeCallbackSubscriptionB
     }
 }
 
-void MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::OtaSoftwareUpdateProvider::OTAApplyUpdateAction value)
 {
     NSNumber * _Nonnull objCValue;
@@ -14206,11 +14206,11 @@ void MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
     auto * self
-        = static_cast<MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge *>(context);
+        = static_cast<MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -14224,7 +14224,7 @@ void MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSub
     }
 }
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge::OnSuccessFn(void * context,
+void MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge::OnSuccessFn(void * context,
     const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTAApplyUpdateAction> & value)
 {
     NSNumber * _Nullable objCValue;
@@ -14236,10 +14236,10 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCal
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge *>(
+    auto * self = static_cast<MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge *>(
         context);
     if (!self->mQueue) {
         return;
@@ -14254,7 +14254,7 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCal
     }
 }
 
-void MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::OtaSoftwareUpdateProvider::OTADownloadProtocol value)
 {
     NSNumber * _Nonnull objCValue;
@@ -14262,10 +14262,10 @@ void MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -14279,7 +14279,7 @@ void MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubs
     }
 }
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge::OnSuccessFn(void * context,
+void MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge::OnSuccessFn(void * context,
     const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTADownloadProtocol> & value)
 {
     NSNumber * _Nullable objCValue;
@@ -14291,11 +14291,11 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCall
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
     auto * self
-        = static_cast<MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge *>(context);
+        = static_cast<MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -14309,7 +14309,7 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCall
     }
 }
 
-void MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::OtaSoftwareUpdateProvider::OTAQueryStatus value)
 {
     NSNumber * _Nonnull objCValue;
@@ -14317,9 +14317,9 @@ void MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::O
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
+void MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -14333,7 +14333,7 @@ void MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscript
     }
 }
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::OnSuccessFn(
+void MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge::OnSuccessFn(
     void * context, const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTAQueryStatus> & value)
 {
     NSNumber * _Nullable objCValue;
@@ -14345,11 +14345,11 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackB
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
     auto * self
-        = static_cast<MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge *>(context);
+        = static_cast<MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -14363,7 +14363,7 @@ void MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackS
     }
 }
 
-void MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason value)
 {
     NSNumber * _Nonnull objCValue;
@@ -14371,11 +14371,11 @@ void MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackB
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
     auto * self
-        = static_cast<MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge *>(context);
+        = static_cast<MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -14389,7 +14389,7 @@ void MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackS
     }
 }
 
-void MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge::OnSuccessFn(void * context,
+void MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge::OnSuccessFn(void * context,
     const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason> & value)
 {
     NSNumber * _Nullable objCValue;
@@ -14401,11 +14401,11 @@ void MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeC
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge::
+void MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge::
     OnSubscriptionEstablished(void * context)
 {
     auto * self
-        = static_cast<MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge *>(
+        = static_cast<MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge *>(
             context);
     if (!self->mQueue) {
         return;
@@ -14420,7 +14420,7 @@ void MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeC
     }
 }
 
-void MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum value)
 {
     NSNumber * _Nonnull objCValue;
@@ -14428,11 +14428,11 @@ void MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBri
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
     auto * self
-        = static_cast<MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge *>(context);
+        = static_cast<MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -14446,7 +14446,7 @@ void MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSub
     }
 }
 
-void MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge::OnSuccessFn(void * context,
+void MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge::OnSuccessFn(void * context,
     const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum> & value)
 {
     NSNumber * _Nullable objCValue;
@@ -14458,10 +14458,10 @@ void MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCal
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge *>(
+    auto * self = static_cast<MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge *>(
         context);
     if (!self->mQueue) {
         return;
@@ -14476,7 +14476,7 @@ void MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCal
     }
 }
 
-void MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge::OnSuccessFn(
+void MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge::OnSuccessFn(
     void * context, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum value)
 {
     NSNumber * _Nonnull objCValue;
@@ -14484,10 +14484,10 @@ void MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBrid
     DispatchSuccess(context, objCValue);
 };
 
-void MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
-    auto * self = static_cast<MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge *>(context);
+    auto * self = static_cast<MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }
@@ -14501,7 +14501,7 @@ void MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubs
     }
 }
 
-void MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge::OnSuccessFn(void * context,
+void MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge::OnSuccessFn(void * context,
     const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum> & value)
 {
     NSNumber * _Nullable objCValue;
@@ -14513,11 +14513,11 @@ void MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCall
     DispatchSuccess(context, objCValue);
 };
 
-void MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
+void MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge::OnSubscriptionEstablished(
     void * context)
 {
     auto * self
-        = static_cast<MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge *>(context);
+        = static_cast<MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge *>(context);
     if (!self->mQueue) {
         return;
     }

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCallbackBridge_internal.h
@@ -55,9 +55,9 @@ typedef void (*ScenesClusterEnhancedViewSceneResponseCallbackType)(
     void *, const chip::app::Clusters::Scenes::Commands::EnhancedViewSceneResponse::DecodableType &);
 typedef void (*ScenesClusterCopySceneResponseCallbackType)(
     void *, const chip::app::Clusters::Scenes::Commands::CopySceneResponse::DecodableType &);
-typedef void (*OtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType)(
+typedef void (*OTASoftwareUpdateProviderClusterQueryImageResponseCallbackType)(
     void *, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType &);
-typedef void (*OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType)(
+typedef void (*OTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackType)(
     void *, const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::ApplyUpdateResponse::DecodableType &);
 typedef void (*GeneralCommissioningClusterArmFailSafeResponseCallbackType)(
     void *, const chip::app::Clusters::GeneralCommissioning::Commands::ArmFailSafeResponse::DecodableType &);
@@ -189,29 +189,29 @@ typedef void (*NullableActionsClusterActionTypeEnumAttributeCallback)(
 typedef void (*ActionsClusterEndpointListTypeEnumAttributeCallback)(void *, chip::app::Clusters::Actions::EndpointListTypeEnum);
 typedef void (*NullableActionsClusterEndpointListTypeEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::Actions::EndpointListTypeEnum> &);
-typedef void (*OtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback)(
+typedef void (*OTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback)(
     void *, chip::app::Clusters::OtaSoftwareUpdateProvider::OTAApplyUpdateAction);
-typedef void (*NullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback)(
+typedef void (*NullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTAApplyUpdateAction> &);
-typedef void (*OtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback)(
+typedef void (*OTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback)(
     void *, chip::app::Clusters::OtaSoftwareUpdateProvider::OTADownloadProtocol);
-typedef void (*NullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback)(
+typedef void (*NullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTADownloadProtocol> &);
-typedef void (*OtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback)(
+typedef void (*OTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback)(
     void *, chip::app::Clusters::OtaSoftwareUpdateProvider::OTAQueryStatus);
-typedef void (*NullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback)(
+typedef void (*NullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTAQueryStatus> &);
-typedef void (*OtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback)(
+typedef void (*OTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback)(
     void *, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason);
-typedef void (*NullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback)(
+typedef void (*NullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason> &);
-typedef void (*OtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback)(
+typedef void (*OTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback)(
     void *, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum);
-typedef void (*NullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback)(
+typedef void (*NullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum> &);
-typedef void (*OtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback)(
+typedef void (*OTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback)(
     void *, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum);
-typedef void (*NullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback)(
+typedef void (*NullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback)(
     void *, const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum> &);
 typedef void (*TimeFormatLocalizationClusterCalendarTypeAttributeCallback)(
     void *, chip::app::Clusters::TimeFormatLocalization::CalendarType);
@@ -600,7 +600,7 @@ typedef void (*BindingAcceptedCommandListListAttributeCallback)(void * context,
                                                                 const chip::app::DataModel::DecodableList<chip::CommandId> & data);
 typedef void (*BindingAttributeListListAttributeCallback)(void * context,
                                                           const chip::app::DataModel::DecodableList<chip::AttributeId> & data);
-typedef void (*AccessControlAclListAttributeCallback)(
+typedef void (*AccessControlACLListAttributeCallback)(
     void * context,
     const chip::app::DataModel::DecodableList<chip::app::Clusters::AccessControl::Structs::AccessControlEntry::DecodableType> &
         data);
@@ -633,21 +633,21 @@ typedef void (*BasicAcceptedCommandListListAttributeCallback)(void * context,
                                                               const chip::app::DataModel::DecodableList<chip::CommandId> & data);
 typedef void (*BasicAttributeListListAttributeCallback)(void * context,
                                                         const chip::app::DataModel::DecodableList<chip::AttributeId> & data);
-typedef void (*OtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallback)(
+typedef void (*OTASoftwareUpdateProviderGeneratedCommandListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
-typedef void (*OtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallback)(
+typedef void (*OTASoftwareUpdateProviderAcceptedCommandListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
-typedef void (*OtaSoftwareUpdateProviderAttributeListListAttributeCallback)(
+typedef void (*OTASoftwareUpdateProviderAttributeListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & data);
-typedef void (*OtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback)(
+typedef void (*OTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback)(
     void * context,
     const chip::app::DataModel::DecodableList<
         chip::app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::DecodableType> & data);
-typedef void (*OtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallback)(
+typedef void (*OTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
-typedef void (*OtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallback)(
+typedef void (*OTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
-typedef void (*OtaSoftwareUpdateRequestorAttributeListListAttributeCallback)(
+typedef void (*OTASoftwareUpdateRequestorAttributeListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & data);
 typedef void (*LocalizationConfigurationSupportedLocalesListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::CharSpan> & data);
@@ -964,11 +964,11 @@ typedef void (*OccupancySensingAcceptedCommandListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
 typedef void (*OccupancySensingAttributeListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & data);
-typedef void (*WakeOnLanGeneratedCommandListListAttributeCallback)(
+typedef void (*WakeOnLANGeneratedCommandListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
-typedef void (*WakeOnLanAcceptedCommandListListAttributeCallback)(
+typedef void (*WakeOnLANAcceptedCommandListListAttributeCallback)(
     void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & data);
-typedef void (*WakeOnLanAttributeListListAttributeCallback)(void * context,
+typedef void (*WakeOnLANAttributeListListAttributeCallback)(void * context,
                                                             const chip::app::DataModel::DecodableList<chip::AttributeId> & data);
 typedef void (*ChannelChannelListListAttributeCallback)(
     void * context,
@@ -3783,21 +3783,21 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRAccessControlAclListAttributeCallbackBridge : public MTRCallbackBridge<AccessControlAclListAttributeCallback>
+class MTRAccessControlACLListAttributeCallbackBridge : public MTRCallbackBridge<AccessControlACLListAttributeCallback>
 {
 public:
-    MTRAccessControlAclListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, MTRLocalActionBlock action,
+    MTRAccessControlACLListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler, MTRLocalActionBlock action,
                                                    bool keepAlive = false) :
-        MTRCallbackBridge<AccessControlAclListAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        MTRCallbackBridge<AccessControlACLListAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRAccessControlAclListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller,
+    MTRAccessControlACLListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller,
                                                    ResponseHandler handler, MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<AccessControlAclListAttributeCallback>(queue, nodeID, controller, handler, action, OnSuccessFn,
+        MTRCallbackBridge<AccessControlACLListAttributeCallback>(queue, nodeID, controller, handler, action, OnSuccessFn,
                                                                  keepAlive){};
 
-    MTRAccessControlAclListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler,
+    MTRAccessControlACLListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler,
                                                    MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<AccessControlAclListAttributeCallback>(queue, device, handler, action, OnSuccessFn, keepAlive){};
+        MTRCallbackBridge<AccessControlACLListAttributeCallback>(queue, device, handler, action, OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(
         void * context,
@@ -3805,21 +3805,21 @@ public:
             value);
 };
 
-class MTRAccessControlAclListAttributeCallbackSubscriptionBridge : public MTRAccessControlAclListAttributeCallbackBridge
+class MTRAccessControlACLListAttributeCallbackSubscriptionBridge : public MTRAccessControlACLListAttributeCallbackBridge
 {
 public:
-    MTRAccessControlAclListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTRAccessControlACLListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                MTRDeviceController * controller, ResponseHandler handler,
                                                                MTRActionBlock action,
                                                                MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRAccessControlAclListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
+        MTRAccessControlACLListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRAccessControlAclListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTRAccessControlACLListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                ResponseHandler handler, MTRActionBlock action,
                                                                MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRAccessControlAclListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTRAccessControlACLListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -4431,48 +4431,48 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallback>
+class MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateProviderGeneratedCommandListListAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                 MTRLocalActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateProviderGeneratedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                               keepAlive){};
 
-    MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                 MTRDeviceController * controller,
                                                                                 ResponseHandler handler, MTRActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateProviderGeneratedCommandListListAttributeCallback>(queue, nodeID, controller, handler,
                                                                                               action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                 ResponseHandler handler, MTRActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderGeneratedCommandListListAttributeCallback>(queue, device, handler, action,
                                                                                               OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value);
 };
 
-class MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge
+class MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                     true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateProviderGeneratedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -4482,47 +4482,47 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallback>
+class MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateProviderAcceptedCommandListListAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateProviderAcceptedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                              keepAlive){};
 
-    MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                MTRDeviceController * controller,
                                                                                ResponseHandler handler, MTRActionBlock action,
                                                                                bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateProviderAcceptedCommandListListAttributeCallback>(queue, nodeID, controller, handler,
                                                                                              action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                ResponseHandler handler, MTRActionBlock action,
                                                                                bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderAcceptedCommandListListAttributeCallback>(queue, device, handler, action,
                                                                                              OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value);
 };
 
-class MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge
+class MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                    true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateProviderAcceptedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -4532,45 +4532,45 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateProviderAttributeListListAttributeCallback>
+class MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateProviderAttributeListListAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                          MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderAttributeListListAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateProviderAttributeListListAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                        keepAlive){};
 
-    MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                          MTRDeviceController * controller, ResponseHandler handler,
                                                                          MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderAttributeListListAttributeCallback>(queue, nodeID, controller, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderAttributeListListAttributeCallback>(queue, nodeID, controller, handler, action,
                                                                                        OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                          ResponseHandler handler, MTRActionBlock action,
                                                                          bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderAttributeListListAttributeCallback>(queue, device, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateProviderAttributeListListAttributeCallback>(queue, device, handler, action, OnSuccessFn,
                                                                                        keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value);
 };
 
-class MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge
+class MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
+        MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderAttributeListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateProviderAttributeListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -4580,27 +4580,27 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback>
+class MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                 MTRLocalActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                               keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                 MTRDeviceController * controller,
                                                                                 ResponseHandler handler, MTRActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback>(queue, nodeID, controller, handler,
                                                                                               action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                 ResponseHandler handler, MTRActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallback>(queue, device, handler, action,
                                                                                               OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context,
@@ -4608,22 +4608,22 @@ public:
                                 chip::app::Clusters::OtaSoftwareUpdateRequestor::Structs::ProviderLocation::DecodableType> & value);
 };
 
-class MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge
+class MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                     true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateRequestorDefaultOtaProvidersListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -4633,48 +4633,48 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallback>
+class MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                  MTRLocalActionBlock action,
                                                                                  bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                                keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                  MTRDeviceController * controller,
                                                                                  ResponseHandler handler, MTRActionBlock action,
                                                                                  bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallback>(queue, nodeID, controller, handler,
                                                                                                action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                  ResponseHandler handler, MTRActionBlock action,
                                                                                  bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallback>(queue, device, handler, action,
                                                                                                OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value);
 };
 
-class MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge
+class MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                      true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateRequestorGeneratedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -4684,48 +4684,48 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallback>
+class MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                 MTRLocalActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                               keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                 MTRDeviceController * controller,
                                                                                 ResponseHandler handler, MTRActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallback>(queue, nodeID, controller, handler,
                                                                                               action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                 ResponseHandler handler, MTRActionBlock action,
                                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallback>(queue, device, handler, action,
                                                                                               OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value);
 };
 
-class MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge
+class MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                     true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateRequestorAcceptedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -4735,45 +4735,45 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateRequestorAttributeListListAttributeCallback>
+class MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateRequestorAttributeListListAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                           MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorAttributeListListAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorAttributeListListAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                         keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                           MTRDeviceController * controller, ResponseHandler handler,
                                                                           MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorAttributeListListAttributeCallback>(queue, nodeID, controller, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorAttributeListListAttributeCallback>(queue, nodeID, controller, handler, action,
                                                                                         OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                           ResponseHandler handler, MTRActionBlock action,
                                                                           bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorAttributeListListAttributeCallback>(queue, device, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorAttributeListListAttributeCallback>(queue, device, handler, action, OnSuccessFn,
                                                                                         keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value);
 };
 
-class MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge
+class MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
+        MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateRequestorAttributeListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -11827,45 +11827,45 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge
-    : public MTRCallbackBridge<WakeOnLanGeneratedCommandListListAttributeCallback>
+class MTRWakeOnLANGeneratedCommandListListAttributeCallbackBridge
+    : public MTRCallbackBridge<WakeOnLANGeneratedCommandListListAttributeCallback>
 {
 public:
-    MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTRWakeOnLANGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                 MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanGeneratedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        MTRCallbackBridge<WakeOnLANGeneratedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTRWakeOnLANGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                 MTRDeviceController * controller, ResponseHandler handler,
                                                                 MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanGeneratedCommandListListAttributeCallback>(queue, nodeID, controller, handler, action,
+        MTRCallbackBridge<WakeOnLANGeneratedCommandListListAttributeCallback>(queue, nodeID, controller, handler, action,
                                                                               OnSuccessFn, keepAlive){};
 
-    MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTRWakeOnLANGeneratedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                 ResponseHandler handler, MTRActionBlock action,
                                                                 bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanGeneratedCommandListListAttributeCallback>(queue, device, handler, action, OnSuccessFn,
+        MTRCallbackBridge<WakeOnLANGeneratedCommandListListAttributeCallback>(queue, device, handler, action, OnSuccessFn,
                                                                               keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value);
 };
 
-class MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge
-    : public MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge
+class MTRWakeOnLANGeneratedCommandListListAttributeCallbackSubscriptionBridge
+    : public MTRWakeOnLANGeneratedCommandListListAttributeCallbackBridge
 {
 public:
-    MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTRWakeOnLANGeneratedCommandListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                             MTRDeviceController * controller,
                                                                             ResponseHandler handler, MTRActionBlock action,
                                                                             MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
+        MTRWakeOnLANGeneratedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRWakeOnLanGeneratedCommandListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTRWakeOnLANGeneratedCommandListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                             ResponseHandler handler, MTRActionBlock action,
                                                                             MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRWakeOnLanGeneratedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTRWakeOnLANGeneratedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -11875,45 +11875,45 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge
-    : public MTRCallbackBridge<WakeOnLanAcceptedCommandListListAttributeCallback>
+class MTRWakeOnLANAcceptedCommandListListAttributeCallbackBridge
+    : public MTRCallbackBridge<WakeOnLANAcceptedCommandListListAttributeCallback>
 {
 public:
-    MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTRWakeOnLANAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanAcceptedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        MTRCallbackBridge<WakeOnLANAcceptedCommandListListAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTRWakeOnLANAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                MTRDeviceController * controller, ResponseHandler handler,
                                                                MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanAcceptedCommandListListAttributeCallback>(queue, nodeID, controller, handler, action,
+        MTRCallbackBridge<WakeOnLANAcceptedCommandListListAttributeCallback>(queue, nodeID, controller, handler, action,
                                                                              OnSuccessFn, keepAlive){};
 
-    MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTRWakeOnLANAcceptedCommandListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                ResponseHandler handler, MTRActionBlock action,
                                                                bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanAcceptedCommandListListAttributeCallback>(queue, device, handler, action, OnSuccessFn,
+        MTRCallbackBridge<WakeOnLANAcceptedCommandListListAttributeCallback>(queue, device, handler, action, OnSuccessFn,
                                                                              keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::CommandId> & value);
 };
 
-class MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge
-    : public MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge
+class MTRWakeOnLANAcceptedCommandListListAttributeCallbackSubscriptionBridge
+    : public MTRWakeOnLANAcceptedCommandListListAttributeCallbackBridge
 {
 public:
-    MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTRWakeOnLANAcceptedCommandListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                            MTRDeviceController * controller,
                                                                            ResponseHandler handler, MTRActionBlock action,
                                                                            MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
+        MTRWakeOnLANAcceptedCommandListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRWakeOnLanAcceptedCommandListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTRWakeOnLANAcceptedCommandListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                            ResponseHandler handler, MTRActionBlock action,
                                                                            MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRWakeOnLanAcceptedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTRWakeOnLANAcceptedCommandListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -11923,41 +11923,41 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRWakeOnLanAttributeListListAttributeCallbackBridge : public MTRCallbackBridge<WakeOnLanAttributeListListAttributeCallback>
+class MTRWakeOnLANAttributeListListAttributeCallbackBridge : public MTRCallbackBridge<WakeOnLANAttributeListListAttributeCallback>
 {
 public:
-    MTRWakeOnLanAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTRWakeOnLANAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                          MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanAttributeListListAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
+        MTRCallbackBridge<WakeOnLANAttributeListListAttributeCallback>(queue, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRWakeOnLanAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTRWakeOnLANAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                          MTRDeviceController * controller, ResponseHandler handler,
                                                          MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanAttributeListListAttributeCallback>(queue, nodeID, controller, handler, action, OnSuccessFn,
+        MTRCallbackBridge<WakeOnLANAttributeListListAttributeCallback>(queue, nodeID, controller, handler, action, OnSuccessFn,
                                                                        keepAlive){};
 
-    MTRWakeOnLanAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler,
+    MTRWakeOnLANAttributeListListAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler,
                                                          MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<WakeOnLanAttributeListListAttributeCallback>(queue, device, handler, action, OnSuccessFn, keepAlive){};
+        MTRCallbackBridge<WakeOnLANAttributeListListAttributeCallback>(queue, device, handler, action, OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, const chip::app::DataModel::DecodableList<chip::AttributeId> & value);
 };
 
-class MTRWakeOnLanAttributeListListAttributeCallbackSubscriptionBridge : public MTRWakeOnLanAttributeListListAttributeCallbackBridge
+class MTRWakeOnLANAttributeListListAttributeCallbackSubscriptionBridge : public MTRWakeOnLANAttributeListListAttributeCallbackBridge
 {
 public:
-    MTRWakeOnLanAttributeListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTRWakeOnLANAttributeListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                      MTRDeviceController * controller, ResponseHandler handler,
                                                                      MTRActionBlock action,
                                                                      MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRWakeOnLanAttributeListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
+        MTRWakeOnLANAttributeListListAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRWakeOnLanAttributeListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTRWakeOnLANAttributeListListAttributeCallbackSubscriptionBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                      ResponseHandler handler, MTRActionBlock action,
                                                                      MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRWakeOnLanAttributeListListAttributeCallbackBridge(queue, device, handler, action, true),
+        MTRWakeOnLANAttributeListListAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -15399,25 +15399,25 @@ public:
     static void OnSuccessFn(void * context, const chip::app::Clusters::Scenes::Commands::CopySceneResponse::DecodableType & data);
 };
 
-class MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>
+class MTROTASoftwareUpdateProviderClusterQueryImageResponseCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateProviderClusterQueryImageResponseCallbackType>
 {
 public:
-    MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                         MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterQueryImageResponseCallbackType>(queue, handler, action, OnSuccessFn,
                                                                                           keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                         MTRDeviceController * controller, ResponseHandler handler,
                                                                         MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterQueryImageResponseCallbackType>(queue, nodeID, controller, handler,
                                                                                           action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                         ResponseHandler handler, MTRActionBlock action,
                                                                         bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterQueryImageResponseCallbackType>(queue, device, handler, action,
                                                                                           OnSuccessFn, keepAlive){};
 
     static void
@@ -15425,25 +15425,25 @@ public:
                 const chip::app::Clusters::OtaSoftwareUpdateProvider::Commands::QueryImageResponse::DecodableType & data);
 };
 
-class MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>
+class MTROTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>
 {
 public:
-    MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                          MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>(queue, handler, action, OnSuccessFn,
                                                                                            keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                          MTRDeviceController * controller, ResponseHandler handler,
                                                                          MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>(queue, nodeID, controller, handler,
                                                                                            action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                          ResponseHandler handler, MTRActionBlock action,
                                                                          bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>(queue, device, handler, action,
                                                                                            OnSuccessFn, keepAlive){};
 
     static void
@@ -17932,48 +17932,48 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>
+class MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                    MTRLocalActionBlock action,
                                                                                    bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(queue, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(queue, handler, action,
                                                                                                  OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                    MTRDeviceController * controller,
                                                                                    ResponseHandler handler, MTRActionBlock action,
                                                                                    bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(queue, nodeID, controller, handler,
                                                                                                  action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                    ResponseHandler handler, MTRActionBlock action,
                                                                                    bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(queue, device, handler, action,
                                                                                                  OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, chip::app::Clusters::OtaSoftwareUpdateProvider::OTAApplyUpdateAction value);
 };
 
-class MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge
+class MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                        true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -17983,26 +17983,26 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge
-    : public MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>
+class MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge
+    : public MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>
 {
 public:
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(dispatch_queue_t queue,
+    MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(dispatch_queue_t queue,
                                                                                            ResponseHandler handler,
                                                                                            MTRLocalActionBlock action,
                                                                                            bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(queue, handler, action,
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(queue, handler, action,
                                                                                                          OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(
             queue, nodeID, controller, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallback>(
             queue, device, handler, action, OnSuccessFn, keepAlive){};
 
     static void
@@ -18010,22 +18010,22 @@ public:
                 const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTAApplyUpdateAction> & value);
 };
 
-class MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge
-    : public MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge
+class MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge
+    : public MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge
 {
 public:
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(queue, nodeID, controller, handler,
+        MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(queue, nodeID, controller, handler,
                                                                                                action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(queue, device, handler, action,
+        MTRNullableOTASoftwareUpdateProviderClusterOTAApplyUpdateActionAttributeCallbackBridge(queue, device, handler, action,
                                                                                                true),
         mEstablishedHandler(establishedHandler)
     {}
@@ -18036,48 +18036,48 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>
+class MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                   MTRLocalActionBlock action,
                                                                                   bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                                 keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                   MTRDeviceController * controller,
                                                                                   ResponseHandler handler, MTRActionBlock action,
                                                                                   bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(queue, nodeID, controller, handler,
                                                                                                 action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                   ResponseHandler handler, MTRActionBlock action,
                                                                                   bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(queue, device, handler, action,
                                                                                                 OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, chip::app::Clusters::OtaSoftwareUpdateProvider::OTADownloadProtocol value);
 };
 
-class MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge
+class MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                       true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -18087,26 +18087,26 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge
-    : public MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>
+class MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge
+    : public MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>
 {
 public:
-    MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(dispatch_queue_t queue,
+    MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(dispatch_queue_t queue,
                                                                                           ResponseHandler handler,
                                                                                           MTRLocalActionBlock action,
                                                                                           bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(queue, handler, action,
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(queue, handler, action,
                                                                                                         OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(
             queue, nodeID, controller, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallback>(
             queue, device, handler, action, OnSuccessFn, keepAlive){};
 
     static void
@@ -18114,22 +18114,22 @@ public:
                 const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTADownloadProtocol> & value);
 };
 
-class MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge
-    : public MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge
+class MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge
+    : public MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge
 {
 public:
-    MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(queue, nodeID, controller, handler,
+        MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(queue, nodeID, controller, handler,
                                                                                               action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(queue, device, handler, action, true),
+        MTRNullableOTASoftwareUpdateProviderClusterOTADownloadProtocolAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -18139,46 +18139,46 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>
+class MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                              MTRLocalActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                            keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                              MTRDeviceController * controller,
                                                                              ResponseHandler handler, MTRActionBlock action,
                                                                              bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, nodeID, controller, handler,
                                                                                            action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                              ResponseHandler handler, MTRActionBlock action,
                                                                              bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, device, handler, action,
                                                                                            OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, chip::app::Clusters::OtaSoftwareUpdateProvider::OTAQueryStatus value);
 };
 
-class MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge
+class MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
+        MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(queue, nodeID, controller, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -18188,28 +18188,28 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge
-    : public MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>
+class MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge
+    : public MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>
 {
 public:
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue,
+    MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue,
                                                                                      ResponseHandler handler,
                                                                                      MTRLocalActionBlock action,
                                                                                      bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, handler, action,
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, handler, action,
                                                                                                    OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                      MTRDeviceController * controller,
                                                                                      ResponseHandler handler, MTRActionBlock action,
                                                                                      bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(
             queue, nodeID, controller, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                      ResponseHandler handler, MTRActionBlock action,
                                                                                      bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<NullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallback>(queue, device, handler, action,
                                                                                                    OnSuccessFn, keepAlive){};
 
     static void
@@ -18217,22 +18217,22 @@ public:
                 const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateProvider::OTAQueryStatus> & value);
 };
 
-class MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge
-    : public MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge
+class MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge
+    : public MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge
 {
 public:
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                          true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(queue, device, handler, action, true),
+        MTRNullableOTASoftwareUpdateProviderClusterOTAQueryStatusAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -18242,49 +18242,49 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>
+class MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(dispatch_queue_t queue,
+    MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(dispatch_queue_t queue,
                                                                                      ResponseHandler handler,
                                                                                      MTRLocalActionBlock action,
                                                                                      bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(queue, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(queue, handler, action,
                                                                                                    OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                      MTRDeviceController * controller,
                                                                                      ResponseHandler handler, MTRActionBlock action,
                                                                                      bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(
             queue, nodeID, controller, handler, action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                      ResponseHandler handler, MTRActionBlock action,
                                                                                      bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(queue, device, handler, action,
                                                                                                    OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason value);
 };
 
-class MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge
+class MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                          true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -18294,26 +18294,26 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge
-    : public MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>
+class MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge
+    : public MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>
 {
 public:
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(dispatch_queue_t queue,
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(dispatch_queue_t queue,
                                                                                              ResponseHandler handler,
                                                                                              MTRLocalActionBlock action,
                                                                                              bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(
             queue, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(
             queue, nodeID, controller, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallback>(
             queue, device, handler, action, OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(
@@ -18321,22 +18321,22 @@ public:
         const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAAnnouncementReason> & value);
 };
 
-class MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge
-    : public MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge
+class MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge
+    : public MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge
 {
 public:
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(queue, nodeID, controller, handler,
+        MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(queue, nodeID, controller, handler,
                                                                                                  action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(queue, device, handler, action,
+        MTRNullableOTASoftwareUpdateRequestorClusterOTAAnnouncementReasonAttributeCallbackBridge(queue, device, handler, action,
                                                                                                  true),
         mEstablishedHandler(establishedHandler)
     {}
@@ -18347,48 +18347,48 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>
+class MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                    MTRLocalActionBlock action,
                                                                                    bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(queue, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(queue, handler, action,
                                                                                                  OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                    MTRDeviceController * controller,
                                                                                    ResponseHandler handler, MTRActionBlock action,
                                                                                    bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(queue, nodeID, controller, handler,
                                                                                                  action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                    ResponseHandler handler, MTRActionBlock action,
                                                                                    bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(queue, device, handler, action,
                                                                                                  OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum value);
 };
 
-class MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge
+class MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                        true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -18398,26 +18398,26 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge
-    : public MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>
+class MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge
+    : public MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>
 {
 public:
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(dispatch_queue_t queue,
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(dispatch_queue_t queue,
                                                                                            ResponseHandler handler,
                                                                                            MTRLocalActionBlock action,
                                                                                            bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(queue, handler, action,
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(queue, handler, action,
                                                                                                          OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(
             queue, nodeID, controller, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallback>(
             queue, device, handler, action, OnSuccessFn, keepAlive){};
 
     static void
@@ -18425,22 +18425,22 @@ public:
                 const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAChangeReasonEnum> & value);
 };
 
-class MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge
-    : public MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge
+class MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge
+    : public MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge
 {
 public:
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(queue, nodeID, controller, handler,
+        MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(queue, nodeID, controller, handler,
                                                                                                action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(queue, device, handler, action,
+        MTRNullableOTASoftwareUpdateRequestorClusterOTAChangeReasonEnumAttributeCallbackBridge(queue, device, handler, action,
                                                                                                true),
         mEstablishedHandler(establishedHandler)
     {}
@@ -18451,48 +18451,48 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge
-    : public MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>
+class MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge
+    : public MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>
 {
 public:
-    MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
+    MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(dispatch_queue_t queue, ResponseHandler handler,
                                                                                   MTRLocalActionBlock action,
                                                                                   bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(queue, handler, action, OnSuccessFn,
                                                                                                 keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
+    MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(dispatch_queue_t queue, chip::NodeId nodeID,
                                                                                   MTRDeviceController * controller,
                                                                                   ResponseHandler handler, MTRActionBlock action,
                                                                                   bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(queue, nodeID, controller, handler,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(queue, nodeID, controller, handler,
                                                                                                 action, OnSuccessFn, keepAlive){};
 
-    MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
+    MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(dispatch_queue_t queue, MTRBaseDevice * device,
                                                                                   ResponseHandler handler, MTRActionBlock action,
                                                                                   bool keepAlive = false) :
-        MTRCallbackBridge<OtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(queue, device, handler, action,
+        MTRCallbackBridge<OTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(queue, device, handler, action,
                                                                                                 OnSuccessFn, keepAlive){};
 
     static void OnSuccessFn(void * context, chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum value);
 };
 
-class MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge
-    : public MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge
+class MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge
+    : public MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge
 {
 public:
-    MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(queue, nodeID, controller, handler, action,
+        MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(queue, nodeID, controller, handler, action,
                                                                                       true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge(
+    MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTROtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(queue, device, handler, action, true),
+        MTROTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
@@ -18502,26 +18502,26 @@ private:
     MTRSubscriptionEstablishedHandler mEstablishedHandler;
 };
 
-class MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge
-    : public MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>
+class MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge
+    : public MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>
 {
 public:
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(dispatch_queue_t queue,
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(dispatch_queue_t queue,
                                                                                           ResponseHandler handler,
                                                                                           MTRLocalActionBlock action,
                                                                                           bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(queue, handler, action,
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(queue, handler, action,
                                                                                                         OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(
             queue, nodeID, controller, handler, action, OnSuccessFn, keepAlive){};
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action, bool keepAlive = false) :
-        MTRCallbackBridge<NullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(
+        MTRCallbackBridge<NullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallback>(
             queue, device, handler, action, OnSuccessFn, keepAlive){};
 
     static void
@@ -18529,22 +18529,22 @@ public:
                 const chip::app::DataModel::Nullable<chip::app::Clusters::OtaSoftwareUpdateRequestor::OTAUpdateStateEnum> & value);
 };
 
-class MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge
-    : public MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge
+class MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge
+    : public MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge
 {
 public:
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, chip::NodeId nodeID, MTRDeviceController * controller, ResponseHandler handler,
         MTRActionBlock action, MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(queue, nodeID, controller, handler,
+        MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(queue, nodeID, controller, handler,
                                                                                               action, true),
         mEstablishedHandler(establishedHandler)
     {}
 
-    MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge(
+    MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackSubscriptionBridge(
         dispatch_queue_t queue, MTRBaseDevice * device, ResponseHandler handler, MTRActionBlock action,
         MTRSubscriptionEstablishedHandler establishedHandler) :
-        MTRNullableOtaSoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(queue, device, handler, action, true),
+        MTRNullableOTASoftwareUpdateRequestorClusterOTAUpdateStateEnumAttributeCallbackBridge(queue, device, handler, action, true),
         mEstablishedHandler(establishedHandler)
     {}
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusterConstants.h
@@ -34,8 +34,8 @@ typedef NS_ENUM(uint32_t, MTRClusterIDType) {
     MTRClusterIDTypeAccessControlID = 0x0000001F,
     MTRClusterIDTypeActionsID = 0x00000025,
     MTRClusterIDTypeBasicID = 0x00000028,
-    MTRClusterIDTypeOtaSoftwareUpdateProviderID = 0x00000029,
-    MTRClusterIDTypeOtaSoftwareUpdateRequestorID = 0x0000002A,
+    MTRClusterIDTypeOTASoftwareUpdateProviderID = 0x00000029,
+    MTRClusterIDTypeOTASoftwareUpdateRequestorID = 0x0000002A,
     MTRClusterIDTypeLocalizationConfigurationID = 0x0000002B,
     MTRClusterIDTypeTimeFormatLocalizationID = 0x0000002C,
     MTRClusterIDTypeUnitLocalizationID = 0x0000002D,
@@ -77,7 +77,7 @@ typedef NS_ENUM(uint32_t, MTRClusterIDType) {
     MTRClusterIDTypeFlowMeasurementID = 0x00000404,
     MTRClusterIDTypeRelativeHumidityMeasurementID = 0x00000405,
     MTRClusterIDTypeOccupancySensingID = 0x00000406,
-    MTRClusterIDTypeWakeOnLanID = 0x00000503,
+    MTRClusterIDTypeWakeOnLANID = 0x00000503,
     MTRClusterIDTypeChannelID = 0x00000504,
     MTRClusterIDTypeTargetNavigatorID = 0x00000505,
     MTRClusterIDTypeMediaPlaybackID = 0x00000506,
@@ -226,7 +226,7 @@ typedef NS_ENUM(uint32_t, MTRAttributeIDType) {
     MTRAttributeIDTypeClusterBindingAttributeClusterRevisionID = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
     // Cluster AccessControl attributes
-    MTRAttributeIDTypeClusterAccessControlAttributeAclID = 0x00000000,
+    MTRAttributeIDTypeClusterAccessControlAttributeACLID = 0x00000000,
     MTRAttributeIDTypeClusterAccessControlAttributeExtensionID = 0x00000001,
     MTRAttributeIDTypeClusterAccessControlAttributeSubjectsPerAccessControlEntryID = 0x00000002,
     MTRAttributeIDTypeClusterAccessControlAttributeTargetsPerAccessControlEntryID = 0x00000003,
@@ -274,28 +274,28 @@ typedef NS_ENUM(uint32_t, MTRAttributeIDType) {
     MTRAttributeIDTypeClusterBasicAttributeFeatureMapID = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
     MTRAttributeIDTypeClusterBasicAttributeClusterRevisionID = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
-    // Cluster OtaSoftwareUpdateProvider attributes
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeGeneratedCommandListID
+    // Cluster OTASoftwareUpdateProvider attributes
+    MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeGeneratedCommandListID
     = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAcceptedCommandListID
+    MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeAcceptedCommandListID
     = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAttributeListID = MTRAttributeIDTypeGlobalAttributeAttributeListID,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeFeatureMapID = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeClusterRevisionID
+    MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeAttributeListID = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeFeatureMapID = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeClusterRevisionID
     = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
-    // Cluster OtaSoftwareUpdateRequestor attributes
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID = 0x00000000,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdatePossibleID = 0x00000001,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateID = 0x00000002,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateProgressID = 0x00000003,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeGeneratedCommandListID
+    // Cluster OTASoftwareUpdateRequestor attributes
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeDefaultOtaProvidersID = 0x00000000,
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeUpdatePossibleID = 0x00000001,
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeUpdateStateID = 0x00000002,
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeUpdateStateProgressID = 0x00000003,
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeGeneratedCommandListID
     = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAcceptedCommandListID
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeAcceptedCommandListID
     = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAttributeListID = MTRAttributeIDTypeGlobalAttributeAttributeListID,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeFeatureMapID = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
-    MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeClusterRevisionID
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeAttributeListID = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeFeatureMapID = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeClusterRevisionID
     = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
     // Cluster LocalizationConfiguration attributes
@@ -1090,9 +1090,9 @@ typedef NS_ENUM(uint32_t, MTRAttributeIDType) {
     MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancyID = 0x00000000,
     MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancySensorTypeID = 0x00000001,
     MTRAttributeIDTypeClusterOccupancySensingAttributeOccupancySensorTypeBitmapID = 0x00000002,
-    MTRAttributeIDTypeClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID = 0x00000010,
-    MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID = 0x00000011,
-    MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID = 0x00000012,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePIROccupiedToUnoccupiedDelayID = 0x00000010,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePIRUnoccupiedToOccupiedDelayID = 0x00000011,
+    MTRAttributeIDTypeClusterOccupancySensingAttributePIRUnoccupiedToOccupiedThresholdID = 0x00000012,
     MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicOccupiedToUnoccupiedDelayID = 0x00000020,
     MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedDelayID = 0x00000021,
     MTRAttributeIDTypeClusterOccupancySensingAttributeUltrasonicUnoccupiedToOccupiedThresholdID = 0x00000022,
@@ -1107,13 +1107,13 @@ typedef NS_ENUM(uint32_t, MTRAttributeIDType) {
     MTRAttributeIDTypeClusterOccupancySensingAttributeFeatureMapID = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
     MTRAttributeIDTypeClusterOccupancySensingAttributeClusterRevisionID = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
-    // Cluster WakeOnLan attributes
-    MTRAttributeIDTypeClusterWakeOnLanAttributeMACAddressID = 0x00000000,
-    MTRAttributeIDTypeClusterWakeOnLanAttributeGeneratedCommandListID = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
-    MTRAttributeIDTypeClusterWakeOnLanAttributeAcceptedCommandListID = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
-    MTRAttributeIDTypeClusterWakeOnLanAttributeAttributeListID = MTRAttributeIDTypeGlobalAttributeAttributeListID,
-    MTRAttributeIDTypeClusterWakeOnLanAttributeFeatureMapID = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
-    MTRAttributeIDTypeClusterWakeOnLanAttributeClusterRevisionID = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
+    // Cluster WakeOnLAN attributes
+    MTRAttributeIDTypeClusterWakeOnLANAttributeMACAddressID = 0x00000000,
+    MTRAttributeIDTypeClusterWakeOnLANAttributeGeneratedCommandListID = MTRAttributeIDTypeGlobalAttributeGeneratedCommandListID,
+    MTRAttributeIDTypeClusterWakeOnLANAttributeAcceptedCommandListID = MTRAttributeIDTypeGlobalAttributeAcceptedCommandListID,
+    MTRAttributeIDTypeClusterWakeOnLANAttributeAttributeListID = MTRAttributeIDTypeGlobalAttributeAttributeListID,
+    MTRAttributeIDTypeClusterWakeOnLANAttributeFeatureMapID = MTRAttributeIDTypeGlobalAttributeFeatureMapID,
+    MTRAttributeIDTypeClusterWakeOnLANAttributeClusterRevisionID = MTRAttributeIDTypeGlobalAttributeClusterRevisionID,
 
     // Cluster Channel attributes
     MTRAttributeIDTypeClusterChannelAttributeChannelListID = 0x00000000,
@@ -1537,15 +1537,15 @@ typedef NS_ENUM(uint32_t, MTRCommandIDType) {
     // Cluster Basic commands
     MTRCommandIDTypeClusterBasicCommandMfgSpecificPingID = 0x10020000,
 
-    // Cluster OtaSoftwareUpdateProvider commands
-    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandQueryImageID = 0x00000000,
-    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandQueryImageResponseID = 0x00000001,
-    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandApplyUpdateRequestID = 0x00000002,
-    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandApplyUpdateResponseID = 0x00000003,
-    MTRCommandIDTypeClusterOtaSoftwareUpdateProviderCommandNotifyUpdateAppliedID = 0x00000004,
+    // Cluster OTASoftwareUpdateProvider commands
+    MTRCommandIDTypeClusterOTASoftwareUpdateProviderCommandQueryImageID = 0x00000000,
+    MTRCommandIDTypeClusterOTASoftwareUpdateProviderCommandQueryImageResponseID = 0x00000001,
+    MTRCommandIDTypeClusterOTASoftwareUpdateProviderCommandApplyUpdateRequestID = 0x00000002,
+    MTRCommandIDTypeClusterOTASoftwareUpdateProviderCommandApplyUpdateResponseID = 0x00000003,
+    MTRCommandIDTypeClusterOTASoftwareUpdateProviderCommandNotifyUpdateAppliedID = 0x00000004,
 
-    // Cluster OtaSoftwareUpdateRequestor commands
-    MTRCommandIDTypeClusterOtaSoftwareUpdateRequestorCommandAnnounceOtaProviderID = 0x00000000,
+    // Cluster OTASoftwareUpdateRequestor commands
+    MTRCommandIDTypeClusterOTASoftwareUpdateRequestorCommandAnnounceOtaProviderID = 0x00000000,
 
     // Cluster GeneralCommissioning commands
     MTRCommandIDTypeClusterGeneralCommissioningCommandArmFailSafeID = 0x00000000,
@@ -1808,10 +1808,10 @@ typedef NS_ENUM(uint32_t, MTREventIDType) {
     MTREventIDTypeClusterBasicEventLeaveID = 0x00000002,
     MTREventIDTypeClusterBasicEventReachableChangedID = 0x00000003,
 
-    // Cluster OtaSoftwareUpdateRequestor events
-    MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventStateTransitionID = 0x00000000,
-    MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventVersionAppliedID = 0x00000001,
-    MTREventIDTypeClusterOtaSoftwareUpdateRequestorEventDownloadErrorID = 0x00000002,
+    // Cluster OTASoftwareUpdateRequestor events
+    MTREventIDTypeClusterOTASoftwareUpdateRequestorEventStateTransitionID = 0x00000000,
+    MTREventIDTypeClusterOTASoftwareUpdateRequestorEventVersionAppliedID = 0x00000001,
+    MTREventIDTypeClusterOTASoftwareUpdateRequestorEventDownloadErrorID = 0x00000002,
 
     // Cluster GeneralDiagnostics events
     MTREventIDTypeClusterGeneralDiagnosticsEventHardwareFaultChangeID = 0x00000000,

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Identify
- *
+ *    Attributes and commands for putting a device into Identification mode (e.g. flashing a light).
  */
 @interface MTRClusterIdentify : MTRCluster
 
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Groups
- *
+ *    Attributes and commands for group configuration and manipulation.
  */
 @interface MTRClusterGroups : MTRCluster
 
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Scenes
- *
+ *    Attributes and commands for scene configuration and manipulation.
  */
 @interface MTRClusterScenes : MTRCluster
 
@@ -215,7 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster On/Off
- *
+ *    Attributes and commands for switching devices between 'On' and 'Off' states.
  */
 @interface MTRClusterOnOff : MTRCluster
 
@@ -302,7 +302,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster On/off Switch Configuration
- *
+ *    Attributes and commands for configuring On/Off switching devices.
  */
 @interface MTRClusterOnOffSwitchConfiguration : MTRCluster
 
@@ -336,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Level Control
- *
+ *    Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'
  */
 @interface MTRClusterLevelControl : MTRCluster
 
@@ -461,7 +461,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Binary Input (Basic)
- *
+ *    An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
  */
 @interface MTRClusterBinaryInputBasic : MTRCluster
 
@@ -534,7 +534,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Descriptor
- *
+ *    The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its
+ * endpoints and clusters.
  */
 @interface MTRClusterDescriptor : MTRCluster
 
@@ -567,7 +568,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Binding
- *
+ *    The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
  */
 @interface MTRClusterBinding : MTRCluster
 
@@ -599,7 +600,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Access Control
- *
+ *    The Access Control Cluster exposes a data model view of a
+      Node's Access Control List (ACL), which codifies the rules used to manage
+      and enforce Access Control for the Node's endpoints and their associated
+      cluster instances.
  */
 @interface MTRClusterAccessControl : MTRCluster
 
@@ -607,10 +611,10 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (NSDictionary<NSString *, id> *)readAttributeAclWithParams:(MTRReadParams * _Nullable)params;
-- (void)writeAttributeAclWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (NSDictionary<NSString *, id> *)readAttributeACLWithParams:(MTRReadParams * _Nullable)params;
+- (void)writeAttributeACLWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
              expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
-- (void)writeAttributeAclWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributeACLWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
              expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                             params:(MTRWriteParams * _Nullable)params;
 
@@ -644,7 +648,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Actions
- *
+ *    This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
  */
 @interface MTRClusterActions : MTRCluster
 
@@ -724,7 +728,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Basic
- *
+ *    This cluster provides attributes and events for determining basic information about Nodes, which supports both
+      Commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
+      which apply to the whole Node. Also allows setting user device information such as location.
  */
 @interface MTRClusterBasic : MTRCluster
 
@@ -812,25 +818,25 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster OTA Software Update Provider
- *
+ *    Provides an interface for providing OTA software updates
  */
-@interface MTRClusterOtaSoftwareUpdateProvider : MTRCluster
+@interface MTRClusterOTASoftwareUpdateProvider : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRDevice *)device
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)queryImageWithParams:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
+- (void)queryImageWithParams:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params
               expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
        expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                  completion:(void (^)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
+                  completion:(void (^)(MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion;
-- (void)applyUpdateRequestWithParams:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
+- (void)applyUpdateRequestWithParams:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
-                          completion:(void (^)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                          completion:(void (^)(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion;
-- (void)notifyUpdateAppliedWithParams:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
+- (void)notifyUpdateAppliedWithParams:(MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                 expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                            completion:(MTRStatusCompletion)completion;
@@ -852,15 +858,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster OTA Software Update Requestor
- *
+ *    Provides an interface for downloading and applying OTA software updates
  */
-@interface MTRClusterOtaSoftwareUpdateRequestor : MTRCluster
+@interface MTRClusterOTASoftwareUpdateRequestor : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRDevice *)device
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
-- (void)announceOtaProviderWithParams:(MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
+- (void)announceOtaProviderWithParams:(MTROTASoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> * _Nullable)expectedDataValueDictionaries
                 expectedValueInterval:(NSNumber * _Nullable)expectedValueIntervalMs
                            completion:(MTRStatusCompletion)completion;
@@ -895,7 +901,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Localization Configuration
- *
+ *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing common languages, units of measurements, and numerical formatting
+      standards. As such, Nodes that visually or audibly convey information need a mechanism by which
+      they can be configured to use a user’s preferred language, units, etc
  */
 @interface MTRClusterLocalizationConfiguration : MTRCluster
 
@@ -929,7 +938,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Time Format Localization
- *
+ *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
+      or audibly convey time information need a mechanism by which they can be configured to use a
+      user’s preferred format.
  */
 @interface MTRClusterTimeFormatLocalization : MTRCluster
 
@@ -970,7 +982,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Unit Localization
- *
+ *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing preferences for the units in which values are conveyed in communication to a
+      user. As such, Nodes that visually or audibly convey measurable values to the user need a
+      mechanism by which they can be configured to use a user’s preferred unit.
  */
 @interface MTRClusterUnitLocalization : MTRCluster
 
@@ -1002,7 +1017,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Power Source Configuration
- *
+ *    This cluster is used to describe the configuration and capabilities of a Device's power system.
  */
 @interface MTRClusterPowerSourceConfiguration : MTRCluster
 
@@ -1029,7 +1044,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Power Source
- *
+ *    This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the
+ * Node.
  */
 @interface MTRClusterPowerSource : MTRCluster
 
@@ -1116,7 +1132,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster General Commissioning
- *
+ *    This cluster is used to manage global aspects of the Commissioning flow.
  */
 @interface MTRClusterGeneralCommissioning : MTRCluster
 
@@ -1179,7 +1195,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Network Commissioning
- *
+ *    Functionality to configure, enable, disable network credentials and access on a Matter device.
  */
 @interface MTRClusterNetworkCommissioning : MTRCluster
 
@@ -1256,7 +1272,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Diagnostic Logs
- *
+ *    The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
  */
 @interface MTRClusterDiagnosticLogs : MTRCluster
 
@@ -1287,7 +1303,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster General Diagnostics
- *
+ *    The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics
+ * metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRClusterGeneralDiagnostics : MTRCluster
 
@@ -1335,7 +1352,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Software Diagnostics
- *
+ *    The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRClusterSoftwareDiagnostics : MTRCluster
 
@@ -1376,7 +1394,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Thread Network Diagnostics
- *
+ *    The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
+ * to assist a user or Administrative Node in diagnosing potential problems
  */
 @interface MTRClusterThreadNetworkDiagnostics : MTRCluster
 
@@ -1535,7 +1554,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster WiFi Network Diagnostics
- *
+ *    The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
+ * to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRClusterWiFiNetworkDiagnostics : MTRCluster
 
@@ -1594,7 +1614,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Ethernet Network Diagnostics
- *
+ *    The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a
+ * Node to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRClusterEthernetNetworkDiagnostics : MTRCluster
 
@@ -1645,7 +1666,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Bridged Device Basic
- *
+ *    This Cluster serves two purposes towards a Node communicating with a Bridge: indicate that the functionality on
+          the Endpoint where it is placed (and its Parts) is bridged from a non-CHIP technology; and provide a centralized
+          collection of attributes that the Node MAY collect to aid in conveying information regarding the Bridged Device to a user,
+          such as the vendor name, the model name, or user-assigned name.
  */
 @interface MTRClusterBridgedDeviceBasic : MTRCluster
 
@@ -1705,7 +1729,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Switch
- *
+ *    This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
+Two types of switch devices are supported: latching switch (e.g. rocker switch) and momentary switch (e.g. push button),
+distinguished with their feature flags. Interactions with the switch device are exposed as attributes (for the latching switch) and
+as events (for both types of switches). An interested party MAY subscribe to these attributes/events and thus be informed of the
+interactions, and can perform actions based on this, for example by sending commands to perform an action such as controlling a
+light or a window shade.
  */
 @interface MTRClusterSwitch : MTRCluster
 
@@ -1736,7 +1765,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster AdministratorCommissioning
- *
+ *    Commands to trigger a Node to allow a new Administrator to commission it.
  */
 @interface MTRClusterAdministratorCommissioning : MTRCluster
 
@@ -1783,7 +1812,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Operational Credentials
- *
+ *    This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated
+ * Fabrics.
  */
 @interface MTRClusterOperationalCredentials : MTRCluster
 
@@ -1860,7 +1890,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Group Key Management
- *
+ *    The Group Key Management Cluster is the mechanism by which group keys are managed.
  */
 @interface MTRClusterGroupKeyManagement : MTRCluster
 
@@ -1917,7 +1947,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Fixed Label
- *
+ *    The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
+labels.
  */
 @interface MTRClusterFixedLabel : MTRCluster
 
@@ -1944,7 +1975,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster User Label
- *
+ *    The User Label Cluster provides a feature to tag an endpoint with zero or more labels.
  */
 @interface MTRClusterUserLabel : MTRCluster
 
@@ -1976,7 +2007,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Boolean State
- *
+ *    This cluster provides an interface to a boolean state called StateValue.
  */
 @interface MTRClusterBooleanState : MTRCluster
 
@@ -2003,7 +2034,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Mode Select
- *
+ *    Attributes and commands for selecting a mode from a list of supported options.
  */
 @interface MTRClusterModeSelect : MTRCluster
 
@@ -2055,7 +2086,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Door Lock
- *
+ *    An interface to a generic way to secure a door
  */
 @interface MTRClusterDoorLock : MTRCluster
 
@@ -2320,7 +2351,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Window Covering
- *
+ *    Provides an interface for controlling and adjusting automatic window coverings.
  */
 @interface MTRClusterWindowCovering : MTRCluster
 
@@ -2432,7 +2463,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Barrier Control
- *
+ *    This cluster provides control of a barrier (garage door).
  */
 @interface MTRClusterBarrierControl : MTRCluster
 
@@ -2519,7 +2550,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Pump Configuration and Control
- *
+ *    An interface for configuring and controlling pumps.
  */
 @interface MTRClusterPumpConfigurationAndControl : MTRCluster
 
@@ -2610,7 +2641,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Thermostat
- *
+ *    An interface for configuring and controlling the functionality of a thermostat.
  */
 @interface MTRClusterThermostat : MTRCluster
 
@@ -2889,7 +2920,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Fan Control
- *
+ *    An interface for controlling a fan in a heating/cooling system.
  */
 @interface MTRClusterFanControl : MTRCluster
 
@@ -2966,7 +2997,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Thermostat User Interface Configuration
- *
+ *    An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
  */
 @interface MTRClusterThermostatUserInterfaceConfiguration : MTRCluster
 
@@ -3012,7 +3043,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Color Control
- *
+ *    Attributes and commands for controlling the color properties of a color-capable light.
  */
 @interface MTRClusterColorControl : MTRCluster
 
@@ -3283,7 +3314,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Ballast Configuration
- *
+ *    Attributes and commands for configuring a lighting ballast.
  */
 @interface MTRClusterBallastConfiguration : MTRCluster
 
@@ -3386,7 +3417,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Illuminance Measurement
- *
+ *    Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
  */
 @interface MTRClusterIlluminanceMeasurement : MTRCluster
 
@@ -3421,7 +3452,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Temperature Measurement
- *
+ *    Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
  */
 @interface MTRClusterTemperatureMeasurement : MTRCluster
 
@@ -3454,7 +3485,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Pressure Measurement
- *
+ *    Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.
  */
 @interface MTRClusterPressureMeasurement : MTRCluster
 
@@ -3497,7 +3528,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Flow Measurement
- *
+ *    Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
  */
 @interface MTRClusterFlowMeasurement : MTRCluster
 
@@ -3530,7 +3561,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Relative Humidity Measurement
- *
+ *    Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
  */
 @interface MTRClusterRelativeHumidityMeasurement : MTRCluster
 
@@ -3563,7 +3594,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Occupancy Sensing
- *
+ *    Attributes and commands for configuring occupancy sensing, and reporting occupancy status.
  */
 @interface MTRClusterOccupancySensing : MTRCluster
 
@@ -3577,24 +3608,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (NSDictionary<NSString *, id> *)readAttributeOccupancySensorTypeBitmapWithParams:(MTRReadParams * _Nullable)params;
 
-- (NSDictionary<NSString *, id> *)readAttributePirOccupiedToUnoccupiedDelayWithParams:(MTRReadParams * _Nullable)params;
-- (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (NSDictionary<NSString *, id> *)readAttributePIROccupiedToUnoccupiedDelayWithParams:(MTRReadParams * _Nullable)params;
+- (void)writeAttributePIROccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                       expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
-- (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIROccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                       expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                                                      params:(MTRWriteParams * _Nullable)params;
 
-- (NSDictionary<NSString *, id> *)readAttributePirUnoccupiedToOccupiedDelayWithParams:(MTRReadParams * _Nullable)params;
-- (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (NSDictionary<NSString *, id> *)readAttributePIRUnoccupiedToOccupiedDelayWithParams:(MTRReadParams * _Nullable)params;
+- (void)writeAttributePIRUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                       expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
-- (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIRUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                       expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                                                      params:(MTRWriteParams * _Nullable)params;
 
-- (NSDictionary<NSString *, id> *)readAttributePirUnoccupiedToOccupiedThresholdWithParams:(MTRReadParams * _Nullable)params;
-- (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (NSDictionary<NSString *, id> *)readAttributePIRUnoccupiedToOccupiedThresholdWithParams:(MTRReadParams * _Nullable)params;
+- (void)writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                           expectedValueInterval:(NSNumber *)expectedValueIntervalMs;
-- (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                           expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                                                          params:(MTRWriteParams * _Nullable)params;
 
@@ -3658,9 +3689,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Wake on LAN
- *
+ *    This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
  */
-@interface MTRClusterWakeOnLan : MTRCluster
+@interface MTRClusterWakeOnLAN : MTRCluster
 
 - (instancetype _Nullable)initWithDevice:(MTRDevice *)device
                                 endpoint:(NSNumber *)endpoint
@@ -3685,7 +3716,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Channel
- *
+ *    This cluster provides an interface for controlling the current Channel on a device.
  */
 @interface MTRClusterChannel : MTRCluster
 
@@ -3730,7 +3761,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Target Navigator
- *
+ *    This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
  */
 @interface MTRClusterTargetNavigator : MTRCluster
 
@@ -3765,7 +3796,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Media Playback
- *
+ *    This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or
+ * Speaker.
  */
 @interface MTRClusterMediaPlayback : MTRCluster
 
@@ -3892,7 +3924,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Media Input
- *
+ *    This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
  */
 @interface MTRClusterMediaInput : MTRCluster
 
@@ -3944,7 +3976,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Low Power
- *
+ *    This cluster provides an interface for managing low power mode on a device.
  */
 @interface MTRClusterLowPower : MTRCluster
 
@@ -3977,7 +4009,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Keypad Input
- *
+ *    This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
  */
 @interface MTRClusterKeypadInput : MTRCluster
 
@@ -4008,7 +4040,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Content Launcher
- *
+ *    This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRClusterContentLauncher : MTRCluster
 
@@ -4053,7 +4085,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Audio Output
- *
+ *    This cluster provides an interface for controlling the Output on a media device such as a TV.
  */
 @interface MTRClusterAudioOutput : MTRCluster
 
@@ -4091,7 +4123,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Application Launcher
- *
+ *    This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRClusterApplicationLauncher : MTRCluster
 
@@ -4141,7 +4173,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Application Basic
- *
+ *    This cluster provides information about an application running on a TV or media player device which is represented as an
+ * endpoint.
  */
 @interface MTRClusterApplicationBasic : MTRCluster
 
@@ -4182,7 +4215,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Account Login
- *
+ *    This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App
+ * running on a Video Player device, which is represented as an endpoint (see [TV Architecture]), can use this cluster to help make
+ * the user account on the Content App match the user account on the Client.
  */
 @interface MTRClusterAccountLogin : MTRCluster
 
@@ -4224,7 +4259,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Electrical Measurement
- *
+ *    Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need
+ * to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..
  */
 @interface MTRClusterElectricalMeasurement : MTRCluster
 
@@ -4557,7 +4593,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Test Cluster
- *
+ *    The Test Cluster is meant to validate the generated code
  */
 @interface MTRClusterTestCluster : MTRCluster
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.mm
@@ -2647,20 +2647,20 @@ using chip::SessionHandle;
     return self;
 }
 
-- (NSDictionary<NSString *, id> *)readAttributeAclWithParams:(MTRReadParams * _Nullable)params
+- (NSDictionary<NSString *, id> *)readAttributeACLWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
                                           clusterID:@(MTRClusterIDTypeAccessControlID)
-                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeAclID)
+                                        attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeACLID)
                                              params:params];
 }
 
-- (void)writeAttributeAclWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributeACLWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
              expectedValueInterval:(NSNumber *)expectedValueIntervalMs
 {
-    [self writeAttributeAclWithValue:dataValueDictionary expectedValueInterval:expectedValueIntervalMs params:nil];
+    [self writeAttributeACLWithValue:dataValueDictionary expectedValueInterval:expectedValueIntervalMs params:nil];
 }
-- (void)writeAttributeAclWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributeACLWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
              expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                             params:(MTRWriteParams * _Nullable)params
 {
@@ -2668,7 +2668,7 @@ using chip::SessionHandle;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
                                     clusterID:@(MTRClusterIDTypeAccessControlID)
-                                  attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeAclID)
+                                  attributeID:@(MTRAttributeIDTypeClusterAccessControlAttributeACLID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3627,7 +3627,7 @@ using chip::SessionHandle;
 
 @end
 
-@implementation MTRClusterOtaSoftwareUpdateProvider
+@implementation MTRClusterOTASoftwareUpdateProvider
 
 - (instancetype)initWithDevice:(MTRDevice *)device endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue
 {
@@ -3642,17 +3642,17 @@ using chip::SessionHandle;
     return self;
 }
 
-- (void)queryImageWithParams:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
+- (void)queryImageWithParams:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params
               expectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
        expectedValueInterval:(NSNumber *)expectedValueIntervalMs
-                  completion:(void (^)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
+                  completion:(void (^)(MTROTASoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion
 {
     // Make a copy of params before we go async.
     params = [params copy];
     MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:@(self.device.nodeID)
                                                             controller:self.device.deviceController];
-    new MTROtaSoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(self.callbackQueue, baseDevice, completion,
+    new MTROTASoftwareUpdateProviderClusterQueryImageResponseCallbackBridge(self.callbackQueue, baseDevice, completion,
         ^(ExchangeManager & exchangeManager, const SessionHandle & session, Cancelable * success, Cancelable * failure) {
             chip::Optional<uint16_t> timedInvokeTimeoutMs;
             ListFreer listFreer;
@@ -3705,7 +3705,7 @@ using chip::SessionHandle;
                 definedValue_0 = [self asByteSpan:params.metadataForProvider];
             }
 
-            auto successFn = Callback<OtaSoftwareUpdateProviderClusterQueryImageResponseCallbackType>::FromCancelable(success);
+            auto successFn = Callback<OTASoftwareUpdateProviderClusterQueryImageResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<DefaultFailureCallbackType>::FromCancelable(failure);
             chip::Controller::OtaSoftwareUpdateProviderCluster cppCluster(exchangeManager, session, self->_endpoint);
             return cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall, timedInvokeTimeoutMs);
@@ -3714,17 +3714,17 @@ using chip::SessionHandle;
     [self.device setExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs];
 }
 
-- (void)applyUpdateRequestWithParams:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
+- (void)applyUpdateRequestWithParams:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
                       expectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
                expectedValueInterval:(NSNumber *)expectedValueIntervalMs
-                          completion:(void (^)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
+                          completion:(void (^)(MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion
 {
     // Make a copy of params before we go async.
     params = [params copy];
     MTRBaseDevice * baseDevice = [[MTRBaseDevice alloc] initWithNodeID:@(self.device.nodeID)
                                                             controller:self.device.deviceController];
-    new MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(self.callbackQueue, baseDevice, completion,
+    new MTROTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackBridge(self.callbackQueue, baseDevice, completion,
         ^(ExchangeManager & exchangeManager, const SessionHandle & session, Cancelable * success, Cancelable * failure) {
             chip::Optional<uint16_t> timedInvokeTimeoutMs;
             ListFreer listFreer;
@@ -3737,7 +3737,7 @@ using chip::SessionHandle;
             request.updateToken = [self asByteSpan:params.updateToken];
             request.newVersion = params.newVersion.unsignedIntValue;
 
-            auto successFn = Callback<OtaSoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>::FromCancelable(success);
+            auto successFn = Callback<OTASoftwareUpdateProviderClusterApplyUpdateResponseCallbackType>::FromCancelable(success);
             auto failureFn = Callback<DefaultFailureCallbackType>::FromCancelable(failure);
             chip::Controller::OtaSoftwareUpdateProviderCluster cppCluster(exchangeManager, session, self->_endpoint);
             return cppCluster.InvokeCommand(request, successFn->mContext, successFn->mCall, failureFn->mCall, timedInvokeTimeoutMs);
@@ -3746,7 +3746,7 @@ using chip::SessionHandle;
     [self.device setExpectedValues:expectedValues expectedValueInterval:expectedValueIntervalMs];
 }
 
-- (void)notifyUpdateAppliedWithParams:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
+- (void)notifyUpdateAppliedWithParams:(MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
                 expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                            completion:(MTRStatusCompletion)completion
@@ -3785,8 +3785,8 @@ using chip::SessionHandle;
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
-                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeGeneratedCommandListID)
+                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateProviderID)
+                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeGeneratedCommandListID)
                              params:params];
 }
 
@@ -3794,38 +3794,38 @@ using chip::SessionHandle;
 {
     return
         [self.device readAttributeWithEndpointID:@(_endpoint)
-                                       clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
-                                     attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAcceptedCommandListID)
+                                       clusterID:@(MTRClusterIDTypeOTASoftwareUpdateProviderID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeAcceptedCommandListID)
                                           params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
-                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateProviderID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
-                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateProviderID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateProviderID)
-                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateProviderAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateProviderID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateProviderAttributeClusterRevisionID)
                                              params:params];
 }
 
 @end
 
-@implementation MTRClusterOtaSoftwareUpdateRequestor
+@implementation MTRClusterOTASoftwareUpdateRequestor
 
 - (instancetype)initWithDevice:(MTRDevice *)device endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue
 {
@@ -3840,7 +3840,7 @@ using chip::SessionHandle;
     return self;
 }
 
-- (void)announceOtaProviderWithParams:(MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
+- (void)announceOtaProviderWithParams:(MTROTASoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
                        expectedValues:(NSArray<NSDictionary<NSString *, id> *> *)expectedValues
                 expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                            completion:(MTRStatusCompletion)completion
@@ -3886,8 +3886,8 @@ using chip::SessionHandle;
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID)
+                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeDefaultOtaProvidersID)
                              params:params];
 }
 
@@ -3903,8 +3903,8 @@ using chip::SessionHandle;
     NSNumber * timedWriteTimeout = params.timedWriteTimeout;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
-                                    clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                                  attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeDefaultOtaProvidersID)
+                                    clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeDefaultOtaProvidersID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
@@ -3913,16 +3913,16 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeUpdatePossibleWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdatePossibleID)
+                                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeUpdatePossibleID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeUpdateStateWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateID)
+                                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeUpdateStateID)
                                              params:params];
 }
 
@@ -3930,8 +3930,8 @@ using chip::SessionHandle;
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeUpdateStateProgressID)
+                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeUpdateStateProgressID)
                              params:params];
 }
 
@@ -3939,8 +3939,8 @@ using chip::SessionHandle;
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeGeneratedCommandListID)
+                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeGeneratedCommandListID)
                              params:params];
 }
 
@@ -3948,32 +3948,32 @@ using chip::SessionHandle;
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
-                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAcceptedCommandListID)
+                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeAcceptedCommandListID)
                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeOtaSoftwareUpdateRequestorID)
-                                        attributeID:@(MTRAttributeIDTypeClusterOtaSoftwareUpdateRequestorAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeOTASoftwareUpdateRequestorID)
+                                        attributeID:@(MTRAttributeIDTypeClusterOTASoftwareUpdateRequestorAttributeClusterRevisionID)
                                              params:params];
 }
 
@@ -14706,23 +14706,23 @@ using chip::SessionHandle;
                                              params:params];
 }
 
-- (NSDictionary<NSString *, id> *)readAttributePirOccupiedToUnoccupiedDelayWithParams:(MTRReadParams * _Nullable)params
+- (NSDictionary<NSString *, id> *)readAttributePIROccupiedToUnoccupiedDelayWithParams:(MTRReadParams * _Nullable)params
 {
     return
         [self.device readAttributeWithEndpointID:@(_endpoint)
                                        clusterID:@(MTRClusterIDTypeOccupancySensingID)
-                                     attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePIROccupiedToUnoccupiedDelayID)
                                           params:params];
 }
 
-- (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIROccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                       expectedValueInterval:(NSNumber *)expectedValueIntervalMs
 {
-    [self writeAttributePirOccupiedToUnoccupiedDelayWithValue:dataValueDictionary
+    [self writeAttributePIROccupiedToUnoccupiedDelayWithValue:dataValueDictionary
                                         expectedValueInterval:expectedValueIntervalMs
                                                        params:nil];
 }
-- (void)writeAttributePirOccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIROccupiedToUnoccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                       expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                                                      params:(MTRWriteParams * _Nullable)params
 {
@@ -14730,29 +14730,29 @@ using chip::SessionHandle;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
                                     clusterID:@(MTRClusterIDTypeOccupancySensingID)
-                                  attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirOccupiedToUnoccupiedDelayID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePIROccupiedToUnoccupiedDelayID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
 }
 
-- (NSDictionary<NSString *, id> *)readAttributePirUnoccupiedToOccupiedDelayWithParams:(MTRReadParams * _Nullable)params
+- (NSDictionary<NSString *, id> *)readAttributePIRUnoccupiedToOccupiedDelayWithParams:(MTRReadParams * _Nullable)params
 {
     return
         [self.device readAttributeWithEndpointID:@(_endpoint)
                                        clusterID:@(MTRClusterIDTypeOccupancySensingID)
-                                     attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID)
+                                     attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePIRUnoccupiedToOccupiedDelayID)
                                           params:params];
 }
 
-- (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIRUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                       expectedValueInterval:(NSNumber *)expectedValueIntervalMs
 {
-    [self writeAttributePirUnoccupiedToOccupiedDelayWithValue:dataValueDictionary
+    [self writeAttributePIRUnoccupiedToOccupiedDelayWithValue:dataValueDictionary
                                         expectedValueInterval:expectedValueIntervalMs
                                                        params:nil];
 }
-- (void)writeAttributePirUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIRUnoccupiedToOccupiedDelayWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                       expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                                                      params:(MTRWriteParams * _Nullable)params
 {
@@ -14760,29 +14760,29 @@ using chip::SessionHandle;
 
     [self.device writeAttributeWithEndpointID:@(_endpoint)
                                     clusterID:@(MTRClusterIDTypeOccupancySensingID)
-                                  attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedDelayID)
+                                  attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePIRUnoccupiedToOccupiedDelayID)
                                         value:dataValueDictionary
                         expectedValueInterval:expectedValueIntervalMs
                             timedWriteTimeout:timedWriteTimeout];
 }
 
-- (NSDictionary<NSString *, id> *)readAttributePirUnoccupiedToOccupiedThresholdWithParams:(MTRReadParams * _Nullable)params
+- (NSDictionary<NSString *, id> *)readAttributePIRUnoccupiedToOccupiedThresholdWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device
         readAttributeWithEndpointID:@(_endpoint)
                           clusterID:@(MTRClusterIDTypeOccupancySensingID)
-                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID)
+                        attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePIRUnoccupiedToOccupiedThresholdID)
                              params:params];
 }
 
-- (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                           expectedValueInterval:(NSNumber *)expectedValueIntervalMs
 {
-    [self writeAttributePirUnoccupiedToOccupiedThresholdWithValue:dataValueDictionary
+    [self writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:dataValueDictionary
                                             expectedValueInterval:expectedValueIntervalMs
                                                            params:nil];
 }
-- (void)writeAttributePirUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
+- (void)writeAttributePIRUnoccupiedToOccupiedThresholdWithValue:(NSDictionary<NSString *, id> *)dataValueDictionary
                                           expectedValueInterval:(NSNumber *)expectedValueIntervalMs
                                                          params:(MTRWriteParams * _Nullable)params
 {
@@ -14791,7 +14791,7 @@ using chip::SessionHandle;
     [self.device
         writeAttributeWithEndpointID:@(_endpoint)
                            clusterID:@(MTRClusterIDTypeOccupancySensingID)
-                         attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePirUnoccupiedToOccupiedThresholdID)
+                         attributeID:@(MTRAttributeIDTypeClusterOccupancySensingAttributePIRUnoccupiedToOccupiedThresholdID)
                                value:dataValueDictionary
                expectedValueInterval:expectedValueIntervalMs
                    timedWriteTimeout:timedWriteTimeout];
@@ -15028,7 +15028,7 @@ using chip::SessionHandle;
 
 @end
 
-@implementation MTRClusterWakeOnLan
+@implementation MTRClusterWakeOnLAN
 
 - (instancetype)initWithDevice:(MTRDevice *)device endpoint:(NSNumber *)endpoint queue:(dispatch_queue_t)queue
 {
@@ -15046,48 +15046,48 @@ using chip::SessionHandle;
 - (NSDictionary<NSString *, id> *)readAttributeMACAddressWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
-                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeMACAddressID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLANID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLANAttributeMACAddressID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeGeneratedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
-                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeGeneratedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLANID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLANAttributeGeneratedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAcceptedCommandListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
-                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeAcceptedCommandListID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLANID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLANAttributeAcceptedCommandListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeAttributeListWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
-                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeAttributeListID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLANID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLANAttributeAttributeListID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeFeatureMapWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
-                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeFeatureMapID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLANID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLANAttributeFeatureMapID)
                                              params:params];
 }
 
 - (NSDictionary<NSString *, id> *)readAttributeClusterRevisionWithParams:(MTRReadParams * _Nullable)params
 {
     return [self.device readAttributeWithEndpointID:@(_endpoint)
-                                          clusterID:@(MTRClusterIDTypeWakeOnLanID)
-                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLanAttributeClusterRevisionID)
+                                          clusterID:@(MTRClusterIDTypeWakeOnLANID)
+                                        attributeID:@(MTRAttributeIDTypeClusterWakeOnLANAttributeClusterRevisionID)
                                              params:params];
 }
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters_internal.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters_internal.h
@@ -83,12 +83,12 @@
 @property (nonatomic, readonly) MTRDevice * device;
 @end
 
-@interface MTRClusterOtaSoftwareUpdateProvider ()
+@interface MTRClusterOTASoftwareUpdateProvider ()
 @property (nonatomic, readonly) uint16_t endpoint;
 @property (nonatomic, readonly) MTRDevice * device;
 @end
 
-@interface MTRClusterOtaSoftwareUpdateRequestor ()
+@interface MTRClusterOTASoftwareUpdateRequestor ()
 @property (nonatomic, readonly) uint16_t endpoint;
 @property (nonatomic, readonly) MTRDevice * device;
 @end
@@ -278,7 +278,7 @@
 @property (nonatomic, readonly) MTRDevice * device;
 @end
 
-@interface MTRClusterWakeOnLan ()
+@interface MTRClusterWakeOnLAN ()
 @property (nonatomic, readonly) uint16_t endpoint;
 @property (nonatomic, readonly) MTRDevice * device;
 @end

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.h
@@ -1490,7 +1490,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterQueryImageParams : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateProviderClusterQueryImageParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull vendorId;
 
@@ -1526,7 +1526,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateProviderClusterQueryImageResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull status;
 
@@ -1562,7 +1562,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSData * _Nonnull updateToken;
 
@@ -1586,7 +1586,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull action;
 
@@ -1610,7 +1610,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
-@interface MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSData * _Nonnull updateToken;
 
@@ -1634,7 +1634,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)init;
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
-@interface MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateRequestorClusterAnnounceOtaProviderParams : NSObject <NSCopying>
 
 @property (nonatomic, copy) NSNumber * _Nonnull providerNodeId;
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRCommandPayloadsObjc.mm
@@ -1985,7 +1985,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
-@implementation MTROtaSoftwareUpdateProviderClusterQueryImageParams
+@implementation MTROTASoftwareUpdateProviderClusterQueryImageParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2012,7 +2012,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 {
-    auto other = [[MTROtaSoftwareUpdateProviderClusterQueryImageParams alloc] init];
+    auto other = [[MTROTASoftwareUpdateProviderClusterQueryImageParams alloc] init];
 
     other.vendorId = self.vendorId;
     other.productId = self.productId;
@@ -2038,7 +2038,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
-@implementation MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams
+@implementation MTROTASoftwareUpdateProviderClusterQueryImageResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2065,7 +2065,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 {
-    auto other = [[MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams alloc] init];
+    auto other = [[MTROTASoftwareUpdateProviderClusterQueryImageResponseParams alloc] init];
 
     other.status = self.status;
     other.delayedActionTime = self.delayedActionTime;
@@ -2092,7 +2092,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
-@implementation MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams
+@implementation MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2107,7 +2107,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 {
-    auto other = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
+    auto other = [[MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams alloc] init];
 
     other.updateToken = self.updateToken;
     other.newVersion = self.newVersion;
@@ -2125,7 +2125,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
-@implementation MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams
+@implementation MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2140,7 +2140,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 {
-    auto other = [[MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams alloc] init];
+    auto other = [[MTROTASoftwareUpdateProviderClusterApplyUpdateResponseParams alloc] init];
 
     other.action = self.action;
     other.delayedActionTime = self.delayedActionTime;
@@ -2157,7 +2157,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
-@implementation MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams
+@implementation MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2172,7 +2172,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 {
-    auto other = [[MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
+    auto other = [[MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams alloc] init];
 
     other.updateToken = self.updateToken;
     other.softwareVersion = self.softwareVersion;
@@ -2190,7 +2190,7 @@ NS_ASSUME_NONNULL_BEGIN
 }
 
 @end
-@implementation MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams
+@implementation MTROTASoftwareUpdateRequestorClusterAnnounceOtaProviderParams
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -2211,7 +2211,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 {
-    auto other = [[MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams alloc] init];
+    auto other = [[MTROTASoftwareUpdateRequestorClusterAnnounceOtaProviderParams alloc] init];
 
     other.providerNodeId = self.providerNodeId;
     other.vendorId = self.vendorId;

--- a/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTREventTLVValueDecoder.mm
@@ -136,8 +136,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRAccessControlClusterAccessControlEntryChangedEvent * value =
-                [MTRAccessControlClusterAccessControlEntryChangedEvent new];
+            __auto_type * value = [MTRAccessControlClusterAccessControlEntryChangedEvent new];
 
             do {
                 NSNumber * _Nullable memberValue;
@@ -247,8 +246,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRAccessControlClusterAccessControlExtensionChangedEvent * value =
-                [MTRAccessControlClusterAccessControlExtensionChangedEvent new];
+            __auto_type * value = [MTRAccessControlClusterAccessControlExtensionChangedEvent new];
 
             do {
                 NSNumber * _Nullable memberValue;
@@ -311,7 +309,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRActionsClusterStateChangedEvent * value = [MTRActionsClusterStateChangedEvent new];
+            __auto_type * value = [MTRActionsClusterStateChangedEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -339,7 +337,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRActionsClusterActionFailedEvent * value = [MTRActionsClusterActionFailedEvent new];
+            __auto_type * value = [MTRActionsClusterActionFailedEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -382,7 +380,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBasicClusterStartUpEvent * value = [MTRBasicClusterStartUpEvent new];
+            __auto_type * value = [MTRBasicClusterStartUpEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -400,7 +398,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBasicClusterShutDownEvent * value = [MTRBasicClusterShutDownEvent new];
+            __auto_type * value = [MTRBasicClusterShutDownEvent new];
 
             return value;
         }
@@ -412,7 +410,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBasicClusterLeaveEvent * value = [MTRBasicClusterLeaveEvent new];
+            __auto_type * value = [MTRBasicClusterLeaveEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -430,7 +428,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBasicClusterReachableChangedEvent * value = [MTRBasicClusterReachableChangedEvent new];
+            __auto_type * value = [MTRBasicClusterReachableChangedEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -468,8 +466,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent * value =
-                [MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent new];
+            __auto_type * value = [MTROTASoftwareUpdateRequestorClusterStateTransitionEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -506,8 +503,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent * value =
-                [MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent new];
+            __auto_type * value = [MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -530,8 +526,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent * value =
-                [MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent new];
+            __auto_type * value = [MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -662,8 +657,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent * value =
-                [MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent new];
+            __auto_type * value = [MTRGeneralDiagnosticsClusterHardwareFaultChangeEvent new];
 
             do {
                 NSArray * _Nonnull memberValue;
@@ -716,7 +710,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRGeneralDiagnosticsClusterRadioFaultChangeEvent * value = [MTRGeneralDiagnosticsClusterRadioFaultChangeEvent new];
+            __auto_type * value = [MTRGeneralDiagnosticsClusterRadioFaultChangeEvent new];
 
             do {
                 NSArray * _Nonnull memberValue;
@@ -769,7 +763,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRGeneralDiagnosticsClusterNetworkFaultChangeEvent * value = [MTRGeneralDiagnosticsClusterNetworkFaultChangeEvent new];
+            __auto_type * value = [MTRGeneralDiagnosticsClusterNetworkFaultChangeEvent new];
 
             do {
                 NSArray * _Nonnull memberValue;
@@ -822,7 +816,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRGeneralDiagnosticsClusterBootReasonEvent * value = [MTRGeneralDiagnosticsClusterBootReasonEvent new];
+            __auto_type * value = [MTRGeneralDiagnosticsClusterBootReasonEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -850,7 +844,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRSoftwareDiagnosticsClusterSoftwareFaultEvent * value = [MTRSoftwareDiagnosticsClusterSoftwareFaultEvent new];
+            __auto_type * value = [MTRSoftwareDiagnosticsClusterSoftwareFaultEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -899,8 +893,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRThreadNetworkDiagnosticsClusterConnectionStatusEvent * value =
-                [MTRThreadNetworkDiagnosticsClusterConnectionStatusEvent new];
+            __auto_type * value = [MTRThreadNetworkDiagnosticsClusterConnectionStatusEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -918,8 +911,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent * value =
-                [MTRThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent new];
+            __auto_type * value = [MTRThreadNetworkDiagnosticsClusterNetworkFaultChangeEvent new];
 
             do {
                 NSArray * _Nonnull memberValue;
@@ -982,7 +974,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRWiFiNetworkDiagnosticsClusterDisconnectionEvent * value = [MTRWiFiNetworkDiagnosticsClusterDisconnectionEvent new];
+            __auto_type * value = [MTRWiFiNetworkDiagnosticsClusterDisconnectionEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1000,8 +992,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRWiFiNetworkDiagnosticsClusterAssociationFailureEvent * value =
-                [MTRWiFiNetworkDiagnosticsClusterAssociationFailureEvent new];
+            __auto_type * value = [MTRWiFiNetworkDiagnosticsClusterAssociationFailureEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1024,8 +1015,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRWiFiNetworkDiagnosticsClusterConnectionStatusEvent * value =
-                [MTRWiFiNetworkDiagnosticsClusterConnectionStatusEvent new];
+            __auto_type * value = [MTRWiFiNetworkDiagnosticsClusterConnectionStatusEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1063,7 +1053,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBridgedDeviceBasicClusterStartUpEvent * value = [MTRBridgedDeviceBasicClusterStartUpEvent new];
+            __auto_type * value = [MTRBridgedDeviceBasicClusterStartUpEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1081,7 +1071,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBridgedDeviceBasicClusterShutDownEvent * value = [MTRBridgedDeviceBasicClusterShutDownEvent new];
+            __auto_type * value = [MTRBridgedDeviceBasicClusterShutDownEvent new];
 
             return value;
         }
@@ -1093,7 +1083,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBridgedDeviceBasicClusterLeaveEvent * value = [MTRBridgedDeviceBasicClusterLeaveEvent new];
+            __auto_type * value = [MTRBridgedDeviceBasicClusterLeaveEvent new];
 
             return value;
         }
@@ -1105,7 +1095,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBridgedDeviceBasicClusterReachableChangedEvent * value = [MTRBridgedDeviceBasicClusterReachableChangedEvent new];
+            __auto_type * value = [MTRBridgedDeviceBasicClusterReachableChangedEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1133,7 +1123,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRSwitchClusterSwitchLatchedEvent * value = [MTRSwitchClusterSwitchLatchedEvent new];
+            __auto_type * value = [MTRSwitchClusterSwitchLatchedEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1151,7 +1141,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRSwitchClusterInitialPressEvent * value = [MTRSwitchClusterInitialPressEvent new];
+            __auto_type * value = [MTRSwitchClusterInitialPressEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1169,7 +1159,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRSwitchClusterLongPressEvent * value = [MTRSwitchClusterLongPressEvent new];
+            __auto_type * value = [MTRSwitchClusterLongPressEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1187,7 +1177,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRSwitchClusterShortReleaseEvent * value = [MTRSwitchClusterShortReleaseEvent new];
+            __auto_type * value = [MTRSwitchClusterShortReleaseEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1205,7 +1195,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRSwitchClusterLongReleaseEvent * value = [MTRSwitchClusterLongReleaseEvent new];
+            __auto_type * value = [MTRSwitchClusterLongReleaseEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1223,7 +1213,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRSwitchClusterMultiPressOngoingEvent * value = [MTRSwitchClusterMultiPressOngoingEvent new];
+            __auto_type * value = [MTRSwitchClusterMultiPressOngoingEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1246,7 +1236,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRSwitchClusterMultiPressCompleteEvent * value = [MTRSwitchClusterMultiPressCompleteEvent new];
+            __auto_type * value = [MTRSwitchClusterMultiPressCompleteEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1329,7 +1319,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRBooleanStateClusterStateChangeEvent * value = [MTRBooleanStateClusterStateChangeEvent new];
+            __auto_type * value = [MTRBooleanStateClusterStateChangeEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1367,7 +1357,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRDoorLockClusterDoorLockAlarmEvent * value = [MTRDoorLockClusterDoorLockAlarmEvent new];
+            __auto_type * value = [MTRDoorLockClusterDoorLockAlarmEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1385,7 +1375,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRDoorLockClusterDoorStateChangeEvent * value = [MTRDoorLockClusterDoorStateChangeEvent new];
+            __auto_type * value = [MTRDoorLockClusterDoorStateChangeEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1403,7 +1393,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRDoorLockClusterLockOperationEvent * value = [MTRDoorLockClusterLockOperationEvent new];
+            __auto_type * value = [MTRDoorLockClusterLockOperationEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1484,7 +1474,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRDoorLockClusterLockOperationErrorEvent * value = [MTRDoorLockClusterLockOperationErrorEvent new];
+            __auto_type * value = [MTRDoorLockClusterLockOperationErrorEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1570,7 +1560,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRDoorLockClusterLockUserChangeEvent * value = [MTRDoorLockClusterLockUserChangeEvent new];
+            __auto_type * value = [MTRDoorLockClusterLockUserChangeEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -1664,8 +1654,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterSupplyVoltageLowEvent * value =
-                [MTRPumpConfigurationAndControlClusterSupplyVoltageLowEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterSupplyVoltageLowEvent new];
 
             return value;
         }
@@ -1677,8 +1666,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterSupplyVoltageHighEvent * value =
-                [MTRPumpConfigurationAndControlClusterSupplyVoltageHighEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterSupplyVoltageHighEvent new];
 
             return value;
         }
@@ -1690,8 +1678,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterPowerMissingPhaseEvent * value =
-                [MTRPumpConfigurationAndControlClusterPowerMissingPhaseEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterPowerMissingPhaseEvent new];
 
             return value;
         }
@@ -1703,8 +1690,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterSystemPressureLowEvent * value =
-                [MTRPumpConfigurationAndControlClusterSystemPressureLowEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterSystemPressureLowEvent new];
 
             return value;
         }
@@ -1716,8 +1702,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterSystemPressureHighEvent * value =
-                [MTRPumpConfigurationAndControlClusterSystemPressureHighEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterSystemPressureHighEvent new];
 
             return value;
         }
@@ -1729,8 +1714,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterDryRunningEvent * value =
-                [MTRPumpConfigurationAndControlClusterDryRunningEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterDryRunningEvent new];
 
             return value;
         }
@@ -1742,8 +1726,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterMotorTemperatureHighEvent * value =
-                [MTRPumpConfigurationAndControlClusterMotorTemperatureHighEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterMotorTemperatureHighEvent new];
 
             return value;
         }
@@ -1755,8 +1738,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent * value =
-                [MTRPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterPumpMotorFatalFailureEvent new];
 
             return value;
         }
@@ -1768,8 +1750,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterElectronicTemperatureHighEvent * value =
-                [MTRPumpConfigurationAndControlClusterElectronicTemperatureHighEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterElectronicTemperatureHighEvent new];
 
             return value;
         }
@@ -1781,8 +1762,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterPumpBlockedEvent * value =
-                [MTRPumpConfigurationAndControlClusterPumpBlockedEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterPumpBlockedEvent new];
 
             return value;
         }
@@ -1794,8 +1774,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterSensorFailureEvent * value =
-                [MTRPumpConfigurationAndControlClusterSensorFailureEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterSensorFailureEvent new];
 
             return value;
         }
@@ -1807,8 +1786,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent * value =
-                [MTRPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterElectronicNonFatalFailureEvent new];
 
             return value;
         }
@@ -1820,8 +1798,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterElectronicFatalFailureEvent * value =
-                [MTRPumpConfigurationAndControlClusterElectronicFatalFailureEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterElectronicFatalFailureEvent new];
 
             return value;
         }
@@ -1833,8 +1810,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterGeneralFaultEvent * value =
-                [MTRPumpConfigurationAndControlClusterGeneralFaultEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterGeneralFaultEvent new];
 
             return value;
         }
@@ -1846,7 +1822,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterLeakageEvent * value = [MTRPumpConfigurationAndControlClusterLeakageEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterLeakageEvent new];
 
             return value;
         }
@@ -1858,8 +1834,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterAirDetectionEvent * value =
-                [MTRPumpConfigurationAndControlClusterAirDetectionEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterAirDetectionEvent new];
 
             return value;
         }
@@ -1871,8 +1846,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRPumpConfigurationAndControlClusterTurbineOperationEvent * value =
-                [MTRPumpConfigurationAndControlClusterTurbineOperationEvent new];
+            __auto_type * value = [MTRPumpConfigurationAndControlClusterTurbineOperationEvent new];
 
             return value;
         }
@@ -2134,7 +2108,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRTestClusterClusterTestEventEvent * value = [MTRTestClusterClusterTestEventEvent new];
+            __auto_type * value = [MTRTestClusterClusterTestEventEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;
@@ -2227,7 +2201,7 @@ id MTRDecodeEventPayload(const ConcreteEventPath & aPath, TLV::TLVReader & aRead
                 return nil;
             }
 
-            MTRTestClusterClusterTestFabricScopedEventEvent * value = [MTRTestClusterClusterTestFabricScopedEventEvent new];
+            __auto_type * value = [MTRTestClusterClusterTestFabricScopedEventEvent new];
 
             do {
                 NSNumber * _Nonnull memberValue;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.h
@@ -180,7 +180,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
-@interface MTROtaSoftwareUpdateRequestorClusterProviderLocation : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateRequestorClusterProviderLocation : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull providerNodeID;
 @property (nonatomic, copy) NSNumber * _Nonnull endpoint;
 @property (nonatomic, copy) NSNumber * _Nonnull fabricIndex;
@@ -189,7 +189,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
-@interface MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateRequestorClusterStateTransitionEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull previousState;
 @property (nonatomic, copy, getter=getNewState) NSNumber * _Nonnull newState;
 @property (nonatomic, copy) NSNumber * _Nonnull reason;
@@ -199,7 +199,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
-@interface MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
 @property (nonatomic, copy) NSNumber * _Nonnull productID;
 
@@ -207,7 +207,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (id)copyWithZone:(NSZone * _Nullable)zone;
 @end
 
-@interface MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent : NSObject <NSCopying>
+@interface MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent : NSObject <NSCopying>
 @property (nonatomic, copy) NSNumber * _Nonnull softwareVersion;
 @property (nonatomic, copy) NSNumber * _Nonnull bytesDownloaded;
 @property (nonatomic, copy) NSNumber * _Nullable progressPercent;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRStructsObjc.mm
@@ -630,7 +630,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation MTROtaSoftwareUpdateRequestorClusterProviderLocation
+@implementation MTROTASoftwareUpdateRequestorClusterProviderLocation
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -646,7 +646,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone
 {
-    auto other = [[MTROtaSoftwareUpdateRequestorClusterProviderLocation alloc] init];
+    auto other = [[MTROTASoftwareUpdateRequestorClusterProviderLocation alloc] init];
 
     other.providerNodeID = self.providerNodeID;
     other.endpoint = self.endpoint;
@@ -664,7 +664,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent
+@implementation MTROTASoftwareUpdateRequestorClusterStateTransitionEvent
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -682,7 +682,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone
 {
-    auto other = [[MTROtaSoftwareUpdateRequestorClusterStateTransitionEvent alloc] init];
+    auto other = [[MTROTASoftwareUpdateRequestorClusterStateTransitionEvent alloc] init];
 
     other.previousState = self.previousState;
     other.newState = self.newState;
@@ -702,7 +702,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent
+@implementation MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -716,7 +716,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone
 {
-    auto other = [[MTROtaSoftwareUpdateRequestorClusterVersionAppliedEvent alloc] init];
+    auto other = [[MTROTASoftwareUpdateRequestorClusterVersionAppliedEvent alloc] init];
 
     other.softwareVersion = self.softwareVersion;
     other.productID = self.productID;
@@ -733,7 +733,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@implementation MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent
+@implementation MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent
 - (instancetype)init
 {
     if (self = [super init]) {
@@ -751,7 +751,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (id)copyWithZone:(NSZone * _Nullable)zone
 {
-    auto other = [[MTROtaSoftwareUpdateRequestorClusterDownloadErrorEvent alloc] init];
+    auto other = [[MTROTASoftwareUpdateRequestorClusterDownloadErrorEvent alloc] init];
 
     other.softwareVersion = self.softwareVersion;
     other.bytesDownloaded = self.bytesDownloaded;

--- a/src/darwin/Framework/CHIPTests/MTRTestOTAProvider.m
+++ b/src/darwin/Framework/CHIPTests/MTRTestOTAProvider.m
@@ -22,21 +22,21 @@
 @implementation MTRTestOTAProvider
 - (void)handleQueryImageForNodeID:(NSNumber *)nodeID
                        controller:(MTRDeviceController *)controller
-                           params:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
+                           params:(MTROTASoftwareUpdateProviderClusterQueryImageParams *)params
                        completion:(MTRQueryImageCompletionHandler)completion
 {
 }
 
 - (void)handleApplyUpdateRequestForNodeID:(NSNumber *)nodeID
                                controller:(MTRDeviceController *)controller
-                                   params:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
+                                   params:(MTROTASoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
                                completion:(MTRApplyUpdateRequestCompletionHandler)completion
 {
 }
 
 - (void)handleNotifyUpdateAppliedForNodeID:(NSNumber *)nodeID
                                 controller:(MTRDeviceController *)controller
-                                    params:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
+                                    params:(MTROTASoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                                 completion:(MTRStatusCompletion)completion
 {
 }


### PR DESCRIPTION
#### Issue Being Resolved

This PR fixes part 2 and 3 from #22545 and it relies on a zap update (notably https://github.com/project-chip/zap/pull/726)

#### Change overview
 * Update darwin and darwin-framework-tool templates to use the new option from `asUpperCamelCase` in order to not convert acronyms such as `ACL` to `Acl`.
 * Update generated code.