### PR TITLE
Make sure there is only one state that an MTRControllerFactory with no controllers can be in.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRControllerFactory.mm
@@ -309,6 +309,14 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
             return;
         }
 
+        // Make sure we don't leave a system state running while we have no
+        // controllers started.  This is working around the fact that a system
+        // state is brought up live on factory init, and not when it comes time
+        // to actually start a controller, and does not actually clean itself up
+        // until its refcount (which starts as 0) goes to 0.
+        _controllerFactory->RetainSystemState();
+        _controllerFactory->ReleaseSystemState();
+
         self->_isRunning = YES;
     });
 


### PR DESCRIPTION
We don't want to be in different states in the "started no controllers" and "started one controller and then shut it down" cases.

