### PR TITLE
Removing static intializers

### DIFF
--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -112,7 +112,7 @@ public:
 
         Entry() = default;
 
-        Entry(Entry && other) : mDelegate(other.mDelegate) { other.mDelegate = &mDefaultDelegate; }
+        Entry(Entry && other) : mDelegate(other.mDelegate) { other.mDelegate = Entry::_GetDefaultDelegate(); }
 
         Entry & operator=(Entry && other)
         {
@@ -120,7 +120,7 @@ public:
             {
                 mDelegate->Release();
                 mDelegate       = other.mDelegate;
-                other.mDelegate = &mDefaultDelegate;
+                other.mDelegate = Entry::_GetDefaultDelegate();
             }
             return *this;
         }
@@ -216,7 +216,7 @@ public:
          */
         CHIP_ERROR RemoveTarget(size_t index) { return mDelegate->RemoveTarget(index); }
 
-        bool HasDefaultDelegate() const { return mDelegate == &mDefaultDelegate; }
+        bool HasDefaultDelegate() const { return mDelegate == Entry::_GetDefaultDelegate(); }
 
         const Delegate & GetDelegate() const { return *mDelegate; }
 
@@ -231,12 +231,12 @@ public:
         void ResetDelegate()
         {
             mDelegate->Release();
-            mDelegate = &mDefaultDelegate;
+            mDelegate = Entry::_GetDefaultDelegate();
         }
 
     private:
-        static Delegate mDefaultDelegate;
-        Delegate * mDelegate = &mDefaultDelegate;
+        static Delegate * _GetDefaultDelegate(void);
+        Delegate * mDelegate = Entry::_GetDefaultDelegate();
     };
 
     /**
@@ -284,12 +284,12 @@ public:
         void ResetDelegate()
         {
             mDelegate->Release();
-            mDelegate = &mDefaultDelegate;
+            mDelegate = EntryIterator::_GetDefaultDelegate();
         }
 
     private:
-        static Delegate mDefaultDelegate;
-        Delegate * mDelegate = &mDefaultDelegate;
+        static Delegate * _GetDefaultDelegate(void);
+        Delegate * mDelegate = EntryIterator::_GetDefaultDelegate();
     };
 
     /**

--- a/src/app/EventManagement.cpp
+++ b/src/app/EventManagement.cpp
@@ -31,9 +31,17 @@
 
 using namespace chip::TLV;
 
+namespace {
+
+chip::app::EventManagement & sGetInstance() {
+    static auto *instance = new chip::app::EventManagement{};
+    return *instance;
+}
+
+} // namespace
+
 namespace chip {
 namespace app {
-static EventManagement sInstance;
 
 /**
  * @brief
@@ -60,7 +68,7 @@ public:
 
 EventManagement & EventManagement::GetInstance(void)
 {
-    return sInstance;
+    return sGetInstance();
 }
 
 struct ReclaimEventCtx
@@ -330,7 +338,7 @@ void EventManagement::CreateEventManagement(Messaging::ExchangeManager * apExcha
                                             MonotonicallyIncreasingCounter<EventNumber> * apEventNumberCounter)
 {
 
-    sInstance.Init(apExchangeManager, aNumBuffers, apCircularEventBuffer, apLogStorageResources, apEventNumberCounter);
+    sGetInstance().Init(apExchangeManager, aNumBuffers, apCircularEventBuffer, apLogStorageResources, apEventNumberCounter);
 }
 
 /**
@@ -338,9 +346,10 @@ void EventManagement::CreateEventManagement(Messaging::ExchangeManager * apExcha
  */
 void EventManagement::DestroyEventManagement()
 {
-    sInstance.mState        = EventManagementStates::Shutdown;
-    sInstance.mpEventBuffer = nullptr;
-    sInstance.mpExchangeMgr = nullptr;
+    auto & instance = sGetInstance();
+    instance.mState        = EventManagementStates::Shutdown;
+    instance.mpEventBuffer = nullptr;
+    instance.mpExchangeMgr = nullptr;
 }
 
 CircularEventBuffer * EventManagement::GetPriorityBuffer(PriorityLevel aPriority) const

--- a/src/app/InteractionModelEngine.cpp
+++ b/src/app/InteractionModelEngine.cpp
@@ -35,18 +35,26 @@
 
 extern bool emberAfContainsAttribute(chip::EndpointId endpoint, chip::ClusterId clusterId, chip::AttributeId attributeId);
 
+namespace {
+
+chip::app::InteractionModelEngine * sGetInteractionModelEngine()
+{
+    static auto * modelEngine = new chip::app::InteractionModelEngine{};
+    return modelEngine;
+}
+
+} // namespace
+
 namespace chip {
 namespace app {
 
 using Protocols::InteractionModel::Status;
 
-InteractionModelEngine sInteractionModelEngine;
-
 InteractionModelEngine::InteractionModelEngine() {}
 
 InteractionModelEngine * InteractionModelEngine::GetInstance()
 {
-    return &sInteractionModelEngine;
+    return sGetInteractionModelEngine();
 }
 
 CHIP_ERROR InteractionModelEngine::Init(Messaging::ExchangeManager * apExchangeMgr, FabricTable * apFabricTable,

--- a/src/controller/CHIPDeviceControllerFactory.cpp
+++ b/src/controller/CHIPDeviceControllerFactory.cpp
@@ -45,6 +45,13 @@ using namespace chip::Credentials;
 namespace chip {
 namespace Controller {
 
+DeviceControllerFactory & DeviceControllerFactory::GetInstance()
+{
+    static DeviceControllerFactory* instance = new DeviceControllerFactory{};
+    return *instance;
+}
+
+
 CHIP_ERROR DeviceControllerFactory::Init(FactoryInitParams params)
 {
 

--- a/src/controller/CHIPDeviceControllerFactory.h
+++ b/src/controller/CHIPDeviceControllerFactory.h
@@ -128,11 +128,7 @@ struct FactoryInitParams
 class DeviceControllerFactory
 {
 public:
-    static DeviceControllerFactory & GetInstance()
-    {
-        static DeviceControllerFactory instance;
-        return instance;
-    }
+    static DeviceControllerFactory & GetInstance();
 
     CHIP_ERROR Init(FactoryInitParams params);
 

--- a/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DefaultDeviceAttestationVerifier.cpp
@@ -46,10 +46,15 @@ namespace {
 // As per specifications section 11.22.5.1. Constant RESP_MAX
 constexpr size_t kMaxResponseLength = 900;
 
-static const ByteSpan kTestPaaRoots[] = {
-    TestCerts::sTestCert_PAA_FFF1_Cert,
-    TestCerts::sTestCert_PAA_NoVID_Cert,
-};
+
+std::array<ByteSpan, 2> const& sGetTestPaaRoots()
+{
+    static auto const* paaRoots = new std::array<ByteSpan, 2>{
+        TestCerts::sTestCert_PAA_FFF1_Cert,
+        TestCerts::sTestCert_PAA_NoVID_Cert,
+    };
+    return *paaRoots;
+}
 
 // Test CD Signing Key from `credentials/test/certification-declaration/Chip-Test-CD-Signing-Cert.pem`
 // used to verify any in-SDK development CDs. The associated keypair to do actual signing is in
@@ -390,7 +395,7 @@ void DefaultDACVerifier::VerifyAttestationInformation(const DeviceAttestationVer
 
         if (err == CHIP_ERROR_NOT_IMPLEMENTED)
         {
-            VerifyOrExit(kTestAttestationTrustStore.GetProductAttestationAuthorityCert(akid, paaDerBuffer) == CHIP_NO_ERROR,
+            VerifyOrExit(sGetTestAttestationTrustStore().GetProductAttestationAuthorityCert(akid, paaDerBuffer) == CHIP_NO_ERROR,
                          attestationError = AttestationVerificationResult::kPaaNotFound);
         }
 
@@ -671,14 +676,14 @@ CHIP_ERROR CsaCdKeysTrustStore::LookupVerifyingKey(const ByteSpan & kid, Crypto:
 
 const AttestationTrustStore * GetTestAttestationTrustStore()
 {
-    return &kTestAttestationTrustStore;
+    return &sGetTestAttestationTrustStore();
 }
 
 DeviceAttestationVerifier * GetDefaultDACVerifier(const AttestationTrustStore * paaRootStore)
 {
-    static DefaultDACVerifier defaultDACVerifier{ paaRootStore };
+    static auto *defaultDACVerifier = new DefaultDACVerifier{ paaRootStore };
 
-    return &defaultDACVerifier;
+    return defaultDACVerifier;
 }
 
 } // namespace Credentials

--- a/src/credentials/attestation_verifier/DeviceAttestationVerifier.cpp
+++ b/src/credentials/attestation_verifier/DeviceAttestationVerifier.cpp
@@ -73,9 +73,18 @@ public:
 
 // Default to avoid nullptr on getter and cleanly handle new products/clients before
 // they provide their own.
-UnimplementedDACVerifier gDefaultDACVerifier;
+UnimplementedDACVerifier * sGetDefaultDACVerifier()
+{
+    static auto* verifier = new UnimplementedDACVerifier{};
+    return verifier;
+}
 
-DeviceAttestationVerifier * gDacVerifier = &gDefaultDACVerifier;
+
+DeviceAttestationVerifier ** sGetDeviceAttestationVerifierPtr()
+{
+    static DeviceAttestationVerifier *verifier = sGetDefaultDACVerifier();
+    return &verifier;
+}
 
 } // namespace
 
@@ -100,7 +109,7 @@ CHIP_ERROR DeviceAttestationVerifier::ValidateAttestationSignature(const P256Pub
 
 DeviceAttestationVerifier * GetDeviceAttestationVerifier()
 {
-    return gDacVerifier;
+    return *sGetDeviceAttestationVerifierPtr();;
 }
 
 void SetDeviceAttestationVerifier(DeviceAttestationVerifier * verifier)
@@ -110,7 +119,8 @@ void SetDeviceAttestationVerifier(DeviceAttestationVerifier * verifier)
         return;
     }
 
-    gDacVerifier = verifier;
+    auto **ptr = sGetDeviceAttestationVerifierPtr();
+    *ptr = verifier;
 }
 
 static inline Platform::ScopedMemoryBufferWithSize<uint8_t> CopyByteSpanHelper(const ByteSpan & span_to_copy)

--- a/src/darwin/Framework/CHIP/MTRControllerAccessControl.mm
+++ b/src/darwin/Framework/CHIP/MTRControllerAccessControl.mm
@@ -39,7 +39,7 @@ public:
     {
         return app::IsDeviceTypeOnEndpoint(deviceType, endpoint);
     }
-} gDeviceTypeResolver;
+};
 
 // TODO: Make the policy more configurable by consumers.
 class AccessControlDelegate : public Access::AccessControl::Delegate {
@@ -68,7 +68,16 @@ class AccessControlDelegate : public Access::AccessControl::Delegate {
     }
 };
 
-AccessControlDelegate gDelegate;
+DeviceTypeResolver& sGetDeviceTypeResolver() {
+    static DeviceTypeResolver* resolver = new DeviceTypeResolver{};
+    return *resolver;
+}
+
+AccessControlDelegate& sGetDelegate() {
+    static AccessControlDelegate* delegate = new AccessControlDelegate{};
+    return *delegate;
+}
+
 } // anonymous namespace
 
 @implementation MTRControllerAccessControl
@@ -77,7 +86,7 @@ AccessControlDelegate gDelegate;
 {
     static dispatch_once_t onceToken;
     dispatch_once(&onceToken, ^{
-        GetAccessControl().Init(&gDelegate, gDeviceTypeResolver);
+        GetAccessControl().Init(&sGetDelegate(), sGetDeviceTypeResolver());
     });
 }
 

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -54,7 +54,11 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-static Optional<System::Clock::Seconds32> sFirmwareBuildChipEpochTime;
+static Optional<System::Clock::Seconds32> & sGetFirmwareBuildChipEpochTime()
+{
+    static auto *epochTime = new Optional<System::Clock::Seconds32>{};
+    return *epochTime;
+}
 
 #if CHIP_USE_TRANSITIONAL_COMMISSIONABLE_DATA_PROVIDER
 
@@ -277,9 +281,9 @@ template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetFirmwareBuildChipEpochTime(System::Clock::Seconds32 & chipEpochTime)
 {
     // If the setter was called and we have a value in memory, return this.
-    if (sFirmwareBuildChipEpochTime.HasValue())
+    if (sGetFirmwareBuildChipEpochTime().HasValue())
     {
-        chipEpochTime = sFirmwareBuildChipEpochTime.Value();
+        chipEpochTime = sGetFirmwareBuildChipEpochTime().Value();
         return CHIP_NO_ERROR;
     }
     // Else, attempt to read the hard-coded values.
@@ -306,7 +310,7 @@ CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::SetFirmwareBuildChipEpo
     //
     // Implementations that can't use the hard-coded time for whatever reason
     // should set this at each init.
-    sFirmwareBuildChipEpochTime.SetValue(chipEpochTime);
+    sGetFirmwareBuildChipEpochTime().SetValue(chipEpochTime);
     return CHIP_NO_ERROR;
 }
 

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -349,7 +349,11 @@ CHIP_ERROR AddTxtRecord(TxtFieldKey key, TextEntry * entries, size_t & entriesCo
 
 } // namespace
 
-DiscoveryImplPlatform DiscoveryImplPlatform::sManager;
+DiscoveryImplPlatform & DiscoveryImplPlatform::_GetManager()
+{
+    static auto * manager = new DiscoveryImplPlatform{};
+    return *manager;
+}
 
 DiscoveryImplPlatform::DiscoveryImplPlatform() = default;
 
@@ -640,7 +644,7 @@ CHIP_ERROR DiscoveryImplPlatform::StopDiscovery()
 
 DiscoveryImplPlatform & DiscoveryImplPlatform::GetInstance()
 {
-    return sManager;
+    return DiscoveryImplPlatform::_GetManager();
 }
 
 ServiceAdvertiser & chip::Dnssd::ServiceAdvertiser::Instance()

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -93,7 +93,7 @@ private:
 
     ResolverProxy mResolverProxy;
 
-    static DiscoveryImplPlatform sManager;
+    static DiscoveryImplPlatform & _GetManager();
 };
 
 } // namespace Dnssd

--- a/src/messaging/ApplicationExchangeDispatch.cpp
+++ b/src/messaging/ApplicationExchangeDispatch.cpp
@@ -26,6 +26,13 @@
 namespace chip {
 namespace Messaging {
 
+ExchangeMessageDispatch & ApplicationExchangeDispatch::Instance()
+{
+    static ApplicationExchangeDispatch *instance = new ApplicationExchangeDispatch{};
+    return *instance;
+}
+
+
 bool ApplicationExchangeDispatch::MessagePermitted(Protocols::Id protocol, uint8_t type)
 {
     // TODO: Change this check to only include the protocol and message types that are allowed

--- a/src/messaging/ApplicationExchangeDispatch.h
+++ b/src/messaging/ApplicationExchangeDispatch.h
@@ -33,11 +33,7 @@ namespace Messaging {
 class ApplicationExchangeDispatch : public ExchangeMessageDispatch
 {
 public:
-    static ExchangeMessageDispatch & Instance()
-    {
-        static ApplicationExchangeDispatch instance;
-        return instance;
-    }
+    static ExchangeMessageDispatch & Instance();
 
     ApplicationExchangeDispatch() {}
     ~ApplicationExchangeDispatch() override {}

--- a/src/messaging/EphemeralExchangeDispatch.h
+++ b/src/messaging/EphemeralExchangeDispatch.h
@@ -27,8 +27,8 @@ class EphemeralExchangeDispatch : public ExchangeMessageDispatch
 public:
     static ExchangeMessageDispatch & Instance()
     {
-        static EphemeralExchangeDispatch instance;
-        return instance;
+        static EphemeralExchangeDispatch* instance = new EphemeralExchangeDispatch{};
+        return *instance;
     }
 
     EphemeralExchangeDispatch() {}

--- a/src/platform/Ameba/SystemTimeSupport.cpp
+++ b/src/platform/Ameba/SystemTimeSupport.cpp
@@ -47,7 +47,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)

--- a/src/platform/Beken/SystemTimeSupport.cpp
+++ b/src/platform/Beken/SystemTimeSupport.cpp
@@ -31,7 +31,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 Clock::Milliseconds64 baseTime;

--- a/src/platform/Darwin/BLEManagerImpl.cpp
+++ b/src/platform/Darwin/BLEManagerImpl.cpp
@@ -40,7 +40,12 @@ namespace chip {
 namespace DeviceLayer {
 namespace Internal {
 
-BLEManagerImpl BLEManagerImpl::sInstance;
+BLEManagerImpl & BLEManagerImpl::_GetInstance(void)
+{
+    static auto *instance = new BLEManagerImpl{};
+    return *instance;
+}
+
 
 CHIP_ERROR BLEManagerImpl::_Init()
 {

--- a/src/platform/Darwin/BLEManagerImpl.h
+++ b/src/platform/Darwin/BLEManagerImpl.h
@@ -63,7 +63,7 @@ private:
     friend BLEManager & BLEMgr(void);
     friend BLEManagerImpl & BLEMgrImpl(void);
 
-    static BLEManagerImpl sInstance;
+    static BLEManagerImpl & _GetInstance(void);
 
     BleConnectionDelegate * mConnectionDelegate   = nullptr;
     BlePlatformDelegate * mPlatformDelegate       = nullptr;
@@ -78,7 +78,7 @@ private:
  */
 inline BLEManager & BLEMgr(void)
 {
-    return BLEManagerImpl::sInstance;
+    return BLEManagerImpl::_GetInstance();
 }
 
 /**
@@ -89,7 +89,7 @@ inline BLEManager & BLEMgr(void)
  */
 inline BLEManagerImpl & BLEMgrImpl(void)
 {
-    return BLEManagerImpl::sInstance;
+    return BLEManagerImpl::_GetInstance();
 }
 
 } // namespace Internal

--- a/src/platform/Darwin/DnssdImpl.cpp
+++ b/src/platform/Darwin/DnssdImpl.cpp
@@ -163,7 +163,11 @@ private:
 namespace chip {
 namespace Dnssd {
 
-MdnsContexts MdnsContexts::sInstance;
+MdnsContexts & MdnsContexts::_GetInstance(void)
+{
+    static auto * instance = new MdnsContexts{};
+    return *instance;
+}
 
 namespace {
 

--- a/src/platform/Darwin/DnssdImpl.h
+++ b/src/platform/Darwin/DnssdImpl.h
@@ -57,7 +57,7 @@ public:
     MdnsContexts(const MdnsContexts &) = delete;
     MdnsContexts & operator=(const MdnsContexts &) = delete;
     ~MdnsContexts();
-    static MdnsContexts & GetInstance() { return sInstance; }
+    static MdnsContexts & GetInstance() { return MdnsContexts::_GetInstance(); }
 
     CHIP_ERROR Add(GenericContext * context, DNSServiceRef sdRef);
     CHIP_ERROR Remove(GenericContext * context);
@@ -85,7 +85,7 @@ public:
 
 private:
     MdnsContexts(){};
-    static MdnsContexts sInstance;
+    static MdnsContexts & _GetInstance(void);
 
     std::vector<GenericContext *> mContexts;
 };

--- a/src/platform/Darwin/PlatformManagerImpl.cpp
+++ b/src/platform/Darwin/PlatformManagerImpl.cpp
@@ -40,7 +40,11 @@
 namespace chip {
 namespace DeviceLayer {
 
-PlatformManagerImpl PlatformManagerImpl::sInstance;
+PlatformManagerImpl& PlatformManagerImpl::_GetInstance()
+{
+    static auto* instance = new PlatformManagerImpl{};
+    return *instance;
+}
 
 CHIP_ERROR PlatformManagerImpl::_InitChipStack()
 {

--- a/src/platform/Darwin/PlatformManagerImpl.h
+++ b/src/platform/Darwin/PlatformManagerImpl.h
@@ -81,7 +81,7 @@ private:
     friend PlatformManagerImpl & PlatformMgrImpl(void);
     friend class Internal::BLEManagerImpl;
 
-    static PlatformManagerImpl sInstance;
+    static PlatformManagerImpl& _GetInstance();
 
     System::Clock::Timestamp mStartTime = System::Clock::kZero;
 
@@ -106,7 +106,7 @@ private:
  */
 inline PlatformManager & PlatformMgr(void)
 {
-    return PlatformManagerImpl::sInstance;
+    return PlatformManagerImpl::_GetInstance();
 }
 
 /**
@@ -117,7 +117,7 @@ inline PlatformManager & PlatformMgr(void)
  */
 inline PlatformManagerImpl & PlatformMgrImpl(void)
 {
-    return PlatformManagerImpl::sInstance;
+    return PlatformManagerImpl::_GetInstance();
 }
 
 } // namespace DeviceLayer

--- a/src/platform/Darwin/SystemTimeSupport.cpp
+++ b/src/platform/Darwin/SystemTimeSupport.cpp
@@ -38,7 +38,13 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    static auto * clockImpl = new ClockImpl{};
+    return *clockImpl;
+}
+
 } // namespace Internal
 
 Microseconds64 ClockImpl::GetMonotonicMicroseconds64()

--- a/src/platform/ESP32/SystemTimeSupport.cpp
+++ b/src/platform/ESP32/SystemTimeSupport.cpp
@@ -35,7 +35,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)

--- a/src/platform/FreeRTOS/SystemTimeSupport.cpp
+++ b/src/platform/FreeRTOS/SystemTimeSupport.cpp
@@ -34,7 +34,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 namespace {

--- a/src/platform/Infineon/CYW30739/SystemTimeSupport.cpp
+++ b/src/platform/Infineon/CYW30739/SystemTimeSupport.cpp
@@ -33,7 +33,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 Clock::Microseconds64 ClockImpl::GetMonotonicMicroseconds64(void)

--- a/src/platform/Linux/SystemTimeSupport.cpp
+++ b/src/platform/Linux/SystemTimeSupport.cpp
@@ -37,7 +37,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 Microseconds64 ClockImpl::GetMonotonicMicroseconds64()

--- a/src/platform/Tizen/SystemTimeSupport.cpp
+++ b/src/platform/Tizen/SystemTimeSupport.cpp
@@ -38,7 +38,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 Microseconds64 ClockImpl::GetMonotonicMicroseconds64()

--- a/src/platform/Zephyr/SystemTimeSupport.cpp
+++ b/src/platform/Zephyr/SystemTimeSupport.cpp
@@ -36,7 +36,12 @@ namespace Clock {
 
 namespace Internal {
 
-ClockImpl gClockImpl;
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
 
 } // namespace Internal
 

--- a/src/platform/mbed/SystemTimeSupport.cpp
+++ b/src/platform/mbed/SystemTimeSupport.cpp
@@ -40,7 +40,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 namespace {

--- a/src/platform/webos/SystemTimeSupport.cpp
+++ b/src/platform/webos/SystemTimeSupport.cpp
@@ -37,7 +37,14 @@ namespace System {
 namespace Clock {
 
 namespace Internal {
-ClockImpl gClockImpl;
+
+static ClockImpl gClockImpl;
+
+ClockImpl & GetClockImpl()
+{
+    return gClockImpl;
+}
+
 } // namespace Internal
 
 Microseconds64 ClockImpl::GetMonotonicMicroseconds64()

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.cpp
@@ -28,6 +28,14 @@ namespace chip {
 
 using namespace Messaging;
 
+ExchangeMessageDispatch & SessionEstablishmentExchangeDispatch::Instance()
+{
+    static SessionEstablishmentExchangeDispatch* instance = new SessionEstablishmentExchangeDispatch{};
+    return *instance;
+}
+
+
+
 bool SessionEstablishmentExchangeDispatch::MessagePermitted(Protocols::Id protocol, uint8_t type)
 {
     if (protocol == Protocols::SecureChannel::Id)

--- a/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
+++ b/src/protocols/secure_channel/SessionEstablishmentExchangeDispatch.h
@@ -31,11 +31,7 @@ namespace chip {
 class SessionEstablishmentExchangeDispatch : public Messaging::ExchangeMessageDispatch
 {
 public:
-    static ExchangeMessageDispatch & Instance()
-    {
-        static SessionEstablishmentExchangeDispatch instance;
-        return instance;
-    }
+    static ExchangeMessageDispatch & Instance();
 
     SessionEstablishmentExchangeDispatch() {}
     ~SessionEstablishmentExchangeDispatch() override {}

--- a/src/system/SystemClock.cpp
+++ b/src/system/SystemClock.cpp
@@ -52,12 +52,20 @@ namespace Clock {
 namespace Internal {
 
 #if CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME
-extern ClockImpl gClockImpl;
+extern ClockImpl & GetClockImpl();
 #else  // CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME
-ClockImpl gClockImpl;
+ClockImpl & GetClockImpl()
+{
+    static auto * clockImpl = new ClockImpl{};
+    return *clockImpl;
+}
 #endif // CHIP_SYSTEM_CONFIG_PLATFORM_PROVIDES_TIME
 
-ClockBase * gClockBase = &gClockImpl;
+ClockBase ** GetClockBasePtr(void)
+{
+    static ClockBase * clockBase = &GetClockImpl();
+    return &clockBase;
+}
 
 } // namespace Internal
 

--- a/src/system/SystemClock.h
+++ b/src/system/SystemClock.h
@@ -296,11 +296,12 @@ public:
 namespace Internal {
 
 // This should only be used via SystemClock() below.
-extern ClockBase * gClockBase;
+ClockBase ** GetClockBasePtr(void);
 
 inline void SetSystemClockForTesting(Clock::ClockBase * clock)
 {
-    Clock::Internal::gClockBase = clock;
+    auto ** clockBasePtr = GetClockBasePtr();
+    *clockBasePtr = clock;
 }
 
 // Provide a mock implementation for use by unit tests.
@@ -344,7 +345,7 @@ void ToTimeval(Microseconds64 in, timeval & out);
 
 inline Clock::ClockBase & SystemClock()
 {
-    return *Clock::Internal::gClockBase;
+    return **Clock::Internal::GetClockBasePtr();
 }
 
 } // namespace System

--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -45,8 +45,15 @@
 #include <transport/SecureMessageCodec.h>
 #include <transport/TransportMgr.h>
 
-// Global object
-chip::Transport::GroupPeerTable mGroupPeerMsgCounter;
+namespace {
+
+chip::Transport::GroupPeerTable & sGetGroupPeerMsgCounter()
+{
+    static auto* table = new chip::Transport::GroupPeerTable{};
+    return *table;
+}
+
+} // namespace
 
 namespace chip {
 
@@ -135,7 +142,7 @@ void SessionManager::Shutdown()
  */
 void SessionManager::FabricRemoved(FabricIndex fabricIndex)
 {
-    mGroupPeerMsgCounter.FabricRemoved(fabricIndex);
+    sGetGroupPeerMsgCounter().FabricRemoved(fabricIndex);
 }
 
 CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, PayloadHeader & payloadHeader,
@@ -823,7 +830,7 @@ void SessionManager::SecureGroupMessageDispatch(const PacketHeader & packetHeade
     Transport::PeerMessageCounter * counter = nullptr;
 
     if (CHIP_NO_ERROR ==
-        mGroupPeerMsgCounter.FindOrAddPeer(groupContext.fabric_index, packetHeader.GetSourceNodeId().Value(),
+        sGetGroupPeerMsgCounter().FindOrAddPeer(groupContext.fabric_index, packetHeader.GetSourceNodeId().Value(),
                                            packetHeader.IsSecureSessionControlMsg(), counter))
     {
 


### PR DESCRIPTION
As matter is used on more platforms, and more apps, static initializers eat space in each process. 

We should move these to only allocate when used.