### PR TITLE
Fix K32W build rules (ToT CI failure)

### DIFF
--- a/.github/workflows/examples-k32w.yaml
+++ b/.github/workflows/examples-k32w.yaml
@@ -71,7 +71,7 @@ jobs:
               run: |
                   scripts/run_in_build_env.sh "\
                       ./scripts/build/build_examples.py \
-                      --target k32w-light \
+                      --target k32w-light-no-ble-se05x \
                       --target k32w-light-no-ota \
                       --target k32w-lock-low-power-nologs \
                       --target k32w-contact-low-power-nologs \

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -45,7 +45,7 @@ import re
 
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 
 @dataclass(init=False)
@@ -54,7 +54,7 @@ class TargetPart:
     name: str
 
     # The build arguments to apply to a builder if this part is active
-    build_arguments: dict[str, Any]
+    build_arguments: Dict[str, Any]
 
     # Part should be included if and only if the final string MATCHES the
     # given regular expression

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -350,6 +350,8 @@ def BuildK32WTarget():
         TargetPart('contact', app=K32WApp.CONTACT, release=True),
     ])
 
+    target.AppendModifier(name="se05x", se05x=True)
+    target.AppendModifier(name="no-ble", disable_ble=True)
     target.AppendModifier(name="no-ota", disable_ota=True)
     target.AppendModifier(name="low-power", low_power=True).OnlyIfRe("-nologs")
     target.AppendModifier(name="nologs", disable_logs=True)


### PR DESCRIPTION
Two python fixes:
   - Python 3.8 does not like `dict` as a type, use `Dict` from typing instead
   - Disable BLE and enable se05x on light app in K32W since otherwise we run out of flash.
