### PR TITLE
[compiler] Add -Wshorten-64-to-32 compiler flag for is_clang

### DIFF
--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -256,6 +256,7 @@ config("strict_warnings") {
     cflags += [
       "-Wimplicit-fallthrough",
       "-Wheader-hygiene",
+      "-Wshorten-64-to-32",
       "-Wformat-type-confusion",
     ]
   }

--- a/examples/common/tracing/TraceDecoder.cpp
+++ b/examples/common/tracing/TraceDecoder.cpp
@@ -130,7 +130,7 @@ CHIP_ERROR TraceDecoder::ReadString(const char * str)
 
 CHIP_ERROR TraceDecoder::LogJSON(Json::Value & json)
 {
-    uint32_t protocol   = json[kProtocolIdKey].asLargestUInt();
+    auto protocol       = json[kProtocolIdKey].asLargestUInt();
     uint16_t vendorId   = protocol >> 16;
     uint16_t protocolId = protocol & 0xFFFF;
     if (!mOptions.IsProtocolEnabled(chip::Protocols::Id(chip::VendorId(vendorId), protocolId)))

--- a/examples/darwin-framework-tool/commands/provider/OTASoftwareUpdateInteractive.mm
+++ b/examples/darwin-framework-tool/commands/provider/OTASoftwareUpdateInteractive.mm
@@ -78,14 +78,14 @@ static bool ParseJsonFileAndPopulateCandidates(
 
         auto vendorId = [NSNumber numberWithUnsignedInt:iter.get("vendorId", 1).asUInt()];
         auto productId = [NSNumber numberWithUnsignedInt:iter.get("productId", 1).asUInt()];
-        auto softwareVersion = [NSNumber numberWithUnsignedLong:iter.get("softwareVersion", 10).asUInt64()];
+        auto softwareVersion = [NSNumber numberWithUnsignedLongLong:iter.get("softwareVersion", 10).asUInt64()];
         auto softwareVersionString = [NSString stringWithUTF8String:iter.get("softwareVersionString", "1.0.0").asCString()];
         auto cDVersionNumber = [NSNumber numberWithUnsignedInt:iter.get("cDVersionNumber", 0).asUInt()];
         auto softwareVersionValid = iter.get("softwareVersionValid", true).asBool() ? YES : NO;
         auto minApplicableSoftwareVersion =
-            [NSNumber numberWithUnsignedLong:iter.get("minApplicableSoftwareVersion", 0).asUInt64()];
+            [NSNumber numberWithUnsignedLongLong:iter.get("minApplicableSoftwareVersion", 0).asUInt64()];
         auto maxApplicableSoftwareVersion =
-            [NSNumber numberWithUnsignedLong:iter.get("maxApplicableSoftwareVersion", 1000).asUInt64()];
+            [NSNumber numberWithUnsignedLongLong:iter.get("maxApplicableSoftwareVersion", 1000).asUInt64()];
         auto otaURL = [NSString stringWithUTF8String:iter.get("otaURL", "https://test.com").asCString()];
 
         candidate.deviceModelData.vendorId = vendorId;

--- a/examples/platform/linux/Options.cpp
+++ b/examples/platform/linux/Options.cpp
@@ -28,6 +28,7 @@
 #include <lib/core/CHIPError.h>
 #include <lib/support/Base64.h>
 #include <lib/support/BytesToHex.h>
+#include <lib/support/SafeInt.h>
 
 #include <credentials/examples/DeviceAttestationCredsExample.h>
 
@@ -233,16 +234,11 @@ bool Base64ArgToVector(const char * arg, size_t maxSize, std::vector<uint8_t> & 
     outVector.resize(maxSize);
 
     size_t argLen = strlen(arg);
-    if (argLen > maxBase64Size)
-    {
-        return false;
-    }
+    VerifyOrReturnValue(argLen <= maxBase64Size, false);
+    VerifyOrReturnValue(chip::CanCastTo<uint32_t>(argLen), false);
 
-    size_t decodedLen = chip::Base64Decode32(arg, argLen, reinterpret_cast<uint8_t *>(outVector.data()));
-    if (decodedLen == 0)
-    {
-        return false;
-    }
+    size_t decodedLen = chip::Base64Decode32(arg, static_cast<uint32_t>(argLen), reinterpret_cast<uint8_t *>(outVector.data()));
+    VerifyOrReturnValue(decodedLen != 0, false);
 
     outVector.resize(decodedLen);
     return true;

--- a/scripts/idl/generators/java/ChipClustersCpp.jinja
+++ b/scripts/idl/generators/java/ChipClustersCpp.jinja
@@ -33,11 +33,11 @@
       auto * listHolder_{{depth}} = new ListHolder<ListMemberType_{{depth}}>({{source}}Size);
       listFreer.add(listHolder_{{depth}});
 
-      for (size_t i_{{depth}} = 0; i_{{depth}} < static_cast<size_t>({{source}}Size); ++i_{{depth}}) {
+      for (jint i_{{depth}} = 0; i_{{depth}} < {{source}}Size; ++i_{{depth}}) {
         jobject element_{{depth}};
         chip::JniReferences::GetInstance().GetListItem({{source}}, i_{{depth}}, element_{{depth}});
         {{encode_value(
-           "listHolder_{}->mList[i_{}]".format(depth, depth),
+           "listHolder_{}->mList[static_cast<uint32_t>(i_{})]".format(depth, depth),
            "element_{}".format(depth),
            depth+1, encodable.without_list()
         )}}

--- a/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
+++ b/src/controller/java/AndroidOperationalCredentialsIssuer.cpp
@@ -169,18 +169,25 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
         return err;
     }
 
+    VerifyOrReturnError(CanCastTo<uint32_t>(csrElements.size()), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<uint32_t>(csrNonce.size()), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<uint32_t>(csrElementsSignature.size()), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<uint32_t>(attestationChallenge.size()), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<uint32_t>(DAC.size()), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<uint32_t>(PAI.size()), CHIP_ERROR_INVALID_ARGUMENT);
+
     mOnNOCCompletionCallback = onCompletion;
 
     env->ExceptionClear();
 
     jbyteArray javaCsrElements;
-    JniReferences::GetInstance().N2J_ByteArray(env, csrElements.data(), csrElements.size(), javaCsrElements);
+    JniReferences::GetInstance().N2J_ByteArray(env, csrElements.data(), static_cast<uint32_t>(csrElements.size()), javaCsrElements);
 
     jbyteArray javaCsrNonce;
-    JniReferences::GetInstance().N2J_ByteArray(env, csrNonce.data(), csrNonce.size(), javaCsrNonce);
+    JniReferences::GetInstance().N2J_ByteArray(env, csrNonce.data(), static_cast<uint32_t>(csrNonce.size()), javaCsrNonce);
 
     jbyteArray javaCsrElementsSignature;
-    JniReferences::GetInstance().N2J_ByteArray(env, csrElementsSignature.data(), csrElementsSignature.size(),
+    JniReferences::GetInstance().N2J_ByteArray(env, csrElementsSignature.data(), static_cast<uint32_t>(csrElementsSignature.size()),
                                                javaCsrElementsSignature);
 
     ChipLogProgress(Controller, "Parsing Certificate Signing Request");
@@ -202,8 +209,10 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
     ByteSpan csr(reader.GetReadPoint(), reader.GetLength());
     reader.ExitContainer(containerType);
 
+    VerifyOrReturnError(CanCastTo<uint32_t>(csr.size()), CHIP_ERROR_INVALID_ARGUMENT);
+
     jbyteArray javaCsr;
-    JniReferences::GetInstance().N2J_ByteArray(env, csr.data(), csr.size(), javaCsr);
+    JniReferences::GetInstance().N2J_ByteArray(env, csr.data(), static_cast<uint32_t>(csr.size()), javaCsr);
 
     P256PublicKey pubkey;
     ReturnErrorOnFailure(VerifyCertificateSigningRequest(csr.data(), csr.size(), pubkey));
@@ -218,28 +227,36 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
     }
 
     jbyteArray javaAttestationChallenge;
-    JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), attestationChallenge.size(),
+    JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), static_cast<uint32_t>(attestationChallenge.size()),
                                                javaAttestationChallenge);
 
     const ByteSpan & attestationElements = mAutoCommissioner->GetAttestationElements();
+    VerifyOrReturnError(CanCastTo<uint32_t>(attestationElements.size()), CHIP_ERROR_INVALID_ARGUMENT);
+
     jbyteArray javaAttestationElements;
-    JniReferences::GetInstance().N2J_ByteArray(env, attestationElements.data(), attestationElements.size(),
+    JniReferences::GetInstance().N2J_ByteArray(env, attestationElements.data(), static_cast<uint32_t>(attestationElements.size()),
                                                javaAttestationElements);
 
     const ByteSpan & attestationNonce = mAutoCommissioner->GetAttestationNonce();
+    VerifyOrReturnError(CanCastTo<uint32_t>(attestationNonce.size()), CHIP_ERROR_INVALID_ARGUMENT);
+
     jbyteArray javaAttestationNonce;
-    JniReferences::GetInstance().N2J_ByteArray(env, attestationNonce.data(), attestationNonce.size(), javaAttestationNonce);
+    JniReferences::GetInstance().N2J_ByteArray(env, attestationNonce.data(), static_cast<uint32_t>(attestationNonce.size()),
+                                               javaAttestationNonce);
 
     const ByteSpan & attestationElementsSignature = mAutoCommissioner->GetAttestationSignature();
+    VerifyOrReturnError(CanCastTo<uint32_t>(attestationElementsSignature.size()), CHIP_ERROR_INVALID_ARGUMENT);
+
     jbyteArray javaAttestationElementsSignature;
-    JniReferences::GetInstance().N2J_ByteArray(env, attestationElementsSignature.data(), attestationElementsSignature.size(),
+    JniReferences::GetInstance().N2J_ByteArray(env, attestationElementsSignature.data(),
+                                               static_cast<uint32_t>(attestationElementsSignature.size()),
                                                javaAttestationElementsSignature);
 
     jbyteArray javaDAC;
-    JniReferences::GetInstance().N2J_ByteArray(env, DAC.data(), DAC.size(), javaDAC);
+    JniReferences::GetInstance().N2J_ByteArray(env, DAC.data(), static_cast<uint32_t>(DAC.size()), javaDAC);
 
     jbyteArray javaPAI;
-    JniReferences::GetInstance().N2J_ByteArray(env, PAI.data(), PAI.size(), javaPAI);
+    JniReferences::GetInstance().N2J_ByteArray(env, PAI.data(), static_cast<uint32_t>(PAI.size()), javaPAI);
 
     ByteSpan certificationDeclarationSpan;
     ByteSpan attestationNonceSpan;
@@ -255,12 +272,16 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::CallbackGenerateNOCChain(const B
         return err;
     }
 
+    VerifyOrReturnError(CanCastTo<uint32_t>(certificationDeclarationSpan.size()), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<uint32_t>(firmwareInfoSpan.size()), CHIP_ERROR_INVALID_ARGUMENT);
+
     jbyteArray javaCD;
-    JniReferences::GetInstance().N2J_ByteArray(env, certificationDeclarationSpan.data(), certificationDeclarationSpan.size(),
-                                               javaCD);
+    JniReferences::GetInstance().N2J_ByteArray(env, certificationDeclarationSpan.data(),
+                                               static_cast<uint32_t>(certificationDeclarationSpan.size()), javaCD);
 
     jbyteArray javaFirmwareInfo;
-    JniReferences::GetInstance().N2J_ByteArray(env, firmwareInfoSpan.data(), firmwareInfoSpan.size(), javaFirmwareInfo);
+    JniReferences::GetInstance().N2J_ByteArray(env, firmwareInfoSpan.data(), static_cast<uint32_t>(firmwareInfoSpan.size()),
+                                               javaFirmwareInfo);
 
     jobject attestationInfo;
     err = N2J_AttestationInfo(env, javaAttestationChallenge, javaAttestationNonce, javaAttestationElements,
@@ -304,6 +325,8 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::LocalGenerateNOCChain(const Byte
         ChipLogError(Controller, "Error invoking onOpCSRGenerationComplete: %" CHIP_ERROR_FORMAT, err.Format());
         return err;
     }
+
+    VerifyOrReturnError(CanCastTo<uint32_t>(csrElements.size()), CHIP_ERROR_INVALID_ARGUMENT);
 
     NodeId assignedId;
     if (mNodeIdRequested)
@@ -374,7 +397,7 @@ CHIP_ERROR AndroidOperationalCredentialsIssuer::LocalGenerateNOCChain(const Byte
     jbyteArray javaCsr;
     JniReferences::GetInstance().GetEnvForCurrentThread()->ExceptionClear();
     JniReferences::GetInstance().N2J_ByteArray(JniReferences::GetInstance().GetEnvForCurrentThread(), csrElements.data(),
-                                               csrElements.size(), javaCsr);
+                                               static_cast<uint32_t>(csrElements.size()), javaCsr);
     JniReferences::GetInstance().GetEnvForCurrentThread()->CallVoidMethod(mJavaObjectRef, method, javaCsr);
     return CHIP_NO_ERROR;
 }

--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -421,8 +421,14 @@ JNI_METHOD(void, pairDevice)
 
     ChipLogProgress(Controller, "pairDevice() called with device ID, connection object, and pincode");
 
+    if (!chip::CanCastTo<uint32_t>(pinCode))
+    {
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, CHIP_ERROR_INVALID_ARGUMENT);
+        return;
+    }
+
     RendezvousParameters rendezvousParams = RendezvousParameters()
-                                                .SetSetupPINCode(pinCode)
+                                                .SetSetupPINCode(static_cast<uint32_t>(pinCode))
 #if CONFIG_NETWORK_LAYER_BLE
                                                 .SetConnectionObject(reinterpret_cast<BLE_CONNECTION_OBJECT>(connObj))
 #endif
@@ -455,12 +461,18 @@ JNI_METHOD(void, pairDeviceWithAddress)
 
     ChipLogProgress(Controller, "pairDeviceWithAddress() called");
 
+    if (!chip::CanCastTo<uint32_t>(pinCode))
+    {
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, CHIP_ERROR_INVALID_ARGUMENT);
+        return;
+    }
+
     JniUtfString addrJniString(env, address);
 
     RendezvousParameters rendezvousParams =
         RendezvousParameters()
             .SetDiscriminator(discriminator)
-            .SetSetupPINCode(pinCode)
+            .SetSetupPINCode(static_cast<uint32_t>(pinCode))
             .SetPeerAddress(Transport::PeerAddress::UDP(const_cast<char *>(addrJniString.c_str()), port));
 
     CommissioningParameters commissioningParams = wrapper->GetCommissioningParameters();
@@ -484,8 +496,14 @@ JNI_METHOD(void, establishPaseConnection)(JNIEnv * env, jobject self, jlong hand
     CHIP_ERROR err                           = CHIP_NO_ERROR;
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
 
+    if (!chip::CanCastTo<uint32_t>(pinCode))
+    {
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, CHIP_ERROR_INVALID_ARGUMENT);
+        return;
+    }
+
     RendezvousParameters rendezvousParams = RendezvousParameters()
-                                                .SetSetupPINCode(pinCode)
+                                                .SetSetupPINCode(static_cast<uint32_t>(pinCode))
 #if CONFIG_NETWORK_LAYER_BLE
                                                 .SetConnectionObject(reinterpret_cast<BLE_CONNECTION_OBJECT>(connObj))
 #endif
@@ -507,10 +525,18 @@ JNI_METHOD(void, establishPaseConnectionByAddress)
     CHIP_ERROR err                           = CHIP_NO_ERROR;
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
 
+    if (!chip::CanCastTo<uint32_t>(pinCode))
+    {
+        JniReferences::GetInstance().ThrowError(env, sChipDeviceControllerExceptionCls, CHIP_ERROR_INVALID_ARGUMENT);
+        return;
+    }
+
     JniUtfString addrJniString(env, address);
 
-    RendezvousParameters rendezvousParams = RendezvousParameters().SetSetupPINCode(pinCode).SetPeerAddress(
-        Transport::PeerAddress::UDP(const_cast<char *>(addrJniString.c_str()), port));
+    RendezvousParameters rendezvousParams =
+        RendezvousParameters()
+            .SetSetupPINCode(static_cast<uint32_t>(pinCode))
+            .SetPeerAddress(Transport::PeerAddress::UDP(const_cast<char *>(addrJniString.c_str()), port));
 
     err = wrapper->Controller()->EstablishPASEConnection(deviceId, rendezvousParams);
 
@@ -597,7 +623,9 @@ JNI_METHOD(jbyteArray, convertX509CertToMatterCert)
         err = chip::Credentials::ConvertX509CertToChipCert(x509CertBytes.byteSpan(), outBytes);
         SuccessOrExit(err);
 
-        err = JniReferences::GetInstance().N2J_ByteArray(env, outBytes.data(), outBytes.size(), outJbytes);
+        VerifyOrExit(chip::CanCastTo<uint32_t>(outBytes.size()), err = CHIP_ERROR_INTERNAL);
+
+        err = JniReferences::GetInstance().N2J_ByteArray(env, outBytes.data(), static_cast<uint32_t>(outBytes.size()), outJbytes);
         SuccessOrExit(err);
     }
 
@@ -868,6 +896,8 @@ JNI_METHOD(jboolean, openPairingWindow)(JNIEnv * env, jobject self, jlong handle
 JNI_METHOD(jboolean, openPairingWindowWithPIN)
 (JNIEnv * env, jobject self, jlong handle, jlong devicePtr, jint duration, jlong iteration, jint discriminator, jlong setupPinCode)
 {
+    VerifyOrReturnValue(chip::CanCastTo<uint32_t>(iteration), false);
+
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -882,8 +912,8 @@ JNI_METHOD(jboolean, openPairingWindowWithPIN)
 
     chip::SetupPayload setupPayload;
     err = AutoCommissioningWindowOpener::OpenCommissioningWindow(
-        wrapper->Controller(), chipDevice->GetDeviceId(), System::Clock::Seconds16(duration), iteration, discriminator,
-        MakeOptional(static_cast<uint32_t>(setupPinCode)), NullOptional, setupPayload);
+        wrapper->Controller(), chipDevice->GetDeviceId(), System::Clock::Seconds16(duration), static_cast<uint32_t>(iteration),
+        discriminator, MakeOptional(static_cast<uint32_t>(setupPinCode)), NullOptional, setupPayload);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -925,6 +955,8 @@ JNI_METHOD(jboolean, openPairingWindowWithPINCallback)
 (JNIEnv * env, jobject self, jlong handle, jlong devicePtr, jint duration, jlong iteration, jint discriminator, jlong setupPinCode,
  jobject jcallback)
 {
+    VerifyOrReturnValue(chip::CanCastTo<uint32_t>(iteration), false);
+
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err = CHIP_NO_ERROR;
 
@@ -939,8 +971,8 @@ JNI_METHOD(jboolean, openPairingWindowWithPINCallback)
 
     chip::SetupPayload setupPayload;
     err = AndroidCommissioningWindowOpener::OpenCommissioningWindow(
-        wrapper->Controller(), chipDevice->GetDeviceId(), System::Clock::Seconds16(duration), iteration, discriminator,
-        MakeOptional(static_cast<uint32_t>(setupPinCode)), NullOptional, jcallback, setupPayload);
+        wrapper->Controller(), chipDevice->GetDeviceId(), System::Clock::Seconds16(duration), static_cast<uint32_t>(iteration),
+        discriminator, MakeOptional(static_cast<uint32_t>(setupPinCode)), NullOptional, jcallback, setupPayload);
 
     if (err != CHIP_NO_ERROR)
     {
@@ -978,8 +1010,8 @@ JNI_METHOD(jbyteArray, getAttestationChallenge)
     SuccessOrExit(err);
     VerifyOrExit(attestationChallenge.size() == 16, err = CHIP_ERROR_INVALID_ARGUMENT);
 
-    err = JniReferences::GetInstance().N2J_ByteArray(env, attestationChallenge.data(), attestationChallenge.size(),
-                                                     attestationChallengeJbytes);
+    err = JniReferences::GetInstance().N2J_ByteArray(
+        env, attestationChallenge.data(), static_cast<uint32_t>(attestationChallenge.size()), attestationChallengeJbytes);
     SuccessOrExit(err);
 
 exit:
@@ -1019,7 +1051,12 @@ JNI_METHOD(jobject, computePaseVerifier)
     ChipLogProgress(Controller, "computePaseVerifier() called");
 
     AndroidDeviceControllerWrapper * wrapper = AndroidDeviceControllerWrapper::FromJNIHandle(handle);
-    err = wrapper->Controller()->ComputePASEVerifier(iterations, setupPincode, jniSalt.byteSpan(), verifier);
+
+    VerifyOrExit(chip::CanCastTo<uint32_t>(iterations), err = CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrExit(chip::CanCastTo<uint32_t>(setupPincode), err = CHIP_ERROR_INVALID_ARGUMENT);
+
+    err = wrapper->Controller()->ComputePASEVerifier(static_cast<uint32_t>(iterations), static_cast<uint32_t>(setupPincode),
+                                                     jniSalt.byteSpan(), verifier);
     SuccessOrExit(err);
 
     err = verifier.Serialize(serializedVerifierSpan);
@@ -1272,7 +1309,7 @@ CHIP_ERROR GetChipPathIdValue(jobject chipPathId, uint32_t wildcardValue, uint32
 
     jmethodID getIdMethod = nullptr;
     ReturnErrorOnFailure(JniReferences::GetInstance().FindMethod(env, chipPathId, "getId", "()J", &getIdMethod));
-    outValue = env->CallLongMethod(chipPathId, getIdMethod);
+    outValue = static_cast<uint32_t>(env->CallLongMethod(chipPathId, getIdMethod));
     VerifyOrReturnError(!env->ExceptionCheck(), CHIP_JNI_ERROR_EXCEPTION_THROWN);
 
     return CHIP_NO_ERROR;

--- a/src/controller/java/templates/CHIPClustersWrite-JNI.zapt
+++ b/src/controller/java/templates/CHIPClustersWrite-JNI.zapt
@@ -20,6 +20,9 @@
 #include <platform/PlatformManager.h>
 #include <vector>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+
 #define JNI_METHOD(RETURN, CLASS_NAME, METHOD_NAME)                                                                                            \
     extern "C" JNIEXPORT RETURN JNICALL Java_chip_devicecontroller_ChipClusters_00024##CLASS_NAME##_##METHOD_NAME
 
@@ -75,3 +78,5 @@ JNI_METHOD(void, {{asUpperCamelCase ../name}}Cluster, write{{asUpperCamelCase na
 {{/chip_server_cluster_attributes}}
 {{/chip_client_clusters}}
 {{/if}}
+
+#pragma clang diagnostic pop

--- a/src/controller/java/templates/CHIPReadCallbacks-src.zapt
+++ b/src/controller/java/templates/CHIPReadCallbacks-src.zapt
@@ -8,6 +8,7 @@
 #include <lib/support/JniReferences.h>
 #include <lib/support/JniTypeWrappers.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
 #include <platform/PlatformManager.h>
 
 {{#chip_server_global_responses}}
@@ -65,9 +66,10 @@ void CHIP{{chipCallback.name}}AttributeCallback::CallbackFn(void * context, {{ch
     err = chip::JniReferences::GetInstance().FindMethod(env, javaCallbackRef, "onSuccess", "([B)V", &javaMethod);
     VerifyOrReturn(err == CHIP_NO_ERROR, ChipLogError(Zcl, "Could not find onSuccess method"));
 
-    jbyteArray valueArr = env->NewByteArray(value.size());
+    VerifyOrReturn(chip::CanCastTo<uint32_t>(value.size()), ChipLogError(Zcl, "Value too long"));
+    jbyteArray valueArr = env->NewByteArray(static_cast<uint32_t>(value.size()));
     env->ExceptionClear();
-    env->SetByteArrayRegion(valueArr, 0, value.size(), reinterpret_cast<const jbyte *>(value.data()));
+    env->SetByteArrayRegion(valueArr, 0, static_cast<uint32_t>(value.size()), reinterpret_cast<const jbyte *>(value.data()));
 
     env->CallVoidMethod(javaCallbackRef, javaMethod, valueArr);
     {{/if}}

--- a/src/controller/java/templates/partials/encode_value.zapt
+++ b/src/controller/java/templates/partials/encode_value.zapt
@@ -24,7 +24,7 @@
       auto * listHolder_{{depth}} = new ListHolder<ListMemberType_{{depth}}>({{source}}Size);
       listFreer.add(listHolder_{{depth}});
 
-      for (size_t i_{{depth}} = 0; i_{{depth}} < static_cast<size_t>({{source}}Size); ++i_{{depth}}) {
+      for (jint i_{{depth}} = 0; i_{{depth}} < {{source}}Size; ++i_{{depth}}) {
         jobject element_{{depth}};
         chip::JniReferences::GetInstance().GetListItem({{source}}, i_{{depth}}, element_{{depth}});
         {{>encode_value target=(concat "listHolder_" depth "->mList[i_" depth "]") source=(concat "element_" depth) cluster=cluster depth=(incrementDepth depth) isArray=false}}

--- a/src/controller/java/zap-generated/CHIPClustersWrite-JNI.cpp
+++ b/src/controller/java/zap-generated/CHIPClustersWrite-JNI.cpp
@@ -36,6 +36,9 @@
 #include <platform/PlatformManager.h>
 #include <vector>
 
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wshorten-64-to-32"
+
 #define JNI_METHOD(RETURN, CLASS_NAME, METHOD_NAME)                                                                                \
     extern "C" JNIEXPORT RETURN JNICALL Java_chip_devicecontroller_ChipClusters_00024##CLASS_NAME##_##METHOD_NAME
 
@@ -839,7 +842,7 @@ JNI_METHOD(void, BindingCluster, writeBindingAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -972,7 +975,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -1008,7 +1011,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
                             auto * listHolder_3 = new ListHolder<ListMemberType_3>(element_0_subjectsItem_1Size);
                             listFreer.add(listHolder_3);
 
-                            for (size_t i_3 = 0; i_3 < static_cast<size_t>(element_0_subjectsItem_1Size); ++i_3)
+                            for (jint i_3 = 0; i_3 < element_0_subjectsItem_1Size; ++i_3)
                             {
                                 jobject element_3;
                                 chip::JniReferences::GetInstance().GetListItem(element_0_subjectsItem_1, i_3, element_3);
@@ -1043,7 +1046,7 @@ JNI_METHOD(void, AccessControlCluster, writeAclAttribute)
                             auto * listHolder_3 = new ListHolder<ListMemberType_3>(element_0_targetsItem_1Size);
                             listFreer.add(listHolder_3);
 
-                            for (size_t i_3 = 0; i_3 < static_cast<size_t>(element_0_targetsItem_1Size); ++i_3)
+                            for (jint i_3 = 0; i_3 < element_0_targetsItem_1Size; ++i_3)
                             {
                                 jobject element_3;
                                 chip::JniReferences::GetInstance().GetListItem(element_0_targetsItem_1, i_3, element_3);
@@ -1169,7 +1172,7 @@ JNI_METHOD(void, AccessControlCluster, writeExtensionAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -1408,7 +1411,7 @@ JNI_METHOD(void, OtaSoftwareUpdateRequestorCluster, writeDefaultOtaProvidersAttr
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -1861,7 +1864,7 @@ JNI_METHOD(void, GroupKeyManagementCluster, writeGroupKeyMapAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -1950,7 +1953,7 @@ JNI_METHOD(void, UserLabelCluster, writeLabelListAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -6506,7 +6509,7 @@ JNI_METHOD(void, TestClusterCluster, writeListInt8uAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -6580,7 +6583,7 @@ JNI_METHOD(void, TestClusterCluster, writeListOctetStringAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -6655,7 +6658,7 @@ JNI_METHOD(void, TestClusterCluster, writeListStructOctetStringAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -7047,7 +7050,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -7341,7 +7344,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                             auto * listHolder_3 = new ListHolder<ListMemberType_3>(element_0_nullableListItem_1Size);
                             listFreer.add(listHolder_3);
 
-                            for (size_t i_3 = 0; i_3 < static_cast<size_t>(element_0_nullableListItem_1Size); ++i_3)
+                            for (jint i_3 = 0; i_3 < element_0_nullableListItem_1Size; ++i_3)
                             {
                                 jobject element_3;
                                 chip::JniReferences::GetInstance().GetListItem(element_0_nullableListItem_1, i_3, element_3);
@@ -7376,7 +7379,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                                 auto * listHolder_3 = new ListHolder<ListMemberType_3>(optionalValue_2Size);
                                 listFreer.add(listHolder_3);
 
-                                for (size_t i_3 = 0; i_3 < static_cast<size_t>(optionalValue_2Size); ++i_3)
+                                for (jint i_3 = 0; i_3 < optionalValue_2Size; ++i_3)
                                 {
                                     jobject element_3;
                                     chip::JniReferences::GetInstance().GetListItem(optionalValue_2, i_3, element_3);
@@ -7420,7 +7423,7 @@ JNI_METHOD(void, TestClusterCluster, writeListNullablesAndOptionalsStructAttribu
                                     auto * listHolder_4 = new ListHolder<ListMemberType_4>(optionalValue_2Size);
                                     listFreer.add(listHolder_4);
 
-                                    for (size_t i_4 = 0; i_4 < static_cast<size_t>(optionalValue_2Size); ++i_4)
+                                    for (jint i_4 = 0; i_4 < optionalValue_2Size; ++i_4)
                                     {
                                         jobject element_4;
                                         chip::JniReferences::GetInstance().GetListItem(optionalValue_2, i_4, element_4);
@@ -7766,7 +7769,7 @@ JNI_METHOD(void, TestClusterCluster, writeListLongOctetStringAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -7841,7 +7844,7 @@ JNI_METHOD(void, TestClusterCluster, writeListFabricScopedAttribute)
             auto * listHolder_0 = new ListHolder<ListMemberType_0>(valueSize);
             listFreer.add(listHolder_0);
 
-            for (size_t i_0 = 0; i_0 < static_cast<size_t>(valueSize); ++i_0)
+            for (jint i_0 = 0; i_0 < valueSize; ++i_0)
             {
                 jobject element_0;
                 chip::JniReferences::GetInstance().GetListItem(value, i_0, element_0);
@@ -7975,7 +7978,7 @@ JNI_METHOD(void, TestClusterCluster, writeListFabricScopedAttribute)
                         auto * listHolder_2 = new ListHolder<ListMemberType_2>(element_0_fabricSensitiveInt8uListItem_1Size);
                         listFreer.add(listHolder_2);
 
-                        for (size_t i_2 = 0; i_2 < static_cast<size_t>(element_0_fabricSensitiveInt8uListItem_1Size); ++i_2)
+                        for (jint i_2 = 0; i_2 < element_0_fabricSensitiveInt8uListItem_1Size; ++i_2)
                         {
                             jobject element_2;
                             chip::JniReferences::GetInstance().GetListItem(element_0_fabricSensitiveInt8uListItem_1, i_2,
@@ -10164,3 +10167,5 @@ JNI_METHOD(void, TestClusterCluster, writeNullableRangeRestrictedInt16sAttribute
     onSuccess.release();
     onFailure.release();
 }
+
+#pragma clang diagnostic pop

--- a/src/controller/tests/data_model/TestRead.cpp
+++ b/src/controller/tests/data_model/TestRead.cpp
@@ -102,7 +102,8 @@ CHIP_ERROR ReadSingleClusterData(const Access::SubjectDescriptor & aSubjectDescr
         {
             ConcreteAttributePath path(aPath);
             // Use an incorrect attribute id for some of the responses.
-            path.mAttributeId = path.mAttributeId + (i / 2) + (responseDirective == kSendManyDataResponsesWrongPath);
+            path.mAttributeId =
+                static_cast<AttributeId>(path.mAttributeId + (i / 2) + (responseDirective == kSendManyDataResponsesWrongPath));
             AttributeValueEncoder::AttributeEncodeState state =
                 (apEncoderState == nullptr ? AttributeValueEncoder::AttributeEncodeState() : *apEncoderState);
             AttributeValueEncoder valueEncoder(aAttributeReports, aSubjectDescriptor.fabricIndex, path,

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -35,6 +35,7 @@
 #include <lib/support/BytesToHex.h>
 #include <lib/support/CHIPMem.h>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
 #include <lib/support/ScopedBuffer.h>
 #include <platform/BuildTime.h>
 #include <platform/CommissionableDataProvider.h>
@@ -182,7 +183,10 @@ CHIP_ERROR LegacyTemporaryCommissionableDataProvider<ConfigClass>::GetSpake2pSal
 #endif // defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_SALT)
 
     ReturnErrorOnFailure(err);
-    size_t saltLen = chip::Base64Decode32(saltB64, saltB64Len, reinterpret_cast<uint8_t *>(saltB64));
+
+    VerifyOrReturnError(chip::CanCastTo<uint32_t>(saltB64Len), CHIP_ERROR_INTERNAL);
+
+    size_t saltLen = chip::Base64Decode32(saltB64, static_cast<uint32_t>(saltB64Len), reinterpret_cast<uint8_t *>(saltB64));
 
     ReturnErrorCodeIf(saltLen > saltBuf.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
     memcpy(saltBuf.data(), saltB64, saltLen);
@@ -216,7 +220,11 @@ CHIP_ERROR LegacyTemporaryCommissionableDataProvider<ConfigClass>::GetSpake2pVer
 #endif // defined(CHIP_DEVICE_CONFIG_USE_TEST_SPAKE2P_VERIFIER)
 
     ReturnErrorOnFailure(err);
-    verifierLen = chip::Base64Decode32(verifierB64, verifierB64Len, reinterpret_cast<uint8_t *>(verifierB64));
+
+    VerifyOrReturnError(chip::CanCastTo<uint32_t>(verifierB64Len), CHIP_ERROR_INTERNAL);
+    verifierLen =
+        chip::Base64Decode32(verifierB64, static_cast<uint32_t>(verifierB64Len), reinterpret_cast<uint8_t *>(verifierB64));
+
     ReturnErrorCodeIf(verifierLen > verifierBuf.size(), CHIP_ERROR_BUFFER_TOO_SMALL);
     memcpy(verifierBuf.data(), verifierB64, verifierLen);
     verifierBuf.reduce_size(verifierLen);

--- a/src/lib/shell/commands/Base64.cpp
+++ b/src/lib/shell/commands/Base64.cpp
@@ -29,6 +29,7 @@
 #include <lib/support/Base64.h>
 #include <lib/support/CHIPArgParser.hpp>
 #include <lib/support/CodeUtils.h>
+#include <lib/support/SafeInt.h>
 
 chip::Shell::Engine sShellBase64Commands;
 
@@ -63,7 +64,11 @@ static CHIP_ERROR Base64EncodeHandler(int argc, char ** argv)
     uint32_t binarySize, base64Size;
 
     VerifyOrReturnError(argc > 0, CHIP_ERROR_INVALID_ARGUMENT);
-    ArgParser::ParseHexString(argv[0], strlen(argv[0]), binary, sizeof(binary), binarySize);
+
+    size_t argLen = strlen(argv[0]);
+    VerifyOrReturnError(CanCastTo<uint32_t>(argLen), CHIP_ERROR_INVALID_ARGUMENT);
+
+    ArgParser::ParseHexString(argv[0], static_cast<uint32_t>(argLen), binary, sizeof(binary), binarySize);
     base64Size = Base64Encode(binary, binarySize, base64);
     streamer_printf(sout, "%.*s\r\n", base64Size, base64);
     return CHIP_NO_ERROR;

--- a/src/platform/Darwin/SystemTimeSupport.cpp
+++ b/src/platform/Darwin/SystemTimeSupport.cpp
@@ -83,7 +83,7 @@ CHIP_ERROR ClockImpl::SetClock_RealTime(Microseconds64 aNewCurTime)
 {
     struct timeval tv;
     tv.tv_sec  = static_cast<time_t>(aNewCurTime.count() / UINT64_C(1000000));
-    tv.tv_usec = static_cast<long>(aNewCurTime.count() % UINT64_C(1000000));
+    tv.tv_usec = static_cast<__darwin_suseconds_t>(aNewCurTime.count() % UINT64_C(1000000));
     if (settimeofday(&tv, nullptr) != 0)
     {
         return (errno == EPERM) ? CHIP_ERROR_ACCESS_DENIED : CHIP_ERROR_POSIX(errno);

--- a/src/platform/android/CHIPP256KeypairBridge.cpp
+++ b/src/platform/android/CHIPP256KeypairBridge.cpp
@@ -20,6 +20,7 @@
 #include "lib/support/CHIPJNIError.h"
 #include "lib/support/JniReferences.h"
 #include "lib/support/JniTypeWrappers.h"
+#include "lib/support/SafeInt.h"
 
 #include <array>
 #include <cstdint>
@@ -115,12 +116,14 @@ CHIP_ERROR CHIPP256KeypairBridge::ECDSA_sign_msg(const uint8_t * msg, size_t msg
         return CHIP_ERROR_INCORRECT_STATE;
     }
 
+    VerifyOrReturnError(CanCastTo<uint32_t>(msg_length), CHIP_ERROR_INVALID_ARGUMENT);
+
     CHIP_ERROR err = CHIP_NO_ERROR;
     jbyteArray jniMsg;
     jobject signedResult = nullptr;
     JNIEnv * env         = JniReferences::GetInstance().GetEnvForCurrentThread();
     VerifyOrReturnError(env != nullptr, err = CHIP_JNI_ERROR_NO_ENV);
-    err = JniReferences::GetInstance().N2J_ByteArray(env, msg, msg_length, jniMsg);
+    err = JniReferences::GetInstance().N2J_ByteArray(env, msg, static_cast<uint32_t>(msg_length), jniMsg);
     VerifyOrReturnError(err == CHIP_NO_ERROR, err);
     VerifyOrReturnError(jniMsg != nullptr, err);
 

--- a/src/platform/android/CommissionableDataProviderImpl.cpp
+++ b/src/platform/android/CommissionableDataProviderImpl.cpp
@@ -151,7 +151,7 @@ CHIP_ERROR CommissionableDataProviderImpl::Update(JNIEnv * env, jstring spake2pV
     mPaseIterationCount = spake2pIterationCount;
     if (havePasscode)
     {
-        mSetupPasscode.SetValue(setupPasscode);
+        mSetupPasscode.SetValue(static_cast<uint32_t>(setupPasscode));
     }
 
     // Set to global CommissionableDataProvider once success first time

--- a/src/platform/android/DiagnosticDataProviderImpl.cpp
+++ b/src/platform/android/DiagnosticDataProviderImpl.cpp
@@ -163,7 +163,8 @@ CHIP_ERROR DiagnosticDataProviderImpl::GetNetworkInterfaces(NetworkInterface ** 
             {
                 size_t len = env->GetArrayLength(jHardwareAddressObj);
                 len        = (len > kMaxHardwareAddrSize) ? kMaxHardwareAddrSize : len;
-                env->GetByteArrayRegion(jHardwareAddressObj, 0, len, reinterpret_cast<jbyte *>(ifp->MacAddress));
+                env->GetByteArrayRegion(jHardwareAddressObj, 0, static_cast<uint32_t>(len),
+                                        reinterpret_cast<jbyte *>(ifp->MacAddress));
                 ifp->hardwareAddress = ByteSpan(ifp->MacAddress, 6);
             }
 

--- a/src/platform/android/DnssdImpl.cpp
+++ b/src/platform/android/DnssdImpl.cpp
@@ -88,6 +88,8 @@ CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCal
 {
     VerifyOrReturnError(service != nullptr, CHIP_ERROR_INVALID_ARGUMENT);
     VerifyOrReturnError(sResolverObject != nullptr && sPublishMethod != nullptr, CHIP_ERROR_INCORRECT_STATE);
+    VerifyOrReturnError(CanCastTo<uint32_t>(service->mTextEntrySize), CHIP_ERROR_INVALID_ARGUMENT);
+    VerifyOrReturnError(CanCastTo<uint32_t>(service->mSubTypeSize), CHIP_ERROR_INVALID_ARGUMENT);
 
     JNIEnv * env = JniReferences::GetInstance().GetEnvForCurrentThread();
     UtfString jniName(env, service->mName);
@@ -98,23 +100,28 @@ CHIP_ERROR ChipDnssdPublishService(const DnssdService * service, DnssdPublishCal
     serviceType += (service->mProtocol == DnssdServiceProtocol::kDnssdProtocolUdp ? "_udp" : "_tcp");
     UtfString jniServiceType(env, serviceType.c_str());
 
+    auto textEntrySize = static_cast<uint32_t>(service->mTextEntrySize);
+
     jclass stringClass = env->FindClass("java/lang/String");
-    jobjectArray keys  = env->NewObjectArray(service->mTextEntrySize, stringClass, nullptr);
+    jobjectArray keys  = env->NewObjectArray(textEntrySize, stringClass, nullptr);
 
     jclass arrayElemType = env->FindClass("[B");
-    jobjectArray datas   = env->NewObjectArray(service->mTextEntrySize, arrayElemType, nullptr);
+    jobjectArray datas   = env->NewObjectArray(textEntrySize, arrayElemType, nullptr);
 
-    for (size_t i = 0; i < service->mTextEntrySize; i++)
+    for (uint32_t i = 0; i < textEntrySize; i++)
     {
         UtfString jniKey(env, service->mTextEntries[i].mKey);
         env->SetObjectArrayElement(keys, i, jniKey.jniValue());
 
-        ByteArray jniData(env, (const jbyte *) service->mTextEntries[i].mData, service->mTextEntries[i].mDataSize);
+        VerifyOrReturnError(CanCastTo<uint32_t>(service->mTextEntries[i].mDataSize), CHIP_ERROR_INVALID_ARGUMENT);
+        auto dataSize = static_cast<uint32_t>(service->mTextEntries[i].mDataSize);
+        ByteArray jniData(env, (const jbyte *) service->mTextEntries[i].mData, dataSize);
         env->SetObjectArrayElement(datas, i, jniData.jniValue());
     }
 
-    jobjectArray subTypes = env->NewObjectArray(service->mSubTypeSize, stringClass, nullptr);
-    for (size_t i = 0; i < service->mSubTypeSize; i++)
+    auto subTypeSize      = static_cast<uint32_t>(service->mSubTypeSize);
+    jobjectArray subTypes = env->NewObjectArray(subTypeSize, stringClass, nullptr);
+    for (uint32_t i = 0; i < subTypeSize; i++)
     {
         UtfString jniSubType(env, service->mSubTypes[i]);
         env->SetObjectArrayElement(subTypes, i, jniSubType.jniValue());
@@ -316,13 +323,13 @@ void HandleResolve(jstring instanceName, jstring serviceType, jstring hostName, 
     if (textEntries != nullptr)
     {
         jobjectArray keys   = (jobjectArray) env->CallObjectMethod(sMdnsCallbackObject, sGetTextEntryKeysMethod, textEntries);
-        size_t size         = env->GetArrayLength(keys);
+        auto size           = env->GetArrayLength(keys);
         TextEntry * entries = new (std::nothrow) TextEntry[size];
         VerifyOrExit(entries != nullptr, ChipLogError(Discovery, "entries alloc failure"));
         memset(entries, 0, sizeof(entries[0]) * size);
 
         service.mTextEntries = entries;
-        for (size_t i = 0; i < size; i++)
+        for (decltype(size) i = 0; i < size; i++)
         {
             jstring jniKeyObject = (jstring) env->GetObjectArrayElement(keys, i);
             JniUtfString key(env, jniKeyObject);
@@ -391,9 +398,9 @@ void HandleBrowse(jobjectArray instanceName, jstring serviceType, jlong callback
 
     VerifyOrReturn(strlen(jniServiceType.c_str()) <= kDnssdTypeAndProtocolMaxSize, dispatch(CHIP_ERROR_INVALID_ARGUMENT));
 
-    size_t size            = env->GetArrayLength(instanceName);
+    auto size              = env->GetArrayLength(instanceName);
     DnssdService * service = new DnssdService[size];
-    for (size_t i = 0; i < size; i++)
+    for (decltype(size) i = 0; i < size; i++)
     {
         JniUtfString jniInstanceName(env, (jstring) env->GetObjectArrayElement(instanceName, i));
         VerifyOrReturn(strlen(jniInstanceName.c_str()) <= Operational::kInstanceNameMaxLength,

--- a/src/setup_payload/java/SetupPayloadParser-JNI.cpp
+++ b/src/setup_payload/java/SetupPayloadParser-JNI.cpp
@@ -288,7 +288,7 @@ void TransformSetupPayloadFromJobject(JNIEnv * env, jobject jPayload, SetupPaylo
     payload.productID         = env->GetIntField(jPayload, productId);
     payload.commissioningFlow = static_cast<CommissioningFlow>(env->GetIntField(jPayload, commissioningFlow));
     payload.discriminator.SetLongValue(env->GetIntField(jPayload, discriminator));
-    payload.setUpPINCode = env->GetLongField(jPayload, setUpPinCode);
+    payload.setUpPINCode = static_cast<uint32_t>(env->GetLongField(jPayload, setUpPinCode));
 
     jobject discoveryCapabilitiesObj = env->GetObjectField(jPayload, discoveryCapabilities);
     CreateCapabilitiesFromHashSet(env, discoveryCapabilitiesObj,

--- a/third_party/boringssl/repo/BUILD.gn
+++ b/third_party/boringssl/repo/BUILD.gn
@@ -12,12 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
+import("${build_root}/config/compiler/compiler.gni")
+
 import("BUILD.generated.gni")
 
 config("boringssl_config") {
   include_dirs = [ "src/include" ]
 
   cflags = [ "-Wno-unused-variable" ]
+
+  if (is_clang) {
+    cflags += [ "-Wno-shorten-64-to-32" ]
+  }
 
   # We want the basic crypto impl with no asm primitives until we hook-up platform-based
   # support to the build later.

--- a/third_party/editline/BUILD.gn
+++ b/third_party/editline/BUILD.gn
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
+import("${build_root}/config/compiler/compiler.gni")
+
 config("editline_config") {
   include_dirs = [ "repo/include" ]
+
+  if (is_clang) {
+    cflags = [ "-Wno-shorten-64-to-32" ]
+  }
 }
 
 static_library("editline") {

--- a/third_party/mbedtls/mbedtls.gni
+++ b/third_party/mbedtls/mbedtls.gni
@@ -14,6 +14,9 @@
 
 import("//build_overrides/mbedtls.gni")
 
+import("//build_overrides/build.gni")
+import("${build_root}/config/compiler/compiler.gni")
+
 template("mbedtls_target") {
   mbedtls_target_name = target_name
 
@@ -26,6 +29,10 @@ template("mbedtls_target") {
       "-Wno-unused-but-set-parameter",
       "-Wno-format-nonliteral",  # Because of mbedtls_debug_print_msg
     ]
+
+    if (is_clang) {
+      cflags += [ "-Wno-shorten-64-to-32" ]
+    }
   }
 
   config("${mbedtls_target_name}_config") {

--- a/third_party/nlunit-test/BUILD.gn
+++ b/third_party/nlunit-test/BUILD.gn
@@ -12,8 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
+import("${build_root}/config/compiler/compiler.gni")
+
 config("nlunit-test_config") {
   include_dirs = [ "repo/src" ]
+
+  if (is_clang) {
+    cflags = [ "-Wno-shorten-64-to-32" ]
+  }
 }
 
 static_library("nlunit-test") {


### PR DESCRIPTION
#### Problem

Some `uint64_t` are sometimes shortened to `uint32_t`

#### Changes

This PR adds `-Wshorten-64-to-32` for clang based builds.
