### PR TITLE
Reduce targets for cloudbuild smoketest

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -33,7 +33,7 @@ steps:
                  --target esp32-m5stack-all-clusters-minimal-rpc-ipv6only
                  --target esp32-m5stack-all-clusters-rpc
                  --target esp32-m5stack-ota-requestor
-                 build 
+                 build
                  --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap
@@ -82,7 +82,7 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
-              ./scripts/build/build_examples.py 
+              ./scripts/build/build_examples.py
                   --enable-flashbundle
                   --target linux-arm64-clang-all-clusters
                   --target linux-arm64-clang-all-clusters-app-nodeps-ipv6only

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,10 +1,11 @@
 steps:
-    - name: gcr.io/cloud-builders/git
+    - name: "connectedhomeip/chip-build-vscode:0.6.02"
+      entrypoint: 'bash'
       args:
-          - submodule
-          - update
-          - "--init"
-          - "--recursive"
+          - '-c'
+          - |
+            git config --global --add safe.directory `pwd`
+            git submodule update --init --recursive
       id: Submodules
     - name: "connectedhomeip/chip-build-vscode:0.6.02"
       env:

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -4,7 +4,7 @@ steps:
       args:
           - '-c'
           - |
-            git config --global --add safe.directory `pwd`
+            git config --global --add safe.directory "*"
             git submodule update --init --recursive
       id: Submodules
     - name: "connectedhomeip/chip-build-vscode:0.6.02"

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -27,9 +27,14 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
-              ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob '*-m5stack-*' build --create-archives
-              /workspace/artifacts/
+              ./scripts/build/build_examples.py
+                 --enable-flashbundle
+                 --target esp32-m5stack-all-clusters-ipv6only
+                 --target esp32-m5stack-all-clusters-minimal-rpc-ipv6only
+                 --target esp32-m5stack-all-clusters-rpc
+                 --target esp32-m5stack-ota-requestor
+                 build 
+                 --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap
       entrypoint: ./scripts/run_in_build_env.sh
@@ -77,9 +82,44 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
-              ./scripts/build/build_examples.py --enable-flashbundle
-              --target-glob 'linux-*' --skip-target-glob '*-tests*' build
-              --create-archives /workspace/artifacts/
+              ./scripts/build/build_examples.py 
+                  --enable-flashbundle
+                  --target linux-arm64-clang-all-clusters
+                  --target linux-arm64-clang-all-clusters-app-nodeps-ipv6only
+                  --target linux-arm64-clang-all-clusters-minimal-ipv6only
+                  --target linux-arm64-clang-bridge-ipv6only
+                  --target linux-arm64-clang-chip-tool-ipv6only
+                  --target linux-arm64-clang-chip-tool-nodeps-ipv6only
+                  --target linux-arm64-clang-dynamic-bridge-ipv6only
+                  --target linux-arm64-clang-light-rpc-ipv6only
+                  --target linux-arm64-clang-lock-ipv6only
+                  --target linux-arm64-clang-minmdns
+                  --target linux-arm64-clang-ota-provider-nodeps-ipv6only
+                  --target linux-arm64-clang-ota-requestor-nodeps-ipv6only
+                  --target linux-arm64-clang-python-bindings
+                  --target linux-arm64-clang-shell-ipv6only
+                  --target linux-arm64-clang-thermostat-ipv6only
+                  --target linux-arm64-clang-tv-app-ipv6only
+                  --target linux-arm64-clang-tv-casting-app-ipv6only
+                  --target linux-x64-address-resolve-tool
+                  --target linux-x64-all-clusters-app-nodeps-ipv6only
+                  --target linux-x64-all-clusters-coverage
+                  --target linux-x64-bridge-ipv6only
+                  --target linux-x64-chip-cert
+                  --target linux-x64-chip-tool-ipv6only
+                  --target linux-x64-dynamic-bridge-ipv6only
+                  --target linux-x64-light-rpc-ipv6only
+                  --target linux-x64-lock-ipv6only
+                  --target linux-x64-minmdns-ipv6only
+                  --target linux-x64-ota-provider-ipv6only
+                  --target linux-x64-ota-requestor-ipv6only
+                  --target linux-x64-python-bindings
+                  --target linux-x64-rpc-console
+                  --target linux-x64-shell-ipv6only
+                  --target linux-x64-thermostat-ipv6only
+                  --target linux-x64-tv-app-ipv6only
+                  --target linux-x64-tv-casting-app-ipv6only
+                  --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap
           - EFR32

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -119,6 +119,7 @@ steps:
                   --target linux-x64-thermostat-ipv6only
                   --target linux-x64-tv-app-ipv6only
                   --target linux-x64-tv-casting-app-ipv6only
+                  build
                   --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap


### PR DESCRIPTION
Cloudbuild uses a glob for smoketest, however after recent target additons this seems to take more than 2.5h on a 32core to compile.

This seems to be due to variant explosion: on linux we would compile 84 different variants, esp32 also has some quite redundant versions (rpc, ipv6, nodeps combinations).

This change explicitly picks the targets to compile: still a somewhat long list, but at least a 50% reduction for linux which should save 30min to 1h or compile time.
