### PR TITLE
[TraceDecoder] Add decrypted data

### DIFF
--- a/examples/common/tracing/TraceDecoder.cpp
+++ b/examples/common/tracing/TraceDecoder.cpp
@@ -175,9 +175,9 @@ CHIP_ERROR TraceDecoder::MaybeLogAndConsumeEncryptedPayload(Json::Value & json)
         size_t size = static_cast<uint16_t>(json[kPayloadEncryptedSizeKey].asLargestUInt());
         if (size)
         {
-            auto payload       = json[kPayloadEncryptedDataKey].asString();
-            auto bufferPtr     = json[kPayloadEncryptedBufferPtrKey].asString();
-            auto scoppedIndent = ScopedLogIndentWithSize("Encrypted Payload", size);
+            auto payload      = json[kPayloadEncryptedDataKey].asString();
+            auto bufferPtr    = json[kPayloadEncryptedBufferPtrKey].asString();
+            auto scopedIndent = ScopedLogIndentWithSize("Encrypted Payload", size);
             Log("data", payload.c_str());
             Log("buffer_ptr", bufferPtr.c_str());
         }
@@ -272,6 +272,12 @@ CHIP_ERROR TraceDecoder::MaybeLogAndConsumePayload(Json::Value & json, bool isRe
     auto size = static_cast<uint16_t>(json[kPayloadSizeKey].asLargestUInt());
     if (size)
     {
+        {
+            auto payload      = json[kPayloadDataKey].asString();
+            auto scopedIndent = ScopedLogIndentWithSize("Decrypted Payload", size);
+            Log("data", payload.c_str());
+        }
+
         bool shouldDecode = !isResponse || mOptions.mEnableProtocolInteractionModelResponse;
         auto payload      = json[kPayloadDataKey].asString();
         auto protocolId   = json[kProtocolIdKey].asLargestUInt();


### PR DESCRIPTION
#### Problem

The options `trace_decode 1` does not log the decrypted payload.

