### PR TITLE
[QPG] Updating README's to QMatter repo link

### DIFF
--- a/examples/lighting-app/qpg/APPLICATION.md
+++ b/examples/lighting-app/qpg/APPLICATION.md
@@ -4,13 +4,12 @@
 
 A lighting example application showing the use of
 [Matter](https://github.com/project-chip/connectedhomeip) on the Qorvo QPG6105
-can be found in the
-[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/examples/lighting-app/APPLICATION.md).
+can be found in this folder.
 
 ## Qorvo SDK
 
 More detailed information on the Qorvo SDK can be found in the
-[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6105/doc/README.md).
+[Qorvo Matter SDK](https://github.com/Qorvo/QMatter).
 
 ## More information
 

--- a/examples/lock-app/qpg/APPLICATION.md
+++ b/examples/lock-app/qpg/APPLICATION.md
@@ -4,13 +4,12 @@
 
 A lock example application showing the use of
 [Matter](https://github.com/project-chip/connectedhomeip) on the Qorvo QPG6105
-can be found in the
-[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/examples/lock-app/APPLICATION.md).
+can be found in this folder.
 
 ## Qorvo SDK
 
 More detailed information on the Qorvo SDK can be found in the
-[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6105/doc/README.md).
+[Qorvo Matter SDK](https://github.com/Qorvo/QMatter).
 
 ## More information
 

--- a/examples/platform/qpg/README.md
+++ b/examples/platform/qpg/README.md
@@ -3,7 +3,7 @@
 ## Qorvo SDK
 
 More detailed information on the Qorvo SDK can be found in the
-[Qorvo Matter Documentation repository](https://github.com/Qorvo/qpg-connectedhomeip/blob/master/qpg6105/doc/README.md).
+[Qorvo Matter SDK](https://github.com/Qorvo/QMatter).
 
 ## More information
 


### PR DESCRIPTION
* Issue:
README.md's referenced the old `qpg-connectedhomeip` SDK submodule.

* Update
Links moved to `QMatter`

