### PR TITLE
Revert "[privacy] Don't enable privacy when privacy is not supported."

### DIFF
--- a/src/transport/SessionManager.cpp
+++ b/src/transport/SessionManager.cpp
@@ -166,6 +166,7 @@ CHIP_ERROR SessionManager::PrepareMessage(const SessionHandle & sessionHandle, P
         packetHeader.SetDestinationGroupId(groupSession->GetGroupId());
         packetHeader.SetMessageCounter(mGroupClientCounter.GetCounter(isControlMsg));
         mGroupClientCounter.IncrementCounter(isControlMsg);
+        packetHeader.SetFlags(Header::SecFlagValues::kPrivacyFlag);
         packetHeader.SetSessionType(Header::SessionType::kGroupSession);
         NodeId sourceNodeId = fabric->GetNodeId();
         packetHeader.SetSourceNodeId(sourceNodeId);

--- a/src/transport/raw/MessageHeader.h
+++ b/src/transport/raw/MessageHeader.h
@@ -203,14 +203,14 @@ public:
     {
         // Check is based on spec 4.11.2
         return (IsGroupSession() && GetSourceNodeId().HasValue() && GetDestinationGroupId().HasValue() &&
-                !IsSecureSessionControlMsg());
+                !IsSecureSessionControlMsg() && HasPrivacyFlag());
     }
 
     bool IsValidMCSPMsg() const
     {
         // Check is based on spec 4.9.2.4
         return (IsGroupSession() && GetSourceNodeId().HasValue() && GetDestinationNodeId().HasValue() &&
-                IsSecureSessionControlMsg());
+                IsSecureSessionControlMsg() && HasPrivacyFlag());
     }
 
     bool IsEncrypted() const { return !((mSessionId == kMsgUnicastSessionIdUnsecured) && IsUnicastSession()); }

--- a/src/transport/raw/tests/TestMessageHeader.cpp
+++ b/src/transport/raw/tests/TestMessageHeader.cpp
@@ -151,6 +151,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
 
     header.ClearDestinationNodeId();
     header.SetSessionType(Header::SessionType::kGroupSession);
+    header.SetFlags(Header::SecFlagValues::kPrivacyFlag);
     header.SetSecureSessionControlMsg(false);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
@@ -164,7 +165,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.IsValidGroupMsg());
 
     // Verify MCSP state
-    header.ClearDestinationGroupId().SetDestinationNodeId(42);
+    header.ClearDestinationGroupId().SetDestinationNodeId(42).SetFlags(Header::SecFlagValues::kPrivacyFlag);
     header.SetSecureSessionControlMsg(true);
     NL_TEST_ASSERT(inSuite, header.Encode(buffer, &encodeLen) == CHIP_NO_ERROR);
 
@@ -173,6 +174,7 @@ void TestPacketHeaderEncodeDecode(nlTestSuite * inSuite, void * inContext)
     NL_TEST_ASSERT(inSuite, header.Decode(buffer, &decodeLen) == CHIP_NO_ERROR);
     NL_TEST_ASSERT(inSuite, header.GetDestinationNodeId() == Optional<uint64_t>::Value(42ull));
     NL_TEST_ASSERT(inSuite, !header.GetDestinationGroupId().HasValue());
+    NL_TEST_ASSERT(inSuite, header.HasPrivacyFlag());
     NL_TEST_ASSERT(inSuite, header.IsValidMCSPMsg());
 }
 


### PR DESCRIPTION
This reverts commit 59d32d458cde08549e590c3cafeb2d7510aa6cd7 or PR #22452.

SVE2 group messages are sent with P=1, plaintext headers, and drop group messages with P=0.
v1.0-branch group messages are sent with P=0, plaintext headers, and accept group messages with P=0 or P=1.

The use of the privacy flag in SVE2 was invalid and not spec compliant, but PR #22452 was unfortunately never applied to SVE2.

Now the invalid SVE2 behavior is considered the golden reference for backwards compatibility.  This reversion would effectively deprecate the Pflag as defined in the spec and align master, v1.0-branch, and sve-2 to sve-2 behavior with regard to what is considered a valid group message.
