### PR TITLE
reworking example code to avoid compiler warning

### DIFF
--- a/examples/lighting-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lighting-app/infineon/psoc6/src/AppTask.cpp
@@ -305,41 +305,40 @@ void AppTask::AppTaskMain(void * pvParameter)
 
 void AppTask::LightActionEventHandler(AppEvent * event)
 {
-    bool initiated = false;
     LightingManager::Action_t action;
-    int32_t actor  = 0;
-    CHIP_ERROR err = CHIP_NO_ERROR;
+    int32_t actor;
 
-    if (event->Type == AppEvent::kEventType_Light)
+    switch (event->Type)
     {
-        action = static_cast<LightingManager::Action_t>(event->LightEvent.Action);
-        actor  = event->LightEvent.Actor;
-    }
-    else if (event->Type == AppEvent::kEventType_Button)
-    {
-        if (LightMgr().IsLightOn())
+        case AppEvent::kEventType_Light:
         {
-            action = LightingManager::OFF_ACTION;
+            action = static_cast<LightingManager::Action_t>(event->LightEvent.Action);
+            actor  = event->LightEvent.Actor;
+            break;
         }
-        else
+
+        case AppEvent::kEventType_Button:
         {
-            action = LightingManager::ON_ACTION;
+            if (LightMgr().IsLightOn())
+            {
+                action = LightingManager::OFF_ACTION;
+            }
+            else
+            {
+                action = LightingManager::ON_ACTION;
+            }
+
+            actor = AppEvent::kEventType_Button;
+            break;
         }
-        actor = AppEvent::kEventType_Button;
-    }
-    else
-    {
-        err = APP_ERROR_UNHANDLED_EVENT;
+
+        default:
+            return;
     }
 
-    if (err == CHIP_NO_ERROR)
+    if (!LightMgr().InitiateAction(actor, action))
     {
-        initiated = LightMgr().InitiateAction(actor, action);
-
-        if (!initiated)
-        {
-            P6_LOG("Action is already in progress or active.");
-        }
+        P6_LOG("Action is already in progress or active.");
     }
 }
 

--- a/examples/lighting-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lighting-app/infineon/psoc6/src/AppTask.cpp
@@ -310,30 +310,28 @@ void AppTask::LightActionEventHandler(AppEvent * event)
 
     switch (event->Type)
     {
-        case AppEvent::kEventType_Light:
+    case AppEvent::kEventType_Light: {
+        action = static_cast<LightingManager::Action_t>(event->LightEvent.Action);
+        actor  = event->LightEvent.Actor;
+        break;
+    }
+
+    case AppEvent::kEventType_Button: {
+        if (LightMgr().IsLightOn())
         {
-            action = static_cast<LightingManager::Action_t>(event->LightEvent.Action);
-            actor  = event->LightEvent.Actor;
-            break;
+            action = LightingManager::OFF_ACTION;
+        }
+        else
+        {
+            action = LightingManager::ON_ACTION;
         }
 
-        case AppEvent::kEventType_Button:
-        {
-            if (LightMgr().IsLightOn())
-            {
-                action = LightingManager::OFF_ACTION;
-            }
-            else
-            {
-                action = LightingManager::ON_ACTION;
-            }
+        actor = AppEvent::kEventType_Button;
+        break;
+    }
 
-            actor = AppEvent::kEventType_Button;
-            break;
-        }
-
-        default:
-            return;
+    default:
+        return;
     }
 
     if (!LightMgr().InitiateAction(actor, action))

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -393,30 +393,28 @@ void AppTask::LockActionEventHandler(AppEvent * event)
 
     switch (event->Type)
     {
-        case AppEvent::kEventType_Lock:
+    case AppEvent::kEventType_Lock: {
+        action = static_cast<LockManager::Action_t>(event->LockEvent.Action);
+        actor  = event->LockEvent.Actor;
+        break;
+    }
+
+    case AppEvent::kEventType_Button: {
+        if (LockMgr().NextState() == true)
         {
-            action = static_cast<LockManager::Action_t>(event->LockEvent.Action);
-            actor  = event->LockEvent.Actor;
-            break;
+            action = LockManager::LOCK_ACTION;
+        }
+        else
+        {
+            action = LockManager::UNLOCK_ACTION;
         }
 
-        case AppEvent::kEventType_Button:
-        {
-            if (LockMgr().NextState() == true)
-            {
-                action = LockManager::LOCK_ACTION;
-            }
-            else
-            {
-                action = LockManager::UNLOCK_ACTION;
-            }
+        actor = AppEvent::kEventType_Button;
+        break;
+    }
 
-            actor = AppEvent::kEventType_Button;
-            break;
-        }
-
-        default:
-            return;
+    default:
+        return;
     }
 
     if (!LockMgr().InitiateAction(actor, action))

--- a/examples/lock-app/infineon/psoc6/src/AppTask.cpp
+++ b/examples/lock-app/infineon/psoc6/src/AppTask.cpp
@@ -388,41 +388,40 @@ void AppTask::AppTaskMain(void * pvParameter)
 
 void AppTask::LockActionEventHandler(AppEvent * event)
 {
-    bool initiated = false;
     LockManager::Action_t action;
     int32_t actor;
-    CHIP_ERROR err = CHIP_NO_ERROR;
 
-    if (event->Type == AppEvent::kEventType_Lock)
+    switch (event->Type)
     {
-        action = static_cast<LockManager::Action_t>(event->LockEvent.Action);
-        actor  = event->LockEvent.Actor;
-    }
-    else if (event->Type == AppEvent::kEventType_Button)
-    {
-        if (LockMgr().NextState() == true)
+        case AppEvent::kEventType_Lock:
         {
-            action = LockManager::LOCK_ACTION;
+            action = static_cast<LockManager::Action_t>(event->LockEvent.Action);
+            actor  = event->LockEvent.Actor;
+            break;
         }
-        else
+
+        case AppEvent::kEventType_Button:
         {
-            action = LockManager::UNLOCK_ACTION;
+            if (LockMgr().NextState() == true)
+            {
+                action = LockManager::LOCK_ACTION;
+            }
+            else
+            {
+                action = LockManager::UNLOCK_ACTION;
+            }
+
+            actor = AppEvent::kEventType_Button;
+            break;
         }
-        actor = AppEvent::kEventType_Button;
-    }
-    else
-    {
-        err = APP_ERROR_UNHANDLED_EVENT;
+
+        default:
+            return;
     }
 
-    if (err == CHIP_NO_ERROR)
+    if (!LockMgr().InitiateAction(actor, action))
     {
-        initiated = LockMgr().InitiateAction(actor, action);
-
-        if (!initiated)
-        {
-            P6_LOG("Action is already in progress or active.");
-        }
+        P6_LOG("Action is already in progress or active.");
     }
 }
 


### PR DESCRIPTION
Fixes #23295 (https://github.com/project-chip/connectedhomeip/issues/23295)

There is a compiler warning with a function in the Infineon lock-app example.  This pull request resolves that.  Also took the opportunity to rework/simplify that function. There is a similar function in the lighting-app, so did the same there.
