### PR TITLE
Fix build system unit tests

### DIFF
--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -43,9 +43,8 @@ import logging
 import os
 import re
 
-from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Iterable
 
 
 @dataclass(init=False)

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -12,7 +12,7 @@ linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,therm
 linux-x64-efr32-test-runner[-clang]
 imx-{chip-tool,lighting-app,thermostat,all-clusters-app,all-clusters-minimal-app,ota-provider-app}[-release]
 infineon-psoc6-{lock,light,all-clusters,all-clusters-minimal}[-ota][-updateimage]
-k32w-{light,shell,lock,contact}[-no-ota][-low-power][-nologs]
+k32w-{light,shell,lock,contact}[-se05x][-no-ble][-no-ota][-low-power][-nologs]
 mbed-cy8cproto_062_4343w-{lock,light,all-clusters,all-clusters-minimal,pigweed,shell}[-release][-develop][-debug]
 mw320-all-clusters-app
 nrf-{nrf5340dk,nrf52840dk,nrf52840dongle}-{all-clusters,all-clusters-minimal,lock,light,shell,pump,pump-controller}[-rpc]


### PR DESCRIPTION
After changes in #23126, build targets changed and that requires a unit test update.

Also fix another python 3.8 compatibility issue (iterable should be imported from typing not abc)