### PR TITLE
[K32W0] Disable ble in shell-app due to size constraints

### DIFF
--- a/examples/shell/nxp/k32w/k32w0/args.gni
+++ b/examples/shell/nxp/k32w/k32w0/args.gni
@@ -19,4 +19,4 @@ import("${chip_root}/src/platform/nxp/k32w/k32w0/args.gni")
 
 k32w0_sdk_target = get_label_info(":sdk", "label_no_toolchain")
 
-chip_enable_ble = true
+chip_enable_ble = false


### PR DESCRIPTION
This PR disables ble in shell-app due to size constrains.
This hotfix is for the PR #23240, which adds bytes beyond the limit.

