### PR TITLE
Feature/scene table

### DIFF
--- a/src/app/PersistentData.h
+++ b/src/app/PersistentData.h
@@ -1,0 +1,173 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+#pragma once
+
+#include <lib/core/CHIPPersistentStorageDelegate.h>
+#include <lib/core/CHIPTLV.h>
+#include <lib/support/DefaultStorageKeyAllocator.h>
+
+namespace chip {
+
+constexpr size_t kPersistentBufferMax = 128;
+
+template <size_t kMaxSerializedSize>
+struct PersistentData
+{
+    virtual ~PersistentData() = default;
+
+    virtual CHIP_ERROR UpdateKey(DefaultStorageKeyAllocator & key) = 0;
+    virtual CHIP_ERROR Serialize(TLV::TLVWriter & writer) const    = 0;
+    virtual CHIP_ERROR Deserialize(TLV::TLVReader & reader)        = 0;
+    virtual void Clear()                                           = 0;
+
+    virtual CHIP_ERROR Save(PersistentStorageDelegate * storage)
+    {
+        VerifyOrReturnError(nullptr != storage, CHIP_ERROR_INVALID_ARGUMENT);
+
+        uint8_t buffer[kMaxSerializedSize] = { 0 };
+        DefaultStorageKeyAllocator key;
+        // Update storage key
+        ReturnErrorOnFailure(UpdateKey(key));
+
+        // Serialize the data
+        TLV::TLVWriter writer;
+        writer.Init(buffer, sizeof(buffer));
+        ReturnErrorOnFailure(Serialize(writer));
+
+        // Save serialized data
+        return storage->SyncSetKeyValue(key.KeyName(), buffer, static_cast<uint16_t>(writer.GetLengthWritten()));
+    }
+
+    CHIP_ERROR Load(PersistentStorageDelegate * storage)
+    {
+        VerifyOrReturnError(nullptr != storage, CHIP_ERROR_INVALID_ARGUMENT);
+
+        uint8_t buffer[kMaxSerializedSize] = { 0 };
+        DefaultStorageKeyAllocator key;
+
+        // Set data to defaults
+        Clear();
+
+        // Update storage key
+        ReturnErrorOnFailure(UpdateKey(key));
+
+        // Load the serialized data
+        uint16_t size  = static_cast<uint16_t>(sizeof(buffer));
+        CHIP_ERROR err = storage->SyncGetKeyValue(key.KeyName(), buffer, size);
+        VerifyOrReturnError(CHIP_ERROR_PERSISTED_STORAGE_VALUE_NOT_FOUND != err, CHIP_ERROR_NOT_FOUND);
+        ReturnErrorOnFailure(err);
+
+        // Decode serialized data
+        TLV::TLVReader reader;
+        reader.Init(buffer, size);
+        return Deserialize(reader);
+    }
+
+    virtual CHIP_ERROR Delete(PersistentStorageDelegate * storage)
+    {
+        VerifyOrReturnError(nullptr != storage, CHIP_ERROR_INVALID_ARGUMENT);
+
+        DefaultStorageKeyAllocator key;
+        // Update storage key
+        ReturnErrorOnFailure(UpdateKey(key));
+        // Delete stored data
+        return storage->SyncDeleteKeyValue(key.KeyName());
+    }
+};
+
+struct FabricList : public PersistentData<kPersistentBufferMax>
+{
+    static constexpr TLV::Tag TagFirstFabric() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagFabricCount() { return TLV::ContextTag(2); }
+
+    chip::FabricIndex first_fabric = kUndefinedFabricIndex;
+    uint8_t fabric_count           = 0;
+
+    FabricList() = default;
+    FabricList(chip::FabricIndex first) : first_fabric(first), fabric_count(1) {}
+
+    CHIP_ERROR UpdateKey(DefaultStorageKeyAllocator & key) override
+    {
+        key.FabricList();
+        return CHIP_NO_ERROR;
+    }
+
+    void Clear() override
+    {
+        first_fabric = kUndefinedFabricIndex;
+        fabric_count = 0;
+    }
+
+    CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
+    {
+        TLV::TLVType container;
+        ReturnErrorOnFailure(writer.StartContainer(TLV::AnonymousTag(), TLV::kTLVType_Structure, container));
+
+        ReturnErrorOnFailure(writer.Put(TagFirstFabric(), static_cast<uint16_t>(first_fabric)));
+        ReturnErrorOnFailure(writer.Put(TagFabricCount(), static_cast<uint16_t>(fabric_count)));
+
+        return writer.EndContainer(container);
+    }
+
+    CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
+    {
+        ReturnErrorOnFailure(reader.Next(TLV::AnonymousTag()));
+        VerifyOrReturnError(TLV::kTLVType_Structure == reader.GetType(), CHIP_ERROR_INTERNAL);
+
+        TLV::TLVType container;
+        ReturnErrorOnFailure(reader.EnterContainer(container));
+
+        // first_fabric
+        ReturnErrorOnFailure(reader.Next(TagFirstFabric()));
+        ReturnErrorOnFailure(reader.Get(first_fabric));
+        // fabric_count
+        ReturnErrorOnFailure(reader.Next(TagFabricCount()));
+        ReturnErrorOnFailure(reader.Get(fabric_count));
+
+        return reader.ExitContainer(container);
+    }
+};
+
+/**
+ * Template used to iterate the stored data
+ */
+template <typename T>
+class Iterator
+{
+public:
+    virtual ~Iterator() = default;
+    /**
+     *  @retval The number of entries in total that will be iterated.
+     */
+    virtual size_t Count() = 0;
+    /**
+     *   @param[out] item  Value associated with the next element in the iteration.
+     *  @retval true if the next entry is successfully retrieved.
+     *  @retval false if no more entries can be found.
+     */
+    virtual bool Next(T & item) = 0;
+    /**
+     * Release the memory allocated by this iterator.
+     * Must be called before the pointer goes out of scope.
+     */
+    virtual void Release() = 0;
+
+protected:
+    Iterator() = default;
+};
+
+} // namespace chip

--- a/src/app/scenes/SceneStorage.cpp
+++ b/src/app/scenes/SceneStorage.cpp
@@ -1,0 +1,358 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#include <app/PersistentData.h>
+#include <app/scenes/SceneStorage.h>
+#include <lib/support/CodeUtils.h>
+#include <stdlib.h>
+#include <string.h>
+
+namespace chip {
+namespace scenes {
+
+struct FabricData : public PersistentData<kPersistentBufferMax>
+{
+    static constexpr TLV::Tag TagFirstEndpoint() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagEndpointCount() { return TLV::ContextTag(2); }
+    static constexpr TLV::Tag TagNext() { return TLV::ContextTag(3); }
+
+    FabricIndex fabric_index  = kUndefinedFabricIndex;
+    EndpointId first_endpoint = kRootEndpointId;
+    uint16_t group_count      = 0;
+    FabricIndex next          = kUndefinedFabricIndex;
+
+    FabricData() = default;
+    FabricData(FabricIndex fabric) : fabric_index(fabric) {}
+
+    CHIP_ERROR UpdateKey(DefaultStorageKeyAllocator & key) override
+    {
+        // TODO: fill in logic to update storage key
+    }
+
+    void Clear() override
+    {
+        // TODO: fill in logic to clear the fabric data linked list
+    }
+
+    CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
+    {
+        // TODO: fill in logic for serialize function
+    }
+
+    CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
+    {
+        // TODO: fill in logic for deserialize function
+    }
+
+    // Register the fabric in the fabrics' linked-list
+    CHIP_ERROR Register(PersistentStorageDelegate * storage)
+    {
+        FabricList fabric_list;
+        CHIP_ERROR err = fabric_list.Load(storage);
+        if (CHIP_ERROR_NOT_FOUND == err)
+        {
+            // New fabric list
+            fabric_list.first_fabric = fabric_index;
+            fabric_list.fabric_count = 1;
+            return fabric_list.Save(storage);
+        }
+        ReturnErrorOnFailure(err);
+
+        // Existing fabric list, search for existing entry
+        FabricData fabric(fabric_list.first_fabric);
+        for (size_t i = 0; i < fabric_list.fabric_count; i++)
+        {
+            err = fabric.Load(storage);
+            if (CHIP_NO_ERROR != err)
+            {
+                break;
+            }
+            if (fabric.fabric_index == this->fabric_index)
+            {
+                // Fabric already registered
+                return CHIP_NO_ERROR;
+            }
+            fabric.fabric_index = fabric.next;
+        }
+        // Add this fabric to the fabric list
+        this->next               = fabric_list.first_fabric;
+        fabric_list.first_fabric = this->fabric_index;
+        fabric_list.fabric_count++;
+        return fabric_list.Save(storage);
+    }
+
+    // Remove the fabric from the fabrics' linked list
+    CHIP_ERROR Unregister(PersistentStorageDelegate * storage) const
+    {
+        FabricList fabric_list;
+        CHIP_ERROR err = fabric_list.Load(storage);
+        VerifyOrReturnError(CHIP_NO_ERROR == err || CHIP_ERROR_NOT_FOUND == err, err);
+
+        // Existing fabric list, search for existing entry
+        FabricData fabric(fabric_list.first_fabric);
+        FabricData prev;
+
+        for (size_t i = 0; i < fabric_list.fabric_count; i++)
+        {
+            err = fabric.Load(storage);
+            if (CHIP_NO_ERROR != err)
+            {
+                break;
+            }
+            if (fabric.fabric_index == this->fabric_index)
+            {
+                // Fabric found
+                if (i == 0)
+                {
+                    // Remove first fabric
+                    fabric_list.first_fabric = this->next;
+                }
+                else
+                {
+                    // Remove intermediate fabric
+                    prev.next = this->next;
+                    ReturnErrorOnFailure(prev.Save(storage));
+                }
+                VerifyOrReturnError(fabric_list.fabric_count > 0, CHIP_ERROR_INTERNAL);
+                fabric_list.fabric_count--;
+                return fabric_list.Save(storage);
+            }
+            prev                = fabric;
+            fabric.fabric_index = fabric.next;
+        }
+        // Fabric not in the list
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+    // Check the fabric is registered in the fabrics' linked list
+    CHIP_ERROR Validate(PersistentStorageDelegate * storage) const
+    {
+        FabricList fabric_list;
+        ReturnErrorOnFailure(fabric_list.Load(storage));
+
+        // Existing fabric list, search for existing entry
+        FabricData fabric(fabric_list.first_fabric);
+
+        for (size_t i = 0; i < fabric_list.fabric_count; i++)
+        {
+            ReturnErrorOnFailure(fabric.Load(storage));
+            if (fabric.fabric_index == this->fabric_index)
+            {
+                return CHIP_NO_ERROR;
+            }
+            fabric.fabric_index = fabric.next;
+        }
+        // Fabric not in the list
+        return CHIP_ERROR_NOT_FOUND;
+    }
+
+    CHIP_ERROR Save(PersistentStorageDelegate * storage) override
+    {
+        ReturnErrorOnFailure(Register(storage));
+        return PersistentData::Save(storage);
+    }
+
+    CHIP_ERROR Delete(PersistentStorageDelegate * storage) override
+    {
+        ReturnErrorOnFailure(Unregister(storage));
+        return PersistentData::Delete(storage);
+    }
+};
+
+struct EndpointData : public SceneStorage::FabricEndpoint, PersistentData<kPersistentBufferMax>
+{
+    static constexpr TLV::Tag TagFirstScene() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagSceneCount() { return TLV::ContextTag(2); }
+    static constexpr TLV::Tag TagNext() { return TLV::ContextTag(3); }
+
+    EndpointData() = default;
+    EndpointData(SceneId scene, GroupId group, EndpointId endpoint) : endpoint_id(endpoint) {}
+
+    EndpointId endpoint_id = kInvalidEndpointId;
+
+    bool operator==(const EndpointData & other) const { return this->endpoint_id == other.endpoint_id; }
+
+    CHIP_ERROR UpdateKey(DefaultStorageKeyAllocator & key) override
+    {
+        // TODO: fill in logic to update storage key
+    }
+
+    void Clear() override
+    {
+        // TODO: fill in logic to clear the endpoint data linked list
+    }
+
+    CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
+    {
+        // TODO: fill in logic for serialize function
+    }
+
+    CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
+    {
+        // TODO: fill in logic for deserialize function
+    }
+};
+
+struct SceneTable : public SceneStorage::SceneTableEntry, PersistentData<kPersistentBufferMax>
+{
+    static constexpr TLV::Tag TagSceneGroupID() { return TLV::ContextTag(1); }
+    static constexpr TLV::Tag TagSceneID() { return TLV::ContextTag(2); }
+    static constexpr TLV::Tag TagSceneName() { return TLV::ContextTag(3); }
+    static constexpr TLV::Tag TagSceneTransitionTime() { return TLV::ContextTag(4); }
+    static constexpr TLV::Tag TagExtensionFieldSets() { return TLV::ContextTag(5); }
+    static constexpr TLV::Tag TagNext() { return TLV::ContextTag(5); }
+
+    FabricIndex fabric_index = kUndefinedFabricIndex;
+    EndpointId endpoint_id   = kInvalidEndpointId;
+    uint16_t endpoint_count  = 0;
+    uint16_t index           = 0;
+    SceneId next             = 0;
+    SceneId prev             = 0;
+    bool first               = true;
+
+    SceneId first_scene  = kUndefinedSceneId;
+    uint16_t scene_count = 0;
+
+    SceneTable() : SceneTableEntry(nullptr) {}
+    SceneTable(FabricIndex fabric, EndpointId endpoint) : fabric_index(fabric), endpoint_id(endpoint) {}
+    SceneTable(FabricIndex fabric, EndpointId endpoint, SceneId scene, SceneGroupID groupId) :
+        SceneTableEntry(scene, groupId, nullptr), fabric_index(fabric), endpoint_id(endpoint)
+    {}
+
+    CHIP_ERROR UpdateKey(DefaultStorageKeyAllocator & key) override
+    {
+        // TODO: fill in logic to update storage key
+    }
+
+    void Clear() override
+    {
+        // TODO: fill in logic to clear the Scene Table
+    }
+
+    CHIP_ERROR Serialize(TLV::TLVWriter & writer) const override
+    {
+        // TODO: fill in logic for serialize function
+    }
+
+    CHIP_ERROR Deserialize(TLV::TLVReader & reader) override
+    {
+        // TODO: fill in logic for deserialize function
+    }
+
+    bool Find(PersistentStorageDelegate * storage, const FabricData & fabric, const EndpointData & endpoint, SceneId target_scene)
+    {
+        // TODO: fill in logic to fin a scene by fabric and endpoint based on the sceneID
+    }
+};
+
+SceneStorage::SceneStorage(){
+    // TODO: fill in logic for default creator
+};
+
+SceneStorage::SceneStorage(uint16_t maxScenesPerFabric){
+    // TODO: fill in logic for creator with max scene verification
+};
+
+void SceneStorage::SetStorageDelegate(PersistentStorageDelegate * storage)
+{
+    VerifyOrDie(storage != nullptr);
+    mStorage = storage;
+}
+
+CHIP_ERROR SceneStorage::Init()
+{
+    // TODO: fill in logic for initialization
+}
+
+void SceneStorage::Finish()
+{
+    // TODO: fill in logic for clearing the scene storage object
+}
+
+CHIP_ERROR SceneStorage::SetSceneTableEntry(FabricIndex fabric_index, EndpointId endpoint_id, const SceneTableEntry & entry)
+{
+    // TODO: fill in logic to store a scene entry in the storage
+}
+CHIP_ERROR SceneStorage::GetSceneTableEntry(FabricIndex fabric_index, EndpointId endpoint_id, SceneId scene_id,
+                                            SceneTableEntry & entry)
+{
+    // TODO: fill in logic to get a scene entry from storage
+}
+CHIP_ERROR SceneStorage::RemoveSceneTableEntry(FabricIndex fabric_index, EndpointId endpoint_id, SceneId scene_id)
+{
+    // TODO: fill in logic to remove Scene from Table
+}
+
+SceneStorage::EndpointIterator * SceneStorage::IterateEndpoint(FabricIndex fabric_index)
+{
+    VerifyOrReturnError(IsInitialized(), nullptr);
+    return mEndpointIterators.CreateObject(*this, fabric_index);
+}
+
+SceneStorage::EndpointIterator::EndpointIterator(SceneStorage & provider, FabricIndex fabric_index) :
+    mProvider(provider), mFabric(fabric_index)
+{
+    // TODO: fill in logic to create Endpoint
+}
+
+size_t SceneStorage::EndpointIterator::Count()
+{
+    // TODO: fill in logic to count through endpoint iterator
+}
+
+bool SceneStorage::EndpointIterator::Next(FabricEndpoint & output)
+{
+    // TODO: fill in logic to iterate though endpoints
+}
+
+void SceneStorage::EndpointIterator::Release()
+{
+    // TODO: fill in logic to release iterator
+}
+
+SceneStorage::SceneEntryIterator * SceneStorage::IterateSceneEntry(EndpointId endpoint_id)
+{
+    VerifyOrReturnError(IsInitialized(), nullptr);
+    return mSceneEntryIterators.CreateObject(*this, endpoint_id);
+}
+
+SceneStorage::SceneEntryIterator::SceneEntryIterator(SceneStorage & provider, FabricIndex fabric_index, EndpointId endpoint_id) :
+    mProvider(provider), mFabric(fabric_index), mEndpoint(endpoint_id)
+{
+    SceneTable scene(fabric_index, endpoint_id);
+    if (CHIP_NO_ERROR == scene.Load(provider.mStorage))
+    {
+        mNextSceneId = scene.first_scene;
+        mTotalScene  = scene.scene_count;
+        mSceneCount  = 0;
+    }
+}
+
+size_t SceneStorage::SceneEntryIterator::Count()
+{
+    return mTotalScene;
+}
+
+bool SceneStorage::SceneEntryIterator::Next(SceneTableEntry & output) {}
+
+void SceneStorage::SceneEntryIterator::Release()
+{
+    // TODO: fill in logic to release iterator
+}
+
+} // namespace scenes
+} // namespace chip

--- a/src/app/scenes/SceneStorage.h
+++ b/src/app/scenes/SceneStorage.h
@@ -1,0 +1,168 @@
+/**
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+#include <app/PersistentData.h>
+#include <lib/core/DataModelTypes.h>
+#include <lib/core/SceneId.h>
+#include <lib/support/Pool.h>
+
+namespace chip {
+namespace scenes {
+
+class SceneStorage
+{
+public:
+    static constexpr size_t kIteratorsMax = CHIP_CONFIG_MAX_GROUP_CONCURRENT_ITERATORS;
+
+    struct FabricEndpoint
+    {
+        FabricEndpoint() = default;
+        FabricEndpoint(EndpointId endpoint) : endpoint_id(endpoint) {}
+
+        // Endpoint on the fabric where the scene message has been sent
+        EndpointId endpoint_id = kInvalidEndpointId;
+
+        bool operator==(const FabricEndpoint & other) const { return this->endpoint_id == other.endpoint_id; }
+    };
+
+    struct SceneTableEntry
+    {
+        static constexpr size_t kSceneNameMax = ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH;
+
+        // Identifies group within the scope of the given Fabric
+        SceneGroupID sceneGroupId = kGlobalGroupSceneId;
+        SceneId sceneId           = kUndefinedSceneId;
+        // Lastest group name written for a given GroupId on any Endpoint via the Groups cluster
+        char name[kSceneNameMax + 1]            = { 0 };
+        SceneTransitionTime sceneTransitionTime = 0;
+        ExtensionFieldsSets extentsionFieldsSets;
+
+        SceneTableEntry() { SetName(nullptr); }
+        SceneTableEntry(const char * sceneName) { SetName(sceneName); }
+        SceneTableEntry(const CharSpan & sceneName) { SetName(sceneName); }
+        SceneTableEntry(SceneId id, SceneGroupID groupId) : sceneGroupId(groupId), sceneId(id) { SetName(nullptr); }
+        SceneTableEntry(SceneId id, SceneGroupID groupId, const char * sceneName) : sceneGroupId(groupId), sceneId(id)
+        {
+            SetName(sceneName);
+        }
+        SceneTableEntry(SceneId id, SceneGroupID groupId, const CharSpan & sceneName) : sceneGroupId(groupId), sceneId(id)
+        {
+            SetName(sceneName);
+        }
+        void SetName(const char * sceneName)
+        {
+            if (nullptr == sceneName)
+            {
+                name[0] = 0;
+            }
+            else
+            {
+                Platform::CopyString(name, sceneName);
+            }
+        }
+        void SetName(const CharSpan & sceneName)
+        {
+            if (nullptr == sceneName.data())
+            {
+                name[0] = 0;
+            }
+            else
+            {
+                Platform::CopyString(name, sceneName);
+            }
+        }
+        bool operator==(const SceneTableEntry & other)
+        {
+            return (this->sceneId == other.sceneId) &&
+                !strncmp(this->name, other.name, kSceneNameMax && this->sceneGroupId == other.sceneGroupId);
+        }
+    };
+
+    class EndpointIterator : public Iterator<FabricEndpoint>
+    {
+    public:
+        EndpointIterator(SceneStorage & provider, FabricIndex fabric_index);
+        size_t Count() override;
+        bool Next(FabricEndpoint & output) override;
+        void Release() override;
+
+    protected:
+        SceneStorage & mProvider;
+        FabricIndex mFabric = kUndefinedFabricIndex;
+        EndpointId mFirstEndpoint;
+        size_t mEndpointCount  = 0;
+        size_t mEndpointIndex  = 0;
+        size_t mNextEndpointID = 0;
+        bool mFirst            = true;
+    };
+
+    class SceneEntryIterator : public Iterator<SceneTableEntry>
+    {
+    public:
+        SceneEntryIterator(SceneStorage & provider, FabricIndex fabric_index, EndpointId endpoint_id);
+        size_t Count() override;
+        bool Next(SceneTableEntry & output) override;
+        void Release() override;
+
+    protected:
+        SceneStorage & mProvider;
+        FabricIndex mFabric   = kUndefinedFabricIndex;
+        EndpointId mEndpoint  = kUnusedEndpointId;
+        SceneId mFirstScene   = kUndefinedSceneId;
+        size_t mSceneCount    = 0;
+        uint16_t mNextSceneId = 0;
+        size_t mTotalScene    = 0;
+    };
+
+    SceneStorage() = default;
+    SceneStorage(uint16_t maxScenesPerFabric);
+
+    ~SceneStorage() = default;
+    /**
+     * @brief Set the storage implementation used for non-volatile storage of configuration data.
+     *        This method MUST be called before Init().
+     *
+     * @param storage Pointer to storage instance to set. Cannot be nullptr, will assert.
+     */
+    void SetStorageDelegate(PersistentStorageDelegate * storage);
+
+    CHIP_ERROR Init();
+    void Finish();
+
+    //
+    // Scene Data
+    //
+
+    // By id
+    CHIP_ERROR SetSceneTableEntry(FabricIndex fabric_index, EndpointId endpoint_id, const SceneTableEntry & entry);
+    CHIP_ERROR GetSceneTableEntry(FabricIndex fabric_index, EndpointId endpoint_id, SceneId scene_id, SceneTableEntry & entry);
+    CHIP_ERROR RemoveSceneTableEntry(FabricIndex fabric_index, EndpointId endpoint_id, SceneId scene_id);
+
+    // Iterators
+    EndpointIterator * IterateEndpoint(FabricIndex fabric_index);
+    SceneEntryIterator * IterateSceneEntry(EndpointId endpoint_id);
+
+protected:
+    bool IsInitialized() { return (mStorage != nullptr); }
+
+    chip::PersistentStorageDelegate * mStorage = nullptr;
+    ObjectPool<SceneEntryIterator, kIteratorsMax> mSceneEntryIterators;
+    ObjectPool<EndpointIterator, kIteratorsMax> mEndpointIterators;
+}; // class SceneStorage
+} // namespace scenes
+} // namespace chip

--- a/src/credentials/GroupDataProvider.h
+++ b/src/credentials/GroupDataProvider.h
@@ -21,6 +21,7 @@
 #include <sys/types.h>
 
 #include <app-common/zap-generated/cluster-objects.h>
+#include <app/PersistentData.h>
 #include <app/util/basic-types.h>
 #include <crypto/CHIPCryptoPAL.h>
 #include <lib/core/CHIPError.h>
@@ -229,7 +230,7 @@ public:
     virtual ~GroupDataProvider() = default;
 
     // Not copyable
-    GroupDataProvider(const GroupDataProvider &) = delete;
+    GroupDataProvider(const GroupDataProvider &)             = delete;
     GroupDataProvider & operator=(const GroupDataProvider &) = delete;
 
     uint16_t GetMaxGroupsPerFabric() const { return mMaxGroupsPerFabric; }

--- a/src/lib/core/SceneId.h
+++ b/src/lib/core/SceneId.h
@@ -1,0 +1,58 @@
+/*
+ *
+ *    Copyright (c) 2022 Project CHIP Authors
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+#pragma once
+
+#include <cstdint>
+#include <lib/core/CHIPTLV.h>
+#include <lib/core/GroupId.h>
+#include <string.h>
+
+/**
+ * @brief Indicates the absence of a Scene table entry.
+ */
+#define EMBER_AF_SCENE_TABLE_NULL_INDEX 0xFF
+/**
+ * @brief Value used when setting or getting the endpoint in a Scene table
+ * entry.  It indicates that the entry is not in use.
+ */
+#define EMBER_AF_SCENE_TABLE_UNUSED_ENDPOINT_ID 0x00
+/**
+ * @brief Maximum length of Scene names, not including the length byte.
+ */
+#define ZCL_SCENES_CLUSTER_MAXIMUM_NAME_LENGTH 16
+/**
+ * @brief The group identifier for the global scene.
+ */
+#define ZCL_SCENES_GLOBAL_SCENE_GROUP_ID 0x0000
+/**
+ * @brief The scene identifier for the global scene.
+ */
+#define ZCL_SCENES_GLOBAL_SCENE_SCENE_ID 0x00
+
+namespace chip {
+
+typedef GroupId SceneGroupID;
+typedef uint8_t SceneId;
+typedef uint16_t SceneTransitionTime;
+typedef TLV::TLVReader ExtensionFieldsSets;
+
+constexpr GroupId kGlobalGroupSceneId = ZCL_SCENES_GLOBAL_SCENE_GROUP_ID;
+constexpr SceneId kUndefinedSceneId   = ZCL_SCENES_GLOBAL_SCENE_SCENE_ID;
+constexpr SceneId kUnusedEndpointId   = EMBER_AF_SCENE_TABLE_UNUSED_ENDPOINT_ID;
+
+} // namespace chip

--- a/src/lib/support/DefaultStorageKeyAllocator.h
+++ b/src/lib/support/DefaultStorageKeyAllocator.h
@@ -44,6 +44,9 @@ public:
     DefaultStorageKeyAllocator() = default;
     const char * KeyName() { return mKeyName; }
 
+    // Fabric List
+    const char * FabricList() { return SetConst("g/gfl"); }
+
     // Fabric Table
     const char * FabricIndexInfo() { return SetConst("g/fidx"); }
     const char * FabricNOC(FabricIndex fabric) { return Format("f/%x/n", fabric); }
@@ -85,7 +88,6 @@ public:
     // Group Data Provider
 
     // List of fabric indices that have endpoint-to-group associations defined.
-    const char * GroupFabricList() { return SetConst("g/gfl"); }
     const char * FabricGroups(chip::FabricIndex fabric) { return Format("f/%x/g", fabric); }
     const char * FabricGroup(chip::FabricIndex fabric, chip::GroupId group) { return Format("f/%x/g/%x", fabric, group); }
     const char * FabricGroupKey(chip::FabricIndex fabric, uint16_t index) { return Format("f/%x/gk/%x", fabric, index); }


### PR DESCRIPTION
This PR sets the stage to implement the scene table storage in two commits:

The first one moves element from the group data provider and the group data implementation into a common location to minimise code duplication when implementing the scene table storage.

The second holds the partially filed scene table source files. The aim of this PR is to validate the structure suggested (based on the group data implementation) before moving forward with the complete logic implementation.
