### PR TITLE
Fix EFR cloudbuild smoke tests, add more targets

### DIFF
--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -69,10 +69,10 @@ steps:
       args:
           - >-
               ./scripts/build/build_examples.py --enable-flashbundle
-              --target nrf-nrf52840dk-light
-              --target nrf-nrf52840dk-light-rpc
-              --target nrf-nrf52840dk-lock
-              --target nrf-nrf52840dongle-light
+              --target efr32-brd4161a-light
+              --target efr32-brd4161a-light-rpc
+              --target efr32-brd4161a-lock
+              --target efr32-brd4161a-lock-rpc
               build
               --create-archives /workspace/artifacts/
       waitFor:
@@ -98,7 +98,8 @@ steps:
               --target linux-arm64-chip-tool-ipv6only-clang
               --target linux-arm64-chip-tool-nodeps-ipv6only-clang
               --target linux-arm64-dynamic-bridge-ipv6only-clang
-              --target linux-arm64-light-rpc-ipv6only-clang
+              --target linux-arm64-light-clang-rpc-ipv6only
+              --target linux-arm64-light-clang-rpc-ipv6only-minmdns-verbose
               --target linux-arm64-lock-ipv6only-clang
               --target linux-arm64-minmdns-clang
               --target linux-arm64-ota-provider-nodeps-ipv6only-clang

--- a/scripts/build/build/target.py
+++ b/scripts/build/build/target.py
@@ -170,7 +170,7 @@ def _StringIntoParts(full_input: str, remaining_input: str, fixed_targets: List[
         if not modifier.Accept(full_input):
             continue
 
-        result = _StringIntoParts(full_input, suffix, fixed_targets[1:], filter(lambda x: x != modifier, modifiers))
+        result = _StringIntoParts(full_input, suffix, fixed_targets[1:], [x for x in modifiers if x != modifier])
         if result is not None:
             return [modifier] + result
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -144,7 +144,6 @@ def BuildHostTarget():
     target.AppendModifier('test', extra_tests=True)
     target.AppendModifier('rpc', enable_rpcs=True)
 
-
     return target
 
 

--- a/scripts/build/build/targets.py
+++ b/scripts/build/build/targets.py
@@ -103,7 +103,6 @@ def BuildHostTarget():
         TargetPart('thermostat', app=HostApp.THERMOSTAT),
         TargetPart('minmdns', app=HostApp.MIN_MDNS),
         TargetPart('light', app=HostApp.LIGHT),
-        TargetPart('light-rpc', app=HostApp.LIGHT, enable_rpcs=True),
         TargetPart('lock', app=HostApp.LOCK),
         TargetPart('shell', app=HostApp.SHELL),
         TargetPart('ota-provider', app=HostApp.OTA_PROVIDER, enable_ble=False),
@@ -143,6 +142,8 @@ def BuildHostTarget():
     target.AppendModifier('dmalloc', use_dmalloc=True)
     target.AppendModifier('clang', use_clang=True)
     target.AppendModifier('test', extra_tests=True)
+    target.AppendModifier('rpc', enable_rpcs=True)
+
 
     return target
 

--- a/scripts/build/testdata/all_targets_linux_x64.txt
+++ b/scripts/build/testdata/all_targets_linux_x64.txt
@@ -8,7 +8,7 @@ efr32-{brd4161a,brd4187c,brd4163a,brd4164a,brd4166a,brd4170a,brd4186a,brd4187a,b
 esp32-{m5stack,c3devkit,devkitc,qemu}-{all-clusters,all-clusters-minimal,ota-requestor,ota-requestor,shell,light,lock,bridge,temperature-measurement,ota-requestor,tests}[-rpc][-ipv6only]
 genio-lighting-app
 linux-fake-tests[-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang]
-linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,thermostat,minmdns,light,light-rpc,lock,shell,ota-provider,ota-requestor,python-bindings,tv-app,tv-casting-app,bridge,dynamic-bridge,tests,chip-cert,address-resolve-tool}[-nodeps][-minmdns-verbose][-libnl][-same-event-loop][-no-interactive][-ipv6only][-no-ble][-no-wifi][-no-thread][-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang][-test]
+linux-{x64,arm64}-{rpc-console,all-clusters,all-clusters-minimal,chip-tool,thermostat,minmdns,light,lock,shell,ota-provider,ota-requestor,python-bindings,tv-app,tv-casting-app,bridge,dynamic-bridge,tests,chip-cert,address-resolve-tool}[-nodeps][-minmdns-verbose][-libnl][-same-event-loop][-no-interactive][-ipv6only][-no-ble][-no-wifi][-no-thread][-mbedtls][-boringssl][-asan][-tsan][-libfuzzer][-coverage][-dmalloc][-clang][-test][-rpc]
 linux-x64-efr32-test-runner[-clang]
 imx-{chip-tool,lighting-app,thermostat,all-clusters-app,all-clusters-minimal-app,ota-provider-app}[-release]
 infineon-psoc6-{lock,light,all-clusters,all-clusters-minimal}[-ota][-updateimage]


### PR DESCRIPTION
Updated a few build_example-related items:

- cloudbuild smoketest had a copy & paste issue and was building nrf builds when it was claiming EFR builds. Fixed that
- target.py string splitting was not considering all iterators due to filter usage. Changed it to create list in-place
- added min-mdns verbose variant for linux-arm64 builds as well.
- `light-rpc` was parsed as a separate app, when rpc seems to actually be a modifier. Moved rpc as a modifier.