### PR TITLE
Disable shorten 64 to 32 error for arm64 (do not make it fatal)

### DIFF
--- a/.github/workflows/examples-linux-arm.yaml
+++ b/.github/workflows/examples-linux-arm.yaml
@@ -73,6 +73,7 @@ jobs:
                         --target linux-arm64-chip-tool-ipv6only-clang \
                         --target linux-arm64-lock-clang \
                         --target linux-arm64-minmdns-clang \
+                        --target linux-arm64-light-rpc-ipv6only-clang \
                         --target linux-arm64-thermostat-no-ble-clang \
                         build \
                      "

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -259,6 +259,14 @@ config("strict_warnings") {
       "-Wshorten-64-to-32",
       "-Wformat-type-confusion",
     ]
+
+    # TODO: can make this back fatal in once pigweed updates can be take again
+    #
+    # Currently `./scripts/build/build_examples.py --target linux-arm64-light-rpc-ipv6only-clang build`
+    # fails in third_party/pigweed/repo/pw_protobuf 
+    if ((current_cpu == "arm64") && (current_os == "linux")) {
+      cflags += [ "-Wno-error=shorten-64-to-32" ]
+    }
   }
 
   if (!is_asan && (current_os == "linux" || current_os == "android")) {

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -263,8 +263,8 @@ config("strict_warnings") {
     # TODO: can make this back fatal in once pigweed updates can be take again
     #
     # Currently `./scripts/build/build_examples.py --target linux-arm64-light-rpc-ipv6only-clang build`
-    # fails in third_party/pigweed/repo/pw_protobuf 
-    if ((current_cpu == "arm64") && (current_os == "linux")) {
+    # fails in third_party/pigweed/repo/pw_protobuf
+    if (current_cpu == "arm64" && current_os == "linux") {
       cflags += [ "-Wno-error=shorten-64-to-32" ]
     }
   }

--- a/build/config/compiler/BUILD.gn
+++ b/build/config/compiler/BUILD.gn
@@ -260,7 +260,8 @@ config("strict_warnings") {
       "-Wformat-type-confusion",
     ]
 
-    # TODO: can make this back fatal in once pigweed updates can be take again
+    # TODO: can make this back fatal in once pigweed updates can be taken again.
+    #       See https://github.com/project-chip/connectedhomeip/pull/22079
     #
     # Currently `./scripts/build/build_examples.py --target linux-arm64-light-rpc-ipv6only-clang build`
     # fails in third_party/pigweed/repo/pw_protobuf


### PR DESCRIPTION
Arm64 builds like `./scripts/build/build_examples.py --target linux-arm64-light-rpc-ipv6only-clang build` were failing because pigweed casting errors in pw_tokenizer and pw_rpc.

Since pigweed updates take a bit (need some build system updates after the 1.0 freeze), I am disabling these errors for linux+arm64 (but we keep them for other platforms, so hopefully we keep having good code).

Fixes #23238 

