### PR TITLE
[QPG] Use Doorlock cluster attribute API and fix door lock application behavior

### DIFF
--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -29,6 +29,7 @@
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>
@@ -542,12 +543,14 @@ void AppTask::DispatchEvent(AppEvent * aEvent)
  */
 void AppTask::UpdateClusterState(void)
 {
+    using namespace chip::app::Clusters;
+    auto newValue = BoltLockMgr().IsUnlocked() ? DoorLock::DlLockState::kUnlocked : DoorLock::DlLockState::kLocked;
+
     ChipLogProgress(NotSpecified, "UpdateClusterState");
 
-    // write the new on/off value
-    EmberAfStatus status = Clusters::OnOff::Attributes::OnOff::Set(QPG_LOCK_ENDPOINT_ID, !BoltLockMgr().IsUnlocked());
+    EmberAfStatus status = DoorLock::Attributes::LockState::Set(DOOR_LOCK_SERVER_ENDPOINT, newValue);
     if (status != EMBER_ZCL_STATUS_SUCCESS)
     {
-        ChipLogError(NotSpecified, "ERR: updating on/off %x", status);
+        ChipLogError(NotSpecified, "ERR: updating DoorLock %x", status);
     }
 }

--- a/examples/lock-app/qpg/src/AppTask.cpp
+++ b/examples/lock-app/qpg/src/AppTask.cpp
@@ -29,7 +29,6 @@
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
-#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app/server/Dnssd.h>
 #include <app/server/Server.h>
 #include <app/util/attribute-storage.h>

--- a/examples/lock-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lock-app/qpg/src/ZclCallbacks.cpp
@@ -45,14 +45,6 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
     default:
         break;
     }
-
-    if (path.mAttributeId != OnOff::Attributes::OnOff::Id)
-    {
-        ChipLogProgress(Zcl, "Unknown attribute ID: " ChipLogFormatMEI, ChipLogValueMEI(path.mAttributeId));
-        return;
-    }
-
-    BoltLockMgr().InitiateAction(0, *value ? BoltLockManager::LOCK_ACTION : BoltLockManager::UNLOCK_ACTION);
 }
 
 bool emberAfPluginDoorLockGetUser(EndpointId endpointId, uint16_t userIndex, EmberAfPluginDoorLockUserInfo & user)
@@ -83,13 +75,27 @@ bool emberAfPluginDoorLockSetCredential(EndpointId endpointId, uint16_t credenti
 
 bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode, DlOperationError & err)
 {
-    return BoltLockMgr().ValidatePIN(pinCode, err);
+    bool returnValue = false;
+
+    if ( BoltLockMgr().ValidatePIN(pinCode, err) )
+    {
+        returnValue = BoltLockMgr().InitiateAction(0, BoltLockManager::LOCK_ACTION);
+    }
+
+    return returnValue;
 }
 
 bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<ByteSpan> & pinCode,
                                               DlOperationError & err)
 {
-    return BoltLockMgr().ValidatePIN(pinCode, err);
+    bool returnValue = false;
+
+    if ( BoltLockMgr().ValidatePIN(pinCode, err) )
+    {
+        returnValue = BoltLockMgr().InitiateAction(0, BoltLockManager::UNLOCK_ACTION);
+    }
+
+    return returnValue;
 }
 
 void emberAfDoorLockClusterInitCallback(EndpointId endpoint)

--- a/examples/lock-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lock-app/qpg/src/ZclCallbacks.cpp
@@ -77,7 +77,7 @@ bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const O
 {
     bool returnValue = false;
 
-    if ( BoltLockMgr().ValidatePIN(pinCode, err) )
+    if (BoltLockMgr().ValidatePIN(pinCode, err))
     {
         returnValue = BoltLockMgr().InitiateAction(0, BoltLockManager::LOCK_ACTION);
     }
@@ -90,7 +90,7 @@ bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const
 {
     bool returnValue = false;
 
-    if ( BoltLockMgr().ValidatePIN(pinCode, err) )
+    if (BoltLockMgr().ValidatePIN(pinCode, err))
     {
         returnValue = BoltLockMgr().InitiateAction(0, BoltLockManager::UNLOCK_ACTION);
     }


### PR DESCRIPTION
**Issue Being Resolved**
Fixes #22722

**Problem**
- Door lock application was still partially using OnOff cluster
- Door lock commands were not triggering application events

**Change overview**
- Updated code to use Doorlock cluster commands
- Added application link when a Doolock cluster command is triggered.

**Testing**
 Triggered Doolock cluster commands using chip-tool to check the lock changes its state.
Tested on QPG6105 DK
