### PR TITLE
Fix duplicate light app gen

### DIFF
--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -26,6 +26,7 @@ from dataclasses import dataclass
 CHIP_ROOT_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '../..'))
 
+
 @dataclass(eq=True, frozen=True)
 class ZapDistinctOutput:
     """Defines the properties that determine if some output seems unique or 
@@ -52,7 +53,7 @@ class ZAPGenerateTarget:
             self.output_dir = None
 
     def distinct_output(self):
-        return ZapDistinctOutput(input_template = self.template, output_directory = self.output_dir)
+        return ZapDistinctOutput(input_template=self.template, output_directory=self.output_dir)
 
     def log_command(self):
         """Log the command that will get run for this target
@@ -243,7 +244,7 @@ def getTargets(type, test_target):
             logging.error("Same output %r:" % o)
             for t in targets:
                 if t.distinct_output() == o:
-                   logging.error("   %s" % t.zap_config)
+                    logging.error("   %s" % t.zap_config)
 
             raise Exception("Duplicate/overlapping output directory: %r" % o)
 

--- a/scripts/tools/zap_regen_all.py
+++ b/scripts/tools/zap_regen_all.py
@@ -21,9 +21,22 @@ from pathlib import Path
 import sys
 import subprocess
 import logging
+from dataclasses import dataclass
 
 CHIP_ROOT_DIR = os.path.realpath(
     os.path.join(os.path.dirname(__file__), '../..'))
+
+@dataclass(eq=True, frozen=True)
+class ZapDistinctOutput:
+    """Defines the properties that determine if some output seems unique or 
+       not, for the purposes of detecting codegen overlap.
+
+       Not perfect, since separate templates may use the same file names, but
+       better than nothing.
+    """
+
+    input_template: str
+    output_directory: str
 
 
 class ZAPGenerateTarget:
@@ -37,6 +50,9 @@ class ZAPGenerateTarget:
             self.output_dir = str(output_dir)
         else:
             self.output_dir = None
+
+    def distinct_output(self):
+        return ZapDistinctOutput(input_template = self.template, output_directory = self.output_dir)
 
     def log_command(self):
         """Log the command that will get run for this target
@@ -135,10 +151,17 @@ def getGlobalTemplatesTargets():
         logging.info("Found example %s (via %s)" %
                      (example_name, str(filepath)))
 
+        generate_subdir = example_name
+
+        # Special casing lighting app because separate folders
+        if example_name == "lighting-app":
+            if 'nxp' in str(filepath):
+                generate_subdir = f"{example_name}/nxp"
+
         # The name zap-generated is to make includes clear by using
         # a name like <zap-generated/foo.h>
         output_dir = os.path.join(
-            'zzz_generated', example_name, 'zap-generated')
+            'zzz_generated', generate_subdir, 'zap-generated')
         targets.append(ZAPGenerateTarget(filepath, output_dir=output_dir))
 
     targets.append(ZAPGenerateTarget(
@@ -161,19 +184,6 @@ def getTestsTemplatesTargets(test_target):
             'output_dir': 'zzz_generated/darwin-framework-tool/zap-generated'
         }
     }
-
-    # Place holder has apps within each build
-    for filepath in Path('./examples/placeholder').rglob('*.zap'):
-        example_name = filepath.as_posix()
-        example_name = example_name[example_name.index(
-            'apps/') + len('apps/'):]
-        example_name = example_name[:example_name.index('/')]
-
-        templates[example_name] = {
-            'zap': filepath,
-            'template': 'examples/placeholder/templates/templates.json',
-            'output_dir': os.path.join('zzz_generated', 'placeholder', example_name, 'zap-generated')
-        }
 
     targets = []
     for key, target in templates.items():
@@ -222,6 +232,22 @@ def getTargets(type, test_target):
     logging.info("Targets to be generated:")
     for target in targets:
         target.log_command()
+
+    # validate that every target as a DISTINCT directory (we had bugs here
+    # for various examples duplicating zap files)
+    distinct_outputs = set()
+    for target in targets:
+        o = target.distinct_output()
+
+        if o in distinct_outputs:
+            logging.error("Same output %r:" % o)
+            for t in targets:
+                if t.distinct_output() == o:
+                   logging.error("   %s" % t.zap_config)
+
+            raise Exception("Duplicate/overlapping output directory: %r" % o)
+
+        distinct_outputs.add(o)
 
     return targets
 

--- a/zzz_generated/lighting-app/nxp/zap-generated/endpoint_config.h
+++ b/zzz_generated/lighting-app/nxp/zap-generated/endpoint_config.h
@@ -320,7 +320,7 @@
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(4) },                                 /* ClusterRevision */   \
                                                                                                                                    \
             /* Endpoint: 1, Cluster: Groups (server) */                                                                            \
-            { 0x00000000, ZAP_TYPE(BITMAP8), 1, 0, ZAP_EMPTY_DEFAULT() },    /* name support */                                    \
+            { 0x00000000, ZAP_TYPE(BITMAP8), 1, 0, ZAP_EMPTY_DEFAULT() },    /* NameSupport */                                     \
             { 0x0000FFFC, ZAP_TYPE(BITMAP32), 4, 0, ZAP_SIMPLE_DEFAULT(0) }, /* FeatureMap */                                      \
             { 0x0000FFFD, ZAP_TYPE(INT16U), 2, 0, ZAP_SIMPLE_DEFAULT(4) },   /* ClusterRevision */                                 \
                                                                                                                                    \


### PR DESCRIPTION
Lighting app had 2 zap files: common and nxp. regen script was regenertating everything in the same folder, resulting in potentially different configurations.

Changes in the PR:
  - added a "detect overlapping generations" code that I checked would flag lighting app
  - duplicate detection also flagged app1/2 because its generation was added by both "tests" and "examples". I removed tests to remove the duplication
  - Special-cased lighting app for NXP
  

