### PR TITLE
Fix telink examples on vscode image

### DIFF
--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -1163,23 +1163,23 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/qpg '--args=qpg_target_ic="qpg6105"' {out}/qpg-shell
 
 # Generating telink-tlsr9518adk80d-light
-bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
 export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
-export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-light -b tlsr9518adk80d {root}/examples/lighting-app/telink'
 
 # Generating telink-tlsr9518adk80d-light-switch
-bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
 export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
-export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-light-switch -b tlsr9518adk80d {root}/examples/light-switch-app/telink'
 
 # Generating telink-tlsr9518adk80d-ota-requestor
-bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
 export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
-export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-ota-requestor -b tlsr9518adk80d {root}/examples/ota-requestor-app/telink'
 
@@ -2402,13 +2402,22 @@ ninja -C {out}/qpg-persistent-storage
 ninja -C {out}/qpg-shell
 
 # Building telink-tlsr9518adk80d-light
-ninja -C {out}/telink-tlsr9518adk80d-light
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
+ninja -C {out}/telink-tlsr9518adk80d-light'
 
 # Building telink-tlsr9518adk80d-light-switch
-ninja -C {out}/telink-tlsr9518adk80d-light-switch
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
+ninja -C {out}/telink-tlsr9518adk80d-light-switch'
 
 # Building telink-tlsr9518adk80d-ota-requestor
-ninja -C {out}/telink-tlsr9518adk80d-ota-requestor
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
+ninja -C {out}/telink-tlsr9518adk80d-ota-requestor'
 
 # Building tizen-arm-all-clusters
 ninja -C {out}/tizen-arm-all-clusters


### PR DESCRIPTION
This fixes building:

```
./scripts/build/build_examples.py --target telink-tlsr9518adk80d-ota-requestor build
```

This was failing with `Assertion failed: GNUARMEMB_TOOLCHAIN_PATH is not set`

From what I could tell, this is due to ZEPHYR_TOOLCHAIN_VARIANT not having been set during the build phase. I have moved the ZEPHYR_TOOLCHAIN_VARIANT and ZEPHYR_BASE to be both set during both build and generation phases (was generation only before)