### PR TITLE
Initial java controller cli hello world test

### DIFF
--- a/BUILD.gn
+++ b/BUILD.gn
@@ -213,6 +213,7 @@ if (current_toolchain != "${dir_pw_toolchain}/default:default") {
       deps += [
         "${chip_root}/src/app/server/java",
         "${chip_root}/src/controller/java",
+        "${chip_root}/src/controller/tests/java",
         "${chip_root}/src/platform/android:java",
         "${chip_root}/src/setup_payload/java",
       ]

--- a/src/controller/tests/java/BUILD.gn
+++ b/src/controller/tests/java/BUILD.gn
@@ -1,0 +1,43 @@
+# Copyright (c) 2020-2021 Project CHIP Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build_overrides/build.gni")
+import("//build_overrides/chip.gni")
+import("${build_root}/config/android_abi.gni")
+import("${chip_root}/build/chip/java/rules.gni")
+
+android_library("java") {
+  output_name = "ControllerCLI.jar"
+
+  deps = [
+    ":android",
+    "${chip_root}/src/controller/java:java",
+    "${chip_root}/src/setup_payload/java:java",
+    "${chip_root}/third_party/android_deps:annotation",
+  ]
+
+  data_deps = [
+    "${chip_root}/build/chip/java:shared_cpplib",
+  ]
+
+  sources = [
+    "${chip_root}/src/controller/tests/java/ControllerCLI.java",
+  ]
+
+  javac_flags = [ "-Xlint:deprecation" ]
+}
+
+java_prebuilt("android") {
+  jar_path = "${android_sdk_root}/platforms/android-21/android.jar"
+}

--- a/src/controller/tests/java/ControllerCLI.java
+++ b/src/controller/tests/java/ControllerCLI.java
@@ -1,0 +1,33 @@
+/*
+ *   Copyright (c) 2020-2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+package chip.devicecontroller;
+
+import android.util.Log;
+import androidx.annotation.Nullable;
+import chip.devicecontroller.GetConnectedDeviceCallbackJni.GetConnectedDeviceCallback;
+import chip.devicecontroller.model.ChipAttributePath;
+import chip.devicecontroller.model.ChipEventPath;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+class HelloWorld {
+  public static void main(String[] args) {
+      System.out.println("Hello, World!"); 
+  }
+}


### PR DESCRIPTION
Problems:
Need to create initial java controller e2e test

This PR adds the java controller hello world test program.

Test:
./scripts/run_in_build_env.sh                   "./scripts/build/build_examples.py --no-log-timestamps --target android-x86-chip-tool build"
java -cp ./out/android-x86-chip-tool/lib/src/controller/tests/java/ControllerCLI.jar chip.devicecontroller.HelloWorld

