### PR TITLE
Bootstrap should sync submodules.

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -32,6 +32,8 @@ _bootstrap_or_activate() {
 
     if [ "$_BOOTSTRAP_NAME" = "bootstrap.sh" ] ||
         [ ! -f "$_CHIP_ROOT/third_party/pigweed/repo/pw_env_setup/util.sh" ]; then
+        # Make sure our submodule remotes are correct for this revision.
+        git submodule sync --recursive
         git submodule update --init
     fi
 


### PR DESCRIPTION
When submodule URLs change, re-bootstrap will fail unless something does "git submodule sync".  We should just do that as part of bootstrap, instead of assuming that developers know to do it.

Fixes https://github.com/project-chip/connectedhomeip/issues/23059

