### PR TITLE
[Ameba] Fix Trailing Null

### DIFF
--- a/src/platform/Ameba/AmebaConfig.cpp
+++ b/src/platform/Ameba/AmebaConfig.cpp
@@ -152,6 +152,7 @@ CHIP_ERROR AmebaConfig::ReadConfigValueStr(Key key, char * buf, size_t bufSize, 
 
     if (success == 0)
     {
+        outLen -= 1; // Don't count trailing null
         return CHIP_NO_ERROR;
     }
     else


### PR DESCRIPTION
#### Issue Being Resolved
* TC-BINFO-2.1 when reading location, it shows 3 chars. Remove trailing null after getPref_str_new

#### Change overview
* src/platform/Ameba/AmebaConfig.cpp