### PR TITLE
Revert "Ensure that CHIPDeviceControllerFactory calls FabricTable::Sh…

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -463,7 +463,6 @@ void DeviceControllerSystemState::Shutdown()
 
     if (mTempFabricTable != nullptr)
     {
-        mTempFabricTable->Shutdown();
         chip::Platform::Delete(mTempFabricTable);
         mTempFabricTable = nullptr;
         // if we created a temp fabric table, then mFabrics points to it.


### PR DESCRIPTION
…utdown (#22932)"

This reverts commit 57c7321fbf962d6dd2a6dd27da753a526f7507ac.

Master shows that after this commit CHIP-repl tests are failing, seemingly with a segmentation fault. It is unclear why this is, likely we use some fabric objects after shutdown, however narrowing this down proved difficult.

Reverting for now to make CI green, will have to add this back with a fix once we figure out what is wrong.