### PR TITLE
Make the app name known for dynamic bridge

### DIFF
--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -166,8 +166,8 @@ class HostApp(Enum):
             yield 'chip-bridge-app'
             yield 'chip-bridge-app.map'
         elif self == HostApp.DYNAMIC_BRIDGE:
-            return 'dynamic-chip-bridge-app'
-            return 'dynamic-chip-bridge-app.map'
+            yield 'dynamic-chip-bridge-app'
+            yield 'dynamic-chip-bridge-app.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -165,6 +165,9 @@ class HostApp(Enum):
         elif self == HostApp.BRIDGE:
             yield 'chip-bridge-app'
             yield 'chip-bridge-app.map'
+        elif self == HostApp.DYNAMIC_BRIDGE:
+            return 'dynamic-chip-bridge-app'
+            return 'dynamic-chip-bridge-app.map'
         else:
             raise Exception('Unknown app type: %r' % self)
 


### PR DESCRIPTION
Dynamic bridge example build instructions did not include info on what artifacts are generated. As a result this gets a compile error:

```sh
./scripts/build/build_examples.py --target linux-x64-dynamic-bridge build --copy-artifacts-to out/artifacts
```

Log looks like: 

```
...
Step #5 - "Linux":   File "/workspace/./scripts/build/build_examples.py", line 224, in cmd_build
Step #5 - "Linux":     context.obj.CreateArtifactArchives(create_archives)
Step #5 - "Linux":   File "/workspace/scripts/build/build/__init__.py", line 83, in CreateArtifactArchives
Step #5 - "Linux":     builder.CompressArtifacts(os.path.join(
Step #5 - "Linux":   File "/workspace/scripts/build/builders/builder.py", line 98, in CompressArtifacts
Step #5 - "Linux":     for target_name, source_name in self.outputs().items():
Step #5 - "Linux":   File "/workspace/scripts/build/builders/builder.py", line 83, in outputs
Step #5 - "Linux":     artifacts = self.build_outputs()
Step #5 - "Linux":   File "/workspace/scripts/build/builders/host.py", line 399, in build_outputs
Step #5 - "Linux":     for name in self.app.OutputNames():
Step #5 - "Linux":   File "/workspace/scripts/build/builders/host.py", line 169, in OutputNames
Step #5 - "Linux":     raise Exception('Unknown app type: %r' % self)
Step #5 - "Linux": Exception: Unknown app type: <HostApp.DYNAMIC_BRIDGE: 22>
```

This PR adds the name of the output files for the dynamic bridge, so that artifact generation works.