### PR TITLE
RPC: Fix console python dependency

### DIFF
--- a/examples/common/pigweed/rpc_console/py/BUILD.gn
+++ b/examples/common/pigweed/rpc_console/py/BUILD.gn
@@ -37,6 +37,7 @@ pw_python_package("chip_rpc") {
     "$dir_pw_log_tokenized/py",
     "$dir_pw_protobuf_compiler/py",
     "$dir_pw_rpc/py",
+    "$dir_pw_tokenizer/py",
     "${chip_root}/examples/common/pigweed:attributes_service.python",
     "${chip_root}/examples/common/pigweed:button_service.python",
     "${chip_root}/examples/common/pigweed:descriptor_service.python",


### PR DESCRIPTION

#### Issue Being Resolved
Rpc console packages is missing the tokenizer whl in the artifacts #22902 :
```
Traceback (most recent call last):
  File "/home/gtvchrome/venv/rpc_console/bin/chip-console", line 5, in <module>
    from chip_rpc.console import main
  File "/home/gtvchrome/venv/rpc_console/lib/python3.9/site-packages/chip_rpc/console.py", line 61, in <module>
    from pw_tokenizer.database import LoadTokenDatabases
ModuleNotFoundError: No module named 'pw_tokenizer'
```

#### Change overview
Add missing pw_tokenizer dependency.
