### PR TITLE
Avoid polluting Pigweed environment namespace

### DIFF
--- a/scripts/setup/bootstrap.sh
+++ b/scripts/setup/bootstrap.sh
@@ -30,6 +30,7 @@ _bootstrap_or_activate() {
 
     if [ -n "$PW_CONFIG_FILE" ]; then
         _CONFIG_FILE="$PW_CONFIG_FILE"
+        unset PW_CONFIG_FILE
     fi
 
     if [ ! -f "$_CHIP_ROOT/third_party/pigweed/repo/pw_env_setup/util.sh" ]; then


### PR DESCRIPTION
#### Issue Being Resolved

Sourcing with custom Pigweed environment currently fails:

```
$ PW_CONFIG_FILE=scripts/environment_no_cipd.json source scripts/bootstrap.sh
...
Traceback (most recent call last):                                                                                                                                                                                                                                                                                            
  File "/home/sag/projects/project-chip/connectedhomeip3/.environment/gn_out/../../third_party/pigweed/repo/pw_protobuf_compiler/py/pw_protobuf_compiler/generate_protos.py", line 211, in <module>                                                                                                                           
    setup_logging()                                                                                                                                                                                                                                                                                                           
  File "/home/sag/projects/project-chip/connectedhomeip3/third_party/pigweed/repo/pw_cli/py/pw_cli/log.py", line 118, in install                                                                                                                                                                                              
    colors = pw_cli.color.colors(use_color)                                                                                                                                                                                                                                                                                   
  File "/home/sag/projects/project-chip/connectedhomeip3/third_party/pigweed/repo/pw_cli/py/pw_cli/color.py", line 66, in colors                                                                                                                                                                                              
    env = pw_cli.env.pigweed_environment()                                                                                                                                                                                                                                                                                    
  File "/home/sag/projects/project-chip/connectedhomeip3/third_party/pigweed/repo/pw_cli/py/pw_cli/env.py", line 86, in pigweed_environment                                                                                                                                                                                   
    _memoized_environment = pigweed_environment_parser().parse_env()                                                                                                                                                                                                                                                          
  File "/home/sag/projects/project-chip/connectedhomeip3/third_party/pigweed/repo/pw_cli/py/pw_cli/envparse.py", line 153, in parse_env                                                                                                                                                                                       
    raise ValueError(                                                                                                                                                                                                                                                                                                         
ValueError: Unrecognized environment variable PW_CONFIG_FILE
```
This presumably broke due to a Pigweed update.

#### Change overview

Clear the relevant environment variable to avoid Pigweed complaining about unknown environment variable.
