### PR TITLE
[Ameba] Replace BLE C2 notify with indicate as required by Matter Spec

### DIFF
--- a/integrations/docker/images/chip-build-ameba/Dockerfile
+++ b/integrations/docker/images/chip-build-ameba/Dockerfile
@@ -3,7 +3,7 @@ FROM connectedhomeip/chip-build:${VERSION}
 
 # Setup Ameba
 ARG AMEBA_DIR=/opt/ameba
-ARG TAG_NAME=ameba_update_2022_07_25
+ARG TAG_NAME=ameba_update_2022_10_03
 RUN set -x \
     && apt-get update \
     && mkdir ${AMEBA_DIR} \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.02 Version bump reason: Update NXP SDK PATH
+0.6.03 Version bump reason: [Ameba] Replace C2 notify with indicate as required by Matter spec


### PR DESCRIPTION
-  Replace BLE C2 notify with indicate
-  Update docker image

