### PR TITLE
Set of fixes to unit-tests code

### DIFF
--- a/src/app/tests/TestReadInteraction.cpp
+++ b/src/app/tests/TestReadInteraction.cpp
@@ -1565,8 +1565,6 @@ void TestReadInteraction::TestSubscribeRoundtrip(nlTestSuite * apSuite, void * a
         delegate.mGotEventResponse     = false;
         delegate.mNumAttributeResponse = 0;
 
-        printf("HereHere\n");
-
         err = engine->GetReportingEngine().SetDirty(dirtyPath1);
         NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
         err = engine->GetReportingEngine().SetDirty(dirtyPath2);
@@ -1840,13 +1838,16 @@ void TestReadInteraction::TestSubscribeWildcard(nlTestSuite * apSuite, void * ap
             err = engine->GetReportingEngine().SetDirty(dirtyPath);
             NL_TEST_ASSERT(apSuite, err == CHIP_NO_ERROR);
 
-            ctx.DrainAndServiceIO();
-
             //
-            // Not sure why I had to add this, and didn't have cycles to figure out why.
-            // Tracked in Issue #17528.
+            // We need to DrainAndServiceIO() until attribute callback will be called.
+            // This is not correct behavior and is tracked in Issue #17528.
             //
-            ctx.DrainAndServiceIO();
+            int last;
+            do
+            {
+                last = delegate.mNumAttributeResponse;
+                ctx.DrainAndServiceIO();
+            } while (last != delegate.mNumAttributeResponse);
 
             NL_TEST_ASSERT(apSuite, delegate.mGotReport);
             // Mock endpoint3 has 13 attributes in total, and we subscribed twice.

--- a/src/controller/tests/TestEventChunking.cpp
+++ b/src/controller/tests/TestEventChunking.cpp
@@ -542,10 +542,10 @@ nlTestSuite sSuite =
 
 } // namespace
 
-int TestReadChunkingTests()
+int TestEventChunkingTests()
 {
     gSuite = &sSuite;
     return chip::ExecuteTestsWithContext<TestContext>(&sSuite);
 }
 
-CHIP_REGISTER_TEST_SUITE(TestReadChunkingTests)
+CHIP_REGISTER_TEST_SUITE(TestEventChunkingTests)

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -2642,8 +2642,8 @@ void TestReadInteraction::TestReadHandler_MultipleSubscriptionsWithDataVersionFi
             numSuccessCalls == (app::InteractionModelEngine::kReadHandlerPoolSize + 1);
     });
 
-    ChipLogError(Zcl, "Success call cnt: %u (expect %u) subscription cnt: %u (expect %u)", numSuccessCalls,
-                 uint32_t(app::InteractionModelEngine::kReadHandlerPoolSize + 1), numSubscriptionEstablishedCalls,
+    ChipLogError(Zcl, "Success call cnt: %" PRIu32 " (expect %" PRIu32 ") subscription cnt: %" PRIu32 " (expect %" PRIu32 ")",
+                 numSuccessCalls, uint32_t(app::InteractionModelEngine::kReadHandlerPoolSize + 1), numSubscriptionEstablishedCalls,
                  uint32_t(app::InteractionModelEngine::kReadHandlerPoolSize + 1));
 
     NL_TEST_ASSERT(apSuite, numSuccessCalls == (app::InteractionModelEngine::kReadHandlerPoolSize + 1));

--- a/src/inet/tests/TestInetCommonPosix.cpp
+++ b/src/inet/tests/TestInetCommonPosix.cpp
@@ -37,6 +37,7 @@
 #include "TestInetCommon.h"
 #include "TestInetCommonOptions.h"
 
+#include <assert.h>
 #include <errno.h>
 #include <vector>
 

--- a/src/lib/support/jsontlv/TlvJson.cpp
+++ b/src/lib/support/jsontlv/TlvJson.cpp
@@ -95,7 +95,7 @@ void InsertKeyValue(Json::Value & json, const KeyContext & keyContext, T val)
     }
     else if (keyContext.keyType == KeyContext::kStructField)
     {
-        snprintf(keyBuf, sizeof(keyBuf), "%" PRIu32, keyContext.key);
+        snprintf(keyBuf, sizeof(keyBuf), "%u", keyContext.key);
         json[keyBuf] = val;
     }
     else

--- a/src/lib/support/tests/TestBytesToHex.cpp
+++ b/src/lib/support/tests/TestBytesToHex.cpp
@@ -433,8 +433,10 @@ const nlTest sTests[] = {
     NL_TEST_DEF("TestBytesToHexErrors", TestBytesToHexErrors),                       //
     NL_TEST_DEF("TestBytesToHexUint64", TestBytesToHexUint64),                       //
     NL_TEST_DEF("TestHexToBytesAndUint", TestHexToBytesAndUint),                     //
-    NL_TEST_DEF("TestLogBufferAsHex", TestLogBufferAsHex),                           //
-    NL_TEST_SENTINEL()                                                               //
+#ifdef CHIP_PROGRESS_LOGGING
+    NL_TEST_DEF("TestLogBufferAsHex", TestLogBufferAsHex), //
+#endif
+    NL_TEST_SENTINEL() //
 };
 
 } // namespace

--- a/src/lib/support/tests/TestCHIPArgParser.cpp
+++ b/src/lib/support/tests/TestCHIPArgParser.cpp
@@ -137,7 +137,7 @@ static size_t sCallbackRecordCount = 0;
 static OptionDef sOptionSetA_Defs[] =
 {
     { "foo",  kNoArgument, '1'  },
-    { "bar",  kNoArgument, 1001 },
+    { "bar",  kNoArgument, 1002 },
     { "baz",  kArgumentRequired, 'Z'  },
     { }
 };
@@ -350,7 +350,7 @@ static void SimpleParseTest_VariousShortAndLongWithArgs()
     VerifyHandleOptionCallback(0, __FUNCTION__, &sOptionSetA, '1', "--foo", nullptr);
     VerifyHandleOptionCallback(1, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value");
     VerifyHandleOptionCallback(2, __FUNCTION__, &sOptionSetB, 's', "-s", nullptr);
-    VerifyHandleOptionCallback(3, __FUNCTION__, &sOptionSetA, 1001, "--bar", nullptr);
+    VerifyHandleOptionCallback(3, __FUNCTION__, &sOptionSetA, 1002, "--bar", nullptr);
     VerifyHandleOptionCallback(4, __FUNCTION__, &sOptionSetA, '1', "-1", nullptr);
     VerifyHandleOptionCallback(5, __FUNCTION__, &sOptionSetA, 'Z', "-Z", "baz-value");
     VerifyHandleOptionCallback(6, __FUNCTION__, &sOptionSetB, 1000, "--run", "run-value-2");
@@ -779,7 +779,12 @@ int TestCHIPArgParser(void)
     UnknownOptionTest_UnknownShortOptionBeforeKnown();
     UnknownOptionTest_UnknownLongOptionAfterArgs();
     UnknownOptionTest_IgnoreUnknownShortOption();
+
+    /* Skip this test because the parser successfully captures all the options
+       but the error reporting is incorrect in this case due to long_opt limitations */
+#ifndef CHIP_CONFIG_NON_POSIX_LONG_OPT
     UnknownOptionTest_IgnoreUnknownLongOption();
+#endif // !CHIP_CONFIG_NON_POSIX_LONG_OPT
 
     MissingValueTest_MissingShortOptionValue();
     MissingValueTest_MissingLongOptionValue();

--- a/src/transport/raw/tests/TestPeerAddress.cpp
+++ b/src/transport/raw/tests/TestPeerAddress.cpp
@@ -93,8 +93,11 @@ void TestToString(nlTestSuite * inSuite, void * inContext)
     {
         IPAddress::FromString("1223::3456:789a", ip);
         PeerAddress::UDP(ip, 8080).ToString(buff);
+        // IPV6 does not specify case
+        int res1 = strcmp(buff, "UDP:[1223::3456:789a]:8080");
+        int res2 = strcmp(buff, "UDP:[1223::3456:789A]:8080");
 
-        NL_TEST_ASSERT(inSuite, !strcmp(buff, "UDP:[1223::3456:789a]:8080"));
+        NL_TEST_ASSERT(inSuite, (!res1 || !res2));
     }
 
     {


### PR DESCRIPTION
This PR contains some fixes inside the unit-test code for different modules.
Fixes:
 - Execute TestLogBufferAsHex only if CHIP_PROGRESS_LOGGING
 - PeerAddress string conversion test - allow uppercase IPV6 string conversion - check both cases
 - ArgParser in the support library - fix parse args for embedded non posix long_opt implementation, disable a parse args unit test for non posix long_opt, changed id in option sets in ParseArgs unit test
 - remove warnings of incorrect types in printf formatting
 - add missing assert header include in TestInetCommonPosix
 - TestReadInteraction - remove leftover debug printf,  drain and service IO repeatedly until the condition is met (#17528)
 - controller - fix test naming


