### PR TITLE
[ZAP] Increase maximum memory usage to 9gb instead of 8gb

### DIFF
--- a/scripts/tools/zap/generate.py
+++ b/scripts/tools/zap/generate.py
@@ -212,8 +212,8 @@ def runJavaPrettifier(templates_file, output_dir):
 def main():
     checkPythonVersion()
 
-    # The maximum meory usage is over 4GB (#15620)
-    os.environ["NODE_OPTIONS"] = "--max-old-space-size=8192"
+    # The maximum memory usage is over 4GB (#15620)
+    os.environ["NODE_OPTIONS"] = "--max-old-space-size=9216"
     zap_file, zcl_file, templates_file, output_dir = runArgumentsParser()
     runGeneration(zap_file, zcl_file, templates_file, output_dir)
 


### PR DESCRIPTION
#### Issue Being Resolved
On ToT, I can see errors like the following in the ZAP template task.
```
<--- Last few GCs --->
[1474](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1475)

[1475](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1476)
[5200:0x5121680]  2853867 ms: Scavenge (reduce) 8092.4 (8238.5) -> 8091.8 (8238.8) MB, 146.1 / 0.0 ms  (average mu = 0.339, current mu = 0.458) allocation failure 
[1476](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1477)
[5200:0x5121680]  2854302 ms: Scavenge (reduce) 8092.6 (8238.8) -> 8092.0 (8238.8) MB, 137.0 / 0.0 ms  (average mu = 0.339, current mu = 0.458) allocation failure 
[1477](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1478)
[5200:0x5121680]  2854560 ms: Scavenge (reduce) 8092.8 (8238.8) -> 8092.1 (8239.0) MB, 135.8 / 0.0 ms  (average mu = 0.339, current mu = 0.458) allocation failure 
[1478](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1479)

[1479](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1480)

[1480](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1481)
<--- JS stacktrace --->
[1481](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1482)


[1482](https://github.com/project-chip/connectedhomeip/actions/runs/3084968246/jobs/4987726277#step:7:1483)
FATAL ERROR: Ineffective mark-compacts near heap limit Allocation failed - JavaScript heap out of memory
```

Short term solution is to increase the available memory. A longer term solution would be to look at what happens exactly and why do we consume so much memory.

#### Change overview
* Increase the memory available
