### PR TITLE
[ESP32] fix the issue when setting target esp32h2

### DIFF
--- a/config/esp32/components/chip/Kconfig
+++ b/config/esp32/components/chip/Kconfig
@@ -520,25 +520,30 @@ menu "CHIP Device Layer"
         visible if ENABLE_ETHERNET_TELEMETRY
 
         config GPIO_RANGE_MIN
-            int 
+            int
+            depends on ENABLE_ETHERNET_TELEMETRY
             default 0
 
         config GPIO_RANGE_MAX
-            int 
+            int
+            depends on ENABLE_ETHERNET_TELEMETRY
             default 33 if IDF_TARGET_ESP32
             default 46 if IDF_TARGET_ESP32S2
             default 19 if IDF_TARGET_ESP32C3
             default 48 if IDF_TARGET_ESP32S3
+            default 26 if IDF_TARGET_ESP32H2
 
         config ETH_MDC_GPIO
             int "SMI MDC GPIO number"
+            depends on ENABLE_ETHERNET_TELEMETRY
             range GPIO_RANGE_MIN GPIO_RANGE_MAX
-            default 23 if ENABLE_ETHERNET_TELEMETRY 
+            default 23 if ENABLE_ETHERNET_TELEMETRY
             help
                 Set the GPIO number used by SMI MDC.
 
         config ETH_MDIO_GPIO
             int "SMI MDIO GPIO number"
+            depends on ENABLE_ETHERNET_TELEMETRY
             range GPIO_RANGE_MIN GPIO_RANGE_MAX
             default 18 if ENABLE_ETHERNET_TELEMETRY
             help
@@ -546,6 +551,7 @@ menu "CHIP Device Layer"
 
         config ETH_PHY_RST_GPIO
             int "PHY Reset GPIO number"
+            depends on ENABLE_ETHERNET_TELEMETRY
             range -1 GPIO_RANGE_MAX
             default 5 if ENABLE_ETHERNET_TELEMETRY
             help


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22785

#### Change overview
* Add default value `GPIO_RANGE_MAX` for ESP32H2
* Make all the Ethernet Kconfig options depend on `ENABLE_ETHERNET_TELEMETRY`
