### PR TITLE
Increase chef GCB Bootstrap timeout to 45 Minutes

### DIFF
--- a/integrations/cloudbuild/chef.yaml
+++ b/integrations/cloudbuild/chef.yaml
@@ -10,7 +10,7 @@ steps:
       volumes:
           - name: pwenv
             path: /pwenv
-      timeout: 900s
+      timeout: 2700s
 
     - name: "connectedhomeip/chip-build-vscode:0.5.99"
       env:


### PR DESCRIPTION
GCB builds from 1.0 are timing out in bootstrap (Same as Issue #22913). This is a cherry pick to address. 
Apologies in advance if the branch is not open.
