### PR TITLE
[darwin] Make CHIPCommandStorageDelegate less chatty by default to no…

### DIFF
--- a/examples/darwin-framework-tool/commands/common/CHIPCommandStorageDelegate.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandStorageDelegate.mm
@@ -2,6 +2,8 @@
 
 #import <Matter/Matter.h>
 
+#define LOG_DEBUG_PERSISTENT_STORAGE_DELEGATE 0
+
 NSString * const kCHIPToolDefaultsDomain = @"com.apple.chiptool";
 
 id MTRGetDomainValueForKey(NSString * domain, NSString * key)
@@ -39,9 +41,13 @@ BOOL CHIPClearAllDomain(NSString * domain)
 {
 
     NSArray * allKeys = CHIPGetDomainKeyList(domain);
+#if LOG_DEBUG_PERSISTENT_STORAGE_DELEGATE
     NSLog(@"Removing keys: %@ %@", allKeys, domain);
+#endif
     for (id key in allKeys) {
+#if LOG_DEBUG_PERSISTENT_STORAGE_DELEGATE
         NSLog(@"Removing key: %@", key);
+#endif
         if (!MTRRemoveDomainValueForKey(domain, (NSString *) key)) {
             return NO;
         }
@@ -61,7 +67,9 @@ BOOL CHIPClearAllDomain(NSString * domain)
 - (nullable NSData *)storageDataForKey:(NSString *)key
 {
     NSData * value = MTRGetDomainValueForKey(kCHIPToolDefaultsDomain, key);
+#if LOG_DEBUG_PERSISTENT_STORAGE_DELEGATE
     NSLog(@"CHIPPersistentStorageDelegate Get Value for Key: %@, value %@", key, value);
+#endif
     return value;
 }
 

--- a/src/darwin/Framework/CHIP/MTRPersistentStorageDelegateBridge.mm
+++ b/src/darwin/Framework/CHIP/MTRPersistentStorageDelegateBridge.mm
@@ -17,6 +17,8 @@
 
 #import "MTRPersistentStorageDelegateBridge.h"
 
+#define LOG_DEBUG_PERSISTENT_STORAGE_DELEGATE 0
+
 MTRPersistentStorageDelegateBridge::MTRPersistentStorageDelegateBridge(id<MTRStorage> delegate)
     : mDelegate(delegate)
     , mWorkQueue(dispatch_queue_create("com.csa.matter.framework.storage.workqueue", DISPATCH_QUEUE_SERIAL))
@@ -35,7 +37,9 @@ CHIP_ERROR MTRPersistentStorageDelegateBridge::SyncGetKeyValue(const char * key,
     NSString * keyString = [NSString stringWithUTF8String:key];
 
     dispatch_sync(mWorkQueue, ^{
+#if LOG_DEBUG_PERSISTENT_STORAGE_DELEGATE
         NSLog(@"PersistentStorageDelegate Sync Get Value for Key: %@", keyString);
+#endif
 
         NSData * value = [mDelegate storageDataForKey:keyString];
 
@@ -76,7 +80,9 @@ CHIP_ERROR MTRPersistentStorageDelegateBridge::SyncSetKeyValue(const char * key,
 
     __block CHIP_ERROR error = CHIP_NO_ERROR;
     dispatch_sync(mWorkQueue, ^{
+#if LOG_DEBUG_PERSISTENT_STORAGE_DELEGATE
         NSLog(@"PersistentStorageDelegate Set Key %@", keyString);
+#endif
 
         if ([mDelegate setStorageData:valueData forKey:keyString] == NO) {
             error = CHIP_ERROR_PERSISTED_STORAGE_FAILED;
@@ -92,7 +98,9 @@ CHIP_ERROR MTRPersistentStorageDelegateBridge::SyncDeleteKeyValue(const char * k
 
     __block CHIP_ERROR error = CHIP_NO_ERROR;
     dispatch_sync(mWorkQueue, ^{
+#if LOG_DEBUG_PERSISTENT_STORAGE_DELEGATE
         NSLog(@"PersistentStorageDelegate Delete Key: %@", keyString);
+#endif
 
         if ([mDelegate removeStorageDataForKey:keyString] == NO) {
             error = CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND;


### PR DESCRIPTION
…t pollute logs

#### Issue Being Resolved
* When debugging #22715 it was annoying because the `Darwin-framework-tool` and more generally the persistent storage code on darwin is very chatty, while providing useless information if you are not debugging it.

#### Change overview
 * Make it less chatty by adding the debugging logs behind an ifdef.
