### PR TITLE
[BUG] Fix ReadClient to use the right parameters when computing the liveness timeout

### DIFF
--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -32,17 +32,19 @@ namespace chip {
 using namespace System::Clock::Literals;
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-static System::Clock::Milliseconds32 idleRetransTimeoutOverride   = 0_ms32;
-static System::Clock::Milliseconds32 activeRetransTimeoutOverride = 0_ms32;
+static Optional<System::Clock::Timeout> idleRetransTimeoutOverride   = NullOptional;
+static Optional<System::Clock::Timeout> activeRetransTimeoutOverride = NullOptional;
 
-void OverrideDefaultIdleMRPConfig(System::Clock::Milliseconds32 idleRetransTimeout)
+void OverrideLocalMRPConfig(System::Clock::Timeout idleRetransTimeout, System::Clock::Timeout activeRetransTimeout)
 {
-    idleRetransTimeoutOverride = idleRetransTimeout;
+    idleRetransTimeoutOverride.SetValue(idleRetransTimeout);
+    activeRetransTimeoutOverride.SetValue(activeRetransTimeout);
 }
 
-void OverrideDefaultActiveMRPConfig(System::Clock::Milliseconds32 activeRetransTimeout)
+void ClearLocalMRPConfigOverride()
 {
-    activeRetransTimeoutOverride = activeRetransTimeout;
+    activeRetransTimeoutOverride.ClearValue();
+    idleRetransTimeoutOverride.ClearValue();
 }
 #endif
 
@@ -71,14 +73,14 @@ Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig()
 #endif
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-    if (idleRetransTimeoutOverride != 0_ms32)
+    if (idleRetransTimeoutOverride.HasValue())
     {
-        config.mIdleRetransTimeout = idleRetransTimeoutOverride;
+        config.mIdleRetransTimeout = idleRetransTimeoutOverride.Value();
     }
 
-    if (activeRetransTimeoutOverride != 0_ms32)
+    if (activeRetransTimeoutOverride.HasValue())
     {
-        config.mActiveRetransTimeout = activeRetransTimeoutOverride;
+        config.mActiveRetransTimeout = activeRetransTimeoutOverride.Value();
     }
 #endif
 

--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -31,6 +31,21 @@ namespace chip {
 
 using namespace System::Clock::Literals;
 
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+static System::Clock::Milliseconds32 idleRetransTimeoutOverride   = 0_ms32;
+static System::Clock::Milliseconds32 activeRetransTimeoutOverride = 0_ms32;
+
+void OverrideDefaultIdleMRPConfig(System::Clock::Milliseconds32 idleRetransTimeout)
+{
+    idleRetransTimeoutOverride = idleRetransTimeout;
+}
+
+void OverrideDefaultActiveMRPConfig(System::Clock::Milliseconds32 activeRetransTimeout)
+{
+    activeRetransTimeoutOverride = activeRetransTimeout;
+}
+#endif
+
 ReliableMessageProtocolConfig GetDefaultMRPConfig()
 {
     // Default MRP intervals are defined in spec <2.11.3. Parameters and Constants>
@@ -52,6 +67,18 @@ Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig()
         // which the device can be at sleep and not be able to receive any messages).
         config.mIdleRetransTimeout += sedIntervalsConfig.IdleIntervalMS;
         config.mActiveRetransTimeout += sedIntervalsConfig.ActiveIntervalMS;
+    }
+#endif
+
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+    if (idleRetransTimeoutOverride != 0_ms32)
+    {
+        config.mIdleRetransTimeout = idleRetransTimeoutOverride;
+    }
+
+    if (activeRetransTimeoutOverride != 0_ms32)
+    {
+        config.mActiveRetransTimeout = activeRetransTimeoutOverride;
     }
 #endif
 

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -143,20 +143,6 @@ struct ReliableMessageProtocolConfig
     }
 };
 
-#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-
-/**
- * @brief
- *
- * Functions to override the default idle/active MRP intervals in test.
- *
- * Set to 0 to disable the override.
- *
- */
-void OverrideDefaultIdleMRPConfig(System::Clock::Milliseconds32 idleRetransTimeout);
-void OverrideDefaultActiveMRPConfig(System::Clock::Milliseconds32 activeRetransTimeout);
-#endif
-
 /// @brief The default MRP config. The value is defined by spec, and shall be same for all implementations,
 ReliableMessageProtocolConfig GetDefaultMRPConfig();
 
@@ -169,5 +155,25 @@ ReliableMessageProtocolConfig GetDefaultMRPConfig();
  *          use it when communicating with us.
  */
 Optional<ReliableMessageProtocolConfig> GetLocalMRPConfig();
+
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+
+/**
+ * @brief
+ *
+ * Overrides the local idle and active retransmission timeout parameters (which are usually set through compile
+ * time defines). This is reserved for tests that need the ability to set these at runtime to make certain test scenarios possible.
+ *
+ */
+void OverrideLocalMRPConfig(System::Clock::Timeout idleRetransTimeout, System::Clock::Timeout activeRetransTimeout);
+
+/**
+ * @brief
+ *
+ * Disables the overrides set previously in OverrideLocalMRPConfig().
+ *
+ */
+void ClearLocalMRPConfigOverride();
+#endif
 
 } // namespace chip

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -143,6 +143,20 @@ struct ReliableMessageProtocolConfig
     }
 };
 
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+
+/**
+ * @brief
+ *
+ * Functions to override the default idle/active MRP intervals in test.
+ *
+ * Set to 0 to disable the override.
+ *
+ */
+void OverrideDefaultIdleMRPConfig(System::Clock::Milliseconds32 idleRetransTimeout);
+void OverrideDefaultActiveMRPConfig(System::Clock::Milliseconds32 activeRetransTimeout);
+#endif
+
 /// @brief The default MRP config. The value is defined by spec, and shall be same for all implementations,
 ReliableMessageProtocolConfig GetDefaultMRPConfig();
 

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -97,6 +97,9 @@ void MessagingContext::ShutdownAndRestoreExisting(MessagingContext & existing)
 
 using namespace System::Clock::Literals;
 
+constexpr chip::System::Clock::Timeout MessagingContext::kResponsiveIdleRetransTimeout;
+constexpr chip::System::Clock::Timeout MessagingContext::kResponsiveActiveRetransTimeout;
+
 void MessagingContext::SetMRPMode(MRPMode mode)
 {
     if (mode == MRPMode::kDefault)
@@ -107,8 +110,7 @@ void MessagingContext::SetMRPMode(MRPMode mode)
         mSessionDavidToCharlie->AsSecureSession()->SetRemoteMRPConfig(GetDefaultMRPConfig());
 
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-        OverrideDefaultIdleMRPConfig(0_ms32);
-        OverrideDefaultActiveMRPConfig(0_ms32);
+        ClearLocalMRPConfigOverride();
 #else
         //
         // A test is calling this function assuming the overrides above are going to work
@@ -120,8 +122,7 @@ void MessagingContext::SetMRPMode(MRPMode mode)
     else
     {
 #if CONFIG_BUILD_FOR_HOST_UNIT_TEST
-        OverrideDefaultIdleMRPConfig(10_ms32);
-        OverrideDefaultActiveMRPConfig(10_ms32);
+        OverrideLocalMRPConfig(MessagingContext::kResponsiveIdleRetransTimeout, MessagingContext::kResponsiveActiveRetransTimeout);
 #else
         //
         // A test is calling this function assuming the overrides above are going to work
@@ -130,14 +131,14 @@ void MessagingContext::SetMRPMode(MRPMode mode)
         VerifyOrDie(false);
 #endif
 
-        mSessionBobToAlice->AsSecureSession()->SetRemoteMRPConfig(
-            ReliableMessageProtocolConfig(System::Clock::Milliseconds32(10), System::Clock::Milliseconds32(10)));
-        mSessionAliceToBob->AsSecureSession()->SetRemoteMRPConfig(
-            ReliableMessageProtocolConfig(System::Clock::Milliseconds32(10), System::Clock::Milliseconds32(10)));
-        mSessionCharlieToDavid->AsSecureSession()->SetRemoteMRPConfig(
-            ReliableMessageProtocolConfig(System::Clock::Milliseconds32(10), System::Clock::Milliseconds32(10)));
-        mSessionDavidToCharlie->AsSecureSession()->SetRemoteMRPConfig(
-            ReliableMessageProtocolConfig(System::Clock::Milliseconds32(10), System::Clock::Milliseconds32(10)));
+        mSessionBobToAlice->AsSecureSession()->SetRemoteMRPConfig(ReliableMessageProtocolConfig(
+            MessagingContext::kResponsiveIdleRetransTimeout, MessagingContext::kResponsiveActiveRetransTimeout));
+        mSessionAliceToBob->AsSecureSession()->SetRemoteMRPConfig(ReliableMessageProtocolConfig(
+            MessagingContext::kResponsiveIdleRetransTimeout, MessagingContext::kResponsiveActiveRetransTimeout));
+        mSessionCharlieToDavid->AsSecureSession()->SetRemoteMRPConfig(ReliableMessageProtocolConfig(
+            MessagingContext::kResponsiveIdleRetransTimeout, MessagingContext::kResponsiveActiveRetransTimeout));
+        mSessionDavidToCharlie->AsSecureSession()->SetRemoteMRPConfig(ReliableMessageProtocolConfig(
+            MessagingContext::kResponsiveIdleRetransTimeout, MessagingContext::kResponsiveActiveRetransTimeout));
     }
 }
 

--- a/src/messaging/tests/MessagingContext.cpp
+++ b/src/messaging/tests/MessagingContext.cpp
@@ -95,6 +95,8 @@ void MessagingContext::ShutdownAndRestoreExisting(MessagingContext & existing)
     existing.mTransport->SetSessionManager(&existing.GetSecureSessionManager());
 }
 
+using namespace System::Clock::Literals;
+
 void MessagingContext::SetMRPMode(MRPMode mode)
 {
     if (mode == MRPMode::kDefault)
@@ -103,9 +105,31 @@ void MessagingContext::SetMRPMode(MRPMode mode)
         mSessionAliceToBob->AsSecureSession()->SetRemoteMRPConfig(GetDefaultMRPConfig());
         mSessionCharlieToDavid->AsSecureSession()->SetRemoteMRPConfig(GetDefaultMRPConfig());
         mSessionDavidToCharlie->AsSecureSession()->SetRemoteMRPConfig(GetDefaultMRPConfig());
+
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+        OverrideDefaultIdleMRPConfig(0_ms32);
+        OverrideDefaultActiveMRPConfig(0_ms32);
+#else
+        //
+        // A test is calling this function assuming the overrides above are going to work
+        // when in fact, they won't because the compile flag is not set correctly.
+        //
+        VerifyOrDie(false);
+#endif
     }
     else
     {
+#if CONFIG_BUILD_FOR_HOST_UNIT_TEST
+        OverrideDefaultIdleMRPConfig(10_ms32);
+        OverrideDefaultActiveMRPConfig(10_ms32);
+#else
+        //
+        // A test is calling this function assuming the overrides above are going to work
+        // when in fact, they won't because the compile flag is not set correctly.
+        //
+        VerifyOrDie(false);
+#endif
+
         mSessionBobToAlice->AsSecureSession()->SetRemoteMRPConfig(
             ReliableMessageProtocolConfig(System::Clock::Milliseconds32(10), System::Clock::Milliseconds32(10)));
         mSessionAliceToBob->AsSecureSession()->SetRemoteMRPConfig(

--- a/src/messaging/tests/MessagingContext.h
+++ b/src/messaging/tests/MessagingContext.h
@@ -85,6 +85,12 @@ public:
                          //      i.e IDLE = 10ms, ACTIVE = 10ms
     };
 
+    //
+    // See above for a description of the values used.
+    //
+    static constexpr System::Clock::Timeout kResponsiveIdleRetransTimeout   = System::Clock::Milliseconds32(10);
+    static constexpr System::Clock::Timeout kResponsiveActiveRetransTimeout = System::Clock::Milliseconds32(10);
+
     MessagingContext() :
         mInitialized(false), mAliceAddress(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT + 1)),
         mBobAddress(Transport::PeerAddress::UDP(GetAddress(), CHIP_PORT))


### PR DESCRIPTION
This fixes the logic in ReadClient to use the local IDLE interval when computing the liveness timeout instead of the IDLE interval of our peer.

### Testing:

Using the REPL and the liveness timer print, confirmed the fixes are indeed applied.

#### Issue Being Resolved
* fixes #22652 