### PR TITLE
Remove reporting of rejected parts during target expand

### DIFF
--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -289,7 +289,7 @@ class BuildTarget:
 
         fixed_indices = [0]*len(self.fixed_targets)
 
-        # Make the log a bit less spammy. Expand is expected to hit a lot 
+        # Make the log a bit less spammy. Expand is expected to hit a lot
         # of these
         while True:
 

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -48,6 +48,9 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 
+report_rejected_parts = True
+
+
 @dataclass(init=False)
 class TargetPart:
     # SubTarget/Modifier name
@@ -79,14 +82,16 @@ class TargetPart:
     def Accept(self, full_input: str):
         if self.except_if_re:
             if self.except_if_re.search(full_input):
-                # likely nothing will match when we get such an error
-                logging.error(f"'{self.name}' does not support '{full_input}' due to rule EXCEPT IF '{self.except_if_re.pattern}'")
+                if report_rejected_parts:
+                    # likely nothing will match when we get such an error
+                    logging.error(f"'{self.name}' does not support '{full_input}' due to rule EXCEPT IF '{self.except_if_re.pattern}'")
                 return False
 
         if self.only_if_re:
             if not self.only_if_re.search(full_input):
-                # likely nothing will match when we get such an error
-                logging.error(f"'{self.name}' does not support '{full_input}' due to rule ONLY IF '{self.only_if_re.pattern}'")
+                if report_rejected_parts:
+                    # likely nothing will match when we get such an error
+                    logging.error(f"'{self.name}' does not support '{full_input}' due to rule ONLY IF '{self.only_if_re.pattern}'")
                 return False
 
         return True
@@ -284,6 +289,8 @@ class BuildTarget:
 
         fixed_indices = [0]*len(self.fixed_targets)
 
+        # Make the log a bit less spammy. Expand is expected to hit a lot 
+        # of these
         while True:
 
             prefix = "-".join(map(

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -289,8 +289,6 @@ class BuildTarget:
 
         fixed_indices = [0]*len(self.fixed_targets)
 
-        # Make the log a bit less spammy. Expand is expected to hit a lot
-        # of these
         while True:
 
             prefix = "-".join(map(

--- a/scripts/build/build_examples.py
+++ b/scripts/build/build_examples.py
@@ -162,6 +162,7 @@ def cmd_generate(context):
 def cmd_targets(context, expand):
     for target in build.targets.BUILD_TARGETS:
         if expand:
+            build.target.report_rejected_parts = False
             for s in target.AllVariants():
                 print(s)
         else:


### PR DESCRIPTION
`./scripts/build/build_examples.py targets --expand` will run through all possible build variants/modifiers and this will result in a lot of 'rejected' errors.

In case of target expand, explicitly disable reporting of 'path was rejected' to make the output less spammy.

I tested this manually running the command, saw no error logs.