### PR TITLE
Android tv-casting-app: Fixing issues with handling responses for Media commands

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -78,7 +78,7 @@ public class TvCastingApp {
    * APPLICATION LAUNCHER CLUSTER
    */
   public native boolean applicationLauncher_launchApp(
-      short catalogVendorId, String applicationId, String data, Object responseHandler);
+      short catalogVendorId, String applicationId, byte[] data, Object responseHandler);
 
   public native boolean applicationLauncher_stopApp(
       short catalogVendorId, String applicationId, Object responseHandler);

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.cpp
@@ -125,12 +125,13 @@ JNI_METHOD(void, init)(JNIEnv *, jobject)
 JNI_METHOD(jboolean, contentLauncherLaunchURL)
 (JNIEnv * env, jobject, jstring contentUrl, jstring contentDisplayStr, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD contentLauncherLaunchURL called");
     const char * nativeContentUrl        = env->GetStringUTFChars(contentUrl, 0);
     const char * nativeContentDisplayStr = env->GetStringUTFChars(contentDisplayStr, 0);
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ContentLauncher_LaunchURL);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ContentLauncher_LaunchURL).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI::SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -152,21 +153,22 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, levelControl_step)
+JNI_METHOD(jboolean, levelControl_1step)
 (JNIEnv * env, jobject, jbyte stepMode, jbyte stepSize, jshort transitionTime, jbyte optionMask, jbyte optionOverride,
  jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD levelControl_step called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(LevelControl_Step);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(LevelControl_Step).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = CastingServer::GetInstance()->LevelControl_Step(static_cast<chip::app::Clusters::LevelControl::StepMode>(stepMode),
-                                                          static_cast<uint8_t>(stepSize), static_cast<uint16_t>(transitionTime),
-                                                          static_cast<uint8_t>(optionMask), static_cast<uint8_t>(optionOverride),
-                                                          [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    err = CastingServer::GetInstance()->LevelControl_Step(
+        static_cast<chip::app::Clusters::LevelControl::StepMode>(stepMode), static_cast<uint8_t>(stepSize),
+        static_cast<uint16_t>(transitionTime), static_cast<uint8_t>(optionMask), static_cast<uint8_t>(optionOverride),
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(LevelControl_Step).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.LevelControl_Step failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -179,19 +181,21 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, levelControl_moveToLevel)
+JNI_METHOD(jboolean, levelControl_1moveToLevel)
 (JNIEnv * env, jobject, jbyte level, jshort transitionTime, jbyte optionMask, jbyte optionOverride, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD levelControl_moveToLevel called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(LevelControl_MoveToLevel);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(LevelControl_MoveToLevel).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->LevelControl_MoveToLevel(
         static_cast<uint8_t>(level), static_cast<uint16_t>(transitionTime), static_cast<uint8_t>(optionMask),
-        static_cast<uint8_t>(optionOverride), [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+        static_cast<uint8_t>(optionOverride),
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(LevelControl_MoveToLevel).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.LevelControl_MoveToLevel failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -204,17 +208,19 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, mediaPlayback_play)
+JNI_METHOD(jboolean, mediaPlayback_1play)
 (JNIEnv * env, jobject, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_play called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Play);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Play).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = CastingServer::GetInstance()->MediaPlayback_Play([&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    err = CastingServer::GetInstance()->MediaPlayback_Play(
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Play).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_Play failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -227,17 +233,19 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, mediaPlayback_pause)
+JNI_METHOD(jboolean, mediaPlayback_1pause)
 (JNIEnv * env, jobject, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_pause called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Pause);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Pause).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = CastingServer::GetInstance()->MediaPlayback_Pause([&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    err = CastingServer::GetInstance()->MediaPlayback_Pause(
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Pause).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_Pause failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -250,18 +258,19 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, mediaPlayback_stopPlayback)
+JNI_METHOD(jboolean, mediaPlayback_1stopPlayback)
 (JNIEnv * env, jobject, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_stopPlayback called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_StopPlayback);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_StopPlayback).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->MediaPlayback_StopPlayback(
-        [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_StopPlayback).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_StopPlayback failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -274,17 +283,19 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, mediaPlayback_next)
+JNI_METHOD(jboolean, mediaPlayback_1next)
 (JNIEnv * env, jobject, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_next called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Next);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Next).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = CastingServer::GetInstance()->MediaPlayback_Next([&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    err = CastingServer::GetInstance()->MediaPlayback_Next(
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Next).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_Next failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -297,18 +308,20 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, mediaPlayback_seek)
+JNI_METHOD(jboolean, mediaPlayback_1seek)
 (JNIEnv * env, jobject, jlong position, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_seek called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Seek);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Seek).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = CastingServer::GetInstance()->MediaPlayback_Seek(static_cast<uint64_t>(position),
-                                                           [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    err = CastingServer::GetInstance()->MediaPlayback_Seek(static_cast<uint64_t>(position), [](CHIP_ERROR err) {
+        TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_Seek).Handle(err);
+    });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_Seek failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -321,18 +334,20 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, mediaPlayback_skipForward)
+JNI_METHOD(jboolean, mediaPlayback_1skipForward)
 (JNIEnv * env, jobject, jlong deltaPositionMilliseconds, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_skipForward called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_SkipForward);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_SkipForward).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->MediaPlayback_SkipForward(
-        static_cast<uint64_t>(deltaPositionMilliseconds), [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+        static_cast<uint64_t>(deltaPositionMilliseconds),
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_SkipForward).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_SkipForward failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -345,18 +360,20 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, mediaPlayback_skipBackward)
+JNI_METHOD(jboolean, mediaPlayback_1skipBackward)
 (JNIEnv * env, jobject, jlong deltaPositionMilliseconds, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD mediaPlayback_skipBackward called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_SkipBackward);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_SkipBackward).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->MediaPlayback_SkipBackward(
-        static_cast<uint64_t>(deltaPositionMilliseconds), [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+        static_cast<uint64_t>(deltaPositionMilliseconds),
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(MediaPlayback_SkipBackward).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.MediaPlayback_SkipBackward failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -369,9 +386,11 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, applicationLauncher_launchApp)
+JNI_METHOD(jboolean, applicationLauncher_1launchApp)
 (JNIEnv * env, jobject, jshort catalogVendorId, jstring applicationId, jbyteArray data, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD applicationLauncher_launchApp called");
 
     chip::app::Clusters::ApplicationLauncher::Structs::Application::Type application;
@@ -380,14 +399,14 @@ JNI_METHOD(jboolean, applicationLauncher_launchApp)
     application.applicationId        = CharSpan::fromCharString(nativeApplicationId);
     JniByteArray dataByteArray(env, data);
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_LaunchApp);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err =
+        TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_LaunchApp).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->ApplicationLauncher_LaunchApp(
         application, chip::MakeOptional(dataByteArray.byteSpan()),
-        [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_LaunchApp).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.ApplicationLauncher_LaunchApp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -401,9 +420,11 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, applicationLauncher_stopApp)
+JNI_METHOD(jboolean, applicationLauncher_1stopApp)
 (JNIEnv * env, jobject, jshort catalogVendorId, jstring applicationId, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD applicationLauncher_stopApp called");
 
     chip::app::Clusters::ApplicationLauncher::Structs::Application::Type application;
@@ -411,13 +432,13 @@ JNI_METHOD(jboolean, applicationLauncher_stopApp)
     const char * nativeApplicationId = env->GetStringUTFChars(applicationId, 0);
     application.applicationId        = CharSpan::fromCharString(nativeApplicationId);
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_StopApp);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_StopApp).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = CastingServer::GetInstance()->ApplicationLauncher_StopApp(
-        application, [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    err = CastingServer::GetInstance()->ApplicationLauncher_StopApp(application, [&](CHIP_ERROR err) {
+        TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_StopApp).Handle(err);
+    });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.ApplicationLauncher_StopApp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -431,9 +452,11 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, applicationLauncher_hideApp)
+JNI_METHOD(jboolean, applicationLauncher_1hideApp)
 (JNIEnv * env, jobject, jshort catalogVendorId, jstring applicationId, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD applicationLauncher_hideApp called");
 
     chip::app::Clusters::ApplicationLauncher::Structs::Application::Type application;
@@ -441,13 +464,13 @@ JNI_METHOD(jboolean, applicationLauncher_hideApp)
     const char * nativeApplicationId = env->GetStringUTFChars(applicationId, 0);
     application.applicationId        = CharSpan::fromCharString(nativeApplicationId);
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_HideApp);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_HideApp).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = CastingServer::GetInstance()->ApplicationLauncher_HideApp(
-        application, [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    err = CastingServer::GetInstance()->ApplicationLauncher_HideApp(application, [](CHIP_ERROR err) {
+        TvCastingAppJNIMgr().getMediaCommandResponseHandler(ApplicationLauncher_HideApp).Handle(err);
+    });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.ApplicationLauncher_HideApp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -461,21 +484,23 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, targetNavigator_navigateTarget)
+JNI_METHOD(jboolean, targetNavigator_1navigateTarget)
 (JNIEnv * env, jobject, jbyte target, jstring data, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD targetNavigator_navigateTarget called");
 
     const char * nativeData = env->GetStringUTFChars(data, 0);
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(TargetNavigator_NavigateTarget);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err =
+        TvCastingAppJNIMgr().getMediaCommandResponseHandler(TargetNavigator_NavigateTarget).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
     err = CastingServer::GetInstance()->TargetNavigator_NavigateTarget(
         static_cast<uint8_t>(target), chip::MakeOptional(CharSpan::fromCharString(nativeData)),
-        [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(TargetNavigator_NavigateTarget).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.TargetNavigator_NavigateTarget failed %" CHIP_ERROR_FORMAT, err.Format()));
 
@@ -489,18 +514,20 @@ exit:
     return true;
 }
 
-JNI_METHOD(jboolean, keypadInput_sendKey)
+JNI_METHOD(jboolean, keypadInput_1sendKey)
 (JNIEnv * env, jobject, jbyte keyCode, jobject jResponseHandler)
 {
+    chip::DeviceLayer::StackLock lock;
+
     ChipLogProgress(AppServer, "JNI_METHOD keypadInput_sendKey called");
 
-    MatterCallbackHandlerJNI responseHandler = TvCastingAppJNIMgr().getMediaCommandResponseHandler(KeypadInput_SendKey);
-    CHIP_ERROR err                           = responseHandler.SetUp(env, jResponseHandler);
+    CHIP_ERROR err = TvCastingAppJNIMgr().getMediaCommandResponseHandler(KeypadInput_SendKey).SetUp(env, jResponseHandler);
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "MatterCallbackHandlerJNI.SetUp failed %" CHIP_ERROR_FORMAT, err.Format()));
 
-    err = CastingServer::GetInstance()->KeypadInput_SendKey(static_cast<chip::app::Clusters::KeypadInput::CecKeyCode>(keyCode),
-                                                            [&responseHandler](CHIP_ERROR err) { responseHandler.Handle(err); });
+    err = CastingServer::GetInstance()->KeypadInput_SendKey(
+        static_cast<chip::app::Clusters::KeypadInput::CecKeyCode>(keyCode),
+        [](CHIP_ERROR err) { TvCastingAppJNIMgr().getMediaCommandResponseHandler(KeypadInput_SendKey).Handle(err); });
     VerifyOrExit(CHIP_NO_ERROR == err,
                  ChipLogError(AppServer, "CastingServer.KeypadInput_SendKey failed %" CHIP_ERROR_FORMAT, err.Format()));
 


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22700 

#### Change overview
1. Updated how the response Handler is passed to the lambda in C++ calling the Java response handler.
2. Added the required _1 as separator for the new Media commands (added after contentLauncherLaunchUrl) to satisfy JNI naming requirements.
3. Added StackLocks before making calls into the SDK for each of the JNI methods for the media commands.

#### Testing
Tested using the Android tv-casting-app example.
