### PR TITLE
Update default MRP config to match the spec

### DIFF
--- a/src/messaging/ReliableMessageProtocolConfig.cpp
+++ b/src/messaging/ReliableMessageProtocolConfig.cpp
@@ -51,7 +51,7 @@ void ClearLocalMRPConfigOverride()
 ReliableMessageProtocolConfig GetDefaultMRPConfig()
 {
     // Default MRP intervals are defined in spec <2.11.3. Parameters and Constants>
-    static constexpr const System::Clock::Milliseconds32 idleRetransTimeout   = 4000_ms32;
+    static constexpr const System::Clock::Milliseconds32 idleRetransTimeout   = 300_ms32;
     static constexpr const System::Clock::Milliseconds32 activeRetransTimeout = 300_ms32;
     return ReliableMessageProtocolConfig(idleRetransTimeout, activeRetransTimeout);
 }

--- a/src/messaging/ReliableMessageProtocolConfig.h
+++ b/src/messaging/ReliableMessageProtocolConfig.h
@@ -39,7 +39,7 @@ namespace chip {
  *    subsequent failures in milliseconds.
  *
  *  This is the default value, that might be adjusted by end device depending on its
- *  needs (e.g. sleeping period) using Service Discovery TXT record CRA key.
+ *  needs (e.g. sleeping period) using Service Discovery TXT record SAI key.
  *
  */
 #ifndef CHIP_CONFIG_MRP_LOCAL_ACTIVE_RETRY_INTERVAL
@@ -54,10 +54,10 @@ namespace chip {
  *    failure in milliseconds.
  *
  * This is the default value, that might be adjusted by end device depending on its
- * needs (e.g. sleeping period) using Service Discovery TXT record CRI key.
+ * needs (e.g. sleeping period) using Service Discovery TXT record SII key.
  */
 #ifndef CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
-#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL (5000_ms32)
+#define CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL (300_ms32)
 #endif // CHIP_CONFIG_MRP_LOCAL_IDLE_RETRY_INTERVAL
 
 /**


### PR DESCRIPTION
#### Problem

It could be just me misunderstanding `12.5. Parameters and Constants` but my understanding is that `SLEEPY_IDLE_INTERVAL` is `300ms` per default.

@Damian-Nordic I have seen that you said: `4000` in https://github.com/project-chip/connectedhomeip/pull/19753#discussion_r903834229 but this is for the active threshold or am I misunderstanding it ?
