### PR TITLE
 Class MTRErrorHolder is implemented in both out/darwin-x64-darwin-fr…

### DIFF
--- a/examples/darwin-framework-tool/commands/common/MTRError.mm
+++ b/examples/darwin-framework-tool/commands/common/MTRError.mm
@@ -26,11 +26,11 @@
 #import <lib/support/TypeTraits.h>
 
 // Stolen for now from the framework, need to export this properly.
-@interface MTRErrorHolder : NSObject
+@interface DFTErrorHolder : NSObject
 @property (nonatomic, readonly) CHIP_ERROR error;
 @end
 
-@implementation MTRErrorHolder
+@implementation DFTErrorHolder
 
 - (instancetype)initWithError:(CHIP_ERROR)error
 {
@@ -64,8 +64,8 @@ CHIP_ERROR MTRErrorToCHIPErrorCode(NSError * error)
 
     if (error.userInfo != nil) {
         id underlyingError = error.userInfo[@"underlyingError"];
-        if (underlyingError != nil && [underlyingError isKindOfClass:[MTRErrorHolder class]]) {
-            return ((MTRErrorHolder *) underlyingError).error;
+        if (underlyingError != nil && [underlyingError isKindOfClass:[DFTErrorHolder class]]) {
+            return ((DFTErrorHolder *) underlyingError).error;
         }
     }
 


### PR DESCRIPTION
…amework-tool-no-ble-asan-clang/macos_framework_output/Build/Products/Debug/Matter.framework/Versions/A/Matter and ./out/darwin-x64-darwin-framework-tool-no-ble-asan-clang/darwin-framework-tool. One of the two will be used. Which one is undefined.

#### Issue Being Resolved
* When debugging #22715 there was a message in the logs saying that the `MTRError` class will be used is implemented twice and that implementation that is used will be chosen randomly...

#### Change overview
* Update the name of the class in `examples/darwin-framework-tool` to ensure they do not collide.