### PR TITLE
[vscode] Add debug configuration for chip-all-clusters-app

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -387,6 +387,14 @@
         },
 
         {
+            "name": "CHIP All Clusters App (Linux)",
+            "type": "lldb",
+            "request": "launch",
+            "program": "${workspaceFolder}/out/debug/standalone/chip-all-clusters-app",
+            "cwd": "${workspaceFolder}"
+        },
+
+        {
             "name": "OTA Requestor App (Linux)",
             "type": "lldb",
             "request": "launch",


### PR DESCRIPTION
vscode configuration target miss chip-all-clusters-app, which is most frequently used target during debug in matter. Add new configuration for chip-all-clusters-app in vscode launch settings

