### PR TITLE
Make sure to ignore setDeviceControllerDelegate calls on non-running controllers

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -535,7 +535,11 @@ static NSString * const kErrorSpake2pVerifierSerializationFailed = @"PASE verifi
 
 - (void)setDeviceControllerDelegate:(id<MTRDeviceControllerDelegate>)delegate queue:(dispatch_queue_t)queue
 {
+    VerifyOrReturn([self checkIsRunning]);
+
     dispatch_async(_chipWorkQueue, ^{
+        VerifyOrReturn([self checkIsRunning]);
+
         self->_deviceControllerDelegateBridge->setDelegate(self, delegate, queue);
     });
 }


### PR DESCRIPTION
Otherwise we can end up with null-derefs trying to touch members that no longer exist.

#### Issue Being Resolved
* Fixes #22776

#### Change overview
What's in this PR
