### PR TITLE
[ESP32] fix error when enabling ESP32 OTA image build

### DIFF
--- a/config/esp32/components/chip/ota-image.cmake
+++ b/config/esp32/components/chip/ota-image.cmake
@@ -36,9 +36,9 @@ function(chip_ota_image TARGET_NAME)
         "--product-id"
         ${CONFIG_DEVICE_PRODUCT_ID}
         "--version"
-        ${CONFIG_DEVICE_SOFTWARE_VERSION_NUMBER}
+        ${PROJECT_VER_NUMBER}
         "--version-str"
-        ${CONFIG_DEVICE_SOFTWARE_VERSION}
+        ${PROJECT_VER}
         "--digest-algorithm"
         "sha256"
     )


### PR DESCRIPTION
#### Issue Being Resolved
Fixes #22952 

#### Change overview
* Change the version and version-str to the correct value in ota-image.cmake