### PR TITLE
[Zephyr] remove BLE advertisement rerun flag

### DIFF
--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -235,7 +235,6 @@ struct BLEManagerImpl::ServiceData
 CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 {
     int err                       = 0;
-    const bool isAdvertisingRerun = mFlags.Has(Flags::kAdvertising);
 
     // At first run always select fast advertising, on the next attempt slow down interval.
     const uint32_t intervalMin = mFlags.Has(Flags::kFastAdvertisingEnabled) ? CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MIN

--- a/src/platform/Zephyr/BLEManagerImpl.cpp
+++ b/src/platform/Zephyr/BLEManagerImpl.cpp
@@ -234,7 +234,7 @@ struct BLEManagerImpl::ServiceData
 
 CHIP_ERROR BLEManagerImpl::StartAdvertising(void)
 {
-    int err                       = 0;
+    int err = 0;
 
     // At first run always select fast advertising, on the next attempt slow down interval.
     const uint32_t intervalMin = mFlags.Has(Flags::kFastAdvertisingEnabled) ? CHIP_DEVICE_CONFIG_BLE_FAST_ADVERTISING_INTERVAL_MIN


### PR DESCRIPTION
If present, debug builds (using the Zephyr config `CONFIG_DEBUG`) will fail with `unused-variable`-error by the compiler. Since not used anymore, `isAdvertisingRerun` can be deleted.

Code which used the variable was removed with cba92c08a8d343b0b01ff4441d2af230fa1e6900.
