### PR TITLE
[Tizen] Do not notify the resolve error of dnssd

### DIFF
--- a/src/platform/Tizen/DnssdImpl.cpp
+++ b/src/platform/Tizen/DnssdImpl.cpp
@@ -671,10 +671,7 @@ CHIP_ERROR DnssdTizen::Resolve(const DnssdService & browseResult, chip::Inet::In
 
 exit:
     if (err != CHIP_NO_ERROR)
-    { // Notify caller about error
-        callback(context, nullptr, chip::Span<chip::Inet::IPAddress>(), err);
         RemoveContext(resolveCtx);
-    }
     return err;
 }
 


### PR DESCRIPTION
#### Problem
DNSSD Platform contract does not expect callback to be called from within the Resolve call. In particular, the `::Resolve` error state is already returned as a return code of the method and does not need to be re-iterated within the callback (doing so seems to result in double-error handling)

For reference, at least the linux-avahi and darwin implementations also do not call the callback if an error occurs within the resolve initiation.

#### Change overview
Remove a notification about resolve error of dnssd.

#### Testing
chip-tool and chip-lighting-app examples
