### PR TITLE
[Tizen] Release BLE when no longer needed

### DIFF
--- a/src/platform/Linux/BLEManagerImpl.cpp
+++ b/src/platform/Linux/BLEManagerImpl.cpp
@@ -570,6 +570,7 @@ void BLEManagerImpl::DriveBLEState()
     if (!mIsCentral && mServiceMode == ConnectivityManager::kCHIPoBLEServiceMode_Enabled && !mFlags.Has(Flags::kAppRegistered))
     {
         err = BluezGattsAppRegister(mpEndpoint);
+        SuccessOrExit(err);
         mFlags.Set(Flags::kControlOpInProgress);
         ExitNow();
     }

--- a/src/platform/Tizen/BLEManagerImpl.cpp
+++ b/src/platform/Tizen/BLEManagerImpl.cpp
@@ -484,7 +484,7 @@ void BLEManagerImpl::OnChipDeviceScanned(void * device, const chip::Ble::ChipBLE
     ConnectHandler(deviceInfo->remote_address);
 }
 
-void BLEManagerImpl::OnChipScanComplete(void)
+void BLEManagerImpl::OnChipScanComplete()
 {
     if (mBLEScanConfig.mBleScanState != BleScanState::kScanForDiscriminator &&
         mBLEScanConfig.mBleScanState != BleScanState::kScanForAddress)
@@ -579,7 +579,7 @@ exit:
     return ret;
 }
 
-int BLEManagerImpl::StartAdvertising()
+int BLEManagerImpl::StartBLEAdvertising()
 {
     int ret                                                    = BT_ERROR_NONE;
     CHIP_ERROR err                                             = CHIP_NO_ERROR;
@@ -649,7 +649,7 @@ exit:
     return ret;
 }
 
-int BLEManagerImpl::StopAdvertising()
+int BLEManagerImpl::StopBLEAdvertising()
 {
     int ret = BT_ERROR_NONE;
 
@@ -664,7 +664,7 @@ exit:
     return ret;
 }
 
-void BLEManagerImpl::InitConnectionData(void)
+void BLEManagerImpl::InitConnectionData()
 {
     /* Initialize Hashmap */
     if (!mConnectionMap)
@@ -872,13 +872,13 @@ void BLEManagerImpl::DriveBLEState()
     {
         if (!mFlags.Has(Flags::kAdvertising))
         {
-            ret = StartAdvertising();
+            ret = StartBLEAdvertising();
             VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Start Advertising Failed. ret: %d", ret));
         }
         else if (mFlags.Has(Flags::kAdvertisingRefreshNeeded))
         {
             ChipLogProgress(DeviceLayer, "Advertising Refreshed Needed. Stop Advertising");
-            ret = StopAdvertising();
+            ret = StopBLEAdvertising();
             VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Stop Advertising Failed. ret: %d", ret));
         }
     }
@@ -886,7 +886,7 @@ void BLEManagerImpl::DriveBLEState()
     {
         ChipLogProgress(DeviceLayer, "Stop Advertising");
 
-        ret = StopAdvertising();
+        ret = StopBLEAdvertising();
         VerifyOrExit(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "Stop Advertising Failed. ret: %d", ret));
 
         ret = bt_adapter_le_destroy_advertiser(mAdvertiser);
@@ -906,7 +906,7 @@ void BLEManagerImpl::DriveBLEState(intptr_t arg)
     sInstance.DriveBLEState();
 }
 
-CHIP_ERROR BLEManagerImpl::_Init(void)
+CHIP_ERROR BLEManagerImpl::_Init()
 {
     CHIP_ERROR err;
     bool ret;
@@ -924,6 +924,12 @@ CHIP_ERROR BLEManagerImpl::_Init(void)
 
 exit:
     return err;
+}
+
+void BLEManagerImpl::_Shutdown()
+{
+    int ret = bt_deinitialize();
+    VerifyOrReturn(ret == BT_ERROR_NONE, ChipLogError(DeviceLayer, "bt_deinitialize() failed. ret: %d", ret));
 }
 
 CHIP_ERROR BLEManagerImpl::_SetAdvertisingEnabled(bool val)
@@ -994,7 +1000,7 @@ exit:
     return err;
 }
 
-uint16_t BLEManagerImpl::_NumConnections(void)
+uint16_t BLEManagerImpl::_NumConnections()
 {
     return 0;
 }
@@ -1006,7 +1012,7 @@ CHIP_ERROR BLEManagerImpl::ConfigureBle(uint32_t aAdapterId, bool aIsCentral)
     return CHIP_NO_ERROR;
 }
 
-void BLEManagerImpl::CleanScanConfig(void)
+void BLEManagerImpl::CleanScanConfig()
 {
     if (mBLEScanConfig.mBleScanState == BleScanState::kConnecting)
         chip::DeviceLayer::SystemLayer().CancelTimer(HandleConnectionTimeout, nullptr);

--- a/src/platform/Tizen/BLEManagerImpl.h
+++ b/src/platform/Tizen/BLEManagerImpl.h
@@ -86,18 +86,19 @@ public:
 private:
     // ===== Members that implement the BLEManager internal interface.
 
-    CHIP_ERROR _Init(void);
-    void _Shutdown() {}
-    bool _IsAdvertisingEnabled(void);
+    CHIP_ERROR _Init();
+    void _Shutdown();
+    bool _IsAdvertisingEnabled();
     CHIP_ERROR _SetAdvertisingEnabled(bool val);
-    bool _IsAdvertising(void);
+    bool _IsAdvertising();
     CHIP_ERROR _SetAdvertisingMode(BLEAdvertisingMode mode);
     CHIP_ERROR _GetDeviceName(char * buf, size_t bufSize);
     CHIP_ERROR _SetDeviceName(const char * deviceName);
-    uint16_t _NumConnections(void);
+    uint16_t _NumConnections();
+
     void _OnPlatformEvent(const ChipDeviceEvent * event);
     void HandlePlatformSpecificBLEEvent(const ChipDeviceEvent * event);
-    BleLayer * _GetBleLayer(void);
+    BleLayer * _GetBleLayer();
 
     // ===== Members that implement virtual methods on BlePlatformDelegate.
 
@@ -131,8 +132,8 @@ private:
 
     // ===== Members for internal use by the following friends.
 
-    friend BLEManager & BLEMgr(void);
-    friend BLEManagerImpl & BLEMgrImpl(void);
+    friend BLEManager & BLEMgr();
+    friend BLEManagerImpl & BLEMgrImpl();
 
     static BLEManagerImpl sInstance;
 
@@ -172,7 +173,7 @@ private:
     static void CharacteristicNotificationCb(bt_gatt_h characteristic, char * value, int len, void * userData);
 
     // ==== Connection.
-    void InitConnectionData(void);
+    void InitConnectionData();
     void AddConnectionData(const char * remoteAddr);
     void RemoveConnectionData(const char * remoteAddr);
 
@@ -202,10 +203,10 @@ private:
     void NotifySubscribeOpComplete(BLE_CONNECTION_OBJECT conId, bool isSubscribed);
     void NotifyBLENotificationReceived(System::PacketBufferHandle & buf, BLE_CONNECTION_OBJECT conId);
 
-    int RegisterGATTServer(void);
-    int StartAdvertising(void);
-    int StopAdvertising(void);
-    void CleanScanConfig(void);
+    int RegisterGATTServer();
+    int StartBLEAdvertising();
+    int StopBLEAdvertising();
+    void CleanScanConfig();
 
     CHIPoBLEServiceMode mServiceMode;
     BitFlags<Flags> mFlags;
@@ -230,7 +231,7 @@ private:
  * Internal components should use this to access features of the BLEManager object
  * that are common to all platforms.
  */
-inline BLEManager & BLEMgr(void)
+inline BLEManager & BLEMgr()
 {
     return BLEManagerImpl::sInstance;
 }
@@ -241,7 +242,7 @@ inline BLEManager & BLEMgr(void)
  * Internal components can use this to gain access to features of the BLEManager
  * that are specific to the Tizen platforms.
  */
-inline BLEManagerImpl & BLEMgrImpl(void)
+inline BLEManagerImpl & BLEMgrImpl()
 {
     return BLEManagerImpl::sInstance;
 }


### PR DESCRIPTION
## Problem

Tizen Native API `bt_deinitialize()` is not called when shutting down BLE subsystem. Tizen doc says: "In addition, [bt_deinitialize()](https://docs.tizen.org/application/native/api/iot-headless/5.0/group__CAPI__NETWORK__BLUETOOTH__MODULE.html#ga2cd614b8b1ff2a476e2c4bd40778b53b) should be called when Bluetooth Service is no longer needed."

## Changes

- implement `BLEManagerImpl::_Shutdown` for Tizen
- clang-tidy: modernize redundant void
- add error verification for Linux when registering GATT

## Testing

Manually tested by running chip-tool on Tizen. Now `bt_deinitialize()` is called when `BLEMgr().Shutdown();` is called in `void GenericPlatformManagerImpl<ImplClass>::_Shutdown()`.
