### PR TITLE
[SetUpCodePairer] Pass the MRP parameters to RendezvousParameters in …

### DIFF
--- a/src/controller/CHIPDeviceController.cpp
+++ b/src/controller/CHIPDeviceController.cpp
@@ -686,6 +686,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
 
     mDeviceInPASEEstablishment = device;
     device->Init(GetControllerDeviceInitParams(), remoteDeviceId, peerAddress);
+    device->UpdateDeviceData(params.GetPeerAddress(), params.GetMRPConfig());
 
 #if CONFIG_NETWORK_LAYER_BLE
     if (params.GetPeerAddress().GetTransportType() == Transport::Type::kBle)
@@ -706,8 +707,7 @@ CHIP_ERROR DeviceCommissioner::EstablishPASEConnection(NodeId remoteDeviceId, Re
         }
     }
 #endif
-    // TODO: In some cases like PASE over IP, SAI and SII values from commissionable node service should be used
-    session = mSystemState->SessionMgr()->CreateUnauthenticatedSession(params.GetPeerAddress(), device->GetRemoteMRPConfig());
+    session = mSystemState->SessionMgr()->CreateUnauthenticatedSession(params.GetPeerAddress(), params.GetMRPConfig());
     VerifyOrExit(session.HasValue(), err = CHIP_ERROR_NO_MEMORY);
 
     // Allocate the exchange immediately before calling PASESession::Pair.

--- a/src/controller/SetUpCodePairer.cpp
+++ b/src/controller/SetUpCodePairer.cpp
@@ -344,6 +344,19 @@ void SetUpCodePairer::NotifyCommissionableDeviceDiscovered(const Dnssd::Discover
         Transport::PeerAddress::UDP(nodeData.resolutionData.ipAddress[0], nodeData.resolutionData.port, interfaceId);
     mDiscoveredParameters.emplace();
     mDiscoveredParameters.back().SetPeerAddress(peerAddress);
+
+    if (nodeData.resolutionData.mrpRetryIntervalIdle.HasValue())
+    {
+        auto interval = nodeData.resolutionData.mrpRetryIntervalIdle.Value();
+        mDiscoveredParameters.back().SetIdleInterval(interval);
+    }
+
+    if (nodeData.resolutionData.mrpRetryIntervalActive.HasValue())
+    {
+        auto interval = nodeData.resolutionData.mrpRetryIntervalActive.Value();
+        mDiscoveredParameters.back().SetActiveInterval(interval);
+    }
+
     ConnectToDiscoveredDevice();
 }
 


### PR DESCRIPTION
…order to get them used in the initial pairing session

#### Problem

The discovered MRP parameters over the network are not used during commissioning with the `SetUpCodePairer`.