### PR TITLE
Add missing pthread header

### DIFF
--- a/examples/platform/linux/NamedPipeCommands.cpp
+++ b/examples/platform/linux/NamedPipeCommands.cpp
@@ -20,6 +20,7 @@
 
 #include <fcntl.h>
 #include <lib/support/CodeUtils.h>
+#include <pthread.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22832

#### Change overview
Adds a missing include of `pthread.h` to `NamedPipeCommands.cpp`.
