### PR TITLE
[app] Implement deferred attribute persister

### DIFF
--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -92,7 +92,7 @@ chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
 DeferredAttribute gCurrentLevelPersister(ConcreteAttributePath(kLightEndpointId, Clusters::LevelControl::Id,
                                                                Clusters::LevelControl::Attributes::CurrentLevel::Id));
-DeferredAttributePersistenceProvider gDeferredAttributePersister(Server::GetInstance().GetAttributePersister(),
+DeferredAttributePersistenceProvider gDeferredAttributePersister(Server::GetInstance().GetDefaultAttributePersister(),
                                                                  Span<DeferredAttribute>(&gCurrentLevelPersister, 1),
                                                                  System::Clock::Milliseconds32(5000));
 

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -28,6 +28,7 @@
 #include <app-common/zap-generated/attribute-type.h>
 #include <app-common/zap-generated/attributes/Accessors.h>
 #include <app-common/zap-generated/cluster-id.h>
+#include <app/DeferredAttributePersistenceProvider.h>
 #include <app/clusters/identify-server/identify-server.h>
 #include <app/clusters/ota-requestor/OTATestEventTriggerDelegate.h>
 #include <app/server/Dnssd.h>
@@ -88,6 +89,12 @@ bool sIsThreadEnabled                    = false;
 bool sHaveBLEConnections                 = false;
 
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
+
+DeferredAttribute gCurrentLevelPersister(ConcreteAttributePath(kLightEndpointId, Clusters::LevelControl::Id,
+                                                               Clusters::LevelControl::Attributes::CurrentLevel::Id));
+DeferredAttributePersistenceProvider gDeferredAttributePersister(Server::GetInstance().GetAttributePersister(),
+                                                                 Span<DeferredAttribute>(&gCurrentLevelPersister, 1),
+                                                                 System::Clock::Milliseconds32(5000));
 
 } // namespace
 
@@ -195,6 +202,7 @@ CHIP_ERROR AppTask::Init()
 
     gExampleDeviceInfoProvider.SetStorageDelegate(&Server::GetInstance().GetPersistentStorage());
     chip::DeviceLayer::SetDeviceInfoProvider(&gExampleDeviceInfoProvider);
+    app::SetAttributePersistenceProvider(&gDeferredAttributePersister);
 
     ConfigurationMgr().LogDeviceConfig();
     PrintOnboardingCodes(chip::RendezvousInformationFlags(chip::RendezvousInformationFlag::kBLE));

--- a/examples/lighting-app/nrfconnect/main/AppTask.cpp
+++ b/examples/lighting-app/nrfconnect/main/AppTask.cpp
@@ -90,6 +90,11 @@ bool sHaveBLEConnections                 = false;
 
 chip::DeviceLayer::DeviceInfoProviderImpl gExampleDeviceInfoProvider;
 
+// Define a custom attribute persister which makes actual write of the CurrentLevel attribute value
+// to the non-volatile storage only when it has remained constant for 5 seconds. This is to reduce
+// the flash wearout when the attribute changes frequently as a result of MoveToLevel command.
+// DeferredAttribute object describes a deferred attribute, but also holds a buffer with a value to
+// be written, so it must live so long as the DeferredAttributePersistenceProvider object.
 DeferredAttribute gCurrentLevelPersister(ConcreteAttributePath(kLightEndpointId, Clusters::LevelControl::Id,
                                                                Clusters::LevelControl::Attributes::CurrentLevel::Id));
 DeferredAttributePersistenceProvider gDeferredAttributePersister(Server::GetInstance().GetDefaultAttributePersister(),

--- a/src/app/AttributePersistenceProvider.h
+++ b/src/app/AttributePersistenceProvider.h
@@ -37,7 +37,6 @@ public:
      * list) to non-volatile memory.
      *
      * @param [in] aPath the attribute path for the data being written.
-     * @param [in] aMetadata the attribute metadata, as a convenience.
      * @param [in] aValue the data to write.  Integers and floats are
      *             represented in native endianness.  Strings are represented
      *             as Pascal-style strings, as in ZCL, with a length prefix
@@ -51,8 +50,7 @@ public:
      *             of the data in the string (including the length prefix),
      *             which is no larger than the `size` member of aMetadata.
      */
-    virtual CHIP_ERROR WriteValue(const ConcreteAttributePath & aPath, const EmberAfAttributeMetadata * aMetadata,
-                                  const ByteSpan & aValue) = 0;
+    virtual CHIP_ERROR WriteValue(const ConcreteAttributePath & aPath, const ByteSpan & aValue) = 0;
 
     /**
      * Read an attribute value from non-volatile memory.

--- a/src/app/BUILD.gn
+++ b/src/app/BUILD.gn
@@ -82,6 +82,7 @@ static_library("app") {
     "CommandResponseHelper.h",
     "CommandSender.cpp",
     "DefaultAttributePersistenceProvider.cpp",
+    "DeferredAttributePersistenceProvider.cpp",
     "DeviceProxy.cpp",
     "DeviceProxy.h",
     "EventManagement.cpp",

--- a/src/app/DefaultAttributePersistenceProvider.cpp
+++ b/src/app/DefaultAttributePersistenceProvider.cpp
@@ -22,8 +22,7 @@
 namespace chip {
 namespace app {
 
-CHIP_ERROR DefaultAttributePersistenceProvider::WriteValue(const ConcreteAttributePath & aPath,
-                                                           const EmberAfAttributeMetadata * aMetadata, const ByteSpan & aValue)
+CHIP_ERROR DefaultAttributePersistenceProvider::WriteValue(const ConcreteAttributePath & aPath, const ByteSpan & aValue)
 {
     VerifyOrReturnError(mStorage != nullptr, CHIP_ERROR_INCORRECT_STATE);
 

--- a/src/app/DefaultAttributePersistenceProvider.h
+++ b/src/app/DefaultAttributePersistenceProvider.h
@@ -49,8 +49,7 @@ public:
     void Shutdown() {}
 
     // AttributePersistenceProvider implementation.
-    CHIP_ERROR WriteValue(const ConcreteAttributePath & aPath, const EmberAfAttributeMetadata * aMetadata,
-                          const ByteSpan & aValue) override;
+    CHIP_ERROR WriteValue(const ConcreteAttributePath & aPath, const ByteSpan & aValue) override;
     CHIP_ERROR ReadValue(const ConcreteAttributePath & aPath, const EmberAfAttributeMetadata * aMetadata,
                          MutableByteSpan & aValue) override;
 

--- a/src/app/DeferredAttributePersistenceProvider.cpp
+++ b/src/app/DeferredAttributePersistenceProvider.cpp
@@ -1,0 +1,70 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/DeferredAttributePersistenceProvider.h>
+
+#include <platform/CHIPDeviceLayer.h>
+
+namespace chip {
+namespace app {
+
+CHIP_ERROR DeferredAttribute::PrepareWrite(AttributePersistenceProvider & persister, const EmberAfAttributeMetadata * metadata,
+                                           const ByteSpan & value)
+{
+    mPersister = &persister;
+    mMetadata  = metadata;
+
+    if (mValue.AllocatedSize() != value.size())
+    {
+        mValue.Alloc(value.size());
+        ReturnErrorCodeIf(!mValue, CHIP_ERROR_NO_MEMORY);
+    }
+
+    memcpy(mValue.Get(), value.data(), value.size());
+    return CHIP_NO_ERROR;
+}
+
+void DeferredAttribute::Flush()
+{
+    VerifyOrReturn(mValue);
+    mPersister->WriteValue(mPath, mMetadata, ByteSpan(mValue.Get(), mValue.AllocatedSize()));
+    mValue.Release();
+}
+
+CHIP_ERROR DeferredAttributePersistenceProvider::WriteValue(const ConcreteAttributePath & path,
+                                                            const EmberAfAttributeMetadata * metadata, const ByteSpan & value)
+{
+    for (DeferredAttribute & da : mDeferredAttributes)
+    {
+        if (da.Matches(path))
+        {
+            ReturnErrorOnFailure(da.PrepareWrite(mPersister, metadata, value));
+            DeviceLayer::SystemLayer().StartTimer(System::Clock::Milliseconds32(mWriteDelay), Flush, &da);
+            return CHIP_NO_ERROR;
+        }
+    }
+
+    return mPersister.WriteValue(path, metadata, value);
+}
+
+CHIP_ERROR DeferredAttributePersistenceProvider::ReadValue(const ConcreteAttributePath & path,
+                                                           const EmberAfAttributeMetadata * metadata, MutableByteSpan & value)
+{
+    return mPersister.ReadValue(path, metadata, value);
+}
+
+} // namespace app
+} // namespace chip

--- a/src/app/DeferredAttributePersistenceProvider.h
+++ b/src/app/DeferredAttributePersistenceProvider.h
@@ -1,0 +1,72 @@
+/*
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <app/AttributePersistenceProvider.h>
+#include <lib/support/ScopedBuffer.h>
+#include <lib/support/Span.h>
+
+namespace chip {
+namespace app {
+
+class DeferredAttribute
+{
+public:
+    explicit DeferredAttribute(const ConcreteAttributePath & path) : mPath(path) {}
+
+    bool Matches(const ConcreteAttributePath & path) const { return mPath == path; }
+    CHIP_ERROR PrepareWrite(AttributePersistenceProvider & persister, const EmberAfAttributeMetadata * metadata,
+                            const ByteSpan & value);
+    void Flush();
+
+private:
+    const ConcreteAttributePath mPath;
+    AttributePersistenceProvider * mPersister;
+    const EmberAfAttributeMetadata * mMetadata;
+    Platform::ScopedMemoryBufferWithSize<uint8_t> mValue;
+};
+
+/**
+ * Decorator class for the AttributePersistenceProvider implementation that
+ * defers writes of selected attributes.
+ *
+ * This class is useful to increase the flash lifetime by reducing the number
+ * of writes of fast-changing attributes, such as CurrentLevel attribute of the
+ * LevelControl cluster.
+ */
+class DeferredAttributePersistenceProvider : public AttributePersistenceProvider
+{
+public:
+    DeferredAttributePersistenceProvider(AttributePersistenceProvider & persister,
+                                         const Span<DeferredAttribute> & deferredAttributes,
+                                         System::Clock::Milliseconds32 writeDelay) :
+        mPersister(persister),
+        mDeferredAttributes(deferredAttributes), mWriteDelay(writeDelay)
+    {}
+
+    CHIP_ERROR WriteValue(const ConcreteAttributePath & path, const EmberAfAttributeMetadata * metadata, const ByteSpan & value);
+    CHIP_ERROR ReadValue(const ConcreteAttributePath & path, const EmberAfAttributeMetadata * metadata, MutableByteSpan & value);
+
+private:
+    static void Flush(System::Layer *, void * deferredAttr) { static_cast<DeferredAttribute *>(deferredAttr)->Flush(); }
+
+    AttributePersistenceProvider & mPersister;
+    const Span<DeferredAttribute> mDeferredAttributes;
+    const System::Clock::Milliseconds32 mWriteDelay;
+};
+
+} // namespace app
+} // namespace chip

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -340,7 +340,7 @@ public:
 
     Credentials::OperationalCertificateStore * GetOpCertStore() { return mOpCertStore; }
 
-    app::DefaultAttributePersistenceProvider & GetAttributePersister() { return mAttributePersister; }
+    app::DefaultAttributePersistenceProvider & GetDefaultAttributePersister() { return mAttributePersister; }
 
     /**
      * This function send the ShutDown event before stopping

--- a/src/app/server/Server.h
+++ b/src/app/server/Server.h
@@ -340,6 +340,8 @@ public:
 
     Credentials::OperationalCertificateStore * GetOpCertStore() { return mOpCertStore; }
 
+    app::DefaultAttributePersistenceProvider & GetAttributePersister() { return mAttributePersister; }
+
     /**
      * This function send the ShutDown event before stopping
      * the event loop.

--- a/src/app/util/attribute-storage.cpp
+++ b/src/app/util/attribute-storage.cpp
@@ -1300,8 +1300,7 @@ void emAfSaveAttributeToStorageIfNeeded(uint8_t * data, EndpointId endpoint, Clu
     auto * attrStorage = app::GetAttributePersistenceProvider();
     if (attrStorage)
     {
-        attrStorage->WriteValue(app::ConcreteAttributePath(endpoint, clusterId, metadata->attributeId), metadata,
-                                ByteSpan(data, dataSize));
+        attrStorage->WriteValue(app::ConcreteAttributePath(endpoint, clusterId, metadata->attributeId), ByteSpan(data, dataSize));
     }
     else
     {


### PR DESCRIPTION
Fast-changing attributes with NVM storage, such as CurrentLevel of the LevelControl cluster, may result in rapid flash wearout using the default attribute persister which stores all values immediately.
Implement a helper adapter class for the attribute persistence interface to defer writes of selected attributes.

Use the new class in nRF Connect lighting-app for verification.
Fixes #23222.