### PR TITLE
[darwin] Update the build scripts to not override some user defined settings

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -19,7 +19,7 @@ import("${build_root}/config/compiler/compiler.gni")
 import("${build_root}/config/sysroot.gni")
 import("${build_root}/config/target.gni")
 
-if (current_os == "mac") {
+if (current_os == "mac" || current_os == "ios") {
   import("${build_root}/config/mac/mac_sdk.gni")
 }
 
@@ -49,13 +49,11 @@ config("debug_default") {
 
 config("abi_default") {
   cflags = []
-  if (current_os == "mac") {
+  if (current_os == "mac" || current_os == "ios") {
     cflags += [
       "-target",
       mac_target_triple,
     ]
-  } else if (current_os == "ios") {
-    # iOS ABI currently set by chip_xcode_build_connector.sh
   }
 
   if (current_os != "mac" && current_os != "ios") {

--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -12,21 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-_mac_deployment_target = "10.15"
+target_arch = current_cpu
+if (current_cpu == "x86") {
+  target_arch = "i386"
+} else if (current_cpu == "x64") {
+  target_arch = "x86_64"
+} else if (current_cpu == "armv7") {
+  target_arch = "arm"
+} else if (current_cpu == "arm64") {
+  target_arch = "arm64"
+}
 
-if (current_cpu == "arm64") {
-  _mac_deployment_target = "11.0"
+target_sdk = "macos"
+if (current_os != "mac") {
+  target_sdk = current_os
+}
+
+deployment_target = "10.15"
+if (current_os == "mac") {
+  if (current_cpu == "arm64") {
+    deployment_target = "11.0"
+  }
+} else {
+  deployment_target = "13.4"
 }
 
 declare_args() {
-  # OS X version to target when compiling.
-  mac_deployment_target = _mac_deployment_target
+  # SDK version to target when compiling.
+  mac_deployment_target = target_sdk + deployment_target
 }
 
-if (current_cpu == "x64") {
-  mac_target_arch = "x86_64"
-} else {
-  mac_target_arch = current_cpu
-}
-
-mac_target_triple = "${mac_target_arch}-apple-macos${mac_deployment_target}"
+mac_target_triple = "${target_arch}-apple-${mac_deployment_target}"

--- a/build_overrides/boringssl.gni
+++ b/build_overrides/boringssl.gni
@@ -13,7 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/chip.gni")
+
 declare_args() {
   # Root directory for BoringSSL
-  boringssl_root = "//third_party/boringssl/repo"
+  boringssl_root = "${chip_root}/third_party/boringssl/repo"
 }

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -24,6 +24,10 @@ if (config_use_interactive_mode) {
 
 assert(chip_build_tools)
 
+declare_args() {
+  chip_codesign = current_os == "ios"
+}
+
 if (current_os == "ios") {
   output_sdk_type = "Debug-iphoneos"
 } else {
@@ -157,4 +161,21 @@ executable("darwin-framework-tool") {
   public_configs = [ ":config" ]
 
   output_dir = root_out_dir
+}
+
+if (chip_codesign) {
+  action("codesign") {
+    script = "entitlements/codesign.py"
+    public_deps = [ ":darwin-framework-tool" ]
+
+    args = [
+      "--target_path",
+      rebase_path("${root_build_dir}/darwin-framework-tool", root_build_dir),
+      "--log_path",
+      rebase_path("${root_build_dir}/codesign_log.txt", root_build_dir),
+    ]
+
+    output_name = "codesign_log.txt"
+    outputs = [ "${root_build_dir}/${output_name}" ]
+  }
 }

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -24,6 +24,12 @@ if (config_use_interactive_mode) {
 
 assert(chip_build_tools)
 
+if (current_os == "ios") {
+  output_sdk_type = "Debug-iphoneos"
+} else {
+  output_sdk_type = "Debug"
+}
+
 action("build-darwin-framework") {
   script = "${chip_root}/scripts/build/build_darwin_framework.py"
 
@@ -47,7 +53,7 @@ action("build-darwin-framework") {
 
   output_name = "Matter.framework"
   outputs = [
-    "${root_out_dir}/macos_framework_output/Build/Products/Debug/${output_name}",
+    "${root_out_dir}/macos_framework_output/Build/Products/${output_sdk_type}/${output_name}",
     "${root_build_dir}/darwin_framework_build.log",
     "${root_out_dir}/macos_framework_output/ModuleCache.noindex/",
     "${root_out_dir}/macos_framework_output/Logs",
@@ -64,11 +70,12 @@ config("config") {
     "${chip_root}/zzz_generated/controller-clusters",
     "${chip_root}/examples/chip-tool",
     "${chip_root}/zzz_generated/chip-tool",
-    "${root_out_dir}/macos_framework_output/Build/Products/Debug/",
+    "${root_out_dir}/macos_framework_output/Build/Products/${output_sdk_type}/",
   ]
 
-  framework_dirs =
-      [ "${root_out_dir}/macos_framework_output/Build/Products/Debug/" ]
+  framework_dirs = [
+    "${root_out_dir}/macos_framework_output/Build/Products/${output_sdk_type}/",
+  ]
 
   defines = [
     "CONFIG_ENABLE_YAML_TESTS=${config_enable_yaml_tests}",
@@ -139,7 +146,7 @@ executable("darwin-framework-tool") {
 
   ldflags = [
     "-rpath",
-    "@executable_path/macos_framework_output/Build/Products/Debug/",
+    "@executable_path/macos_framework_output/Build/Products/${output_sdk_type}/",
   ]
 
   frameworks = [

--- a/examples/darwin-framework-tool/args.gni
+++ b/examples/darwin-framework-tool/args.gni
@@ -15,3 +15,5 @@
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/config/standalone/args.gni")
+
+chip_crypto = "boringssl"

--- a/examples/darwin-framework-tool/entitlements/codesign.py
+++ b/examples/darwin-framework-tool/entitlements/codesign.py
@@ -45,9 +45,8 @@ def get_identity():
 
 
 def codesign(args):
-    command = "codesign --force -d --sign {identity} --entitlements {entitlement} {target}".format(
+    command = "codesign --force -d --sign {identity} {target}".format(
         identity=get_identity(),
-        entitlement=args.entitlements_path,
         target=args.target_path)
     command_result = run_command(command)
 
@@ -59,8 +58,6 @@ def codesign(args):
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
         description='Codesign the darwin-framework-tool binary')
-    parser.add_argument('--entitlements_path', default='entitlements/darwin-framework-tool.entitlements',
-                        help='Set the entitlements for codesign', required=True)
     parser.add_argument(
         '--log_path', help='Output log file destination', required=True)
     parser.add_argument('--target_path', help='Binary to sign', required=True)

--- a/scripts/build/build_darwin_framework.py
+++ b/scripts/build/build_darwin_framework.py
@@ -42,18 +42,28 @@ def build_darwin_framework(args):
     if not os.path.exists(abs_path):
         os.mkdir(abs_path)
 
+    sdk = 'macosx' if os.environ.get('SDKROOT') == None else os.environ.get('SDKROOT')
+    arch = platform.machine() if sdk.startswith('macosx') else 'arm64'
+
     command = [
         'xcodebuild',
         '-scheme',
         args.target,
         '-sdk',
-        'macosx',
+        sdk,
         '-project',
         args.project_path,
         '-derivedDataPath',
         abs_path,
-        "PLATFORM_PREFERRED_ARCH={}".format(platform.machine())
+        "PLATFORM_PREFERRED_ARCH={}".format(arch),
     ]
+
+    if sdk != "macosx":
+        command += [
+            # Build Matter.framework as a static library
+            "SUPPORTS_TEXT_BASED_API=NO",
+            "MACH_O_TYPE=staticlib",
+        ]
     command_result = run_command(command)
 
     print("Build Framework Result: {}".format(command_result))

--- a/src/controller/python/BUILD.gn
+++ b/src/controller/python/BUILD.gn
@@ -314,8 +314,10 @@ chip_python_wheel_action("chip-core") {
   }
 
   if (current_os == "mac") {
-    py_platform_tag =
-        "macosx_" + string_replace(mac_deployment_target, ".", "_")
+    py_platform_tag = string_replace(
+            string_replace(mac_deployment_target, "macos", "macosx."),
+            ".",
+            "_")
   } else {
     py_platform_tag = current_os
   }

--- a/src/crypto/BUILD.gn
+++ b/src/crypto/BUILD.gn
@@ -92,7 +92,7 @@ if (chip_crypto == "openssl") {
     public_deps = [ ":public_headers" ]
   }
 } else if (chip_crypto == "boringssl") {
-  import("//build_overrides/boringssl.gni")
+  import("${chip_root}/build_overrides/boringssl.gni")
 
   source_set("cryptopal_boringssl") {
     # BoringSSL is close enough to OpenSSL that it uses same PAL, with minor #ifdef differences

--- a/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
+++ b/src/darwin/CHIPTool/CHIPTool.xcodeproj/project.pbxproj
@@ -579,6 +579,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
@@ -602,6 +603,7 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SDKROOT = iphoneos;
+				SUPPORTS_MACCATALYST = YES;
 				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
@@ -611,6 +613,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CHIPToolTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (
@@ -630,6 +633,7 @@
 			buildSettings = {
 				BUNDLE_LOADER = "$(TEST_HOST)";
 				CODE_SIGN_STYLE = Automatic;
+				DEVELOPMENT_TEAM = "";
 				INFOPLIST_FILE = CHIPToolTests/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 13.4;
 				LD_RUNPATH_SEARCH_PATHS = (

--- a/src/darwin/CHIPTool/CHIPTool/CHIPTool.entitlements
+++ b/src/darwin/CHIPTool/CHIPTool/CHIPTool.entitlements
@@ -1,5 +1,20 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.device.bluetooth</key>
+	<true/>
+	<key>com.apple.security.device.camera</key>
+	<true/>
+	<key>com.apple.security.network.client</key>
+	<true/>
+	<key>com.apple.security.network.server</key>
+	<true/>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.matter.CHIPTool</string>
+	</array>
+</dict>
 </plist>

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -79,12 +79,15 @@ case $PLATFORM_PREFERRED_ARCH in
         ;;
 esac
 
-declare target_cflags='"-target","'"$PLATFORM_PREFERRED_ARCH"'-'"$LLVM_TARGET_TRIPLE_VENDOR"'-'"$LLVM_TARGET_TRIPLE_OS_VERSION"'"'
+declare target_cflags=""
 
 read -r -a archs <<<"$ARCHS"
 
 for arch in "${archs[@]}"; do
-    target_cflags+=',"-arch","'"$arch"'"'
+    if [ -n "$target_cflags" ]; then
+        target_cflags+=','
+    fi
+    target_cflags+='"-arch","'"$arch"'"'
 done
 
 [[ $ENABLE_BITCODE == YES ]] && {
@@ -96,11 +99,13 @@ declare -a args=(
     'chip_crypto="boringssl"'
     'chip_build_tools=false'
     'chip_build_tests=false'
+    'chip_enable_wifi=false'
     'chip_log_message_max_size=4096' # might as well allow nice long log messages
     'chip_disable_platform_kvs=true'
     'target_cpu="'"$target_cpu"'"'
     'target_defines='"$target_defines"
     'target_cflags=['"$target_cflags"']'
+    'mac_deployment_target="'"$LLVM_TARGET_TRIPLE_OS_VERSION"''"$LLVM_TARGET_TRIPLE_SUFFIX"'"'
 )
 
 [[ $CONFIGURATION != Debug* ]] && args+='is_debug=true'

--- a/src/pybindings/pycontroller/BUILD.gn
+++ b/src/pybindings/pycontroller/BUILD.gn
@@ -132,7 +132,10 @@ pw_python_action("pycontroller") {
   }
 
   if (current_os == "mac") {
-    platform_tag = "macosx_" + string_replace(mac_deployment_target, ".", "_")
+    platform_tag = string_replace(
+            string_replace(mac_deployment_target, "macos", "macosx."),
+            ".",
+            "_")
   } else {
     platform_tag = current_os
   }

--- a/third_party/boringssl/repo/BUILD.gn
+++ b/third_party/boringssl/repo/BUILD.gn
@@ -17,6 +17,8 @@ import("BUILD.generated.gni")
 config("boringssl_config") {
   include_dirs = [ "src/include" ]
 
+  cflags = [ "-Wno-unused-variable" ]
+
   # We want the basic crypto impl with no asm primitives until we hook-up platform-based
   # support to the build later.
   defines = [ "OPENSSL_NO_ASM=1" ]


### PR DESCRIPTION

#### Problem
`chip_xcode_build_connector.sh` scripts when used for building `ios` is the one that defines the `target` uses for building. That does not works fine with things such as Mac Catalyst

Additionally, if one wants to build `darwin-framework-tool` with borings using `./scripts/examples/gn_build_example.sh` the current setup complains since it is using `//` and not `${chip_root}` while `examples/darwin-framework-tool`, like many other examples, does not have all the third_party repo as soft links directly into their `third_party` folder which usually contains `connectedhomeip`.

Lastly, when building `darwin-framework-tool` the SDKROOT setting is overriden.