### PR TITLE
[platform] Move more product attributes to DeviceInstanceInfoProvider

### DIFF
--- a/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
+++ b/scripts/tools/nrfconnect/generate_nrfconnect_chip_factory_data.py
@@ -298,6 +298,7 @@ class FactoryDataGenerator:
             self._add_entry("vendor_name", self._args.vendor_name)
             self._add_entry("product_name", self._args.product_name)
             self._add_entry("product_label", self._args.product_label)
+            self._add_entry("product_url", self._args.product_url)
             self._add_entry("part_number", self._args.part_number)
             self._add_entry("date", self._args.date)
             self._add_entry("hw_ver", self._args.hw_ver)
@@ -434,6 +435,8 @@ def main():
                                      the setup code. Discriminator is used during a discovery process.")
 
     # optional keys
+    optional_arguments.add_argument("--product_url", type=str,
+                                    help="[string] provide link to product-specific web page")
     optional_arguments.add_argument("--product_label", type=str,
                                     help="[string] provide human-readable product label")
     optional_arguments.add_argument("--part_number", type=str,

--- a/scripts/tools/nrfconnect/nrfconnect_factory_data.schema
+++ b/scripts/tools/nrfconnect/nrfconnect_factory_data.schema
@@ -60,6 +60,11 @@
             "type": "string",
             "maxLength": 64
         },
+        "product_url": {
+            "description": "link to product-specific web page",
+            "type": "string",
+            "maxLength": 256
+        },
         "part_number": {
             "description": "human-readable vendor assigned part number",
             "type": "string",

--- a/scripts/tools/nrfconnect/tests/test_generate_factory_data.py
+++ b/scripts/tools/nrfconnect/tests/test_generate_factory_data.py
@@ -156,7 +156,7 @@ class TestGenerateFactoryData(unittest.TestCase):
                                    '--vendor_name', 'Nordic Semiconductor ASA',
                                    '--product_name', 'Lock Gen2',
                                    '--part_number', 'PCA10056',
-                                   '--product_url', 'https://nonexistentlockfactory.com/lock',
+                                   '--product_url', 'https://example.com/lock',
                                    '--product_label', 'Lock',
                                    '--date', '2022-07-20',
                                    '--hw_ver', '101',
@@ -183,7 +183,7 @@ class TestGenerateFactoryData(unittest.TestCase):
             self.assertEqual(factory_data.get('vendor_name'), 'Nordic Semiconductor ASA')
             self.assertEqual(factory_data.get('product_name'), 'Lock Gen2')
             self.assertEqual(factory_data.get('part_number'), 'PCA10056')
-            self.assertEqual(factory_data.get('product_url'), 'https://nonexistentlockfactory.com/lock')
+            self.assertEqual(factory_data.get('product_url'), 'https://example.com/lock')
             self.assertEqual(factory_data.get('product_label'), 'Lock')
             self.assertEqual(factory_data.get('date'), '2022-07-20')
             self.assertEqual(factory_data.get('hw_ver'), 101)

--- a/scripts/tools/nrfconnect/tests/test_generate_factory_data.py
+++ b/scripts/tools/nrfconnect/tests/test_generate_factory_data.py
@@ -155,8 +155,9 @@ class TestGenerateFactoryData(unittest.TestCase):
                                    '--product_id', '0xABCD',
                                    '--vendor_name', 'Nordic Semiconductor ASA',
                                    '--product_name', 'Lock Gen2',
-                                   '--product_label', 'Lock',
                                    '--part_number', 'PCA10056',
+                                   '--product_url', 'https://nonexistentlockfactory.com/lock',
+                                   '--product_label', 'Lock',
                                    '--date', '2022-07-20',
                                    '--hw_ver', '101',
                                    '--hw_ver_str', 'v1.1',
@@ -181,8 +182,9 @@ class TestGenerateFactoryData(unittest.TestCase):
             self.assertEqual(factory_data.get('product_id'), 0xABCD)
             self.assertEqual(factory_data.get('vendor_name'), 'Nordic Semiconductor ASA')
             self.assertEqual(factory_data.get('product_name'), 'Lock Gen2')
-            self.assertEqual(factory_data.get('product_label'), 'Lock')
             self.assertEqual(factory_data.get('part_number'), 'PCA10056')
+            self.assertEqual(factory_data.get('product_url'), 'https://nonexistentlockfactory.com/lock')
+            self.assertEqual(factory_data.get('product_label'), 'Lock')
             self.assertEqual(factory_data.get('date'), '2022-07-20')
             self.assertEqual(factory_data.get('hw_ver'), 101)
             self.assertEqual(factory_data.get('hw_ver_str'), 'v1.1')

--- a/src/app/clusters/basic/basic.cpp
+++ b/src/app/clusters/basic/basic.cpp
@@ -191,7 +191,7 @@ CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attrib
     case PartNumber::Id: {
         constexpr size_t kMaxLen     = DeviceLayer::ConfigurationManager::kMaxPartNumberLength;
         char partNumber[kMaxLen + 1] = { 0 };
-        status                       = ConfigurationMgr().GetPartNumber(partNumber, sizeof(partNumber));
+        status                       = GetDeviceInstanceInfoProvider()->GetPartNumber(partNumber, sizeof(partNumber));
 
         // TODO: Remove defaulting once proper runtime defaulting of unimplemented factory data is done
         if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
@@ -207,7 +207,7 @@ CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attrib
     case ProductURL::Id: {
         constexpr size_t kMaxLen     = DeviceLayer::ConfigurationManager::kMaxProductURLLength;
         char productUrl[kMaxLen + 1] = { 0 };
-        status                       = ConfigurationMgr().GetProductURL(productUrl, sizeof(productUrl));
+        status                       = GetDeviceInstanceInfoProvider()->GetProductURL(productUrl, sizeof(productUrl));
 
         // TODO: Remove defaulting once proper runtime defaulting of unimplemented factory data is done
         if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)
@@ -223,7 +223,7 @@ CHIP_ERROR BasicAttrAccess::Read(const ConcreteReadAttributePath & aPath, Attrib
     case ProductLabel::Id: {
         constexpr size_t kMaxLen       = DeviceLayer::ConfigurationManager::kMaxProductLabelLength;
         char productLabel[kMaxLen + 1] = { 0 };
-        status                         = ConfigurationMgr().GetProductLabel(productLabel, sizeof(productLabel));
+        status                         = GetDeviceInstanceInfoProvider()->GetProductLabel(productLabel, sizeof(productLabel));
 
         // TODO: Remove defaulting once proper runtime defaulting of unimplemented factory data is done
         if (status == CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND || status == CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE)

--- a/src/include/platform/ConfigurationManager.h
+++ b/src/include/platform/ConfigurationManager.h
@@ -116,9 +116,6 @@ public:
     virtual CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours)      = 0;
     virtual CHIP_ERROR GetBootReason(uint32_t & bootReason)                            = 0;
     virtual CHIP_ERROR StoreBootReason(uint32_t bootReason)                            = 0;
-    virtual CHIP_ERROR GetPartNumber(char * buf, size_t bufSize)                       = 0;
-    virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize)                       = 0;
-    virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize)                     = 0;
     virtual CHIP_ERROR GetUniqueId(char * buf, size_t bufSize)                         = 0;
     virtual CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen)        = 0;
     virtual CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize)                    = 0;

--- a/src/include/platform/DeviceInstanceInfoProvider.h
+++ b/src/include/platform/DeviceInstanceInfoProvider.h
@@ -31,7 +31,7 @@ public:
     /**
      * @brief Obtain the Vendor Name from the device's factory data.
      *
-     * @param[in, out] buf Buffer to copy string.
+     * @param[out] buf Buffer to copy string.
      *                 On CHIP_NO_ERROR return from this function this buffer will be null-terminated.
      *                 On error CHIP_ERROR_BUFFER_TOO_SMALL there is no guarantee that buffer will be null-terminated.
      * @param[in] bufSize Size of data, including the null terminator, that can be written to buf.
@@ -71,6 +71,33 @@ public:
      *          if access fails.
      */
     virtual CHIP_ERROR GetProductId(uint16_t & productId) = 0;
+
+    /**
+     * @brief Obtain Part Number from the device factory data.
+     *
+     * @param[out] buf     Buffer to store the null-terminated result string.
+     * @param[in] bufSize  Size of the buffer. The buffer should allow for fitting in Part Number
+     *                     (max 32 characters) and the null terminator.
+     **/
+    virtual CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) = 0;
+
+    /**
+     * @brief Obtain Product URL from the device factory data.
+     *
+     * @param[out] buf     Buffer to store the null-terminated result string.
+     * @param[in] bufSize  Size of the buffer. The buffer should allow for fitting in Product URL
+     *                     (max 256 characters) and the null terminator.
+     **/
+    virtual CHIP_ERROR GetProductURL(char * buf, size_t bufSize) = 0;
+
+    /**
+     * @brief Obtain Product Label from the device factory data.
+     *
+     * @param[out] buf     Buffer to store the null-terminated result string.
+     * @param[in] bufSize  Size of the buffer. The buffer should allow for fitting in Product Label
+     *                     (max 64 characters) and the null terminator.
+     **/
+    virtual CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) = 0;
 
     /**
      * @brief Obtain the Serial Number from the device's factory data.

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.h
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.h
@@ -100,9 +100,6 @@ public:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
     CHIP_ERROR GetBootReason(uint32_t & bootReason) override;
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override;
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
     CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override;
     CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override;

--- a/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
+++ b/src/include/platform/internal/GenericConfigurationManagerImpl.ipp
@@ -482,24 +482,6 @@ CHIP_ERROR GenericConfigurationManagerImpl<ImplClass>::StoreBootReason(uint32_t 
 }
 
 template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetPartNumber(char * buf, size_t bufSize)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductURL(char * buf, size_t bufSize)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ConfigClass>
-CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetProductLabel(char * buf, size_t bufSize)
-{
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
-}
-
-template <class ConfigClass>
 CHIP_ERROR GenericConfigurationManagerImpl<ConfigClass>::GetUniqueId(char * buf, size_t bufSize)
 {
     CHIP_ERROR err;

--- a/src/include/platform/internal/GenericDeviceInstanceInfoProvider.h
+++ b/src/include/platform/internal/GenericDeviceInstanceInfoProvider.h
@@ -45,6 +45,9 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
     CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;

--- a/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
+++ b/src/include/platform/internal/GenericDeviceInstanceInfoProvider.ipp
@@ -53,6 +53,42 @@ CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetProductName(char *
 }
 
 template <class ConfigClass>
+CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetPartNumber(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetProductURL(char * buf, size_t bufSize)
+{
+#if CHIP_DEVICE_LAYER_TARGET_ESP32
+    CHIP_ERROR err = mGenericConfigManager.ReadConfigValueStr(ConfigClass::kConfigKey_ProductURL, buf, bufSize, bufSize);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
+#else
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif
+}
+
+template <class ConfigClass>
+CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetProductLabel(char * buf, size_t bufSize)
+{
+#if CHIP_DEVICE_LAYER_TARGET_ESP32
+    CHIP_ERROR err = mGenericConfigManager.ReadConfigValueStr(ConfigClass::kConfigKey_ProductLabel, buf, bufSize, bufSize);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
+#else
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+#endif
+}
+
+template <class ConfigClass>
 CHIP_ERROR GenericDeviceInstanceInfoProvider<ConfigClass>::GetSerialNumber(char * buf, size_t bufSize)
 {
     ChipError err       = CHIP_NO_ERROR;

--- a/src/platform/Ameba/FactoryDataProvider.cpp
+++ b/src/platform/Ameba/FactoryDataProvider.cpp
@@ -330,6 +330,21 @@ CHIP_ERROR FactoryDataProvider::GetProductId(uint16_t & productId)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR FactoryDataProvider::GetPartNumber(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductURL(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductLabel(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
 CHIP_ERROR FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 {
     ChipError err       = CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;

--- a/src/platform/Ameba/FactoryDataProvider.h
+++ b/src/platform/Ameba/FactoryDataProvider.h
@@ -50,6 +50,9 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
     CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;

--- a/src/platform/ESP32/ConfigurationManagerImpl.cpp
+++ b/src/platform/ESP32/ConfigurationManagerImpl.cpp
@@ -185,26 +185,6 @@ CHIP_ERROR ConfigurationManagerImpl::StoreTotalOperationalHours(uint32_t totalOp
     return WriteConfigValue(ESP32Config::kCounterKey_TotalOperationalHours, totalOperationalHours);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetProductURL(char * buf, size_t bufSize)
-{
-    CHIP_ERROR err = ReadConfigValueStr(ESP32Config::kConfigKey_ProductURL, buf, bufSize, bufSize);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
-    return err;
-}
-
-CHIP_ERROR ConfigurationManagerImpl::GetProductLabel(char * buf, size_t bufSize)
-{
-    CHIP_ERROR err = ReadConfigValueStr(ESP32Config::kConfigKey_ProductLabel, buf, bufSize, bufSize);
-    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
-    {
-        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
-    }
-    return err;
-}
-
 CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char * buf, size_t bufSize)
 {
     memset(buf, 0, bufSize);

--- a/src/platform/ESP32/ConfigurationManagerImpl.h
+++ b/src/platform/ESP32/ConfigurationManagerImpl.h
@@ -53,8 +53,6 @@ public:
     CHIP_ERROR StoreRebootCount(uint32_t rebootCount) override;
     CHIP_ERROR GetTotalOperationalHours(uint32_t & totalOperationalHours) override;
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override;
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize);
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
     static ConfigurationManagerImpl & GetDefaultInstance();

--- a/src/platform/ESP32/ESP32FactoryDataProvider.cpp
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.cpp
@@ -189,6 +189,26 @@ CHIP_ERROR ESP32FactoryDataProvider::GetProductId(uint16_t & productId)
     return err;
 }
 
+CHIP_ERROR ESP32FactoryDataProvider::GetProductURL(char * buf, size_t bufSize)
+{
+    CHIP_ERROR err = ESP32Config::ReadConfigValueStr(ESP32Config::kConfigKey_ProductURL, buf, bufSize, bufSize);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
+}
+
+CHIP_ERROR ESP32FactoryDataProvider::GetProductLabel(char * buf, size_t bufSize)
+{
+    CHIP_ERROR err = ESP32Config::ReadConfigValueStr(ESP32Config::kConfigKey_ProductLabel, buf, bufSize, bufSize);
+    if (err == CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND)
+    {
+        return CHIP_DEVICE_ERROR_CONFIG_NOT_FOUND;
+    }
+    return err;
+}
+
 CHIP_ERROR ESP32FactoryDataProvider::GetHardwareVersionString(char * buf, size_t bufSize)
 {
     size_t hardwareVersionStringLen = 0; // without counting null-terminator

--- a/src/platform/ESP32/ESP32FactoryDataProvider.h
+++ b/src/platform/ESP32/ESP32FactoryDataProvider.h
@@ -66,6 +66,8 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
     CHIP_ERROR GetRotatingDeviceIdUniqueId(MutableByteSpan & uniqueIdSpan) override;
 #endif // CHIP_DEVICE_CONFIG_ENABLE_DEVICE_INSTANCE_INFO_PROVIDER

--- a/src/platform/android/ConfigurationManagerImpl.cpp
+++ b/src/platform/android/ConfigurationManagerImpl.cpp
@@ -191,24 +191,6 @@ CHIP_ERROR ConfigurationManagerImpl::GetSoftwareVersionString(char * buf, size_t
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetPartNumber(char * buf, size_t bufSize)
-{
-    size_t dateLen;
-    return ReadConfigValueStr(AndroidConfig::kConfigKey_PartNumber, buf, bufSize, dateLen);
-}
-
-CHIP_ERROR ConfigurationManagerImpl::GetProductURL(char * buf, size_t bufSize)
-{
-    size_t dateLen;
-    return ReadConfigValueStr(AndroidConfig::kConfigKey_ProductURL, buf, bufSize, dateLen);
-}
-
-CHIP_ERROR ConfigurationManagerImpl::GetProductLabel(char * buf, size_t bufSize)
-{
-    size_t dateLen;
-    return ReadConfigValueStr(AndroidConfig::kConfigKey_ProductLabel, buf, bufSize, dateLen);
-}
-
 CHIP_ERROR ConfigurationManagerImpl::GetUniqueId(char * buf, size_t bufSize)
 {
     size_t dateLen;

--- a/src/platform/android/ConfigurationManagerImpl.h
+++ b/src/platform/android/ConfigurationManagerImpl.h
@@ -42,9 +42,6 @@ public:
     static ConfigurationManagerImpl & GetDefaultInstance();
     CHIP_ERROR GetSoftwareVersionString(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSoftwareVersion(uint32_t & softwareVer) override;
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override;
 
 private:

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -55,19 +55,19 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductId(uint16_t & productId)
     return CHIP_NO_ERROR;
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetPartNumber(char * buf, size_t bufSize)
+CHIP_ERROR DeviceInstanceInfoProviderImpl::GetPartNumber(char * buf, size_t bufSize)
 {
     size_t dateLen;
     return Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_PartNumber, buf, bufSize, dateLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetProductURL(char * buf, size_t bufSize)
+CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductURL(char * buf, size_t bufSize)
 {
     size_t dateLen;
     return Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_ProductURL, buf, bufSize, dateLen);
 }
 
-CHIP_ERROR ConfigurationManagerImpl::GetPartNumber(char * buf, size_t bufSize)
+CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductLabel(char * buf, size_t bufSize)
 {
     size_t dateLen;
     return Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_ProductLabel, buf, bufSize, dateLen);

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.cpp
@@ -55,6 +55,24 @@ CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductId(uint16_t & productId)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR ConfigurationManagerImpl::GetPartNumber(char * buf, size_t bufSize)
+{
+    size_t dateLen;
+    return Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_PartNumber, buf, bufSize, dateLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetProductURL(char * buf, size_t bufSize)
+{
+    size_t dateLen;
+    return Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_ProductURL, buf, bufSize, dateLen);
+}
+
+CHIP_ERROR ConfigurationManagerImpl::GetPartNumber(char * buf, size_t bufSize)
+{
+    size_t dateLen;
+    return Internal::AndroidConfig::ReadConfigValueStr(Internal::AndroidConfig::kConfigKey_ProductLabel, buf, bufSize, dateLen);
+}
+
 CHIP_ERROR DeviceInstanceInfoProviderImpl::GetProductName(char * buf, size_t bufSize)
 {
     CHIP_ERROR err;

--- a/src/platform/android/DeviceInstanceInfoProviderImpl.h
+++ b/src/platform/android/DeviceInstanceInfoProviderImpl.h
@@ -29,6 +29,9 @@ class DeviceInstanceInfoProviderImpl : public Internal::GenericDeviceInstanceInf
 public:
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
 
     DeviceInstanceInfoProviderImpl(ConfigurationManagerImpl & configManager) :

--- a/src/platform/fake/ConfigurationManagerImpl.h
+++ b/src/platform/fake/ConfigurationManagerImpl.h
@@ -82,9 +82,6 @@ private:
     CHIP_ERROR StoreTotalOperationalHours(uint32_t totalOperationalHours) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetBootReason(uint32_t & bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreBootReason(uint32_t bootReason) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
-    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GetUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR StoreUniqueId(const char * uniqueId, size_t uniqueIdLen) override { return CHIP_ERROR_NOT_IMPLEMENTED; }
     CHIP_ERROR GenerateUniqueId(char * buf, size_t bufSize) override { return CHIP_ERROR_NOT_IMPLEMENTED; }

--- a/src/platform/nrfconnect/FactoryDataParser.c
+++ b/src/platform/nrfconnect/FactoryDataParser.c
@@ -149,6 +149,18 @@ bool ParseFactoryData(uint8_t * buffer, uint16_t bufferSize, struct FactoryData 
         {
             res = res && zcbor_bstr_decode(states, (struct zcbor_string *) &factoryData->product_name);
         }
+        else if (strncmp("part_number", (const char *) currentString.value, currentString.len) == 0)
+        {
+            res = res && zcbor_bstr_decode(states, (struct zcbor_string *) &factoryData->part_number);
+        }
+        else if (strncmp("product_url", (const char *) currentString.value, currentString.len) == 0)
+        {
+            res = res && zcbor_bstr_decode(states, (struct zcbor_string *) &factoryData->product_url);
+        }
+        else if (strncmp("product_label", (const char *) currentString.value, currentString.len) == 0)
+        {
+            res = res && zcbor_bstr_decode(states, (struct zcbor_string *) &factoryData->product_label);
+        }
         else if (strncmp("enable_key", (const char *) currentString.value, currentString.len) == 0)
         {
             res = res && zcbor_bstr_decode(states, (struct zcbor_string *) &factoryData->enable_key);

--- a/src/platform/nrfconnect/FactoryDataParser.h
+++ b/src/platform/nrfconnect/FactoryDataParser.h
@@ -42,6 +42,9 @@ struct FactoryData
     uint16_t product_id;
     struct FactoryDataString vendor_name;
     struct FactoryDataString product_name;
+    struct FactoryDataString part_number;
+    struct FactoryDataString product_url;
+    struct FactoryDataString product_label;
     uint16_t hw_ver;
     struct FactoryDataString hw_ver_str;
     struct FactoryDataString rd_uid;

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -268,6 +268,24 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetProductId(uint16_t & produc
 }
 
 template <class FlashFactoryData>
+CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetPartNumber(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class FlashFactoryData>
+CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetProductURL(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class FlashFactoryData>
+CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetProductLabel(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetSerialNumber(char * buf, size_t bufSize)
 {
     ReturnErrorCodeIf(bufSize < mFactoryData.sn.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);

--- a/src/platform/nrfconnect/FactoryDataProvider.cpp
+++ b/src/platform/nrfconnect/FactoryDataProvider.cpp
@@ -37,6 +37,18 @@ CHIP_ERROR LoadKeypairFromRaw(ByteSpan privateKey, ByteSpan publicKey, Crypto::P
     memcpy(serializedKeypair.Bytes() + publicKey.size(), privateKey.data(), privateKey.size());
     return keypair.Deserialize(serializedKeypair);
 }
+
+CHIP_ERROR GetFactoryDataString(const FactoryDataString & str, char * buf, size_t bufSize)
+{
+    ReturnErrorCodeIf(bufSize < str.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
+    ReturnErrorCodeIf(!str.data, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
+
+    memcpy(buf, str.data, str.len);
+    buf[str.len] = 0;
+
+    return CHIP_NO_ERROR;
+}
+
 } // namespace
 
 namespace DeviceLayer {
@@ -230,13 +242,7 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::SetSetupPasscode(uint32_t setu
 template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetVendorName(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < mFactoryData.vendor_name.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
-    ReturnErrorCodeIf(!mFactoryData.vendor_name.data, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-
-    memcpy(buf, mFactoryData.vendor_name.data, mFactoryData.vendor_name.len);
-    buf[mFactoryData.vendor_name.len] = 0;
-
-    return CHIP_NO_ERROR;
+    return GetFactoryDataString(mFactoryData.vendor_name, buf, bufSize);
 }
 
 template <class FlashFactoryData>
@@ -250,13 +256,7 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetVendorId(uint16_t & vendorI
 template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetProductName(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < mFactoryData.product_name.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
-    ReturnErrorCodeIf(!mFactoryData.product_name.data, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-
-    memcpy(buf, mFactoryData.product_name.data, mFactoryData.product_name.len);
-    buf[mFactoryData.product_name.len] = 0;
-
-    return CHIP_NO_ERROR;
+    return GetFactoryDataString(mFactoryData.product_name, buf, bufSize);
 }
 
 template <class FlashFactoryData>
@@ -270,31 +270,25 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetProductId(uint16_t & produc
 template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetPartNumber(char * buf, size_t bufSize)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return GetFactoryDataString(mFactoryData.part_number, buf, bufSize);
 }
 
 template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetProductURL(char * buf, size_t bufSize)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return GetFactoryDataString(mFactoryData.product_url, buf, bufSize);
 }
 
 template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetProductLabel(char * buf, size_t bufSize)
 {
-    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+    return GetFactoryDataString(mFactoryData.product_label, buf, bufSize);
 }
 
 template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetSerialNumber(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < mFactoryData.sn.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
-    ReturnErrorCodeIf(!mFactoryData.sn.data, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-
-    memcpy(buf, mFactoryData.sn.data, mFactoryData.sn.len);
-    buf[mFactoryData.sn.len] = 0;
-
-    return CHIP_NO_ERROR;
+    return GetFactoryDataString(mFactoryData.sn, buf, bufSize);
 }
 
 template <class FlashFactoryData>
@@ -318,13 +312,7 @@ CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetHardwareVersion(uint16_t & 
 template <class FlashFactoryData>
 CHIP_ERROR FactoryDataProvider<FlashFactoryData>::GetHardwareVersionString(char * buf, size_t bufSize)
 {
-    ReturnErrorCodeIf(bufSize < mFactoryData.hw_ver_str.len + 1, CHIP_ERROR_BUFFER_TOO_SMALL);
-    ReturnErrorCodeIf(!mFactoryData.hw_ver_str.data, CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND);
-
-    memcpy(buf, mFactoryData.hw_ver_str.data, mFactoryData.hw_ver_str.len);
-    buf[mFactoryData.hw_ver_str.len] = 0;
-
-    return CHIP_NO_ERROR;
+    return GetFactoryDataString(mFactoryData.hw_ver_str, buf, bufSize);
 }
 
 template <class FlashFactoryData>

--- a/src/platform/nrfconnect/FactoryDataProvider.h
+++ b/src/platform/nrfconnect/FactoryDataProvider.h
@@ -99,6 +99,9 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
     CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;

--- a/src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.cpp
+++ b/src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.cpp
@@ -294,6 +294,21 @@ CHIP_ERROR K32W0FactoryDataProvider::GetProductId(uint16_t & productId)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR K32W0FactoryDataProvider::GetPartNumber(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR K32W0FactoryDataProvider::GetProductURL(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR K32W0FactoryDataProvider::GetProductLabel(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
 CHIP_ERROR K32W0FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.h
+++ b/src/platform/nxp/k32w/k32w0/K32W0FactoryDataProvider.h
@@ -66,6 +66,9 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;

--- a/src/platform/nxp/mw320/FactoryDataProvider.cpp
+++ b/src/platform/nxp/mw320/FactoryDataProvider.cpp
@@ -289,6 +289,21 @@ CHIP_ERROR FactoryDataProvider::GetProductId(uint16_t & productId)
     return CHIP_NO_ERROR;
 }
 
+CHIP_ERROR FactoryDataProvider::GetPartNumber(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductURL(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductLabel(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
 CHIP_ERROR FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 {
     return CHIP_ERROR_NOT_IMPLEMENTED;

--- a/src/platform/nxp/mw320/FactoryDataProvider.h
+++ b/src/platform/nxp/mw320/FactoryDataProvider.h
@@ -66,6 +66,9 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetHardwareVersionString(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;

--- a/src/platform/qpg/FactoryDataProvider.cpp
+++ b/src/platform/qpg/FactoryDataProvider.cpp
@@ -281,6 +281,21 @@ CHIP_ERROR FactoryDataProvider::GetProductId(uint16_t & productId)
     return MapQorvoError(status);
 }
 
+CHIP_ERROR FactoryDataProvider::GetPartNumber(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductURL(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
+CHIP_ERROR FactoryDataProvider::GetProductLabel(char * buf, size_t bufSize)
+{
+    return CHIP_ERROR_UNSUPPORTED_CHIP_FEATURE;
+}
+
 CHIP_ERROR FactoryDataProvider::GetSerialNumber(char * buf, size_t bufSize)
 {
     return MapQorvoError(qvCHIP_FactoryDataGetValue(TAG_ID_SERIAL_NUMBER, (uint8_t *) buf, bufSize, NULL));

--- a/src/platform/qpg/FactoryDataProvider.h
+++ b/src/platform/qpg/FactoryDataProvider.h
@@ -54,6 +54,9 @@ public:
     CHIP_ERROR GetVendorId(uint16_t & vendorId) override;
     CHIP_ERROR GetProductName(char * buf, size_t bufSize) override;
     CHIP_ERROR GetProductId(uint16_t & productId) override;
+    CHIP_ERROR GetPartNumber(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductURL(char * buf, size_t bufSize) override;
+    CHIP_ERROR GetProductLabel(char * buf, size_t bufSize) override;
     CHIP_ERROR GetSerialNumber(char * buf, size_t bufSize) override;
     CHIP_ERROR GetManufacturingDate(uint16_t & year, uint8_t & month, uint8_t & day) override;
     CHIP_ERROR GetHardwareVersion(uint16_t & hardwareVersion) override;


### PR DESCRIPTION
Vendor and product identifiers were already moved from ConfigurationManager to DeviceInstanceInfoProvider to allow for easier integration with platform factory data providers as they may differ across devices running the same firmware.

Somehow PartNumber, ProductURL and ProductLabel slipped unnoticed. Move accessors of these attributes to DeviceInstanceInfoProvider and update all implementations to preserve the existing behavior.

Followup on #23253: for nRF Connect add implementation that retrieves the mentioned attributes from the factory data partition.
