### PR TITLE
Re-add some APIs to MTRDeviceControllerFactory, but deprecate them.

### DIFF
--- a/.github/workflows/darwin.yaml
+++ b/.github/workflows/darwin.yaml
@@ -66,11 +66,19 @@ jobs:
             - name: Run iOS Build Debug
               timeout-minutes: 30
               working-directory: src/darwin/Framework
-              run: xcodebuild -target "Matter" -sdk iphoneos
+              # For now disable unguarded-availability-new warnings because we
+              # internally use APIs that we are annotating as only available on
+              # new enough versions.  Maybe we should change out deployment
+              # target versions instead?
+              run: xcodebuild -target "Matter" -sdk iphoneos OTHER_CFLAGS='${inherited} -Wno-unguarded-availability-new'
             - name: Run iOS Build Release
               timeout-minutes: 30
               working-directory: src/darwin/Framework
-              run: xcodebuild -target "Matter" -sdk iphoneos -configuration Release
+              # For now disable unguarded-availability-new warnings because we
+              # internally use APIs that we are annotating as only available on
+              # new enough versions.  Maybe we should change out deployment
+              # target versions instead?
+              run: xcodebuild -target "Matter" -sdk iphoneos -configuration Release OTHER_CFLAGS='${inherited} -Wno-unguarded-availability-new'
             - name: Clean Build
               run: xcodebuild clean
               working-directory: src/darwin/Framework
@@ -85,7 +93,11 @@ jobs:
               #
               # Enable -Wconversion by hand as well, because it seems to not be
               # enabled by default in the Xcode config.
-              run: xcodebuild -target "Matter" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wconversion'
+              #
+              # Disable -Wunguarded-availability-new because we internally use
+              # APIs we added after our deployment target version.  Maybe we
+              # should change the deployment target version instead?
+              run: xcodebuild -target "Matter" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wconversion -Wno-unguarded-availability-new'
               working-directory: src/darwin/Framework
             - name: Clean Build
               run: xcodebuild clean
@@ -107,10 +119,14 @@ jobs:
               continue-on-error: true
             - name: Run Framework Tests
               timeout-minutes: 15
+              # For now disable unguarded-availability-new warnings because we
+              # internally use APIs that we are annotating as only available on
+              # new enough versions.  Maybe we should change out deployment
+              # target versions instead?
               run: |
                   mkdir -p /tmp/darwin/framework-tests
                   ../../../out/debug/chip-all-clusters-app --interface-id -1 > >(tee /tmp/darwin/framework-tests/all-cluster-app.log) 2> >(tee /tmp/darwin/framework-tests/all-cluster-app-err.log >&2) &
-                  xcodebuild test -target "Matter" -scheme "Matter Framework Tests" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wconversion -Wno-incomplete-umbrella' > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
+                  xcodebuild test -target "Matter" -scheme "Matter Framework Tests" -sdk macosx OTHER_CFLAGS='${inherited} -Werror -Wconversion -Wno-incomplete-umbrella -Wno-unguarded-availability-new' > >(tee /tmp/darwin/framework-tests/darwin-tests.log) 2> >(tee /tmp/darwin/framework-tests/darwin-tests-err.log >&2)
               working-directory: src/darwin/Framework
             - name: Uploading log files
               uses: actions/upload-artifact@v2

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -90,6 +90,10 @@ config("config") {
   cflags = [
     "-Wconversion",
     "-fobjc-arc",
+
+    # For now disable unguarded-availability-new warnings because we
+    # are not building against a system Matter.framework here anyway.
+    "-Wno-unguarded-availability-new",
   ]
 }
 

--- a/scripts/build/build_darwin_framework.py
+++ b/scripts/build/build_darwin_framework.py
@@ -56,6 +56,11 @@ def build_darwin_framework(args):
         '-derivedDataPath',
         abs_path,
         "PLATFORM_PREFERRED_ARCH={}".format(arch),
+        # For now disable unguarded-availability-new warnings because we
+        # internally use APIs that we are annotating as only available on
+        # new enough versions.  Maybe we should change out deployment
+        # target versions instead?
+        "OTHER_CFLAGS=${inherited} -Wno-unguarded-availability-new",
     ]
 
     if sdk != "macosx":

--- a/src/darwin/Framework/CHIP/MTRControllerFactory.h
+++ b/src/darwin/Framework/CHIP/MTRControllerFactory.h
@@ -1,0 +1,32 @@
+/**
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <Matter/MTRDeviceControllerFactory.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+API_DEPRECATED("Please use MTRDeviceControllerFactory", ios(16.1, 16.2), macos(13.0, 13.1), watchos(9.1, 9.2), tvos(16.1, 16.2))
+@interface MTRControllerFactory : MTRDeviceControllerFactory
++ (instancetype)sharedInstance;
+- (BOOL)startup:(MTRControllerFactoryParams *)startupParams;
+- (void)shutdown;
+- (MTRDeviceController * _Nullable)startControllerOnExistingFabric:(MTRDeviceControllerStartupParams *)startupParams;
+- (MTRDeviceController * _Nullable)startControllerOnNewFabric:(MTRDeviceControllerStartupParams *)startupParams;
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerFactory.h
@@ -25,12 +25,14 @@
 NS_ASSUME_NONNULL_BEGIN
 
 @protocol MTRStorage;
+@protocol MTRPersistentStorageDelegate;
 @protocol MTROTAProviderDelegate;
 @protocol MTRKeypair;
 
 @class MTRDeviceController;
 @class MTRDeviceControllerStartupParams;
 
+API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 @interface MTRDeviceControllerFactoryParams : NSObject
 /*
  * Storage delegate must be provided for correct functioning of Matter
@@ -70,6 +72,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 - (instancetype)initWithStorage:(id<MTRStorage>)storage;
+@end
+
+API_DEPRECATED(
+    "Please use MTRDeviceControllerFactoryParams", ios(16.1, 16.2), macos(13.0, 13.1), watchos(9.1, 9.2), tvos(16.1, 16.2))
+@interface MTRControllerFactoryParams : MTRDeviceControllerFactoryParams
+@property (nonatomic, strong, readonly) id<MTRPersistentStorageDelegate> storageDelegate;
+@property (nonatomic, assign) BOOL startServer;
 @end
 
 @interface MTRDeviceControllerFactory : NSObject

--- a/src/darwin/Framework/CHIP/MTRPersistentStorageDelegate.h
+++ b/src/darwin/Framework/CHIP/MTRPersistentStorageDelegate.h
@@ -1,0 +1,28 @@
+/**
+ *
+ *    Copyright (c) 2020 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#import <Foundation/Foundation.h>
+
+#import <Matter/MTRStorage.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+API_DEPRECATED("Please use MTRStorage directly", ios(16.1, 16.2), macos(13.0, 13.1), watchos(9.1, 9.2), tvos(16.1, 16.2))
+@protocol MTRPersistentStorageDelegate <MTRStorage>
+@end
+
+NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -29,6 +29,7 @@
 #import <Matter/MTRClusters.h>
 #import <Matter/MTRCommandPayloadsObjc.h>
 #import <Matter/MTRCommissioningParameters.h>
+#import <Matter/MTRControllerFactory.h>
 #import <Matter/MTRDevice.h>
 #import <Matter/MTRDeviceAttestationDelegate.h>
 #import <Matter/MTRDeviceController+XPC.h>
@@ -41,6 +42,7 @@
 #import <Matter/MTRNOCChainIssuer.h>
 #import <Matter/MTROTAHeader.h>
 #import <Matter/MTROTAProviderDelegate.h>
+#import <Matter/MTRPersistentStorageDelegate.h>
 #import <Matter/MTRSetupPayload.h>
 #import <Matter/MTRStorage.h>
 #import <Matter/MTRStructsObjc.h>

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -103,6 +103,52 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([factory isRunning]);
 }
 
+- (void)testDeprecatedControllerLifecycle
+{
+    __auto_type * factory = [MTRControllerFactory sharedInstance];
+    XCTAssertNotNil(factory);
+
+    __auto_type * storage = [[MTRTestStorage alloc] init];
+    __auto_type * factoryParams = [[MTRControllerFactoryParams alloc] initWithStorage:storage];
+    XCTAssertTrue([factory startup:factoryParams]);
+    XCTAssertTrue([factory isRunning]);
+
+    __auto_type * testKeys = [[MTRTestKeys alloc] init];
+    XCTAssertNotNil(testKeys);
+
+    __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithIPK:testKeys.ipk fabricID:@(1) nocSigner:testKeys];
+    XCTAssertNotNil(params);
+
+    params.vendorID = @(kTestVendorId);
+
+    MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
+    XCTAssertNotNil(controller);
+    XCTAssertTrue([controller isRunning]);
+
+    [controller shutdown];
+    XCTAssertFalse([controller isRunning]);
+
+    // now try to restart the controller
+    controller = [factory startControllerOnExistingFabric:params];
+    XCTAssertNotNil(controller);
+    XCTAssertTrue([controller isRunning]);
+
+    [controller shutdown];
+    XCTAssertFalse([controller isRunning]);
+
+    // now try to restart the controller without providing a vendor id.
+    params.vendorID = nil;
+    controller = [factory startControllerOnExistingFabric:params];
+    XCTAssertNotNil(controller);
+    XCTAssertTrue([controller isRunning]);
+
+    [controller shutdown];
+    XCTAssertFalse([controller isRunning]);
+
+    [factory shutdown];
+    XCTAssertFalse([factory isRunning]);
+}
+
 - (void)testFactoryShutdownShutsDownController
 {
     __auto_type * factory = [MTRDeviceControllerFactory sharedInstance];

--- a/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
+++ b/src/darwin/Framework/Matter.xcodeproj/project.pbxproj
@@ -52,9 +52,11 @@
 		51431AFB27D29CA4008A7943 /* ota-provider.cpp in Sources */ = {isa = PBXBuildFile; fileRef = 51431AFA27D29CA4008A7943 /* ota-provider.cpp */; };
 		515C1C6F284F9FFB00A48F0C /* MTRMemory.mm in Sources */ = {isa = PBXBuildFile; fileRef = 515C1C6D284F9FFB00A48F0C /* MTRMemory.mm */; };
 		515C1C70284F9FFB00A48F0C /* MTRMemory.h in Headers */ = {isa = PBXBuildFile; fileRef = 515C1C6E284F9FFB00A48F0C /* MTRMemory.h */; };
+		5178DA9928F6607800B48133 /* MTRPersistentStorageDelegate.h in Headers */ = {isa = PBXBuildFile; fileRef = 5178DA9828F6607800B48133 /* MTRPersistentStorageDelegate.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		517BF3F0282B62B800A8B7DB /* MTRCertificates.h in Headers */ = {isa = PBXBuildFile; fileRef = 517BF3EE282B62B800A8B7DB /* MTRCertificates.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		517BF3F1282B62B800A8B7DB /* MTRCertificates.mm in Sources */ = {isa = PBXBuildFile; fileRef = 517BF3EF282B62B800A8B7DB /* MTRCertificates.mm */; };
 		517BF3F3282B62CB00A8B7DB /* MTRCertificateTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 517BF3F2282B62CB00A8B7DB /* MTRCertificateTests.m */; };
+		517FEECC28F6620700CFCBAC /* MTRControllerFactory.h in Headers */ = {isa = PBXBuildFile; fileRef = 517FEECB28F6620700CFCBAC /* MTRControllerFactory.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C1E2740CB0A008D5055 /* MTRStructsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C1D2740CB0A008D5055 /* MTRStructsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C222740CB1D008D5055 /* MTRCommandPayloadsObjc.h in Headers */ = {isa = PBXBuildFile; fileRef = 51B22C212740CB1D008D5055 /* MTRCommandPayloadsObjc.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		51B22C262740CB32008D5055 /* MTRStructsObjc.mm in Sources */ = {isa = PBXBuildFile; fileRef = 51B22C252740CB32008D5055 /* MTRStructsObjc.mm */; };
@@ -191,9 +193,11 @@
 		51431AFA27D29CA4008A7943 /* ota-provider.cpp */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.cpp; name = "ota-provider.cpp"; path = "../../../app/clusters/ota-provider/ota-provider.cpp"; sourceTree = "<group>"; };
 		515C1C6D284F9FFB00A48F0C /* MTRMemory.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRMemory.mm; sourceTree = "<group>"; };
 		515C1C6E284F9FFB00A48F0C /* MTRMemory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRMemory.h; sourceTree = "<group>"; };
+		5178DA9828F6607800B48133 /* MTRPersistentStorageDelegate.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRPersistentStorageDelegate.h; sourceTree = "<group>"; };
 		517BF3EE282B62B800A8B7DB /* MTRCertificates.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRCertificates.h; sourceTree = "<group>"; };
 		517BF3EF282B62B800A8B7DB /* MTRCertificates.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; path = MTRCertificates.mm; sourceTree = "<group>"; };
 		517BF3F2282B62CB00A8B7DB /* MTRCertificateTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = MTRCertificateTests.m; sourceTree = "<group>"; };
+		517FEECB28F6620700CFCBAC /* MTRControllerFactory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = MTRControllerFactory.h; sourceTree = "<group>"; };
 		51B22C1D2740CB0A008D5055 /* MTRStructsObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MTRStructsObjc.h; path = "zap-generated/MTRStructsObjc.h"; sourceTree = "<group>"; };
 		51B22C212740CB1D008D5055 /* MTRCommandPayloadsObjc.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = MTRCommandPayloadsObjc.h; path = "zap-generated/MTRCommandPayloadsObjc.h"; sourceTree = "<group>"; };
 		51B22C252740CB32008D5055 /* MTRStructsObjc.mm */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.cpp.objcpp; name = MTRStructsObjc.mm; path = "zap-generated/MTRStructsObjc.mm"; sourceTree = "<group>"; };
@@ -451,6 +455,8 @@
 				3CF134AE289D90FF0017A19E /* MTRNOCChainIssuer.h */,
 				511913FA28C100EF009235E9 /* MTRBaseSubscriptionCallback.h */,
 				511913F928C100EF009235E9 /* MTRBaseSubscriptionCallback.mm */,
+				5178DA9828F6607800B48133 /* MTRPersistentStorageDelegate.h */,
+				517FEECB28F6620700CFCBAC /* MTRControllerFactory.h */,
 			);
 			path = CHIP;
 			sourceTree = "<group>";
@@ -494,6 +500,8 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				517FEECC28F6620700CFCBAC /* MTRControllerFactory.h in Headers */,
+				5178DA9928F6607800B48133 /* MTRPersistentStorageDelegate.h in Headers */,
 				517BF3F0282B62B800A8B7DB /* MTRCertificates.h in Headers */,
 				51E51FBF282AD37A00FC978D /* MTRDeviceControllerStartupParams.h in Headers */,
 				5136661628067D550025EDAE /* MTRDeviceControllerFactory.h in Headers */,


### PR DESCRIPTION
Some of the 1.0-targeted API changes did not happen soon enough.


