### PR TITLE
src/controller/java/CHIPDeviceController-JNI.cpp: Error: implicit con…

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -253,7 +253,7 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject contr
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err                           = CHIP_NO_ERROR;
     AndroidDeviceControllerWrapper * wrapper = NULL;
-    long result                              = 0;
+    jlong result                             = 0;
 
     ChipLogProgress(Controller, "newDeviceController() called");
 


### PR DESCRIPTION
…version loses integer precision: 'jlong' (aka 'long long') to 'long'

#### Problem

ToT is not building because of `-WShorten-64-to-32` . I just don't understand how #23111 was building Android and why it does not now, something has probably changed in the build settings somewhere.