### PR TITLE
[darwin] Use DNSServiceReconfirmRecord for A and AAAA records to miti…

### DIFF
--- a/src/controller/SetUpCodePairer.h
+++ b/src/controller/SetUpCodePairer.h
@@ -48,6 +48,17 @@ namespace Controller {
 
 class DeviceCommissioner;
 
+class SetUpCodePairerParameters : public RendezvousParameters
+{
+public:
+    SetUpCodePairerParameters(const Dnssd::CommonResolutionData & data);
+#if CONFIG_NETWORK_LAYER_BLE
+    SetUpCodePairerParameters(BLE_CONNECTION_OBJECT connObj);
+#endif // CONFIG_NETWORK_LAYER_BLE
+    char mHostName[Dnssd::kHostNameMaxLength + 1] = {};
+    Inet::InterfaceId mInterfaceId;
+};
+
 enum class SetupCodePairerBehaviour : uint8_t
 {
     kCommission,
@@ -180,7 +191,12 @@ private:
     // Queue of things we have discovered but not tried connecting to yet.  The
     // general discovery/pairing process will terminate once this queue is empty
     // and all the booleans in mWaitingForDiscovery are false.
-    std::queue<RendezvousParameters> mDiscoveredParameters;
+    std::queue<SetUpCodePairerParameters> mDiscoveredParameters;
+
+    // Current thing we are trying to connect to over UDP. If a PASE connection fails with
+    // a CHIP_ERROR_TIMEOUT, the discovered parameters will be used to ask the
+    // mdns daemon to invalidate the
+    Optional<SetUpCodePairerParameters> mCurrentPASEParameters;
 
     // mWaitingForPASE is true if we have called either
     // EstablishPASEConnection or PairDevice on mCommissioner and are now just

--- a/src/controller/tests/TestCommissionableNodeController.cpp
+++ b/src/controller/tests/TestCommissionableNodeController.cpp
@@ -43,6 +43,10 @@ public:
         return CHIP_ERROR_NOT_IMPLEMENTED;
     }
     CHIP_ERROR StopDiscovery() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
 
     CHIP_ERROR InitStatus                  = CHIP_NO_ERROR;
     CHIP_ERROR ResolveNodeIdStatus         = CHIP_NO_ERROR;

--- a/src/lib/dnssd/Discovery_ImplPlatform.cpp
+++ b/src/lib/dnssd/Discovery_ImplPlatform.cpp
@@ -641,6 +641,12 @@ CHIP_ERROR DiscoveryImplPlatform::StopDiscovery()
     return mResolverProxy.StopDiscovery();
 }
 
+CHIP_ERROR DiscoveryImplPlatform::ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId)
+{
+    ReturnErrorOnFailure(InitImpl());
+    return mResolverProxy.ReconfirmRecord(hostname, address, interfaceId);
+}
+
 DiscoveryImplPlatform & DiscoveryImplPlatform::GetInstance()
 {
     return sManager;
@@ -748,6 +754,11 @@ CHIP_ERROR ResolverProxy::StopDiscovery()
     CHIP_ERROR err = ChipDnssdStopBrowse(mDiscoveryContext.Value());
     mDiscoveryContext.ClearValue();
     return err;
+}
+
+CHIP_ERROR ResolverProxy::ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId)
+{
+    return ChipDnssdReconfirmRecord(hostname, address, interfaceId);
 }
 
 } // namespace Dnssd

--- a/src/lib/dnssd/Discovery_ImplPlatform.h
+++ b/src/lib/dnssd/Discovery_ImplPlatform.h
@@ -58,6 +58,7 @@ public:
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR StopDiscovery() override;
+    CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 
     static DiscoveryImplPlatform & GetInstance();
 

--- a/src/lib/dnssd/Resolver.h
+++ b/src/lib/dnssd/Resolver.h
@@ -399,6 +399,12 @@ public:
     virtual CHIP_ERROR StopDiscovery() = 0;
 
     /**
+     * Verify the validity of an address that appears to be out of date (for example
+     * because establishing a connection to it has failed).
+     */
+    virtual CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) = 0;
+
+    /**
      * Provides the system-wide implementation of the service resolver
      */
     static Resolver & Instance();

--- a/src/lib/dnssd/ResolverProxy.h
+++ b/src/lib/dnssd/ResolverProxy.h
@@ -153,6 +153,7 @@ public:
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR StopDiscovery() override;
+    CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 
 private:
     ResolverDelegateProxy * mDelegate                            = nullptr;

--- a/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
+++ b/src/lib/dnssd/Resolver_ImplMinimalMdns.cpp
@@ -282,6 +282,7 @@ public:
     CHIP_ERROR DiscoverCommissionableNodes(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override;
     CHIP_ERROR StopDiscovery() override;
+    CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override;
 
 private:
     OperationalResolveDelegate * mOperationalDelegate     = nullptr;
@@ -639,6 +640,11 @@ CHIP_ERROR MinMdnsResolver::StopDiscovery()
     return mActiveResolves.CompleteAllBrowses();
 }
 
+CHIP_ERROR MinMdnsResolver::ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 CHIP_ERROR MinMdnsResolver::BrowseNodes(DiscoveryType type, DiscoveryFilter filter)
 {
     mActiveResolves.MarkPending(filter, type);
@@ -719,6 +725,11 @@ CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
 }
 
 CHIP_ERROR ResolverProxy::StopDiscovery()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ResolverProxy::ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/lib/dnssd/Resolver_ImplNone.cpp
+++ b/src/lib/dnssd/Resolver_ImplNone.cpp
@@ -43,6 +43,10 @@ public:
     }
     CHIP_ERROR DiscoverCommissioners(DiscoveryFilter filter = DiscoveryFilter()) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StopDiscovery() override { return CHIP_ERROR_NOT_IMPLEMENTED; }
+    CHIP_ERROR ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId) override
+    {
+        return CHIP_ERROR_NOT_IMPLEMENTED;
+    }
 };
 
 NoneResolver gResolver;
@@ -75,6 +79,11 @@ CHIP_ERROR ResolverProxy::DiscoverCommissioners(DiscoveryFilter filter)
 }
 
 CHIP_ERROR ResolverProxy::StopDiscovery()
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
+CHIP_ERROR ResolverProxy::ReconfirmRecord(const char * hostname, Inet::IPAddress address, Inet::InterfaceId interfaceId)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }

--- a/src/lib/dnssd/platform/Dnssd.h
+++ b/src/lib/dnssd/platform/Dnssd.h
@@ -245,5 +245,15 @@ CHIP_ERROR ChipDnssdStopBrowse(intptr_t browseIdentifier);
 CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId interface, DnssdResolveCallback callback,
                             void * context);
 
+/**
+ * This function asks the mdns daemon to asynchronously reconfirm an address that appears to be out of date.
+ *
+ * @param[in] hostname      The hostname the address belongs to.
+ * @param[in] address       The address to reconfirm.
+ * @param[in] interfaceId   The interfaceId of the address.
+ *
+ */
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface);
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/ESP32/DnssdImpl.cpp
+++ b/src/platform/ESP32/DnssdImpl.cpp
@@ -511,5 +511,10 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
     return error;
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/Linux/DnssdImpl.cpp
+++ b/src/platform/Linux/DnssdImpl.cpp
@@ -872,5 +872,10 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
                                             browseResult->mAddressType, Inet::IPAddressType::kAny, interface, callback, context);
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/OpenThread/DnssdImpl.cpp
+++ b/src/platform/OpenThread/DnssdImpl.cpp
@@ -122,5 +122,10 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, Inet::InterfaceId inter
 #endif // CHIP_DEVICE_CONFIG_ENABLE_THREAD_SRP_CLIENT && CHIP_DEVICE_CONFIG_ENABLE_THREAD_DNS_CLIENT
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -823,5 +823,10 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
     return DnssdTizen::GetInstance().Resolve(*browseResult, interface, callback, context);
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -214,6 +214,11 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, Inet::InterfaceId interface,
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 // Implemention of Java-specific functions
 
 void InitializeWithObjects(jobject resolverObject, jobject browserObject, jobject mdnsCallbackObject)

--- a/src/platform/bouffalolab/BL602/DnssdImpl.cpp
+++ b/src/platform/bouffalolab/BL602/DnssdImpl.cpp
@@ -313,5 +313,10 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * /*service*/, chip::Inet::InterfaceId 
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/fake/DnssdImpl.cpp
+++ b/src/platform/fake/DnssdImpl.cpp
@@ -132,6 +132,11 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
     return CHIP_ERROR_NOT_IMPLEMENTED;
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 void GetMdnsTimeout(timeval & timeout) {}
 void HandleMdnsTimeout() {}
 

--- a/src/platform/mt793x/DnssdImpl.cpp
+++ b/src/platform/mt793x/DnssdImpl.cpp
@@ -273,5 +273,10 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * service, chip::Inet::InterfaceId inte
     return error;
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace Dnssd
 } // namespace chip

--- a/src/platform/webos/DnssdImpl.cpp
+++ b/src/platform/webos/DnssdImpl.cpp
@@ -869,5 +869,10 @@ CHIP_ERROR ChipDnssdResolve(DnssdService * browseResult, chip::Inet::InterfaceId
                                             browseResult->mAddressType, Inet::IPAddressType::kAny, interface, callback, context);
 }
 
+CHIP_ERROR ChipDnssdReconfirmRecord(const char * hostname, chip::Inet::IPAddress address, chip::Inet::InterfaceId interface)
+{
+    return CHIP_ERROR_NOT_IMPLEMENTED;
+}
+
 } // namespace Dnssd
 } // namespace chip


### PR DESCRIPTION
…gate stale cache issues

#### Problem

Sometimes there are stale DNS A and AAAA records. This patch instruct the daemon to verify the validity of such records. It does not prevent stale records to be used but reduce their lifetime and may help for subsequent pairing attempts.
