### PR TITLE
[darwin-framework-tool] Make some parts of examples/darwin-framework-…

### DIFF
--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -28,11 +28,12 @@ declare_args() {
   chip_codesign = current_os == "ios"
 }
 
-if (current_os == "ios") {
-  output_sdk_type = "Debug-iphoneos"
-} else {
-  output_sdk_type = "Debug"
+sdk_build_dir_suffix = ""
+if (getenv("SDKROOT") != "") {
+  sdk_root_parts = string_split(getenv("SDKROOT"), ".")
+  sdk_build_dir_suffix = "-${sdk_root_parts[0]}"
 }
+output_sdk_type = "Debug${sdk_build_dir_suffix}"
 
 action("build-darwin-framework") {
   script = "${chip_root}/scripts/build/build_darwin_framework.py"


### PR DESCRIPTION
…tool/BUILD.gn a bit more generic when it comes to SDKROOT variants

#### Problem

Some parts of the build for `darwin-framework-tool` relies on the output folder from Xcode. For now it is tied to the `current_os` variable but at the end of the day it is really tied to which SDKROOT is used.