### PR TITLE
add android dummy stub for java matter controller application

### DIFF
--- a/examples/build_overrides/build.gni
+++ b/examples/build_overrides/build.gni
@@ -15,4 +15,5 @@
 declare_args() {
   # Root directory for build files.
   build_root = "//third_party/connectedhomeip/build"
+  build_java_matter_controller = false
 }

--- a/examples/java-matter-controller/java/src/com/matter/controller/Main.java
+++ b/examples/java-matter-controller/java/src/com/matter/controller/Main.java
@@ -17,8 +17,17 @@
  */
 package com.matter.controller;
 
+import chip.devicecontroller.ChipDeviceController;
+import chip.devicecontroller.ControllerParams;
+
 public class Main {
   public static void main(String[] args) {
+    ChipDeviceController controller =
+        new ChipDeviceController(
+            ControllerParams.newBuilder()
+                .setUdpListenPort(0)
+                .setControllerVendorId(0xFFF1)
+                .build());
     System.out.println("Hello Matter Controller!");
 
     for (String s : args) {

--- a/src/controller/java/BUILD.gn
+++ b/src/controller/java/BUILD.gn
@@ -17,6 +17,12 @@ import("//build_overrides/chip.gni")
 import("${build_root}/config/android_abi.gni")
 import("${chip_root}/build/chip/java/rules.gni")
 
+if (defined(build_java_matter_controller)) {
+  build_java_matter_controller = build_java_matter_controller
+} else {
+  build_java_matter_controller = false
+}
+
 shared_library("jni") {
   output_name = "libCHIPController"
 
@@ -67,10 +73,7 @@ shared_library("jni") {
 android_library("java") {
   output_name = "CHIPController.jar"
 
-  deps = [
-    ":android",
-    "${chip_root}/third_party/java_deps:annotation",
-  ]
+  deps = [ "${chip_root}/third_party/java_deps:annotation" ]
 
   data_deps = [
     ":jni",
@@ -122,12 +125,25 @@ android_library("java") {
     "zap-generated/chip/devicecontroller/ClusterWriteMapping.java",
   ]
 
+  if (build_java_matter_controller) {
+    deps += [
+      "${chip_root}/third_party/java_deps:json",
+      "${chip_root}/third_party/java_deps/stub_src",
+    ]
+  } else {
+    deps += [ ":android" ]
+
+    data_deps += [ "${chip_root}/build/chip/java:shared_cpplib" ]
+  }
+
   javac_flags = [ "-Xlint:deprecation" ]
 
   # TODO: add classpath support (we likely need to add something like
   #  ..../platforms/android-21/android.jar to access BLE items)
 }
 
-java_prebuilt("android") {
-  jar_path = "${android_sdk_root}/platforms/android-21/android.jar"
+if (!build_java_matter_controller) {
+  java_prebuilt("android") {
+    jar_path = "${android_sdk_root}/platforms/android-21/android.jar"
+  }
 }

--- a/src/setup_payload/java/BUILD.gn
+++ b/src/setup_payload/java/BUILD.gn
@@ -18,6 +18,12 @@ import("//build_overrides/chip.gni")
 import("${build_root}/config/android_abi.gni")
 import("${chip_root}/build/chip/java/rules.gni")
 
+if (defined(build_java_matter_controller)) {
+  build_java_matter_controller = build_java_matter_controller
+} else {
+  build_java_matter_controller = false
+}
+
 shared_library("jni") {
   output_name = "libSetupPayloadParser"
 
@@ -34,10 +40,11 @@ shared_library("jni") {
 android_library("java") {
   output_name = "SetupPayloadParser.jar"
 
-  data_deps = [
-    ":jni",
-    "${chip_root}/build/chip/java:shared_cpplib",
-  ]
+  data_deps = [ ":jni" ]
+
+  if (!build_java_matter_controller) {
+    data_deps += [ "${chip_root}/build/chip/java:shared_cpplib" ]
+  }
 
   sources = [
     "src/chip/setuppayload/DiscoveryCapability.java",

--- a/third_party/java_deps/BUILD.gn
+++ b/third_party/java_deps/BUILD.gn
@@ -20,3 +20,7 @@ import("${chip_root}/build/chip/java/rules.gni")
 java_prebuilt("annotation") {
   jar_path = "artifacts/jsr305-3.0.2.jar"
 }
+
+java_prebuilt("json") {
+  jar_path = "artifacts/json-20220924.jar"
+}

--- a/third_party/java_deps/set_up_java_deps.sh
+++ b/third_party/java_deps/set_up_java_deps.sh
@@ -18,3 +18,4 @@
 
 mkdir third_party/java_deps/artifacts
 curl --fail --location --silent --show-error https://repo1.maven.org/maven2/com/google/code/findbugs/jsr305/3.0.2/jsr305-3.0.2.jar -o third_party/java_deps/artifacts/jsr305-3.0.2.jar
+curl --fail --location --silent --show-error https://repo1.maven.org/maven2/org/json/json/20220924/json-20220924.jar -o third_party/java_deps/artifacts/json-20220924.jar

--- a/third_party/java_deps/stub_src/BUILD.gn
+++ b/third_party/java_deps/stub_src/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright (c) 2022 Project CHIP Authors
+# Copyright (c) 2020-2021 Project CHIP Authors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,28 +12,27 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#TODO: Decouple Android Bluetooth stuff from ChipDeviceController.Java, remove dummy implemenation here.
+#TODO: Decouple Android Logging from from ChipDeviceController.Java, remove dummy implemenation here.
+
 import("//build_overrides/build.gni")
 import("//build_overrides/chip.gni")
-
 import("${build_root}/config/android_abi.gni")
 import("${chip_root}/build/chip/java/rules.gni")
-import("${chip_root}/build/chip/tools.gni")
 
-build_java_matter_controller = true
+android_library("stub_src") {
+  output_name = "Android.jar"
 
-android_binary("java-matter-controller") {
-  output_name = "java-matter-controller"
-  deps = [
-    "${chip_root}/src/controller/java",
-    "${chip_root}/src/setup_payload/java",
-    "${chip_root}/third_party/java_deps:annotation",
+  sources = [
+    "android/bluetooth/BluetoothGatt.java",
+    "android/bluetooth/BluetoothGattCallback.java",
+    "android/bluetooth/BluetoothGattCharacteristic.java",
+    "android/bluetooth/BluetoothGattDescriptor.java",
+    "android/bluetooth/BluetoothGattService.java",
+    "android/bluetooth/BluetoothProfile.java",
+    "android/os/Build.java",
+    "android/util/Log.java",
   ]
 
-  sources = [ "java/src/com/matter/controller/Main.java" ]
-
   javac_flags = [ "-Xlint:deprecation" ]
-}
-
-group("default") {
-  deps = [ ":java-matter-controller" ]
 }

--- a/third_party/java_deps/stub_src/android/bluetooth/BluetoothGatt.java
+++ b/third_party/java_deps/stub_src/android/bluetooth/BluetoothGatt.java
@@ -1,0 +1,53 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/** BluetoothGatt.java Stub file to allow compiling standalone, without Android SDK. */
+package android.bluetooth;
+
+import java.util.List;
+import java.util.UUID;
+
+// Stub class to allow standalone compilation without Android
+public final class BluetoothGatt {
+
+  public static final int GATT_SUCCESS = 0;
+
+  public void close() {}
+
+  public BluetoothGattService getService(UUID uuid) {
+    return null;
+  }
+
+  public List<BluetoothGattService> getServices() {
+    return null;
+  }
+
+  public boolean setCharacteristicNotification(
+      BluetoothGattCharacteristic characteristic, boolean enable) {
+    return false;
+  }
+
+  public boolean writeCharacteristic(BluetoothGattCharacteristic characteristic) {
+    return false;
+  }
+
+  public boolean writeDescriptor(BluetoothGattDescriptor descriptor) {
+    return false;
+  }
+}

--- a/third_party/java_deps/stub_src/android/bluetooth/BluetoothGattCallback.java
+++ b/third_party/java_deps/stub_src/android/bluetooth/BluetoothGattCallback.java
@@ -1,0 +1,43 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/** BluetoothGattCallback.java Stub file to allow compiling standalone, without Android SDK. */
+package android.bluetooth;
+
+// Stub class to allow standalone compilation without Android
+public abstract class BluetoothGattCallback {
+  public void onCharacteristicChanged(
+      BluetoothGatt gatt, BluetoothGattCharacteristic characteristic) {}
+
+  public void onCharacteristicRead(
+      BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {}
+
+  public void onCharacteristicWrite(
+      BluetoothGatt gatt, BluetoothGattCharacteristic characteristic, int status) {}
+
+  public void onConnectionStateChange(BluetoothGatt gatt, int status, int newState) {}
+
+  public void onDescriptorRead(
+      BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {}
+
+  public void onDescriptorWrite(
+      BluetoothGatt gatt, BluetoothGattDescriptor descriptor, int status) {}
+
+  public void onServicesDiscovered(BluetoothGatt gatt, int status) {}
+}

--- a/third_party/java_deps/stub_src/android/bluetooth/BluetoothGattCharacteristic.java
+++ b/third_party/java_deps/stub_src/android/bluetooth/BluetoothGattCharacteristic.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/**
+ * BluetoothGattCharacteristic.java Stub file to allow compiling standalone, without Android SDK.
+ */
+package android.bluetooth;
+
+import java.util.UUID;
+
+// Stub class to allow standalone compilation without Android
+public class BluetoothGattCharacteristic {
+  protected UUID mUuid;
+
+  public BluetoothGattDescriptor getDescriptor(UUID uuid) {
+    return null;
+  }
+
+  public BluetoothGattService getService() {
+    return null;
+  }
+
+  public UUID getUuid() {
+    return mUuid;
+  }
+
+  public byte[] getValue() {
+    return null;
+  }
+
+  public boolean setValue(byte[] value) {
+    return false;
+  }
+}

--- a/third_party/java_deps/stub_src/android/bluetooth/BluetoothGattDescriptor.java
+++ b/third_party/java_deps/stub_src/android/bluetooth/BluetoothGattDescriptor.java
@@ -1,0 +1,50 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/** BluetoothGattDescriptor.java Stub file to allow compiling standalone, without Android SDK. */
+package android.bluetooth;
+
+import java.util.UUID;
+
+// Stub class to allow standalone compilation without Android
+public class BluetoothGattDescriptor {
+  public static final byte[] ENABLE_NOTIFICATION_VALUE = {0x01, 0x00};
+
+  public static final byte[] ENABLE_INDICATION_VALUE = {0x02, 0x00};
+
+  public static final byte[] DISABLE_NOTIFICATION_VALUE = {0x00, 0x00};
+
+  protected UUID mUuid;
+
+  public BluetoothGattCharacteristic getCharacteristic() {
+    return null;
+  }
+
+  public UUID getUuid() {
+    return mUuid;
+  }
+
+  public byte[] getValue() {
+    return null;
+  }
+
+  public boolean setValue(byte[] value) {
+    return true;
+  }
+}

--- a/third_party/java_deps/stub_src/android/bluetooth/BluetoothGattService.java
+++ b/third_party/java_deps/stub_src/android/bluetooth/BluetoothGattService.java
@@ -1,0 +1,41 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/** BluetoothGattService.java Stub file to allow compiling standalone, without Android SDK. */
+package android.bluetooth;
+
+import java.util.List;
+import java.util.UUID;
+
+// Stub class to allow standalone compilation without Android
+public class BluetoothGattService {
+  protected UUID mUuid;
+
+  public BluetoothGattCharacteristic getCharacteristic(UUID uuid) {
+    return null;
+  }
+
+  public List<BluetoothGattCharacteristic> getCharacteristics() {
+    return null;
+  }
+
+  public UUID getUuid() {
+    return mUuid;
+  }
+}

--- a/third_party/java_deps/stub_src/android/bluetooth/BluetoothProfile.java
+++ b/third_party/java_deps/stub_src/android/bluetooth/BluetoothProfile.java
@@ -1,0 +1,34 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/** BluetoothProfile.java Stub file to allow compiling standalone, without Android SDK. */
+package android.bluetooth;
+
+// Stub class to allow standalone compilation without Android
+public final class BluetoothProfile {
+
+  /** The profile is in disconnected state */
+  public static final int STATE_DISCONNECTED = 0;
+  /** The profile is in connecting state */
+  public static final int STATE_CONNECTING = 1;
+  /** The profile is in connected state */
+  public static final int STATE_CONNECTED = 2;
+  /** The profile is in disconnecting state */
+  public static final int STATE_DISCONNECTING = 3;
+}

--- a/third_party/java_deps/stub_src/android/os/Build.java
+++ b/third_party/java_deps/stub_src/android/os/Build.java
@@ -1,0 +1,35 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/** Build.java Stub file to allow compiling standalone, without Android SDK. */
+package android.os;
+
+public final class Build {
+  public static class VERSION {
+    public static final int SDK_INT = 0;
+  }
+
+  public static class VERSION_CODES {
+    public static final int JELLY_BEAN_MR2 = 18;
+  }
+
+  public static final String MANUFACTURER = "Unknown";
+
+  public static final String MODEL = "Unknown";
+}

--- a/third_party/java_deps/stub_src/android/util/Log.java
+++ b/third_party/java_deps/stub_src/android/util/Log.java
@@ -1,0 +1,39 @@
+/*
+ *
+ *    Copyright (c) 2023 Project CHIP Authors
+ *    Copyright (c) 2015-2017 Nest Labs, Inc.
+ *    All rights reserved.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+/** Log.java Stub file to allow compiling standalone, without Android SDK. */
+package android.util;
+
+public final class Log {
+  public static int d(String tag, String message) {
+    return 0;
+  }
+
+  public static int e(String tag, String msg) {
+    return 0;
+  }
+
+  public static int e(String tag, String msg, Throwable tr) {
+    return 0;
+  }
+
+  public static int w(String tag, String message) {
+    return 0;
+  }
+}


### PR DESCRIPTION
Problems:
https://github.com/project-chip/connectedhomeip/issues/23811

The goal for java controller application is to exercise the java layer's commission and cluster interaction flow against all-cluster-app or other server app in CI, mac and linux machines. Currently java controller application depends on prebuilt android.jar targeted for android phone, which cannot be run directly in mac and linux host, in addition, multiple shared libraries from NDM, like libm.so, cannot run in host directly.

We need resolve this issue with two stages:
1.  Since several android specific APIs have been used in multiple controller java files, for example, logging, bluetooth , we are providing the dummy stub implementation to bypass the actual android library, this way, we still can exercise the key commissioning code flow and cluster interactions. The dummy stub are provided in this PR.

2. We need to rework https://github.com/project-chip/connectedhomeip/pull/23048 where it use ndk's compiler, instead, we should use linux/mac chip-tool example as reference and start to the compiler from host directly. After this works, the shared libaries used by controller application should work as espected.

