### PR TITLE
[Doc - Silabs] Update docs to point the SMG docs

### DIFF
--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -18,7 +18,7 @@
 -   [nRF Connect - Software Update](./nrfconnect_examples_software_update.md)
 -   [NXP - Android Commissioning](./nxp_k32w_android_commissioning.md)
 -   [NXP - Linux Examples](./nxp_imx8m_linux_examples.md)
--   [Silicon Labs - SMG Documentation](https://github.com/SiliconLabs/matter#readme)
+-   [Silicon Labs - Documentation](https://github.com/SiliconLabs/matter#readme)
 -   [Silicon Labs - Building](./silabs_efr32_building.md)
 -   [Silicon Labs - Software Update](./silabs_efr32_software_update.md)
 -   [TI - Platform Overview](./ti_platform_overview.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -18,8 +18,9 @@
 -   [nRF Connect - Software Update](./nrfconnect_examples_software_update.md)
 -   [NXP - Android Commissioning](./nxp_k32w_android_commissioning.md)
 -   [NXP - Linux Examples](./nxp_imx8m_linux_examples.md)
+-   [Silicon Labs - SMG Documentation](https://github.com/SiliconLabs/matter/tree/v0.3.0/docs/silabs))
 -   [Silicon Labs - Building](./silabs_efr32_building.md)
--   [Silicon Labs - Building](./silabs_efr32_software_update.md)
+-   [Silicon Labs - Software Update](./silabs_efr32_software_update.md)
 -   [TI - Platform Overview](./ti_platform_overview.md)
 
 ## Development Guides

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -18,7 +18,7 @@
 -   [nRF Connect - Software Update](./nrfconnect_examples_software_update.md)
 -   [NXP - Android Commissioning](./nxp_k32w_android_commissioning.md)
 -   [NXP - Linux Examples](./nxp_imx8m_linux_examples.md)
--   [Silicon Labs - SMG Documentation](https://github.com/SiliconLabs/matter/tree/v0.3.0/docs/silabs))
+-   [Silicon Labs - SMG Documentation](https://github.com/SiliconLabs/matter/tree/v0.3.0/docs/silabs)
 -   [Silicon Labs - Building](./silabs_efr32_building.md)
 -   [Silicon Labs - Software Update](./silabs_efr32_software_update.md)
 -   [TI - Platform Overview](./ti_platform_overview.md)

--- a/docs/guides/README.md
+++ b/docs/guides/README.md
@@ -18,7 +18,7 @@
 -   [nRF Connect - Software Update](./nrfconnect_examples_software_update.md)
 -   [NXP - Android Commissioning](./nxp_k32w_android_commissioning.md)
 -   [NXP - Linux Examples](./nxp_imx8m_linux_examples.md)
--   [Silicon Labs - SMG Documentation](https://github.com/SiliconLabs/matter/tree/v0.3.0/docs/silabs)
+-   [Silicon Labs - SMG Documentation](https://github.com/SiliconLabs/matter#readme)
 -   [Silicon Labs - Building](./silabs_efr32_building.md)
 -   [Silicon Labs - Software Update](./silabs_efr32_software_update.md)
 -   [TI - Platform Overview](./ti_platform_overview.md)

--- a/docs/guides/silabs_efr32_building.md
+++ b/docs/guides/silabs_efr32_building.md
@@ -17,7 +17,7 @@ The GitHub repository also includes tools for testing your Matter project.
 
 Silicon Laboratories now maintains a public matter GitHub repo with frequent
 releases thoroughly tested and validated. Developers looking to develop matter
-products with silabs hardware are encouraged to use our latest release with 
+products with silabs hardware are encouraged to use our latest release with
 added tools and documentation.
 [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
 

--- a/docs/guides/silabs_efr32_building.md
+++ b/docs/guides/silabs_efr32_building.md
@@ -17,12 +17,12 @@ The GitHub repository also includes tools for testing your Matter project.
 
 Silicon Laboratories now maintains a public matter GitHub repo with frequent
 releases thoroughly tested and validated. Developers looking to develop matter
-products with silabs hardware are encouraged to use our latest release,
-currently 0.3.0, with added tools and documentation.
-[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases/tag/v0.3.0)
+products with silabs hardware are encouraged to use our latest release with 
+added tools and documentation.
+[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
 
 The complete Silabs documentation can be found here
-[SMG Documentation](https://github.com/SiliconLabs/matter/tree/v0.3.0/docs/silabs)
+[SMG Documentation](https://github.com/SiliconLabs/matter#readme)
 
 ## Getting Started with Matter on EFR32
 

--- a/docs/guides/silabs_efr32_building.md
+++ b/docs/guides/silabs_efr32_building.md
@@ -13,8 +13,18 @@ The full list of examples can be found
 [here](https://github.com/project-chip/connectedhomeip/tree/master/examples).
 The GitHub repository also includes tools for testing your Matter project.
 
+## Silicon Labs Matter Github (SMG)
+
+Silicon Laboratories now maintains a public matter GitHub repo with frequent
+releases thoroughly tested and validated. Developers looking to develop matter
+products with silabs hardware are encouraged to use our latest release,
+currently 0.3.0, with added tools and documentation.
+[Silabs Matter Github](https://github.com/SiliconLabs/matter/releases/tag/v0.3.0)
+
+The complete Silabs documentation can be found here
+[SMG Documentation](https://github.com/SiliconLabs/matter/tree/v0.3.0/docs/silabs)
+
 ## Getting Started with Matter on EFR32
 
 Developers can find more resources on
-[Silicon Labs Matter Community Page](https://community.silabs.com/s/article/connected-home-over-ip-chip-faq?language=en_US)
-.
+[Silicon Labs Matter Community Page](https://community.silabs.com/s/article/connected-home-over-ip-chip-faq?language=en_US).

--- a/docs/guides/silabs_efr32_building.md
+++ b/docs/guides/silabs_efr32_building.md
@@ -13,7 +13,7 @@ The full list of examples can be found
 [here](https://github.com/project-chip/connectedhomeip/tree/master/examples).
 The GitHub repository also includes tools for testing your Matter project.
 
-## Silicon Labs Matter Github (SMG)
+## Silicon Labs Matter Github
 
 Silicon Laboratories now maintains a public matter GitHub repo with frequent
 releases thoroughly tested and validated. Developers looking to develop matter
@@ -22,7 +22,7 @@ added tools and documentation.
 [Silabs Matter Github](https://github.com/SiliconLabs/matter/releases)
 
 The complete Silabs documentation can be found here
-[SMG Documentation](https://github.com/SiliconLabs/matter#readme)
+[Silabs Matter Github Documentation](https://github.com/SiliconLabs/matter#readme)
 
 ## Getting Started with Matter on EFR32
 


### PR DESCRIPTION
Update some documentation files in the repo to point silabs's users to additional documentation tied with our stable silabs matter releases offering

