### PR TITLE
Fix file naming for genio

### DIFF
--- a/scripts/build/builders/genio.py
+++ b/scripts/build/builders/genio.py
@@ -19,9 +19,9 @@ class GenioApp(Enum):
 
     def AppNamePrefix(self):
         if self == GenioApp.LIGHT:
-            return 'chip-genio-lighting-app-example'
+            return 'chip-mt793x-lighting-app-example'
         elif self == GenioApp.SHELL:
-            return 'chip-genio-shell-example'
+            return 'chip-mt793x-shell-example'
         else:
             raise Exception('Unknown app type: %r' % self)
 


### PR DESCRIPTION
After genio was added in #22404, the naming of output was not actually 'genio' but 'mt793x'. This fixes:

```
./scripts/build/build_examples.py --target genio-lighting-app build --copy-artifacts-to out/artifacts
```

Without this change, the naming is wrong and we get:

```
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/out/genio-lighting-app/chip-genio-lighting-app-example.out'
```