### PR TITLE
Catch UnsatisfiedLinkError when load native library

### DIFF
--- a/src/setup_payload/java/src/chip/setuppayload/SetupPayloadParser.java
+++ b/src/setup_payload/java/src/chip/setuppayload/SetupPayloadParser.java
@@ -1,7 +1,12 @@
 package chip.setuppayload;
 
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
 /** Parser for scanned QR code or manual entry code. */
 public class SetupPayloadParser {
+
+  private static final Logger LOGGER = Logger.getLogger(SetupPayloadParser.class.getSimpleName());
 
   /**
    * Returns {@link SetupPayload} parsed from the QR code string. If an invalid element is included
@@ -69,7 +74,11 @@ public class SetupPayloadParser {
       throws InvalidEntryCodeFormatException, SetupPayloadException;
 
   static {
-    System.loadLibrary("SetupPayloadParser");
+    try {
+      System.loadLibrary("SetupPayloadParser");
+    } catch (UnsatisfiedLinkError e) {
+      LOGGER.log(Level.SEVERE, "Cannot load library.", e);
+    }
   }
 
   public static class UnrecognizedQrCodeException extends Exception {


### PR DESCRIPTION
When the native library cannot be loaded, catch the exception so that the logs can be parsed later on. This makes this issue a bit easier to debug.
