### PR TITLE
[Telink]: Update to Zephyr with factory data

### DIFF
--- a/integrations/docker/images/chip-build-telink/Dockerfile
+++ b/integrations/docker/images/chip-build-telink/Dockerfile
@@ -17,7 +17,7 @@ RUN set -x \
     && : # last line
 
 # Setup Zephyr
-ARG ZEPHYR_REVISION=c57ffb4738251a3b670ded02ba514aa5c650563a
+ARG ZEPHYR_REVISION=dac17979d626bb820268660b4272a56d04d8083b
 WORKDIR /opt/telink/zephyrproject
 RUN set -x \
     && python3 -m pip install -U --no-cache-dir \

--- a/integrations/docker/images/chip-build/version
+++ b/integrations/docker/images/chip-build/version
@@ -1,1 +1,1 @@
-0.6.05 Version bump reason: [nrfconnect] Update nRF Connect SDK version.
+0.6.06 Version bump reason: [Telink] Update Telink Docker.


### PR DESCRIPTION
**Problem**
Need Zephyr with Telink factory data support.

**Change overview**
Updated to Telink Zephyr version with factory data support.

**Testing**
Tested manually.
**Steps:**

- Build image
- Run docker
- Check if Telink examples able to be built successfully