### PR TITLE
[CI] Ensure that running threads started as dependencies of a test ar…

### DIFF
--- a/scripts/tests/chiptest/test_definition.py
+++ b/scripts/tests/chiptest/test_definition.py
@@ -39,6 +39,7 @@ class App:
         self.lastLogIndex = 0
         self.kvsPathSet = {'/tmp/chip_kvs'}
         self.options = None
+        self.killed = False
 
     def start(self, options=None):
         if not self.process:
@@ -85,9 +86,13 @@ class App:
     def kill(self):
         if self.process:
             self.process.kill()
+        self.killed = True
 
     def wait(self, timeout=None):
         while True:
+            # If the App was never started, AND was killed, exit immediately
+            if self.killed:
+                return 0
             # If the App was never started, wait cannot be called on the process
             if self.process == None:
                 time.sleep(0.1)


### PR DESCRIPTION
…e freed, even if the process has never been started

#### Issue Being Resolved

Trying to locally runs the test suite with an iteration count > 100 never succeeds on my laptop:
```
./scripts/run_in_build_env.sh \
                  "./scripts/tests/run_test_suite.py \
                     --chip-tool ./out/darwin-x64-darwin-framework-tool-no-ble-asan-clang/darwin-framework-tool \
                     --target Test_TC_RH_1_1 \
                     run \
                     --iterations 300 \
                     --test-timeout-seconds 120 \
                     --all-clusters-app ./out/darwin-x64-all-clusters-no-ble-asan-clang/chip-all-clusters-app \
                     --lock-app ./out/darwin-x64-lock-no-ble-asan-clang/chip-lock-app \
                     --ota-provider-app ./out/darwin-x64-ota-provider-no-ble-asan-clang/chip-ota-provider-app \
                     --ota-requestor-app ./out/darwin-x64-ota-requestor-no-ble-asan-clang/chip-ota-requestor-app \
                     --tv-app ./out/darwin-x64-tv-app-no-ble-asan-clang/chip-tv-app \
                  "
```

At some point the test are starting to get slower, and some output is dropped randomly.
I have tracked that down to a regression from #17727.

To summary, #17727 has changed the behaviour of the test suite to pass all the applications declared as targets into the test suite as dependencies of the current test. This is fine by itself, the issue is that the code waiting for a process to be stopped just loop forever if one of the dependency has not been started - which happens for most of the dependencies.

As a result, we may end up with more than a thousand threads just sleeping (`time.sleep(0.1)`) until the point where the situation stops beeing tractable for the underlying hardware.

I suspect that to be the root cause of the intermittent failure that happens on darwin for `Test_RH_2_1`. `Test_RH_2_1` being the one that is at the limit of what the CI hardware can supports. Why, does it happens more for darwin than for Linux ? Again that may depends on the hardware running the test suite. And why does it happens more for `darwin-framework-tool` than for `chip-tool` itself ? I suspect the tests running under the `Darwin-framework-tool` to be more "chatty", which may results into some stdout buffers beeing completely filled up when the test is running, and so we are more likely to miss the "interesting" part.

So all of this is just theory at the moment, I guess CI runs will prove me right or wrong...
If my CI run is green for the darwin bits on the first run, I will tagged this one has hot fix at the current redness on the CI is a pain.

#### Change overview
* Ensure to stop the python threads for non running processes that have been tentatively killed.
