### PR TITLE
Fix indent on cloudbuild to consider input as a single argument

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -28,14 +28,12 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
-              ./scripts/build/build_examples.py
-              --enable-flashbundle
-              --target esp32-m5stack-all-clusters-ipv6only
-              --target esp32-m5stack-all-clusters-minimal-rpc-ipv6only
-              --target esp32-m5stack-all-clusters-rpc
-              --target esp32-m5stack-ota-requestor
-              build
-              --create-archives /workspace/artifacts/
+              ./scripts/build/build_examples.py --enable-flashbundle --target
+              esp32-m5stack-all-clusters-ipv6only --target
+              esp32-m5stack-all-clusters-minimal-rpc-ipv6only --target
+              esp32-m5stack-all-clusters-rpc --target
+              esp32-m5stack-ota-requestor build --create-archives
+              /workspace/artifacts/
       waitFor:
           - Bootstrap
       entrypoint: ./scripts/run_in_build_env.sh
@@ -83,45 +81,37 @@ steps:
           - PW_ENVIRONMENT_ROOT=/pwenv
       args:
           - >-
-              ./scripts/build/build_examples.py
-              --enable-flashbundle
-              --target linux-arm64-clang-all-clusters
-              --target linux-arm64-clang-all-clusters-app-nodeps-ipv6only
-              --target linux-arm64-clang-all-clusters-minimal-ipv6only
-              --target linux-arm64-clang-bridge-ipv6only
-              --target linux-arm64-clang-chip-tool-ipv6only
-              --target linux-arm64-clang-chip-tool-nodeps-ipv6only
-              --target linux-arm64-clang-dynamic-bridge-ipv6only
-              --target linux-arm64-clang-light-rpc-ipv6only
-              --target linux-arm64-clang-lock-ipv6only
-              --target linux-arm64-clang-minmdns
-              --target linux-arm64-clang-ota-provider-nodeps-ipv6only
-              --target linux-arm64-clang-ota-requestor-nodeps-ipv6only
-              --target linux-arm64-clang-python-bindings
-              --target linux-arm64-clang-shell-ipv6only
-              --target linux-arm64-clang-thermostat-ipv6only
-              --target linux-arm64-clang-tv-app-ipv6only
-              --target linux-arm64-clang-tv-casting-app-ipv6only
-              --target linux-x64-address-resolve-tool
-              --target linux-x64-all-clusters-app-nodeps-ipv6only
-              --target linux-x64-all-clusters-coverage
-              --target linux-x64-bridge-ipv6only
-              --target linux-x64-chip-cert
-              --target linux-x64-chip-tool-ipv6only
-              --target linux-x64-dynamic-bridge-ipv6only
-              --target linux-x64-light-rpc-ipv6only
-              --target linux-x64-lock-ipv6only
-              --target linux-x64-minmdns-ipv6only
-              --target linux-x64-ota-provider-ipv6only
-              --target linux-x64-ota-requestor-ipv6only
-              --target linux-x64-python-bindings
-              --target linux-x64-rpc-console
-              --target linux-x64-shell-ipv6only
-              --target linux-x64-thermostat-ipv6only
-              --target linux-x64-tv-app-ipv6only
-              --target linux-x64-tv-casting-app-ipv6only
-              build
-              --create-archives /workspace/artifacts/
+              ./scripts/build/build_examples.py --enable-flashbundle --target
+              linux-arm64-clang-all-clusters --target
+              linux-arm64-clang-all-clusters-app-nodeps-ipv6only --target
+              linux-arm64-clang-all-clusters-minimal-ipv6only --target
+              linux-arm64-clang-bridge-ipv6only --target
+              linux-arm64-clang-chip-tool-ipv6only --target
+              linux-arm64-clang-chip-tool-nodeps-ipv6only --target
+              linux-arm64-clang-dynamic-bridge-ipv6only --target
+              linux-arm64-clang-light-rpc-ipv6only --target
+              linux-arm64-clang-lock-ipv6only --target linux-arm64-clang-minmdns
+              --target linux-arm64-clang-ota-provider-nodeps-ipv6only --target
+              linux-arm64-clang-ota-requestor-nodeps-ipv6only --target
+              linux-arm64-clang-python-bindings --target
+              linux-arm64-clang-shell-ipv6only --target
+              linux-arm64-clang-thermostat-ipv6only --target
+              linux-arm64-clang-tv-app-ipv6only --target
+              linux-arm64-clang-tv-casting-app-ipv6only --target
+              linux-x64-address-resolve-tool --target
+              linux-x64-all-clusters-app-nodeps-ipv6only --target
+              linux-x64-all-clusters-coverage --target linux-x64-bridge-ipv6only
+              --target linux-x64-chip-cert --target linux-x64-chip-tool-ipv6only
+              --target linux-x64-dynamic-bridge-ipv6only --target
+              linux-x64-light-rpc-ipv6only --target linux-x64-lock-ipv6only
+              --target linux-x64-minmdns-ipv6only --target
+              linux-x64-ota-provider-ipv6only --target
+              linux-x64-ota-requestor-ipv6only --target
+              linux-x64-python-bindings --target linux-x64-rpc-console --target
+              linux-x64-shell-ipv6only --target linux-x64-thermostat-ipv6only
+              --target linux-x64-tv-app-ipv6only --target
+              linux-x64-tv-casting-app-ipv6only build --create-archives
+              /workspace/artifacts/
       waitFor:
           - Bootstrap
           - EFR32

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -1,11 +1,11 @@
 steps:
     - name: "connectedhomeip/chip-build-vscode:0.6.02"
-      entrypoint: 'bash'
+      entrypoint: "bash"
       args:
-          - '-c'
+          - "-c"
           - |
-            git config --global --add safe.directory "*"
-            git submodule update --init --recursive
+              git config --global --add safe.directory "*"
+              git submodule update --init --recursive
       id: Submodules
     - name: "connectedhomeip/chip-build-vscode:0.6.02"
       env:
@@ -29,13 +29,13 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py
-                 --enable-flashbundle
-                 --target esp32-m5stack-all-clusters-ipv6only
-                 --target esp32-m5stack-all-clusters-minimal-rpc-ipv6only
-                 --target esp32-m5stack-all-clusters-rpc
-                 --target esp32-m5stack-ota-requestor
-                 build
-                 --create-archives /workspace/artifacts/
+              --enable-flashbundle
+              --target esp32-m5stack-all-clusters-ipv6only
+              --target esp32-m5stack-all-clusters-minimal-rpc-ipv6only
+              --target esp32-m5stack-all-clusters-rpc
+              --target esp32-m5stack-ota-requestor
+              build
+              --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap
       entrypoint: ./scripts/run_in_build_env.sh
@@ -84,44 +84,44 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py
-                  --enable-flashbundle
-                  --target linux-arm64-clang-all-clusters
-                  --target linux-arm64-clang-all-clusters-app-nodeps-ipv6only
-                  --target linux-arm64-clang-all-clusters-minimal-ipv6only
-                  --target linux-arm64-clang-bridge-ipv6only
-                  --target linux-arm64-clang-chip-tool-ipv6only
-                  --target linux-arm64-clang-chip-tool-nodeps-ipv6only
-                  --target linux-arm64-clang-dynamic-bridge-ipv6only
-                  --target linux-arm64-clang-light-rpc-ipv6only
-                  --target linux-arm64-clang-lock-ipv6only
-                  --target linux-arm64-clang-minmdns
-                  --target linux-arm64-clang-ota-provider-nodeps-ipv6only
-                  --target linux-arm64-clang-ota-requestor-nodeps-ipv6only
-                  --target linux-arm64-clang-python-bindings
-                  --target linux-arm64-clang-shell-ipv6only
-                  --target linux-arm64-clang-thermostat-ipv6only
-                  --target linux-arm64-clang-tv-app-ipv6only
-                  --target linux-arm64-clang-tv-casting-app-ipv6only
-                  --target linux-x64-address-resolve-tool
-                  --target linux-x64-all-clusters-app-nodeps-ipv6only
-                  --target linux-x64-all-clusters-coverage
-                  --target linux-x64-bridge-ipv6only
-                  --target linux-x64-chip-cert
-                  --target linux-x64-chip-tool-ipv6only
-                  --target linux-x64-dynamic-bridge-ipv6only
-                  --target linux-x64-light-rpc-ipv6only
-                  --target linux-x64-lock-ipv6only
-                  --target linux-x64-minmdns-ipv6only
-                  --target linux-x64-ota-provider-ipv6only
-                  --target linux-x64-ota-requestor-ipv6only
-                  --target linux-x64-python-bindings
-                  --target linux-x64-rpc-console
-                  --target linux-x64-shell-ipv6only
-                  --target linux-x64-thermostat-ipv6only
-                  --target linux-x64-tv-app-ipv6only
-                  --target linux-x64-tv-casting-app-ipv6only
-                  build
-                  --create-archives /workspace/artifacts/
+              --enable-flashbundle
+              --target linux-arm64-clang-all-clusters
+              --target linux-arm64-clang-all-clusters-app-nodeps-ipv6only
+              --target linux-arm64-clang-all-clusters-minimal-ipv6only
+              --target linux-arm64-clang-bridge-ipv6only
+              --target linux-arm64-clang-chip-tool-ipv6only
+              --target linux-arm64-clang-chip-tool-nodeps-ipv6only
+              --target linux-arm64-clang-dynamic-bridge-ipv6only
+              --target linux-arm64-clang-light-rpc-ipv6only
+              --target linux-arm64-clang-lock-ipv6only
+              --target linux-arm64-clang-minmdns
+              --target linux-arm64-clang-ota-provider-nodeps-ipv6only
+              --target linux-arm64-clang-ota-requestor-nodeps-ipv6only
+              --target linux-arm64-clang-python-bindings
+              --target linux-arm64-clang-shell-ipv6only
+              --target linux-arm64-clang-thermostat-ipv6only
+              --target linux-arm64-clang-tv-app-ipv6only
+              --target linux-arm64-clang-tv-casting-app-ipv6only
+              --target linux-x64-address-resolve-tool
+              --target linux-x64-all-clusters-app-nodeps-ipv6only
+              --target linux-x64-all-clusters-coverage
+              --target linux-x64-bridge-ipv6only
+              --target linux-x64-chip-cert
+              --target linux-x64-chip-tool-ipv6only
+              --target linux-x64-dynamic-bridge-ipv6only
+              --target linux-x64-light-rpc-ipv6only
+              --target linux-x64-lock-ipv6only
+              --target linux-x64-minmdns-ipv6only
+              --target linux-x64-ota-provider-ipv6only
+              --target linux-x64-ota-requestor-ipv6only
+              --target linux-x64-python-bindings
+              --target linux-x64-rpc-console
+              --target linux-x64-shell-ipv6only
+              --target linux-x64-thermostat-ipv6only
+              --target linux-x64-tv-app-ipv6only
+              --target linux-x64-tv-casting-app-ipv6only
+              build
+              --create-archives /workspace/artifacts/
       waitFor:
           - Bootstrap
           - EFR32


### PR DESCRIPTION
It seems that indenting yaml after `- >-` in cloudbuild makes the arguments for the build instruction not work as expected.

Updated indent so that compilation works.