### PR TITLE
Make GetMRPBaseTimeout method const

### DIFF
--- a/src/transport/GroupSession.h
+++ b/src/transport/GroupSession.h
@@ -66,7 +66,7 @@ public:
         return cfg;
     }
 
-    System::Clock::Timestamp GetMRPBaseTimeout() override { return System::Clock::kZero; }
+    System::Clock::Timestamp GetMRPBaseTimeout() const override { return System::Clock::kZero; }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {
@@ -117,7 +117,7 @@ public:
         return cfg;
     }
 
-    System::Clock::Timestamp GetMRPBaseTimeout() override { return System::Clock::kZero; }
+    System::Clock::Timestamp GetMRPBaseTimeout() const override { return System::Clock::kZero; }
 
     System::Clock::Milliseconds32 GetAckTimeout() const override
     {

--- a/src/transport/SecureSession.h
+++ b/src/transport/SecureSession.h
@@ -220,9 +220,12 @@ public:
         }
     }
 
-    bool IsPeerActive() { return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime); }
+    bool IsPeerActive() const
+    {
+        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime);
+    }
 
-    System::Clock::Timestamp GetMRPBaseTimeout() override
+    System::Clock::Timestamp GetMRPBaseTimeout() const override
     {
         return IsPeerActive() ? GetRemoteMRPConfig().mActiveRetransTimeout : GetRemoteMRPConfig().mIdleRetransTimeout;
     }

--- a/src/transport/Session.h
+++ b/src/transport/Session.h
@@ -199,7 +199,7 @@ public:
     virtual Access::SubjectDescriptor GetSubjectDescriptor() const           = 0;
     virtual bool RequireMRP() const                                          = 0;
     virtual const ReliableMessageProtocolConfig & GetRemoteMRPConfig() const = 0;
-    virtual System::Clock::Timestamp GetMRPBaseTimeout()                     = 0;
+    virtual System::Clock::Timestamp GetMRPBaseTimeout() const               = 0;
     virtual System::Clock::Milliseconds32 GetAckTimeout() const              = 0;
 
     // Returns a suggested timeout value based on the round-trip time it takes for the peer at the other end of the session to

--- a/src/transport/UnauthenticatedSessionTable.h
+++ b/src/transport/UnauthenticatedSessionTable.h
@@ -111,9 +111,12 @@ public:
     const PeerAddress & GetPeerAddress() const { return mPeerAddress; }
     void SetPeerAddress(const PeerAddress & peerAddress) { mPeerAddress = peerAddress; }
 
-    bool IsPeerActive() { return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime); }
+    bool IsPeerActive() const
+    {
+        return ((System::SystemClock().GetMonotonicTimestamp() - GetLastPeerActivityTime()) < kMinActiveTime);
+    }
 
-    System::Clock::Timestamp GetMRPBaseTimeout() override
+    System::Clock::Timestamp GetMRPBaseTimeout() const override
     {
         return IsPeerActive() ? GetRemoteMRPConfig().mActiveRetransTimeout : GetRemoteMRPConfig().mIdleRetransTimeout;
     }


### PR DESCRIPTION
#### Problem

`GetMRPBaseTimeout` is not const. This is the only one that is not.