### PR TITLE
Scripts updated Sep 19

### DIFF
--- a/src/app/tests/suites/certification/PICS.yaml
+++ b/src/app/tests/suites/certification/PICS.yaml
@@ -807,6 +807,9 @@ PICS:
     - label: "Does the device implement the ACCapacityFormat attribute?"
       id: TSTAT.S.A0047
 
+    - label: "Is the MinSetpointDeadBand attribute writeable?"
+      id: TSTAT.S.M.MinSetpointDeadBandWritable
+
     #Thermostat commands
     - label: "Does the device implement the SetpointRaiseLower command?"
       id: TSTAT.S.C00.Rsp

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_1.yaml
@@ -21,6 +21,9 @@ config:
     nodeId: 0x12344321
     cluster: "Audio Output"
     endpoint: 1
+    Index:
+        type: int8u
+        defaultValue: 1
 
 tests:
     - label: "Wait for the commissioned device to be retrieved"
@@ -45,11 +48,11 @@ tests:
       arguments:
           values:
               - name: "Index"
-                value: 1
+                value: Index
 
     - label: "Reads the CurrentOutput attribute"
       PICS: AUDIOOUTPUT.S.A0001 && AUDIOOUTPUT.S.C00.Rsp
       command: "readAttribute"
       attribute: "CurrentOutput"
       response:
-          value: 1
+          value: Index

--- a/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_AUDIOOUTPUT_7_2.yaml
@@ -21,6 +21,9 @@ config:
     nodeId: 0x12344321
     cluster: "Audio Output"
     endpoint: 1
+    Index:
+        type: int8u
+        defaultValue: 1
 
 tests:
     - label: "Wait for the commissioned device to be retrieved"
@@ -46,7 +49,7 @@ tests:
       arguments:
           values:
               - name: "Index"
-                value: 1
+                value: Index
               - name: "name"
                 value: "CertTest"
 

--- a/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_BINFO_2_1.yaml
@@ -648,25 +648,13 @@ tests:
       response:
           value: UniqueIDValue
 
+    #This step implicitly validating the attribute(CapabilityMinima)constraints, as long as the payload is being parsed successfully
     - label: "TH reads CapabilityMinima attribute from the DUT."
       PICS: BINFO.S.A0013
       command: "readAttribute"
       attribute: "CapabilityMinima"
       response:
           saveAs: CapabilityMinimaValue
-
-    - label:
-          "Step 56 is implicitly validating the attribute(CapabilityMinima)
-          constraints, as long as the payload is being parsed successfully"
-      cluster: "LogCommands"
-      command: "UserPrompt"
-      PICS: PICS_USER_PROMPT && BINFO.S.A0013
-      arguments:
-          values:
-              - name: "message"
-                value: "Please enter 'y' for success"
-              - name: "expectedValue"
-                value: "y"
 
     - label: "TH writes CapabilityMinima from the DUT."
       PICS: BINFO.S.A0013

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_11.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_11.yaml
@@ -217,6 +217,7 @@ tests:
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
+          clusterError: 2
 
     - label: "TH_CR1 reads the list of Fabrics on DUT_CE"
       cluster: "Operational Credentials"
@@ -297,6 +298,7 @@ tests:
                 value: discriminator
       response:
           error: FAILURE
+          clusterError: 2
 
     - label:
           "Wait for the expiration of PIXIT.CADMIN.CwDuration seconds that was
@@ -353,3 +355,4 @@ tests:
                 value: discriminator
       response:
           error: FAILURE
+          clusterError: 2

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_13.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_13.yaml
@@ -294,6 +294,7 @@ tests:
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
+          clusterError: 2
 
     - label: "TH_CR1 reads the list of Fabrics on DUT_CE"
       identity: "alpha"
@@ -395,6 +396,7 @@ tests:
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
+          clusterError: 2
 
     - label: "TH_CR1 reads the list of Fabrics on DUT_CE"
       identity: "alpha"
@@ -460,6 +462,7 @@ tests:
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
+          clusterError: 2
 
     - label: "Wait for the expiration of PIXIT.CADMIN.CwDuration seconds"
       cluster: "DelayCommands"

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_15.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_15.yaml
@@ -228,6 +228,36 @@ tests:
           constraints:
               type: list
 
+    #Check for DNS-SD advertisement is not possible in YAML
+    - label:
+          "Verify DUT_CE is now discoverable over DNS-SD with 2 Operational
+          service records (_matter._tcp SRV records)."
+      verification: |
+          Execute the below command in any linux platform or in TH_CR1
+          grl@grl-ThinkPad-L480:~/may16_cntrl03/connectedhomeip/examples/chip-tool/out/debug$ avahi-browse -rt _matter._tcp
+          + wlp5s0 IPv6 8E50A59FAF52A809-0000000000000001             _matter._tcp         local
+          + wlp5s0 IPv6 03E707466A904C7E-0000000000000003             _matter._tcp         local
+          = wlp5s0 IPv6 8E50A59FAF52A809-0000000000000001             _matter._tcp         local
+            hostname = [E45F010F27530000.local]
+            address = [fe80::e65f:1ff:fe0f:2753]
+            port = [5540]
+            txt = ["T=1" "SAI=300" "SII=5000"]
+          = wlp5s0 IPv6 03E707466A904C7E-0000000000000003             _matter._tcp         local
+            hostname = [E45F010F27530000.local]
+            address = [fe80::e65f:1ff:fe0f:2753]
+            port = [5540]
+            txt = ["T=1" "SAI=300" "SII=5000"]
+          grl@grl-ThinkPad-L480:~/may16_cntrl03/connectedhomeip/examples/chip-tool/out/debug$
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_SKIP_SAMPLE_APP
+      arguments:
+          values:
+              - name: "message"
+                value: "enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
+
     - label: "TH_CR1 opens a commissioning window on DUT_CE using ECM"
       identity: "alpha"
       PICS: CADMIN.S.C00.Rsp

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_3.yaml
@@ -148,13 +148,46 @@ tests:
               - name: "nodeId"
                 value: nodeId2
 
+    #Check for DNS-SD advertisement is not possible in YAML
+    - label:
+          "Verify DUT_CE is now discoverable over DNS-SD with two SRV Records"
+      verification: |
+          On TH_CR2 send the below command
+
+          Verify if the DUT_CE is broadcasting using
+
+          ubuntu@ubuntu:~/may16_cntrl/connectedhomeip/examples/chip-tool/out/debug$ avahi-browse -rt _matter._tcp
+          +   eth0 IPv6 9B9C01C971F4119F-0000000000000001             _matter._tcp         local
+          +   eth0 IPv6 C8A60CCA27F33379-0000000000000002             _matter._tcp         local
+          =   eth0 IPv6 9B9C01C971F4119F-0000000000000001             _matter._tcp         local
+            hostname = [E45F010F27530000.local]
+            address = [fe80::e65f:1ff:fe0f:2753]
+            port = [5540]
+            txt = ["T=1" "SAI=300" "SII=5000"]
+          =   eth0 IPv6 C8A60CCA27F33379-0000000000000002             _matter._tcp         local
+            hostname = [E45F010F27530000.local]
+            address = [fe80::e65f:1ff:fe0f:2753]
+            port = [5540]
+            txt = ["T=1" "SAI=300" "SII=5000"]
+          ubuntu@ubuntu:~/may16_cntrl/connectedhomeip/examples/chip-tool/out/debug$
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_SKIP_SAMPLE_APP
+      arguments:
+          values:
+              - name: "message"
+                value: "enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
+
     - label: "TH_CR1 reads the list of Fabrics on DUT_CE"
       command: "readAttribute"
       cluster: "Operational Credentials"
       attribute: "Fabrics"
       PICS: OPCREDS.S.A0001
+      fabricFiltered: false
       response:
-          value: [{ Label: "", nodeId: nodeId }]
+          value: [{ Label: "", nodeId: nodeId }, { Label: "", nodeId: nodeId2 }]
           constraints:
               type: list
 
@@ -287,3 +320,4 @@ tests:
                 value: payload
       response:
           error: FAILURE
+          clusterError: 9

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_4.yaml
@@ -142,9 +142,9 @@ tests:
     - label:
           "Verify DUT_CE is now discoverable over DNS-SD with two SRV Records"
       verification: |
-          On TH_CR2 send the below command  
+          On TH_CR2 send the below command
 
-          Verify if the DUT_CE is broadcasting using 
+          Verify if the DUT_CE is broadcasting using
 
           ubuntu@ubuntu:~/may16_cntrl2/connectedhomeip/examples/chip-tool/out/debug$ avahi-browse -rt _matter._tcp
           +   eth0 IPv6 C8A60CCA27F33379-0000000000000002             _matter._tcp         local

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_4.yaml
@@ -138,13 +138,45 @@ tests:
               - name: "nodeId"
                 value: nodeId2
 
+    #Check for DNS-SD advertisement is not possible in YAML
+    - label:
+          "Verify DUT_CE is now discoverable over DNS-SD with two SRV Records"
+      verification: |
+          On TH_CR2 send the below command  
+
+          Verify if the DUT_CE is broadcasting using 
+
+          ubuntu@ubuntu:~/may16_cntrl2/connectedhomeip/examples/chip-tool/out/debug$ avahi-browse -rt _matter._tcp
+          +   eth0 IPv6 C8A60CCA27F33379-0000000000000002             _matter._tcp         local
+          +   eth0 IPv6 3C26C93CF201458F-0000000000000001             _matter._tcp         local
+          =   eth0 IPv6 C8A60CCA27F33379-0000000000000002             _matter._tcp         local
+            hostname = [E45F010F27530000.local]
+            address = [fe80::e65f:1ff:fe0f:2753]
+            port = [5540]
+            txt = ["T=1" "SAI=300" "SII=5000"]
+          =   eth0 IPv6 3C26C93CF201458F-0000000000000001             _matter._tcp         local
+            hostname = [E45F010F27530000.local]
+            address = [fe80::e65f:1ff:fe0f:2753]
+            port = [5540]
+            txt = ["T=1" "SAI=300" "SII=5000"]
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_SKIP_SAMPLE_APP
+      arguments:
+          values:
+              - name: "message"
+                value: "enter 'y' after success"
+              - name: "expectedValue"
+                value: "y"
+
     - label: "TH_CR1 reads the list of Fabrics on DUT_CE"
       command: "readAttribute"
       cluster: "Operational Credentials"
       PICS: OPCREDS.S.A0001
       attribute: "Fabrics"
+      fabricFiltered: false
       response:
-          value: [{ Label: "", nodeId: nodeId }]
+          value: [{ Label: "", nodeId: nodeId }, { Label: "", nodeId: nodeId2 }]
           constraints:
               type: list
 
@@ -154,8 +186,9 @@ tests:
       cluster: "Operational Credentials"
       attribute: "Fabrics"
       PICS: OPCREDS.S.A0001
+      fabricFiltered: false
       response:
-          value: [{ Label: "", nodeId: nodeId2 }]
+          value: [{ Label: "", nodeId: nodeId }, { Label: "", nodeId: nodeId2 }]
           constraints:
               type: list
 
@@ -264,3 +297,4 @@ tests:
                 value: payload
       response:
           error: FAILURE
+          clusterError: 9

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_5.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_5.yaml
@@ -218,6 +218,7 @@ tests:
                 value: "SPAKE2P Key Salt"
       response:
           error: FAILURE
+          clusterError: 3
 
     - label: "TH_CR1 opens a new commissioning window on DUT_CE using ECM"
       cluster: "AdministratorCommissioning"
@@ -269,6 +270,16 @@ tests:
                 value: nodeId2
               - name: "payload"
                 value: payload
+
+    - label: "DUT_CE is commissioned by TH_CR2"
+      identity: "beta"
+      cluster: "DelayCommands"
+      command: "WaitForCommissionee"
+      PICS: CADMIN.S
+      arguments:
+          values:
+              - name: "nodeId"
+                value: nodeId2
 
     - label:
           "TH_CR1 tries to revoke the commissioning window on DUT_CE using

--- a/src/app/tests/suites/certification/Test_TC_CADMIN_1_6.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CADMIN_1_6.yaml
@@ -207,6 +207,7 @@ tests:
                 value: 180
       response:
           error: FAILURE
+          clusterError: 2
 
     - label: "TH_CR2 starts a commissioning process on DUT_CE"
       identity: "beta"
@@ -238,6 +239,7 @@ tests:
       timedInteractionTimeoutMs: 10000
       response:
           error: FAILURE
+          clusterError: 4
 
     - label: "TH_CR3 starts a commissioning process with DUT_CE"
       identity: "gamma"

--- a/src/app/tests/suites/certification/Test_TC_CC_2_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_2_1.yaml
@@ -200,7 +200,8 @@ tests:
               minValue: 0
               maxValue: 65535
 
-    - label: "TH reads FeatureMap attribute from DUT"
+    - label:
+          "Saving for comparision in step 19 reads FeatureMap attribute from DUT"
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
@@ -275,7 +276,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read  primary1x 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0011 DataVersion: 540305990
           [1651483665.109697][3245:3250] CHIP:TOO:   primary 1 x: 0
           [1651483665.109797][3245:3250] CHIP:EM: Sending Standalone Ack for MessageCounter:12731123 on exchange 55053i
@@ -296,7 +298,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read  primary1y 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0012 DataVersion: 540305990
           [1651483698.733322][3253:3259] CHIP:TOO:   primary 1 y: 0
           [1651483698.733420][3253:3259] CHIP:EM: Sending Standalone Ack for MessageCounter:7863787 on exchange 13103i
@@ -316,7 +319,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary1intensity 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint8 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0013 DataVersion: 540305990
           [1651483742.297459][3263:3268] CHIP:TOO:   primary 1 intensity: 0
           [1651483742.297558][3263:3268] CHIP:EM: Sending Standalone Ack for MessageCounter:10210809 on exchange 7007i
@@ -337,7 +341,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary2x 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0015 DataVersion: 540305990
           [1651483777.233498][3270:3275] CHIP:TOO:   primary 2 x: 0
           [1651483777.233614][3270:3275] CHIP:EM: Sending Standalone Ack for MessageCounter:1684573 on exchange 21377i
@@ -358,7 +363,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary2y 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0016 DataVersion: 540305990
           [1651483805.650796][3279:3284] CHIP:TOO:   primary 2 y: 0
           [1651483805.650942][3279:3284] CHIP:EM: Sending Standalone Ack for MessageCounter:16277541 on exchange 10435i
@@ -378,7 +384,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary2intensity 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint8 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0017 DataVersion: 540305990
           [1651483834.596380][3285:3290] CHIP:TOO:   primary 2 intensity: 0
           [1651483834.596470][3285:3290] CHIP:EM: Sending Standalone Ack for MessageCounter:5986355 on exchange 855i
@@ -399,7 +406,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary3x 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0019 DataVersion: 540305990
           [1651483937.072323][3298:3303] CHIP:TOO:   primary 3 x: 0
           [1651483937.072405][3298:3303] CHIP:EM: Sending Standalone Ack for MessageCounter:6092298 on exchange 12519i
@@ -420,7 +428,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary3y 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_001A DataVersion: 540305990
           [1651483967.386334][3305:3310] CHIP:TOO:   primary 3 y: 0
           [1651483967.386427][3305:3310] CHIP:EM: Sending Standalone Ack for MessageCounter:3329418 on exchange 11657i
@@ -440,10 +449,11 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary3intensity 1 1
 
-          Verify in  TH  Logs:
-          CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_001B DataVersion: 540305990
-          [1651484113.812178][3316:3321] CHIP:TOO:   primary 3 intensity: 0
-          [1651484113.812270][3316:3321] CHIP:EM: Sending Standalone Ack for MessageCounter:41658 on exchange 9618i
+           Verify response contains an uint8 in  TH(chip-tool)  Logs:
+
+           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_001B DataVersion: 540305990
+           [1651484113.812178][3316:3321] CHIP:TOO:   primary 3 intensity: 0
+           [1651484113.812270][3316:3321] CHIP:EM: Sending Standalone Ack for MessageCounter:41658 on exchange 9618i
       cluster: "LogCommands"
       command: "UserPrompt"
       PICS: PICS_USER_PROMPT && CC.S.A001b
@@ -462,7 +472,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary4x 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0020 DataVersion: 540305990
           [1651484143.778301][3324:3329] CHIP:TOO:   primary 4 x: 0
           [1651484143.778392][3324:3329] CHIP:EM: Sending Standalone Ack for MessageCounter:2094184 on exchange 50270i
@@ -483,7 +494,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary4y 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0021 DataVersion: 540305990
           [1651484171.921901][3334:3339] CHIP:TOO:   primary 4 y: 0
           [1651484171.921984][3334:3339] CHIP:EM: Sending Standalone Ack for MessageCounter:3701827 on exchange 16726i
@@ -503,7 +515,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary4intensity 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint8 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0022 DataVersion: 540305990
           [1651484198.443415][3341:3346] CHIP:TOO:   primary 4 intensity: 0
           [1651484198.443528][3341:3346] CHIP:EM: Sending Standalone Ack for MessageCounter:1740063 on exchange 36245i
@@ -524,7 +537,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary5x 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0024 DataVersion: 540305990
           [1651484241.467661][3350:3355] CHIP:TOO:   primary 5 x: 0
           [1651484241.467788][3350:3355] CHIP:EM: Sending Standalone Ack for MessageCounter:5350139 on exchange 63040i
@@ -545,7 +559,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary5y 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0025 DataVersion: 540305990
           [1651484286.709863][3358:3363] CHIP:TOO:   primary 5 y: 0
           [1651484286.709964][3358:3363] CHIP:EM: Sending Standalone Ack for MessageCounter:7199124 on exchange 47604i
@@ -565,7 +580,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary5intensity 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint8 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0026 DataVersion: 540305990
           [1651484304.715731][3365:3370] CHIP:TOO:   primary 5 intensity: 0
           [1651484304.715829][3365:3370] CHIP:EM: Sending Standalone Ack for MessageCounter:8654922 on exchange 29272i
@@ -586,7 +602,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary6x 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0028 DataVersion: 540305990
           [1651484349.601181][3372:3377] CHIP:TOO:   primary 6 x: 0
           [1651484349.601269][3372:3377] CHIP:EM: Sending Standalone Ack for MessageCounter:13704291 on exchange 30507i
@@ -607,10 +624,11 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary6y 1 1
 
-          Verify in  TH  Logs:
-          CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0028 DataVersion: 540305990
-          [1651484349.601181][3372:3377] CHIP:TOO:   primary 6 x: 0
-          [1651484349.601269][3372:3377] CHIP:EM: Sending Standalone Ack for MessageCounter:13704291 on exchange 30507i
+          Verify response contains an uint16 in  TH(chip-tool)  Logs:
+
+          [1663318323.234522][132277:132282] CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_0029 DataVersion: 3053940635
+          [1663318323.234951][132277:132282] CHIP:TOO:   Primary6Y: 0
+          [1663318323.235117][132277:132282] CHIP:EM: Sending Standalone Ack for MessageCounter:208977845 on exchange 35151i
       cluster: "LogCommands"
       command: "UserPrompt"
       PICS: PICS_USER_PROMPT && CC.S.A0029
@@ -627,7 +645,8 @@ tests:
       verification: |
           ./chip-tool colorcontrol read primary6intensity 1 1
 
-          Verify in  TH  Logs:
+          Verify response contains an uint8 in  TH(chip-tool)  Logs:
+
           CHIP:TOO: Endpoint: 1 Cluster: 0x0000_0300 Attribute 0x0000_002A DataVersion: 540305990
           [1651484392.490974][3378:3383] CHIP:TOO:   primary 6 intensity: 0
           [1651484392.491074][3378:3383] CHIP:EM: Sending Standalone Ack for MessageCounter:2427165 on exchange 17769i

--- a/src/app/tests/suites/certification/Test_TC_CC_3_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_3_1.yaml
@@ -206,6 +206,7 @@ tests:
               - name: "ms"
                 value: 10000
 
+    #https://github.com/CHIP-Specifications/chip-test-scripts/issues/416#issuecomment-1228072461
     - label: "TH reads CurrentHue attribute from DUT"
       PICS: CC.S.F00 && CC.S.A0000 && PICS_SKIP_SAMPLE_APP
       verification: |

--- a/src/app/tests/suites/certification/Test_TC_CC_4_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_4_2.yaml
@@ -44,7 +44,7 @@ tests:
       command: "On"
 
     - label:
-          "TH sends MoveToSaturation command to DUT with Saturation=60 and
+          "TH sends MoveToSaturation command to DUT with Saturation=150 and
           TransitionTime=0 (immediately)"
       PICS: CC.S.F00 && CC.S.C03.Rsp
       command: "MoveToSaturation"

--- a/src/app/tests/suites/certification/Test_TC_CC_5_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_1.yaml
@@ -545,7 +545,7 @@ tests:
           value: 32768
 
     - label: "TH reads ColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A0008
+      PICS: CC.S.F03 && CC.S.A0008
       command: "readAttribute"
       attribute: "ColorMode"
       response:
@@ -555,7 +555,7 @@ tests:
               maxValue: 2
 
     - label: "TH reads EnhancedColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A4001
+      PICS: CC.S.F03 && CC.S.A4001
       command: "readAttribute"
       attribute: "EnhancedColorMode"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_5_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_2.yaml
@@ -194,7 +194,7 @@ tests:
               maxValue: 33350
 
     - label: "TH reads ColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A0008
+      PICS: CC.S.F03 && CC.S.A0008
       command: "readAttribute"
       attribute: "ColorMode"
       response:
@@ -204,7 +204,7 @@ tests:
               maxValue: 2
 
     - label: "TH reads EnhancedColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A4001
+      PICS: CC.S.F03 && CC.S.A4001
       command: "readAttribute"
       attribute: "EnhancedColorMode"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_5_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_5_3.yaml
@@ -162,7 +162,7 @@ tests:
           value: 14000
 
     - label: "TH reads ColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A0008
+      PICS: CC.S.F03 && CC.S.A0008
       command: "readAttribute"
       attribute: "ColorMode"
       response:
@@ -172,7 +172,7 @@ tests:
               maxValue: 2
 
     - label: "TH reads EnhancedColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A4001
+      PICS: CC.S.F03 && CC.S.A4001
       command: "readAttribute"
       attribute: "EnhancedColorMode"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_1.yaml
@@ -485,7 +485,7 @@ tests:
           value: 6000
 
     - label: "TH reads ColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A0008
+      PICS: CC.S.F01 && CC.S.A0008
       command: "readAttribute"
       attribute: "ColorMode"
       response:
@@ -495,7 +495,7 @@ tests:
               maxValue: 2
 
     - label: "TH reads EnhancedColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A4001
+      PICS: CC.S.F01 && CC.S.A4001
       command: "readAttribute"
       attribute: "EnhancedColorMode"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_2.yaml
@@ -298,7 +298,7 @@ tests:
               maxValue: 11500
 
     - label: "TH reads ColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A0008
+      PICS: CC.S.F01 && CC.S.A0008
       command: "readAttribute"
       attribute: "ColorMode"
       response:
@@ -308,7 +308,7 @@ tests:
               maxValue: 2
 
     - label: "TH reads EnhancedColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A4001
+      PICS: CC.S.F01 && CC.S.A4001
       command: "readAttribute"
       attribute: "EnhancedColorMode"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_3.yaml
@@ -264,7 +264,7 @@ tests:
           value: 6000
 
     - label: "TH reads ColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A0008
+      PICS: CC.S.F01 && CC.S.A0008
       command: "readAttribute"
       attribute: "ColorMode"
       response:
@@ -274,7 +274,7 @@ tests:
               maxValue: 2
 
     - label: "TH reads EnhancedColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A4001
+      PICS: CC.S.F01 && CC.S.A4001
       command: "readAttribute"
       attribute: "EnhancedColorMode"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_7_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_7_4.yaml
@@ -180,7 +180,7 @@ tests:
           value: 80
 
     - label: "TH reads ColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A0008
+      PICS: CC.S.F01 && CC.S.A0008
       command: "readAttribute"
       attribute: "ColorMode"
       response:
@@ -190,7 +190,7 @@ tests:
               maxValue: 2
 
     - label: "TH reads EnhancedColorMode attribute from DUT"
-      PICS: CC.S.F00 && CC.S.A4001
+      PICS: CC.S.F01 && CC.S.A4001
       command: "readAttribute"
       attribute: "EnhancedColorMode"
       response:

--- a/src/app/tests/suites/certification/Test_TC_CC_8_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_8_1.yaml
@@ -109,7 +109,7 @@ tests:
       attribute: "CurrentHue"
       response:
           constraints:
-              minValue: 215
+              minValue: 216
               maxValue: 254
 
     - label: "Wait 2s"
@@ -126,7 +126,7 @@ tests:
       attribute: "CurrentHue"
       response:
           constraints:
-              minValue: 215
+              minValue: 216
               maxValue: 254
 
     - label:
@@ -210,9 +210,7 @@ tests:
       command: "readAttribute"
       attribute: "CurrentSaturation"
       response:
-          constraints:
-              minValue: CurrentSaturationValue
-              maxValue: 230
+          value: CurrentSaturationValue
 
     - label: "TH reads ColorTempPhysicalMinMireds attribute from DUT"
       PICS: CC.S.A400b
@@ -311,9 +309,7 @@ tests:
       response:
           saveAs: ColorTemperatureMiredsStep4f
           constraints:
-              minValue:
-                  ( ColorTempPhysicalMaxMireds + ColorTempPhysicalMinMireds ) /
-                  2
+              minValue: ColorTempPhysicalMinMireds
               maxValue: ColorTempPhysicalMaxMireds
 
     - label: "Wait 2s"
@@ -414,9 +410,7 @@ tests:
       PICS: CC.S.A4000 && CC.S.C47.Rsp
       attribute: "EnhancedCurrentHue"
       response:
-          constraints:
-              minValue: EnhancedCurrentHueValue
-              maxValue: 28750
+          value: EnhancedCurrentHueValue
 
     - label: "Turn Off light that we turned on"
       PICS: OO.S.C00.Rsp

--- a/src/app/tests/suites/certification/Test_TC_CC_9_1.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_1.yaml
@@ -232,7 +232,9 @@ tests:
               - name: "ms"
                 value: 30000
 
-    - label: "Read ColorLoopStartEnhancedHue attribute from DUT"
+    - label:
+          "Saving value for comparison in step 8d read ColorLoopStartEnhancedHue
+          attribute from DUT"
       command: "readAttribute"
       attribute: "ColorLoopStartEnhancedHue"
       PICS: CC.S.F02 && CC.S.F01 && CC.S.A4005 && CC.S.C44.Rsp
@@ -296,7 +298,9 @@ tests:
       response:
           value: 0
 
-    - label: "Read ColorLoopStoredEnhancedHue attribute from DUT."
+    - label:
+          "Saving value for comparison in step 6c read
+          ColorLoopStoredEnhancedHue attribute from DUT."
       command: "readAttribute"
       attribute: "ColorLoopStoredEnhancedHue"
       PICS: CC.S.F02 && CC.S.F01 && CC.S.A4006 && CC.S.C44.Rsp
@@ -385,7 +389,9 @@ tests:
               - name: "ms"
                 value: 30000
 
-    - label: "Read ColorLoopStartEnhancedHue attribute from DUT"
+    - label:
+          "Saving value for comparision in step 8d read
+          ColorLoopStartEnhancedHue attribute from DUT"
       command: "readAttribute"
       attribute: "ColorLoopStartEnhancedHue"
       PICS: CC.S.F02 && CC.S.F01 && CC.S.A4005 && CC.S.C44.Rsp
@@ -449,7 +455,9 @@ tests:
       response:
           value: 0
 
-    - label: "Read ColorLoopStoredEnhancedHue attribute from DUT"
+    - label:
+          "Saving value for comparision in step 9c read
+          ColorLoopStoredEnhancedHue attribute from DUT"
       command: "readAttribute"
       attribute: "ColorLoopStoredEnhancedHue"
       PICS: CC.S.F02 && CC.S.F01 && CC.S.A4006 && CC.S.C44.Rsp
@@ -571,7 +579,9 @@ tests:
               - name: "ms"
                 value: 30000
 
-    - label: "Read ColorLoopStartEnhancedHue attribute from DUT"
+    - label:
+          "Saving value for comparision in step 12d read
+          ColorLoopStartEnhancedHue attribute from DUT"
       command: "readAttribute"
       attribute: "ColorLoopStartEnhancedHue"
       PICS: CC.S.F02 && CC.S.F01 && CC.S.A4005 && CC.S.C44.Rsp
@@ -635,7 +645,9 @@ tests:
       response:
           value: 0
 
-    - label: "Read ColorLoopStoredEnhancedHue attribute from DUT."
+    - label:
+          "Saving value for comparision in step 13c read
+          ColorLoopStoredEnhancedHue attribute from DUT."
       command: "readAttribute"
       attribute: "ColorLoopStoredEnhancedHue"
       PICS: CC.S.F02 && CC.S.F01 && CC.S.A4006 && CC.S.C44.Rsp
@@ -724,7 +736,9 @@ tests:
               - name: "ms"
                 value: 30000
 
-    - label: "Read ColorLoopStartEnhancedHue attribute from DUT"
+    - label:
+          "Saving value for comparision in step 15d read
+          ColorLoopStartEnhancedHue attribute from DUT"
       command: "readAttribute"
       attribute: "ColorLoopStartEnhancedHue"
       PICS: CC.S.F02 && CC.S.F01 && CC.S.A4005 && CC.S.C44.Rsp
@@ -788,7 +802,9 @@ tests:
       response:
           value: 0
 
-    - label: "Read ColorLoopStoredEnhancedHue attribute from DUT."
+    - label:
+          "Saving value for comparision in step 16b read
+          ColorLoopStoredEnhancedHue attribute from DUT."
       command: "readAttribute"
       attribute: "ColorLoopStoredEnhancedHue"
       PICS: CC.S.F02 && CC.S.F01 && CC.S.A4006 && CC.S.C44.Rsp

--- a/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_2.yaml
@@ -168,7 +168,9 @@ tests:
               - name: "ms"
                 value: 30000
 
-    - label: "Read ColorLoopStartEnhancedHue attribute from DUT."
+    - label:
+          "Saving value for comparision read ColorLoopStartEnhancedHue attribute
+          from DUT."
       command: "readAttribute"
       attribute: "ColorLoopStartEnhancedHue"
       PICS: CC.S.F01 && CC.S.F02 && CC.S.A4005 && CC.S.C44.Rsp
@@ -241,7 +243,9 @@ tests:
               - name: "ms"
                 value: 30000
 
-    - label: "Read ColorLoopStartEnhancedHue attribute from DUT."
+    - label:
+          "Saving value for comparision read ColorLoopStartEnhancedHue attribute
+          from DUT."
       command: "readAttribute"
       attribute: "ColorLoopStartEnhancedHue"
       PICS: CC.S.F01 && CC.S.F02 && CC.S.A4005 && CC.S.C44.Rsp
@@ -305,7 +309,9 @@ tests:
       response:
           value: 0
 
-    - label: "Read ColorLoopStoredEnhancedHue attribute from DUT."
+    - label:
+          "Saving value for comparision read ColorLoopStoredEnhancedHue
+          attribute from DUT."
       command: "readAttribute"
       PICS: CC.S.F01 && CC.S.F02 && CC.S.A4006 && CC.S.C44.Rsp
       attribute: "ColorLoopStoredEnhancedHue"

--- a/src/app/tests/suites/certification/Test_TC_CC_9_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_CC_9_3.yaml
@@ -167,7 +167,9 @@ tests:
               - name: "ms"
                 value: 30000
 
-    - label: "Read ColorLoopStartEnhancedHue attribute from DUT."
+    - label:
+          "Saving value for comparision read ColorLoopStartEnhancedHue attribute
+          from DUT."
       command: "readAttribute"
       attribute: "ColorLoopStartEnhancedHue"
       PICS: CC.S.F01 && CC.S.F02 && CC.S.A4005 && CC.S.C44.Rsp
@@ -296,7 +298,9 @@ tests:
       response:
           value: 0
 
-    - label: "Read ColorLoopStoredEnhancedHue attribute from DUT."
+    - label:
+          "Saving value for comparision read ColorLoopStoredEnhancedHue
+          attribute from DUT."
       command: "readAttribute"
       attribute: "ColorLoopStoredEnhancedHue"
       PICS: CC.S.F01 && CC.S.F02 && CC.S.A4006 && CC.S.C44.Rsp

--- a/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_1_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAINPUT_1_4.yaml
@@ -42,13 +42,22 @@ tests:
               type: int16u
 
     - label: "Read the global attribute: FeatureMap"
+      PICS: " !MEDIAINPUT.S.NU "
+      command: "readAttribute"
+      attribute: "FeatureMap"
+      response:
+          value: 0
+          constraints:
+              type: bitmap32
+
+    - label: "Given MEDIAINPUT.S.NU ensure featuremap has the correct bit set"
+      PICS: MEDIAINPUT.S.NU
       command: "readAttribute"
       attribute: "FeatureMap"
       response:
           constraints:
               type: bitmap32
-              minValue: 0
-              maxValue: 1
+              hasMasksSet: [0x1]
 
     - label: "Read the global attribute: AttributeList"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_3.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_3.yaml
@@ -175,3 +175,14 @@ tests:
           values:
               - name: "status"
                 value: 5
+
+    - label: "verify that the media has not moved."
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_USER_PROMPT && MEDIAPLAYBACK.S.C0B.Rsp
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' if media has not moved"
+              - name: "expectedValue"
+                value: "y"

--- a/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_4.yaml
+++ b/src/app/tests/suites/certification/Test_TC_MEDIAPLAYBACK_6_4.yaml
@@ -63,6 +63,17 @@ tests:
               - name: "status"
                 value: 0
 
+    - label: "verify that the media state is playing"
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_USER_PROMPT && MEDIAPLAYBACK.S.C07.Rsp
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' if media state is playing"
+              - name: "expectedValue"
+                value: "y"
+
     - label: "Reads the CurrentState attribute"
       PICS: MEDIAPLAYBACK.S.A0000 && MEDIAPLAYBACK.S.C07.Rsp
       command: "readAttribute"
@@ -85,6 +96,17 @@ tests:
               - name: "status"
                 value: 0
 
+    - label: "verify that the media play speed has increased."
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_USER_PROMPT && MEDIAPLAYBACK.S.C07.Rsp
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' if media play speed has increased."
+              - name: "expectedValue"
+                value: "y"
+
     - label: "Reads the PlaybackSpeed attribute from the DUT"
       PICS: MEDIAPLAYBACK.S.A0004 && MEDIAPLAYBACK.S.C07.Rsp
       command: "readAttribute"
@@ -99,6 +121,17 @@ tests:
           values:
               - name: "status"
                 value: 0
+
+    - label: "verify that the media play has reversed direction."
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_USER_PROMPT && MEDIAPLAYBACK.S.C06.Rsp
+      arguments:
+          values:
+              - name: "message"
+                value: "Please enter 'y' if media play has reversed direction"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Reads the CurrentState attribute"
       PICS: MEDIAPLAYBACK.S.A0000 && MEDIAPLAYBACK.S.C06.Rsp
@@ -132,6 +165,21 @@ tests:
               - name: "status"
                 value: 0
 
+    - label:
+          "verify that the media play speed has increased in the reverse
+          direction."
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_USER_PROMPT && MEDIAPLAYBACK.S.C06.Rsp
+      arguments:
+          values:
+              - name: "message"
+                value:
+                    "Please enter 'y' if media play speed has increased in the
+                    reverse direction"
+              - name: "expectedValue"
+                value: "y"
+
     #Issue 19800
     - label: "Reads the PlaybackSpeed attribute from the DUT"
       verification: |
@@ -156,6 +204,21 @@ tests:
           values:
               - name: "status"
                 value: 0
+
+    - label:
+          "verify that the media is has resumed playing forward at the default
+          speed."
+      cluster: "LogCommands"
+      command: "UserPrompt"
+      PICS: PICS_USER_PROMPT && MEDIAPLAYBACK.S.C00.Rsp
+      arguments:
+          values:
+              - name: "message"
+                value:
+                    "Please enter 'y' if media is has resumed playing forward at
+                    the default speed"
+              - name: "expectedValue"
+                value: "y"
 
     - label: "Reads the PlaybackSpeed attribute from the DUT"
       command: "readAttribute"

--- a/src/app/tests/suites/certification/Test_TC_TSTAT_2_2.yaml
+++ b/src/app/tests/suites/certification/Test_TC_TSTAT_2_2.yaml
@@ -209,7 +209,6 @@ tests:
       attribute: "UnoccupiedCoolingSetpoint"
       PICS: TSTAT.S.F02 && TSTAT.S.F01
       response:
-          value: 2600
           constraints:
               type: int16s
               minValue: 1600
@@ -280,7 +279,6 @@ tests:
       attribute: "UnoccupiedHeatingSetpoint"
       PICS: TSTAT.S.F02 && TSTAT.S.F00
       response:
-          value: 2000
           constraints:
               type: int16s
               minValue: 700
@@ -289,7 +287,6 @@ tests:
     - label:
           "Writes a value back that is different but valid for
           UnoccupiedHeatingSetpoint attribute"
-
       command: "writeAttribute"
       attribute: "UnoccupiedHeatingSetpoint"
       PICS: TSTAT.S.F02 && TSTAT.S.F00
@@ -352,7 +349,6 @@ tests:
       attribute: "MinHeatSetpointLimit"
       PICS: TSTAT.S.F00 && TSTAT.S.A0015
       response:
-          value: 700
           constraints:
               type: int16s
               minValue: 700
@@ -432,7 +428,6 @@ tests:
       attribute: "MaxHeatSetpointLimit"
       PICS: TSTAT.S.F00  && TSTAT.S.A0016 && !TSTAT.S.F05
       response:
-          value: 3000
           constraints:
               type: int16s
               minValue: 700
@@ -523,7 +518,6 @@ tests:
       attribute: "MinCoolSetpointLimit"
       PICS: TSTAT.S.F01 && TSTAT.S.A0017
       response:
-          value: 1600
           constraints:
               type: int16s
               minValue: 1600
@@ -602,7 +596,6 @@ tests:
       attribute: "MaxCoolSetpointLimit"
       PICS: TSTAT.S.F01 && TSTAT.S.A0018
       response:
-          value: 3200
           constraints:
               type: int16s
               minValue: 1600
@@ -675,14 +668,14 @@ tests:
     - label: "Writes (sets back)default value of MaxHeatSetpointLimit"
       command: "writeAttribute"
       attribute: "MaxHeatSetpointLimit"
-      PICS: TSTAT.S.F01 && TSTAT.S.A0016 &&!TSTAT.S.F05
+      PICS: TSTAT.S.F01 && TSTAT.S.A0016 && !TSTAT.S.F05
       arguments:
           value: 3000
 
     - label: "Writes MaxHeatSetpointLimit That meets the deadband of 2.5C"
       command: "writeAttribute"
       attribute: "MaxHeatSetpointLimit"
-      PICS: TSTAT.S.F01 && TSTAT.S.A0016 &&!TSTAT.S.F05
+      PICS: TSTAT.S.F01 && TSTAT.S.A0016 && !TSTAT.S.F05
       arguments:
           value: 2950
 
@@ -707,7 +700,6 @@ tests:
       attribute: "MinSetpointDeadBand"
       PICS: TSTAT.S.F05
       response:
-          value: 25
           constraints:
               type: int8s
               minValue: 0
@@ -718,7 +710,7 @@ tests:
           MinSetpointDeadBand attribute"
       command: "writeAttribute"
       attribute: "MinSetpointDeadBand"
-      PICS: TSTAT.S.F05
+      PICS: TSTAT.S.F05 && TSTAT.S.M.MinSetpointDeadBandWritable
       arguments:
           value: 5
 
@@ -727,14 +719,14 @@ tests:
           MinSetpointDeadBand attribute"
       command: "readAttribute"
       attribute: "MinSetpointDeadBand"
-      PICS: TSTAT.S.F05
+      PICS: TSTAT.S.F05 && TSTAT.S.M.MinSetpointDeadBandWritable
       response:
           value: 5
 
     - label: "Writes the value below MinSetpointDeadBand"
       command: "writeAttribute"
       attribute: "MinSetpointDeadBand"
-      PICS: TSTAT.S.F05
+      PICS: TSTAT.S.F05 && TSTAT.S.M.MinSetpointDeadBandWritable
       arguments:
           value: -1
       response:
@@ -743,7 +735,7 @@ tests:
     - label: "Writes the value above MinSetpointDeadBand "
       command: "writeAttribute"
       attribute: "MinSetpointDeadBand"
-      PICS: TSTAT.S.F05
+      PICS: TSTAT.S.F05 && TSTAT.S.M.MinSetpointDeadBandWritable
       arguments:
           value: 30
       response:
@@ -752,14 +744,14 @@ tests:
     - label: "Writes the min limit of MinSetpointDeadBand"
       command: "writeAttribute"
       attribute: "MinSetpointDeadBand"
-      PICS: TSTAT.S.F05
+      PICS: TSTAT.S.F05 && TSTAT.S.M.MinSetpointDeadBandWritable
       arguments:
           value: 0
 
     - label: "Writes the max limit of MinSetpointDeadBand"
       command: "writeAttribute"
       attribute: "MinSetpointDeadBand"
-      PICS: TSTAT.S.F05
+      PICS: TSTAT.S.F05 && TSTAT.S.M.MinSetpointDeadBandWritable
       arguments:
           value: 25
 

--- a/src/app/tests/suites/certification/ci-pics-values
+++ b/src/app/tests/suites/certification/ci-pics-values
@@ -1496,6 +1496,7 @@ TSTAT.S.A0044=0
 TSTAT.S.A0045=0
 TSTAT.S.A0046=0
 TSTAT.S.A0047=0
+TSTAT.S.M.MinSetpointDeadBandWritable=1
 
 #Server commands
 TSTAT.S.C00.Rsp=1


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes[ #472](https://github.com/CHIP-Specifications/chip-test-scripts/issues/472), Fixes part of the TSTAT-2.2 issue: [#562](https://github.com/CHIP-Specifications/chip-certification-tool/issues/562)
Modified scripts:
TC-AUDIOOUTPUT-7.1 : Updated Index value configurable
TC-AUDIOOUTPUT-7.2 :  Updated Index value configurable
TC-BINFO-2.1: Added comment for the last step
TC-CADMIN-1.3: Added ClusterError field for Failure response
TC-CADMIN-1.4: Added ClusterError field for Failure response
TC-CADMIN-1.5: Added ClusterError field for Failure response
TC-CADMIN-1.6: Added ClusterError field for Failure response
TC-CADMIN-1.11: Added ClusterError field for Failure response
TC-CADMIN-1.13: Added ClusterError field for Failure response
TC-CADMIN-1.15: Added ClusterError field for Failure response
TC-CC-2.1: Updated prompt logs
TC-CC-3.1: Added comment for the prompt step
TC-CC-4.2: Fixed the typo error
TC-CC-5.1: Updated the PICS in last step
TC-CC-5.2: Updated the PICS in last step
TC-CC-5.3: Updated the PICS in last step
TC-CC-7.1: Updated the PICS in last step
TC-CC-7.2: Updated the PICS in last step
TC-CC-7.3: Updated the PICS in last step
TC-CC-7.4: Updated the PICS in last step
TC-CC-8.1: Updated script as per testplan
TC-CC-9.1: Updated label changes
TC-CC-9.2: Updated label changes
TC-CC-9.2: Updated label changes
TC-MEDIAINPUT-1.4: Added Bit check for FeatureMap
TC-MEDIAPLAYBACK-6.3: Added prompts for Manual verification step
TC-MEDIAPLAYBACK-6.4: Added prompts for Manual verification step
TC-TSTAT-2.2: Added the PICS for attribute: MinSetpointDeadBand
Added auto generated files

Tested