### PR TITLE
Add efr32 unit test to cloud builds

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -44,6 +44,7 @@ steps:
               --target efr32-brd4161a-lock
               --target efr32-brd4161a-switch
               --target efr32-brd4161a-window-covering
+              --target efr32-brd4161a-unit-test
               --target efr32-brd4187c-window-covering
               --target esp32-c3devkit-all-clusters
               --target esp32-c3devkit-all-clusters-minimal

--- a/integrations/cloudbuild/smoke-test.yaml
+++ b/integrations/cloudbuild/smoke-test.yaml
@@ -73,6 +73,7 @@ steps:
               --target efr32-brd4161a-light-rpc
               --target efr32-brd4161a-lock
               --target efr32-brd4161a-lock-rpc
+              --target efr32-brd4161a-unit-test
               build
               --create-archives /workspace/artifacts/
       waitFor:


### PR DESCRIPTION
Cloudbuild pre-builds do not have efr32 unit tests in them. They used to be available before and are a useful compilation test.

Added them back both in smoke and all-builds.
