### PR TITLE
Run yaml and unit test for unified coverage

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -204,6 +204,13 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         }
         deps += [ "${chip_root}/src/controller/python:chip-repl" ]
       }
+      if (chip_can_build_all_clusters_app) {
+        if (is_libfuzzer) {
+          deps += [ "${chip_root}/examples/all-clusters-app/linux:chip-all-clusters-app-fuzzing" ]
+        } else {
+          deps += [ "${chip_root}/examples/all-clusters-app/linux:chip-all-clusters-app" ]
+        }
+      }
     }
 
     if (current_os == "android") {

--- a/BUILD.gn
+++ b/BUILD.gn
@@ -43,6 +43,9 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         (current_os == "mac" || current_os == "linux") &&
         (host_cpu == "x64" || host_cpu == "arm64" || host_cpu == "arm")
     enable_pylib = false
+
+    # Build the Linux all clusters app example with default group
+    chip_build_all_clusters_app = false
   }
 
   if (enable_fuzz_test_targets) {
@@ -204,13 +207,6 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
         }
         deps += [ "${chip_root}/src/controller/python:chip-repl" ]
       }
-      if (chip_can_build_all_clusters_app) {
-        if (is_libfuzzer) {
-          deps += [ "${chip_root}/examples/all-clusters-app/linux:chip-all-clusters-app-fuzzing" ]
-        } else {
-          deps += [ "${chip_root}/examples/all-clusters-app/linux:chip-all-clusters-app" ]
-        }
-      }
     }
 
     if (current_os == "android") {
@@ -224,6 +220,16 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
 
     if (build_tv_casting_common_a) {
       deps += [ "${chip_root}/examples/tv-casting-app/tv-casting-common:tvCastingCommon" ]
+    }
+
+    if (chip_build_all_clusters_app) {
+      if (is_libfuzzer) {
+        deps += [ "${chip_root}/examples/all-clusters-app/linux:chip-all-clusters-app-fuzzing" ]
+      } else {
+        deps += [
+          "${chip_root}/examples/all-clusters-app/linux:chip-all-clusters-app",
+        ]
+      }
     }
   }
 

--- a/build/chip/tools.gni
+++ b/build/chip/tools.gni
@@ -24,4 +24,6 @@ declare_args() {
        (current_os != "android" && current_os != "freertos" &&
         current_os != "zephyr" && current_os != "mbed" &&
         current_os != "webos"))
+
+  chip_can_build_all_clusters_app = false
 }

--- a/build/chip/tools.gni
+++ b/build/chip/tools.gni
@@ -24,6 +24,4 @@ declare_args() {
        (current_os != "android" && current_os != "freertos" &&
         current_os != "zephyr" && current_os != "mbed" &&
         current_os != "webos"))
-
-  chip_can_build_all_clusters_app = false
 }

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -93,7 +93,7 @@ source "$CHIP_ROOT/scripts/activate.sh"
 
 # Generates ninja files
 if [ "$skip_gn" == false ]; then
-    gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args='use_coverage=true chip_can_build_all_clusters_app=true'
+    gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args='use_coverage=true chip_build_all_clusters_app=true'
     ninja -C "$OUTPUT_ROOT"
 fi
 

--- a/scripts/build_coverage.sh
+++ b/scripts/build_coverage.sh
@@ -46,6 +46,7 @@ CHIP_ROOT=$(_normpath "$(dirname "$0")/..")
 OUTPUT_ROOT="$CHIP_ROOT/out/coverage"
 COVERAGE_ROOT="$OUTPUT_ROOT/coverage"
 skip_gn=false
+run_yaml=false
 
 help() {
 
@@ -53,6 +54,7 @@ help() {
 
     echo "General Options:
   -h, --help                Display this information.
+  -f, --full                Run both yaml and unit tests for unified coverage.
 Input Options:
   -o, --output_root         Set the build output directory.  When set manually, performs only lcov stage
                             on provided build output.  Assumes output_root has been built with 'use_coverage=true'
@@ -67,6 +69,9 @@ while (($#)); do
         --help | -h)
             help
             exit 1
+            ;;
+        --full | -f)
+            run_yaml=true
             ;;
         --output_root | -o)
             OUTPUT_ROOT=$2
@@ -88,8 +93,25 @@ source "$CHIP_ROOT/scripts/activate.sh"
 
 # Generates ninja files
 if [ "$skip_gn" == false ]; then
-    gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args='use_coverage=true'
+    gn --root="$CHIP_ROOT" gen "$OUTPUT_ROOT" --args='use_coverage=true chip_can_build_all_clusters_app=true'
+    ninja -C "$OUTPUT_ROOT"
+fi
+
+# Run unit tests
+if [ "$skip_gn" == false ]; then
     ninja -C "$OUTPUT_ROOT" check
+fi
+
+# Run yaml tests
+if [ "$run_yaml" == true ]; then
+    scripts/run_in_build_env.sh \
+        "./scripts/tests/run_test_suite.py \
+         --chip-tool ""$OUTPUT_ROOT/chip-tool \
+         run \
+         --iterations 1 \
+         --test-timeout-seconds 120 \
+         --all-clusters-app ""$OUTPUT_ROOT/chip-all-clusters-app
+      "
 fi
 
 # Remove unit test itself from coverage statistics


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22887 

Currently, build_coverage only run against unit test, we should include raml test into the statistics to have more comprehensive coverage.

#### Change overview
Include yaml test into test coverage result,

'./scripts/build_coverage.sh' only run unit tests for coverage
'./scripts/build_coverage.sh --full' run both yaml and unit tests for coverage 

```
yufengw@yufengw-SEi:~/connectedhomeip$ ./scripts/build_coverage.sh -h
Usage: build_coverage.sh [ options ... ]
General Options:
  -h, --help                Display this information.
  -f, --full                Run both yaml and unit tests for unified coverage.
Input Options:
  -o, --output_root         Set the build output directory.  When set manually, performs only lcov stage
                            on provided build output.  Assumes output_root has been built with 'use_coverage=true'
                            and that 'ninja check' was run.
  
```

