### PR TITLE
Disable MDNS lookup on first message deliver failure be default

### DIFF
--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -18,7 +18,7 @@ declare_args() {
   # Allows to change time between retries during the case session
   chip_case_retry_delta = ""
 
-  chip_config_mrp_on_first_msg_fail_do_mdsn_lookup = ""
+  chip_config_resolve_peer_on_first_transmit_failure = ""
 }
 
 defines = []
@@ -28,8 +28,8 @@ if (chip_case_retry_delta != "") {
       [ "CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL=${chip_case_retry_delta}" ]
 }
 
-if (chip_config_mrp_on_first_msg_fail_do_mdsn_lookup != "") {
-  defines += [ "CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP=${chip_config_mrp_on_first_msg_fail_do_mdsn_lookup}" ]
+if (chip_config_resolve_peer_on_first_transmit_failure != "") {
+  defines += [ "CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE=${chip_config_resolve_peer_on_first_transmit_failure}" ]
 }
 
 source_set("messaging_mrp_config") {

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -29,8 +29,7 @@ if (chip_case_retry_delta != "") {
 }
 
 if (chip_config_mrp_on_first_msg_fail_do_mdsn_lookup != "") {
-  defines +=
-      [ "CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP=${chip_config_mrp_on_first_msg_fail_do_mdsn_lookup}" ]
+  defines += [ "CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP=${chip_config_mrp_on_first_msg_fail_do_mdsn_lookup}" ]
 }
 
 source_set("messaging_mrp_config") {

--- a/src/messaging/BUILD.gn
+++ b/src/messaging/BUILD.gn
@@ -17,6 +17,8 @@ import("//build_overrides/chip.gni")
 declare_args() {
   # Allows to change time between retries during the case session
   chip_case_retry_delta = ""
+
+  chip_config_mrp_on_first_msg_fail_do_mdsn_lookup = ""
 }
 
 defines = []
@@ -24,6 +26,11 @@ defines = []
 if (chip_case_retry_delta != "") {
   defines +=
       [ "CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL=${chip_case_retry_delta}" ]
+}
+
+if (chip_config_mrp_on_first_msg_fail_do_mdsn_lookup != "") {
+  defines +=
+      [ "CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP=${chip_config_mrp_on_first_msg_fail_do_mdsn_lookup}" ]
 }
 
 source_set("messaging_mrp_config") {

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -316,6 +316,7 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 
     if (err == CHIP_NO_ERROR)
     {
+#if CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
         const ExchangeManager * exchangeMgr = entry->ec->GetExchangeMgr();
         // TODO: investigate why in ReliableMessageMgr::CheckResendApplicationMessageWithPeerExchange unit test released exchange
         // context with mExchangeMgr==nullptr is used.
@@ -329,6 +330,7 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
                 mSessionUpdateDelegate->UpdatePeerAddress(entry->ec->GetSessionHandle()->GetPeer());
             }
         }
+#endif // CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
     }
     else
     {

--- a/src/messaging/ReliableMessageMgr.cpp
+++ b/src/messaging/ReliableMessageMgr.cpp
@@ -316,7 +316,7 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
 
     if (err == CHIP_NO_ERROR)
     {
-#if CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+#if CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE
         const ExchangeManager * exchangeMgr = entry->ec->GetExchangeMgr();
         // TODO: investigate why in ReliableMessageMgr::CheckResendApplicationMessageWithPeerExchange unit test released exchange
         // context with mExchangeMgr==nullptr is used.
@@ -330,7 +330,7 @@ CHIP_ERROR ReliableMessageMgr::SendFromRetransTable(RetransTableEntry * entry)
                 mSessionUpdateDelegate->UpdatePeerAddress(entry->ec->GetSessionHandle()->GetPeer());
             }
         }
-#endif // CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+#endif // CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE
     }
     else
     {

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -47,6 +47,22 @@ namespace chip {
 #endif // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
 
 /**
+ *  @def CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+ *
+ *  @brief
+ *    Should an address lookup of the peer happen on every first message that fails
+ *    to send on the link.
+ *
+ *  The default value selected to not perform lookup was for the following reasons:
+ *    1. The likelihood of the IP address changing right away is extremely slim.
+ *    2. On bad links, there resolutions occur extremely frequently, making the link
+ *       worse.
+ */
+#ifndef CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+#define CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP 0
+#endif // CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+
+/**
  *  @def CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
  *
  *  @brief

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -72,20 +72,24 @@ namespace chip {
 #endif // CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT
 
 /**
- *  @def CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+ *  @def CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE
  *
  *  @brief
  *    Should an address lookup of the peer happen on every first message that fails
  *    to send on the link.
  *
- *  The default value selected to not perform lookup was for the following reasons:
- *    1. The likelihood of the IP address changing right away is extremely slim.
- *    2. On bad links, there resolutions occur extremely frequently, making the link
- *       worse.
+ *  The default value to not perform lookup was selected because most implementations
+ *  of address lookup are not cache the and a request is sent on the link. Failing
+ *  to deliver the first message is far more likely to happen due to lossy link
+ *  than an actual address change where the peer did not reset. In the lossy link
+ *  situation the frequent lookup would make the link even worse. Additionally,
+ *  every message that arrives from a peer updates the address. If the peer has fallen
+ *  off the link due to any other reason, a re-resolve may not achieve an address that
+ *  is reachable, even if a resolve response occurs.
  */
-#ifndef CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
-#define CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP 0
-#endif // CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+#ifndef CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE
+#define CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE 0
+#endif // CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE
 
 /**
  *  @def CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -82,10 +82,10 @@ namespace chip {
  *  of address lookup are not cache the and a request is sent on the link. Failing
  *  to deliver the first message is far more likely to happen due to lossy link
  *  than an actual address change where the peer did not reset. In the lossy link
- *  situation the frequent lookup would make the link even worse. Additionally,
- *  every message that arrives from a peer updates the address. If the peer has fallen
- *  off the link due to any other reason, a re-resolve may not achieve an address that
- *  is reachable, even if a resolve response occurs.
+ *  situation, doing further DNS resolutions on a degraded link can exacerbate that
+ *  problem greatly. Additionally, every message that arrives from a peer updates the
+ *  address. If the peer has fallen off the link due to any other reason, a re-resolve
+ *  may not achieve an address that is reachable, even if a resolve response occurs.
  */
 #ifndef CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE
 #define CHIP_CONFIG_RESOLVE_PEER_ON_FIRST_TRANSMIT_FAILURE 0

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -47,22 +47,6 @@ namespace chip {
 #endif // CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
 
 /**
- *  @def CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
- *
- *  @brief
- *    Should an address lookup of the peer happen on every first message that fails
- *    to send on the link.
- *
- *  The default value selected to not perform lookup was for the following reasons:
- *    1. The likelihood of the IP address changing right away is extremely slim.
- *    2. On bad links, there resolutions occur extremely frequently, making the link
- *       worse.
- */
-#ifndef CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
-#define CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP 0
-#endif // CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
-
-/**
  *  @def CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
  *
  *  @brief
@@ -86,6 +70,22 @@ namespace chip {
 #ifndef CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT
 #define CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT (200_ms32)
 #endif // CHIP_CONFIG_RMP_DEFAULT_ACK_TIMEOUT
+
+/**
+ *  @def CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+ *
+ *  @brief
+ *    Should an address lookup of the peer happen on every first message that fails
+ *    to send on the link.
+ *
+ *  The default value selected to not perform lookup was for the following reasons:
+ *    1. The likelihood of the IP address changing right away is extremely slim.
+ *    2. On bad links, there resolutions occur extremely frequently, making the link
+ *       worse.
+ */
+#ifndef CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
+#define CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP 0
+#endif // CHIP_CONFIG_MRP_ON_FIRST_MSG_FAIL_DO_MDNS_LOOKUP
 
 /**
  *  @def CHIP_CONFIG_RMP_RETRANS_TABLE_SIZE


### PR DESCRIPTION
#### Issue Being Resolved
* Addresses #22670 in a manner that allows platforms/application to re-enable should they choose in 1.0 timeframe

#### Change overview
* Disable MDNS lookup on first message deliver failure be default, but allow it to be enabled via gn argument