### PR TITLE
Another android fix

### DIFF
--- a/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
+++ b/examples/tv-casting-app/tv-casting-common/src/PersistenceManager.cpp
@@ -150,7 +150,7 @@ CHIP_ERROR PersistenceManager::ReadAllVideoPlayers(TargetVideoPlayerInfo outVide
     ReturnErrorOnFailure(chip::DeviceLayer::PersistedStorage::KeyValueStoreMgr().Get(kCastingDataKey, castingData,
                                                                                      kCastingDataMaxBytes, &castingDataSize));
     ChipLogProgress(AppServer, "PersistenceManager::ReadAllVideoPlayers Read TLV(CastingData) from KVS store with size: %lu bytes",
-                    castingDataSize);
+                    static_cast<unsigned long>(castingDataSize));
 
     TLV::TLVReader reader;
     reader.Init(castingData);


### PR DESCRIPTION
More android compile fixes, this time for the TV app. After #23111 we error out if 64/32 bit inconsistencies exist.

