### PR TITLE
Do not set SO_REUSEPORT for UDP communication

### DIFF
--- a/src/inet/UDPEndPointImplSockets.cpp
+++ b/src/inet/UDPEndPointImplSockets.cpp
@@ -485,7 +485,7 @@ CHIP_ERROR UDPEndPointImplSockets::GetSocket(IPAddressType addressType)
         // multiplexing between these.
         //
         // We only want to allow port reuse for multicast (in which case all
-        // bound sockets will receieve a copy of the datagram), and SO_REUSEADDR
+        // bound sockets will receive a copy of the datagram), and SO_REUSEADDR
         // already gives us that behavior.
 
         // If creating an IPv6 socket, tell the kernel that it will be


### PR DESCRIPTION
This allows multiple sockets to bind to the same ip:port.  But we only want that for multicast UDP, and SO_REUSEADDR already gives us this.

This had been seen to break the stack with multiple matter instances on the same machine bound to an ephemeral port.

Fixes #23108