### PR TITLE
[darwin-framework-tool] Update some NSLog format to works properly fo…

### DIFF
--- a/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.mm
+++ b/examples/darwin-framework-tool/commands/pairing/DeviceControllerDelegateBridge.mm
@@ -25,7 +25,7 @@
 @implementation CHIPToolDeviceControllerDelegate
 - (void)onStatusUpdate:(MTRCommissioningStatus)status
 {
-    NSLog(@"Pairing Status Update: %lu", status);
+    NSLog(@"Pairing Status Update: %tu", status);
     switch (status) {
     case MTRCommissioningStatusSuccess:
         ChipLogProgress(chipTool, "Secure Pairing Success");

--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -76,7 +76,7 @@ CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
     NSLog(@"Version:       %@", payload.version);
     NSLog(@"VendorID:      %@", payload.vendorID);
     NSLog(@"ProductID:     %@", payload.productID);
-    NSLog(@"Custom flow:   %lu    (%@)", payload.commissioningFlow, CustomFlowString(payload.commissioningFlow));
+    NSLog(@"Custom flow:   %tu    (%@)", payload.commissioningFlow, CustomFlowString(payload.commissioningFlow));
     {
         if (payload.discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
             NSLog(@"Capabilities:  UNKNOWN");
@@ -100,7 +100,7 @@ CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
                 [humanFlags appendString:@"ON NETWORK"];
             }
 
-            NSLog(@"Capabilities:  0x%02lX (%@)", value, humanFlags);
+            NSLog(@"Capabilities:  0x%02lX (%@)", static_cast<long>(value), humanFlags);
         }
     }
     NSLog(@"Discriminator: %@", payload.discriminator);


### PR DESCRIPTION
#### Problem
The format for printing used into some `NSLog` is incorrect when it comes to `NSENUM` and `NSOPTIONS`

#### Changes
 * The log formats has been updated.
