### PR TITLE
[SetUpCodePairer] Try to pair over all discovered ips instead of only the first one tha…

### DIFF
--- a/scripts/tools/check_includes_config.py
+++ b/scripts/tools/check_includes_config.py
@@ -149,9 +149,9 @@ ALLOW: Dict[str, Set[str]] = {
     # Uses platform-define to switch between list and array
     'src/lib/dnssd/minimal_mdns/ResponseSender.h': {'list'},
 
-    # Not really for embedded consumers; uses std::queue to keep track
+    # Not really for embedded consumers; uses std::deque to keep track
     # of a list of discovered things.
-    'src/controller/SetUpCodePairer.h': {'queue'},
+    'src/controller/SetUpCodePairer.h': {'deque'},
 
     'src/controller/ExamplePersistentStorage.cpp': {'fstream'}
 }

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -224,7 +224,7 @@ bool SetUpCodePairer::ConnectToDiscoveredDevice()
         // connection attempt fails and calls right back into us to try the next
         // thing.
         SetUpCodePairerParameters params(mDiscoveredParameters.front());
-        mDiscoveredParameters.pop();
+        mDiscoveredParameters.pop_front();
 
         params.SetSetupPINCode(mSetUpPINCode);
 
@@ -272,7 +272,7 @@ void SetUpCodePairer::OnDiscoveredDeviceOverBle(BLE_CONNECTION_OBJECT connObj)
 
     mWaitingForDiscovery[kBLETransport] = false;
 
-    mDiscoveredParameters.emplace(connObj);
+    mDiscoveredParameters.emplace_front(connObj);
     ConnectToDiscoveredDevice();
 }
 
@@ -341,7 +341,12 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
 
     ChipLogProgress(Controller, "Discovered device to be commissioned over DNS-SD");
 
-    mDiscoveredParameters.emplace(nodeData.resolutionData);
+    auto & resolutionData = nodeData.resolutionData;
+    for (size_t i = 0; i < resolutionData.numIPs; i++)
+    {
+        mDiscoveredParameters.emplace_back(nodeData.resolutionData, i);
+    }
+
     ConnectToDiscoveredDevice();
 }
 
@@ -394,7 +399,7 @@ void SetUpCodePairer::ResetDiscoveryState()
 
     while (!mDiscoveredParameters.empty())
     {
-        mDiscoveredParameters.pop();
+        mDiscoveredParameters.pop_front();
     }
 
     mCurrentPASEParameters.ClearValue();
@@ -542,12 +547,12 @@ void SetUpCodePairer::OnDeviceDiscoveredTimeoutCallback(System::Layer * layer, v
     }
 }
 
-SetUpCodePairerParameters::SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data)
+SetUpCodePairerParameters::SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data, size_t index)
 {
     mInterfaceId = data.interfaceId;
     Platform::CopyString(mHostName, data.hostName);
 
-    auto & ip = data.ipAddress[0];
+    auto & ip = data.ipAddress[index];
     SetPeerAddress(Transport::PeerAddress::UDP(ip, data.port, ip.IsIPv6LinkLocal() ? data.interfaceId : Inet::InterfaceId::Null()));
 
     if (data.mrpRetryIntervalIdle.HasValue())

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -41,7 +41,7 @@
 
 #include <controller/DeviceDiscoveryDelegate.h>
 
-#include <queue>
+#include <deque>
 
 namespace chip {
 namespace Controller {
@@ -51,7 +51,7 @@ class DeviceCommissioner;
 class SetUpCodePairerParameters : public RendezvousParameters
 {
 public:
-    SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data);
+    SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data, size_t index);
 #if CONFIG_NETWORK_LAYER_BLE
     SetUpCodePairerParameters(BLE_CONNECTION_OBJECT connObj);
 #endif // CONFIG_NETWORK_LAYER_BLE
@@ -188,10 +188,10 @@ private:
     // process happening via the relevant transport.
     bool mWaitingForDiscovery[kTransportTypeCount] = { false };
 
-    // Queue of things we have discovered but not tried connecting to yet.  The
+    // Double ended-queue of things we have discovered but not tried connecting to yet.  The
     // general discovery/pairing process will terminate once this queue is empty
     // and all the booleans in mWaitingForDiscovery are false.
-    std::queue<SetUpCodePairerParameters> mDiscoveredParameters;
+    std::deque<SetUpCodePairerParameters> mDiscoveredParameters;
 
     // Current thing we are trying to connect to over UDP. If a PASE connection fails with
     // a CHIP_ERROR_TIMEOUT, the discovered parameters will be used to ask the


### PR DESCRIPTION
…t has been discovered

#### Issue Being Resolved
* While pairing, it may happens that some of the discovered ips from mdns are stale cache entry. It does not cost much to try all the discovered ips while pairing using the `SetUpCodePairer`.

#### Change overview
 * Use all the discovered mdns ips as targets for pairing, not only the first one.
