### PR TITLE
Enable dependabot updates for OpenThread

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,4 @@ updates:
     allow:
       - dependency-name: "third_party/pigweed/repo"
       - dependency-name: "third_party/mbedtls/repo"
+      - dependancy-name: "third_party/openthread/repo"


### PR DESCRIPTION
#### Problem

Dependencies should be kept up to date.

#### Change overview

Enable automatic updates of OpenThread via dependabot.

#### Testing

Untested.