### PR TITLE
Give more time for pairing

### DIFF
--- a/src/lib/address_resolve/AddressResolve.h
+++ b/src/lib/address_resolve/AddressResolve.h
@@ -142,7 +142,7 @@ public:
 
 private:
     static constexpr uint32_t kMinLookupTimeMsDefault = 200;
-    static constexpr uint32_t kMaxLookupTimeMsDefault = 15000;
+    static constexpr uint32_t kMaxLookupTimeMsDefault = 45000;
 
     PeerId mPeerId;
     System::Clock::Milliseconds32 mMinLookupTimeMs{ kMinLookupTimeMsDefault };


### PR DESCRIPTION
Internal tests have shown that 15 seconds to complete all of pairing, fails a significant amount (10%+) of pairings early. mDNS timeouts, network delay, device delay. 

Further break downs to come, but we've found that moving this to 45s significantly reduces the amount of outliers (almost to 0).