### PR TITLE
[test] Fix #22903 - fix unit test break when SECURITY_TEST_MODE=1

### DIFF
--- a/src/transport/CryptoContext.cpp
+++ b/src/transport/CryptoContext.cpp
@@ -97,11 +97,12 @@ CHIP_ERROR CryptoContext::InitFromSecret(const ByteSpan & secret, const ByteSpan
     (void) infoLen;
 
 #warning                                                                                                                           \
-    "Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation... All sessions will use known, fixed test key, and NodeID=0 in NONCE. Node can only communicate with other nodes built with this flag set. Requires build flag 'treat_warnings_as_errors=false'."
-    ChipLogError(SecureChannel,
-                 "Warning: CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation... All sessions will use known, fixed test key, "
-                 "and NodeID=0 in NONCE. "
-                 "Node can only communicate with other nodes built with this flag set.");
+    "Warning: CHIP_CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation... All sessions will use known, fixed test key, and NodeID=0 in NONCE. Node can only communicate with other nodes built with this flag set. Requires build flag 'treat_warnings_as_errors=false'."
+    ChipLogError(
+        SecureChannel,
+        "Warning: CHIP_CONFIG_SECURITY_TEST_MODE=1 bypassing key negotiation... All sessions will use known, fixed test key, "
+        "and NodeID=0 in NONCE. "
+        "Node can only communicate with other nodes built with this flag set.");
 
     ReturnErrorOnFailure(mHKDF.HKDF_SHA256(kTestSharedSecret, CHIP_CONFIG_TEST_SHARED_SECRET_LENGTH, testSalt.data(),
                                            testSalt.size(), SEKeysInfo, sizeof(SEKeysInfo), &mKeys[0][0], sizeof(mKeys)));

--- a/src/transport/tests/TestSessionManagerDispatch.cpp
+++ b/src/transport/tests/TestSessionManagerDispatch.cpp
@@ -140,6 +140,7 @@ struct MessageTestEntry theMessageTestVector[] = {
         .sessionId  = 0x0bb8, // 3000
         .peerNodeId = 0x0000000000000000ULL,
     },
+#if !CHIP_CONFIG_SECURITY_TEST_MODE
     {
         .name     = "secure group message (no privacy)",
         .peerAddr = "::1",
@@ -169,6 +170,7 @@ struct MessageTestEntry theMessageTestVector[] = {
         .groupId      = 2,
         .sourceNodeId = 0x0000000000000002ULL,
     },
+#endif // !CHIP_CONFIG_SECURITY_TEST_MODE
 };
 
 const uint16_t theMessageTestVectorLength = sizeof(theMessageTestVector) / sizeof(theMessageTestVector[0]);


### PR DESCRIPTION
#### Issue Being Resolved
* Fixes #22903 

#### Change overview
Disable group unit test with explicit keys when `CHIP_CONFIG_SECURITY_TEST_MODE=1`.
