### PR TITLE
Add an assert to guard the FIXED_ENDPOINT_COUNT value

### DIFF
--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -107,6 +107,9 @@ void emberAfEndpointConfigure(void)
 {
     uint16_t ep;
 
+    static_assert(FIXED_ENDPOINT_COUNT <= std::numeric_limits<typeof(ep)>::max(),
+                  "FIXED_ENDPOINT_COUNT must not exceed the size of the endpoint data type");
+
 #if !defined(EMBER_SCRIPTED_TEST)
     uint16_t fixedEndpoints[]             = FIXED_ENDPOINT_ARRAY;
     uint16_t fixedDeviceTypeListLengths[] = FIXED_DEVICE_TYPE_LENGTHS;


### PR DESCRIPTION
Add an assert in `emberAfEndpointConfigure()` to guard FIXED_ENDPOINT_COUNT value against the endpoint ID data type size overflow. 