### PR TITLE
Remove clusters_header and cluster_header from app templates

### DIFF
--- a/src/app/zap-templates/app-templates.json
+++ b/src/app/zap-templates/app-templates.json
@@ -16,14 +16,6 @@
             "path": "partials/header.zapt"
         },
         {
-            "name": "clusters_header",
-            "path": "partials/clusters_header.zapt"
-        },
-        {
-            "name": "cluster_header",
-            "path": "partials/cluster_header.zapt"
-        },
-        {
             "name": "im_command_handler_cluster_commands",
             "path": "partials/im_command_handler_cluster_commands.zapt"
         },


### PR DESCRIPTION
These seem unused by the templates that are actually referenced from app_templates.json

Found these with an automated script and checked that zap_regen_all still works.
ZAP CI will also validate that nothing breaks.
