### PR TITLE
remove parcelable in android device controller network credential

### DIFF
--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/CHIPToolActivity.kt
@@ -28,7 +28,7 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.fragment.app.Fragment
-import chip.devicecontroller.NetworkCredentials
+import com.google.chip.chiptool.NetworkCredentialsParcelable
 import chip.setuppayload.SetupPayload
 import chip.setuppayload.SetupPayloadParser
 import chip.setuppayload.SetupPayloadParser.UnrecognizedQrCodeException
@@ -133,7 +133,7 @@ class CHIPToolActivity :
     showFragment(AddressCommissioningFragment.newInstance(), false)
   }
 
-  override fun onNetworkCredentialsEntered(networkCredentials: NetworkCredentials) {
+  override fun onNetworkCredentialsEntered(networkCredentials: NetworkCredentialsParcelable) {
     showFragment(DeviceProvisioningFragment.newInstance(deviceInfo!!, networkCredentials))
   }
 

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/NetworkCredentialsParcelable.java
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/NetworkCredentialsParcelable.java
@@ -1,0 +1,170 @@
+/*
+ *   Copyright (c) 2020-2022 Project CHIP Authors
+ *   All rights reserved.
+ *
+ *   Licensed under the Apache License, Version 2.0 (the "License");
+ *   you may not use this file except in compliance with the License.
+ *   You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *   Unless required by applicable law or agreed to in writing, software
+ *   distributed under the License is distributed on an "AS IS" BASIS,
+ *   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *   See the License for the specific language governing permissions and
+ *   limitations under the License.
+ *
+ */
+
+package com.google.chip.chiptool;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import androidx.annotation.Nullable;
+
+/** Class for holding WiFi or Thread credentials, but not both. */
+public class NetworkCredentialsParcelable implements Parcelable {
+  @Nullable private WiFiCredentials wifiCredentials;
+  @Nullable private ThreadCredentials threadCredentials;
+
+  private NetworkCredentialsParcelable(
+      @Nullable WiFiCredentials wifiCredentials, @Nullable ThreadCredentials threadCredentials) {
+    this.wifiCredentials = wifiCredentials;
+    this.threadCredentials = threadCredentials;
+  }
+
+  /**
+   * Return a NetworkCredentialsParcelable object with the given WiFiCredentials and null
+   * ThreadCredentials.
+   */
+  public static NetworkCredentialsParcelable forWiFi(WiFiCredentials wifiCredentials) {
+    return new NetworkCredentialsParcelable(wifiCredentials, null);
+  }
+
+  /**
+   * Return a NetworkCredentialsParcelable object with the given ThreadCredentials and null
+   * WiFiCredentials.
+   */
+  public static NetworkCredentialsParcelable forThread(ThreadCredentials threadCredentials) {
+    return new NetworkCredentialsParcelable(null, threadCredentials);
+  }
+
+  public WiFiCredentials getWiFiCredentials() {
+    return wifiCredentials;
+  }
+
+  public ThreadCredentials getThreadCredentials() {
+    return threadCredentials;
+  }
+
+  // Begin Parcelable implementation
+
+  private NetworkCredentialsParcelable(Parcel in) {
+    wifiCredentials = in.readParcelable(WiFiCredentials.class.getClassLoader());
+    threadCredentials = in.readParcelable(ThreadCredentials.class.getClassLoader());
+  }
+
+  public int describeContents() {
+    return 0;
+  }
+
+  public void writeToParcel(Parcel out, int flags) {
+    out.writeParcelable(wifiCredentials, 0);
+    out.writeParcelable(threadCredentials, 0);
+  }
+
+  public static final Parcelable.Creator<NetworkCredentialsParcelable> CREATOR =
+      new Parcelable.Creator<NetworkCredentialsParcelable>() {
+        public NetworkCredentialsParcelable createFromParcel(Parcel in) {
+          return new NetworkCredentialsParcelable(in);
+        }
+
+        public NetworkCredentialsParcelable[] newArray(int size) {
+          return new NetworkCredentialsParcelable[size];
+        }
+      };
+
+  public static class WiFiCredentials implements Parcelable {
+    private final String ssid;
+    private final String password;
+
+    public WiFiCredentials(String ssid, String password) {
+      this.ssid = ssid;
+      this.password = password;
+    }
+
+    public String getSsid() {
+      return ssid;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    // Begin Parcelable implementation
+
+    private WiFiCredentials(Parcel in) {
+      ssid = in.readString();
+      password = in.readString();
+    }
+
+    public int describeContents() {
+      return 0;
+    }
+
+    public void writeToParcel(Parcel out, int flags) {
+      out.writeString(ssid);
+      out.writeString(password);
+    }
+
+    public static final Parcelable.Creator<WiFiCredentials> CREATOR =
+        new Parcelable.Creator<WiFiCredentials>() {
+          public WiFiCredentials createFromParcel(Parcel in) {
+            return new WiFiCredentials(in);
+          }
+
+          public WiFiCredentials[] newArray(int size) {
+            return new WiFiCredentials[size];
+          }
+        };
+  }
+
+  public static class ThreadCredentials implements Parcelable {
+    private final byte[] operationalDataset;
+
+    public ThreadCredentials(byte[] operationalDataset) {
+      this.operationalDataset = operationalDataset;
+    }
+
+    public byte[] getOperationalDataset() {
+      return operationalDataset;
+    }
+
+    // Begin Parcelable implementation
+
+    private ThreadCredentials(Parcel in) {
+      operationalDataset = new byte[in.readInt()];
+      in.readByteArray(operationalDataset);
+    }
+
+    public int describeContents() {
+      return 0;
+    }
+
+    public void writeToParcel(Parcel out, int flags) {
+      out.writeInt(operationalDataset.length);
+      out.writeByteArray(operationalDataset);
+    }
+
+    public static final Parcelable.Creator<ThreadCredentials> CREATOR =
+        new Parcelable.Creator<ThreadCredentials>() {
+          public ThreadCredentials createFromParcel(Parcel in) {
+            return new ThreadCredentials(in);
+          }
+
+          public ThreadCredentials[] newArray(int size) {
+            return new ThreadCredentials[size];
+          }
+        };
+  }
+}

--- a/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
+++ b/examples/android/CHIPTool/app/src/main/java/com/google/chip/chiptool/provisioning/EnterNetworkFragment.kt
@@ -23,9 +23,9 @@ import android.view.View
 import android.view.ViewGroup
 import android.widget.Toast
 import androidx.fragment.app.Fragment
-import chip.devicecontroller.NetworkCredentials
 import com.google.chip.chiptool.R
 import com.google.chip.chiptool.util.FragmentUtil
+import com.google.chip.chiptool.NetworkCredentialsParcelable
 import kotlinx.android.synthetic.main.enter_thread_network_fragment.channelEd
 import kotlinx.android.synthetic.main.enter_thread_network_fragment.masterKeyEd
 import kotlinx.android.synthetic.main.enter_thread_network_fragment.panIdEd
@@ -44,7 +44,7 @@ class EnterNetworkFragment : Fragment() {
     )
 
   interface Callback {
-    fun onNetworkCredentialsEntered(networkCredentials: NetworkCredentials)
+    fun onNetworkCredentialsEntered(networkCredentials: NetworkCredentialsParcelable)
   }
 
   override fun onCreateView(
@@ -79,8 +79,8 @@ class EnterNetworkFragment : Fragment() {
       return
     }
 
-    val networkCredentials = NetworkCredentials.forWiFi(
-      NetworkCredentials.WiFiCredentials(ssid.toString(), pwd.toString())
+    val networkCredentials = NetworkCredentialsParcelable.forWiFi(
+      NetworkCredentialsParcelable.WiFiCredentials(ssid.toString(), pwd.toString())
     )
     FragmentUtil.getHost(this, Callback::class.java)
       ?.onNetworkCredentialsEntered(networkCredentials)
@@ -130,7 +130,7 @@ class EnterNetworkFragment : Fragment() {
     )
 
     val networkCredentials =
-      NetworkCredentials.forThread(NetworkCredentials.ThreadCredentials(operationalDataset))
+      NetworkCredentialsParcelable.forThread(NetworkCredentialsParcelable.ThreadCredentials(operationalDataset))
     FragmentUtil.getHost(this, Callback::class.java)
       ?.onNetworkCredentialsEntered(networkCredentials)
   }

--- a/examples/android/CHIPTool/chip-library/build.gradle
+++ b/examples/android/CHIPTool/chip-library/build.gradle
@@ -33,7 +33,8 @@ android {
                     '../../../setup_payload/java/src',
                     '../../../controller/java/zap-generated',
                     '../../../controller/java/src',
-                    '../../../platform/android/java'
+                    '../../../platform/android/java',
+                    '../app/src/main/java/com/google/chip/chiptool'
             ]
         }
     }

--- a/src/controller/java/src/chip/devicecontroller/NetworkCredentials.java
+++ b/src/controller/java/src/chip/devicecontroller/NetworkCredentials.java
@@ -17,14 +17,14 @@
  */
 package chip.devicecontroller;
 
-import android.os.Parcel;
-import android.os.Parcelable;
 import javax.annotation.Nullable;
 
 /** Class for holding WiFi or Thread credentials, but not both. */
-public class NetworkCredentials implements Parcelable {
+public class NetworkCredentials {
   @Nullable private WiFiCredentials wifiCredentials;
   @Nullable private ThreadCredentials threadCredentials;
+
+  public NetworkCredentials() {}
 
   private NetworkCredentials(
       @Nullable WiFiCredentials wifiCredentials, @Nullable ThreadCredentials threadCredentials) {
@@ -54,38 +54,23 @@ public class NetworkCredentials implements Parcelable {
     return threadCredentials;
   }
 
-  // Begin Parcelable implementation
-
-  private NetworkCredentials(Parcel in) {
-    wifiCredentials = in.readParcelable(WiFiCredentials.class.getClassLoader());
-    threadCredentials = in.readParcelable(ThreadCredentials.class.getClassLoader());
+  public void setWiFiCredentials(String ssid, String password) {
+    wifiCredentials.set(ssid, password);
   }
 
-  public int describeContents() {
-    return 0;
+  public void setThreadCredentials(byte[] operationalDataset) {
+    threadCredentials.set(operationalDataset);
   }
 
-  public void writeToParcel(Parcel out, int flags) {
-    out.writeParcelable(wifiCredentials, 0);
-    out.writeParcelable(threadCredentials, 0);
-  }
-
-  public static final Parcelable.Creator<NetworkCredentials> CREATOR =
-      new Parcelable.Creator<NetworkCredentials>() {
-        public NetworkCredentials createFromParcel(Parcel in) {
-          return new NetworkCredentials(in);
-        }
-
-        public NetworkCredentials[] newArray(int size) {
-          return new NetworkCredentials[size];
-        }
-      };
-
-  public static class WiFiCredentials implements Parcelable {
-    private final String ssid;
-    private final String password;
+  public static class WiFiCredentials {
+    private String ssid;
+    private String password;
 
     public WiFiCredentials(String ssid, String password) {
+      set(ssid, password);
+    }
+
+    public void set(String ssid, String password) {
       this.ssid = ssid;
       this.password = password;
     }
@@ -97,71 +82,21 @@ public class NetworkCredentials implements Parcelable {
     public String getPassword() {
       return password;
     }
-
-    // Begin Parcelable implementation
-
-    private WiFiCredentials(Parcel in) {
-      ssid = in.readString();
-      password = in.readString();
-    }
-
-    public int describeContents() {
-      return 0;
-    }
-
-    public void writeToParcel(Parcel out, int flags) {
-      out.writeString(ssid);
-      out.writeString(password);
-    }
-
-    public static final Parcelable.Creator<WiFiCredentials> CREATOR =
-        new Parcelable.Creator<WiFiCredentials>() {
-          public WiFiCredentials createFromParcel(Parcel in) {
-            return new WiFiCredentials(in);
-          }
-
-          public WiFiCredentials[] newArray(int size) {
-            return new WiFiCredentials[size];
-          }
-        };
   }
 
-  public static class ThreadCredentials implements Parcelable {
-    private final byte[] operationalDataset;
+  public static class ThreadCredentials {
+    private byte[] operationalDataset;
 
     public ThreadCredentials(byte[] operationalDataset) {
+      set(operationalDataset);
+    }
+
+    public void set(byte[] operationalDataset) {
       this.operationalDataset = operationalDataset;
     }
 
     public byte[] getOperationalDataset() {
       return operationalDataset;
     }
-
-    // Begin Parcelable implementation
-
-    private ThreadCredentials(Parcel in) {
-      operationalDataset = new byte[in.readInt()];
-      in.readByteArray(operationalDataset);
-    }
-
-    public int describeContents() {
-      return 0;
-    }
-
-    public void writeToParcel(Parcel out, int flags) {
-      out.writeInt(operationalDataset.length);
-      out.writeByteArray(operationalDataset);
-    }
-
-    public static final Parcelable.Creator<ThreadCredentials> CREATOR =
-        new Parcelable.Creator<ThreadCredentials>() {
-          public ThreadCredentials createFromParcel(Parcel in) {
-            return new ThreadCredentials(in);
-          }
-
-          public ThreadCredentials[] newArray(int size) {
-            return new ThreadCredentials[size];
-          }
-        };
   }
 }


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/issues/23811

we should have no Parcelable structures in the Controller Java API
if anything on android needs to serialize, then it should create its own Parcelable NetworkCredentials & copy the fields into the Controller API one.
For chip-tool android application, we use dedicated NetworkCredentialParcelable, then copy fields from NetworkCredentialParcelable to NetworkCredential so that Java controller can handle it.
This work is part of #23133 and prerequisite for #23261, where we are decouple android stuffs from java device controller.



