### PR TITLE
Add error outparam to MTRSetupPayload's qrCodeString.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDeviceController.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.mm
@@ -373,7 +373,7 @@ static NSString * const kErrorGetAttestationChallenge = @"Failure getting attest
 
         // Try to get a QR code if possible (because it has a better
         // discriminator, etc), then fall back to manual code if that fails.
-        NSString * pairingCode = [payload qrCodeString];
+        NSString * pairingCode = [payload qrCodeString:nil];
         if (pairingCode == nil) {
             pairingCode = [payload manualEntryCode];
         }

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -104,7 +104,7 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
  * Returns nil on failure (e.g. if the setup payload does not have all the
  * information a QR code needs).
  */
-- (NSString * _Nullable)qrCodeString;
+- (NSString * _Nullable)qrCodeString:(NSError * __autoreleasing *)error;
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -289,20 +289,29 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     return [NSString stringWithUTF8String:outDecimalString.c_str()];
 }
 
-- (NSString * _Nullable)qrCodeString
+- (NSString * _Nullable)qrCodeString:(NSError * __autoreleasing *)error
 {
     if (self.commissioningFlow == MTRCommissioningFlowInvalid) {
         // No idea how to map this to the standard codes.
+        if (error != nil) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
         return nil;
     }
 
     if (self.hasShortDiscriminator) {
         // Can't create a QR code with a short discriminator.
+        if (error != nil) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
         return nil;
     }
 
     if (self.rendezvousInformation == nil) {
         // Can't create a QR code if we don't know the discovery capabilities.
+        if (error != nil) {
+            *error = [MTRError errorForCHIPErrorCode:CHIP_ERROR_INCORRECT_STATE];
+        }
         return nil;
     }
 
@@ -320,6 +329,9 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     CHIP_ERROR err = chip::QRCodeSetupPayloadGenerator(payload).payloadBase38Representation(outDecimalString);
 
     if (err != CHIP_NO_ERROR) {
+        if (error != nil) {
+            *error = [MTRError errorForCHIPErrorCode:err];
+        }
         return nil;
     }
 


### PR DESCRIPTION
This lets us communicate the exact error we ran into.