### PR TITLE
Stop holding on to a PASE DeviceProxy pointer in MTRBaseDevice.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice_Internal.h
@@ -30,12 +30,6 @@ NS_ASSUME_NONNULL_BEGIN
 - (instancetype)initWithPASEDevice:(chip::DeviceProxy *)device controller:(MTRDeviceController *)controller;
 
 /**
- * Only returns non-nil if the device is using a PASE session.  Otherwise, the
- * deviceController + nodeId should be used to get a CASE session.
- */
-- (chip::DeviceProxy * _Nullable)paseDevice;
-
-/**
  * Invalidate the CASE session, so an attempt to getConnectedDevice for this
  * device id will have to create a new CASE session.  Ideally this API will go
  * away.
@@ -43,13 +37,19 @@ NS_ASSUME_NONNULL_BEGIN
 - (void)invalidateCASESession;
 
 /**
+ * Whether this device represents a PASE session or not.
+ */
+@property (nonatomic, assign, readonly) BOOL isPASEDevice;
+
+/**
  * Controller that that this MTRDevice was gotten from.
  */
 @property (nonatomic, strong, readonly) MTRDeviceController * deviceController;
 
 /**
- * Node id for this MTRDevice.  Only set to a usable value if this device
- * represents a CASE session.
+ * Node id for this MTRDevice.  If this device represents a CASE session, this
+ * is set to the node ID of the target node.  If this device represents a PASE
+ * session, this is set to the device id of the PASE device.
  */
 @property (nonatomic, assign, readonly) chip::NodeId nodeID;
 
@@ -60,10 +60,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (instancetype)new NS_UNAVAILABLE;
 
 /**
- * Initialize the device object with the given node id and controller.  This
- * will always succeed, even if there is no such node id on the controller's
- * fabric, but attempts to actually use the MTRBaseDevice will fail
- * (asynchronously) in that case.
+ * Initialize the device object as a CASE device with the given node id and
+ * controller.  This will always succeed, even if there is no such node id on
+ * the controller's fabric, but attempts to actually use the MTRBaseDevice will
+ * fail (asynchronously) in that case.
  */
 - (instancetype)initWithNodeID:(NSNumber *)nodeID controller:(MTRDeviceController *)controller;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -489,18 +489,19 @@ static NSString * const kErrorSpake2pVerifierSerializationFailed = @"PASE verifi
 {
     VerifyOrReturnValue([self checkIsRunning:error], nil);
 
-    __block chip::CommissioneeDeviceProxy * deviceProxy;
-
+    __block MTRBaseDevice * device;
     __block BOOL success = NO;
     dispatch_sync(_chipWorkQueue, ^{
         VerifyOrReturn([self checkIsRunning:error]);
 
+        chip::CommissioneeDeviceProxy * deviceProxy;
         auto errorCode = self->_cppCommissioner->GetDeviceBeingCommissioned([nodeID unsignedLongLongValue], &deviceProxy);
         success = ![MTRDeviceController checkForError:errorCode logMsg:kErrorStopPairing error:error];
+        device = [[MTRBaseDevice alloc] initWithPASEDevice:deviceProxy controller:self];
     });
     VerifyOrReturnValue(success, nil);
 
-    return [[MTRBaseDevice alloc] initWithPASEDevice:deviceProxy controller:self];
+    return device;
 }
 
 - (MTRBaseDevice *)baseDeviceForNodeID:(NSNumber *)nodeID
@@ -699,6 +700,38 @@ static NSString * const kErrorSpake2pVerifierSerializationFailed = @"PASE verifi
         // MTRDeviceConnectionBridge always delivers errors async via
         // completion.
         connectionBridge->connect(self->_cppCommissioner, nodeID);
+    });
+
+    return YES;
+}
+
+- (BOOL)getSessionForCommissioneeDevice:(chip::NodeId)deviceID completion:(MTRInternalDeviceConnectionCallback)completion
+{
+    if (![self checkIsRunning]) {
+        return NO;
+    }
+
+    dispatch_async(_chipWorkQueue, ^{
+        NSError * error;
+        if (![self checkIsRunning:&error]) {
+            completion(nullptr, chip::NullOptional, error);
+            return;
+        }
+
+        chip::CommissioneeDeviceProxy * deviceProxy;
+        CHIP_ERROR err = self->_cppCommissioner->GetDeviceBeingCommissioned(deviceID, &deviceProxy);
+        if (err != CHIP_NO_ERROR) {
+            completion(nullptr, chip::NullOptional, [MTRError errorForCHIPErrorCode:err]);
+            return;
+        }
+
+        chip::Optional<chip::SessionHandle> session = deviceProxy->GetSecureSession();
+        if (!session.HasValue() || !session.Value()->AsSecureSession()->IsPASESession()) {
+            completion(nullptr, chip::NullOptional, [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE]);
+            return;
+        }
+
+        completion(deviceProxy->GetExchangeManager(), session, nil);
     });
 
     return YES;

--- a/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController_Internal.h
@@ -121,6 +121,20 @@ NS_ASSUME_NONNULL_BEGIN
 - (BOOL)getSessionForNode:(chip::NodeId)nodeID completion:(MTRInternalDeviceConnectionCallback)completion;
 
 /**
+ * Get a session for the commissionee device with the given device id.  This may
+ * be called on any queue (including the Matter event queue) and will always
+ * call the provided connection callback on the Matter queue, asynchronously.
+ * Consumers must be prepared to run on the Matter queue (an in particular must
+ * not use any APIs that will try to do sync dispatch to the Matter queue).
+ *
+ * If the controller is not running when this function is called, will return NO
+ * and never invoke the completion.  If the controller is not running when the
+ * async dispatch on the Matter queue would happen, an error will be dispatched
+ * to the completion handler.
+ */
+- (BOOL)getSessionForCommissioneeDevice:(chip::NodeId)deviceID completion:(MTRInternalDeviceConnectionCallback)completion;
+
+/**
  * Invalidate the CASE session for the given node ID.  This is a temporary thing
  * just to support MTRBaseDevice's invalidateCASESession.  Must not be called on
  * the Matter event queue.


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22846

#### Change overview
Hold on to the device id, get session info by device id as needed.
