### PR TITLE
Increase -Xmx for android builds from 2G to 4G

### DIFF
--- a/examples/tv-app/android/App/gradle.properties
+++ b/examples/tv-app/android/App/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/examples/tv-casting-app/android/App/gradle.properties
+++ b/examples/tv-casting-app/android/App/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/src/android/CHIPTest/gradle.properties
+++ b/src/android/CHIPTest/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/src/android/CHIPTool/gradle.properties
+++ b/src/android/CHIPTool/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
#### Issue Being Resolved
Got complains for build for x86:

```
...
Step #2 - "CompileAll": 2022-09-27 02:58:07 WARNING 
Step #2 - "CompileAll": 2022-09-27 02:58:07 WARNING * Get more help at https://help.gradle.org
Step #2 - "CompileAll": 2022-09-27 02:58:07 WARNING 
Step #2 - "CompileAll": 2022-09-27 02:58:07 WARNING BUILD FAILED in 52s
Step #2 - "CompileAll": 2022-09-27 02:58:08 INFO    Expiring Daemon because JVM heap space is exhausted
Step #2 - "CompileAll": Traceback (most recent call last):
Step #2 - "CompileAll":   File "/workspace/./scripts/build/build_examples.py", line 228, in <module>
Step #2 - "CompileAll":     main()
....
```

#### Change overview
Standardize gradle jvm arguments and increase mx size from 2G to 4G
