### PR TITLE
Remove fixed versioning for git in cirque

### DIFF
--- a/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
+++ b/integrations/docker/ci-only-images/chip-cirque-device-base/Dockerfile
@@ -21,7 +21,7 @@ RUN apt-get update \
   ca-certificates=20211016~20.04.1 \
   dhcpcd5=7.1.0-2build1 \
   gdb=9.2-0ubuntu1~20.04.1 \
-  git=1:2.25.1-1ubuntu3.5 \
+  git \
   iproute2=5.5.0-1ubuntu1 \
   libavahi-client3=0.7-4ubuntu7.1 \
   libcairo2-dev=1.16.0-4ubuntu1 \


### PR DESCRIPTION
This cherrypicks #23257  into the v1 branch.

Without this, cirque CI is perma-failing.
