### PR TITLE
Fix SecureSession being made defunct after expiration

### DIFF
--- a/src/transport/SecureSession.cpp
+++ b/src/transport/SecureSession.cpp
@@ -120,9 +120,9 @@ void SecureSession::MarkAsDefunct()
 
     case State::kPendingEviction:
         //
-        // Once a session is headed for eviction, we CANNOT bring it back to either being active or defunct.
+        // Once a session is headed for eviction, we CANNOT bring it back to either being active or defunct. Let's just
+        // do nothing and return.
         //
-        VerifyOrDie(false);
         return;
     }
 }


### PR DESCRIPTION
Fixes #23093 

When an UpdateNOC call is received on the server, it expires the associated session and proceeds to send back a response on the associated exchange. If response fails to get ACK'ed, it will result in the session being marked defunct. The SecureSession logic over-aggressively asserts on marking expired sessions as defunct, causing a VerifyOrDie crash to happen.

Fix:
Remove the VerifyOrDie

Testing:
Added a test in TestAbortExchangesForFabric to catch this scenario. Also pivoted most of the secure sessions in those test to be of type CASE to facilitate correctly triggering the various bits of logic in ExchangeMgr and ReliableMessageMgr in these scenarios.