### PR TITLE
Fix KeepSubscription flag handling

### DIFF
--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -793,7 +793,8 @@ bool InteractionModelEngine::TrimFabricForSubscriptions(FabricIndex aFabricIndex
     {
         SubscriptionId subId;
         candidate->GetSubscriptionId(subId);
-        ChipLogProgress(DataManagement, "Evicting Subscription ID %u:0x%04X", candidate->GetSubjectDescriptor().fabricIndex, subId);
+        ChipLogProgress(DataManagement, "Evicting Subscription ID %u:0x%" PRIx32, candidate->GetSubjectDescriptor().fabricIndex,
+                        subId);
         candidate->Close();
         return true;
     }

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -426,6 +426,29 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
 
         SubscribeRequestMessage::Parser subscribeRequestParser;
         VerifyOrReturnError(subscribeRequestParser.Init(reader) == CHIP_NO_ERROR, Status::InvalidAction);
+
+        VerifyOrReturnError(subscribeRequestParser.GetKeepSubscriptions(&keepExistingSubscriptions) == CHIP_NO_ERROR,
+                            Status::InvalidAction);
+        if (!keepExistingSubscriptions)
+        {
+            //
+            // Walk through all existing subscriptions and shut down those whose subscriber matches
+            // that which just came in.
+            //
+            mReadHandlers.ForEachActiveObject([this, apExchangeContext](ReadHandler * handler) {
+                if (handler->IsFromSubscriber(*apExchangeContext))
+                {
+                    ChipLogProgress(InteractionModel,
+                                    "Deleting previous subscription from NodeId: " ChipLogFormatX64 ", FabricIndex: %u",
+                                    ChipLogValueX64(apExchangeContext->GetSessionHandle()->AsSecureSession()->GetPeerNodeId()),
+                                    apExchangeContext->GetSessionHandle()->GetFabricIndex());
+                    mReadHandlers.ReleaseObject(handler);
+                }
+
+                return Loop::Continue;
+            });
+        }
+
         {
             size_t requestedAttributePathCount = 0;
             size_t requestedEventPathCount     = 0;
@@ -491,28 +514,6 @@ Protocols::InteractionModel::Status InteractionModelEngine::OnReadInitialRequest
             {
                 return Status::PathsExhausted;
             }
-        }
-
-        VerifyOrReturnError(subscribeRequestParser.GetKeepSubscriptions(&keepExistingSubscriptions) == CHIP_NO_ERROR,
-                            Status::InvalidAction);
-        if (!keepExistingSubscriptions)
-        {
-            //
-            // Walk through all existing subscriptions and shut down those whose subscriber matches
-            // that which just came in.
-            //
-            mReadHandlers.ForEachActiveObject([this, apExchangeContext](ReadHandler * handler) {
-                if (handler->IsFromSubscriber(*apExchangeContext))
-                {
-                    ChipLogProgress(InteractionModel,
-                                    "Deleting previous subscription from NodeId: " ChipLogFormatX64 ", FabricIndex: %u",
-                                    ChipLogValueX64(apExchangeContext->GetSessionHandle()->AsSecureSession()->GetPeerNodeId()),
-                                    apExchangeContext->GetSessionHandle()->GetFabricIndex());
-                    mReadHandlers.ReleaseObject(handler);
-                }
-
-                return Loop::Continue;
-            });
         }
     }
     else
@@ -790,6 +791,9 @@ bool InteractionModelEngine::TrimFabricForSubscriptions(FabricIndex aFabricIndex
          eventPathsSubscribedByCurrentFabric > perFabricPathCapacity ||
          subscriptionsEstablishedByCurrentFabric > perFabricSubscriptionCapacity))
     {
+        SubscriptionId subId;
+        candidate->GetSubscriptionId(subId);
+        ChipLogProgress(DataManagement, "Evicting Subscription ID %u:0x%04X", candidate->GetSubjectDescriptor().fabricIndex, subId);
         candidate->Close();
         return true;
     }

--- a/src/app/ReadClient.cpp
+++ b/src/app/ReadClient.cpp
@@ -952,9 +952,6 @@ CHIP_ERROR ReadClient::SendSubscribeRequestImpl(const ReadPrepareParams & aReadP
     Span<DataVersionFilter> dataVersionFilters(aReadPrepareParams.mpDataVersionFilterList,
                                                aReadPrepareParams.mDataVersionFilterListSize);
 
-    VerifyOrReturnError(aReadPrepareParams.mAttributePathParamsListSize != 0 || aReadPrepareParams.mEventPathParamsListSize != 0,
-                        CHIP_ERROR_INVALID_ARGUMENT);
-
     System::PacketBufferHandle msgBuf;
     System::PacketBufferTLVWriter writer;
     SubscribeRequestMessage::Builder request;

--- a/src/controller/python/chip/clusters/Attribute.py
+++ b/src/controller/python/chip/clusters/Attribute.py
@@ -955,10 +955,7 @@ def Read(future: Future, eventLoop, device, devCtrl, attributes: List[AttributeP
     if (not attributes) and dataVersionFilters:
         raise ValueError(
             "Must provide valid attribute list when data version filters is not null")
-    if (not attributes) and (not events):
-        raise ValueError(
-            "Must read some something"
-        )
+
     handle = chip.native.GetLibraryHandle()
     transaction = AsyncReadTransaction(
         future, eventLoop, devCtrl, returnClusterObject)


### PR DESCRIPTION
Fixes #22774 

This fixes the KeepSubscription flag handling to be done right at the onset of processing a SubscribeRequest message as per the spec. This ensures that matching existing subscriptions are evicted before we attempt to continue further processing and allocation of ReadHandlers.

This also removes logic in `ReadClient` that checks we have at least some paths in the request. By removing this bit of logic, it permits subscriptions with empty paths to be sent to effect a 'cancel subscription' operation of sorts. The validation of that will now happen server-side and an IM error will be sent back, but this can be used to cancel any prior subscriptions on the target.

Testing:

In addition to the new test in TestRead, validated setting up a sub in chip-tool and then cancelling it by sending another sub to an invalid endpoint:

```
basic subscribe location  0 5 2 0
any subscribe-by-id 0xFFFFFFFF 0xFFFFFFFF 0 5 2 100
```

Also tested by sending an empty subscribe request with the REPL.