### PR TITLE
Mark event paths as urgent when doing node-wide subscriptions in Matter.framework.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -294,6 +294,8 @@ public:
                                // Wildcard endpoint, cluster, attribute, event.
                                auto attributePath = std::make_unique<AttributePathParams>();
                                auto eventPath = std::make_unique<EventPathParams>();
+                               // We want to get event reports at the minInterval, not the maxInterval.
+                               eventPath->mIsUrgentEvent = true;
                                ReadPrepareParams readParams(session.Value());
                                readParams.mMinIntervalFloorSeconds = minInterval;
                                readParams.mMaxIntervalCeilingSeconds = maxInterval;

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -299,6 +299,8 @@ private:
                            // Wildcard endpoint, cluster, attribute, event.
                            auto attributePath = std::make_unique<AttributePathParams>();
                            auto eventPath = std::make_unique<EventPathParams>();
+                           // We want to get event reports at the minInterval, not the maxInterval.
+                           eventPath->mIsUrgentEvent = true;
                            ReadPrepareParams readParams(session.Value());
                            readParams.mMinIntervalFloorSeconds = minInterval;
                            readParams.mMaxIntervalCeilingSeconds = maxInterval;


### PR DESCRIPTION
Otherwise we will not receive events until the max-interval elapses.
