### PR TITLE
[ZAP] Do not use assertSameTestType in examples/chip-tool/templates/t…

### DIFF
--- a/.github/workflows/zap_templates.yaml
+++ b/.github/workflows/zap_templates.yaml
@@ -25,7 +25,7 @@ concurrency:
 jobs:
     zap_templates:
         name: ZAP templates generation
-        timeout-minutes: 120
+        timeout-minutes: 90
 
         runs-on: ubuntu-20.04
         container:

--- a/examples/chip-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt
+++ b/examples/chip-tool/templates/tests/partials/checks/maybeCheckExpectedConstraints.zapt
@@ -10,7 +10,6 @@
     {{~#if (isStrEqual constraint "hasValue")}}
       {{~! Already handled above~}}
     {{~else if (isStrEqual constraint "type")}}
-      {{~assertSameTestType (asTestType ../type ../isArray) value~}}
       VerifyOrReturn(CheckConstraintType("{{asPropertyValue context=..}}", "{{asTestType ../type ../isArray}}", "{{value}}"));
     {{~else if (isStrEqual constraint "format")}}VerifyOrReturn(CheckConstraintFormat("{{asPropertyValue context=..}}", "", "{{value}}"));
 


### PR DESCRIPTION
…ests/partials/checks/maybeCheckExpectedConstraints.zapt as it make the generation extremely slow

#### Issue Being Resolved
* This should fix #22761 and #22752 without the need to increase the memory nor the timeout. This function is used purely as a sanity check but for some reasons it makes the generation super slow.

The culprit on the CI seems to the following run which takes something like `2316s`...
`./scripts/tools/zap/generate.py src/controller/data_model/controller-clusters.zap -t examples/chip-tool/templates/tests/templates.json -o zzz_generated/chip-tool/zap-generated` 

On my laptop the generation running the same script goes from `329s` to `22s` without `assertSameTestType`

#### Change overview
 * Remove `assertSameTestType` which is just convenience but make the generation process super slow...