### PR TITLE
[1.0 Cherrypick] Added reading stored onoff state in lighting app

### DIFF
--- a/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
+++ b/examples/lighting-app/nrfconnect/main/ZclCallbacks.cpp
@@ -19,6 +19,7 @@
 #include "AppTask.h"
 #include "PWMDevice.h"
 
+#include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
@@ -26,6 +27,7 @@
 
 using namespace chip;
 using namespace chip::app::Clusters;
+using namespace chip::app::Clusters::OnOff;
 
 void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & attributePath, uint8_t type, uint16_t size,
                                        uint8_t * value)
@@ -70,5 +72,17 @@ void MatterPostAttributeChangeCallback(const chip::app::ConcreteAttributePath & 
  */
 void emberAfOnOffClusterInitCallback(EndpointId endpoint)
 {
+    EmberAfStatus status;
+    bool storedValue;
+
+    // Read storedValue on/off value
+    status = Attributes::OnOff::Get(endpoint, &storedValue);
+    if (status == EMBER_ZCL_STATUS_SUCCESS)
+    {
+        // Set actual state to the cluster state that was last persisted
+        GetAppTask().GetLightingDevice().InitiateAction(storedValue ? PWMDevice::ON_ACTION : PWMDevice::OFF_ACTION,
+                                                        AppEvent::kEventType_Lighting, reinterpret_cast<uint8_t *>(&storedValue));
+    }
+
     GetAppTask().UpdateClusterState();
 }


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22790 

#### Change overview
OnOff cluster state is not read on lighting-app init, so the state stored before reboot is not recovered.

(cherry picked from commit 1e3c5fe47c1f9b5e706168ea4ce58bec5e9de916)
