### PR TITLE
[EFR32] Adds lwip ipv6 MLD support for neighborhood discovery protocol

### DIFF
--- a/src/lwip/efr32/lwipopts-rs911x.h
+++ b/src/lwip/efr32/lwipopts-rs911x.h
@@ -99,6 +99,7 @@
 #define LWIP_IPV6_REASS (0)
 #define LWIP_IPV6_DHCP6 0
 #define LWIP_IPV6_AUTOCONFIG (1)
+#define LWIP_IPV6_DUP_DETECT_ATTEMPTS 0 // TODO: Enable this after a fix for NS loopback
 #define LWIP_IPV6_ROUTER_SUPPORT 1
 #define LWIP_ND6_LISTEN_RA 1
 

--- a/src/lwip/efr32/lwipopts-wf200.h
+++ b/src/lwip/efr32/lwipopts-wf200.h
@@ -99,6 +99,7 @@
 #define LWIP_IPV6_REASS (0)
 #define LWIP_IPV6_DHCP6 0
 #define LWIP_IPV6_AUTOCONFIG (1)
+#define LWIP_IPV6_DUP_DETECT_ATTEMPTS 0 // TODO: Enable this after a fix for NS loopback
 #define LWIP_IPV6_ROUTER_SUPPORT 1
 #define LWIP_ND6_LISTEN_RA 1
 

--- a/src/platform/EFR32/wifi/ethernetif.cpp
+++ b/src/platform/EFR32/wifi/ethernetif.cpp
@@ -97,6 +97,10 @@ static void low_level_init(struct netif * netif)
 
     /* Accept broadcast address and ARP traffic */
     netif->flags |= NETIF_FLAG_BROADCAST | NETIF_FLAG_ETHARP | NETIF_FLAG_IGMP;
+
+#if LWIP_IPV6_MLD
+    netif->flags |= NETIF_FLAG_MLD6;
+#endif /* LWIP_IPV6_MLD */
 }
 
 /********************************************************************************

--- a/src/platform/EFR32/wifi/lwip_netif.cpp
+++ b/src/platform/EFR32/wifi/lwip_netif.cpp
@@ -91,6 +91,10 @@ void wfx_lwip_set_sta_link_up(void)
     /*
      * Enable IPV6
      */
+
+#if LWIP_IPV6_AUTOCONFIG
+    sta_netif.ip6_autoconfig_enabled = 1;
+#endif /* LWIP_IPV6_AUTOCONFIG */
     netif_create_ip6_linklocal_address(&sta_netif, MAC_48_BIT_SET);
 }
 


### PR DESCRIPTION
 #### Problem
 * Expected behavior
      The DUT should be able to respond to neighborhood solicitation packets when running in IPV6 mode.
 * Actual behavior
      The DUT was not responding to neighborhood solicitation packets when running in IPV6 mode. The DUT was not listening on the `FF02::1:XXXX:XXXX` multicast group.

 #### Solution
Enabled the LWIP_IPV6_MLD flag on the device, temporarily disabling the Duplicate Address Detectation process (since it has some issues).

