### PR TITLE
Extending Media attribute subscriptions to Android tv-casting-app/lib

### DIFF
--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissioningFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/CommissioningFragment.java
@@ -9,6 +9,7 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.chip.casting.MatterCallbackHandler;
+import com.chip.casting.MatterError;
 import com.chip.casting.TvCastingApp;
 import com.chip.casting.dnssd.DiscoveredNodeData;
 import com.chip.casting.util.GlobalCastingConstants;
@@ -53,9 +54,9 @@ public class CommissioningFragment extends Fragment {
             GlobalCastingConstants.CommissioningWindowDurationSecs,
             new MatterCallbackHandler() {
               @Override
-              public void handle(Status status) {
-                Log.d(TAG, "handle() called on CommissioningComplete event with " + status);
-                if (status.isSuccess()) {
+              public void handle(MatterError error) {
+                Log.d(TAG, "handle() called on CommissioningComplete event with " + error);
+                if (error.isNoError()) {
                   callback.handleCommissioningComplete();
                 }
               }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ContentLauncherFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/ContentLauncherFragment.java
@@ -10,6 +10,7 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
 import com.chip.casting.MatterCallbackHandler;
+import com.chip.casting.MatterError;
 import com.chip.casting.TvCastingApp;
 
 /** A {@link Fragment} to send Content Launcher commands from the TV Casting App. */
@@ -55,10 +56,10 @@ public class ContentLauncherFragment extends Fragment {
                 contentDisplayString.getText().toString(),
                 new MatterCallbackHandler() {
                   @Override
-                  public void handle(Status status) {
-                    Log.d(TAG, "handle() called on LaunchURLResponse with success " + status);
+                  public void handle(MatterError error) {
+                    Log.d(TAG, "handle() called on LaunchURLResponse with " + error);
                     TextView launchUrlStatus = getView().findViewById(R.id.launchUrlStatus);
-                    launchUrlStatus.setText(status.isSuccess() ? "Success!" : "Failure!");
+                    launchUrlStatus.setText(error.isNoError() ? "Success!" : "Failure!");
                   }
                 });
           }

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MainActivity.java
@@ -21,7 +21,9 @@ import com.chip.casting.dnssd.DiscoveredNodeData;
 import com.chip.casting.util.GlobalCastingConstants;
 
 public class MainActivity extends AppCompatActivity
-    implements CommissionerDiscoveryFragment.Callback, CommissioningFragment.Callback {
+    implements CommissionerDiscoveryFragment.Callback,
+        CommissioningFragment.Callback,
+        SelectClusterFragment.Callback {
 
   private static final String TAG = MainActivity.class.getSimpleName();
 
@@ -49,7 +51,17 @@ public class MainActivity extends AppCompatActivity
 
   @Override
   public void handleCommissioningComplete() {
+    showFragment(SelectClusterFragment.newInstance());
+  }
+
+  @Override
+  public void handleContentLauncherSelected() {
     showFragment(ContentLauncherFragment.newInstance(tvCastingApp));
+  }
+
+  @Override
+  public void handleMediaPlaybackSelected() {
+    showFragment(MediaPlaybackFragment.newInstance(tvCastingApp));
   }
 
   /**

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MediaPlaybackFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/MediaPlaybackFragment.java
@@ -1,0 +1,133 @@
+package com.chip.casting.app;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+import com.chip.casting.FailureCallback;
+import com.chip.casting.MatterError;
+import com.chip.casting.MediaPlaybackTypes;
+import com.chip.casting.SubscriptionEstablishedCallback;
+import com.chip.casting.SuccessCallback;
+import com.chip.casting.TvCastingApp;
+
+/** A {@link Fragment} for the Media Playback cluster */
+public class MediaPlaybackFragment extends Fragment {
+  private static final String TAG = MediaPlaybackFragment.class.getSimpleName();
+
+  private final TvCastingApp tvCastingApp;
+
+  private View.OnClickListener subscribeToCurrentStateButtonClickListener;
+
+  public MediaPlaybackFragment(TvCastingApp tvCastingApp) {
+    this.tvCastingApp = tvCastingApp;
+  }
+
+  /**
+   * Use this factory method to create a new instance of this fragment using the provided
+   * parameters.
+   *
+   * @param tvCastingApp TV Casting App (JNI)
+   * @return A new instance of fragment MediaPlaybackFragment.
+   */
+  public static MediaPlaybackFragment newInstance(TvCastingApp tvCastingApp) {
+    return new MediaPlaybackFragment(tvCastingApp);
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    this.subscribeToCurrentStateButtonClickListener =
+        new View.OnClickListener() {
+          @Override
+          public void onClick(View v) {
+            Log.d(TAG, "SubscribeToCurrentStateButtonClickListener called");
+            TextView minInterval = getView().findViewById(R.id.minIntervalEditText);
+            TextView maxInterval = getView().findViewById(R.id.maxIntervalEditText);
+            TextView subscriptionStatus =
+                getView().findViewById(R.id.currentStateSubscriptionEstablishedStatus);
+            TextView currentStateValue = getView().findViewById(R.id.currentStateValue);
+
+            SuccessCallback<MediaPlaybackTypes.PlaybackStateEnum> successCallback =
+                playbackStateEnum -> {
+                  Log.d(
+                      TAG,
+                      "handle() called on SuccessCallback<MediaPlaybackResponseTypes.PlaybackStateEnum> with "
+                          + playbackStateEnum);
+                  getActivity()
+                      .runOnUiThread(
+                          new Runnable() {
+                            @Override
+                            public void run() {
+                              if (playbackStateEnum != null) {
+                                currentStateValue.setText(playbackStateEnum.toString());
+                              }
+                            }
+                          });
+                };
+
+            FailureCallback failureCallback =
+                new FailureCallback() {
+                  @Override
+                  public void handle(MatterError matterError) {
+                    Log.d(TAG, "handle() called on FailureCallback with " + matterError);
+                    getActivity()
+                        .runOnUiThread(
+                            new Runnable() {
+                              @Override
+                              public void run() {
+                                currentStateValue.setText("Error!");
+                              }
+                            });
+                  }
+                };
+
+            SubscriptionEstablishedCallback subscriptionEstablishedCallback =
+                (SubscriptionEstablishedCallback)
+                    () -> {
+                      Log.d(TAG, "handle() called on SubscriptionEstablishedCallback");
+                      getActivity()
+                          .runOnUiThread(
+                              new Runnable() {
+                                @Override
+                                public void run() {
+                                  subscriptionStatus.setText("Subscription established!");
+                                }
+                              });
+                    };
+
+            boolean retVal =
+                tvCastingApp.mediaPlayback_subscribeToCurrentState(
+                    successCallback,
+                    failureCallback,
+                    Integer.parseInt(minInterval.getText().toString()),
+                    Integer.parseInt(maxInterval.getText().toString()),
+                    subscriptionEstablishedCallback);
+            Log.d(TAG, "tvCastingApp.mediaPlayback_subscribeToCurrentState returned " + retVal);
+            if (retVal == false) {
+              subscriptionStatus.setText("Subscribe call failed!");
+            }
+          }
+        };
+
+    return inflater.inflate(R.layout.fragment_media_playback, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    Log.d(TAG, "MediaPlaybackFragment.onViewCreated called");
+    getView()
+        .findViewById(R.id.subscribeToCurrentStateButton)
+        .setOnClickListener(subscribeToCurrentStateButtonClickListener);
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/SelectClusterFragment.java
+++ b/examples/tv-casting-app/android/App/app/src/main/java/com/chip/casting/app/SelectClusterFragment.java
@@ -1,0 +1,78 @@
+package com.chip.casting.app;
+
+import android.os.Bundle;
+import android.util.Log;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import androidx.annotation.Nullable;
+import androidx.fragment.app.Fragment;
+
+/** An interstitial {@link Fragment} to select one of the supported media actions to perform */
+public class SelectClusterFragment extends Fragment {
+  private static final String TAG = SelectClusterFragment.class.getSimpleName();
+
+  private View.OnClickListener selectContentLauncherButtonClickListener;
+  private View.OnClickListener selectMediaPlaybackButtonClickListener;
+
+  /**
+   * Use this factory method to create a new instance of this fragment using the provided
+   * parameters.
+   *
+   * @return A new instance of fragment SelectActionFragment.
+   */
+  public static SelectClusterFragment newInstance() {
+    return new SelectClusterFragment();
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+  }
+
+  @Override
+  public View onCreateView(
+      LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    SelectClusterFragment.Callback callback = (SelectClusterFragment.Callback) this.getActivity();
+    this.selectContentLauncherButtonClickListener =
+        new View.OnClickListener() {
+          @Override
+          public void onClick(View v) {
+            Log.d(TAG, "handle() called on selectContentLauncherButtonClickListener");
+            callback.handleContentLauncherSelected();
+          }
+        };
+
+    this.selectMediaPlaybackButtonClickListener =
+        new View.OnClickListener() {
+          @Override
+          public void onClick(View v) {
+            Log.d(TAG, "handle() called on selectMediaPlaybackButtonClickListener");
+            callback.handleMediaPlaybackSelected();
+          }
+        };
+
+    return inflater.inflate(R.layout.fragment_select_cluster, container, false);
+  }
+
+  @Override
+  public void onViewCreated(View view, @Nullable Bundle savedInstanceState) {
+    super.onViewCreated(view, savedInstanceState);
+    Log.d(TAG, "SelectActionFragment.onViewCreated called");
+    getView()
+        .findViewById(R.id.selectContentLauncherButton)
+        .setOnClickListener(selectContentLauncherButtonClickListener);
+    getView()
+        .findViewById(R.id.selectMediaPlaybackButton)
+        .setOnClickListener(selectMediaPlaybackButtonClickListener);
+  }
+
+  /** Interface for notifying the host. */
+  public interface Callback {
+    /** Notifies listener to trigger transition on selection of Content Launcher cluster */
+    void handleContentLauncherSelected();
+
+    /** Notifies listener to trigger transition on selection of Media Playback cluster */
+    void handleMediaPlaybackSelected();
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/ContentLauncherTypes.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/ContentLauncherTypes.java
@@ -1,0 +1,96 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.chip.casting;
+
+import java.util.ArrayList;
+import java.util.Optional;
+
+public class ContentLauncherTypes {
+  public static class AdditionalInfo {
+    public String name;
+    public String value;
+
+    public AdditionalInfo(String name, String value) {
+      this.name = name;
+      this.value = value;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder output = new StringBuilder();
+      output.append("AdditionalInfo {\n");
+      output.append("\tname: ");
+      output.append(name);
+      output.append("\n");
+      output.append("\tvalue: ");
+      output.append(value);
+      output.append("\n");
+      output.append("}\n");
+      return output.toString();
+    }
+  }
+
+  public static class Parameter {
+    public Integer type;
+    public String value;
+    public Optional<ArrayList<AdditionalInfo>> externalIDList;
+
+    public Parameter(
+        Integer type, String value, Optional<ArrayList<AdditionalInfo>> externalIDList) {
+      this.type = type;
+      this.value = value;
+      this.externalIDList = externalIDList;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder output = new StringBuilder();
+      output.append("Parameter {\n");
+      output.append("\ttype: ");
+      output.append(type);
+      output.append("\n");
+      output.append("\tvalue: ");
+      output.append(value);
+      output.append("\n");
+      output.append("\texternalIDList: ");
+      output.append(externalIDList);
+      output.append("\n");
+      output.append("}\n");
+      return output.toString();
+    }
+  }
+
+  public static class ContentSearch {
+    public ArrayList<Parameter> parameterList;
+
+    public ContentSearch(ArrayList<Parameter> parameterList) {
+      this.parameterList = parameterList;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder output = new StringBuilder();
+      output.append("ContentSearch {\n");
+      output.append("\tparameterList: ");
+      output.append(parameterList);
+      output.append("\n");
+      output.append("}\n");
+      return output.toString();
+    }
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/FailureCallback.java
@@ -17,7 +17,7 @@
  */
 package com.chip.casting;
 
-public abstract class MatterCallbackHandler {
+public abstract class FailureCallback {
   public abstract void handle(MatterError err);
 
   public final void handle(int errorCode, String errorMessage) {

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterError.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MatterError.java
@@ -1,0 +1,66 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.chip.casting;
+
+import java.util.Objects;
+
+public class MatterError {
+  private int errorCode;
+  private String errorMessage;
+
+  public static final MatterError NO_ERROR = new MatterError(0, null);
+
+  public MatterError(int errorCode, String errorMessage) {
+    this.errorCode = errorCode;
+    this.errorMessage = errorMessage;
+  }
+
+  public boolean isNoError() {
+    return this.equals(NO_ERROR);
+  }
+
+  public int getErrorCode() {
+    return errorCode;
+  }
+
+  public String getErrorMessage() {
+    return errorMessage;
+  }
+
+  @Override
+  public String toString() {
+    return "MatterError{"
+        + (isNoError()
+            ? "No error"
+            : "errorCode=" + errorCode + ", errorMessage='" + errorMessage + '\'')
+        + '}';
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+    MatterError matterError = (MatterError) o;
+    return errorCode == matterError.errorCode;
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(errorCode);
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MediaPlaybackTypes.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/MediaPlaybackTypes.java
@@ -1,0 +1,56 @@
+/*
+ *   Copyright (c) 2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package com.chip.casting;
+
+public class MediaPlaybackTypes {
+  public enum PlaybackStateEnum {
+    Playing,
+    Paused,
+    NotPlaying,
+    Buffering,
+    Unknown
+  }
+
+  public static class PlaybackPosition {
+    public Long updatedAt;
+    public Long position;
+
+    public PlaybackPosition(Long updatedAt) {
+      this.updatedAt = updatedAt;
+    }
+
+    public PlaybackPosition(Long updatedAt, Long position) {
+      this.updatedAt = updatedAt;
+      this.position = position;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder output = new StringBuilder();
+      output.append("PlaybackPosition {\n");
+      output.append("\tupdatedAt: ");
+      output.append(updatedAt);
+      output.append("\n");
+      output.append("\tposition: ");
+      output.append(position);
+      output.append("\n");
+      output.append("}\n");
+      return output.toString();
+    }
+  }
+}

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java
@@ -17,10 +17,6 @@
  */
 package com.chip.casting;
 
-public abstract class MatterCallbackHandler {
-  public abstract void handle(MatterError err);
-
-  public final void handle(int errorCode, String errorMessage) {
-    handle(new MatterError(errorCode, errorMessage));
-  }
+public interface SubscriptionEstablishedCallback {
+  void handle();
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/SuccessCallback.java
@@ -17,10 +17,6 @@
  */
 package com.chip.casting;
 
-public abstract class MatterCallbackHandler {
-  public abstract void handle(MatterError err);
-
-  public final void handle(int errorCode, String errorMessage) {
-    handle(new MatterError(errorCode, errorMessage));
-  }
+public interface SuccessCallback<R> {
+  void handle(R response);
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TargetNavigatorTypes.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TargetNavigatorTypes.java
@@ -17,10 +17,28 @@
  */
 package com.chip.casting;
 
-public abstract class MatterCallbackHandler {
-  public abstract void handle(MatterError err);
+public class TargetNavigatorTypes {
+  public static class TargetInfo {
+    public Integer identifier;
+    public String name;
 
-  public final void handle(int errorCode, String errorMessage) {
-    handle(new MatterError(errorCode, errorMessage));
+    public TargetInfo(Integer identifier, String name) {
+      this.identifier = identifier;
+      this.name = name;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder output = new StringBuilder();
+      output.append("TargetInfo {\n");
+      output.append("\tidentifier: ");
+      output.append(identifier);
+      output.append("\n");
+      output.append("\tname: ");
+      output.append(name);
+      output.append("\n");
+      output.append("}\n");
+      return output.toString();
+    }
   }
 }

--- a/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/com/chip/casting/TvCastingApp.java
@@ -33,9 +33,24 @@ public class TvCastingApp {
 
   /*
    * CONTENT LAUNCHER CLUSTER
+   *
+   * TODO: Add API to subscribe to AcceptHeader
    */
   public native boolean contentLauncherLaunchURL(
       String contentUrl, String contentDisplayStr, Object launchURLHandler);
+
+  public native boolean contentLauncher_launchContent(
+      ContentLauncherTypes.ContentSearch search,
+      boolean autoPlay,
+      String data,
+      Object responseHandler);
+
+  public native boolean contentLauncher_subscribeToSupportedStreamingProtocols(
+      SuccessCallback<Integer> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
 
   /*
    * LEVEL CONTROL CLUSTER
@@ -54,6 +69,27 @@ public class TvCastingApp {
       byte optionMask,
       byte optionOverridem,
       Object responseHandler);
+
+  public native boolean levelControl_subscribeToCurrentLevel(
+      SuccessCallback<Byte> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean levelControl_subscribeToMinLevel(
+      SuccessCallback<Byte> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean levelControl_subscribeToMaxLevel(
+      SuccessCallback<Byte> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
 
   /*
    * MEDIA PLAYBACK CLUSTER
@@ -74,6 +110,48 @@ public class TvCastingApp {
   public native boolean mediaPlayback_skipBackward(
       long deltaPositionMilliseconds, Object responseHandler);
 
+  public native boolean mediaPlayback_subscribeToCurrentState(
+      SuccessCallback<MediaPlaybackTypes.PlaybackStateEnum> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean mediaPlayback_subscribeToDuration(
+      SuccessCallback<Long> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean mediaPlayback_subscribeToSampledPosition(
+      SuccessCallback<MediaPlaybackTypes.PlaybackPosition> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean mediaPlayback_subscribeToPlaybackSpeed(
+      SuccessCallback<Float> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean mediaPlayback_subscribeToSeekRangeEnd(
+      SuccessCallback<Long> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean mediaPlayback_subscribeToSeekRangeStart(
+      SuccessCallback<Long> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
   /*
    * APPLICATION LAUNCHER CLUSTER
    */
@@ -92,10 +170,64 @@ public class TvCastingApp {
   public native boolean targetNavigator_navigateTarget(
       byte target, String data, Object responseHandler);
 
+  public native boolean targetNavigator_subscribeToCurrentTarget(
+      SuccessCallback<Byte> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean targetNavigator_subscribeToTargetList(
+      SuccessCallback<TargetNavigatorTypes.TargetInfo> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
   /*
    * KEYPAD INPUT CLUSTER
    */
   public native boolean keypadInput_sendKey(byte keyCode, Object responseHandler);
+
+  /**
+   * APPLICATION BASIC
+   *
+   * <p>TODO: Add APIs to subscribe to Application, Status and AllowedVendorList
+   */
+  public native boolean applicationBasic_subscribeToVendorName(
+      SuccessCallback<String> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean applicationBasic_subscribeToVendorID(
+      SuccessCallback<Short> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean applicationBasic_subscribeToApplicationName(
+      SuccessCallback<String> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean applicationBasic_subscribeToProductID(
+      SuccessCallback<Short> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
+
+  public native boolean applicationBasic_subscribeToApplicationVersion(
+      SuccessCallback<String> readSuccessHandler,
+      FailureCallback readFailureHandler,
+      int minInterval,
+      int maxInterval,
+      SubscriptionEstablishedCallback subscriptionEstablishedHandler);
 
   static {
     System.loadLibrary("TvCastingApp");

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/Constants.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/Constants.h
@@ -38,3 +38,29 @@ enum MediaCommandName
 
     MEDIA_COMMAND_COUNT
 };
+
+enum MediaAttributeName
+{
+    ContentLauncher_SupportedStreamingProtocols,
+    ContentLauncher_AcceptHeader,
+    LevelControl_CurrentLevel,
+    LevelControl_MinLevel,
+    LevelControl_MaxLevel,
+    MediaPlayback_CurrentState,
+    MediaPlayback_StartTime,
+    MediaPlayback_Duration,
+    MediaPlayback_SampledPosition,
+    MediaPlayback_PlaybackSpeed,
+    MediaPlayback_SeekRangeEnd,
+    MediaPlayback_SeekRangeStart,
+    ApplicationLauncher_CurrentApp,
+    TargetNavigator_TargetList,
+    TargetNavigator_CurrentTarget,
+    ApplicationBasic_VendorName,
+    ApplicationBasic_VendorID,
+    ApplicationBasic_ApplicationName,
+    ApplicationBasic_ProductID,
+    ApplicationBasic_ApplicationVersion,
+
+    MEDIA_ATTRIBUTE_COUNT
+};

--- a/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.h
+++ b/examples/tv-casting-app/android/App/app/src/main/jni/cpp/TvCastingApp-JNI.h
@@ -32,6 +32,41 @@ public:
         return mMediaCommandResponseHandler[name];
     }
 
+    FailureHandlerJNI & getSubscriptionReadFailureHandler(enum MediaAttributeName name)
+    {
+        return mSubscriptionReadFailureHandler[name];
+    }
+
+    SubscriptionEstablishedHandlerJNI & getSubscriptionEstablishedHandler(enum MediaAttributeName name)
+    {
+        return mSubscriptionEstablishedHandler[name];
+    }
+
+    CurrentStateSuccessHandlerJNI & getCurrentStateSuccessHandler() { return mCurrentStateSuccessHandlerJNI; }
+    DurationSuccessHandlerJNI & getDurationSuccessHandler() { return mDurationSuccessHandlerJNI; }
+    SampledPositionSuccessHandlerJNI & getSampledPositionSuccessHandler() { return mSampledPositionSuccessHandlerJNI; }
+    PlaybackSpeedSuccessHandlerJNI & getPlaybackSpeedSuccessHandler() { return mPlaybackSpeedSuccessHandlerJNI; }
+    SeekRangeEndSuccessHandlerJNI & getSeekRangeEndSuccessHandler() { return mSeekRangeEndSuccessHandlerJNI; }
+    SeekRangeStartSuccessHandlerJNI & getSeekRangeStartSuccessHandler() { return mSeekRangeStartSuccessHandlerJNI; }
+
+    CurrentTargetSuccessHandlerJNI & getCurrentTargetSuccessHandler() { return mCurrentTargetSuccessHandlerJNI; }
+    TargetListSuccessHandlerJNI & getTargetListSuccessHandler() { return mTargetListSuccessHandlerJNI; }
+
+    CurrentLevelSuccessHandlerJNI & getCurrentLevelSuccessHandler() { return mCurrentLevelSuccessHandlerJNI; }
+    MinLevelSuccessHandlerJNI & getMinLevelSuccessHandler() { return mMinLevelSuccessHandlerJNI; }
+    MaxLevelSuccessHandlerJNI & getMaxLevelSuccessHandler() { return mMaxLevelSuccessHandlerJNI; }
+
+    SupportedStreamingProtocolsSuccessHandlerJNI & getSupportedStreamingProtocolsSuccessHandler()
+    {
+        return mSupportedStreamingProtocolsSuccessHandlerJNI;
+    }
+
+    VendorNameSuccessHandlerJNI & getVendorNameSuccessHandler() { return mVendorNameSuccessHandlerJNI; }
+    VendorIDSuccessHandlerJNI & getVendorIDSuccessHandler() { return mVendorIDSuccessHandlerJNI; }
+    ApplicationNameSuccessHandlerJNI & getApplicationNameSuccessHandler() { return mApplicationNameSuccessHandlerJNI; }
+    ProductIDSuccessHandlerJNI & getProductIDSuccessHandler() { return mProductIDSuccessHandlerJNI; }
+    ApplicationVersionSuccessHandlerJNI & getApplicationVersionSuccessHandler() { return mApplicationVersionSuccessHandlerJNI; }
+
 private:
     friend TvCastingAppJNI & TvCastingAppJNIMgr();
 
@@ -39,6 +74,30 @@ private:
 
     MatterCallbackHandlerJNI mCommissioningCompleteHandler;
     MatterCallbackHandlerJNI mMediaCommandResponseHandler[MEDIA_COMMAND_COUNT];
+    FailureHandlerJNI mSubscriptionReadFailureHandler[MEDIA_ATTRIBUTE_COUNT];
+    SubscriptionEstablishedHandlerJNI mSubscriptionEstablishedHandler[MEDIA_ATTRIBUTE_COUNT];
+
+    CurrentStateSuccessHandlerJNI mCurrentStateSuccessHandlerJNI;
+    DurationSuccessHandlerJNI mDurationSuccessHandlerJNI;
+    SampledPositionSuccessHandlerJNI mSampledPositionSuccessHandlerJNI;
+    PlaybackSpeedSuccessHandlerJNI mPlaybackSpeedSuccessHandlerJNI;
+    SeekRangeEndSuccessHandlerJNI mSeekRangeEndSuccessHandlerJNI;
+    SeekRangeStartSuccessHandlerJNI mSeekRangeStartSuccessHandlerJNI;
+
+    CurrentTargetSuccessHandlerJNI mCurrentTargetSuccessHandlerJNI;
+    TargetListSuccessHandlerJNI mTargetListSuccessHandlerJNI;
+
+    CurrentLevelSuccessHandlerJNI mCurrentLevelSuccessHandlerJNI;
+    MinLevelSuccessHandlerJNI mMinLevelSuccessHandlerJNI;
+    MaxLevelSuccessHandlerJNI mMaxLevelSuccessHandlerJNI;
+
+    SupportedStreamingProtocolsSuccessHandlerJNI mSupportedStreamingProtocolsSuccessHandlerJNI;
+
+    VendorNameSuccessHandlerJNI mVendorNameSuccessHandlerJNI;
+    VendorIDSuccessHandlerJNI mVendorIDSuccessHandlerJNI;
+    ApplicationNameSuccessHandlerJNI mApplicationNameSuccessHandlerJNI;
+    ProductIDSuccessHandlerJNI mProductIDSuccessHandlerJNI;
+    ApplicationVersionSuccessHandlerJNI mApplicationVersionSuccessHandlerJNI;
 };
 
 inline class TvCastingAppJNI & TvCastingAppJNIMgr()

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_media_playback.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_media_playback.xml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MediaPlaybackFragment">
+
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="10sp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/media_playback_fragment_title"
+            android:textAppearance="@style/TextAppearance.AppCompat.Display2" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/subscribe_to_current_state_command_title"
+            android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/min_interval_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:layout_marginRight="10sp"/>
+
+            <EditText
+                android:id="@+id/minIntervalEditText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/default_min_interval"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/max_interval_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:layout_marginRight="10sp"/>
+
+            <EditText
+                android:id="@+id/maxIntervalEditText"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/default_max_interval"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal">
+
+            <Button
+                android:id="@+id/subscribeToCurrentStateButton"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/subscribe_to_current_state_button_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+                android:layout_marginRight="10sp" />
+
+            <TextView
+                android:id="@+id/currentStateSubscriptionEstablishedStatus"
+                android:layout_width="250dp"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium" />
+        </LinearLayout>
+
+        <LinearLayout
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:orientation="horizontal" >
+
+            <TextView
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:text="@string/current_state_text"
+                android:textAppearance="@style/TextAppearance.AppCompat.Medium"
+                android:layout_marginRight="10sp"/>
+
+            <TextView
+                android:id="@+id/currentStateValue"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textAppearance="@style/TextAppearance.AppCompat.Large" />
+        </LinearLayout>
+    </LinearLayout>
+</FrameLayout>

--- a/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_select_cluster.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/layout/fragment_select_cluster.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".SelectClusterFragment">
+
+    <LinearLayout
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="10sp">
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/select_cluster_text"
+            android:textAppearance="@style/TextAppearance.AppCompat.Display2" />
+
+        <Button
+            android:id="@+id/selectContentLauncherButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/select_content_launcher_button_text"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            android:layout_marginRight="10sp" />
+
+        <Button
+            android:id="@+id/selectMediaPlaybackButton"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/select_media_playback_button_text"
+            android:textAppearance="@style/TextAppearance.AppCompat.Body1"
+            android:layout_marginRight="10sp" />
+    </LinearLayout>
+</FrameLayout>

--- a/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
+++ b/examples/tv-casting-app/android/App/app/src/main/res/values/strings.xml
@@ -8,4 +8,15 @@
     <string name="content_url_prompt_text">URL</string>
     <string name="content_display_string_prompt_text">Display string</string>
     <string name="discovery_message_text">Discovering commissioners on-network...</string>
+    <string name="select_cluster_text">Select a Cluster</string>
+    <string name="select_content_launcher_button_text">Content Launcher</string>
+    <string name="select_media_playback_button_text">Media Playback</string>
+    <string name="media_playback_fragment_title">Media Playback</string>
+    <string name="subscribe_to_current_state_command_title">Subscribe to Current State</string>
+    <string name="min_interval_text">Minimum interval (in ms)</string>
+    <string name="default_min_interval">0</string>
+    <string name="max_interval_text">Maximum interval (in ms)</string>
+    <string name="default_max_interval">4000</string>
+    <string name="subscribe_to_current_state_button_text">Subscribe</string>
+    <string name="current_state_text">Reported Current State</string>
 </resources>

--- a/examples/tv-casting-app/android/BUILD.gn
+++ b/examples/tv-casting-app/android/BUILD.gn
@@ -60,9 +60,16 @@ android_library("java") {
   ]
 
   sources = [
+    "App/app/src/main/jni/com/chip/casting/ContentLauncherTypes.java",
     "App/app/src/main/jni/com/chip/casting/DACProvider.java",
     "App/app/src/main/jni/com/chip/casting/DACProviderStub.java",
+    "App/app/src/main/jni/com/chip/casting/FailureCallback.java",
     "App/app/src/main/jni/com/chip/casting/MatterCallbackHandler.java",
+    "App/app/src/main/jni/com/chip/casting/MatterError.java",
+    "App/app/src/main/jni/com/chip/casting/MediaPlaybackTypes.java",
+    "App/app/src/main/jni/com/chip/casting/SubscriptionEstablishedCallback.java",
+    "App/app/src/main/jni/com/chip/casting/SuccessCallback.java",
+    "App/app/src/main/jni/com/chip/casting/TargetNavigatorTypes.java",
     "App/app/src/main/jni/com/chip/casting/TvCastingApp.java",
   ]
 

--- a/examples/tv-casting-app/tv-casting-common/BUILD.gn
+++ b/examples/tv-casting-app/tv-casting-common/BUILD.gn
@@ -47,6 +47,7 @@ chip_data_model("tv-casting-common") {
     "${chip_root}/zzz_generated/chip-tool/zap-generated/cluster/logging/DataModelLogger.cpp",
     "commands/clusters/ModelCommand.cpp",
     "commands/common/CHIPCommand.cpp",
+    "include/ApplicationBasic.h",
     "include/ApplicationLauncher.h",
     "include/CastingServer.h",
     "include/Channel.h",

--- a/examples/tv-casting-app/tv-casting-common/include/ApplicationBasic.h
+++ b/examples/tv-casting-app/tv-casting-common/include/ApplicationBasic.h
@@ -1,0 +1,73 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include "MediaSubscriptionBase.h"
+
+#include <zap-generated/CHIPClusters.h>
+
+// SUBSCRIBER CLASSES
+class VendorNameSubscriber : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::VendorName::TypeInfo>
+{
+public:
+    VendorNameSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ApplicationBasic::Id) {}
+};
+
+class VendorIDSubscriber : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo>
+{
+public:
+    VendorIDSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ApplicationBasic::Id) {}
+};
+
+class ApplicationNameSubscriber
+    : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationName::TypeInfo>
+{
+public:
+    ApplicationNameSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ApplicationBasic::Id) {}
+};
+
+class ProductIDSubscriber : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo>
+{
+public:
+    ProductIDSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ApplicationBasic::Id) {}
+};
+
+class ApplicationSubscriber : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::Application::TypeInfo>
+{
+public:
+    ApplicationSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ApplicationBasic::Id) {}
+};
+
+class StatusSubscriber : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::Status::TypeInfo>
+{
+public:
+    StatusSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ApplicationBasic::Id) {}
+};
+
+class ApplicationVersionSubscriber
+    : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::ApplicationVersion::TypeInfo>
+{
+public:
+    ApplicationVersionSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ApplicationBasic::Id) {}
+};
+
+class AllowedVendorListSubscriber
+    : public MediaSubscriptionBase<chip::app::Clusters::ApplicationBasic::Attributes::AllowedVendorList::TypeInfo>
+{
+public:
+    AllowedVendorListSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ApplicationBasic::Id) {}
+};

--- a/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
+++ b/examples/tv-casting-app/tv-casting-common/include/CastingServer.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include "ApplicationBasic.h"
 #include "ApplicationLauncher.h"
 #include "Channel.h"
 #include "ContentLauncher.h"
@@ -86,6 +87,22 @@ public:
     CHIP_ERROR ContentLauncher_LaunchContent(chip::app::Clusters::ContentLauncher::Structs::ContentSearch::Type search,
                                              bool autoPlay, chip::Optional<chip::CharSpan> data,
                                              std::function<void(CHIP_ERROR)> responseCallback);
+    CHIP_ERROR
+    ContentLauncher_SubscribeToAcceptHeader(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+    CHIP_ERROR
+    ContentLauncher_SubscribeToSupportedStreamingProtocols(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
 
     /**
      * @brief Level Control cluster
@@ -230,6 +247,67 @@ public:
                                    std::function<void(CHIP_ERROR)> responseCallback);
 
     /**
+     * @brief Application Basic cluster
+     */
+    CHIP_ERROR ApplicationBasic_SubscribeToVendorName(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ApplicationBasic::Attributes::VendorName::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+    CHIP_ERROR ApplicationBasic_SubscribeToVendorID(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+    CHIP_ERROR ApplicationBasic_SubscribeToApplicationName(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ApplicationBasic::Attributes::ApplicationName::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+    CHIP_ERROR ApplicationBasic_SubscribeToProductID(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+    CHIP_ERROR ApplicationBasic_SubscribeToApplication(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ApplicationBasic::Attributes::Application::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+    CHIP_ERROR
+    ApplicationBasic_SubscribeToStatus(void * context,
+                                       chip::Controller::ReadResponseSuccessCallback<
+                                           chip::app::Clusters::ApplicationBasic::Attributes::Status::TypeInfo::DecodableArgType>
+                                           successFn,
+                                       chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval,
+                                       uint16_t maxInterval,
+                                       chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+    CHIP_ERROR ApplicationBasic_SubscribeToApplicationVersion(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ApplicationBasic::Attributes::ApplicationVersion::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+    CHIP_ERROR ApplicationBasic_SubscribeToAllowedVendorList(
+        void * context,
+        chip::Controller::ReadResponseSuccessCallback<
+            chip::app::Clusters::ApplicationBasic::Attributes::AllowedVendorList::TypeInfo::DecodableArgType>
+            successFn,
+        chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+        chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished);
+
+    /*
      * @brief Channel cluster
      */
     CHIP_ERROR Channel_ChangeChannelCommand(const chip::CharSpan & match, std::function<void(CHIP_ERROR)> responseCallback);
@@ -258,6 +336,9 @@ private:
      */
     LaunchURLCommand mLaunchURLCommand;
     LaunchContentCommand mLaunchContentCommand;
+
+    AcceptHeaderSubscriber mAcceptHeaderSubscriber;
+    SupportedStreamingProtocolsSubscriber mSupportedStreamingProtocolsSubscriber;
 
     /**
      * @brief Level Control cluster
@@ -311,6 +392,18 @@ private:
     SendKeyCommand mSendKeyCommand;
 
     /**
+     * @brief Application Basic cluster
+     */
+    VendorNameSubscriber mVendorNameSubscriber;
+    VendorIDSubscriber mVendorIDSubscriber;
+    ApplicationNameSubscriber mApplicationNameSubscriber;
+    ProductIDSubscriber mProductIDSubscriber;
+    ApplicationSubscriber mApplicationSubscriber;
+    StatusSubscriber mStatusSubscriber;
+    ApplicationVersionSubscriber mApplicationVersionSubscriber;
+    AllowedVendorListSubscriber mAllowedVendorListSubscriber;
+
+    /*
      * @brief Channel cluster
      */
     ChangeChannelCommand mChangeChannelCommand;

--- a/examples/tv-casting-app/tv-casting-common/include/ContentLauncher.h
+++ b/examples/tv-casting-app/tv-casting-common/include/ContentLauncher.h
@@ -17,10 +17,12 @@
  */
 
 #include "MediaCommandBase.h"
+#include "MediaSubscriptionBase.h"
 
 #include <functional>
 #include <zap-generated/CHIPClusters.h>
 
+// COMMAND CLASSES
 class LaunchURLCommand : public MediaCommandBase<chip::app::Clusters::ContentLauncher::Commands::LaunchURL::Type,
                                                  chip::app::Clusters::ContentLauncher::Commands::LaunchResponse::DecodableType>
 {
@@ -40,4 +42,19 @@ public:
 
     CHIP_ERROR Invoke(chip::app::Clusters::ContentLauncher::Structs::ContentSearch::Type search, bool autoPlay,
                       chip::Optional<chip::CharSpan> data, std::function<void(CHIP_ERROR)> responseCallback);
+};
+
+// SUBSCRIBER CLASSES
+class AcceptHeaderSubscriber
+    : public MediaSubscriptionBase<chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::TypeInfo>
+{
+public:
+    AcceptHeaderSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ContentLauncher::Id) {}
+};
+
+class SupportedStreamingProtocolsSubscriber
+    : public MediaSubscriptionBase<chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::TypeInfo>
+{
+public:
+    SupportedStreamingProtocolsSubscriber() : MediaSubscriptionBase(chip::app::Clusters::ContentLauncher::Id) {}
 };

--- a/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/CastingServer.cpp
@@ -302,6 +302,34 @@ CHIP_ERROR CastingServer::ContentLauncher_LaunchContent(chip::app::Clusters::Con
     return mLaunchContentCommand.Invoke(search, autoPlay, data, responseCallback);
 }
 
+CHIP_ERROR
+CastingServer::ContentLauncher_SubscribeToAcceptHeader(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ContentLauncher::Attributes::AcceptHeader::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mAcceptHeaderSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mAcceptHeaderSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                      onSubscriptionEstablished);
+}
+
+CHIP_ERROR
+CastingServer::ContentLauncher_SubscribeToSupportedStreamingProtocols(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ContentLauncher::Attributes::SupportedStreamingProtocols::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mSupportedStreamingProtocolsSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mSupportedStreamingProtocolsSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                                     onSubscriptionEstablished);
+}
+
 /**
  * @brief Level Control cluster
  */
@@ -571,6 +599,115 @@ CHIP_ERROR CastingServer::KeypadInput_SendKey(const chip::app::Clusters::KeypadI
 }
 
 /**
+ * @brief Application Basic cluster
+ */
+CHIP_ERROR CastingServer::ApplicationBasic_SubscribeToVendorName(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ApplicationBasic::Attributes::VendorName::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mVendorNameSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mVendorNameSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                    onSubscriptionEstablished);
+}
+
+CHIP_ERROR
+CastingServer::ApplicationBasic_SubscribeToVendorID(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ApplicationBasic::Attributes::VendorID::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mVendorIDSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mVendorIDSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                  onSubscriptionEstablished);
+}
+
+CHIP_ERROR CastingServer::ApplicationBasic_SubscribeToApplicationName(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ApplicationBasic::Attributes::ApplicationName::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mApplicationNameSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mApplicationNameSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                         onSubscriptionEstablished);
+}
+
+CHIP_ERROR
+CastingServer::ApplicationBasic_SubscribeToProductID(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ApplicationBasic::Attributes::ProductID::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mProductIDSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mProductIDSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                   onSubscriptionEstablished);
+}
+
+CHIP_ERROR CastingServer::ApplicationBasic_SubscribeToApplication(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ApplicationBasic::Attributes::Application::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mApplicationSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mApplicationSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                     onSubscriptionEstablished);
+}
+
+CHIP_ERROR
+CastingServer::ApplicationBasic_SubscribeToStatus(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ApplicationBasic::Attributes::Status::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mStatusSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mStatusSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval, onSubscriptionEstablished);
+}
+
+CHIP_ERROR CastingServer::ApplicationBasic_SubscribeToApplicationVersion(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ApplicationBasic::Attributes::ApplicationVersion::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mApplicationVersionSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mApplicationVersionSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                            onSubscriptionEstablished);
+}
+
+CHIP_ERROR CastingServer::ApplicationBasic_SubscribeToAllowedVendorList(
+    void * context,
+    chip::Controller::ReadResponseSuccessCallback<
+        chip::app::Clusters::ApplicationBasic::Attributes::AllowedVendorList::TypeInfo::DecodableArgType>
+        successFn,
+    chip::Controller::ReadResponseFailureCallback failureFn, uint16_t minInterval, uint16_t maxInterval,
+    chip::Controller::SubscriptionEstablishedCallback onSubscriptionEstablished)
+{
+    ReturnErrorOnFailure(mAllowedVendorListSubscriber.SetTarget(mTargetVideoPlayerInfo, kTvEndpoint));
+    return mAllowedVendorListSubscriber.SubscribeAttribute(context, successFn, failureFn, minInterval, maxInterval,
+                                                           onSubscriptionEstablished);
+}
+
+/*
  * @brief Channel cluster
  */
 CHIP_ERROR CastingServer::Channel_ChangeChannelCommand(const chip::CharSpan & match,


### PR DESCRIPTION
#### Issue Being Resolved
The Android TV Casting app and libTvCastingApp / TvCastingApp.jar do not support subscribing to attributes on a Matter TV.
Fixes #20064

#### Change overview
* Updates to the JNI Layer to subscribe to attributes from the following clusters: MediaPlayback, TargetNavigator, ApplicationBasic, ContentLauncher, LevelControl
* Added GUI to the Android Tv Casting app to demonstrate how the JNI library updates can be used to subscribe to an attribute (with Media Playback's PlaybackStateEnum as the example showcased)

#### Testing
Tested by running the Android tv-casting-app against the tv-app. Checked that the subscription was established successfully and Read response received.

|<img src="https://user-images.githubusercontent.com/31142146/192204054-3ceb3e3d-4475-4ab6-a412-af49967bb64b.jpg" width="281" height="500"> |  <img src="https://user-images.githubusercontent.com/31142146/192204060-e8353d95-8e36-4ea2-b9a9-ff8e16a3a088.jpg" width="281" height="500"> | <img src="https://user-images.githubusercontent.com/31142146/192204061-7f46b53f-4f68-4f91-8356-00a870250f27.jpg" width="281" height="500">
