### PR TITLE
[Darwin] Call ResetSharedConnection and not StartSharedConnection in …

### DIFF
--- a/src/platform/Darwin/DnssdHostNameRegistrar.cpp
+++ b/src/platform/Darwin/DnssdHostNameRegistrar.cpp
@@ -272,7 +272,7 @@ CHIP_ERROR HostNameRegistrar::Register()
     VerifyOrReturnError(!IsLocalOnly(), CHIP_NO_ERROR);
 
     return StartMonitorInterfaces(^(InetInterfacesVector inetInterfaces, Inet6InterfacesVector inet6Interfaces) {
-        ReturnOnFailure(StartSharedConnection());
+        ReturnOnFailure(ResetSharedConnection());
         RegisterInterfaces(inetInterfaces, kDNSServiceType_A);
         RegisterInterfaces(inet6Interfaces, kDNSServiceType_AAAA);
     });
@@ -355,6 +355,8 @@ void HostNameRegistrar::StopMonitorInterfaces()
 
 CHIP_ERROR HostNameRegistrar::StartSharedConnection()
 {
+    VerifyOrReturnError(mServiceRef == nullptr, CHIP_ERROR_INCORRECT_STATE);
+
     auto err = DNSServiceCreateConnection(&mServiceRef);
     VerifyOrReturnValue(kDNSServiceErr_NoError == err, Error::ToChipError(err));
 


### PR DESCRIPTION
…src/platform/Darwin/DnssdHostNameRegistrar.cpp in order to properly unregister / register interfaces addresses

#### Issue Being Resolved
* Fix #22689
As mentioned in #22689 I have written the code for "resetting" interfaces registration but I have written `Start` instead of `Reset` while cleaning up the code...

#### Change overview
* Use the right method call...
