### PR TITLE
use nullable paths for ReportCallback parameters

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/clusterclient/WildcardFragment.kt
@@ -44,7 +44,7 @@ class WildcardFragment : Fragment() {
   private lateinit var addressUpdateFragment: AddressUpdateFragment
 
   private val reportCallback = object : ReportCallback {
-    override fun onError(attributePath: ChipAttributePath, eventPath: ChipEventPath, ex: Exception) {
+    override fun onError(attributePath: ChipAttributePath?, eventPath: ChipEventPath?, ex: Exception) {
       if (attributePath != null)
       {
         Log.e(TAG, "Report error for $attributePath: $ex")


### PR DESCRIPTION
Fixes https://github.com/project-chip/connectedhomeip/issues/23099

when onError in ReportCallback is recieving nullable parameter in kotlin, we need use ? to specify whether this paramter takes nullable thing

