### PR TITLE
[darwin] Allow build setting to override the target-arch

### DIFF
--- a/build/config/mac/mac_sdk.gni
+++ b/build/config/mac/mac_sdk.gni
@@ -17,8 +17,8 @@ if (current_cpu == "x86") {
   target_arch = "i386"
 } else if (current_cpu == "x64") {
   target_arch = "x86_64"
-} else if (current_cpu == "armv7") {
-  target_arch = "arm"
+} else if (current_cpu == "arm") {
+  target_arch = "armv7"
 } else if (current_cpu == "arm64") {
   target_arch = "arm64"
 }
@@ -40,6 +40,7 @@ if (current_os == "mac") {
 declare_args() {
   # SDK version to target when compiling.
   mac_deployment_target = target_sdk + deployment_target
+  mac_target_arch = target_arch
 }
 
-mac_target_triple = "${target_arch}-apple-${mac_deployment_target}"
+mac_target_triple = "${mac_target_arch}-apple-${mac_deployment_target}"

--- a/examples/darwin-framework-tool/BUILD.gn
+++ b/examples/darwin-framework-tool/BUILD.gn
@@ -16,6 +16,7 @@ import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
 
 import("${chip_root}/build/chip/tools.gni")
+import("${chip_root}/build/config/mac/mac_sdk.gni")
 import("${chip_root}/examples//chip-tool/chip-tool.gni")
 
 if (config_use_interactive_mode) {
@@ -28,8 +29,10 @@ declare_args() {
   chip_codesign = current_os == "ios"
 }
 
+sdk = "macosx"
 sdk_build_dir_suffix = ""
 if (getenv("SDKROOT") != "") {
+  sdk = getenv("SDKROOT")
   sdk_root_parts = string_split(getenv("SDKROOT"), ".")
   sdk_build_dir_suffix = "-${sdk_root_parts[0]}"
 }
@@ -55,6 +58,15 @@ action("build-darwin-framework") {
     "--log_path",
     rebase_path("${root_build_dir}/darwin_framework_build.log", root_build_dir),
   ]
+
+  if (sdk != "macosx") {
+    args += [
+      "--target_sdk",
+      sdk,
+      "--target_arch",
+      mac_target_arch,
+    ]
+  }
 
   output_name = "Matter.framework"
   outputs = [

--- a/scripts/build/build_darwin_framework.py
+++ b/scripts/build/build_darwin_framework.py
@@ -42,23 +42,20 @@ def build_darwin_framework(args):
     if not os.path.exists(abs_path):
         os.mkdir(abs_path)
 
-    sdk = 'macosx' if os.environ.get('SDKROOT') == None else os.environ.get('SDKROOT')
-    arch = platform.machine() if sdk.startswith('macosx') else 'arm64'
-
     command = [
         'xcodebuild',
         '-scheme',
         args.target,
         '-sdk',
-        sdk,
+        args.target_sdk,
         '-project',
         args.project_path,
         '-derivedDataPath',
         abs_path,
-        "PLATFORM_PREFERRED_ARCH={}".format(arch),
+        "PLATFORM_PREFERRED_ARCH={}".format(args.target_arch),
     ]
 
-    if sdk != "macosx":
+    if args.target_sdk != "macosx":
         command += [
             # Build Matter.framework as a static library
             "SUPPORTS_TEXT_BASED_API=NO",
@@ -89,6 +86,16 @@ if __name__ == "__main__":
                         default="Matter",
                         help="Name of target to build",
                         required=True)
+    parser.add_argument("--target_sdk",
+                        default="macosx",
+                        help="Set the target sdk",
+                        required=False,
+                        )
+    parser.add_argument("--target_arch",
+                        default=platform.machine(),
+                        help="Set the target architecture",
+                        required=False,
+                        )
     parser.add_argument("--log_path",
                         help="Output log file destination",
                         required=True)

--- a/src/darwin/Framework/chip_xcode_build_connector.sh
+++ b/src/darwin/Framework/chip_xcode_build_connector.sh
@@ -105,6 +105,7 @@ declare -a args=(
     'target_cpu="'"$target_cpu"'"'
     'target_defines='"$target_defines"
     'target_cflags=['"$target_cflags"']'
+    'mac_target_arch="'"$PLATFORM_PREFERRED_ARCH"'"'
     'mac_deployment_target="'"$LLVM_TARGET_TRIPLE_OS_VERSION"''"$LLVM_TARGET_TRIPLE_SUFFIX"'"'
 )
 


### PR DESCRIPTION
#### Problem

The arch use for building the triple used for compiling on darwin can not be overriden completely.
