### PR TITLE
[chip-tool] Regression from #22708. Revert chip::Platform::CopyString…

### DIFF
--- a/examples/chip-tool/commands/clusters/ComplexArgument.h
+++ b/examples/chip-tool/commands/clusters/ComplexArgument.h
@@ -196,7 +196,7 @@ public:
 
         size_t size = strlen(value.asCString());
         auto buffer = static_cast<char *>(chip::Platform::MemoryCalloc(size, sizeof(char)));
-        chip::Platform::CopyString(buffer, size, value.asCString());
+        memcpy(buffer, value.asCString(), size);
 
         request = chip::CharSpan(buffer, size);
         return CHIP_NO_ERROR;


### PR DESCRIPTION
… to memcpy (it previously uses to be strncpy which was confusing)

#### Problem

fix #23200