### PR TITLE
[Tizen] Enable ble configuration in chip-tool for tizen platform

### DIFF
--- a/examples/chip-tool/commands/common/CHIPCommand.cpp
+++ b/examples/chip-tool/commands/common/CHIPCommand.cpp
@@ -89,7 +89,7 @@ CHIP_ERROR CHIPCommand::MaybeSetUpStack()
 
     StartTracing();
 
-#if CHIP_DEVICE_LAYER_TARGET_LINUX && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
+#if (CHIP_DEVICE_LAYER_TARGET_LINUX || CHIP_DEVICE_LAYER_TARGET_TIZEN) && CHIP_DEVICE_CONFIG_ENABLE_CHIPOBLE
     // By default, Linux device is configured as a BLE peripheral while the controller needs a BLE central.
     ReturnLogErrorOnFailure(chip::DeviceLayer::Internal::BLEMgrImpl().ConfigureBle(mBleAdapterId.ValueOr(0), true));
 #endif


### PR DESCRIPTION
# Problem
During the compilation of chip-tool for the Tizen platform, the configuration of ble was disabled. Bonding a new device didn't work because of missing setting if the Tizen device is type central or not. 

# Changes
Add CHIP_DEVICE_LAYER_TARGET_TIZEN to conditional compilation. 

# Testing 
Run chip-lighting-app on one device:
``` sh
./out/linux-x64-light/chip-lighting-app --discriminator 42 --passcode 1234
```
and chip-tool on the Tizen device:
``` sh
./chip-tool pairing ble-wifi 0x01 wifi-name wifi-pass 1234 42
```
