### PR TITLE
[Linux] Mark GLib source as removed when exiting callback

### DIFF
--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -406,6 +406,8 @@ exit:
         // Returning G_SOURCE_REMOVE from the source callback removes the source object
         // from the context. Unset self source ID tag, so we will not call g_source_remove()
         // in BluezOTConnectionDestroy() on already removed source.
+        //
+        // TODO: Investigate whether there is a batter way to handle this.
         conn->mC1Channel.mWatch = 0;
     }
 
@@ -429,6 +431,8 @@ static gboolean bluezCharacteristicDestroyFD(GIOChannel * aChannel, GIOCondition
     // Returning G_SOURCE_REMOVE from the source callback removes the source object
     // from the context. Unset self source ID tag, so we will not call g_source_remove()
     // in BluezOTConnectionDestroy() on already removed source.
+    //
+    // TODO: Investigate whether there is a batter way to handle this.
     conn->mC2Channel.mWatch = 0;
     return G_SOURCE_REMOVE;
 }

--- a/src/platform/Linux/bluez/Helper.cpp
+++ b/src/platform/Linux/bluez/Helper.cpp
@@ -401,7 +401,15 @@ static gboolean BluezCharacteristicWriteFD(GIOChannel * aChannel, GIOCondition a
     isSuccess = true;
 
 exit:
-    return isSuccess ? TRUE : FALSE;
+    if (!isSuccess && (conn != nullptr))
+    {
+        // Returning G_SOURCE_REMOVE from the source callback removes the source object
+        // from the context. Unset self source ID tag, so we will not call g_source_remove()
+        // in BluezOTConnectionDestroy() on already removed source.
+        conn->mC1Channel.mWatch = 0;
+    }
+
+    return isSuccess ? G_SOURCE_CONTINUE : G_SOURCE_REMOVE;
 }
 
 static void Bluez_gatt_characteristic1_complete_acquire_write_with_fd(GDBusMethodInvocation * invocation, int fd, guint16 mtu)
@@ -417,6 +425,11 @@ static void Bluez_gatt_characteristic1_complete_acquire_write_with_fd(GDBusMetho
 
 static gboolean bluezCharacteristicDestroyFD(GIOChannel * aChannel, GIOCondition aCond, gpointer apClosure)
 {
+    BluezConnection * conn = static_cast<BluezConnection *>(apClosure);
+    // Returning G_SOURCE_REMOVE from the source callback removes the source object
+    // from the context. Unset self source ID tag, so we will not call g_source_remove()
+    // in BluezOTConnectionDestroy() on already removed source.
+    conn->mC2Channel.mWatch = 0;
     return G_SOURCE_REMOVE;
 }
 


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22840

#### Change overview
* Mark GLib source as removed when exiting callback function with FALSE.
