### PR TITLE
Better fix for crashes around MTRBaseSubscriptionCallback.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
+++ b/src/darwin/Framework/CHIP/MTRBaseSubscriptionCallback.h
@@ -35,7 +35,16 @@
 /**
  * This file defines a base class for subscription callbacks used by
  * MTRBaseDevice and MTRDevice.  This base class handles everything except the
- * actual conversion from the incoming data to the desired data.
+ * actual conversion from the incoming data to the desired data and the dispatch
+ * of callbacks to the relevant client queues.  Its callbacks are called on the
+ * Matter queue.  This allows MTRDevice and MTRBaseDevice to do any necessary
+ * sync cleanup work before dispatching to the client callbacks on the client
+ * queue.
+ *
+ * After onDoneHandler is invoked, this object will at some point delete itself
+ * and destroy anything it owns (such as the ReadClient or the
+ * ClusterStateCache).  Consumers should drop references to all the relevant
+ * objects in that handler.  This deletion will happen on the Matter queue.
  *
  * The desired data is assumed to be NSObjects that can be stored in NSArray.
  */
@@ -49,12 +58,10 @@ typedef void (^OnDoneHandler)(void);
 
 class MTRBaseSubscriptionCallback : public chip::app::ClusterStateCache::Callback {
 public:
-    MTRBaseSubscriptionCallback(dispatch_queue_t queue, DataReportCallback attributeReportCallback,
-        DataReportCallback eventReportCallback, ErrorCallback errorCallback,
-        MTRDeviceResubscriptionScheduledHandler _Nullable resubscriptionCallback,
+    MTRBaseSubscriptionCallback(DataReportCallback attributeReportCallback, DataReportCallback eventReportCallback,
+        ErrorCallback errorCallback, MTRDeviceResubscriptionScheduledHandler _Nullable resubscriptionCallback,
         SubscriptionEstablishedHandler _Nullable subscriptionEstablishedHandler, OnDoneHandler _Nullable onDoneHandler)
-        : mQueue(queue)
-        , mAttributeReportCallback(attributeReportCallback)
+        : mAttributeReportCallback(attributeReportCallback)
         , mEventReportCallback(eventReportCallback)
         , mErrorCallback(errorCallback)
         , mResubscriptionCallback(resubscriptionCallback)
@@ -117,10 +124,9 @@ protected:
     NSMutableArray * _Nullable mEventReports = nil;
 
 private:
-    dispatch_queue_t mQueue;
     DataReportCallback _Nullable mAttributeReportCallback = nil;
     DataReportCallback _Nullable mEventReportCallback = nil;
-    // We set mErrorCallback to nil when queueing error reports, so we
+    // We set mErrorCallback to nil before calling the error callback, so we
     // make sure to only report one error.
     ErrorCallback _Nullable mErrorCallback = nil;
     MTRDeviceResubscriptionScheduledHandler _Nullable mResubscriptionCallback = nil;
@@ -138,9 +144,11 @@ private:
     // To handle this, enforce the following rules:
     //
     // 1) We guarantee that mErrorCallback is only invoked with an error once.
-    // 2) We ensure that we delete ourselves and the passed in ReadClient only from OnDone or a queued-up
-    //    error callback, but not both, by tracking whether we have a queued-up
-    //    deletion.
+    // 2) We guarantee that mOnDoneHandler is only invoked once, and always
+    //    invoked before we delete ourselves.
+    // 3) We ensure that we delete ourselves and the passed in ReadClient only
+    //    from OnDone or from an error callback but not both, by tracking whether
+    //    we have a queued-up deletion.
     std::unique_ptr<chip::app::ReadClient> mReadClient;
     std::unique_ptr<chip::app::ClusterStateCache> mClusterStateCache;
     bool mHaveQueuedDeletion = false;


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/22978 accidentally reintroduced the crash that
https://github.com/project-chip/connectedhomeip/pull/22324 had fixed.  To avoid more issues along these lines:

1) Add unit tests that reproduce the crashes described in
   https://github.com/project-chip/connectedhomeip/issues/22320 (with the
   changes from https://github.com/project-chip/connectedhomeip/pull/22978) and
   https://github.com/project-chip/connectedhomeip/issues/22935 (without those
   changes).
2) Change MTRBaseSubscriptionCallback to always invoke its callbacks
   synchronously, on the Matter queue, so that we can clean up the
   MTRClusterStateCacheContainer's pointer to the ClusterStateCache before it
   gets deleted on the Matter queue.
3) Move the queueing of callbacks to the client queue into the consumers of
   MTRBaseSubscriptionCallback, so they can do whatever sync work they need
   (like the above cleanup) before going async.
4) Update documentation.

@jtung-apple the MTRBaseDevice changes might be easiest to review in a whitespace-ignoring diff, because it all got reindented.