### PR TITLE
EFR32: Crypto PSA bugfix: Missing return on success.

### DIFF
--- a/src/platform/EFR32/CHIPCryptoPALPsaEfr32.cpp
+++ b/src/platform/EFR32/CHIPCryptoPALPsaEfr32.cpp
@@ -1784,6 +1784,7 @@ CHIP_ERROR ExtractKIDFromX509Cert(bool extractSKID, const ByteSpan & certificate
             {
                 kid.reduce_size(len);
             }
+            ExitNow(error = CHIP_NO_ERROR);
             break;
         }
         p += len;


### PR DESCRIPTION
* Fixes failing platform EFR32 tests:
```
...
	Test x509 Attestation Certificate Format Validation: FAILED
	Test x509 Certificate Chain Validation: ✓
	Test x509 Certificate Timestamp Validation: ✓
	Test Subject Key Id Extraction from x509 Certificate: FAILED
	Test Authority Key Id Extraction from x509 Certificate: FAILED
```

* Tested on BRD4164A