### PR TITLE
[Silabs] Open basic commissioning window on pb0 press and release

### DIFF
--- a/examples/platform/efr32/BaseApplication.cpp
+++ b/examples/platform/efr32/BaseApplication.cpp
@@ -414,7 +414,8 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
     }
     else
     {
-        // If the button was released before factory reset got initiated, start BLE advertissement in fast mode
+        // If the button was released before factory reset got initiated, open the commissioning window and start BLE advertissement
+        // in fast mode
         if (mFunctionTimerActive && mFunction == kFunction_StartBleAdv)
         {
             CancelFunctionTimer();
@@ -431,9 +432,14 @@ void BaseApplication::ButtonHandler(AppEvent * aEvent)
             if (!ConnectivityMgr().IsThreadProvisioned())
 #endif /* !SL_WIFI */
             {
-                // Enable BLE advertisements
-                ConnectivityMgr().SetBLEAdvertisingEnabled(true);
-                ConnectivityMgr().SetBLEAdvertisingMode(ConnectivityMgr().kFastAdvertising);
+                // Open Basic CommissioningWindow. Will start BLE advertisements
+                chip::DeviceLayer::PlatformMgr().LockChipStack();
+                CHIP_ERROR err = chip::Server::GetInstance().GetCommissioningWindowManager().OpenBasicCommissioningWindow();
+                chip::DeviceLayer::PlatformMgr().UnlockChipStack();
+                if (err != CHIP_NO_ERROR)
+                {
+                    EFR32_LOG("Failed to open the Basic Commissioning Window");
+                }
             }
             else { EFR32_LOG("Network is already provisioned, Ble advertissement not enabled"); }
         }


### PR DESCRIPTION
Problem:
There was still some old code in silabs example applications to restart the BLE advertisement on a button press.
However, it didn't amount to much as the commission window was closed.

Changes:
On pb0 short press and release, Open the basic commissioning window. This will also start the BLE advertisement.

Tested manually with an EFR32 with lighting-app.
Wait for the initial advertisement/commissioning window to close. Press PB0, validated the BLE advertisement restarts and that the commissioning can be complete. 

