### PR TITLE
[darwin-framework-tool] Just send a message to read the MTRErrorHolde…

### DIFF
--- a/examples/darwin-framework-tool/commands/common/MTRError.mm
+++ b/examples/darwin-framework-tool/commands/common/MTRError.mm
@@ -25,25 +25,6 @@
 #import <inet/InetError.h>
 #import <lib/support/TypeTraits.h>
 
-// Stolen for now from the framework, need to export this properly.
-@interface DFTErrorHolder : NSObject
-@property (nonatomic, readonly) CHIP_ERROR error;
-@end
-
-@implementation DFTErrorHolder
-
-- (instancetype)initWithError:(CHIP_ERROR)error
-{
-    if (!(self = [super init])) {
-        return nil;
-    }
-
-    _error = error;
-    return self;
-}
-
-@end
-
 CHIP_ERROR MTRErrorToCHIPErrorCode(NSError * error)
 {
     if (error == nil) {
@@ -64,8 +45,13 @@ CHIP_ERROR MTRErrorToCHIPErrorCode(NSError * error)
 
     if (error.userInfo != nil) {
         id underlyingError = error.userInfo[@"underlyingError"];
-        if (underlyingError != nil && [underlyingError isKindOfClass:[DFTErrorHolder class]]) {
-            return ((DFTErrorHolder *) underlyingError).error;
+        if (underlyingError != nil) {
+            NSValue * chipErrorValue = [underlyingError valueForKey:@"error"];
+            if (chipErrorValue != nil) {
+                CHIP_ERROR chipError;
+                [chipErrorValue getValue:&chipError];
+                return chipError;
+            }
         }
     }
 


### PR DESCRIPTION
#### Issue Being Resolved
* This is a followup to #22730 since the changes there just don't work. Sorry :( 

#### Change overview
* Read the instance variable by sending a message instead of declaring the interface/implementation into the `MTRErrorHolder` clone.
