### PR TITLE
[Infineon] Fix CYW30739 KVS.

### DIFF
--- a/src/platform/Infineon/CYW30739/KeyValueStoreManagerImpl.cpp
+++ b/src/platform/Infineon/CYW30739/KeyValueStoreManagerImpl.cpp
@@ -46,6 +46,7 @@ CHIP_ERROR KeyValueStoreManagerImpl::Init(void)
     {
         KeyStorage keyStorage;
         size_t keyStorageLength;
+        memset(keyStorage.mKey, 0, sizeof(keyStorage.mKey));
         err = CYW30739Config::ReadConfigValueBin(CYW30739ConfigKey(Config::kChipKvsKey_KeyBase, configID), &keyStorage,
                                                  sizeof(keyStorage), keyStorageLength);
         if (err != CHIP_NO_ERROR)
@@ -188,7 +189,7 @@ KeyValueStoreManagerImpl::KeyStorage::KeyStorage(const char * key) : mValueSize(
 
 bool KeyValueStoreManagerImpl::KeyStorage::IsMatchKey(const char * key) const
 {
-    return strncmp(mKey, key, sizeof(mKey)) == 0;
+    return strcmp(mKey, key) == 0;
 }
 
 KeyValueStoreManagerImpl::KeyConfigIdEntry * KeyValueStoreManagerImpl::AllocateEntry(const char * key)

--- a/src/platform/Infineon/CYW30739/KeyValueStoreManagerImpl.h
+++ b/src/platform/Infineon/CYW30739/KeyValueStoreManagerImpl.h
@@ -61,16 +61,16 @@ private:
     {
         KeyStorage(const char * key = nullptr);
 
-        constexpr size_t GetSize() const { return sizeof(mValueSize) + strnlen(mKey, sizeof(mKey)); }
+        constexpr size_t GetSize() const { return sizeof(mValueSize) + strlen(mKey); }
         bool IsMatchKey(const char * key) const;
 
         uint16_t mValueSize;
-        char mKey[PersistentStorageDelegate::kKeyLengthMax];
+        char mKey[PersistentStorageDelegate::kKeyLengthMax + 1];
     };
 
     struct KeyConfigIdEntry : public slist_node_t
     {
-        KeyConfigIdEntry(uint8_t configID, const KeyStorage & keyStorage) : mConfigID(configID), mStorage(keyStorage) {}
+        KeyConfigIdEntry(uint8_t configID, const KeyStorage & keyStorage) : mStorage(keyStorage), mConfigID(configID) {}
 
         constexpr Config::Key GetValueConfigKey() const
         {
@@ -85,8 +85,8 @@ private:
         constexpr uint16_t GetValueSize() const { return mStorage.mValueSize; }
         constexpr void SetValueSize(uint16_t valueSize) { mStorage.mValueSize = valueSize; }
 
-        uint8_t mConfigID;
         KeyStorage mStorage;
+        uint8_t mConfigID;
     };
 
     KeyConfigIdEntry * AllocateEntry(const char * key);


### PR DESCRIPTION
#### Problem
CYW30739 storage API audit failed since https://github.com/project-chip/connectedhomeip/pull/22708
```
ErrM CHIP:ATM: ../../third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:271: assertion failed: "err == CHIP_NO_ERROR"
ErrM CHIP:ATM: ../../third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:272: assertion failed: "size == strlen(kStringValue2)"
ErrM CHIP:ATM: ../../third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:273: assertion failed: "0 == memcmp(&buf[0], kStringValue2, strlen(kStringValue2))"
ErrM CHIP:ATM: ../../third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:277: assertion failed: "storage.SyncDoesKeyExist(longKeyString)"
ErrM CHIP:ATM: ../../third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:280: assertion failed: "err == CHIP_NO_ERROR"
ErrM CHIP:ATM: ../../third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:295: assertion failed: "err == CHIP_NO_ERROR"
ErrM CHIP:ATM: ../../third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:297: assertion failed: "0 == memcmp(&largeBuffer, largeBufferForCheck, sizeof(largeBuffer))"
ErrM CHIP:ATM: ../../third_party/connectedhomeip/src/lib/support/PersistentStorageAudit.cpp:300: assertion failed: "err == CHIP_NO_ERROR"
ErrM CHIP:ATM: ==== PersistentStorageDelegate API audit: FAILED: 8/81 failed assertions ====
```

#### Change overview
Allow null-terminated keys in CYW30739 KVS implementation.


#### Testing
Build with API audit enabled:
`gn gen out/debug --args="chip_error_logging=true chip_openthread_ftd=false chip_support_enable_storage_api_audit=true"`

API audit passes with the following line:
`ErrM CHIP:ATM: ==== PersistentStorageDelegate API audit: SUCCESS ====`