### PR TITLE
[QPG] [TC-OO-2.4] lighting-app does not need to update cluster state during init

### DIFF
--- a/examples/lighting-app/qpg/src/ZclCallbacks.cpp
+++ b/examples/lighting-app/qpg/src/ZclCallbacks.cpp
@@ -142,5 +142,5 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
  */
 void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 {
-    GetAppTask().UpdateClusterState();
+    // No additional init currently - startup state handled by cluster.
 }


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22723

#### Change overview
The cluster does not need to be updated to reflect the not yet initialized state of the application.
The 'startup-on-off' attribute did not function correctly due to this.
