### PR TITLE
Fix signdness for device type: DataModelTypes.h says DeviceTypeId is …

### DIFF
--- a/scripts/idl/generators/types.py
+++ b/scripts/idl/generators/types.py
@@ -195,7 +195,7 @@ __CHIP_SIZED_TYPES__ = {
     "command_id": BasicInteger(idl_name="command_id", byte_count=4, is_signed=True),
     "data_ver": BasicInteger(idl_name="data_ver", byte_count=4, is_signed=True),
     "date": BasicInteger(idl_name="date", byte_count=4, is_signed=True),
-    "devtype_id": BasicInteger(idl_name="devtype_id", byte_count=4, is_signed=True),
+    "devtype_id": BasicInteger(idl_name="devtype_id", byte_count=4, is_signed=False),
     "endpoint_no": BasicInteger(idl_name="endpoint_no", byte_count=2, is_signed=True),
     "epoch_s": BasicInteger(idl_name="epoch_s", byte_count=4, is_signed=False),
     "epoch_us": BasicInteger(idl_name="epoch_us", byte_count=8, is_signed=False),


### PR DESCRIPTION
DataModelTypes defines DeviceTypeId as unsigned. Without this fix, dynamic-bridge fails to compile on clang:

```
'chip::DeviceTypeId' (aka 'unsigned int') to 'int32_t' (aka 'int') [-Werror,-Wsign-conversion]
Step #2 - "CompileAll": 2022-10-04 05:16:04 INFO            type = t.type;
Step #2 - "CompileAll": 2022-10-04 05:16:04 INFO                 ~ ~~^~~~
Step #2 - "CompileAll": 2022-10-04 05:16:04 INFO    gen/bridge/Descriptor.h:25:16: error: implicit conversion changes signedness: 'const int32_t' (aka 'const int') to 'chip::DeviceTypeId' (aka 'unsigned int') [-Werror,-Wsign-conversion]
Step #2 - "CompileAll": 2022-10-04 05:16:04 INFO          t.type = type;
Step #2 - "CompileAll": 2022-10-04 05:16:04 INFO                 ~ ^~~~
```

After the fix, compilation succeeds.