### PR TITLE
Cherry-pick [K32W0] Update Docker image to accomodate SDK 2.6.7 (#22921)

### DIFF
--- a/integrations/docker/images/chip-build-k32w/Dockerfile
+++ b/integrations/docker/images/chip-build-k32w/Dockerfile
@@ -12,9 +12,9 @@ RUN set -x \
 WORKDIR /opt/sdk
 # Setup the K32W SDK
 RUN set -x \
-    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_6_6_K32W061DK6.zip \
-    && unzip SDK_2_6_6_K32W061DK6.zip \
-    && rm -rf SDK_2_6_6_K32W061DK6.zip \
+    && wget https://cache.nxp.com/lgfiles/bsps/SDK_2_6_7_K32W061DK6.zip \
+    && unzip SDK_2_6_7_K32W061DK6.zip \
+    && rm -rf SDK_2_6_7_K32W061DK6.zip \
     && : # last line
 
 FROM connectedhomeip/chip-build:${VERSION}

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.5.99 Version bump reason: fix IMX SDK root in vscode dockerfile
+0.6.00 Version bump reason: K32W0-SDK 2.6.7 update


### PR DESCRIPTION
Cherry-pick commit [6dfab6](https://github.com/project-chip/connectedhomeip/commit/6dfab6fb446b0ff86d5e35a5d87c1f8df74534ef) [(#22921)](https://github.com/project-chip/connectedhomeip/pull/22921) from master to v1.0 branch.