### PR TITLE
Make MessageDef byte string logging nicer.

### DIFF
--- a/src/app/MessageDef/MessageDefHelper.cpp
+++ b/src/app/MessageDef/MessageDefHelper.cpp
@@ -217,7 +217,7 @@ CHIP_ERROR CheckIMPayload(TLV::TLVReader & aReader, int aDepth, const char * aLa
         {
             for (size_t i = 0; i < len; i++)
             {
-                PRETTY_PRINT_SAMELINE("0x%x, ", value_b[i]);
+                PRETTY_PRINT_SAMELINE("0x%02x, ", value_b[i]);
             }
         }
 


### PR DESCRIPTION
0-pad the values, so they are constant-width.

#### Issue Being Resolved
* Fixes #22706

#### Change overview
Use `%02x` instead of `%x`.
