### PR TITLE
[nrfconnect] Correct factory data JSON schema

### DIFF
--- a/scripts/tools/nrfconnect/nrfconnect_factory_data.schema
+++ b/scripts/tools/nrfconnect/nrfconnect_factory_data.schema
@@ -68,7 +68,10 @@
         "date": {
             "description": "Manufacturing date according to ISO 8601 in notation YYYY-MM-DD",
             "type": "string",
-            "format": "date"
+            "format": "date",
+            "minLength": 10,
+            "maxLength": 10,
+            "pattern": "^\\d{4}-\\d{2}-\\d{2}$"
         },
         "hw_ver": {
             "description": "Hardware version - integer",
@@ -85,30 +88,29 @@
         "rd_uid": {
             "description": "A randomly-generated 128-bit or longer octet string. Length has been expanded with 'hex:' prefix",
             "type": "string",
-            "pattern:": "^hex:{1}",
+            "pattern": "^hex:([0-9A-Fa-f]{2}){16,}$",
             "minLength": 20,
-            "minLength": 5,
-            "maxLength": 36
+            "minLength": 36
         },
         "dac_cert": {
             "description": "DAC certificate in hex-string format",
             "type": "string",
-            "pattern:": "^hex:{1}([0-9A-Fa-f]){2,}",
-            "minLength": 5,
+            "pattern": "^hex:([0-9A-Fa-f]{2})+$",
+            "minLength": 6,
             "maxLength": 1204
         },
         "dac_key": {
             "description": "DAC Private Key in hex-string format",
             "type": "string",
-            "pattern:": "^hex:{1}([0-9A-Fa-f]){2,}",
+            "pattern": "^hex:([0-9A-Fa-f]{2}){32}$",
             "minLength": 68,
             "maxLength": 68
         },
         "pai_cert": {
             "description": "PAI certificate in hex-string format",
             "type": "string",
-            "pattern:": "^hex:{1}([0-9A-Fa-f]){2,}",
-            "minLength": 5,
+            "pattern": "^hex:([0-9A-Fa-f]{2})+$",
+            "minLength": 6,
             "maxLength": 1204
         },
         "passcode": {
@@ -126,14 +128,14 @@
         "spake2_salt": {
             "description": "A key-derivation function for the Symmetric Password-Authenticated Key Exchange.",
             "type": "string",
-            "pattern:": "^hex:{1}([0-9A-Fa-f]){2,}",
+            "pattern": "^hex:([0-9A-Fa-f]{2})+$",
             "minLength": 36,
             "maxLength": 68
         },
         "spake2_verifier": {
             "description": "A verifier for the Symmetric Password-Authenticated Key Exchange",
             "type": "string",
-            "pattern:": "^hex:{1}([0-9A-Fa-f]){2,}",
+            "pattern": "^hex:([0-9A-Fa-f]{2})+$",
             "minLength": 97
         },
         "discriminator": {
@@ -145,7 +147,7 @@
         "enable_key": {
             "description": "The Enable Key is a 128-bit value that triggers manufacturer-specific action while invoking the TestEventTrigger Command",
             "type": "string",
-            "pattern": "^hex:{1}([0-9A-Fa-f]){32}",
+            "pattern": "^hex:([0-9A-Fa-f]{2}){16}$",
             "minLength": 36, 
             "maxLength": 36
         },

--- a/scripts/tools/nrfconnect/tests/test_generate_factory_data.py
+++ b/scripts/tools/nrfconnect/tests/test_generate_factory_data.py
@@ -148,6 +148,7 @@ class TestGenerateFactoryData(unittest.TestCase):
             write_file(os.path.join(outdir, 'PAI_cert.der'), PAI_DER_CERT)
 
             subprocess.check_call(['python3', os.path.join(TOOLS_DIR, 'generate_nrfconnect_chip_factory_data.py'),
+                                   '-s', os.path.join(TOOLS_DIR, 'nrfconnect_factory_data.schema'),
                                    '--include_passcode',
                                    '--sn', 'SN:12345678',
                                    '--vendor_id', '0x127F',
@@ -167,7 +168,7 @@ class TestGenerateFactoryData(unittest.TestCase):
                                    '--passcode', '13243546',
                                    '--spake2_verifier', 'WN0SgEXLfUN19BbJqp6qn4pS69EtdNLReIMZwv/CIM0ECMP7ytiAJ7txIYJ0Ovlha/rQ3E+88mj3qaqqnviMaZzG+OyXEdSocDIT9ZhmkTCgWwERaHz4Vdh3G37RT6kqbw==',
                                    '--discriminator', '0xFED',
-                                   '--rd_uid', '0123456789ABCDEF',
+                                   '--rd_uid', '91a9c12a7c80700a31ddcfa7fce63e44',
                                    '--enable_key', '00112233445566778899aabbccddeeff',
                                    '-o', os.path.join(outdir, 'fd.json')
                                    ])
@@ -194,7 +195,7 @@ class TestGenerateFactoryData(unittest.TestCase):
                 'WN0SgEXLfUN19BbJqp6qn4pS69EtdNLReIMZwv/CIM0ECMP7ytiAJ7txIYJ0Ovlha/rQ3E+88mj3qaqqnviMaZzG+OyXEdSocDIT9ZhmkTCgWwERaHz4Vdh3G37RT6kqbw=='))
             self.assertEqual(factory_data.get('discriminator'), 0xFED)
             self.assertEqual(factory_data.get('passcode'), 13243546)
-            self.assertEqual(factory_data.get('rd_uid'), 'hex:0123456789ABCDEF')
+            self.assertEqual(factory_data.get('rd_uid'), 'hex:91a9c12a7c80700a31ddcfa7fce63e44')
             self.assertEqual(factory_data.get('enable_key'), 'hex:00112233445566778899aabbccddeeff')
 
 


### PR DESCRIPTION
nRF Connect platform script used to generate the factory data JSON file relies on the schema file to validate user input.
Fix typos and regular expressions in the schema to better catch format errors.