### PR TITLE
[EFR32] Link the door lock relock behaviour with the app UI

### DIFF
--- a/examples/lock-app/efr32/src/ZclCallbacks.cpp
+++ b/examples/lock-app/efr32/src/ZclCallbacks.cpp
@@ -27,7 +27,6 @@
 #include <app-common/zap-generated/ids/Attributes.h>
 #include <app-common/zap-generated/ids/Clusters.h>
 #include <app/ConcreteAttributePath.h>
-#include <app/util/af-event.h>
 #include <lib/support/logging/CHIPLogging.h>
 
 using namespace ::chip::app::Clusters;
@@ -152,8 +151,6 @@ DlStatus emberAfPluginDoorLockSetSchedule(chip::EndpointId endpointId, uint8_t h
 
 void emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId)
 {
-    emberAfDoorLockClusterPrintln("Door Auto relock timer expired. Locking...");
-    emberEventControlSetInactive(&DoorLockServer::Instance().AutolockEvent);
-    DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kLocked);
+    // Apply the relock state in the application control
     LockMgr().InitiateAction(AppEvent::kEventType_Lock, LockManager::LOCK_ACTION);
 }

--- a/src/app/clusters/door-lock-server/door-lock-server-callback.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server-callback.cpp
@@ -61,6 +61,8 @@ emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Opti
     return false;
 }
 
+void __attribute__((weak)) emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId) {}
+
 // =============================================================================
 // 'Default' pre-change callbacks for cluster attributes
 // =============================================================================

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -69,7 +69,7 @@ class DoorLockClusterFabricDelegate : public chip::FabricTable::Delegate
 };
 static DoorLockClusterFabricDelegate gFabricDelegate;
 
-void emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId);
+void DoorLockOnAutoRelockCallback(chip::EndpointId endpointId);
 
 /**********************************************************
  * DoorLockServer public methods
@@ -3380,7 +3380,7 @@ void DoorLockServer::ScheduleAutoRelock(chip::EndpointId endpointId, uint32_t ti
     emberEventControlSetInactive(&AutolockEvent);
 
     AutolockEvent.endpoint = endpointId;
-    AutolockEvent.callback = emberAfPluginDoorLockOnAutoRelock;
+    AutolockEvent.callback = DoorLockOnAutoRelockCallback;
 
     uint32_t timeoutMs =
         (DOOR_LOCK_MAX_LOCK_TIMEOUT_SEC >= timeoutSec) ? timeoutSec * MILLISECOND_TICKS_PER_SECOND : DOOR_LOCK_MAX_LOCK_TIMEOUT_SEC;
@@ -3751,9 +3751,10 @@ void MatterDoorLockClusterServerAttributeChangedCallback(const app::ConcreteAttr
 // Timer callbacks
 // =============================================================================
 
-void __attribute__((weak)) emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId)
+void DoorLockOnAutoRelockCallback(chip::EndpointId endpointId)
 {
     emberAfDoorLockClusterPrintln("Door Auto relock timer expired. Locking...");
     emberEventControlSetInactive(&DoorLockServer::Instance().AutolockEvent);
     DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kLocked, DlOperationSource::kAuto);
+    emberAfPluginDoorLockOnAutoRelock(endpointId);
 }

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -3751,8 +3751,9 @@ void MatterDoorLockClusterServerAttributeChangedCallback(const app::ConcreteAttr
 // Timer callbacks
 // =============================================================================
 
-void emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId)
+void __attribute__((weak)) emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId)
 {
+    emberAfDoorLockClusterPrintln("Door Auto relock timer expired. Locking...");
     emberEventControlSetInactive(&DoorLockServer::Instance().AutolockEvent);
     DoorLockServer::Instance().SetLockState(endpointId, DlLockState::kLocked, DlOperationSource::kAuto);
 }

--- a/src/app/clusters/door-lock-server/door-lock-server.cpp
+++ b/src/app/clusters/door-lock-server/door-lock-server.cpp
@@ -69,8 +69,6 @@ class DoorLockClusterFabricDelegate : public chip::FabricTable::Delegate
 };
 static DoorLockClusterFabricDelegate gFabricDelegate;
 
-void DoorLockOnAutoRelockCallback(chip::EndpointId endpointId);
-
 /**********************************************************
  * DoorLockServer public methods
  *********************************************************/
@@ -3751,7 +3749,7 @@ void MatterDoorLockClusterServerAttributeChangedCallback(const app::ConcreteAttr
 // Timer callbacks
 // =============================================================================
 
-void DoorLockOnAutoRelockCallback(chip::EndpointId endpointId)
+void DoorLockServer::DoorLockOnAutoRelockCallback(chip::EndpointId endpointId)
 {
     emberAfDoorLockClusterPrintln("Door Auto relock timer expired. Locking...");
     emberEventControlSetInactive(&DoorLockServer::Instance().AutolockEvent);

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -463,7 +463,7 @@ private:
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
         const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::DecodableType & commandData);
 
-    friend void emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId);
+    friend void DoorLockOnAutoRelockCallback(chip::EndpointId endpointId);
 
     friend bool emberAfDoorLockClusterSetHolidayScheduleCallback(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
@@ -886,6 +886,13 @@ bool emberAfPluginDoorLockOnDoorLockCommand(chip::EndpointId endpointId, const O
  */
 bool emberAfPluginDoorLockOnDoorUnlockCommand(chip::EndpointId endpointId, const Optional<chip::ByteSpan> & pinCode,
                                               DlOperationError & err);
+
+/**
+ * @brief This callback is called when the AutoRelock timer is expired.
+ *
+ * @param endpointId ID of the endpoint that contains the door lock to be relocked.
+ */
+void emberAfPluginDoorLockOnAutoRelock(chip::EndpointId endpointId);
 
 /**
  * @brief This callback is called when Door Lock cluster needs to access the users database.

--- a/src/app/clusters/door-lock-server/door-lock-server.h
+++ b/src/app/clusters/door-lock-server/door-lock-server.h
@@ -410,6 +410,8 @@ private:
      */
     void ScheduleAutoRelock(chip::EndpointId endpointId, uint32_t timeoutSec);
 
+    static void DoorLockOnAutoRelockCallback(chip::EndpointId endpointId);
+
     /**
      * @brief Send generic event
      *
@@ -462,8 +464,6 @@ private:
     friend bool emberAfDoorLockClusterUnlockWithTimeoutCallback(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,
         const chip::app::Clusters::DoorLock::Commands::UnlockWithTimeout::DecodableType & commandData);
-
-    friend void DoorLockOnAutoRelockCallback(chip::EndpointId endpointId);
 
     friend bool emberAfDoorLockClusterSetHolidayScheduleCallback(
         chip::app::CommandHandler * commandObj, const chip::app::ConcreteCommandPath & commandPath,


### PR DESCRIPTION
The door lock cluster implementation mostly left the callback to be implemented by the app.

However, the relock callback is implemented directly in the cluster server implementation and changes the attribute Lock state directly. Make that callback weak and let an application reimplement it if needed.

Re-Implement the callback in the efr32 application implementation so it updates our UI directly (LCD and LED



