### PR TITLE
Fix android compilation for arm after #23111

### DIFF
--- a/src/controller/java/CHIPDeviceController-JNI.cpp
+++ b/src/controller/java/CHIPDeviceController-JNI.cpp
@@ -253,7 +253,7 @@ JNI_METHOD(jlong, newDeviceController)(JNIEnv * env, jobject self, jobject contr
     chip::DeviceLayer::StackLock lock;
     CHIP_ERROR err                           = CHIP_NO_ERROR;
     AndroidDeviceControllerWrapper * wrapper = NULL;
-    long result                              = 0;
+    jlong result                             = 0;
 
     ChipLogProgress(Controller, "newDeviceController() called");
 


### PR DESCRIPTION
Arm compilation fails because jlong is 64 bit while long is 32bit for arm.

#23111 added warnings (which are treated as errors) for this kind of precision loss. This fixes android builds.
