### PR TITLE
Mark UnauthenticatedSession active when initiating a PASE session

### DIFF
--- a/src/protocols/secure_channel/PASESession.cpp
+++ b/src/protocols/secure_channel/PASESession.cpp
@@ -212,6 +212,10 @@ CHIP_ERROR PASESession::Pair(SessionManager & sessionManager, uint32_t peerSetUp
     mRole = CryptoContext::SessionRole::kInitiator;
 
     mExchangeCtxt = exchangeCtxt;
+
+    // When commissioning starts, the peer is assumed to be active.
+    mExchangeCtxt->GetSessionHandle()->AsUnauthenticatedSession()->MarkActiveRx();
+
     mExchangeCtxt->SetResponseTimeout(kSpake2p_Response_Timeout + mExchangeCtxt->GetSessionHandle()->GetAckTimeout());
 
     mLocalMRPConfig = mrpLocalConfig;


### PR DESCRIPTION
#### Problem

When the `PASE` session is started for commissioning it is *idle*. by default, which makes the MRP retransmission slower than what is should be.

This PR marks it as *active*.

