### PR TITLE
Add 64 bit requirement to debian

### DIFF
--- a/docs/guides/BUILDING.md
+++ b/docs/guides/BUILDING.md
@@ -7,7 +7,7 @@ that generates inputs to [ninja](https://ninja-build.org/).
 Tested on:
 
 -   macOS 10.15
--   Debian 11
+-   Debian 11 (64 bit required)
 -   Ubuntu 22.04 LTS
 
 Build system features:


### PR DESCRIPTION
In #23069 we noticed that the `activate.sh` script does not work on a Raspberry OS Bullseye system with a 32 bit architecture but everything worked out of the box after switching to 64 bit Raspberry OS Bullseye. 

