### PR TITLE
Move zap timeout from 90 to 120 minutes

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     zap_templates:
         name: ZAP templates generation
-        timeout-minutes: 90
+        timeout-minutes: 120
 
         runs-on: ubuntu-20.04
         container:


### PR DESCRIPTION
#### Issue Being Resolved

Frequent timeout in zap. For example https://github.com/project-chip/connectedhomeip/actions/runs/3083271342/jobs/4995926787 timed out 4 times in a row at 90 minutes.

#### Change overview
Move timeout from 90 to 120 minutes.
