### PR TITLE
Fix SessionDelegate::OnSessionHang docs header

### DIFF
--- a/src/transport/SessionDelegate.h
+++ b/src/transport/SessionDelegate.h
@@ -62,9 +62,8 @@ public:
 
     /**
      * @brief
-     *   Called when a session is unresponsive for a while (detected by MRP)
-     *
-     *   Note: the implementation must not do anything that will destroy the session or change the SessionHolder.
+     *   Called when a session is unresponsive for a while (detected by MRP). Callees SHALL NOT make synchronous calls into
+     * SessionManager to allocate a new session. If they desire to do so, it MUST be done asynchronously.
      */
     virtual void OnSessionHang() {}
 };


### PR DESCRIPTION
#### Issue Being Resolved

* Fixes #22925

#### Change overview

The SessionDelegate::OnSessionHang docs header note is inaccurate.  It lists that it is not safe to modify the SessionHolder or underlying Session from this callback context.  That's not correct.   The SessionHolder can be modified (e.g. released) from here, and the Session can be modified.  For instance, changing the session from state kDefunct to kPendingEviction would be legal.

What would not be safe is allocating a new session from this context, as this could cause the underlying session (always in kDefunct state from this context) to be evicted and freed while it is still in use to distribute the OnSessionHang to all holders, resulting in use after free.  This means that the actual limitation is the same as that listed in `OnSessionReleased`.

Change the docs header to reflect.
