### PR TITLE
[ESP32] Release BTDM memory rather than just releasing BLE memory.

### DIFF
--- a/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
@@ -91,7 +91,7 @@ void CommonDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, i
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
                 err = esp_nimble_hci_and_controller_deinit();
 #endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-                err += esp_bt_mem_release(ESP_BT_MODE_BLE);
+                err += esp_bt_mem_release(ESP_BT_MODE_BTDM);
                 if (err == ESP_OK)
                 {
                     ESP_LOGI(TAG, "BLE deinit successful and memory reclaimed");


### PR DESCRIPTION
Once we are done using BLE for commissioning we should release all the bluetooth memory. Releasing with mode ESP_BT_MODE_BLE do not release all the memory. Releasing memory with mode ESP_BT_MODE_BLE will give us approx. ~3K of heap onf ESP32 SOC.

Fixes #23043