### PR TITLE
[Simulated Test] Simulated node does not have a chance to send the in…

### DIFF
--- a/examples/placeholder/linux/include/TestCommand.h
+++ b/examples/placeholder/linux/include/TestCommand.h
@@ -87,7 +87,21 @@ public:
     void Exit(std::string message, CHIP_ERROR err) override
     {
         LogEnd(message, err);
-        SetCommandExitStatus(err);
+
+        if (CHIP_NO_ERROR == err)
+        {
+            chip::DeviceLayer::PlatformMgr().ScheduleWork(AsyncExit, reinterpret_cast<intptr_t>(this));
+        }
+        else
+        {
+            SetCommandExitStatus(err);
+        }
+    }
+
+    static void AsyncExit(intptr_t context)
+    {
+        TestCommand * command = reinterpret_cast<TestCommand *>(context);
+        command->SetCommandExitStatus(CHIP_NO_ERROR);
     }
 
     static void ScheduleNextTest(intptr_t context)


### PR DESCRIPTION
…teraction response for the last step on success

#### Problem

Fix #23104

The last step of the test are not really skipped, but the runner does not have a chance to send the interaction response.
This PR does an async exit so the interaction response can be sent properly.