### PR TITLE
Fix nltest runner builds

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -300,6 +300,9 @@ class HostBuilder(GnBuilder):
 
         if app == HostApp.NL_TEST_RUNNER:
             self.build_command = 'runner'
+            # board will NOT be used, but is required to be able to properly
+            # include things added by the test_runner efr32 build
+            self.extra_gn_options.append('silabs_board="BRD4161A"')
 
         # Crypto library has per-platform defaults (like openssl for linux/mac
         # and mbedtls for android/freertos/zephyr/mbed/...)

--- a/scripts/build/testdata/build_linux_on_x64.txt
+++ b/scripts/build/testdata/build_linux_on_x64.txt
@@ -262,7 +262,7 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/minimal-mdns --args=chip_inet_config_enable_ipv4=false {out}/linux-x64-minmdns-ipv6only
 
 # Generating linux-x64-nl-test-runner
-gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/src/test_driver/efr32 {out}/linux-x64-nl-test-runner
+gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/src/test_driver/efr32 '--args=silabs_board="BRD4161A"' {out}/linux-x64-nl-test-runner
 
 # Generating linux-x64-ota-provider
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/ota-provider-app/linux --args=chip_config_network_layer_ble=false {out}/linux-x64-ota-provider


### PR DESCRIPTION
#### Issue Being Resolved

```
./scripts/build/build_examples.py --target linux-x64-nl-test-runner gen
```

fails to compile.

#### Change overview
#22793 added a requirement on silabs_board being defined. nl_test_runner has some sdk build parts which previously did not seem triggered, however now the SDK usage requires a board.

May need to define better on how to select boards (and if they are even valid).
