### PR TITLE
[Linux]Add build arg to allow external logging implementation

### DIFF
--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -47,6 +47,9 @@ declare_args() {
   # Configure chip logging to output through pigweed logging.
   chip_use_pw_logging = false
 
+  # Configure chip logging to output through external logging implementation.
+  chip_use_external_logging = false
+
   # Enable short error strings.
   chip_config_short_error_str = false
 

--- a/src/lib/core/core.gni
+++ b/src/lib/core/core.gni
@@ -48,6 +48,8 @@ declare_args() {
   chip_use_pw_logging = false
 
   # Configure chip logging to output through external logging implementation.
+  # External code will need to provide implementation for CHIP log output
+  # function (LogV), which is defined in "src/platform/logging/LogV.h".
   chip_use_external_logging = false
 
   # Enable short error strings.

--- a/src/platform/Linux/BUILD.gn
+++ b/src/platform/Linux/BUILD.gn
@@ -67,7 +67,6 @@ static_library("Linux") {
     "InetPlatformConfig.h",
     "KeyValueStoreManagerImpl.cpp",
     "KeyValueStoreManagerImpl.h",
-    "Logging.cpp",
     "NetworkCommissioningDriver.h",
     "NetworkCommissioningEthernetDriver.cpp",
     "PlatformManagerImpl.cpp",
@@ -77,6 +76,10 @@ static_library("Linux") {
     "SystemPlatformConfig.h",
     "SystemTimeSupport.cpp",
   ]
+
+  if (!chip_use_external_logging) {
+    sources += [ "Logging.cpp" ]
+  }
 
   if (chip_enable_openthread) {
     sources += [ "NetworkCommissioningThreadDriver.cpp" ]


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22828 

#### Change overview
Add a build arg to allow target platform/application to provide its own logging implementation.
