### PR TITLE
[Android] Integrate cluster state cache with android Java IM API

### DIFF
--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -532,5 +532,10 @@ exit:
     return err;
 }
 
+CHIP_ERROR ClusterStateCache::GetLastReportDataPath(ConcreteClusterPath & aPath)
+{
+    aPath = mLastReportDataPath;
+    return CHIP_NO_ERROR;
+}
 } // namespace app
 } // namespace chip

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -483,6 +483,8 @@ public:
         mEventStatusCache.clear();
     }
 
+    CHIP_ERROR GetLastReportDataPath(ConcreteClusterPath & aPath);
+
 private:
     using AttributeState = Variant<Platform::ScopedMemoryBufferWithSize<uint8_t>, StatusIB>;
     // mPendingDataVersion represents a tentative data version for a cluster that we have gotten some reports for.

--- a/src/controller/java/AndroidCallbacks.cpp
+++ b/src/controller/java/AndroidCallbacks.cpp
@@ -314,12 +314,10 @@ void ReportCallback::UpdateClusterDataVersion()
 
     // SetDataVersion to NodeState
     jmethodID setDataVersionMethod;
-    CHIP_ERROR err =
-        JniReferences::GetInstance().FindMethod(env, mNodeStateObj, "setDataVersion", "(IJI)V", &setDataVersionMethod);
+    CHIP_ERROR err = JniReferences::GetInstance().FindMethod(env, mNodeStateObj, "setDataVersion", "(IJI)V", &setDataVersionMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Controller, "Could not find setDataVersion method"));
     env->CallVoidMethod(mNodeStateObj, setDataVersionMethod, static_cast<jint>(lastConcreteClusterPath.mEndpointId),
-                        static_cast<jlong>(lastConcreteClusterPath.mClusterId),
-                        static_cast<jint>(committedDataVersion.Value()));
+                        static_cast<jlong>(lastConcreteClusterPath.mClusterId), static_cast<jint>(committedDataVersion.Value()));
     VerifyOrReturn(!env->ExceptionCheck(), env->ExceptionDescribe());
 }
 

--- a/src/controller/java/AndroidCallbacks.h
+++ b/src/controller/java/AndroidCallbacks.h
@@ -42,7 +42,7 @@ struct GetConnectedDeviceCallback
     jobject mJavaCallbackRef    = nullptr;
 };
 
-struct ReportCallback : public app::ReadClient::Callback
+struct ReportCallback : public app::ClusterStateCache::Callback
 {
     /** Subscription established callback can be nullptr. */
     ReportCallback(jobject wrapperCallback, jobject subscriptionEstablishedCallback, jobject reportCallback,
@@ -74,9 +74,11 @@ struct ReportCallback : public app::ReadClient::Callback
 
     CHIP_ERROR CreateChipEventPath(const app::ConcreteEventPath & aPath, jobject & outObj);
 
+    void UpdateClusterDataVersion();
+
     app::ReadClient * mReadClient = nullptr;
 
-    app::BufferedReadCallback mBufferedReadAdapter;
+    app::ClusterStateCache mClusterCacheAdapter;
     jobject mWrapperCallbackRef                 = nullptr;
     jobject mSubscriptionEstablishedCallbackRef = nullptr;
     jobject mResubscriptionAttemptCallbackRef   = nullptr;

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -1077,9 +1077,9 @@ JNI_METHOD(void, subscribe)
 
     auto callback = reinterpret_cast<ReportCallback *>(callbackHandle);
 
-    app::ReadClient * readClient =
-        Platform::New<app::ReadClient>(app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                       callback->mBufferedReadAdapter, app::ReadClient::InteractionType::Subscribe);
+    app::ReadClient * readClient = Platform::New<app::ReadClient>(
+        app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+        callback->mClusterCacheAdapter.GetBufferedCallback(), app::ReadClient::InteractionType::Subscribe);
 
     err = readClient->SendRequest(params);
     if (err != CHIP_NO_ERROR)
@@ -1126,9 +1126,9 @@ JNI_METHOD(void, read)
 
     auto callback = reinterpret_cast<ReportCallback *>(callbackHandle);
 
-    app::ReadClient * readClient =
-        Platform::New<app::ReadClient>(app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
-                                       callback->mBufferedReadAdapter, app::ReadClient::InteractionType::Read);
+    app::ReadClient * readClient = Platform::New<app::ReadClient>(
+        app::InteractionModelEngine::GetInstance(), device->GetExchangeManager(),
+        callback->mClusterCacheAdapter.GetBufferedCallback(), app::ReadClient::InteractionType::Read);
 
     err = readClient->SendRequest(params);
     if (err != CHIP_NO_ERROR)

--- a/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
+++ b/src/controller/java/src/chip/devicecontroller/ChipDeviceController.java
@@ -452,7 +452,7 @@ public class ChipDeviceController {
   }
 
   /** Subscribe to the given attribute path. */
-  public void subscribeToPath(
+  public void subscribeToAttributePath(
       SubscriptionEstablishedCallback subscriptionEstablishedCallback,
       ReportCallback reportCallback,
       long devicePtr,
@@ -524,7 +524,7 @@ public class ChipDeviceController {
   }
 
   /** Read the given attribute path. */
-  public void readPath(
+  public void readAttributePath(
       ReportCallback callback, long devicePtr, List<ChipAttributePath> attributePaths) {
     ReportCallbackJni jniCallback = new ReportCallbackJni(null, callback, null);
     read(

--- a/src/controller/java/src/chip/devicecontroller/model/ClusterState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/ClusterState.java
@@ -19,15 +19,18 @@ package chip.devicecontroller.model;
 
 import androidx.annotation.Nullable;
 import java.util.Map;
+import java.util.Optional;
 
 /** Class for tracking CHIP cluster state in a hierarchical manner. */
 public final class ClusterState {
   private Map<Long, AttributeState> attributes;
   private Map<Long, EventState> events;
+  private Optional<Integer> dataVersion;
 
   public ClusterState(Map<Long, AttributeState> attributes, Map<Long, EventState> events) {
     this.attributes = attributes;
     this.events = events;
+    this.dataVersion = Optional.empty();
   }
 
   public Map<Long, AttributeState> getAttributeStates() {
@@ -36,6 +39,14 @@ public final class ClusterState {
 
   public Map<Long, EventState> getEventStates() {
     return events;
+  }
+
+  public void setDataVersion(int version) {
+    dataVersion = Optional.of(version);
+  }
+
+  public int getDataVersion() {
+    return dataVersion.get();
   }
 
   /**

--- a/src/controller/java/src/chip/devicecontroller/model/ClusterState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/ClusterState.java
@@ -45,8 +45,8 @@ public final class ClusterState {
     dataVersion = Optional.of(version);
   }
 
-  public int getDataVersion() {
-    return dataVersion.get();
+  public Optional<Integer> getDataVersion() {
+    return dataVersion;
   }
 
   /**

--- a/src/controller/java/src/chip/devicecontroller/model/NodeState.java
+++ b/src/controller/java/src/chip/devicecontroller/model/NodeState.java
@@ -34,6 +34,16 @@ public final class NodeState {
   }
 
   // Called from native code only, which ignores access modifiers.
+  private void setDataVersion(int endpointId, long clusterId, int dataVersion) {
+    EndpointState endpointState = getEndpointState(endpointId);
+    ClusterState clusterState = endpointState.getClusterState(clusterId);
+
+    if (clusterState != null) {
+      clusterState.setDataVersion(dataVersion);
+    }
+  }
+
+  // Called from native code only, which ignores access modifiers.
   private void addAttribute(
       int endpointId, long clusterId, long attributeId, AttributeState attributeStateToAdd) {
     EndpointState endpointState = getEndpointState(endpointId);


### PR DESCRIPTION
#### Issue Being Resolved
#19668

#### Change overview
Integrate Java Read/Subscribe API with ClusterStateCache, where it has fine-grained dataVersionFilter and eventFilters support. 
In android, we would not expect to retrieve attributes and events from cluster state cache, instead we have provided the NodeState to collect the attribute and event data from each report transaction, in this change, we piped the committed cluster data version from clusterStateCache to nodeState, which can provide coherent data version view when involving wildcard attribute path read/subscribe.

