### PR TITLE
Add a way to avoid heap pools crashing on exit if items are still live.

### DIFF
--- a/src/darwin/Framework/CHIP/MTRControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRControllerFactory.mm
@@ -39,6 +39,7 @@
 #include <credentials/attestation_verifier/DefaultDeviceAttestationVerifier.h>
 #include <credentials/attestation_verifier/DeviceAttestationVerifier.h>
 #include <crypto/PersistentStorageOperationalKeystore.h>
+#include <lib/support/Pool.h>
 #include <lib/support/TestPersistentStorageDelegate.h>
 #include <platform/PlatformManager.h>
 
@@ -308,6 +309,11 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
             MTR_LOG_ERROR("Error: %@", kErrorControllerFactoryInit);
             return;
         }
+
+        // This needs to happen after DeviceControllerFactory::Init,
+        // because that creates (lazily, by calling functions with
+        // static variables in them) some static-lifetime objects.
+        chip::HeapObjectPoolExitHandling::IgnoreLeaksOnExit();
 
         // Make sure we don't leave a system state running while we have no
         // controllers started.  This is working around the fact that a system

--- a/src/lib/support/Pool.cpp
+++ b/src/lib/support/Pool.cpp
@@ -22,6 +22,33 @@
 
 namespace chip {
 
+#if CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
+
+bool HeapObjectPoolExitHandling::sIgnoringLeaksOnExit   = false;
+bool HeapObjectPoolExitHandling::sExitHandlerRegistered = false;
+
+void HeapObjectPoolExitHandling::IgnoreLeaksOnExit()
+{
+    if (sExitHandlerRegistered)
+    {
+        return;
+    }
+
+    int ret = atexit(ExitHandler);
+    if (ret != 0)
+    {
+        ChipLogError(Controller, "IgnoreLeaksOnExit: atexit failed: %d\n", ret);
+    }
+    sExitHandlerRegistered = true;
+}
+
+void HeapObjectPoolExitHandling::ExitHandler()
+{
+    sIgnoringLeaksOnExit = true;
+}
+
+#endif // CHIP_SYSTEM_CONFIG_POOL_USE_HEAP
+
 namespace internal {
 
 StaticAllocatorBitmap::StaticAllocatorBitmap(void * storage, std::atomic<tBitChunkType> * usage, size_t capacity,


### PR DESCRIPTION
Currently a pool's destructor crashes if there are still live objects in the pool.  For heap pools, add a way to not crash if the pool's destructor is running under exit(), for consumers that don't care about exit-time-only leaks.

