### PR TITLE
Remove some 1.0-only backwards-compat hacks from chip-tool.

### DIFF
--- a/examples/chip-tool/templates/commands.zapt
+++ b/examples/chip-tool/templates/commands.zapt
@@ -90,14 +90,6 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands, CredentialIss
         make_unique<ReadAttribute>(Id, credsIssuerConfig), //
         {{#zcl_attributes_server}}
         make_unique<ReadAttribute>(Id, "{{cleanse_label_as_kebab_case (asUpperCamelCase name)}}", Attributes::{{asUpperCamelCase name}}::Id, credsIssuerConfig), //
-        {{! TODO: Remove after 1.0. See https://github.com/project-chip/connectedhomeip/issues/22341 }}
-        {{#if (isStrEqual (asUpperCamelCase name) "ColorTemperatureMireds")}}
-        make_unique<ReadAttribute>(Id, "color-temperature", Attributes::{{asUpperCamelCase name}}::Id, credsIssuerConfig), //
-        {{/if}}
-        {{! TODO: Remove after 1.0. See https://github.com/project-chip/connectedhomeip/issues/22507 }}
-        {{#if (isStrEqual (asUpperCamelCase name) "DeviceTypeList")}}
-        make_unique<ReadAttribute>(Id, "device-list", Attributes::{{asUpperCamelCase name}}::Id, credsIssuerConfig), //
-        {{/if}}
         {{/zcl_attributes_server}}
         make_unique<WriteAttribute<>>(Id, credsIssuerConfig), //
         {{#zcl_attributes_server}}
@@ -115,14 +107,6 @@ void registerCluster{{asUpperCamelCase name}}(Commands & commands, CredentialIss
         {{#zcl_attributes_server}}
         {{#if isReportable}}
         make_unique<SubscribeAttribute>(Id, "{{cleanse_label_as_kebab_case (asUpperCamelCase name)}}", Attributes::{{asUpperCamelCase name}}::Id, credsIssuerConfig), //
-        {{! TODO: Remove after 1.0. See https://github.com/project-chip/connectedhomeip/issues/22341 }}
-        {{#if (isStrEqual (asUpperCamelCase name) "ColorTemperatureMireds")}}
-        make_unique<SubscribeAttribute>(Id, "color-temperature", Attributes::{{asUpperCamelCase name}}::Id, credsIssuerConfig), //
-        {{/if}}
-        {{! TODO: Remove after 1.0. See https://github.com/project-chip/connectedhomeip/issues/22507 }}
-        {{#if (isStrEqual (asUpperCamelCase name) "DeviceTypeList")}}
-        make_unique<SubscribeAttribute>(Id, "device-list", Attributes::{{asUpperCamelCase name}}::Id, credsIssuerConfig), //
-        {{/if}}
         {{/if}}
         {{/zcl_attributes_server}}
         //

--- a/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
+++ b/zzz_generated/chip-tool/zap-generated/cluster/Commands.h
@@ -8675,7 +8675,6 @@ void registerClusterDescriptor(Commands & commands, CredentialIssuerCommands * c
         //
         make_unique<ReadAttribute>(Id, credsIssuerConfig),                                                                      //
         make_unique<ReadAttribute>(Id, "device-type-list", Attributes::DeviceTypeList::Id, credsIssuerConfig),                  //
-        make_unique<ReadAttribute>(Id, "device-list", Attributes::DeviceTypeList::Id, credsIssuerConfig),                       //
         make_unique<ReadAttribute>(Id, "server-list", Attributes::ServerList::Id, credsIssuerConfig),                           //
         make_unique<ReadAttribute>(Id, "client-list", Attributes::ClientList::Id, credsIssuerConfig),                           //
         make_unique<ReadAttribute>(Id, "parts-list", Attributes::PartsList::Id, credsIssuerConfig),                             //
@@ -8687,7 +8686,6 @@ void registerClusterDescriptor(Commands & commands, CredentialIssuerCommands * c
         make_unique<WriteAttribute<>>(Id, credsIssuerConfig),                                                                   //
         make_unique<SubscribeAttribute>(Id, credsIssuerConfig),                                                                 //
         make_unique<SubscribeAttribute>(Id, "device-type-list", Attributes::DeviceTypeList::Id, credsIssuerConfig),             //
-        make_unique<SubscribeAttribute>(Id, "device-list", Attributes::DeviceTypeList::Id, credsIssuerConfig),                  //
         make_unique<SubscribeAttribute>(Id, "server-list", Attributes::ServerList::Id, credsIssuerConfig),                      //
         make_unique<SubscribeAttribute>(Id, "client-list", Attributes::ClientList::Id, credsIssuerConfig),                      //
         make_unique<SubscribeAttribute>(Id, "parts-list", Attributes::PartsList::Id, credsIssuerConfig),                        //
@@ -11423,7 +11421,6 @@ void registerClusterColorControl(Commands & commands, CredentialIssuerCommands *
         make_unique<ReadAttribute>(Id, "drift-compensation", Attributes::DriftCompensation::Id, credsIssuerConfig),            //
         make_unique<ReadAttribute>(Id, "compensation-text", Attributes::CompensationText::Id, credsIssuerConfig),              //
         make_unique<ReadAttribute>(Id, "color-temperature-mireds", Attributes::ColorTemperatureMireds::Id, credsIssuerConfig), //
-        make_unique<ReadAttribute>(Id, "color-temperature", Attributes::ColorTemperatureMireds::Id, credsIssuerConfig),        //
         make_unique<ReadAttribute>(Id, "color-mode", Attributes::ColorMode::Id, credsIssuerConfig),                            //
         make_unique<ReadAttribute>(Id, "options", Attributes::Options::Id, credsIssuerConfig),                                 //
         make_unique<ReadAttribute>(Id, "number-of-primaries", Attributes::NumberOfPrimaries::Id, credsIssuerConfig),           //
@@ -11516,7 +11513,6 @@ void registerClusterColorControl(Commands & commands, CredentialIssuerCommands *
         make_unique<SubscribeAttribute>(Id, "compensation-text", Attributes::CompensationText::Id, credsIssuerConfig),   //
         make_unique<SubscribeAttribute>(Id, "color-temperature-mireds", Attributes::ColorTemperatureMireds::Id,
                                         credsIssuerConfig),                                                                     //
-        make_unique<SubscribeAttribute>(Id, "color-temperature", Attributes::ColorTemperatureMireds::Id, credsIssuerConfig),    //
         make_unique<SubscribeAttribute>(Id, "color-mode", Attributes::ColorMode::Id, credsIssuerConfig),                        //
         make_unique<SubscribeAttribute>(Id, "options", Attributes::Options::Id, credsIssuerConfig),                             //
         make_unique<SubscribeAttribute>(Id, "number-of-primaries", Attributes::NumberOfPrimaries::Id, credsIssuerConfig),       //


### PR DESCRIPTION
These were just there to avoid changing some command lines from SVE2 to 1.0, but at this point those should be updated as needed.

Fixes https://github.com/project-chip/connectedhomeip/issues/22507 
Fixes https://github.com/project-chip/connectedhomeip/issues/22341
