### PR TITLE
[tinycrypt] bugfix: Missing return on success

### DIFF
--- a/src/crypto/CHIPCryptoPALTinyCrypt.cpp
+++ b/src/crypto/CHIPCryptoPALTinyCrypt.cpp
@@ -1604,6 +1604,7 @@ CHIP_ERROR ExtractKIDFromX509Cert(bool extractSKID, const ByteSpan & certificate
             {
                 kid.reduce_size(len);
             }
+            ExitNow(error = CHIP_NO_ERROR);
             break;
         }
         p += len;


### PR DESCRIPTION
fixes typo in the #22943

similar to #23033 fix