### PR TITLE
Ensure the connection and the disconnect handler are accessed from th…

### DIFF
--- a/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
@@ -174,15 +174,19 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     newConnection.remoteObjectInterface = _clientInterface;
     newConnection.exportedObject = self;
     newConnection.invalidationHandler = ^{
-        NSLog(@"XPC connection disconnected");
-        self.xpcConnection = nil;
-        if (self.xpcDisconnectExpectation) {
-            [self.xpcDisconnectExpectation fulfill];
-            self.xpcDisconnectExpectation = nil;
-        }
+        dispatch_async(dispatch_get_main_queue(), ^{
+            NSLog(@"XPC connection disconnected");
+            self.xpcConnection = nil;
+            if (self.xpcDisconnectExpectation) {
+                [self.xpcDisconnectExpectation fulfill];
+                self.xpcDisconnectExpectation = nil;
+            }
+        });
     };
-    _xpcConnection = newConnection;
-    [newConnection resume];
+    dispatch_async(dispatch_get_main_queue(), ^{
+        self.xpcConnection = newConnection;
+        [newConnection resume];
+    });
     return YES;
 }
 
@@ -2263,6 +2267,8 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
               completion([MTRDeviceController encodeXPCResponseValues:myValues], nil);
           };
 
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
+
     [clusterStateCacheContainer subscribeWithDeviceController:_remoteDeviceController
                                                      deviceID:@(myNodeId)
                                                        params:nil
@@ -2272,7 +2278,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                        XCTAssertNil(error);
                                                        [subscribeExpectation fulfill];
                                                    }];
-    [self waitForExpectations:@[ subscribeExpectation ] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ subscribeExpectation, _xpcDisconnectExpectation ] timeout:kTimeoutInSeconds];
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [clusterStateCacheContainer


### PR DESCRIPTION
…e same dispatch queue in MTRProtocolTests.m

#### Issue Being Resolved

While working on #22715 one of the `Build Darwin` tasks fails with: 
```2022-09-19T11:29:48.3082520Z Test Case '-[MTRXPCProtocolTests testReadClusterStateCacheSuccess]' started.
2022-09-19T11:29:48.3083000Z 2022-09-19 11:29:48.304452+0000 xctest[5116:477757] XPC listener accepting connection
2022-09-19T11:29:48.3083430Z 2022-09-19 11:29:48.304936+0000 xctest[5116:477602] Subscribe attribute cache called
2022-09-19T11:29:48.3083900Z 2022-09-19 11:29:48.305292+0000 xctest[5116:477602] Attribute cache subscription succeeded for device 9876543210
2022-09-19T11:29:48.3084380Z 2022-09-19 11:29:48.305423+0000 xctest[5116:477602] Subscribe completion called with error: (null)
2022-09-19T11:29:48.3084820Z 2022-09-19 11:29:48.305529+0000 xctest[5116:477755] XPC connection disconnected
2022-09-19T11:29:48.3085240Z 2022-09-19 11:29:48.305837+0000 xctest[5116:477757] XPC listener accepting connection
2022-09-19T11:29:53.1864770Z /Users/runner/work/connectedhomeip/connectedhomeip/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m:2290: error: -[MTRXPCProtocolTests testReadClusterStateCacheSuccess] : *** -[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[2] (NSInvalidArgumentException)
2022-09-19T11:29:53.1957260Z Test Case '-[MTRXPCProtocolTests testReadClusterStateCacheSuccess]' failed (4.884 seconds).```

Also there has been a few other intermittent failures stating things like: 
```
src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m:177: error: -[MTRXPCProtocolTests testReadClusterStateCacheSuccess] : ((_xpcConnection) == nil) failed: "<NSXPCConnection: 0x7f883f1c1ac0> connection on anonymousListener or serviceListener from pid 19984"```
```
src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m:2299: error: -[MTRXPCProtocolTests testReadClusterStateCacheSuccess] : ((_xpcConnection) == nil) failed: "<NSXPCConnection: 0x7fbb09333920> connection on anonymousListener or serviceListener from pid 21964"
```

The first failure (the one with `[__NSPlaceholderArray initWithObjects:count:]: attempt to insert nil object from objects[2] (NSInvalidArgumentException)`happens when the xpc disconnect handler is set to `nil`.
It happens because it was read and written from different dispatch queues. 

Those can be reproduce by adding some code to `MTRProtocolTests.m`:
```
- (void)invokeTest
{
    for (int i=0; I<100000; i++) {
        [super invokeTest];
    }    
}
```

And then running those with the following command:
`xcodebuild test -target "Matter" -scheme "Matter Framework Tests" -sdk macosx -only-testing:MatterTests/MTRXPCProtocolTests/testReadClusterStateCacheSuccess`

With the following PR I can not reproduce it.

#### Change overview
* This PR ensure that accessing/setting the connection and the disconnection handler happens onto the same dispatch queue to prevent races.
