### PR TITLE
[chiptool] Fix wrong argument max value for mBleAdapterId

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.h
+++ b/examples/chip-tool/commands/common/CHIPCommand.h
@@ -84,7 +84,7 @@ public:
         AddArgument("trace_log", 0, 1, &mTraceLog);
         AddArgument("trace_decode", 0, 1, &mTraceDecode);
 #endif // CHIP_CONFIG_TRANSPORT_TRACE_ENABLED
-        AddArgument("ble-adapter", 0, UINT64_MAX, &mBleAdapterId);
+        AddArgument("ble-adapter", 0, UINT16_MAX, &mBleAdapterId);
     }
 
     /////////// Command Interface /////////


### PR DESCRIPTION
The maximum value for argument mBleAdapterId is defined as UINT64_MAX in chiptool, but mBleAdapterId is defined as optional unit16_t
`chip::Optional<uint16_t> mBleAdapterId;`

