### PR TITLE
Filter by vendor/product id (if available) in SetUpCodePairer.

### DIFF
--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -190,11 +190,10 @@ CHIP_ERROR SetUpCodePairer::StopConnectOverIP()
 
     mWaitingForDiscovery[kIPTransport] = false;
     mCurrentFilter.type                = Dnssd::DiscoveryFilterType::kNone;
-    mPayloadVendorID                   = 0;
-    mPayloadProductID                  = 0;
+    mPayloadVendorID                   = kNotAvailable;
+    mPayloadProductID                  = kNotAvailable;
 
     mCommissioner->StopCommissionableDiscovery();
-
     return CHIP_NO_ERROR;
 }
 
@@ -292,12 +291,10 @@ void SetUpCodePairer::OnBLEDiscoveryError(CHIP_ERROR err)
 }
 #endif // CONFIG_NETWORK_LAYER_BLE
 
-namespace {
-bool IsPresent(uint16_t vendorOrProductID)
+bool SetUpCodePairer::IdIsPresent(uint16_t vendorOrProductID)
 {
-    return vendorOrProductID != 0;
+    return vendorOrProductID != kNotAvailable;
 }
-} // anonymous namespace
 
 bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData) const
 {
@@ -307,14 +304,14 @@ bool SetUpCodePairer::NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData &
     }
 
     // The advertisement may not include a vendor id.
-    if (IsPresent(mPayloadVendorID) && IsPresent(nodeData.commissionData.vendorId) &&
+    if (IdIsPresent(mPayloadVendorID) && IdIsPresent(nodeData.commissionData.vendorId) &&
         mPayloadVendorID != nodeData.commissionData.vendorId)
     {
         return false;
     }
 
     // The advertisement may not include a product id.
-    if (IsPresent(mPayloadProductID) && IsPresent(nodeData.commissionData.productId) &&
+    if (IdIsPresent(mPayloadProductID) && IdIsPresent(nodeData.commissionData.productId) &&
         mPayloadProductID != nodeData.commissionData.productId)
     {
         return false;

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -151,12 +151,15 @@ private:
 #endif // CONFIG_NETWORK_LAYER_BLE
 
     bool NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData) const;
+    static bool IdIsPresent(uint16_t vendorOrProductID);
+
     Dnssd::DiscoveryFilter mCurrentFilter;
     // The vendor id and product id from the SetupPayload.  They may be 0, which
     // indicates "not available" (e.g. because the SetupPayload came from a
     // short manual code).  In that case we should not filter on those values.
-    uint16_t mPayloadVendorID  = 0;
-    uint16_t mPayloadProductID = 0;
+    static constexpr uint16_t kNotAvailable = 0;
+    uint16_t mPayloadVendorID               = kNotAvailable;
+    uint16_t mPayloadProductID              = kNotAvailable;
 
     DeviceCommissioner * mCommissioner = nullptr;
     System::Layer * mSystemLayer       = nullptr;

--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -151,7 +151,12 @@ private:
 #endif // CONFIG_NETWORK_LAYER_BLE
 
     bool NodeMatchesCurrentFilter(const Dnssd::DiscoveredNodeData & nodeData) const;
-    Dnssd::DiscoveryFilter currentFilter;
+    Dnssd::DiscoveryFilter mCurrentFilter;
+    // The vendor id and product id from the SetupPayload.  They may be 0, which
+    // indicates "not available" (e.g. because the SetupPayload came from a
+    // short manual code).  In that case we should not filter on those values.
+    uint16_t mPayloadVendorID  = 0;
+    uint16_t mPayloadProductID = 0;
 
     DeviceCommissioner * mCommissioner = nullptr;
     System::Layer * mSystemLayer       = nullptr;


### PR DESCRIPTION
If we have vendor/product information, from a QR code or long manual code, we should use that to filter out advertisements for other vendors or products.

