### PR TITLE
Split cloudbuild build-all.yaml into 2 separate build commands to avoid length overflow

### DIFF
--- a/integrations/cloudbuild/build-all.yaml
+++ b/integrations/cloudbuild/build-all.yaml
@@ -74,6 +74,14 @@ steps:
               --target k32w-light-no-ota
               --target k32w-lock
               --target k32w-shell
+              build
+              --create-archives /workspace/artifacts/
+    - name: "connectedhomeip/chip-build-vscode:0.6.03"
+      env:
+          - PW_ENVIRONMENT_ROOT=/pwenv
+      args:
+          - >-
+              ./scripts/build/build_examples.py --enable-flashbundle
               --target linux-arm64-all-clusters-clang
               --target linux-arm64-all-clusters-app-nodeps
               --target linux-arm64-all-clusters-app-nodeps-ipv6only


### PR DESCRIPTION
Build fails otherwise due to too long arguments, it says:

```
Your build failed to run: generic::invalid_argument: invalid build: invalid .steps field: build step 2 arg 0 too long (max: 4000)
```
