### PR TITLE
Update BLE manager to use correct type/remove unnecessary adv interval

### DIFF
--- a/examples/all-clusters-app/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/all-clusters-app/cc13x2x7_26x2x7/chip.syscfg
@@ -152,8 +152,6 @@ ble.connUpdateParamsPeripheral.reqMaxConnInt               = 50;
 
 ble.advSet1.$name                                         = "ti_ble5stack_broadcaster_advertisement_set0";
 ble.advSet1.advParam1.$name                               = "ti_ble5stack_broadcaster_advertisement_params0";
-ble.advSet1.advParam1.primIntMin                    = 100;
-ble.advSet1.advParam1.primIntMax                    = 200;
 
 /* DMM */
 dmm.project                                          = "ti_thread_thermostat_remote_display";

--- a/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/all-clusters-minimal-app/cc13x2x7_26x2x7/chip.syscfg
@@ -152,8 +152,6 @@ ble.connUpdateParamsPeripheral.reqMaxConnInt               = 50;
 
 ble.advSet1.$name                                         = "ti_ble5stack_broadcaster_advertisement_set0";
 ble.advSet1.advParam1.$name                               = "ti_ble5stack_broadcaster_advertisement_params0";
-ble.advSet1.advParam1.primIntMin                    = 100;
-ble.advSet1.advParam1.primIntMax                    = 200;
 
 /* DMM */
 dmm.project                                          = "ti_thread_thermostat_remote_display";

--- a/examples/lock-app/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/lock-app/cc13x2x7_26x2x7/chip.syscfg
@@ -152,8 +152,6 @@ ble.connUpdateParamsPeripheral.reqMaxConnInt               = 50;
 
 ble.advSet1.$name                                         = "ti_ble5stack_broadcaster_advertisement_set0";
 ble.advSet1.advParam1.$name                               = "ti_ble5stack_broadcaster_advertisement_params0";
-ble.advSet1.advParam1.primIntMin                    = 100;
-ble.advSet1.advParam1.primIntMax                    = 200;
 
 /* DMM */
 dmm.project                                          = "ti_thread_thermostat_remote_display";

--- a/examples/pump-app/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/pump-app/cc13x2x7_26x2x7/chip.syscfg
@@ -77,7 +77,6 @@ ble.connUpdateParamsPeripheral.reqMinConnInt = 30;
 ble.connUpdateParamsPeripheral.reqMaxConnInt = 50;
 ble.advSet1.$name                            = "ti_ble5stack_broadcaster_advertisement_set0";
 ble.advSet1.advParam1.$name                  = "ti_ble5stack_broadcaster_advertisement_params0";
-ble.advSet1.advParam1.primIntMax             = 200;
 ble.advSet1.advData1.$name                   = "ti_ble5stack_broadcaster_advertisement_data0";
 ble.advSet1.scanRes1.$name                   = "ti_ble5stack_broadcaster_advertisement_data1";
 

--- a/examples/pump-controller-app/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/pump-controller-app/cc13x2x7_26x2x7/chip.syscfg
@@ -77,7 +77,6 @@ ble.connUpdateParamsPeripheral.reqMinConnInt = 30;
 ble.connUpdateParamsPeripheral.reqMaxConnInt = 50;
 ble.advSet1.$name                            = "ti_ble5stack_broadcaster_advertisement_set0";
 ble.advSet1.advParam1.$name                  = "ti_ble5stack_broadcaster_advertisement_params0";
-ble.advSet1.advParam1.primIntMax             = 200;
 ble.advSet1.advData1.$name                   = "ti_ble5stack_broadcaster_advertisement_data0";
 ble.advSet1.scanRes1.$name                   = "ti_ble5stack_broadcaster_advertisement_data1";
 

--- a/examples/shell/cc13x2x7_26x2x7/chip.syscfg
+++ b/examples/shell/cc13x2x7_26x2x7/chip.syscfg
@@ -117,8 +117,6 @@ ble.connUpdateParamsPeripheral.reqMaxConnInt               = 50;
 
 ble.advSet1.$name                                         = "ti_ble5stack_broadcaster_advertisement_set0";
 ble.advSet1.advParam1.$name                               = "ti_ble5stack_broadcaster_advertisement_params0";
-ble.advSet1.advParam1.primIntMin                    = 100;
-ble.advSet1.advParam1.primIntMax                    = 200;
 
 /* DMM */
 dmm.project                                          = "ti_thread_thermostat_remote_display";

--- a/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
+++ b/src/platform/cc13x2_26x2/BLEManagerImpl.cpp
@@ -467,7 +467,7 @@ void BLEManagerImpl::ConfigureAdvertisements(void)
 
     sInstance.mAdvDatachipOBle[advIndex++] = 0x02;
     sInstance.mAdvDatachipOBle[advIndex++] = GAP_ADTYPE_FLAGS;
-    sInstance.mAdvDatachipOBle[advIndex++] = GAP_ADTYPE_FLAGS_BREDR_NOT_SUPPORTED | GAP_ADTYPE_FLAGS_LIMITED;
+    sInstance.mAdvDatachipOBle[advIndex++] = GAP_ADTYPE_FLAGS_BREDR_NOT_SUPPORTED | GAP_ADTYPE_FLAGS_GENERAL;
     sInstance.mAdvDatachipOBle[advIndex++] = advLength;
     sInstance.mAdvDatachipOBle[advIndex++] = GAP_ADTYPE_SERVICE_DATA;
     sInstance.mAdvDatachipOBle[advIndex++] = static_cast<uint8_t>(LO_UINT16(CHIPOBLE_SERV_UUID));
@@ -792,7 +792,7 @@ void BLEManagerImpl::ProcessEvtHdrMsg(QueuedEvt_t * pMsg)
                     GapAdv_disable(sInstance.advHandleLegacy);
                     sInstance.mFlags.Clear(Flags::kAdvertising);
 
-                    uint16_t newParamMax = 0, newParamMin = 0;
+                    uint32_t newParamMax = 0, newParamMin = 0;
                     if (sInstance.mFlags.Has(Flags::kFastAdvertisingEnabled))
                     {
                         // Update advertising interval


### PR DESCRIPTION
Problem
CC13X2 CC26X2 platform BLE manager utilizes incorrect type for GAP Adv API which may cause instability.
#22696 
Change overview
Update BLE manager to use correct type for API and advertising flags. Remove redundant advertising intervals in sysconfig as this is already being set by the CHIP stack.

Testing
Verified build/commissioning is successful and that advertising interval is still consistent with CHIP specifications.