### PR TITLE
Add a build target for 'verbose minmdns'

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -92,6 +92,7 @@ steps:
               --target linux-arm64-lock-clang
               --target linux-arm64-lock-ipv6only-clang
               --target linux-arm64-minmdns-clang
+              --target linux-arm64-minmdns-clang-minmdns-verbose
               --target linux-arm64-ota-provider-nodeps-ipv6only
               --target linux-arm64-ota-requestor-nodeps-ipv6only
               --target linux-arm64-shell-ipv6only-clang
@@ -102,6 +103,7 @@ steps:
               --target linux-x64-all-clusters
               --target linux-x64-all-clusters-nodeps
               --target linux-x64-all-clusters-nodeps-ipv6only
+              --target linux-x64-all-clusters-nodeps-ipv6only-minmdns-verbose
               --target linux-x64-all-clusters-coverage
               --target linux-x64-all-clusters-ipv6only
               --target linux-x64-all-clusters-minimal
@@ -111,9 +113,11 @@ steps:
               --target linux-x64-chip-tool
               --target linux-x64-chip-tool-coverage
               --target linux-x64-chip-tool-nodeps-ipv6only
+              --target linux-x64-chip-tool-nodeps-ipv6only-minmdns-verbose
               --target linux-x64-dynamic-bridge-ipv6only
               --target linux-x64-efr32-test-runner
               --target linux-x64-light-rpc-ipv6only
+              --target linux-x64-light-rpc-ipv6only-minmdns-verbose
               --target linux-x64-lock-ipv6only
               --target linux-x64-minmdns
               --target linux-x64-nl-test-runner

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -114,11 +114,14 @@ steps:
               --target linux-x64-bridge-ipv6only
               --target linux-x64-chip-cert
               --target linux-x64-chip-tool-ipv6only
+              --target linux-x64-chip-tool-ipv6only-minmdns-verbose
               --target linux-x64-dynamic-bridge-ipv6only
               --target linux-x64-efr32-test-runner
               --target linux-x64-light-rpc-ipv6only
+              --target linux-x64-light-rpc-ipv6only-minmdns-verbose
               --target linux-x64-lock-ipv6only
               --target linux-x64-minmdns-ipv6only
+              --target linux-x64-minmdns-ipv6only-minmdns-verbose
               --target linux-x64-ota-provider-ipv6only
               --target linux-x64-ota-requestor-ipv6only
               --target linux-x64-python-bindings

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -126,7 +126,8 @@ def BuildHostTarget():
     target.AppendModifier('nodeps', enable_ble=False, enable_wifi=False, enable_thread=False,
                           crypto_library=HostCryptoLibrary.MBEDTLS, use_clang=True).ExceptIfRe('-(clang|noble|boringssl|mbedtls)')
 
-    target.AppendModifier('libnl', minmdns_address_policy="libnl").OnlyIfRe('-minmdns')
+    target.AppendModifier('minmdns-verbose', minmdns_high_verbosity=True)
+    target.AppendModifier('libnl', minmdns_address_policy="libnl")
     target.AppendModifier('same-event-loop', separate_event_loop=False).OnlyIfRe('-(chip-tool|darwin-framework-tool)')
     target.AppendModifier('no-interactive', interactive_mode=False).OnlyIfRe('-chip-tool')
     target.AppendModifier("ipv6only", enable_ipv4=False)

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -222,6 +222,7 @@ class HostBuilder(GnBuilder):
                  use_platform_mdns=False, enable_rpcs=False,
                  use_coverage=False, use_dmalloc=False,
                  minmdns_address_policy=None,
+                 minmdns_high_verbosity = False,
                  crypto_library: HostCryptoLibrary = None):
         super(HostBuilder, self).__init__(
             root=os.path.join(root, 'examples', app.ExamplePath()),
@@ -296,6 +297,9 @@ class HostBuilder(GnBuilder):
             # Flag for testing purpose
             self.extra_gn_options.append(
                 'chip_im_force_fabric_quota_check=true')
+
+        if minmdns_high_verbosity:
+            self.extra_gn_options.append('chip_minmdns_high_verbosity=true')
 
         if app == HostApp.TESTS:
             self.extra_gn_options.append('chip_build_tests=true')

--- a/scripts/build/builders/host.py
+++ b/scripts/build/builders/host.py
@@ -222,7 +222,7 @@ class HostBuilder(GnBuilder):
                  use_platform_mdns=False, enable_rpcs=False,
                  use_coverage=False, use_dmalloc=False,
                  minmdns_address_policy=None,
-                 minmdns_high_verbosity = False,
+                 minmdns_high_verbosity=False,
                  crypto_library: HostCryptoLibrary = None):
         super(HostBuilder, self).__init__(
             root=os.path.join(root, 'examples', app.ExamplePath()),

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -8,7 +8,7 @@ efr32-{brd4161a,brd4187c,brd4163a,brd4164a,brd4166a,brd4170a,brd4186a,brd4187a,b
 esp32-{m5stack,c3devkit,devkitc,qemu}-{all-clusters,all-clusters-minimal,ota-requestor,ota-requestor,shell,light,lock,bridge,temperature-measurement,ota-requestor,tests}[-rpc][-ipv6only]
 genio-lighting-app
 linux-fake-tests[-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang]
-linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,thermostat,minmdns,light,light-rpc,lock,shell,ota-provider,ota-requestor,python-bindings,tv-app,tv-casting-app,bridge,dynamic-bridge,tests,chip-cert,address-resolve-tool}[-nodeps][-libnl][-same-event-loop][-no-interactive][-ipv6only][-no-ble][-no-wifi][-no-thread][-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang][-test]
+linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,thermostat,minmdns,light,light-rpc,lock,shell,ota-provider,ota-requestor,python-bindings,tv-app,tv-casting-app,bridge,dynamic-bridge,tests,chip-cert,address-resolve-tool}[-nodeps][-minmdns-verbose][-libnl][-same-event-loop][-no-interactive][-ipv6only][-no-ble][-no-wifi][-no-thread][-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang][-test]
 linux-x64-efr32-test-runner[-clang]
 imx-{chip-tool,lighting-app,thermostat,all-clusters-app,all-clusters-minimal-app,ota-provider-app}[-release]
 infineon-psoc6-{lock,light,all-clusters,all-clusters-minimal}[-ota][-updateimage]


### PR DESCRIPTION
Debugging minmdns issues is a lot easier if we have verbose logging enabled (at a cost of spammy logs).

Provide an option to create build variants using verbose minmdns. Update a few prebuilts in clourbuild to compile such versions.

Also removed restriction of 'minmdns' for 'libnl' since minmdns is a default and we do not expose platformmdns yet (in which case we could libnl-restrict only for non-platform mdns)
