### PR TITLE
Bump up cirque timeouts

### DIFF
--- a/.github/workflows/cirque.yaml
+++ b/.github/workflows/cirque.yaml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
     cirque:
         name: Cirque
-        timeout-minutes: 75
+        timeout-minutes: 90
 
         env:
             DOCKER_RUN_VERSION: 0.5.99
@@ -114,7 +114,7 @@ jobs:
                        && scripts/build/gn_gen_cirque.sh
                       '
             - name: Run Tests
-              timeout-minutes: 25
+              timeout-minutes: 45
               run: |
                   integrations/docker/images/chip-build-cirque/run.sh \
                      --env LOG_DIR=/tmp/cirque_test_output \


### PR DESCRIPTION
#### Issue Being Resolved
Fixes #22679

#### Change overview
Update cirque run tests step timeout from 25 to 45 minutes (large margin to make sure we are not to close for a while)
Overall increased the run timeout from 75 to 90 minutes.
