### PR TITLE
Un-revert #22932 + Fix Python Storage lifetime

### DIFF
--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -463,6 +463,7 @@ void DeviceControllerSystemState::Shutdown()
 
     if (mTempFabricTable != nullptr)
     {
+        mTempFabricTable->Shutdown();
         chip::Platform::Delete(mTempFabricTable);
         mTempFabricTable = nullptr;
         // if we created a temp fabric table, then mFabrics points to it.

--- a/src/controller/python/chip/ChipStack.py
+++ b/src/controller/python/chip/ChipStack.py
@@ -328,11 +328,14 @@ class ChipStack(object):
             self._ChipStackLib.pychip_Stack_SetLogFunct(logFunct)
 
     def Shutdown(self):
-        # Make sure PersistentStorage is destructed before chipStack
-        # to avoid accessing builtins.chipStack after destruction.
+        self.Call(lambda: self._ChipStackLib.pychip_DeviceController_StackShutdown())
+
+        #
+        # We only shutdown the persistent storage layer AFTER we've shut down the stack,
+        # since there is a possibility of interactions with the storage layer during shutdown.
+        #
         self._persistentStorage.Shutdown()
         self._persistentStorage = None
-        self.Call(lambda: self._ChipStackLib.pychip_DeviceController_StackShutdown())
 
         #
         # Stack init happens in native, but shutdown happens here unfortunately.


### PR DESCRIPTION
#22932 shuts down the fabric table as part of shutting down the stack. This entails interactions with the persistent storage layer to update some keys. In Python however, the storage layer has already been shutdown by the time we get to stack shutdown, causing a use-after-free.
    
### Fix
Flip the order in which we shutdown the storage adapter relative to shutting down the rest of the stack.

### Testing

CI should pass, since without this fix, it should fail always.
