### PR TITLE
[AddressResolver] Get Link-Local address before ULA on apple platforms

### DIFF
--- a/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
+++ b/src/lib/address_resolve/AddressResolve_DefaultImpl.cpp
@@ -35,10 +35,15 @@ enum class IpScore : unsigned
     // "Other" IPv6 include:
     //   - invalid addresses (have seen router bugs during interop testing)
     //   - embedded IPv4 (::/80)
-    kOtherIpv6                     = 1,
-    kIpv4                          = 2, // Not Matter SPEC, so low priority
-    kLinkLocal                     = 3, // Valid only on an interface
-    kUniqueLocal                   = 4, // ULA. Thread devices use this
+    kOtherIpv6 = 1,
+    kIpv4      = 2, // Not Matter SPEC, so low priority
+#ifdef __APPLE__
+    kUniqueLocal = 3, // ULA. Thread devices use this
+    kLinkLocal   = 4, // Valid only on an interface
+#else
+    kLinkLocal   = 3, // Valid only on an interface
+    kUniqueLocal = 4, // ULA. Thread devices use this
+#endif                                  // __APPLE__
     kGlobalUnicast                 = 5, // Maybe routable, not local subnet
     kUniqueLocalWithSharedPrefix   = 6, // Prefix seems to match a local interface
     kGlobalUnicastWithSharedPrefix = 7, // Prefix seems to match a local interface


### PR DESCRIPTION
#### Issue Being Resolved
* On Darwin it may better to get Link-Local before ULA address. Similar to #22789 where some stale cache stuff may be lying around.

#### Change overview
 * Update the score for both types
