### PR TITLE
Check WPA supplicant state before saving config

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -963,6 +963,7 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
 
     VerifyOrReturnError(ssid.size() <= kMaxWiFiSSIDLength, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(credentials.size() <= kMaxWiFiKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mWpaSupplicant.iface != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // There is another ongoing connect request, reject the new one.
     VerifyOrReturnError(mpConnectCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1132,7 +1132,13 @@ CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
     gboolean result;
     std::unique_ptr<GError, GErrorDeleter> err;
 
-    ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to network");
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+
+    if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
+    {
+        ChipLogError(DeviceLayer, "wpa_supplicant: CommitConfig: interface proxy not connected");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
 
     result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr,
                                                                        &MakeUniquePointerReceiver(err).Get());
@@ -1196,7 +1202,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(SecurityTypeEnum & secur
 
     if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
     {
-        ChipLogError(DeviceLayer, "wpa_supplicant: _GetWiFiSecurityType: interface proxy not connected");
+        ChipLogError(DeviceLayer, "wpa_supplicant: GetWiFiSecurityType: interface proxy not connected");
         return CHIP_ERROR_INCORRECT_STATE;
     }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1140,6 +1140,8 @@ CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
+    ChipLogProgress(DeviceLayer, "wpa_supplicant: save config");
+
     result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr,
                                                                        &MakeUniquePointerReceiver(err).Get());
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -147,7 +147,8 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-bool ConnectivityManagerImpl::mAssociattionStarted = false;
+
+bool ConnectivityManagerImpl::mAssociationStarted = false;
 BitFlags<Internal::GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>::ConnectivityFlags>
     ConnectivityManagerImpl::mConnectivityFlag;
 struct GDBusWpaSupplicant ConnectivityManagerImpl::mWpaSupplicant;
@@ -397,7 +398,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
             {
                 if (g_strcmp0(value_str, "\'associating\'") == 0)
                 {
-                    mAssociattionStarted = true;
+                    mAssociationStarted = true;
                 }
                 else if (g_strcmp0(value_str, "\'disconnected\'") == 0)
                 {
@@ -409,7 +410,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                         delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kConnected));
                     }
 
-                    if (mAssociattionStarted)
+                    if (mAssociationStarted)
                     {
                         uint8_t associationFailureCause = static_cast<uint8_t>(AssociationFailureCauseEnum::kUnknown);
                         uint16_t status                 = WLAN_STATUS_UNSPECIFIED_FAILURE;
@@ -447,7 +448,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
                     DeviceLayer::SystemLayer().ScheduleLambda([]() { ConnectivityMgrImpl().UpdateNetworkStatus(); });
 
-                    mAssociattionStarted = false;
+                    mAssociationStarted = false;
                 }
                 else if (g_strcmp0(value_str, "\'associated\'") == 0)
                 {
@@ -460,7 +461,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                 }
                 else if (g_strcmp0(value_str, "\'completed\'") == 0)
                 {
-                    if (mAssociattionStarted)
+                    if (mAssociationStarted)
                     {
                         DeviceLayer::SystemLayer().ScheduleLambda([]() {
                             if (mpConnectCallback != nullptr)
@@ -471,7 +472,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                             ConnectivityMgrImpl().PostNetworkConnect();
                         });
                     }
-                    mAssociattionStarted = false;
+                    mAssociationStarted = false;
                 }
             }
 

--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -725,13 +725,7 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
 void ConnectivityManagerImpl::StartWiFiManagement()
 {
     mConnectivityFlag.ClearAll();
-    mWpaSupplicant.state         = GDBusWpaSupplicant::INIT;
-    mWpaSupplicant.scanState     = GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
-    mWpaSupplicant.proxy         = nullptr;
-    mWpaSupplicant.iface         = nullptr;
-    mWpaSupplicant.bss           = nullptr;
-    mWpaSupplicant.interfacePath = nullptr;
-    mWpaSupplicant.networkPath   = nullptr;
+    mWpaSupplicant = GDBusWpaSupplicant{};
 
     ChipLogProgress(DeviceLayer, "wpa_supplicant: Start WiFi management");
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -65,7 +65,7 @@ namespace DeviceLayer {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 struct GDBusWpaSupplicant
 {
-    enum
+    enum WpaState
     {
         INIT,
         WPA_CONNECTING,
@@ -74,19 +74,21 @@ struct GDBusWpaSupplicant
         WPA_NO_INTERFACE_PATH,
         WPA_GOT_INTERFACE_PATH,
         WPA_INTERFACE_CONNECTED,
-    } state;
+    };
 
-    enum
+    enum WpaScanning
     {
         WIFI_SCANNING_IDLE,
         WIFI_SCANNING,
-    } scanState;
+    };
 
-    WpaFiW1Wpa_supplicant1 * proxy;
-    WpaFiW1Wpa_supplicant1Interface * iface;
-    WpaFiW1Wpa_supplicant1BSS * bss;
-    gchar * interfacePath;
-    gchar * networkPath;
+    WpaState state                          = INIT;
+    WpaScanning scanState                   = WIFI_SCANNING_IDLE;
+    WpaFiW1Wpa_supplicant1 * proxy          = nullptr;
+    WpaFiW1Wpa_supplicant1Interface * iface = nullptr;
+    WpaFiW1Wpa_supplicant1BSS * bss         = nullptr;
+    gchar * interfacePath                   = nullptr;
+    gchar * networkPath                     = nullptr;
 };
 #endif
 

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -203,7 +203,7 @@ private:
 
     static bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
 
-    static bool mAssociattionStarted;
+    static bool mAssociationStarted;
     static BitFlags<ConnectivityFlags> mConnectivityFlag;
     static struct GDBusWpaSupplicant mWpaSupplicant;
     static std::mutex mWpaSupplicantMutex;

--- a/src/platform/Linux/ConnectivityManagerImpl.h
+++ b/src/platform/Linux/ConnectivityManagerImpl.h
@@ -207,7 +207,9 @@ private:
 
     static bool mAssociationStarted;
     static BitFlags<ConnectivityFlags> mConnectivityFlag;
-    static struct GDBusWpaSupplicant mWpaSupplicant;
+    static GDBusWpaSupplicant mWpaSupplicant;
+    // Access to mWpaSupplicant has to be protected by a mutex because it is accessed from
+    // the CHIP event loop thread and dedicated D-Bus thread started by platform manager.
     static std::mutex mWpaSupplicantMutex;
 
     NetworkCommissioning::Internal::BaseDriver::NetworkStatusChangeCallback * mpStatusChangeCallback = nullptr;

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -698,13 +698,7 @@ void ConnectivityManagerImpl::_OnWpaProxyReady(GObject * source_object, GAsyncRe
 void ConnectivityManagerImpl::StartWiFiManagement()
 {
     mConnectivityFlag.ClearAll();
-    mWpaSupplicant.state         = GDBusWpaSupplicant::INIT;
-    mWpaSupplicant.scanState     = GDBusWpaSupplicant::WIFI_SCANNING_IDLE;
-    mWpaSupplicant.proxy         = nullptr;
-    mWpaSupplicant.iface         = nullptr;
-    mWpaSupplicant.bss           = nullptr;
-    mWpaSupplicant.interfacePath = nullptr;
-    mWpaSupplicant.networkPath   = nullptr;
+    mWpaSupplicant = GDBusWpaSupplicant{};
 
     ChipLogProgress(DeviceLayer, "wpa_supplicant: Start WiFi management");
 

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -143,7 +143,8 @@ void ConnectivityManagerImpl::_OnPlatformEvent(const ChipDeviceEvent * event)
 }
 
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
-bool ConnectivityManagerImpl::mAssociattionStarted = false;
+
+bool ConnectivityManagerImpl::mAssociationStarted = false;
 BitFlags<Internal::GenericConnectivityManagerImpl_WiFi<ConnectivityManagerImpl>::ConnectivityFlags>
     ConnectivityManagerImpl::mConnectivityFlag;
 struct GDBusWpaSupplicant ConnectivityManagerImpl::mWpaSupplicant;
@@ -393,7 +394,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
             {
                 if (g_strcmp0(value_str, "\'associating\'") == 0)
                 {
-                    mAssociattionStarted = true;
+                    mAssociationStarted = true;
                 }
                 else if (g_strcmp0(value_str, "\'disconnected\'") == 0)
                 {
@@ -405,7 +406,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
                         delegate->OnConnectionStatusChanged(static_cast<uint8_t>(ConnectionStatusEnum::kConnected));
                     }
 
-                    if (mAssociattionStarted)
+                    if (mAssociationStarted)
                     {
                         uint8_t associationFailureCause = static_cast<uint8_t>(AssociationFailureCauseEnum::kUnknown);
                         uint16_t status                 = WLAN_STATUS_UNSPECIFIED_FAILURE;
@@ -435,7 +436,7 @@ void ConnectivityManagerImpl::_OnWpaPropertiesChanged(WpaFiW1Wpa_supplicant1Inte
 
                     DeviceLayer::SystemLayer().ScheduleLambda([]() { ConnectivityMgrImpl().UpdateNetworkStatus(); });
 
-                    mAssociattionStarted = false;
+                    mAssociationStarted = false;
                 }
                 else if (g_strcmp0(value_str, "\'associated\'") == 0)
                 {

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -1094,7 +1094,13 @@ CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
     gboolean result;
     std::unique_ptr<GError, GErrorDeleter> err;
 
-    ChipLogProgress(DeviceLayer, "wpa_supplicant: connected to network");
+    std::lock_guard<std::mutex> lock(mWpaSupplicantMutex);
+
+    if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
+    {
+        ChipLogError(DeviceLayer, "wpa_supplicant: CommitConfig: interface proxy not connected");
+        return CHIP_ERROR_INCORRECT_STATE;
+    }
 
     result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr,
                                                                        &MakeUniquePointerReceiver(err).Get());
@@ -1158,7 +1164,7 @@ CHIP_ERROR ConnectivityManagerImpl::GetWiFiSecurityType(SecurityTypeEnum & secur
 
     if (mWpaSupplicant.state != GDBusWpaSupplicant::WPA_INTERFACE_CONNECTED)
     {
-        ChipLogError(DeviceLayer, "wpa_supplicant: _GetWiFiSecurityType: interface proxy not connected");
+        ChipLogError(DeviceLayer, "wpa_supplicant: GetWiFiSecurityType: interface proxy not connected");
         return CHIP_ERROR_INCORRECT_STATE;
     }
 

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -936,6 +936,7 @@ ConnectivityManagerImpl::ConnectWiFiNetworkAsync(ByteSpan ssid, ByteSpan credent
 
     VerifyOrReturnError(ssid.size() <= kMaxWiFiSSIDLength, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(credentials.size() <= kMaxWiFiKeyLength, CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(mWpaSupplicant.iface != nullptr, CHIP_ERROR_INCORRECT_STATE);
 
     // There is another ongoing connect request, reject the new one.
     VerifyOrReturnError(mpConnectCallback == nullptr, CHIP_ERROR_INCORRECT_STATE);

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -1102,6 +1102,8 @@ CHIP_ERROR ConnectivityManagerImpl::CommitConfig()
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
+    ChipLogProgress(DeviceLayer, "wpa_supplicant: save config");
+
     result = wpa_fi_w1_wpa_supplicant1_interface_call_save_config_sync(mWpaSupplicant.iface, nullptr,
                                                                        &MakeUniquePointerReceiver(err).Get());
 

--- a/src/platform/webos/ConnectivityManagerImpl.h
+++ b/src/platform/webos/ConnectivityManagerImpl.h
@@ -65,7 +65,7 @@ namespace DeviceLayer {
 #if CHIP_DEVICE_CONFIG_ENABLE_WPA
 struct GDBusWpaSupplicant
 {
-    enum
+    enum WpaState
     {
         INIT,
         WPA_CONNECTING,
@@ -74,19 +74,21 @@ struct GDBusWpaSupplicant
         WPA_NO_INTERFACE_PATH,
         WPA_GOT_INTERFACE_PATH,
         WPA_INTERFACE_CONNECTED,
-    } state;
+    };
 
-    enum
+    enum WpaScanning
     {
         WIFI_SCANNING_IDLE,
         WIFI_SCANNING,
-    } scanState;
+    };
 
-    WpaFiW1Wpa_supplicant1 * proxy;
-    WpaFiW1Wpa_supplicant1Interface * iface;
-    WpaFiW1Wpa_supplicant1BSS * bss;
-    gchar * interfacePath;
-    gchar * networkPath;
+    WpaState state                          = INIT;
+    WpaScanning scanState                   = WIFI_SCANNING_IDLE;
+    WpaFiW1Wpa_supplicant1 * proxy          = nullptr;
+    WpaFiW1Wpa_supplicant1Interface * iface = nullptr;
+    WpaFiW1Wpa_supplicant1BSS * bss         = nullptr;
+    gchar * interfacePath                   = nullptr;
+    gchar * networkPath                     = nullptr;
 };
 #endif
 

--- a/src/platform/webos/ConnectivityManagerImpl.h
+++ b/src/platform/webos/ConnectivityManagerImpl.h
@@ -203,7 +203,7 @@ private:
 
     static bool _GetBssInfo(const gchar * bssPath, NetworkCommissioning::WiFiScanResponse & result);
 
-    static bool mAssociattionStarted;
+    static bool mAssociationStarted;
     static BitFlags<ConnectivityFlags> mConnectivityFlag;
     static struct GDBusWpaSupplicant mWpaSupplicant;
     static std::mutex mWpaSupplicantMutex;


### PR DESCRIPTION
### Issue Being Resolved
* Fixes #22894 

### Change overview
- check if iface is connected before saving config

### Testing

Tested locally with BLE commissionig:

```
./chip-lighting-app
....
CHIP:NP: LinuxWiFiDriver: SSID: MatterWiFi
CHIP:NP: Failed to connect to WiFi network: ../../examples/lighting-app/linux/third_party/connectedhomeip/src/platform/Linux/ConnectivityManagerImpl.cpp:970: CHIP Error 0x00000003: Incorrect state 
CHIP:DMG: Command handler moving to [ Preparing]
...
```


```
./chip-lighting-app --wifi
....
CHIP:NP: LinuxWiFiDriver: SSID: MatterWiFi
CHIP:DL: wpa_supplicant: added network: /fi/w1/wpa_supplicant1/Interfaces/0/Networks/0
CHIP:DMG: Decreasing reference count for CommandHandler, remaining 1
CHIP:DL: wpa_supplicant: failed to save config: GDBus.Error:fi.w1.wpa_supplicant1.UnknownError: Not allowed to update configuration (update_config=0)
CHIP:DL: wpa_supplicant:PropertiesChanged:key:State -> 'scanning'
...
```