### PR TITLE
[1.0 Cherrypick] - genio file naming, telink example, increase -Xmx on Android builds

### DIFF
--- a/examples/tv-app/android/App/gradle.properties
+++ b/examples/tv-app/android/App/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/examples/tv-casting-app/android/App/gradle.properties
+++ b/examples/tv-casting-app/android/App/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/scripts/build/builders/genio.py
+++ b/scripts/build/builders/genio.py
@@ -19,9 +19,9 @@ class GenioApp(Enum):
 
     def AppNamePrefix(self):
         if self == GenioApp.LIGHT:
-            return 'chip-genio-lighting-app-example'
+            return 'chip-mt793x-lighting-app-example'
         elif self == GenioApp.SHELL:
-            return 'chip-genio-shell-example'
+            return 'chip-mt793x-shell-example'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/testdata/build_all_except_host.txt
+++ b/scripts/build/testdata/build_all_except_host.txt
@@ -1163,23 +1163,23 @@ gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/exa
 gn gen --check --fail-on-unused-args --export-compile-commands --root={root}/examples/shell/qpg '--args=qpg_target_ic="qpg6105"' {out}/qpg-shell
 
 # Generating telink-tlsr9518adk80d-light
-bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
 export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
-export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-light -b tlsr9518adk80d {root}/examples/lighting-app/telink'
 
 # Generating telink-tlsr9518adk80d-light-switch
-bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
 export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
-export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-light-switch -b tlsr9518adk80d {root}/examples/light-switch-app/telink'
 
 # Generating telink-tlsr9518adk80d-ota-requestor
-bash -c 'export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
 export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
-export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
 source "$ZEPHYR_BASE/zephyr-env.sh";
 west build --cmake-only -d {out}/telink-tlsr9518adk80d-ota-requestor -b tlsr9518adk80d {root}/examples/ota-requestor-app/telink'
 
@@ -2402,13 +2402,22 @@ ninja -C {out}/qpg-persistent-storage
 ninja -C {out}/qpg-shell
 
 # Building telink-tlsr9518adk80d-light
-ninja -C {out}/telink-tlsr9518adk80d-light
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
+ninja -C {out}/telink-tlsr9518adk80d-light'
 
 # Building telink-tlsr9518adk80d-light-switch
-ninja -C {out}/telink-tlsr9518adk80d-light-switch
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
+ninja -C {out}/telink-tlsr9518adk80d-light-switch'
 
 # Building telink-tlsr9518adk80d-ota-requestor
-ninja -C {out}/telink-tlsr9518adk80d-ota-requestor
+bash -c 'export ZEPHYR_TOOLCHAIN_VARIANT=zephyr
+export ZEPHYR_BASE="$TELINK_ZEPHYR_BASE"
+export ZEPHYR_SDK_INSTALL_DIR="$TELINK_ZEPHYR_SDK_DIR"
+ninja -C {out}/telink-tlsr9518adk80d-ota-requestor'
 
 # Building tizen-arm-all-clusters
 ninja -C {out}/tizen-arm-all-clusters

--- a/src/android/CHIPTest/gradle.properties
+++ b/src/android/CHIPTest/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects

--- a/src/android/CHIPTool/gradle.properties
+++ b/src/android/CHIPTool/gradle.properties
@@ -6,7 +6,7 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m
+org.gradle.jvmargs=-Xmx4096m -XX:MaxPermSize=2048m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. More details, visit
 # http://www.gradle.org/docs/current/userguide/multi_project_builds.html#sec:decoupled_projects


### PR DESCRIPTION
# Changes included in this PR
* 2022-09-28    Fix file naming for genio (#22918)
* 2022-09-27    Fix telink examples on vscode image (#22911)
* 2022-09-27    Increase -Xmx for android builds from 2G to 4G (#22910)

# Issues

## Genio

After genio was added in https://github.com/project-chip/connectedhomeip/pull/22404, the naming of output was not actually 'genio' but 'mt793x'. This fixes:
```
./scripts/build/build_examples.py --target genio-lighting-app build --copy-artifacts-to out/artifacts
```
Without this change, the naming is wrong and we get:
```
FileNotFoundError: [Errno 2] No such file or directory: '/workspace/out/genio-lighting-app/chip-genio-lighting-app-example.out'
```

## Telink example

This fixes building:
```
./scripts/build/build_examples.py --target telink-tlsr9518adk80d-ota-requestor build
```
This was failing with Assertion failed: GNUARMEMB_TOOLCHAIN_PATH is not set

From what I could tell, this is due to ZEPHYR_TOOLCHAIN_VARIANT not having been set during the build phase. I have moved the ZEPHYR_TOOLCHAIN_VARIANT and ZEPHYR_BASE to be both set during both build and generation phases (was generation only before)

## Android build issue

Got complains for build for x86:

```
Step #2 - "CompileAll": 2022-09-27 02:58:07 WARNING 
Step #2 - "CompileAll": 2022-09-27 02:58:07 WARNING * Get more help at https://help.gradle.org
Step #2 - "CompileAll": 2022-09-27 02:58:07 WARNING 
Step #2 - "CompileAll": 2022-09-27 02:58:07 WARNING BUILD FAILED in 52s
Step #2 - "CompileAll": 2022-09-27 02:58:08 INFO    Expiring Daemon because JVM heap space is exhausted
Step #2 - "CompileAll": Traceback (most recent call last):
Step #2 - "CompileAll":   File "/workspace/./scripts/build/build_examples.py", line 228, in <module>
Step #2 - "CompileAll":     main()
```

Overview

Standardize gradle jvm arguments and increase mx size from 2G to 4G