### PR TITLE
[privacy] Drop privacy enabled messages until support is implemented.

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -551,6 +551,12 @@ void SessionManager::OnMessageReceived(const PeerAddress & peerAddress, System::
         return;
     }
 
+    if (packetHeader.HasPrivacyFlag())
+    {
+        ChipLogError(Inet, "Received unsupported message with privacy flag set");
+        return;
+    }
+
     if (packetHeader.IsEncrypted())
     {
         if (packetHeader.IsGroupSession())


### PR DESCRIPTION
Given proper privacy parsing (#22783) is taking awhile to pass review and merge, this PR will drop any privacy enabled messages.

This PR is not needed if proper privacy parsing support as posted in #22783 is merged.
