### PR TITLE
Stop excluding MTRBaseClusters files from restyling.

### DIFF
--- a/.restyled.yaml
+++ b/.restyled.yaml
@@ -72,8 +72,6 @@ exclude:
     - "scripts/idl/tests/outputs/**/*" # Matches generated output 1:1
     - "examples/chef/sample_app_util/test_files/*.yaml"
     - "examples/chef/zzz_generated/**/*"
-    - "src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.mm" # https://github.com/project-chip/connectedhomeip/issues/20236
-    - "src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h" # https://github.com/project-chip/connectedhomeip/issues/20236
     - "examples/platform/nxp/k32w/k32w0/scripts/demo_generated_certs/**/*"
     - "integrations/cloudbuild/*.yaml" # uglier long command line content
 


### PR DESCRIPTION
It looks like the restyle job and the zap job agree on them now, as long as we avoid the failure case of an input on which running clang-format once produces different output from running clang-format twice.

Fixes https://github.com/project-chip/connectedhomeip/issues/20236

The clang-format failure case is tracked in https://github.com/llvm/llvm-project/issues/58202