### PR TITLE
Cherry-pick  [ESP32] Release BTDM memory rather than just releasing BLE memory. (#23165)

### DIFF
--- a/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
+++ b/examples/platform/esp32/common/CommonDeviceCallbacks.cpp
@@ -91,7 +91,7 @@ void CommonDeviceCallbacks::DeviceEventCallback(const ChipDeviceEvent * event, i
 #if ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
                 err = esp_nimble_hci_and_controller_deinit();
 #endif // ESP_IDF_VERSION < ESP_IDF_VERSION_VAL(5, 0, 0)
-                err += esp_bt_mem_release(ESP_BT_MODE_BLE);
+                err += esp_bt_mem_release(ESP_BT_MODE_BTDM);
                 if (err == ESP_OK)
                 {
                     ESP_LOGI(TAG, "BLE deinit successful and memory reclaimed");


### PR DESCRIPTION
Cherry-pick e7e1ca9d0bd39845dae74b59d689750cd960dcba (PR: #23165) from master to v1.0-branch.

This will add up ~3K heap after successful commissioning.