### PR TITLE
[Darwin tests] Fix testAnySharedRemoteController and testReadClusterStateCacheFailure

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
@@ -20,7 +20,8 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef void (^MTRFetchControllerIDCompletion)(id _Nullable controllerID, NSError * _Nullable error);
+typedef void (^MTRFetchControllerIDCompletion)(
+    id _Nullable controllerID, MTRDeviceControllerXPCProxyHandle * _Nullable handle, NSError * _Nullable error);
 
 @interface MTRDeviceControllerOverXPC ()
 

--- a/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
@@ -2331,6 +2331,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
               completion(nil, myError);
           };
 
+    _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [clusterStateCacheContainer subscribeWithDeviceController:_remoteDeviceController
                                                      deviceID:@(myNodeId)
                                                        params:nil
@@ -2340,7 +2341,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                        XCTAssertNil(error);
                                                        [subscribeExpectation fulfill];
                                                    }];
-    [self waitForExpectations:@[ subscribeExpectation ] timeout:kTimeoutInSeconds];
+    [self waitForExpectations:@[ subscribeExpectation, _xpcDisconnectExpectation ] timeout:kTimeoutInSeconds];
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [clusterStateCacheContainer


### PR DESCRIPTION
#### Issue Being Resolved
* In #22754 there are some intermittent darwin tests failures related to `testReadClusterStateCacheFailure`
* In #21569 (and many others...) there are some intermittent darwin tests failures related to `testAnySharedRemoteController`

#### Change overview
 * Fix `testReadClusterStateCacheFailure` to wait for the first XPC disconnect before issuing a read...
 * Fix `MTRDeviceControllerOverXPC` and `MTRDeviceOverXPC` in such a way that the proxy handle is not released while setting it up. It just seems that we don't really want to allocate an xpc connection for nothing. As a side effect it was allocated twice with a disconnect in between - which is why tests relying on a single disconnect were failing.
