### PR TITLE
Fix invariant violation if we get a message without piggyback ack while expecting an ack. (#23282)

### DIFF
--- a/src/messaging/ReliableMessageContext.h
+++ b/src/messaging/ReliableMessageContext.h
@@ -36,6 +36,11 @@
 #include <transport/raw/MessageHeader.h>
 
 namespace chip {
+namespace app {
+class TestCommandInteraction;
+class TestReadInteraction;
+class TestWriteInteraction;
+} // namespace app
 namespace Messaging {
 
 class ChipMessageInfo;
@@ -193,6 +198,9 @@ private:
     friend class ReliableMessageMgr;
     friend class ExchangeContext;
     friend class ExchangeMessageDispatch;
+    friend class ::chip::app::TestCommandInteraction;
+    friend class ::chip::app::TestReadInteraction;
+    friend class ::chip::app::TestWriteInteraction;
 
     System::Clock::Timestamp mNextAckTime; // Next time for triggering Solo Ack
     uint32_t mPendingPeerAckMessageCounter;

--- a/src/messaging/ReliableMessageMgr.h
+++ b/src/messaging/ReliableMessageMgr.h
@@ -192,6 +192,15 @@ public:
 #if CHIP_CONFIG_TEST
     // Functions for testing
     int TestGetCountRetransTable();
+
+    // Enumerate the retransmission table.  Clearing an entry while enumerating
+    // that entry is allowed.  F must take a RetransTableEntry as an argument
+    // and return Loop::Continue or Loop::Break.
+    template <typename F>
+    void EnumerateRetransTable(F && functor)
+    {
+        mRetransTable.ForEachActiveObject(std::forward<F>(functor));
+    }
 #endif // CHIP_CONFIG_TEST
 
 private:


### PR DESCRIPTION
* Fix invariant violation if we get a message without piggyback ack while expecting an ack.

Such messages are not allowed per spec, so we should just ignore them.

Fixes https://github.com/project-chip/connectedhomeip/issues/22854

* Fix tests.

* Address review comment.
