### PR TITLE
[nrfconnect] Allow to use PSA crypto API backend

### DIFF
--- a/config/nrfconnect/chip-module/CMakeLists.txt
+++ b/config/nrfconnect/chip-module/CMakeLists.txt
@@ -236,6 +236,10 @@ if (CONFIG_CHIP_ENABLE_DNSSD_SRP)
     chip_gn_arg_string("chip_mdns" "platform")
 endif()
 
+if (CONFIG_CHIP_CRYPTO_PSA)
+    chip_gn_arg_string("chip_crypto" "psa")
+endif()
+
 if (CHIP_PROJECT_CONFIG)
     chip_gn_arg_string("chip_project_config_include"        ${CHIP_PROJECT_CONFIG})
     chip_gn_arg_string("chip_system_project_config_include" ${CHIP_PROJECT_CONFIG})

--- a/config/nrfconnect/chip-module/Kconfig.defaults
+++ b/config/nrfconnect/chip-module/Kconfig.defaults
@@ -281,11 +281,11 @@ config MBEDTLS_PK_WRITE_C
 
 config MBEDTLS_X509_CREATE_C
     bool
-    default y
+    default y if !CHIP_CRYPTO_PSA
 
 config MBEDTLS_X509_CSR_WRITE_C
     bool
-    default y
+    default y if !CHIP_CRYPTO_PSA
 
 # Disable unneeded crypto operations
 
@@ -294,10 +294,6 @@ config MBEDTLS_SHA384_C
     default n
 
 config MBEDTLS_SHA512_C
-    bool
-    default n
-
-config PSA_WANT_ALG_SHA_512
     bool
     default n
 
@@ -322,6 +318,54 @@ config MBEDTLS_GCM_C
     default n
 
 config MBEDTLS_RSA_C
+    bool
+    default n
+
+config PSA_WANT_KEY_TYPE_ARIA
+    bool
+    default n
+
+config PSA_WANT_KEY_TYPE_CHACHA20
+    bool
+    default n
+
+config PSA_WANT_ALG_GCM
+    bool
+    default n
+
+config PSA_WANT_ALG_CHACHA20_POLY1305
+    bool
+    default n
+
+config PSA_WANT_ALG_SHA_1
+    bool
+    default n
+
+config PSA_WANT_ALG_SHA_224
+    bool
+    default n
+
+config PSA_WANT_ALG_SHA_384
+    bool
+    default n
+
+config PSA_WANT_ALG_SHA_512
+    bool
+    default n
+
+config PSA_WANT_ALG_RIPEMD160
+    bool
+    default n
+
+config PSA_WANT_ALG_MD5
+    bool
+    default n
+
+config PSA_WANT_ALG_CFB
+    bool
+    default n
+
+config PSA_WANT_ALG_OFB
     bool
     default n
 

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -196,6 +196,12 @@ config CHIP_OPERATIONAL_TIME_SAVE_INTERVAL
 	  precisely operation time in case of device reboot and maximizing flash memory
 	  lifetime.
 
+config CHIP_CRYPTO_PSA
+	bool "Use PSA crypto API for cryptographic operations"
+	help
+	  Use the backend for the Matter crypto layer that is based on PSA crypto
+	  API instead of the default, based on legacy mbedTLS APIs.
+
 config CHIP_MALLOC_SYS_HEAP
 	bool "Memory allocator based on Zephyr sys_heap"
 	imply SYS_HEAP_RUNTIME_STATS

--- a/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp
+++ b/src/include/platform/internal/GenericPlatformManagerImpl_Zephyr.ipp
@@ -37,6 +37,10 @@
 
 #include <zephyr/sys/reboot.h>
 
+#ifdef CONFIG_CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
+
 #define DEFAULT_MIN_SLEEP_PERIOD (60 * 60 * 24 * 30) // Month [sec]
 
 namespace chip {
@@ -68,6 +72,10 @@ CHIP_ERROR GenericPlatformManagerImpl_Zephyr<ImplClass>::_InitChipStack(void)
                 CHIP_DEVICE_CONFIG_MAX_EVENT_QUEUE_SIZE);
 
     mShouldRunEventLoop = false;
+
+#ifdef CONFIG_CHIP_CRYPTO_PSA
+    VerifyOrReturnError(psa_crypto_init() == PSA_SUCCESS, CHIP_ERROR_INTERNAL);
+#endif
 
     // Call up to the base class _InitChipStack() to perform the bulk of the initialization.
     err = GenericPlatformManagerImpl<ImplClass>::_InitChipStack();

--- a/src/platform/nrfconnect/CHIPPlatformConfig.h
+++ b/src/platform/nrfconnect/CHIPPlatformConfig.h
@@ -23,6 +23,10 @@
 
 #pragma once
 
+#ifdef CONFIG_CHIP_CRYPTO_PSA
+#include <psa/crypto.h>
+#endif
+
 // ==================== General Platform Adaptations ====================
 
 #define CHIP_CONFIG_ABORT() abort()
@@ -34,9 +38,11 @@
 
 // ==================== Security Adaptations ====================
 
+#ifdef CONFIG_CHIP_CRYPTO_PSA
+#define CHIP_CONFIG_SHA256_CONTEXT_SIZE sizeof(psa_hash_operation_t)
+#elif defined(CONFIG_CC3XX_BACKEND)
 // Size of the statically allocated context for SHA256 operations in CryptoPAL
 // determined empirically.
-#ifdef CONFIG_CC3XX_BACKEND
 #define CHIP_CONFIG_SHA256_CONTEXT_SIZE 244
 #else
 #define CHIP_CONFIG_SHA256_CONTEXT_SIZE 208


### PR DESCRIPTION
Add CHIP_CRYPTO_PSA Kconfig variable to enable the crypto backend based on PSA crypto API in nRF Connect examples.
Also, tune the mbedTLS configuration to reduce the flash usage.

Signed-off-by: Damian Krolik <damian.krolik@nordicsemi.no>