### PR TITLE
Ensure darwin-framework-tool is beeing rebuilt when something changes…

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -29,6 +29,7 @@ action("build-darwin-framework") {
 
   inputs = [
     "${chip_root}/src/darwin/Framework/CHIP",
+    "${chip_root}/src/darwin/Framework/CHIP/zap-generated",
     "${chip_root}/src/darwin/Framework/Matter.xcodeproj",
   ]
 


### PR DESCRIPTION
… in the generated code from src/darwin/Framework/CHIP/zap-generated

#### Issue Being Resolved
* When working on #22673 I got fooled thinking the code was compiling because changing only the generated content of `src/darwin/Framework/CHIP/zap-generated` does not trigger the rebuilding of `examples/darwin-framework-tool`

#### Change overview
 * Add `src/darwin/Framework/CHIP/zap-generated` as an input sources in `examples/darwin-framework-tool/BUILD.gn`
