### PR TITLE
[darwin] Add cluster and commands description from XML into MTRBaseClusters.zapt

### DIFF
--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -14,7 +14,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster {{name}}
- *    {{description}}
+ * 
+ * {{description}}
  */
 @interface MTRBaseCluster{{asUpperCamelCase name}} : MTRCluster
 
@@ -23,6 +24,12 @@ NS_ASSUME_NONNULL_BEGIN
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
 {{#chip_cluster_commands}}
+
+/**
+ * Command {{name}}
+ *
+ * {{description}}
+ */
 - (void){{asLowerCamelCase name}}WithParams:(MTR{{asUpperCamelCase parent.name}}Cluster{{asUpperCamelCase name}}Params * {{#unless (commandHasRequiredField .)}}_Nullable{{/unless}})params completion:({{>command_completion_type command=.}})completion;
 {{#unless (hasArguments)}}
 - (void){{asLowerCamelCase name}}WithCompletion:({{>command_completion_type command=.}})completion;

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -27,6 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Identify
  *
+ * Attributes and commands for putting a device into Identification mode (e.g. flashing a light).
  */
 @interface MTRBaseClusterIdentify : MTRCluster
 
@@ -34,7 +35,18 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command Identify
+ *
+ * Command description for Identify
+ */
 - (void)identifyWithParams:(MTRIdentifyClusterIdentifyParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TriggerEffect
+ *
+ * Command description for TriggerEffect
+ */
 - (void)triggerEffectWithParams:(MTRIdentifyClusterTriggerEffectParams *)params completion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeIdentifyTimeWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -144,6 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Groups
  *
+ * Attributes and commands for group configuration and manipulation.
  */
 @interface MTRBaseClusterGroups : MTRCluster
 
@@ -151,20 +164,55 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command AddGroup
+ *
+ * Command description for AddGroup
+ */
 - (void)addGroupWithParams:(MTRGroupsClusterAddGroupParams *)params
                 completion:(void (^)(MTRGroupsClusterAddGroupResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command ViewGroup
+ *
+ * Command description for ViewGroup
+ */
 - (void)viewGroupWithParams:(MTRGroupsClusterViewGroupParams *)params
                  completion:
                      (void (^)(MTRGroupsClusterViewGroupResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command GetGroupMembership
+ *
+ * Command description for GetGroupMembership
+ */
 - (void)getGroupMembershipWithParams:(MTRGroupsClusterGetGroupMembershipParams *)params
                           completion:(void (^)(MTRGroupsClusterGetGroupMembershipResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion;
+
+/**
+ * Command RemoveGroup
+ *
+ * Command description for RemoveGroup
+ */
 - (void)removeGroupWithParams:(MTRGroupsClusterRemoveGroupParams *)params
                    completion:
                        (void (^)(MTRGroupsClusterRemoveGroupResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command RemoveAllGroups
+ *
+ * Command description for RemoveAllGroups
+ */
 - (void)removeAllGroupsWithParams:(MTRGroupsClusterRemoveAllGroupsParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion;
 - (void)removeAllGroupsWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command AddGroupIfIdentifying
+ *
+ * Command description for AddGroupIfIdentifying
+ */
 - (void)addGroupIfIdentifyingWithParams:(MTRGroupsClusterAddGroupIfIdentifyingParams *)params
                              completion:(MTRStatusCompletion)completion;
 
@@ -258,6 +306,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Scenes
  *
+ * Attributes and commands for scene configuration and manipulation.
  */
 @interface MTRBaseClusterScenes : MTRCluster
 
@@ -265,30 +314,93 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command AddScene
+ *
+ * Add a scene to the scene table. Extension field sets are supported, and are inputed as '{"ClusterID": VALUE,
+ * "AttributeValueList":[{"AttributeId": VALUE, "AttributeValue": VALUE}]}'
+ */
 - (void)addSceneWithParams:(MTRScenesClusterAddSceneParams *)params
                 completion:(void (^)(MTRScenesClusterAddSceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command ViewScene
+ *
+ * Retrieves the requested scene entry from its Scene table.
+ */
 - (void)viewSceneWithParams:(MTRScenesClusterViewSceneParams *)params
                  completion:
                      (void (^)(MTRScenesClusterViewSceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command RemoveScene
+ *
+ * Removes the requested scene entry, corresponding to the value of the GroupID field, from its Scene Table
+ */
 - (void)removeSceneWithParams:(MTRScenesClusterRemoveSceneParams *)params
                    completion:
                        (void (^)(MTRScenesClusterRemoveSceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command RemoveAllScenes
+ *
+ * Remove all scenes, corresponding to the value of the GroupID field, from its Scene Table
+ */
 - (void)removeAllScenesWithParams:(MTRScenesClusterRemoveAllScenesParams *)params
                        completion:(void (^)(MTRScenesClusterRemoveAllScenesResponseParams * _Nullable data,
                                       NSError * _Nullable error))completion;
+
+/**
+ * Command StoreScene
+ *
+ * Adds the scene entry into its Scene Table along with all extension field sets corresponding to the current state of other
+ * clusters on the same endpoint
+ */
 - (void)storeSceneWithParams:(MTRScenesClusterStoreSceneParams *)params
                   completion:
                       (void (^)(MTRScenesClusterStoreSceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command RecallScene
+ *
+ * Set the attributes and corresponding state for each other cluster implemented on the endpoint accordingly to the resquested scene
+ * entry in the Scene Table
+ */
 - (void)recallSceneWithParams:(MTRScenesClusterRecallSceneParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GetSceneMembership
+ *
+ * Get an unused scene identifier when no commissioning tool is in the network, or for a commissioning tool to get the used scene
+ * identifiers within a certain group
+ */
 - (void)getSceneMembershipWithParams:(MTRScenesClusterGetSceneMembershipParams *)params
                           completion:(void (^)(MTRScenesClusterGetSceneMembershipResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion;
+
+/**
+ * Command EnhancedAddScene
+ *
+ * Allows a scene to be added using a finer scene transition time than the AddScene command.
+ */
 - (void)enhancedAddSceneWithParams:(MTRScenesClusterEnhancedAddSceneParams *)params
                         completion:(void (^)(MTRScenesClusterEnhancedAddSceneResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion;
+
+/**
+ * Command EnhancedViewScene
+ *
+ * Allows a scene to be retrieved using a finer scene transition time than the ViewScene command
+ */
 - (void)enhancedViewSceneWithParams:(MTRScenesClusterEnhancedViewSceneParams *)params
                          completion:(void (^)(MTRScenesClusterEnhancedViewSceneResponseParams * _Nullable data,
                                         NSError * _Nullable error))completion;
+
+/**
+ * Command CopyScene
+ *
+ * Allows a client to efficiently copy scenes from one group/scene identifier pair to another group/scene identifier pair.
+ */
 - (void)copySceneWithParams:(MTRScenesClusterCopySceneParams *)params
                  completion:
                      (void (^)(MTRScenesClusterCopySceneResponseParams * _Nullable data, NSError * _Nullable error))completion;
@@ -448,6 +560,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster On/Off
  *
+ * Attributes and commands for switching devices between 'On' and 'Off' states.
  */
 @interface MTRBaseClusterOnOff : MTRCluster
 
@@ -455,16 +568,59 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command Off
+ *
+ * On receipt of this command, a device SHALL enter its ‘Off’ state. This state is device dependent, but it is recommended that it
+ * is used for power off or similar functions. On receipt of the Off command, the OnTime attribute SHALL be set to 0.
+ */
 - (void)offWithParams:(MTROnOffClusterOffParams * _Nullable)params completion:(MTRStatusCompletion)completion;
 - (void)offWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command On
+ *
+ * On receipt of this command, a device SHALL enter its ‘On’ state. This state is device dependent, but it is recommended that it is
+ * used for power on or similar functions. On receipt of the On command, if the value of the OnTime attribute is equal to 0, the
+ * device SHALL set the OffWaitTime attribute to 0.
+ */
 - (void)onWithParams:(MTROnOffClusterOnParams * _Nullable)params completion:(MTRStatusCompletion)completion;
 - (void)onWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command Toggle
+ *
+ * On receipt of this command, if a device is in its ‘Off’ state it SHALL enter its ‘On’ state. Otherwise, if it is in its ‘On’
+ * state it SHALL enter its ‘Off’ state. On receipt of the Toggle command, if the value of the OnOff attribute is equal to FALSE and
+ * if the value of the OnTime attribute is equal to 0, the device SHALL set the OffWaitTime attribute to 0. If the value of the
+ * OnOff attribute is equal to TRUE, the OnTime attribute SHALL be set to 0.
+ */
 - (void)toggleWithParams:(MTROnOffClusterToggleParams * _Nullable)params completion:(MTRStatusCompletion)completion;
 - (void)toggleWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command OffWithEffect
+ *
+ * The OffWithEffect command allows devices to be turned off using enhanced ways of fading.
+ */
 - (void)offWithEffectWithParams:(MTROnOffClusterOffWithEffectParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command OnWithRecallGlobalScene
+ *
+ * The OnWithRecallGlobalScene command allows the recall of the settings when the device was turned off.
+ */
 - (void)onWithRecallGlobalSceneWithParams:(MTROnOffClusterOnWithRecallGlobalSceneParams * _Nullable)params
                                completion:(MTRStatusCompletion)completion;
 - (void)onWithRecallGlobalSceneWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command OnWithTimedOff
+ *
+ * The OnWithTimedOff command allows devices to be turned on for a specific duration with a guarded off duration so that SHOULD the
+ * device be subsequently switched off, further OnWithTimedOff commands, received during this time, are prevented from turning the
+ * devices back on.
+ */
 - (void)onWithTimedOffWithParams:(MTROnOffClusterOnWithTimedOffParams *)params completion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeOnOffWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -623,6 +779,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster On/off Switch Configuration
  *
+ * Attributes and commands for configuring On/Off switching devices.
  */
 @interface MTRBaseClusterOnOffSwitchConfiguration : MTRCluster
 
@@ -737,6 +894,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Level Control
  *
+ * Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'
  */
 @interface MTRBaseClusterLevelControl : MTRCluster
 
@@ -744,15 +902,69 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command MoveToLevel
+ *
+ * Command description for MoveToLevel
+ */
 - (void)moveToLevelWithParams:(MTRLevelControlClusterMoveToLevelParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command Move
+ *
+ * Command description for Move
+ */
 - (void)moveWithParams:(MTRLevelControlClusterMoveParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command Step
+ *
+ * Command description for Step
+ */
 - (void)stepWithParams:(MTRLevelControlClusterStepParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command Stop
+ *
+ * Command description for Stop
+ */
 - (void)stopWithParams:(MTRLevelControlClusterStopParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveToLevelWithOnOff
+ *
+ * Command description for MoveToLevelWithOnOff
+ */
 - (void)moveToLevelWithOnOffWithParams:(MTRLevelControlClusterMoveToLevelWithOnOffParams *)params
                             completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveWithOnOff
+ *
+ * Command description for MoveWithOnOff
+ */
 - (void)moveWithOnOffWithParams:(MTRLevelControlClusterMoveWithOnOffParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StepWithOnOff
+ *
+ * Command description for StepWithOnOff
+ */
 - (void)stepWithOnOffWithParams:(MTRLevelControlClusterStepWithOnOffParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StopWithOnOff
+ *
+ * Command description for StopWithOnOff
+ */
 - (void)stopWithOnOffWithParams:(MTRLevelControlClusterStopWithOnOffParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveToClosestFrequency
+ *
+ * Change the currrent frequency to the provided one, or a close
+        approximation if the exact provided one is not possible.
+ */
 - (void)moveToClosestFrequencyWithParams:(MTRLevelControlClusterMoveToClosestFrequencyParams *)params
                               completion:(MTRStatusCompletion)completion;
 
@@ -1049,6 +1261,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Binary Input (Basic)
  *
+ * An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
  */
 @interface MTRBaseClusterBinaryInputBasic : MTRCluster
 
@@ -1274,6 +1487,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Descriptor
  *
+ * The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints
+ * and clusters.
  */
 @interface MTRBaseClusterDescriptor : MTRCluster
 
@@ -1410,6 +1625,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Binding
  *
+ * The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
  */
 @interface MTRBaseClusterBinding : MTRCluster
 
@@ -1512,6 +1728,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Access Control
  *
+ * The Access Control Cluster exposes a data model view of a
+      Node's Access Control List (ACL), which codifies the rules used to manage
+      and enforce Access Control for the Node's endpoints and their associated
+      cluster instances.
  */
 @interface MTRBaseClusterAccessControl : MTRCluster
 
@@ -1683,6 +1903,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Actions
  *
+ * This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
  */
 @interface MTRBaseClusterActions : MTRCluster
 
@@ -1690,21 +1911,93 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command InstantAction
+ *
+ * This command triggers an action (state change) on the involved endpoints.
+ */
 - (void)instantActionWithParams:(MTRActionsClusterInstantActionParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command InstantActionWithTransition
+ *
+ * This command triggers an action (state change) on the involved endpoints, with a specified time to transition from the current
+ * state to the new state.
+ */
 - (void)instantActionWithTransitionWithParams:(MTRActionsClusterInstantActionWithTransitionParams *)params
                                    completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StartAction
+ *
+ * This command triggers the commencement of an action on the involved endpoints.
+ */
 - (void)startActionWithParams:(MTRActionsClusterStartActionParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StartActionWithDuration
+ *
+ * This command triggers the commencement of an action (with a duration) on the involved endpoints.
+ */
 - (void)startActionWithDurationWithParams:(MTRActionsClusterStartActionWithDurationParams *)params
                                completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StopAction
+ *
+ * This command stops the ongoing action on the involved endpoints.
+ */
 - (void)stopActionWithParams:(MTRActionsClusterStopActionParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command PauseAction
+ *
+ * This command pauses an ongoing action.
+ */
 - (void)pauseActionWithParams:(MTRActionsClusterPauseActionParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command PauseActionWithDuration
+ *
+ * This command pauses an ongoing action with a duration.
+ */
 - (void)pauseActionWithDurationWithParams:(MTRActionsClusterPauseActionWithDurationParams *)params
                                completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command ResumeAction
+ *
+ * This command resumes a previously paused action.
+ */
 - (void)resumeActionWithParams:(MTRActionsClusterResumeActionParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command EnableAction
+ *
+ * This command enables a certain action or automation.
+ */
 - (void)enableActionWithParams:(MTRActionsClusterEnableActionParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command EnableActionWithDuration
+ *
+ * This command enables a certain action or automation with a duration.
+ */
 - (void)enableActionWithDurationWithParams:(MTRActionsClusterEnableActionWithDurationParams *)params
                                 completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command DisableAction
+ *
+ * This command disables a certain action or automation.
+ */
 - (void)disableActionWithParams:(MTRActionsClusterDisableActionParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command DisableActionWithDuration
+ *
+ * This command disables a certain action or automation with a duration.
+ */
 - (void)disableActionWithDurationWithParams:(MTRActionsClusterDisableActionWithDurationParams *)params
                                  completion:(MTRStatusCompletion)completion;
 
@@ -1824,6 +2117,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Basic
  *
+ * This cluster provides attributes and events for determining basic information about Nodes, which supports both
+      Commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
+      which apply to the whole Node. Also allows setting user device information such as location.
  */
 @interface MTRBaseClusterBasic : MTRCluster
 
@@ -1831,6 +2127,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command MfgSpecificPing
+ *
+ *
+ */
 - (void)mfgSpecificPingWithParams:(MTRBasicClusterMfgSpecificPingParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion;
 - (void)mfgSpecificPingWithCompletion:(MTRStatusCompletion)completion;
@@ -2199,6 +2500,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster OTA Software Update Provider
  *
+ * Provides an interface for providing OTA software updates
  */
 @interface MTRBaseClusterOtaSoftwareUpdateProvider : MTRCluster
 
@@ -2206,12 +2508,29 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command QueryImage
+ *
+ * Determine availability of a new Software Image
+ */
 - (void)queryImageWithParams:(MTROtaSoftwareUpdateProviderClusterQueryImageParams *)params
                   completion:(void (^)(MTROtaSoftwareUpdateProviderClusterQueryImageResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion;
+
+/**
+ * Command ApplyUpdateRequest
+ *
+ * Determine next action to take for a downloaded Software Image
+ */
 - (void)applyUpdateRequestWithParams:(MTROtaSoftwareUpdateProviderClusterApplyUpdateRequestParams *)params
                           completion:(void (^)(MTROtaSoftwareUpdateProviderClusterApplyUpdateResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion;
+
+/**
+ * Command NotifyUpdateApplied
+ *
+ * Notify OTA Provider that an update was applied
+ */
 - (void)notifyUpdateAppliedWithParams:(MTROtaSoftwareUpdateProviderClusterNotifyUpdateAppliedParams *)params
                            completion:(MTRStatusCompletion)completion;
 
@@ -2292,6 +2611,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster OTA Software Update Requestor
  *
+ * Provides an interface for downloading and applying OTA software updates
  */
 @interface MTRBaseClusterOtaSoftwareUpdateRequestor : MTRCluster
 
@@ -2299,6 +2619,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command AnnounceOtaProvider
+ *
+ * Announce the presence of an OTA Provider
+ */
 - (void)announceOtaProviderWithParams:(MTROtaSoftwareUpdateRequestorClusterAnnounceOtaProviderParams *)params
                            completion:(MTRStatusCompletion)completion;
 
@@ -2440,6 +2765,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Localization Configuration
  *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing common languages, units of measurements, and numerical formatting
+      standards. As such, Nodes that visually or audibly convey information need a mechanism by which
+      they can be configured to use a user’s preferred language, units, etc
  */
 @interface MTRBaseClusterLocalizationConfiguration : MTRCluster
 
@@ -2554,6 +2883,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Time Format Localization
  *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
+      or audibly convey time information need a mechanism by which they can be configured to use a
+      user’s preferred format.
  */
 @interface MTRBaseClusterTimeFormatLocalization : MTRCluster
 
@@ -2690,6 +3023,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Unit Localization
  *
+ * Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing preferences for the units in which values are conveyed in communication to a
+      user. As such, Nodes that visually or audibly convey measurable values to the user need a
+      mechanism by which they can be configured to use a user’s preferred unit.
  */
 @interface MTRBaseClusterUnitLocalization : MTRCluster
 
@@ -2791,6 +3128,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Power Source Configuration
  *
+ * This cluster is used to describe the configuration and capabilities of a Device's power system.
  */
 @interface MTRBaseClusterPowerSourceConfiguration : MTRCluster
 
@@ -2888,6 +3226,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Power Source
  *
+ * This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the Node.
  */
 @interface MTRBaseClusterPowerSource : MTRCluster
 
@@ -3413,6 +3752,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster General Commissioning
  *
+ * This cluster is used to manage global aspects of the Commissioning flow.
  */
 @interface MTRBaseClusterGeneralCommissioning : MTRCluster
 
@@ -3420,12 +3760,30 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command ArmFailSafe
+ *
+ * Arm the persistent fail-safe timer with an expiry time of now + ExpiryLengthSeconds using device clock
+ */
 - (void)armFailSafeWithParams:(MTRGeneralCommissioningClusterArmFailSafeParams *)params
                    completion:(void (^)(MTRGeneralCommissioningClusterArmFailSafeResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion;
+
+/**
+ * Command SetRegulatoryConfig
+ *
+ * Set the regulatory configuration to be used during commissioning
+ */
 - (void)setRegulatoryConfigWithParams:(MTRGeneralCommissioningClusterSetRegulatoryConfigParams *)params
                            completion:(void (^)(MTRGeneralCommissioningClusterSetRegulatoryConfigResponseParams * _Nullable data,
                                           NSError * _Nullable error))completion;
+
+/**
+ * Command CommissioningComplete
+ *
+ * Signals the Server that the Client has successfully completed all steps of Commissioning/Recofiguration needed during fail-safe
+ * period.
+ */
 - (void)commissioningCompleteWithParams:(MTRGeneralCommissioningClusterCommissioningCompleteParams * _Nullable)params
                              completion:
                                  (void (^)(MTRGeneralCommissioningClusterCommissioningCompleteResponseParams * _Nullable data,
@@ -3592,6 +3950,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Network Commissioning
  *
+ * Functionality to configure, enable, disable network credentials and access on a Matter device.
  */
 @interface MTRBaseClusterNetworkCommissioning : MTRCluster
 
@@ -3599,21 +3958,56 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command ScanNetworks
+ *
+ * Detemine the set of networks the device sees as available.
+ */
 - (void)scanNetworksWithParams:(MTRNetworkCommissioningClusterScanNetworksParams * _Nullable)params
                     completion:(void (^)(MTRNetworkCommissioningClusterScanNetworksResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion;
+
+/**
+ * Command AddOrUpdateWiFiNetwork
+ *
+ * Add or update the credentials for a given Wi-Fi network.
+ */
 - (void)addOrUpdateWiFiNetworkWithParams:(MTRNetworkCommissioningClusterAddOrUpdateWiFiNetworkParams *)params
                               completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                              NSError * _Nullable error))completion;
+
+/**
+ * Command AddOrUpdateThreadNetwork
+ *
+ * Add or update the credentials for a given Thread network.
+ */
 - (void)addOrUpdateThreadNetworkWithParams:(MTRNetworkCommissioningClusterAddOrUpdateThreadNetworkParams *)params
                                 completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                                NSError * _Nullable error))completion;
+
+/**
+ * Command RemoveNetwork
+ *
+ * Remove the definition of a given network (including its credentials).
+ */
 - (void)removeNetworkWithParams:(MTRNetworkCommissioningClusterRemoveNetworkParams *)params
                      completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion;
+
+/**
+ * Command ConnectNetwork
+ *
+ * Connect to the specified network, using previously-defined credentials.
+ */
 - (void)connectNetworkWithParams:(MTRNetworkCommissioningClusterConnectNetworkParams *)params
                       completion:(void (^)(MTRNetworkCommissioningClusterConnectNetworkResponseParams * _Nullable data,
                                      NSError * _Nullable error))completion;
+
+/**
+ * Command ReorderNetwork
+ *
+ * Modify the order in which networks will be presented in the Networks attribute.
+ */
 - (void)reorderNetworkWithParams:(MTRNetworkCommissioningClusterReorderNetworkParams *)params
                       completion:(void (^)(MTRNetworkCommissioningClusterNetworkConfigResponseParams * _Nullable data,
                                      NSError * _Nullable error))completion;
@@ -3813,6 +4207,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Diagnostic Logs
  *
+ * The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
  */
 @interface MTRBaseClusterDiagnosticLogs : MTRCluster
 
@@ -3820,6 +4215,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command RetrieveLogsRequest
+ *
+ * Retrieving diagnostic logs from a Node
+ */
 - (void)retrieveLogsRequestWithParams:(MTRDiagnosticLogsClusterRetrieveLogsRequestParams *)params
                            completion:(void (^)(MTRDiagnosticLogsClusterRetrieveLogsResponseParams * _Nullable data,
                                           NSError * _Nullable error))completion;
@@ -3901,6 +4301,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster General Diagnostics
  *
+ * The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics
+ * metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterGeneralDiagnostics : MTRCluster
 
@@ -3908,6 +4310,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command TestEventTrigger
+ *
+ * Provide a means for certification tests to trigger some test-plan-specific events
+ */
 - (void)testEventTriggerWithParams:(MTRGeneralDiagnosticsClusterTestEventTriggerParams *)params
                         completion:(MTRStatusCompletion)completion;
 
@@ -4115,6 +4522,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Software Diagnostics
  *
+ * The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterSoftwareDiagnostics : MTRCluster
 
@@ -4122,6 +4531,12 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command ResetWatermarks
+ *
+ * Reception of this command SHALL reset the values: The StackFreeMinimum field of the ThreadMetrics attribute,
+ * CurrentHeapHighWaterMark attribute.
+ */
 - (void)resetWatermarksWithParams:(MTRSoftwareDiagnosticsClusterResetWatermarksParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion;
 - (void)resetWatermarksWithCompletion:(MTRStatusCompletion)completion;
@@ -4258,6 +4673,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Thread Network Diagnostics
  *
+ * The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems
  */
 @interface MTRBaseClusterThreadNetworkDiagnostics : MTRCluster
 
@@ -4265,6 +4682,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the OverrunCount attributes to 0
+ */
 - (void)resetCountsWithParams:(MTRThreadNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion;
@@ -5231,6 +5653,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster WiFi Network Diagnostics
  *
+ * The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterWiFiNetworkDiagnostics : MTRCluster
 
@@ -5238,6 +5662,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the Breacon and Packet related count attributes to 0
+ */
 - (void)resetCountsWithParams:(MTRWiFiNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion;
@@ -5498,6 +5927,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Ethernet Network Diagnostics
  *
+ * The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
+ * to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRBaseClusterEthernetNetworkDiagnostics : MTRCluster
 
@@ -5505,6 +5936,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command ResetCounts
+ *
+ * Reception of this command SHALL reset the attributes: PacketRxCount, PacketTxCount, TxErrCount, CollisionCount, OverrunCount to 0
+ */
 - (void)resetCountsWithParams:(MTREthernetNetworkDiagnosticsClusterResetCountsParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion;
 - (void)resetCountsWithCompletion:(MTRStatusCompletion)completion;
@@ -5703,6 +6139,10 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Bridged Device Basic
  *
+ * This Cluster serves two purposes towards a Node communicating with a Bridge: indicate that the functionality on
+          the Endpoint where it is placed (and its Parts) is bridged from a non-CHIP technology; and provide a centralized
+          collection of attributes that the Node MAY collect to aid in conveying information regarding the Bridged Device to a user,
+          such as the vendor name, the model name, or user-assigned name.
  */
 @interface MTRBaseClusterBridgedDeviceBasic : MTRCluster
 
@@ -5994,6 +6434,12 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Switch
  *
+ * This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
+Two types of switch devices are supported: latching switch (e.g. rocker switch) and momentary switch (e.g. push button),
+distinguished with their feature flags. Interactions with the switch device are exposed as attributes (for the latching switch) and
+as events (for both types of switches). An interested party MAY subscribe to these attributes/events and thus be informed of the
+interactions, and can perform actions based on this, for example by sending commands to perform an action such as controlling a
+light or a window shade.
  */
 @interface MTRBaseClusterSwitch : MTRCluster
 
@@ -6119,6 +6565,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster AdministratorCommissioning
  *
+ * Commands to trigger a Node to allow a new Administrator to commission it.
  */
 @interface MTRBaseClusterAdministratorCommissioning : MTRCluster
 
@@ -6126,10 +6573,30 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command OpenCommissioningWindow
+ *
+ * This command is used by a current Administrator to instruct a Node to go into commissioning mode using enhanced commissioning
+ * method.
+ */
 - (void)openCommissioningWindowWithParams:(MTRAdministratorCommissioningClusterOpenCommissioningWindowParams *)params
                                completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command OpenBasicCommissioningWindow
+ *
+ * This command is used by a current Administrator to instruct a Node to go into commissioning mode using basic commissioning
+ * method, if the node supports it.
+ */
 - (void)openBasicCommissioningWindowWithParams:(MTRAdministratorCommissioningClusterOpenBasicCommissioningWindowParams *)params
                                     completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command RevokeCommissioning
+ *
+ * This command is used by a current Administrator to instruct a Node to revoke any active Open Commissioning Window or Open Basic
+ * Commissioning Window command.
+ */
 - (void)revokeCommissioningWithParams:(MTRAdministratorCommissioningClusterRevokeCommissioningParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion;
 - (void)revokeCommissioningWithCompletion:(MTRStatusCompletion)completion;
@@ -6250,6 +6717,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Operational Credentials
  *
+ * This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated
+ * Fabrics.
  */
 @interface MTRBaseClusterOperationalCredentials : MTRCluster
 
@@ -6257,27 +6726,75 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command AttestationRequest
+ *
+ * Sender is requesting attestation information from the receiver.
+ */
 - (void)attestationRequestWithParams:(MTROperationalCredentialsClusterAttestationRequestParams *)params
                           completion:(void (^)(MTROperationalCredentialsClusterAttestationResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion;
+
+/**
+ * Command CertificateChainRequest
+ *
+ * Sender is requesting a device attestation certificate from the receiver.
+ */
 - (void)certificateChainRequestWithParams:(MTROperationalCredentialsClusterCertificateChainRequestParams *)params
                                completion:(void (^)(MTROperationalCredentialsClusterCertificateChainResponseParams * _Nullable data,
                                               NSError * _Nullable error))completion;
+
+/**
+ * Command CSRRequest
+ *
+ * Sender is requesting a certificate signing request (CSR) from the receiver.
+ */
 - (void)CSRRequestWithParams:(MTROperationalCredentialsClusterCSRRequestParams *)params
                   completion:(void (^)(MTROperationalCredentialsClusterCSRResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion;
+
+/**
+ * Command AddNOC
+ *
+ * Sender is requesting to add the new node operational certificates.
+ */
 - (void)addNOCWithParams:(MTROperationalCredentialsClusterAddNOCParams *)params
               completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
                              NSError * _Nullable error))completion;
+
+/**
+ * Command UpdateNOC
+ *
+ * Sender is requesting to update the node operational certificates.
+ */
 - (void)updateNOCWithParams:(MTROperationalCredentialsClusterUpdateNOCParams *)params
                  completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion;
+
+/**
+ * Command UpdateFabricLabel
+ *
+ * This command SHALL be used by an Administrative Node to set the user-visible Label field for a given Fabric, as reflected by
+ * entries in the Fabrics attribute.
+ */
 - (void)updateFabricLabelWithParams:(MTROperationalCredentialsClusterUpdateFabricLabelParams *)params
                          completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
                                         NSError * _Nullable error))completion;
+
+/**
+ * Command RemoveFabric
+ *
+ * This command is used by Administrative Nodes to remove a given fabric index and delete all associated fabric-scoped data.
+ */
 - (void)removeFabricWithParams:(MTROperationalCredentialsClusterRemoveFabricParams *)params
                     completion:(void (^)(MTROperationalCredentialsClusterNOCResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion;
+
+/**
+ * Command AddTrustedRootCertificate
+ *
+ * This command SHALL add a Trusted Root CA Certificate, provided as its CHIP Certificate representation.
+ */
 - (void)addTrustedRootCertificateWithParams:(MTROperationalCredentialsClusterAddTrustedRootCertificateParams *)params
                                  completion:(MTRStatusCompletion)completion;
 
@@ -6445,6 +6962,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Group Key Management
  *
+ * The Group Key Management Cluster is the mechanism by which group keys are managed.
  */
 @interface MTRBaseClusterGroupKeyManagement : MTRCluster
 
@@ -6452,11 +6970,34 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command KeySetWrite
+ *
+ * Revoke a Root Key from a Group
+ */
 - (void)keySetWriteWithParams:(MTRGroupKeyManagementClusterKeySetWriteParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command KeySetRead
+ *
+ * Revoke a Root Key from a Group
+ */
 - (void)keySetReadWithParams:(MTRGroupKeyManagementClusterKeySetReadParams *)params
                   completion:(void (^)(MTRGroupKeyManagementClusterKeySetReadResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion;
+
+/**
+ * Command KeySetRemove
+ *
+ * Revoke a Root Key from a Group
+ */
 - (void)keySetRemoveWithParams:(MTRGroupKeyManagementClusterKeySetRemoveParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command KeySetReadAllIndices
+ *
+ * Return the list of Group Key Sets associated with the accessing fabric
+ */
 - (void)keySetReadAllIndicesWithParams:(MTRGroupKeyManagementClusterKeySetReadAllIndicesParams *)params
                             completion:(void (^)(MTRGroupKeyManagementClusterKeySetReadAllIndicesResponseParams * _Nullable data,
                                            NSError * _Nullable error))completion;
@@ -6601,6 +7142,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Fixed Label
  *
+ * The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
+labels.
  */
 @interface MTRBaseClusterFixedLabel : MTRCluster
 
@@ -6698,6 +7241,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster User Label
  *
+ * The User Label Cluster provides a feature to tag an endpoint with zero or more labels.
  */
 @interface MTRBaseClusterUserLabel : MTRCluster
 
@@ -6799,6 +7343,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Boolean State
  *
+ * This cluster provides an interface to a boolean state called StateValue.
  */
 @interface MTRBaseClusterBooleanState : MTRCluster
 
@@ -6896,6 +7441,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Mode Select
  *
+ * Attributes and commands for selecting a mode from a list of supported options.
  */
 @interface MTRBaseClusterModeSelect : MTRCluster
 
@@ -6903,6 +7449,12 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command ChangeToMode
+ *
+ * On receipt of this command, if the NewMode field matches the Mode field in an entry of the SupportedModes list, the server SHALL
+ * set the CurrentMode attribute to the NewMode value, otherwise, the server SHALL respond with an INVALID_COMMAND status response.
+ */
 - (void)changeToModeWithParams:(MTRModeSelectClusterChangeToModeParams *)params completion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeDescriptionWithCompletion:(void (^)(NSString * _Nullable value, NSError * _Nullable error))completion;
@@ -7070,6 +7622,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Door Lock
  *
+ * An interface to a generic way to secure a door
  */
 @interface MTRBaseClusterDoorLock : MTRCluster
 
@@ -7077,40 +7630,147 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command LockDoor
+ *
+ * This command causes the lock device to lock the door.
+ */
 - (void)lockDoorWithParams:(MTRDoorLockClusterLockDoorParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command UnlockDoor
+ *
+ * This command causes the lock device to unlock the door.
+ */
 - (void)unlockDoorWithParams:(MTRDoorLockClusterUnlockDoorParams * _Nullable)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command UnlockWithTimeout
+ *
+ * This command causes the lock device to unlock the door with a timeout parameter.
+ */
 - (void)unlockWithTimeoutWithParams:(MTRDoorLockClusterUnlockWithTimeoutParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command SetWeekDaySchedule
+ *
+ * Set a weekly repeating schedule for a specified user.
+ */
 - (void)setWeekDayScheduleWithParams:(MTRDoorLockClusterSetWeekDayScheduleParams *)params
                           completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GetWeekDaySchedule
+ *
+ * Retrieve the specific weekly schedule for the specific user.
+ */
 - (void)getWeekDayScheduleWithParams:(MTRDoorLockClusterGetWeekDayScheduleParams *)params
                           completion:(void (^)(MTRDoorLockClusterGetWeekDayScheduleResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion;
+
+/**
+ * Command ClearWeekDaySchedule
+ *
+ * Clear the specific weekly schedule or all weekly schedules for the specific user.
+ */
 - (void)clearWeekDayScheduleWithParams:(MTRDoorLockClusterClearWeekDayScheduleParams *)params
                             completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command SetYearDaySchedule
+ *
+ * Set a time-specific schedule ID for a specified user.
+ */
 - (void)setYearDayScheduleWithParams:(MTRDoorLockClusterSetYearDayScheduleParams *)params
                           completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GetYearDaySchedule
+ *
+ * Returns the year day schedule data for the specified schedule and user indexes.
+ */
 - (void)getYearDayScheduleWithParams:(MTRDoorLockClusterGetYearDayScheduleParams *)params
                           completion:(void (^)(MTRDoorLockClusterGetYearDayScheduleResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion;
+
+/**
+ * Command ClearYearDaySchedule
+ *
+ * Clears the specific year day schedule or all year day schedules for the specific user.
+ */
 - (void)clearYearDayScheduleWithParams:(MTRDoorLockClusterClearYearDayScheduleParams *)params
                             completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command SetHolidaySchedule
+ *
+ * Set the holiday Schedule by specifying local start time and local end time with respect to any Lock Operating Mode.
+ */
 - (void)setHolidayScheduleWithParams:(MTRDoorLockClusterSetHolidayScheduleParams *)params
                           completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GetHolidaySchedule
+ *
+ * Get the holiday schedule for the specified index.
+ */
 - (void)getHolidayScheduleWithParams:(MTRDoorLockClusterGetHolidayScheduleParams *)params
                           completion:(void (^)(MTRDoorLockClusterGetHolidayScheduleResponseParams * _Nullable data,
                                          NSError * _Nullable error))completion;
+
+/**
+ * Command ClearHolidaySchedule
+ *
+ * Clears the holiday schedule or all holiday schedules.
+ */
 - (void)clearHolidayScheduleWithParams:(MTRDoorLockClusterClearHolidayScheduleParams *)params
                             completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command SetUser
+ *
+ * Set User into the lock.
+ */
 - (void)setUserWithParams:(MTRDoorLockClusterSetUserParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GetUser
+ *
+ * Retrieve User.
+ */
 - (void)getUserWithParams:(MTRDoorLockClusterGetUserParams *)params
                completion:(void (^)(MTRDoorLockClusterGetUserResponseParams * _Nullable data, NSError * _Nullable error))completion;
+
+/**
+ * Command ClearUser
+ *
+ * Clears a User or all Users.
+ */
 - (void)clearUserWithParams:(MTRDoorLockClusterClearUserParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command SetCredential
+ *
+ * Set a credential (e.g. PIN, RFID, Fingerprint, etc.) into the lock for a new user, existing user, or ProgrammingUser.
+ */
 - (void)setCredentialWithParams:(MTRDoorLockClusterSetCredentialParams *)params
                      completion:(void (^)(MTRDoorLockClusterSetCredentialResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion;
+
+/**
+ * Command GetCredentialStatus
+ *
+ * Retrieve the status of a particular credential (e.g. PIN, RFID, Fingerprint, etc.) by index.
+ */
 - (void)getCredentialStatusWithParams:(MTRDoorLockClusterGetCredentialStatusParams *)params
                            completion:(void (^)(MTRDoorLockClusterGetCredentialStatusResponseParams * _Nullable data,
                                           NSError * _Nullable error))completion;
+
+/**
+ * Command ClearCredential
+ *
+ * Clear one, one type, or all credentials except ProgrammingPIN credential.
+ */
 - (void)clearCredentialWithParams:(MTRDoorLockClusterClearCredentialParams *)params completion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeLockStateWithCompletion:(void (^)(NSNumber * _Nullable value, NSError * _Nullable error))completion;
@@ -7800,6 +8460,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Window Covering
  *
+ * Provides an interface for controlling and adjusting automatic window coverings.
  */
 @interface MTRBaseClusterWindowCovering : MTRCluster
 
@@ -7807,18 +8468,59 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command UpOrOpen
+ *
+ * Moves window covering to InstalledOpenLimitLift and InstalledOpenLimitTilt
+ */
 - (void)upOrOpenWithParams:(MTRWindowCoveringClusterUpOrOpenParams * _Nullable)params completion:(MTRStatusCompletion)completion;
 - (void)upOrOpenWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command DownOrClose
+ *
+ * Moves window covering to InstalledClosedLimitLift and InstalledCloseLimitTilt
+ */
 - (void)downOrCloseWithParams:(MTRWindowCoveringClusterDownOrCloseParams * _Nullable)params
                    completion:(MTRStatusCompletion)completion;
 - (void)downOrCloseWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StopMotion
+ *
+ * Stop any adjusting of window covering
+ */
 - (void)stopMotionWithParams:(MTRWindowCoveringClusterStopMotionParams * _Nullable)params
                   completion:(MTRStatusCompletion)completion;
 - (void)stopMotionWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GoToLiftValue
+ *
+ * Go to lift value specified
+ */
 - (void)goToLiftValueWithParams:(MTRWindowCoveringClusterGoToLiftValueParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GoToLiftPercentage
+ *
+ * Go to lift percentage specified
+ */
 - (void)goToLiftPercentageWithParams:(MTRWindowCoveringClusterGoToLiftPercentageParams *)params
                           completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GoToTiltValue
+ *
+ * Go to tilt value specified
+ */
 - (void)goToTiltValueWithParams:(MTRWindowCoveringClusterGoToTiltValueParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GoToTiltPercentage
+ *
+ * Go to tilt percentage specified
+ */
 - (void)goToTiltPercentageWithParams:(MTRWindowCoveringClusterGoToTiltPercentageParams *)params
                           completion:(MTRStatusCompletion)completion;
 
@@ -8243,6 +8945,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Barrier Control
  *
+ * This cluster provides control of a barrier (garage door).
  */
 @interface MTRBaseClusterBarrierControl : MTRCluster
 
@@ -8250,8 +8953,19 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command BarrierControlGoToPercent
+ *
+ * Command to instruct a barrier to go to a percent open state.
+ */
 - (void)barrierControlGoToPercentWithParams:(MTRBarrierControlClusterBarrierControlGoToPercentParams *)params
                                  completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command BarrierControlStop
+ *
+ * Command that instructs the barrier to stop moving.
+ */
 - (void)barrierControlStopWithParams:(MTRBarrierControlClusterBarrierControlStopParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion;
 - (void)barrierControlStopWithCompletion:(MTRStatusCompletion)completion;
@@ -8507,6 +9221,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Pump Configuration and Control
  *
+ * An interface for configuring and controlling pumps.
  */
 @interface MTRBaseClusterPumpConfigurationAndControl : MTRCluster
 
@@ -8916,6 +9631,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Thermostat
  *
+ * An interface for configuring and controlling the functionality of a thermostat.
  */
 @interface MTRBaseClusterThermostat : MTRCluster
 
@@ -8923,13 +9639,36 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command SetpointRaiseLower
+ *
+ * Command description for SetpointRaiseLower
+ */
 - (void)setpointRaiseLowerWithParams:(MTRThermostatClusterSetpointRaiseLowerParams *)params
                           completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command SetWeeklySchedule
+ *
+ * Command description for SetWeeklySchedule
+ */
 - (void)setWeeklyScheduleWithParams:(MTRThermostatClusterSetWeeklyScheduleParams *)params
                          completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GetWeeklySchedule
+ *
+ * Command description for GetWeeklySchedule
+ */
 - (void)getWeeklyScheduleWithParams:(MTRThermostatClusterGetWeeklyScheduleParams *)params
                          completion:(void (^)(MTRThermostatClusterGetWeeklyScheduleResponseParams * _Nullable data,
                                         NSError * _Nullable error))completion;
+
+/**
+ * Command ClearWeeklySchedule
+ *
+ * The Clear Weekly Schedule command is used to clear the weekly schedule.
+ */
 - (void)clearWeeklyScheduleWithParams:(MTRThermostatClusterClearWeeklyScheduleParams * _Nullable)params
                            completion:(MTRStatusCompletion)completion;
 - (void)clearWeeklyScheduleWithCompletion:(MTRStatusCompletion)completion;
@@ -9850,6 +10589,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Fan Control
  *
+ * An interface for controlling a fan in a heating/cooling system.
  */
 @interface MTRBaseClusterFanControl : MTRCluster
 
@@ -10101,6 +10841,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Thermostat User Interface Configuration
  *
+ * An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
  */
 @interface MTRBaseClusterThermostatUserInterfaceConfiguration : MTRCluster
 
@@ -10243,6 +10984,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Color Control
  *
+ * Attributes and commands for controlling the color properties of a color-capable light.
  */
 @interface MTRBaseClusterColorControl : MTRCluster
 
@@ -10250,30 +10992,143 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command MoveToHue
+ *
+ * Move to specified hue.
+ */
 - (void)moveToHueWithParams:(MTRColorControlClusterMoveToHueParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveHue
+ *
+ * Move hue up or down at specified rate.
+ */
 - (void)moveHueWithParams:(MTRColorControlClusterMoveHueParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StepHue
+ *
+ * Step hue up or down by specified size at specified rate.
+ */
 - (void)stepHueWithParams:(MTRColorControlClusterStepHueParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveToSaturation
+ *
+ * Move to specified saturation.
+ */
 - (void)moveToSaturationWithParams:(MTRColorControlClusterMoveToSaturationParams *)params
                         completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveSaturation
+ *
+ * Move saturation up or down at specified rate.
+ */
 - (void)moveSaturationWithParams:(MTRColorControlClusterMoveSaturationParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StepSaturation
+ *
+ * Step saturation up or down by specified size at specified rate.
+ */
 - (void)stepSaturationWithParams:(MTRColorControlClusterStepSaturationParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveToHueAndSaturation
+ *
+ * Move to hue and saturation.
+ */
 - (void)moveToHueAndSaturationWithParams:(MTRColorControlClusterMoveToHueAndSaturationParams *)params
                               completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveToColor
+ *
+ * Move to specified color.
+ */
 - (void)moveToColorWithParams:(MTRColorControlClusterMoveToColorParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveColor
+ *
+ * Moves the color.
+ */
 - (void)moveColorWithParams:(MTRColorControlClusterMoveColorParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StepColor
+ *
+ * Steps the lighting to a specific color.
+ */
 - (void)stepColorWithParams:(MTRColorControlClusterStepColorParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveToColorTemperature
+ *
+ * Move to a specific color temperature.
+ */
 - (void)moveToColorTemperatureWithParams:(MTRColorControlClusterMoveToColorTemperatureParams *)params
                               completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command EnhancedMoveToHue
+ *
+ * Command description for EnhancedMoveToHue
+ */
 - (void)enhancedMoveToHueWithParams:(MTRColorControlClusterEnhancedMoveToHueParams *)params
                          completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command EnhancedMoveHue
+ *
+ * Command description for EnhancedMoveHue
+ */
 - (void)enhancedMoveHueWithParams:(MTRColorControlClusterEnhancedMoveHueParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command EnhancedStepHue
+ *
+ * Command description for EnhancedStepHue
+ */
 - (void)enhancedStepHueWithParams:(MTRColorControlClusterEnhancedStepHueParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command EnhancedMoveToHueAndSaturation
+ *
+ * Command description for EnhancedMoveToHueAndSaturation
+ */
 - (void)enhancedMoveToHueAndSaturationWithParams:(MTRColorControlClusterEnhancedMoveToHueAndSaturationParams *)params
                                       completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command ColorLoopSet
+ *
+ * Command description for ColorLoopSet
+ */
 - (void)colorLoopSetWithParams:(MTRColorControlClusterColorLoopSetParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StopMoveStep
+ *
+ * Command description for StopMoveStep
+ */
 - (void)stopMoveStepWithParams:(MTRColorControlClusterStopMoveStepParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command MoveColorTemperature
+ *
+ * Command description for MoveColorTemperature
+ */
 - (void)moveColorTemperatureWithParams:(MTRColorControlClusterMoveColorTemperatureParams *)params
                             completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command StepColorTemperature
+ *
+ * Command description for StepColorTemperature
+ */
 - (void)stepColorTemperatureWithParams:(MTRColorControlClusterStepColorTemperatureParams *)params
                             completion:(MTRStatusCompletion)completion;
 
@@ -11137,6 +11992,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Ballast Configuration
  *
+ * Attributes and commands for configuring a lighting ballast.
  */
 @interface MTRBaseClusterBallastConfiguration : MTRCluster
 
@@ -11452,6 +12308,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Illuminance Measurement
  *
+ * Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
  */
 @interface MTRBaseClusterIlluminanceMeasurement : MTRCluster
 
@@ -11601,6 +12458,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Temperature Measurement
  *
+ * Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
  */
 @interface MTRBaseClusterTemperatureMeasurement : MTRCluster
 
@@ -11737,6 +12595,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Pressure Measurement
  *
+ * Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.
  */
 @interface MTRBaseClusterPressureMeasurement : MTRCluster
 
@@ -11938,6 +12797,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Flow Measurement
  *
+ * Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
  */
 @interface MTRBaseClusterFlowMeasurement : MTRCluster
 
@@ -12074,6 +12934,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Relative Humidity Measurement
  *
+ * Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
  */
 @interface MTRBaseClusterRelativeHumidityMeasurement : MTRCluster
 
@@ -12210,6 +13071,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Occupancy Sensing
  *
+ * Attributes and commands for configuring occupancy sensing, and reporting occupancy status.
  */
 @interface MTRBaseClusterOccupancySensing : MTRCluster
 
@@ -12537,6 +13399,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Wake on LAN
  *
+ * This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
  */
 @interface MTRBaseClusterWakeOnLan : MTRCluster
 
@@ -12634,6 +13497,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Channel
  *
+ * This cluster provides an interface for controlling the current Channel on a device.
  */
 @interface MTRBaseClusterChannel : MTRCluster
 
@@ -12641,11 +13505,31 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command ChangeChannel
+ *
+ * Change the channel on the media player to the channel case-insensitive exact matching the value passed as an argument.
+ */
 - (void)changeChannelWithParams:(MTRChannelClusterChangeChannelParams *)params
                      completion:(void (^)(MTRChannelClusterChangeChannelResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion;
+
+/**
+ * Command ChangeChannelByNumber
+ *
+ * Change the channel on the media plaeyer to the channel with the given Number in the ChannelList attribute.
+ */
 - (void)changeChannelByNumberWithParams:(MTRChannelClusterChangeChannelByNumberParams *)params
                              completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command SkipChannel
+ *
+ * This command provides channel up and channel down functionality, but allows channel index jumps of size Count. When the value of
+ * the increase or decrease is larger than the number of channels remaining in the given direction, then the behavior SHALL be to
+ * return to the beginning (or end) of the channel list and continue. For example, if the current channel is at index 0 and count
+ * value of -1 is given, then the current channel should change to the last channel.
+ */
 - (void)skipChannelWithParams:(MTRChannelClusterSkipChannelParams *)params completion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeChannelListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -12770,6 +13654,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Target Navigator
  *
+ * This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
  */
 @interface MTRBaseClusterTargetNavigator : MTRCluster
 
@@ -12777,6 +13662,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command NavigateTarget
+ *
+ * Upon receipt, this SHALL navigation the UX to the target identified.
+ */
 - (void)navigateTargetWithParams:(MTRTargetNavigatorClusterNavigateTargetParams *)params
                       completion:(void (^)(MTRTargetNavigatorClusterNavigateTargetResponseParams * _Nullable data,
                                      NSError * _Nullable error))completion;
@@ -12884,6 +13774,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Media Playback
  *
+ * This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or Speaker.
  */
 @interface MTRBaseClusterMediaPlayback : MTRCluster
 
@@ -12891,52 +13782,122 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command Play
+ *
+ * Upon receipt, this SHALL play media.
+ */
 - (void)playWithParams:(MTRMediaPlaybackClusterPlayParams * _Nullable)params
             completion:
                 (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
 - (void)playWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                NSError * _Nullable error))completion;
+
+/**
+ * Command Pause
+ *
+ * Upon receipt, this SHALL pause media.
+ */
 - (void)pauseWithParams:(MTRMediaPlaybackClusterPauseParams * _Nullable)params
              completion:
                  (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
 - (void)pauseWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion;
+
+/**
+ * Command StopPlayback
+ *
+ * Upon receipt, this SHALL stop media. User experience is context-specific. This will often navigate the user back to the location
+ * where media was originally launched.
+ */
 - (void)stopPlaybackWithParams:(MTRMediaPlaybackClusterStopPlaybackParams * _Nullable)params
                     completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion;
 - (void)stopPlaybackWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion;
+
+/**
+ * Command StartOver
+ *
+ * Upon receipt, this SHALL Start Over with the current media playback item.
+ */
 - (void)startOverWithParams:(MTRMediaPlaybackClusterStartOverParams * _Nullable)params
                  completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion;
 - (void)startOverWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion;
+
+/**
+ * Command Previous
+ *
+ * Upon receipt, this SHALL cause the handler to be invoked for "Previous". User experience is context-specific. This will often Go
+ * back to the previous media playback item.
+ */
 - (void)previousWithParams:(MTRMediaPlaybackClusterPreviousParams * _Nullable)params
                 completion:
                     (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
 - (void)previousWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion;
+
+/**
+ * Command Next
+ *
+ * Upon receipt, this SHALL cause the handler to be invoked for "Next". User experience is context-specific. This will often Go
+ * forward to the next media playback item.
+ */
 - (void)nextWithParams:(MTRMediaPlaybackClusterNextParams * _Nullable)params
             completion:
                 (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
 - (void)nextWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                NSError * _Nullable error))completion;
+
+/**
+ * Command Rewind
+ *
+ * Upon receipt, this SHALL Rewind through media. Different Rewind speeds can be used on the TV based upon the number of sequential
+ * calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).
+ */
 - (void)rewindWithParams:(MTRMediaPlaybackClusterRewindParams * _Nullable)params
               completion:
                   (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
 - (void)rewindWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                  NSError * _Nullable error))completion;
+
+/**
+ * Command FastForward
+ *
+ * Upon receipt, this SHALL Advance through media. Different FF speeds can be used on the TV based upon the number of sequential
+ * calls to this function. This is to avoid needing to define every speed now (multiple fast, slow motion, etc).
+ */
 - (void)fastForwardWithParams:(MTRMediaPlaybackClusterFastForwardParams * _Nullable)params
                    completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion;
 - (void)fastForwardWithCompletion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                       NSError * _Nullable error))completion;
+
+/**
+ * Command SkipForward
+ *
+ * Upon receipt, this SHALL Skip forward in the media by the given number of seconds, using the data as follows:
+ */
 - (void)skipForwardWithParams:(MTRMediaPlaybackClusterSkipForwardParams *)params
                    completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion;
+
+/**
+ * Command SkipBackward
+ *
+ * Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:
+ */
 - (void)skipBackwardWithParams:(MTRMediaPlaybackClusterSkipBackwardParams *)params
                     completion:(void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion;
+
+/**
+ * Command Seek
+ *
+ * Upon receipt, this SHALL Skip backward in the media by the given number of seconds, using the data as follows:
+ */
 - (void)seekWithParams:(MTRMediaPlaybackClusterSeekParams *)params
             completion:
                 (void (^)(MTRMediaPlaybackClusterPlaybackResponseParams * _Nullable data, NSError * _Nullable error))completion;
@@ -13112,6 +14073,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Media Input
  *
+ * This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
  */
 @interface MTRBaseClusterMediaInput : MTRCluster
 
@@ -13119,13 +14081,37 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command SelectInput
+ *
+ * Upon receipt, this SHALL change the input on the media device to the input at a specific index in the Input List.
+ */
 - (void)selectInputWithParams:(MTRMediaInputClusterSelectInputParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command ShowInputStatus
+ *
+ * Upon receipt, this SHALL display the active status of the input list on screen.
+ */
 - (void)showInputStatusWithParams:(MTRMediaInputClusterShowInputStatusParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion;
 - (void)showInputStatusWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command HideInputStatus
+ *
+ * Upon receipt, this SHALL hide the input list from the screen.
+ */
 - (void)hideInputStatusWithParams:(MTRMediaInputClusterHideInputStatusParams * _Nullable)params
                        completion:(MTRStatusCompletion)completion;
 - (void)hideInputStatusWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command RenameInput
+ *
+ * Upon receipt, this SHALL rename the input at a specific index in the Input List. Updates to the input name SHALL appear in the TV
+ * settings menus.
+ */
 - (void)renameInputWithParams:(MTRMediaInputClusterRenameInputParams *)params completion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeInputListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -13231,6 +14217,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Low Power
  *
+ * This cluster provides an interface for managing low power mode on a device.
  */
 @interface MTRBaseClusterLowPower : MTRCluster
 
@@ -13238,6 +14225,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command Sleep
+ *
+ * This command shall put the device into low power mode.
+ */
 - (void)sleepWithParams:(MTRLowPowerClusterSleepParams * _Nullable)params completion:(MTRStatusCompletion)completion;
 - (void)sleepWithCompletion:(MTRStatusCompletion)completion;
 
@@ -13318,6 +14310,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Keypad Input
  *
+ * This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
  */
 @interface MTRBaseClusterKeypadInput : MTRCluster
 
@@ -13325,6 +14318,11 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command SendKey
+ *
+ * Upon receipt, this SHALL process a keycode as input to the media device.
+ */
 - (void)sendKeyWithParams:(MTRKeypadInputClusterSendKeyParams *)params
                completion:
                    (void (^)(MTRKeypadInputClusterSendKeyResponseParams * _Nullable data, NSError * _Nullable error))completion;
@@ -13406,6 +14404,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Content Launcher
  *
+ * This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRBaseClusterContentLauncher : MTRCluster
 
@@ -13413,9 +14412,20 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command LaunchContent
+ *
+ * Upon receipt, this SHALL launch the specified content with optional search criteria.
+ */
 - (void)launchContentWithParams:(MTRContentLauncherClusterLaunchContentParams *)params
                      completion:(void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data,
                                     NSError * _Nullable error))completion;
+
+/**
+ * Command LaunchURL
+ *
+ * Upon receipt, this SHALL launch content from the specified URL.
+ */
 - (void)launchURLWithParams:(MTRContentLauncherClusterLaunchURLParams *)params
                  completion:(void (^)(MTRContentLauncherClusterLaunchResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion;
@@ -13530,6 +14540,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Audio Output
  *
+ * This cluster provides an interface for controlling the Output on a media device such as a TV.
  */
 @interface MTRBaseClusterAudioOutput : MTRCluster
 
@@ -13537,7 +14548,19 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command SelectOutput
+ *
+ * Upon receipt, this SHALL change the output on the media device to the output at a specific index in the Output List.
+ */
 - (void)selectOutputWithParams:(MTRAudioOutputClusterSelectOutputParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command RenameOutput
+ *
+ * Upon receipt, this SHALL rename the output at a specific index in the Output List. Updates to the output name SHALL appear in the
+ * TV settings menus.
+ */
 - (void)renameOutputWithParams:(MTRAudioOutputClusterRenameOutputParams *)params completion:(MTRStatusCompletion)completion;
 
 - (void)readAttributeOutputListWithCompletion:(void (^)(NSArray * _Nullable value, NSError * _Nullable error))completion;
@@ -13643,6 +14666,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Application Launcher
  *
+ * This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRBaseClusterApplicationLauncher : MTRCluster
 
@@ -13650,12 +14674,32 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command LaunchApp
+ *
+ * Upon receipt, this SHALL launch the specified app with optional data. The TV Device SHALL launch and bring to foreground the
+ * identified application in the command if the application is not already launched and in foreground. The TV Device SHALL update
+ * state attribute on the Application Basic cluster of the Endpoint corresponding to the launched application. This command returns
+ * a Launch Response.
+ */
 - (void)launchAppWithParams:(MTRApplicationLauncherClusterLaunchAppParams *)params
                  completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
                                 NSError * _Nullable error))completion;
+
+/**
+ * Command StopApp
+ *
+ * Upon receipt on a Video Player endpoint this SHALL stop the specified application if it is running.
+ */
 - (void)stopAppWithParams:(MTRApplicationLauncherClusterStopAppParams *)params
                completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
                               NSError * _Nullable error))completion;
+
+/**
+ * Command HideApp
+ *
+ * Upon receipt on a Video Player endpoint this SHALL hide the specified application if it is running and visible.
+ */
 - (void)hideAppWithParams:(MTRApplicationLauncherClusterHideAppParams *)params
                completion:(void (^)(MTRApplicationLauncherClusterLauncherResponseParams * _Nullable data,
                               NSError * _Nullable error))completion;
@@ -13771,6 +14815,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Application Basic
  *
+ * This cluster provides information about an application running on a TV or media player device which is represented as an
+ * endpoint.
  */
 @interface MTRBaseClusterApplicationBasic : MTRCluster
 
@@ -13965,6 +15011,9 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Account Login
  *
+ * This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App running
+ * on a Video Player device, which is represented as an endpoint (see [TV Architecture]), can use this cluster to help make the user
+ * account on the Content App match the user account on the Client.
  */
 @interface MTRBaseClusterAccountLogin : MTRCluster
 
@@ -13972,10 +15021,32 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command GetSetupPIN
+ *
+ * Upon receipt, the Content App checks if the account associated with the client Temp Account Identifier Rotating ID is the same
+ * acount that is active on the given Content App. If the accounts are the same, then the Content App includes the Setup PIN in the
+ * GetSetupPIN Response.
+ */
 - (void)getSetupPINWithParams:(MTRAccountLoginClusterGetSetupPINParams *)params
                    completion:(void (^)(MTRAccountLoginClusterGetSetupPINResponseParams * _Nullable data,
                                   NSError * _Nullable error))completion;
+
+/**
+ * Command Login
+ *
+ * Upon receipt, the Content App checks if the account associated with the client’s Temp Account Identifier (Rotating ID) has a
+ * current active Setup PIN with the given value. If the Setup PIN is valid for the user account associated with the Temp Account
+ * Identifier, then the Content App MAY make that user account active.
+ */
 - (void)loginWithParams:(MTRAccountLoginClusterLoginParams *)params completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command Logout
+ *
+ * The purpose of this command is to instruct the Content App to clear the current user account. This command SHOULD be used by
+ * clients of a Content App to indicate the end of a user session.
+ */
 - (void)logoutWithParams:(MTRAccountLoginClusterLogoutParams * _Nullable)params completion:(MTRStatusCompletion)completion;
 - (void)logoutWithCompletion:(MTRStatusCompletion)completion;
 
@@ -14056,6 +15127,8 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Electrical Measurement
  *
+ * Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to
+ * provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..
  */
 @interface MTRBaseClusterElectricalMeasurement : MTRCluster
 
@@ -14063,9 +15136,21 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command GetProfileInfoCommand
+ *
+ * A function which retrieves the power profiling information from the electrical measurement server.
+ */
 - (void)getProfileInfoCommandWithParams:(MTRElectricalMeasurementClusterGetProfileInfoCommandParams * _Nullable)params
                              completion:(MTRStatusCompletion)completion;
 - (void)getProfileInfoCommandWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command GetMeasurementProfileCommand
+ *
+ * A function which retrieves an electricity measurement profile from the electricity measurement server for a specific attribute Id
+ * requested.
+ */
 - (void)getMeasurementProfileCommandWithParams:(MTRElectricalMeasurementClusterGetMeasurementProfileCommandParams *)params
                                     completion:(MTRStatusCompletion)completion;
 
@@ -16081,6 +17166,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Test Cluster
  *
+ * The Test Cluster is meant to validate the generated code
  */
 @interface MTRBaseClusterTestCluster : MTRCluster
 
@@ -16088,73 +17174,227 @@ NS_ASSUME_NONNULL_BEGIN
                                 endpoint:(NSNumber *)endpoint
                                    queue:(dispatch_queue_t)queue NS_DESIGNATED_INITIALIZER;
 
+/**
+ * Command Test
+ *
+ * Simple command without any parameters and without a specific response
+ */
 - (void)testWithParams:(MTRTestClusterClusterTestParams * _Nullable)params completion:(MTRStatusCompletion)completion;
 - (void)testWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TestNotHandled
+ *
+ * Simple command without any parameters and without a specific response not handled by the server
+ */
 - (void)testNotHandledWithParams:(MTRTestClusterClusterTestNotHandledParams * _Nullable)params
                       completion:(MTRStatusCompletion)completion;
 - (void)testNotHandledWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TestSpecific
+ *
+ * Simple command without any parameters and with a specific response
+ */
 - (void)testSpecificWithParams:(MTRTestClusterClusterTestSpecificParams * _Nullable)params
                     completion:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
                                    NSError * _Nullable error))completion;
 - (void)testSpecificWithCompletion:(void (^)(MTRTestClusterClusterTestSpecificResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion;
+
+/**
+ * Command TestUnknownCommand
+ *
+ * Simple command that should not be added to the server.
+ */
 - (void)testUnknownCommandWithParams:(MTRTestClusterClusterTestUnknownCommandParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion;
 - (void)testUnknownCommandWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TestAddArguments
+ *
+ * Command that takes two arguments and returns their sum.
+ */
 - (void)testAddArgumentsWithParams:(MTRTestClusterClusterTestAddArgumentsParams *)params
                         completion:(void (^)(MTRTestClusterClusterTestAddArgumentsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion;
+
+/**
+ * Command TestSimpleArgumentRequest
+ *
+ * Command that takes an argument which is bool
+ */
 - (void)testSimpleArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleArgumentRequestParams *)params
                                  completion:(void (^)(MTRTestClusterClusterTestSimpleArgumentResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completion;
+
+/**
+ * Command TestStructArrayArgumentRequest
+ *
+ * Command that takes various arguments that are arrays, including an array of structs which have a list member.
+ */
 - (void)testStructArrayArgumentRequestWithParams:(MTRTestClusterClusterTestStructArrayArgumentRequestParams *)params
                                       completion:
                                           (void (^)(MTRTestClusterClusterTestStructArrayArgumentResponseParams * _Nullable data,
                                               NSError * _Nullable error))completion;
+
+/**
+ * Command TestStructArgumentRequest
+ *
+ * Command that takes an argument which is struct.  The response echoes the
+        'b' field of the single arg.
+ */
 - (void)testStructArgumentRequestWithParams:(MTRTestClusterClusterTestStructArgumentRequestParams *)params
                                  completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                 NSError * _Nullable error))completion;
+
+/**
+ * Command TestNestedStructArgumentRequest
+ *
+ * Command that takes an argument which is nested struct.  The response
+        echoes the 'b' field of ar1.c.
+ */
 - (void)testNestedStructArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructArgumentRequestParams *)params
                                        completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                       NSError * _Nullable error))completion;
+
+/**
+ * Command TestListStructArgumentRequest
+ *
+ * Command that takes an argument which is a list of structs.  The response
+        returns false if there is some struct in the list whose 'b' field is
+        false, and true otherwise (including if the list is empty).
+ */
 - (void)testListStructArgumentRequestWithParams:(MTRTestClusterClusterTestListStructArgumentRequestParams *)params
                                      completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                     NSError * _Nullable error))completion;
+
+/**
+ * Command TestListInt8UArgumentRequest
+ *
+ * Command that takes an argument which is a list of INT8U.  The response
+        returns false if the list contains a 0 in it, true otherwise (including
+        if the list is empty).
+ */
 - (void)testListInt8UArgumentRequestWithParams:(MTRTestClusterClusterTestListInt8UArgumentRequestParams *)params
                                     completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                    NSError * _Nullable error))completion;
+
+/**
+ * Command TestNestedStructListArgumentRequest
+ *
+ * Command that takes an argument which is a Nested Struct List.  The
+        response returns false if there is some struct in arg1 (either directly
+        in arg1.c or in the arg1.d list) whose 'b' field is false, and true
+        otherwise.
+ */
 - (void)testNestedStructListArgumentRequestWithParams:(MTRTestClusterClusterTestNestedStructListArgumentRequestParams *)params
                                            completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                           NSError * _Nullable error))completion;
+
+/**
+ * Command TestListNestedStructListArgumentRequest
+ *
+ * Command that takes an argument which is a list of Nested Struct List.
+        The response returns false if there is some struct in arg1 (either
+        directly in as the 'c' field of an entry 'd' list of an entry) whose 'b'
+        field is false, and true otherwise (including if the list is empty).
+ */
 - (void)testListNestedStructListArgumentRequestWithParams:
             (MTRTestClusterClusterTestListNestedStructListArgumentRequestParams *)params
                                                completion:(void (^)(MTRTestClusterClusterBooleanResponseParams * _Nullable data,
                                                               NSError * _Nullable error))completion;
+
+/**
+ * Command TestListInt8UReverseRequest
+ *
+ * Command that takes an argument which is a list of INT8U and expects a
+        response that reverses the list.
+ */
 - (void)testListInt8UReverseRequestWithParams:(MTRTestClusterClusterTestListInt8UReverseRequestParams *)params
                                    completion:(void (^)(MTRTestClusterClusterTestListInt8UReverseResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completion;
+
+/**
+ * Command TestEnumsRequest
+ *
+ * Command that sends a vendor id and an enum.  The server is expected to
+        echo them back.
+ */
 - (void)testEnumsRequestWithParams:(MTRTestClusterClusterTestEnumsRequestParams *)params
                         completion:(void (^)(MTRTestClusterClusterTestEnumsResponseParams * _Nullable data,
                                        NSError * _Nullable error))completion;
+
+/**
+ * Command TestNullableOptionalRequest
+ *
+ * Command that takes an argument which is nullable and optional.  The
+        response returns a boolean indicating whether the argument was present,
+        if that's true a boolean indicating whether the argument was null, and
+        if that' false the argument it received.
+ */
 - (void)testNullableOptionalRequestWithParams:(MTRTestClusterClusterTestNullableOptionalRequestParams * _Nullable)params
                                    completion:(void (^)(MTRTestClusterClusterTestNullableOptionalResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completion;
+
+/**
+ * Command TestComplexNullableOptionalRequest
+ *
+ * Command that takes various arguments which can be nullable and/or optional.  The
+        response returns information about which things were received and what
+        their state was.
+ */
 - (void)testComplexNullableOptionalRequestWithParams:(MTRTestClusterClusterTestComplexNullableOptionalRequestParams *)params
                                           completion:
                                               (void (^)(
                                                   MTRTestClusterClusterTestComplexNullableOptionalResponseParams * _Nullable data,
                                                   NSError * _Nullable error))completion;
+
+/**
+ * Command SimpleStructEchoRequest
+ *
+ * Command that takes an argument which is a struct.  The response echoes
+        the struct back.
+ */
 - (void)simpleStructEchoRequestWithParams:(MTRTestClusterClusterSimpleStructEchoRequestParams *)params
                                completion:(void (^)(MTRTestClusterClusterSimpleStructResponseParams * _Nullable data,
                                               NSError * _Nullable error))completion;
+
+/**
+ * Command TimedInvokeRequest
+ *
+ * Command that just responds with a success status if the timed invoke
+        conditions are met.
+ */
 - (void)timedInvokeRequestWithParams:(MTRTestClusterClusterTimedInvokeRequestParams * _Nullable)params
                           completion:(MTRStatusCompletion)completion;
 - (void)timedInvokeRequestWithCompletion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TestSimpleOptionalArgumentRequest
+ *
+ * Command that takes an optional argument which is bool. It responds with a success value if the optional is set to any value.
+ */
 - (void)testSimpleOptionalArgumentRequestWithParams:(MTRTestClusterClusterTestSimpleOptionalArgumentRequestParams * _Nullable)params
                                          completion:(MTRStatusCompletion)completion;
+
+/**
+ * Command TestEmitTestEventRequest
+ *
+ * Command that takes identical arguments to the fields of the TestEvent and logs the TestEvent to the buffer.  Command returns an
+ * event ID as the response.
+ */
 - (void)testEmitTestEventRequestWithParams:(MTRTestClusterClusterTestEmitTestEventRequestParams *)params
                                 completion:(void (^)(MTRTestClusterClusterTestEmitTestEventResponseParams * _Nullable data,
                                                NSError * _Nullable error))completion;
+
+/**
+ * Command TestEmitTestFabricScopedEventRequest
+ *
+ * Command that takes identical arguments to the fields of the TestFabricScopedEvent and logs the TestFabricScopedEvent to the
+ * buffer.  Command returns an event ID as the response.
+ */
 - (void)
     testEmitTestFabricScopedEventRequestWithParams:(MTRTestClusterClusterTestEmitTestFabricScopedEventRequestParams *)params
                                         completion:

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -27,7 +27,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Identify
  *
- * Attributes and commands for putting a device into Identification mode (e.g. flashing a light).
+ *
  */
 @interface MTRBaseClusterIdentify : MTRCluster
 
@@ -156,7 +156,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Groups
  *
- * Attributes and commands for group configuration and manipulation.
+ *
  */
 @interface MTRBaseClusterGroups : MTRCluster
 
@@ -306,7 +306,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Scenes
  *
- * Attributes and commands for scene configuration and manipulation.
+ *
  */
 @interface MTRBaseClusterScenes : MTRCluster
 
@@ -560,7 +560,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster On/Off
  *
- * Attributes and commands for switching devices between 'On' and 'Off' states.
+ *
  */
 @interface MTRBaseClusterOnOff : MTRCluster
 
@@ -779,7 +779,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster On/off Switch Configuration
  *
- * Attributes and commands for configuring On/Off switching devices.
+ *
  */
 @interface MTRBaseClusterOnOffSwitchConfiguration : MTRCluster
 
@@ -894,7 +894,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Level Control
  *
- * Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'
+ *
  */
 @interface MTRBaseClusterLevelControl : MTRCluster
 
@@ -1261,7 +1261,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Binary Input (Basic)
  *
- * An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
+ *
  */
 @interface MTRBaseClusterBinaryInputBasic : MTRCluster
 
@@ -1487,8 +1487,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Descriptor
  *
- * The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its endpoints
- * and clusters.
+ *
  */
 @interface MTRBaseClusterDescriptor : MTRCluster
 
@@ -1625,7 +1624,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Binding
  *
- * The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
+ *
  */
 @interface MTRBaseClusterBinding : MTRCluster
 
@@ -1728,10 +1727,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Access Control
  *
- * The Access Control Cluster exposes a data model view of a
-      Node's Access Control List (ACL), which codifies the rules used to manage
-      and enforce Access Control for the Node's endpoints and their associated
-      cluster instances.
+ *
  */
 @interface MTRBaseClusterAccessControl : MTRCluster
 
@@ -1903,7 +1899,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Actions
  *
- * This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
+ *
  */
 @interface MTRBaseClusterActions : MTRCluster
 
@@ -2117,9 +2113,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Basic
  *
- * This cluster provides attributes and events for determining basic information about Nodes, which supports both
-      Commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
-      which apply to the whole Node. Also allows setting user device information such as location.
+ *
  */
 @interface MTRBaseClusterBasic : MTRCluster
 
@@ -2500,7 +2494,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster OTA Software Update Provider
  *
- * Provides an interface for providing OTA software updates
+ *
  */
 @interface MTRBaseClusterOtaSoftwareUpdateProvider : MTRCluster
 
@@ -2611,7 +2605,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster OTA Software Update Requestor
  *
- * Provides an interface for downloading and applying OTA software updates
+ *
  */
 @interface MTRBaseClusterOtaSoftwareUpdateRequestor : MTRCluster
 
@@ -2765,10 +2759,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Localization Configuration
  *
- * Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing common languages, units of measurements, and numerical formatting
-      standards. As such, Nodes that visually or audibly convey information need a mechanism by which
-      they can be configured to use a user’s preferred language, units, etc
+ *
  */
 @interface MTRBaseClusterLocalizationConfiguration : MTRCluster
 
@@ -2883,10 +2874,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Time Format Localization
  *
- * Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
-      or audibly convey time information need a mechanism by which they can be configured to use a
-      user’s preferred format.
+ *
  */
 @interface MTRBaseClusterTimeFormatLocalization : MTRCluster
 
@@ -3023,10 +3011,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Unit Localization
  *
- * Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing preferences for the units in which values are conveyed in communication to a
-      user. As such, Nodes that visually or audibly convey measurable values to the user need a
-      mechanism by which they can be configured to use a user’s preferred unit.
+ *
  */
 @interface MTRBaseClusterUnitLocalization : MTRCluster
 
@@ -3128,7 +3113,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Power Source Configuration
  *
- * This cluster is used to describe the configuration and capabilities of a Device's power system.
+ *
  */
 @interface MTRBaseClusterPowerSourceConfiguration : MTRCluster
 
@@ -3226,7 +3211,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Power Source
  *
- * This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the Node.
+ *
  */
 @interface MTRBaseClusterPowerSource : MTRCluster
 
@@ -3752,7 +3737,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster General Commissioning
  *
- * This cluster is used to manage global aspects of the Commissioning flow.
+ *
  */
 @interface MTRBaseClusterGeneralCommissioning : MTRCluster
 
@@ -3950,7 +3935,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Network Commissioning
  *
- * Functionality to configure, enable, disable network credentials and access on a Matter device.
+ *
  */
 @interface MTRBaseClusterNetworkCommissioning : MTRCluster
 
@@ -4207,7 +4192,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Diagnostic Logs
  *
- * The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
+ *
  */
 @interface MTRBaseClusterDiagnosticLogs : MTRCluster
 
@@ -4301,8 +4286,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster General Diagnostics
  *
- * The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics
- * metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
+ *
  */
 @interface MTRBaseClusterGeneralDiagnostics : MTRCluster
 
@@ -4522,8 +4506,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Software Diagnostics
  *
- * The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
- * assist a user or Administrative Node in diagnosing potential problems.
+ *
  */
 @interface MTRBaseClusterSoftwareDiagnostics : MTRCluster
 
@@ -4673,8 +4656,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Thread Network Diagnostics
  *
- * The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
- * assist a user or Administrative Node in diagnosing potential problems
+ *
  */
 @interface MTRBaseClusterThreadNetworkDiagnostics : MTRCluster
 
@@ -5653,8 +5635,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster WiFi Network Diagnostics
  *
- * The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
- * assist a user or Administrative Node in diagnosing potential problems.
+ *
  */
 @interface MTRBaseClusterWiFiNetworkDiagnostics : MTRCluster
 
@@ -5927,8 +5908,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Ethernet Network Diagnostics
  *
- * The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
- * to assist a user or Administrative Node in diagnosing potential problems.
+ *
  */
 @interface MTRBaseClusterEthernetNetworkDiagnostics : MTRCluster
 
@@ -6139,10 +6119,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Bridged Device Basic
  *
- * This Cluster serves two purposes towards a Node communicating with a Bridge: indicate that the functionality on
-          the Endpoint where it is placed (and its Parts) is bridged from a non-CHIP technology; and provide a centralized
-          collection of attributes that the Node MAY collect to aid in conveying information regarding the Bridged Device to a user,
-          such as the vendor name, the model name, or user-assigned name.
+ *
  */
 @interface MTRBaseClusterBridgedDeviceBasic : MTRCluster
 
@@ -6434,12 +6411,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Cluster Switch
  *
- * This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
-Two types of switch devices are supported: latching switch (e.g. rocker switch) and momentary switch (e.g. push button),
-distinguished with their feature flags. Interactions with the switch device are exposed as attributes (for the latching switch) and
-as events (for both types of switches). An interested party MAY subscribe to these attributes/events and thus be informed of the
-interactions, and can perform actions based on this, for example by sending commands to perform an action such as controlling a
-light or a window shade.
+ *
  */
 @interface MTRBaseClusterSwitch : MTRCluster
 
@@ -6565,7 +6537,7 @@ light or a window shade.
 /**
  * Cluster AdministratorCommissioning
  *
- * Commands to trigger a Node to allow a new Administrator to commission it.
+ *
  */
 @interface MTRBaseClusterAdministratorCommissioning : MTRCluster
 
@@ -6717,8 +6689,7 @@ light or a window shade.
 /**
  * Cluster Operational Credentials
  *
- * This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated
- * Fabrics.
+ *
  */
 @interface MTRBaseClusterOperationalCredentials : MTRCluster
 
@@ -6962,7 +6933,7 @@ light or a window shade.
 /**
  * Cluster Group Key Management
  *
- * The Group Key Management Cluster is the mechanism by which group keys are managed.
+ *
  */
 @interface MTRBaseClusterGroupKeyManagement : MTRCluster
 
@@ -7142,8 +7113,7 @@ light or a window shade.
 /**
  * Cluster Fixed Label
  *
- * The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
-labels.
+ *
  */
 @interface MTRBaseClusterFixedLabel : MTRCluster
 
@@ -7241,7 +7211,7 @@ labels.
 /**
  * Cluster User Label
  *
- * The User Label Cluster provides a feature to tag an endpoint with zero or more labels.
+ *
  */
 @interface MTRBaseClusterUserLabel : MTRCluster
 
@@ -7343,7 +7313,7 @@ labels.
 /**
  * Cluster Boolean State
  *
- * This cluster provides an interface to a boolean state called StateValue.
+ *
  */
 @interface MTRBaseClusterBooleanState : MTRCluster
 
@@ -7441,7 +7411,7 @@ labels.
 /**
  * Cluster Mode Select
  *
- * Attributes and commands for selecting a mode from a list of supported options.
+ *
  */
 @interface MTRBaseClusterModeSelect : MTRCluster
 
@@ -7622,7 +7592,7 @@ labels.
 /**
  * Cluster Door Lock
  *
- * An interface to a generic way to secure a door
+ *
  */
 @interface MTRBaseClusterDoorLock : MTRCluster
 
@@ -8460,7 +8430,7 @@ labels.
 /**
  * Cluster Window Covering
  *
- * Provides an interface for controlling and adjusting automatic window coverings.
+ *
  */
 @interface MTRBaseClusterWindowCovering : MTRCluster
 
@@ -8945,7 +8915,7 @@ labels.
 /**
  * Cluster Barrier Control
  *
- * This cluster provides control of a barrier (garage door).
+ *
  */
 @interface MTRBaseClusterBarrierControl : MTRCluster
 
@@ -9221,7 +9191,7 @@ labels.
 /**
  * Cluster Pump Configuration and Control
  *
- * An interface for configuring and controlling pumps.
+ *
  */
 @interface MTRBaseClusterPumpConfigurationAndControl : MTRCluster
 
@@ -9631,7 +9601,7 @@ labels.
 /**
  * Cluster Thermostat
  *
- * An interface for configuring and controlling the functionality of a thermostat.
+ *
  */
 @interface MTRBaseClusterThermostat : MTRCluster
 
@@ -10589,7 +10559,7 @@ labels.
 /**
  * Cluster Fan Control
  *
- * An interface for controlling a fan in a heating/cooling system.
+ *
  */
 @interface MTRBaseClusterFanControl : MTRCluster
 
@@ -10841,7 +10811,7 @@ labels.
 /**
  * Cluster Thermostat User Interface Configuration
  *
- * An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
+ *
  */
 @interface MTRBaseClusterThermostatUserInterfaceConfiguration : MTRCluster
 
@@ -10984,7 +10954,7 @@ labels.
 /**
  * Cluster Color Control
  *
- * Attributes and commands for controlling the color properties of a color-capable light.
+ *
  */
 @interface MTRBaseClusterColorControl : MTRCluster
 
@@ -11992,7 +11962,7 @@ labels.
 /**
  * Cluster Ballast Configuration
  *
- * Attributes and commands for configuring a lighting ballast.
+ *
  */
 @interface MTRBaseClusterBallastConfiguration : MTRCluster
 
@@ -12308,7 +12278,7 @@ labels.
 /**
  * Cluster Illuminance Measurement
  *
- * Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
+ *
  */
 @interface MTRBaseClusterIlluminanceMeasurement : MTRCluster
 
@@ -12458,7 +12428,7 @@ labels.
 /**
  * Cluster Temperature Measurement
  *
- * Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
+ *
  */
 @interface MTRBaseClusterTemperatureMeasurement : MTRCluster
 
@@ -12595,7 +12565,7 @@ labels.
 /**
  * Cluster Pressure Measurement
  *
- * Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.
+ *
  */
 @interface MTRBaseClusterPressureMeasurement : MTRCluster
 
@@ -12797,7 +12767,7 @@ labels.
 /**
  * Cluster Flow Measurement
  *
- * Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
+ *
  */
 @interface MTRBaseClusterFlowMeasurement : MTRCluster
 
@@ -12934,7 +12904,7 @@ labels.
 /**
  * Cluster Relative Humidity Measurement
  *
- * Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
+ *
  */
 @interface MTRBaseClusterRelativeHumidityMeasurement : MTRCluster
 
@@ -13071,7 +13041,7 @@ labels.
 /**
  * Cluster Occupancy Sensing
  *
- * Attributes and commands for configuring occupancy sensing, and reporting occupancy status.
+ *
  */
 @interface MTRBaseClusterOccupancySensing : MTRCluster
 
@@ -13399,7 +13369,7 @@ labels.
 /**
  * Cluster Wake on LAN
  *
- * This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
+ *
  */
 @interface MTRBaseClusterWakeOnLan : MTRCluster
 
@@ -13497,7 +13467,7 @@ labels.
 /**
  * Cluster Channel
  *
- * This cluster provides an interface for controlling the current Channel on a device.
+ *
  */
 @interface MTRBaseClusterChannel : MTRCluster
 
@@ -13654,7 +13624,7 @@ labels.
 /**
  * Cluster Target Navigator
  *
- * This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
+ *
  */
 @interface MTRBaseClusterTargetNavigator : MTRCluster
 
@@ -13774,7 +13744,7 @@ labels.
 /**
  * Cluster Media Playback
  *
- * This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or Speaker.
+ *
  */
 @interface MTRBaseClusterMediaPlayback : MTRCluster
 
@@ -14073,7 +14043,7 @@ labels.
 /**
  * Cluster Media Input
  *
- * This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
+ *
  */
 @interface MTRBaseClusterMediaInput : MTRCluster
 
@@ -14217,7 +14187,7 @@ labels.
 /**
  * Cluster Low Power
  *
- * This cluster provides an interface for managing low power mode on a device.
+ *
  */
 @interface MTRBaseClusterLowPower : MTRCluster
 
@@ -14310,7 +14280,7 @@ labels.
 /**
  * Cluster Keypad Input
  *
- * This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
+ *
  */
 @interface MTRBaseClusterKeypadInput : MTRCluster
 
@@ -14404,7 +14374,7 @@ labels.
 /**
  * Cluster Content Launcher
  *
- * This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
+ *
  */
 @interface MTRBaseClusterContentLauncher : MTRCluster
 
@@ -14540,7 +14510,7 @@ labels.
 /**
  * Cluster Audio Output
  *
- * This cluster provides an interface for controlling the Output on a media device such as a TV.
+ *
  */
 @interface MTRBaseClusterAudioOutput : MTRCluster
 
@@ -14666,7 +14636,7 @@ labels.
 /**
  * Cluster Application Launcher
  *
- * This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
+ *
  */
 @interface MTRBaseClusterApplicationLauncher : MTRCluster
 
@@ -14815,8 +14785,7 @@ labels.
 /**
  * Cluster Application Basic
  *
- * This cluster provides information about an application running on a TV or media player device which is represented as an
- * endpoint.
+ *
  */
 @interface MTRBaseClusterApplicationBasic : MTRCluster
 
@@ -15011,9 +14980,7 @@ labels.
 /**
  * Cluster Account Login
  *
- * This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App running
- * on a Video Player device, which is represented as an endpoint (see [TV Architecture]), can use this cluster to help make the user
- * account on the Content App match the user account on the Client.
+ *
  */
 @interface MTRBaseClusterAccountLogin : MTRCluster
 
@@ -15127,8 +15094,7 @@ labels.
 /**
  * Cluster Electrical Measurement
  *
- * Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need to
- * provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..
+ *
  */
 @interface MTRBaseClusterElectricalMeasurement : MTRCluster
 
@@ -17166,7 +17132,7 @@ labels.
 /**
  * Cluster Test Cluster
  *
- * The Test Cluster is meant to validate the generated code
+ *
  */
 @interface MTRBaseClusterTestCluster : MTRCluster
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Identify
- *
+ *    Attributes and commands for putting a device into Identification mode (e.g. flashing a light).
  */
 @interface MTRClusterIdentify : MTRCluster
 
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Groups
- *
+ *    Attributes and commands for group configuration and manipulation.
  */
 @interface MTRClusterGroups : MTRCluster
 
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Scenes
- *
+ *    Attributes and commands for scene configuration and manipulation.
  */
 @interface MTRClusterScenes : MTRCluster
 
@@ -215,7 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster On/Off
- *
+ *    Attributes and commands for switching devices between 'On' and 'Off' states.
  */
 @interface MTRClusterOnOff : MTRCluster
 
@@ -302,7 +302,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster On/off Switch Configuration
- *
+ *    Attributes and commands for configuring On/Off switching devices.
  */
 @interface MTRClusterOnOffSwitchConfiguration : MTRCluster
 
@@ -336,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Level Control
- *
+ *    Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'
  */
 @interface MTRClusterLevelControl : MTRCluster
 
@@ -461,7 +461,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Binary Input (Basic)
- *
+ *    An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
  */
 @interface MTRClusterBinaryInputBasic : MTRCluster
 
@@ -534,7 +534,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Descriptor
- *
+ *    The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its
+ * endpoints and clusters.
  */
 @interface MTRClusterDescriptor : MTRCluster
 
@@ -567,7 +568,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Binding
- *
+ *    The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
  */
 @interface MTRClusterBinding : MTRCluster
 
@@ -599,7 +600,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Access Control
- *
+ *    The Access Control Cluster exposes a data model view of a
+      Node's Access Control List (ACL), which codifies the rules used to manage
+      and enforce Access Control for the Node's endpoints and their associated
+      cluster instances.
  */
 @interface MTRClusterAccessControl : MTRCluster
 
@@ -644,7 +648,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Actions
- *
+ *    This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
  */
 @interface MTRClusterActions : MTRCluster
 
@@ -724,7 +728,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Basic
- *
+ *    This cluster provides attributes and events for determining basic information about Nodes, which supports both
+      Commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
+      which apply to the whole Node. Also allows setting user device information such as location.
  */
 @interface MTRClusterBasic : MTRCluster
 
@@ -812,7 +818,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster OTA Software Update Provider
- *
+ *    Provides an interface for providing OTA software updates
  */
 @interface MTRClusterOtaSoftwareUpdateProvider : MTRCluster
 
@@ -852,7 +858,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster OTA Software Update Requestor
- *
+ *    Provides an interface for downloading and applying OTA software updates
  */
 @interface MTRClusterOtaSoftwareUpdateRequestor : MTRCluster
 
@@ -895,7 +901,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Localization Configuration
- *
+ *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing common languages, units of measurements, and numerical formatting
+      standards. As such, Nodes that visually or audibly convey information need a mechanism by which
+      they can be configured to use a user’s preferred language, units, etc
  */
 @interface MTRClusterLocalizationConfiguration : MTRCluster
 
@@ -929,7 +938,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Time Format Localization
- *
+ *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
+      or audibly convey time information need a mechanism by which they can be configured to use a
+      user’s preferred format.
  */
 @interface MTRClusterTimeFormatLocalization : MTRCluster
 
@@ -970,7 +982,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Unit Localization
- *
+ *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
+      may have differing preferences for the units in which values are conveyed in communication to a
+      user. As such, Nodes that visually or audibly convey measurable values to the user need a
+      mechanism by which they can be configured to use a user’s preferred unit.
  */
 @interface MTRClusterUnitLocalization : MTRCluster
 
@@ -1002,7 +1017,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Power Source Configuration
- *
+ *    This cluster is used to describe the configuration and capabilities of a Device's power system.
  */
 @interface MTRClusterPowerSourceConfiguration : MTRCluster
 
@@ -1029,7 +1044,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Power Source
- *
+ *    This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the
+ * Node.
  */
 @interface MTRClusterPowerSource : MTRCluster
 
@@ -1116,7 +1132,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster General Commissioning
- *
+ *    This cluster is used to manage global aspects of the Commissioning flow.
  */
 @interface MTRClusterGeneralCommissioning : MTRCluster
 
@@ -1179,7 +1195,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Network Commissioning
- *
+ *    Functionality to configure, enable, disable network credentials and access on a Matter device.
  */
 @interface MTRClusterNetworkCommissioning : MTRCluster
 
@@ -1256,7 +1272,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Diagnostic Logs
- *
+ *    The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
  */
 @interface MTRClusterDiagnosticLogs : MTRCluster
 
@@ -1287,7 +1303,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster General Diagnostics
- *
+ *    The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics
+ * metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRClusterGeneralDiagnostics : MTRCluster
 
@@ -1335,7 +1352,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Software Diagnostics
- *
+ *    The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
+ * assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRClusterSoftwareDiagnostics : MTRCluster
 
@@ -1376,7 +1394,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Thread Network Diagnostics
- *
+ *    The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
+ * to assist a user or Administrative Node in diagnosing potential problems
  */
 @interface MTRClusterThreadNetworkDiagnostics : MTRCluster
 
@@ -1535,7 +1554,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster WiFi Network Diagnostics
- *
+ *    The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
+ * to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRClusterWiFiNetworkDiagnostics : MTRCluster
 
@@ -1594,7 +1614,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Ethernet Network Diagnostics
- *
+ *    The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a
+ * Node to assist a user or Administrative Node in diagnosing potential problems.
  */
 @interface MTRClusterEthernetNetworkDiagnostics : MTRCluster
 
@@ -1645,7 +1666,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Bridged Device Basic
- *
+ *    This Cluster serves two purposes towards a Node communicating with a Bridge: indicate that the functionality on
+          the Endpoint where it is placed (and its Parts) is bridged from a non-CHIP technology; and provide a centralized
+          collection of attributes that the Node MAY collect to aid in conveying information regarding the Bridged Device to a user,
+          such as the vendor name, the model name, or user-assigned name.
  */
 @interface MTRClusterBridgedDeviceBasic : MTRCluster
 
@@ -1705,7 +1729,12 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Switch
- *
+ *    This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
+Two types of switch devices are supported: latching switch (e.g. rocker switch) and momentary switch (e.g. push button),
+distinguished with their feature flags. Interactions with the switch device are exposed as attributes (for the latching switch) and
+as events (for both types of switches). An interested party MAY subscribe to these attributes/events and thus be informed of the
+interactions, and can perform actions based on this, for example by sending commands to perform an action such as controlling a
+light or a window shade.
  */
 @interface MTRClusterSwitch : MTRCluster
 
@@ -1736,7 +1765,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster AdministratorCommissioning
- *
+ *    Commands to trigger a Node to allow a new Administrator to commission it.
  */
 @interface MTRClusterAdministratorCommissioning : MTRCluster
 
@@ -1783,7 +1812,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Operational Credentials
- *
+ *    This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated
+ * Fabrics.
  */
 @interface MTRClusterOperationalCredentials : MTRCluster
 
@@ -1860,7 +1890,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Group Key Management
- *
+ *    The Group Key Management Cluster is the mechanism by which group keys are managed.
  */
 @interface MTRClusterGroupKeyManagement : MTRCluster
 
@@ -1917,7 +1947,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Fixed Label
- *
+ *    The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
+labels.
  */
 @interface MTRClusterFixedLabel : MTRCluster
 
@@ -1944,7 +1975,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster User Label
- *
+ *    The User Label Cluster provides a feature to tag an endpoint with zero or more labels.
  */
 @interface MTRClusterUserLabel : MTRCluster
 
@@ -1976,7 +2007,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Boolean State
- *
+ *    This cluster provides an interface to a boolean state called StateValue.
  */
 @interface MTRClusterBooleanState : MTRCluster
 
@@ -2003,7 +2034,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Mode Select
- *
+ *    Attributes and commands for selecting a mode from a list of supported options.
  */
 @interface MTRClusterModeSelect : MTRCluster
 
@@ -2055,7 +2086,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Door Lock
- *
+ *    An interface to a generic way to secure a door
  */
 @interface MTRClusterDoorLock : MTRCluster
 
@@ -2320,7 +2351,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Window Covering
- *
+ *    Provides an interface for controlling and adjusting automatic window coverings.
  */
 @interface MTRClusterWindowCovering : MTRCluster
 
@@ -2432,7 +2463,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Barrier Control
- *
+ *    This cluster provides control of a barrier (garage door).
  */
 @interface MTRClusterBarrierControl : MTRCluster
 
@@ -2519,7 +2550,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Pump Configuration and Control
- *
+ *    An interface for configuring and controlling pumps.
  */
 @interface MTRClusterPumpConfigurationAndControl : MTRCluster
 
@@ -2610,7 +2641,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Thermostat
- *
+ *    An interface for configuring and controlling the functionality of a thermostat.
  */
 @interface MTRClusterThermostat : MTRCluster
 
@@ -2889,7 +2920,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Fan Control
- *
+ *    An interface for controlling a fan in a heating/cooling system.
  */
 @interface MTRClusterFanControl : MTRCluster
 
@@ -2966,7 +2997,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Thermostat User Interface Configuration
- *
+ *    An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
  */
 @interface MTRClusterThermostatUserInterfaceConfiguration : MTRCluster
 
@@ -3012,7 +3043,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Color Control
- *
+ *    Attributes and commands for controlling the color properties of a color-capable light.
  */
 @interface MTRClusterColorControl : MTRCluster
 
@@ -3283,7 +3314,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Ballast Configuration
- *
+ *    Attributes and commands for configuring a lighting ballast.
  */
 @interface MTRClusterBallastConfiguration : MTRCluster
 
@@ -3386,7 +3417,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Illuminance Measurement
- *
+ *    Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
  */
 @interface MTRClusterIlluminanceMeasurement : MTRCluster
 
@@ -3421,7 +3452,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Temperature Measurement
- *
+ *    Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
  */
 @interface MTRClusterTemperatureMeasurement : MTRCluster
 
@@ -3454,7 +3485,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Pressure Measurement
- *
+ *    Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.
  */
 @interface MTRClusterPressureMeasurement : MTRCluster
 
@@ -3497,7 +3528,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Flow Measurement
- *
+ *    Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
  */
 @interface MTRClusterFlowMeasurement : MTRCluster
 
@@ -3530,7 +3561,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Relative Humidity Measurement
- *
+ *    Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
  */
 @interface MTRClusterRelativeHumidityMeasurement : MTRCluster
 
@@ -3563,7 +3594,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Occupancy Sensing
- *
+ *    Attributes and commands for configuring occupancy sensing, and reporting occupancy status.
  */
 @interface MTRClusterOccupancySensing : MTRCluster
 
@@ -3658,7 +3689,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Wake on LAN
- *
+ *    This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
  */
 @interface MTRClusterWakeOnLan : MTRCluster
 
@@ -3685,7 +3716,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Channel
- *
+ *    This cluster provides an interface for controlling the current Channel on a device.
  */
 @interface MTRClusterChannel : MTRCluster
 
@@ -3730,7 +3761,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Target Navigator
- *
+ *    This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
  */
 @interface MTRClusterTargetNavigator : MTRCluster
 
@@ -3765,7 +3796,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Media Playback
- *
+ *    This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or
+ * Speaker.
  */
 @interface MTRClusterMediaPlayback : MTRCluster
 
@@ -3892,7 +3924,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Media Input
- *
+ *    This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
  */
 @interface MTRClusterMediaInput : MTRCluster
 
@@ -3944,7 +3976,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Low Power
- *
+ *    This cluster provides an interface for managing low power mode on a device.
  */
 @interface MTRClusterLowPower : MTRCluster
 
@@ -3977,7 +4009,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Keypad Input
- *
+ *    This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
  */
 @interface MTRClusterKeypadInput : MTRCluster
 
@@ -4008,7 +4040,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Content Launcher
- *
+ *    This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRClusterContentLauncher : MTRCluster
 
@@ -4053,7 +4085,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Audio Output
- *
+ *    This cluster provides an interface for controlling the Output on a media device such as a TV.
  */
 @interface MTRClusterAudioOutput : MTRCluster
 
@@ -4091,7 +4123,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Application Launcher
- *
+ *    This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
  */
 @interface MTRClusterApplicationLauncher : MTRCluster
 
@@ -4141,7 +4173,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Application Basic
- *
+ *    This cluster provides information about an application running on a TV or media player device which is represented as an
+ * endpoint.
  */
 @interface MTRClusterApplicationBasic : MTRCluster
 
@@ -4182,7 +4215,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Account Login
- *
+ *    This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App
+ * running on a Video Player device, which is represented as an endpoint (see [TV Architecture]), can use this cluster to help make
+ * the user account on the Content App match the user account on the Client.
  */
 @interface MTRClusterAccountLogin : MTRCluster
 
@@ -4224,7 +4259,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Electrical Measurement
- *
+ *    Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need
+ * to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..
  */
 @interface MTRClusterElectricalMeasurement : MTRCluster
 
@@ -4557,7 +4593,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Test Cluster
- *
+ *    The Test Cluster is meant to validate the generated code
  */
 @interface MTRClusterTestCluster : MTRCluster
 

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -28,7 +28,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Identify
- *    Attributes and commands for putting a device into Identification mode (e.g. flashing a light).
+ *
  */
 @interface MTRClusterIdentify : MTRCluster
 
@@ -71,7 +71,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Groups
- *    Attributes and commands for group configuration and manipulation.
+ *
  */
 @interface MTRClusterGroups : MTRCluster
 
@@ -129,7 +129,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Scenes
- *    Attributes and commands for scene configuration and manipulation.
+ *
  */
 @interface MTRClusterScenes : MTRCluster
 
@@ -215,7 +215,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster On/Off
- *    Attributes and commands for switching devices between 'On' and 'Off' states.
+ *
  */
 @interface MTRClusterOnOff : MTRCluster
 
@@ -302,7 +302,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster On/off Switch Configuration
- *    Attributes and commands for configuring On/Off switching devices.
+ *
  */
 @interface MTRClusterOnOffSwitchConfiguration : MTRCluster
 
@@ -336,7 +336,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Level Control
- *    Attributes and commands for controlling devices that can be set to a level between fully 'On' and fully 'Off.'
+ *
  */
 @interface MTRClusterLevelControl : MTRCluster
 
@@ -461,7 +461,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Binary Input (Basic)
- *    An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
+ *
  */
 @interface MTRClusterBinaryInputBasic : MTRCluster
 
@@ -534,8 +534,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Descriptor
- *    The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its
- * endpoints and clusters.
+ *
  */
 @interface MTRClusterDescriptor : MTRCluster
 
@@ -568,7 +567,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Binding
- *    The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
+ *
  */
 @interface MTRClusterBinding : MTRCluster
 
@@ -600,10 +599,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Access Control
- *    The Access Control Cluster exposes a data model view of a
-      Node's Access Control List (ACL), which codifies the rules used to manage
-      and enforce Access Control for the Node's endpoints and their associated
-      cluster instances.
+ *
  */
 @interface MTRClusterAccessControl : MTRCluster
 
@@ -648,7 +644,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Actions
- *    This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
+ *
  */
 @interface MTRClusterActions : MTRCluster
 
@@ -728,9 +724,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Basic
- *    This cluster provides attributes and events for determining basic information about Nodes, which supports both
-      Commissioning and operational determination of Node characteristics, such as Vendor ID, Product ID and serial number,
-      which apply to the whole Node. Also allows setting user device information such as location.
+ *
  */
 @interface MTRClusterBasic : MTRCluster
 
@@ -818,7 +812,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster OTA Software Update Provider
- *    Provides an interface for providing OTA software updates
+ *
  */
 @interface MTRClusterOtaSoftwareUpdateProvider : MTRCluster
 
@@ -858,7 +852,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster OTA Software Update Requestor
- *    Provides an interface for downloading and applying OTA software updates
+ *
  */
 @interface MTRClusterOtaSoftwareUpdateRequestor : MTRCluster
 
@@ -901,10 +895,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Localization Configuration
- *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing common languages, units of measurements, and numerical formatting
-      standards. As such, Nodes that visually or audibly convey information need a mechanism by which
-      they can be configured to use a user’s preferred language, units, etc
+ *
  */
 @interface MTRClusterLocalizationConfiguration : MTRCluster
 
@@ -938,10 +929,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Time Format Localization
- *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing preferences for how dates and times are conveyed. As such, Nodes that visually
-      or audibly convey time information need a mechanism by which they can be configured to use a
-      user’s preferred format.
+ *
  */
 @interface MTRClusterTimeFormatLocalization : MTRCluster
 
@@ -982,10 +970,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Unit Localization
- *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
-      may have differing preferences for the units in which values are conveyed in communication to a
-      user. As such, Nodes that visually or audibly convey measurable values to the user need a
-      mechanism by which they can be configured to use a user’s preferred unit.
+ *
  */
 @interface MTRClusterUnitLocalization : MTRCluster
 
@@ -1017,7 +1002,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Power Source Configuration
- *    This cluster is used to describe the configuration and capabilities of a Device's power system.
+ *
  */
 @interface MTRClusterPowerSourceConfiguration : MTRCluster
 
@@ -1044,8 +1029,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Power Source
- *    This cluster is used to describe the configuration and capabilities of a physical power source that provides power to the
- * Node.
+ *
  */
 @interface MTRClusterPowerSource : MTRCluster
 
@@ -1132,7 +1116,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster General Commissioning
- *    This cluster is used to manage global aspects of the Commissioning flow.
+ *
  */
 @interface MTRClusterGeneralCommissioning : MTRCluster
 
@@ -1195,7 +1179,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Network Commissioning
- *    Functionality to configure, enable, disable network credentials and access on a Matter device.
+ *
  */
 @interface MTRClusterNetworkCommissioning : MTRCluster
 
@@ -1272,7 +1256,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Diagnostic Logs
- *    The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
+ *
  */
 @interface MTRClusterDiagnosticLogs : MTRCluster
 
@@ -1303,8 +1287,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster General Diagnostics
- *    The General Diagnostics Cluster, along with other diagnostics clusters, provide a means to acquire standardized diagnostics
- * metrics that MAY be used by a Node to assist a user or Administrative Node in diagnosing potential problems.
+ *
  */
 @interface MTRClusterGeneralDiagnostics : MTRCluster
 
@@ -1352,8 +1335,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Software Diagnostics
- *    The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
- * assist a user or Administrative Node in diagnosing potential problems.
+ *
  */
 @interface MTRClusterSoftwareDiagnostics : MTRCluster
 
@@ -1394,8 +1376,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Thread Network Diagnostics
- *    The Thread Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
- * to assist a user or Administrative Node in diagnosing potential problems
+ *
  */
 @interface MTRClusterThreadNetworkDiagnostics : MTRCluster
 
@@ -1554,8 +1535,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster WiFi Network Diagnostics
- *    The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
- * to assist a user or Administrative Node in diagnosing potential problems.
+ *
  */
 @interface MTRClusterWiFiNetworkDiagnostics : MTRCluster
 
@@ -1614,8 +1594,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Ethernet Network Diagnostics
- *    The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a
- * Node to assist a user or Administrative Node in diagnosing potential problems.
+ *
  */
 @interface MTRClusterEthernetNetworkDiagnostics : MTRCluster
 
@@ -1666,10 +1645,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Bridged Device Basic
- *    This Cluster serves two purposes towards a Node communicating with a Bridge: indicate that the functionality on
-          the Endpoint where it is placed (and its Parts) is bridged from a non-CHIP technology; and provide a centralized
-          collection of attributes that the Node MAY collect to aid in conveying information regarding the Bridged Device to a user,
-          such as the vendor name, the model name, or user-assigned name.
+ *
  */
 @interface MTRClusterBridgedDeviceBasic : MTRCluster
 
@@ -1729,12 +1705,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 /**
  * Cluster Switch
- *    This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
-Two types of switch devices are supported: latching switch (e.g. rocker switch) and momentary switch (e.g. push button),
-distinguished with their feature flags. Interactions with the switch device are exposed as attributes (for the latching switch) and
-as events (for both types of switches). An interested party MAY subscribe to these attributes/events and thus be informed of the
-interactions, and can perform actions based on this, for example by sending commands to perform an action such as controlling a
-light or a window shade.
+ *
  */
 @interface MTRClusterSwitch : MTRCluster
 
@@ -1765,7 +1736,7 @@ light or a window shade.
 
 /**
  * Cluster AdministratorCommissioning
- *    Commands to trigger a Node to allow a new Administrator to commission it.
+ *
  */
 @interface MTRClusterAdministratorCommissioning : MTRCluster
 
@@ -1812,8 +1783,7 @@ light or a window shade.
 
 /**
  * Cluster Operational Credentials
- *    This cluster is used to add or remove Operational Credentials on a Commissionee or Node, as well as manage the associated
- * Fabrics.
+ *
  */
 @interface MTRClusterOperationalCredentials : MTRCluster
 
@@ -1890,7 +1860,7 @@ light or a window shade.
 
 /**
  * Cluster Group Key Management
- *    The Group Key Management Cluster is the mechanism by which group keys are managed.
+ *
  */
 @interface MTRClusterGroupKeyManagement : MTRCluster
 
@@ -1947,8 +1917,7 @@ light or a window shade.
 
 /**
  * Cluster Fixed Label
- *    The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
-labels.
+ *
  */
 @interface MTRClusterFixedLabel : MTRCluster
 
@@ -1975,7 +1944,7 @@ labels.
 
 /**
  * Cluster User Label
- *    The User Label Cluster provides a feature to tag an endpoint with zero or more labels.
+ *
  */
 @interface MTRClusterUserLabel : MTRCluster
 
@@ -2007,7 +1976,7 @@ labels.
 
 /**
  * Cluster Boolean State
- *    This cluster provides an interface to a boolean state called StateValue.
+ *
  */
 @interface MTRClusterBooleanState : MTRCluster
 
@@ -2034,7 +2003,7 @@ labels.
 
 /**
  * Cluster Mode Select
- *    Attributes and commands for selecting a mode from a list of supported options.
+ *
  */
 @interface MTRClusterModeSelect : MTRCluster
 
@@ -2086,7 +2055,7 @@ labels.
 
 /**
  * Cluster Door Lock
- *    An interface to a generic way to secure a door
+ *
  */
 @interface MTRClusterDoorLock : MTRCluster
 
@@ -2351,7 +2320,7 @@ labels.
 
 /**
  * Cluster Window Covering
- *    Provides an interface for controlling and adjusting automatic window coverings.
+ *
  */
 @interface MTRClusterWindowCovering : MTRCluster
 
@@ -2463,7 +2432,7 @@ labels.
 
 /**
  * Cluster Barrier Control
- *    This cluster provides control of a barrier (garage door).
+ *
  */
 @interface MTRClusterBarrierControl : MTRCluster
 
@@ -2550,7 +2519,7 @@ labels.
 
 /**
  * Cluster Pump Configuration and Control
- *    An interface for configuring and controlling pumps.
+ *
  */
 @interface MTRClusterPumpConfigurationAndControl : MTRCluster
 
@@ -2641,7 +2610,7 @@ labels.
 
 /**
  * Cluster Thermostat
- *    An interface for configuring and controlling the functionality of a thermostat.
+ *
  */
 @interface MTRClusterThermostat : MTRCluster
 
@@ -2920,7 +2889,7 @@ labels.
 
 /**
  * Cluster Fan Control
- *    An interface for controlling a fan in a heating/cooling system.
+ *
  */
 @interface MTRClusterFanControl : MTRCluster
 
@@ -2997,7 +2966,7 @@ labels.
 
 /**
  * Cluster Thermostat User Interface Configuration
- *    An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
+ *
  */
 @interface MTRClusterThermostatUserInterfaceConfiguration : MTRCluster
 
@@ -3043,7 +3012,7 @@ labels.
 
 /**
  * Cluster Color Control
- *    Attributes and commands for controlling the color properties of a color-capable light.
+ *
  */
 @interface MTRClusterColorControl : MTRCluster
 
@@ -3314,7 +3283,7 @@ labels.
 
 /**
  * Cluster Ballast Configuration
- *    Attributes and commands for configuring a lighting ballast.
+ *
  */
 @interface MTRClusterBallastConfiguration : MTRCluster
 
@@ -3417,7 +3386,7 @@ labels.
 
 /**
  * Cluster Illuminance Measurement
- *    Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
+ *
  */
 @interface MTRClusterIlluminanceMeasurement : MTRCluster
 
@@ -3452,7 +3421,7 @@ labels.
 
 /**
  * Cluster Temperature Measurement
- *    Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
+ *
  */
 @interface MTRClusterTemperatureMeasurement : MTRCluster
 
@@ -3485,7 +3454,7 @@ labels.
 
 /**
  * Cluster Pressure Measurement
- *    Attributes and commands for configuring the measurement of pressure, and reporting pressure measurements.
+ *
  */
 @interface MTRClusterPressureMeasurement : MTRCluster
 
@@ -3528,7 +3497,7 @@ labels.
 
 /**
  * Cluster Flow Measurement
- *    Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
+ *
  */
 @interface MTRClusterFlowMeasurement : MTRCluster
 
@@ -3561,7 +3530,7 @@ labels.
 
 /**
  * Cluster Relative Humidity Measurement
- *    Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
+ *
  */
 @interface MTRClusterRelativeHumidityMeasurement : MTRCluster
 
@@ -3594,7 +3563,7 @@ labels.
 
 /**
  * Cluster Occupancy Sensing
- *    Attributes and commands for configuring occupancy sensing, and reporting occupancy status.
+ *
  */
 @interface MTRClusterOccupancySensing : MTRCluster
 
@@ -3689,7 +3658,7 @@ labels.
 
 /**
  * Cluster Wake on LAN
- *    This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
+ *
  */
 @interface MTRClusterWakeOnLan : MTRCluster
 
@@ -3716,7 +3685,7 @@ labels.
 
 /**
  * Cluster Channel
- *    This cluster provides an interface for controlling the current Channel on a device.
+ *
  */
 @interface MTRClusterChannel : MTRCluster
 
@@ -3761,7 +3730,7 @@ labels.
 
 /**
  * Cluster Target Navigator
- *    This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
+ *
  */
 @interface MTRClusterTargetNavigator : MTRCluster
 
@@ -3796,8 +3765,7 @@ labels.
 
 /**
  * Cluster Media Playback
- *    This cluster provides an interface for controlling Media Playback (PLAY, PAUSE, etc) on a media device such as a TV or
- * Speaker.
+ *
  */
 @interface MTRClusterMediaPlayback : MTRCluster
 
@@ -3924,7 +3892,7 @@ labels.
 
 /**
  * Cluster Media Input
- *    This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
+ *
  */
 @interface MTRClusterMediaInput : MTRCluster
 
@@ -3976,7 +3944,7 @@ labels.
 
 /**
  * Cluster Low Power
- *    This cluster provides an interface for managing low power mode on a device.
+ *
  */
 @interface MTRClusterLowPower : MTRCluster
 
@@ -4009,7 +3977,7 @@ labels.
 
 /**
  * Cluster Keypad Input
- *    This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
+ *
  */
 @interface MTRClusterKeypadInput : MTRCluster
 
@@ -4040,7 +4008,7 @@ labels.
 
 /**
  * Cluster Content Launcher
- *    This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
+ *
  */
 @interface MTRClusterContentLauncher : MTRCluster
 
@@ -4085,7 +4053,7 @@ labels.
 
 /**
  * Cluster Audio Output
- *    This cluster provides an interface for controlling the Output on a media device such as a TV.
+ *
  */
 @interface MTRClusterAudioOutput : MTRCluster
 
@@ -4123,7 +4091,7 @@ labels.
 
 /**
  * Cluster Application Launcher
- *    This cluster provides an interface for launching content on a media player device such as a TV or Speaker.
+ *
  */
 @interface MTRClusterApplicationLauncher : MTRCluster
 
@@ -4173,8 +4141,7 @@ labels.
 
 /**
  * Cluster Application Basic
- *    This cluster provides information about an application running on a TV or media player device which is represented as an
- * endpoint.
+ *
  */
 @interface MTRClusterApplicationBasic : MTRCluster
 
@@ -4215,9 +4182,7 @@ labels.
 
 /**
  * Cluster Account Login
- *    This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App
- * running on a Video Player device, which is represented as an endpoint (see [TV Architecture]), can use this cluster to help make
- * the user account on the Content App match the user account on the Client.
+ *
  */
 @interface MTRClusterAccountLogin : MTRCluster
 
@@ -4259,8 +4224,7 @@ labels.
 
 /**
  * Cluster Electrical Measurement
- *    Attributes related to the electrical properties of a device. This cluster is used by power outlets and other devices that need
- * to provide instantaneous data as opposed to metrology data which should be retrieved from the metering cluster..
+ *
  */
 @interface MTRClusterElectricalMeasurement : MTRCluster
 
@@ -4593,7 +4557,7 @@ labels.
 
 /**
  * Cluster Test Cluster
- *    The Test Cluster is meant to validate the generated code
+ *
  */
 @interface MTRClusterTestCluster : MTRCluster
 


### PR DESCRIPTION
#### Issue Being Resolved
This PR is exploring the part 1 of #22545
 "In MTRBaseClusters.h, see if we can generate any sort of basic documentation for the interfaces and/or their methods."

The current output contains a lot of not-so informative description such as: "Command description for {{insert command name here}}" but some describe the effect of the command.

This PR relies on a ZAP change at: https://github.com/project-chip/zap/pull/727

#### Change overview
 * Add cluster descriptions and command descriptions to the generated `MTRBaseClusters.h` file.