### PR TITLE
Check if SSID and BSSID properties were fetched

### DIFF
--- a/src/platform/Linux/ConnectivityManagerImpl.cpp
+++ b/src/platform/Linux/ConnectivityManagerImpl.cpp
@@ -1549,6 +1549,14 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     std::unique_ptr<GVariant, GVariantDeleter> ssid(g_dbus_proxy_get_cached_property(G_DBUS_PROXY(bssProxy), "SSID"));
     std::unique_ptr<GVariant, GVariantDeleter> bssid(g_dbus_proxy_get_cached_property(G_DBUS_PROXY(bssProxy), "BSSID"));
 
+    // Network scan is performed in the background, so the BSS
+    // may be gone when we try to get the properties.
+    if (ssid == nullptr || bssid == nullptr)
+    {
+        ChipLogDetail(DeviceLayer, "wpa_supplicant: BSS not found: %s", bssPath);
+        return false;
+    }
+
     const guchar * ssidStr       = nullptr;
     const guchar * bssidBuf      = nullptr;
     char bssidStr[2 * 6 + 5 + 1] = { 0 };

--- a/src/platform/webos/ConnectivityManagerImpl.cpp
+++ b/src/platform/webos/ConnectivityManagerImpl.cpp
@@ -1518,6 +1518,14 @@ bool ConnectivityManagerImpl::_GetBssInfo(const gchar * bssPath, NetworkCommissi
     std::unique_ptr<GVariant, GVariantDeleter> ssid(g_dbus_proxy_get_cached_property(G_DBUS_PROXY(bssProxy), "SSID"));
     std::unique_ptr<GVariant, GVariantDeleter> bssid(g_dbus_proxy_get_cached_property(G_DBUS_PROXY(bssProxy), "BSSID"));
 
+    // Network scan is performed in the background, so the BSS
+    // may be gone when we try to get the properties.
+    if (ssid == nullptr || bssid == nullptr)
+    {
+        ChipLogDetail(DeviceLayer, "wpa_supplicant: BSS not found: %s", bssPath);
+        return false;
+    }
+
     const guchar * ssidStr       = nullptr;
     const guchar * bssidBuf      = nullptr;
     char bssidStr[2 * 6 + 5 + 1] = { 0 };


### PR DESCRIPTION
Network scan is performed in the background by wpa_supplicant. When we are trying to get BSS properties, the BSS may be already gone. This patch prevents passing NULL to g_variant_get_fixed_array().

#### Issue Being Resolved
* Fixes #22929 

#### Change overview
- check for nullptr when getting properties