### PR TITLE
[v1.0 cherrypick] Fix delivery of urgent events to actually work correctly. (#23240)

### DIFF
--- a/src/app/ReadHandler.h
+++ b/src/app/ReadHandler.h
@@ -263,6 +263,9 @@ private:
     bool IsIdle() const { return mState == HandlerState::Idle; }
     bool IsReportable() const
     {
+        // Important: Anything that changes the state IsReportable depends on in
+        // a way that causes IsReportable to become true must call ScheduleRun
+        // on the reporting engine.
         return mState == HandlerState::GeneratingReports && !mFlags.Has(ReadHandlerFlags::HoldReport) &&
             (IsDirty() || !mFlags.Has(ReadHandlerFlags::HoldSync));
     }
@@ -299,7 +302,7 @@ private:
     {
         return (mDirtyGeneration > mPreviousReportsBeginGeneration) || mFlags.Has(ReadHandlerFlags::ForceDirty);
     }
-    void ClearForceDirtyFlag() { mFlags.Clear(ReadHandlerFlags::ForceDirty); }
+    void ClearForceDirtyFlag() { ClearStateFlag(ReadHandlerFlags::ForceDirty); }
     NodeId GetInitiatorNodeId() const
     {
         auto session = GetSession();
@@ -317,7 +320,7 @@ private:
 
     auto GetTransactionStartGeneration() const { return mTransactionStartGeneration; }
 
-    void UnblockUrgentEventDelivery() { mFlags.Set(ReadHandlerFlags::ForceDirty); }
+    void UnblockUrgentEventDelivery();
 
     const AttributeValueEncoder::AttributeEncodeState & GetAttributeEncodeState() const { return mAttributeEncoderState; }
     void SetAttributeEncodeState(const AttributeValueEncoder::AttributeEncodeState & aState) { mAttributeEncoderState = aState; }
@@ -373,6 +376,10 @@ private:
     void MoveToState(const HandlerState aTargetState);
 
     const char * GetStateStr() const;
+
+    // Helpers for managing our state flags properly.
+    void SetStateFlag(ReadHandlerFlags aFlag, bool aValue = true);
+    void ClearStateFlag(ReadHandlerFlags aFlag);
 
     AttributePathExpandIterator mAttributePathExpandIterator = AttributePathExpandIterator(nullptr);
 

--- a/src/app/reporting/Engine.cpp
+++ b/src/app/reporting/Engine.cpp
@@ -838,14 +838,6 @@ CHIP_ERROR Engine::SetDirty(AttributePathParams & aAttributePath)
     }
     ReturnErrorOnFailure(InsertPathIntoDirtySet(aAttributePath));
 
-    // Schedule work to run asynchronously on the CHIP thread. The scheduled
-    // work won't execute until the current execution context has
-    // completed. This ensures that we can 'gather up' multiple attribute
-    // changes that have occurred in the same execution context without
-    // requiring any explicit 'start' or 'end' change calls into the engine to
-    // book-end the change.
-    ScheduleRun();
-
     return CHIP_NO_ERROR;
 }
 
@@ -938,7 +930,7 @@ CHIP_ERROR Engine::ScheduleEventDelivery(ConcreteEventPath & aPath, uint32_t aBy
 
     if (isUrgentEvent)
     {
-        ChipLogDetail(DataManagement, "urgent event would be sent after min interval");
+        ChipLogDetail(DataManagement, "Urgent event will be sent once reporting is not blocked by the min interval");
         return CHIP_NO_ERROR;
     }
 

--- a/src/app/reporting/Engine.h
+++ b/src/app/reporting/Engine.h
@@ -39,6 +39,9 @@
 
 namespace chip {
 namespace app {
+
+class TestReadInteraction;
+
 namespace reporting {
 /*
  *  @class Engine
@@ -138,6 +141,7 @@ private:
     void Run();
 
     friend class TestReportingEngine;
+    friend class ::chip::app::TestReadInteraction;
 
     struct AttributePathParamsWithGeneration : public AttributePathParams
     {


### PR DESCRIPTION
* Fix delivery of urgent events to actually work correctly.

If an urgent event was emitted at a point when the ReadHandler subscribing for it had already gotten its "min interval has elapsed" callback, we would just mark the read handler dirty but not schedule a run of the reporting engine. This would cause us to not report the event until something _did_ trigger such a run (either the max interval being reached, or some other reading/reporting activity).

The fix is to make sure ReadHandler always schedules a run when IsReportable() becomes true.

* Address review comments.

* Make TestSubscribeUrgentWildcardEvent slightly less random-failure-prone.

* Fixes #23270