### PR TITLE
Cherry-pick [Thread] fix assertions in operational dataset (#22858)

### DIFF
--- a/src/lib/support/ThreadOperationalDataset.cpp
+++ b/src/lib/support/ThreadOperationalDataset.cpp
@@ -318,7 +318,7 @@ CHIP_ERROR OperationalDataset::SetExtendedPanId(const uint8_t (&aExtendedPanId)[
 
     tlv->SetValue(aExtendedPanId, sizeof(aExtendedPanId));
 
-    assert(mLength + tlv->GetSize() < sizeof(mData));
+    assert(mLength + tlv->GetSize() <= sizeof(mData));
 
     mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
 
@@ -349,7 +349,7 @@ CHIP_ERROR OperationalDataset::SetMasterKey(const uint8_t (&aMasterKey)[kSizeMas
 
     tlv->SetValue(aMasterKey, sizeof(aMasterKey));
 
-    assert(mLength + tlv->GetSize() < sizeof(mData));
+    assert(mLength + tlv->GetSize() <= sizeof(mData));
 
     mLength = static_cast<uint8_t>(mLength + tlv->GetSize());
 


### PR DESCRIPTION
Cherry-pick commit a8bd3897a5ea57277cded688c00a6a75309a7ae1 (#22858) from master to v1.0 branch. To fix this potential assert in thread platforms.