### PR TITLE
Fixed TLV decoder issue

### DIFF
--- a/src/controller/python/chip/tlv/__init__.py
+++ b/src/controller/python/chip/tlv/__init__.py
@@ -681,7 +681,7 @@ class TLVReader(object):
                     out[decoding["profileTag"]] = decoding["value"]
                 elif "tag" in list(decoding.keys()):
                     if isinstance(out, Mapping):
-                        tag = decoding["tag"] or "Any"
+                        tag = decoding["tag"] if decoding["tag"] is not None else "Any"
                         out[tag] = decoding["value"]
                     else:
                         out.append(decoding["value"])

--- a/src/controller/python/chip/tlv/__init__.py
+++ b/src/controller/python/chip/tlv/__init__.py
@@ -680,13 +680,11 @@ class TLVReader(object):
                 if "profileTag" in list(decoding.keys()):
                     out[decoding["profileTag"]] = decoding["value"]
                 elif "tag" in list(decoding.keys()):
-                    if decoding["tag"] is not None:
-                        out[decoding["tag"]] = decoding["value"]
+                    if isinstance(out, Mapping):
+                        tag = decoding["tag"] or "Any"
+                        out[tag] = decoding["value"]
                     else:
-                        if isinstance(out, Mapping):
-                            out["Any"] = decoding["value"]
-                        elif isinstance(out, Sequence):
-                            out.append(decoding["value"])
+                        out.append(decoding["value"])
                 else:
                     raise ValueError("Attempt to decode unsupported TLV tag")
 

--- a/src/controller/python/test/unit_tests/test_tlv.py
+++ b/src/controller/python/test/unit_tests/test_tlv.py
@@ -148,6 +148,18 @@ class TestTLVReader(unittest.TestCase):
         self._read_case([0b00000101, 0xab, 0xaa], tlvUint(0xaaab))
         self._read_case([0b00000100, 0xab], tlvUint(0xab))
 
+    def test_structure(self):
+        test_cases = [
+            (b'\x15\x36\x01\x15\x35\x01\x26\x00\xBF\xA2\x55\x16\x37\x01\x24\x02\x00\x24\x03\x28\x24\x04\x00\x18\x24\x02\x01\x18\x18\x18\x18',
+            {1: [{1: {0: 374710975, 1: [0, 40, 0], 2: 1}}]}),
+            (b'\x156\x01\x155\x01&\x00\xBF\xA2U\x167\x01$\x02\x00$\x03($\x04\x01\x18,\x02\x18Nordic Semiconductor ASA\x18\x18\x18\x18',
+            {1: [{1: {0: 374710975, 1: [0, 40, 1], 2: 'Nordic Semiconductor ASA'}}]}),
+            (b"\0256\001\0255\001&\000\031\346x\2077\001$\002\001$\003\006$\004\000\030(\002\030\030\030\030",
+            {1: [{1: {0: 2272847385, 1: [1, 6, 0], 2: False}}]})
+        ]
+        for tlv_bytes, answer in test_cases:
+            self._read_case(tlv_bytes, answer)        
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/src/controller/python/test/unit_tests/test_tlv.py
+++ b/src/controller/python/test/unit_tests/test_tlv.py
@@ -151,14 +151,14 @@ class TestTLVReader(unittest.TestCase):
     def test_structure(self):
         test_cases = [
             (b'\x15\x36\x01\x15\x35\x01\x26\x00\xBF\xA2\x55\x16\x37\x01\x24\x02\x00\x24\x03\x28\x24\x04\x00\x18\x24\x02\x01\x18\x18\x18\x18',
-            {1: [{1: {0: 374710975, 1: [0, 40, 0], 2: 1}}]}),
+             {1: [{1: {0: 374710975, 1: [0, 40, 0], 2: 1}}]}),
             (b'\x156\x01\x155\x01&\x00\xBF\xA2U\x167\x01$\x02\x00$\x03($\x04\x01\x18,\x02\x18Nordic Semiconductor ASA\x18\x18\x18\x18',
-            {1: [{1: {0: 374710975, 1: [0, 40, 1], 2: 'Nordic Semiconductor ASA'}}]}),
+             {1: [{1: {0: 374710975, 1: [0, 40, 1], 2: 'Nordic Semiconductor ASA'}}]}),
             (b"\0256\001\0255\001&\000\031\346x\2077\001$\002\001$\003\006$\004\000\030(\002\030\030\030\030",
-            {1: [{1: {0: 2272847385, 1: [1, 6, 0], 2: False}}]})
+             {1: [{1: {0: 2272847385, 1: [1, 6, 0], 2: False}}]})
         ]
         for tlv_bytes, answer in test_cases:
-            self._read_case(tlv_bytes, answer)        
+            self._read_case(tlv_bytes, answer)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Fixed issue of the TLV decoder:

When giving `tlv_bytes = b"\0256\001\0255\001&\000\031\346x\2077\001$\002\001$\003\006$\004\000\030(\002\030\030\030\030"`, the following errors occur:

```
Traceback (most recent call last):
  File "/home/chingtzuchen/exp/tlv2.py", line 743, in <module>
    out = reader.get()
  File "/home/chingtzuchen/exp/tlv2.py", line 459, in get
    self._get(self._tlv, self._decodings, out)
  File "/home/chingtzuchen/exp/tlv2.py", line 674, in _get
    self._decodeVal(tlv, decoding)
  File "/home/chingtzuchen/exp/tlv2.py", line 574, in _decodeVal
    self._get(tlv, decoding["Structure"], decoding["value"])
  File "/home/chingtzuchen/exp/tlv2.py", line 674, in _get
    self._decodeVal(tlv, decoding)
  File "/home/chingtzuchen/exp/tlv2.py", line 578, in _decodeVal
    self._get(tlv, decoding["Array"], decoding["value"])
  File "/home/chingtzuchen/exp/tlv2.py", line 674, in _get
    self._decodeVal(tlv, decoding)
  File "/home/chingtzuchen/exp/tlv2.py", line 574, in _decodeVal
    self._get(tlv, decoding["Structure"], decoding["value"])
  File "/home/chingtzuchen/exp/tlv2.py", line 674, in _get
    self._decodeVal(tlv, decoding)
  File "/home/chingtzuchen/exp/tlv2.py", line 574, in _decodeVal
    self._get(tlv, decoding["Structure"], decoding["value"])
  File "/home/chingtzuchen/exp/tlv2.py", line 674, in _get
    self._decodeVal(tlv, decoding)
  File "/home/chingtzuchen/exp/tlv2.py", line 582, in _decodeVal
    self._get(tlv, decoding["Path"], decoding["value"])
  File "/home/chingtzuchen/exp/tlv2.py", line 685, in _get
    out[decoding["tag"]] = decoding["value"]
IndexError: list assignment index out of range
```

Added condition and made it more clean to fix the issue, after this fix the bytes can be decoded:

```
{'Any': {1: [{1: {0: 2272847385, 1: [1, 6, 0], 2: False}}]}}
```

Unit test result:

```
$ python test_tlv.py 
.....
----------------------------------------------------------------------
Ran 5 tests in 0.000s

OK
```