### PR TITLE
Replace "Id" with "ID" in Darwin APIs.

### DIFF
--- a/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ClusterCommandBridge.h
@@ -74,9 +74,9 @@ public:
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
 
         while (repeatCount--) {
-            [device invokeCommandWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
-                                      clusterId:[NSNumber numberWithUnsignedInteger:clusterId]
-                                      commandId:[NSNumber numberWithUnsignedInteger:commandId]
+            [device invokeCommandWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+                                      clusterID:[NSNumber numberWithUnsignedInteger:clusterId]
+                                      commandID:[NSNumber numberWithUnsignedInteger:commandId]
                                   commandFields:commandFields
                              timedInvokeTimeout:mTimedInteractionTimeoutMs.HasValue()
                                  ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]

--- a/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/ReportCommandBridge.h
@@ -56,9 +56,9 @@ public:
         MTRReadParams * params = [[MTRReadParams alloc] init];
         params.fabricFiltered = mFabricFiltered.HasValue() ? [NSNumber numberWithBool:mFabricFiltered.Value()] : nil;
         [device
-            readAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
-                              clusterId:[NSNumber numberWithUnsignedInteger:mClusterId]
-                            attributeId:[NSNumber numberWithUnsignedInteger:mAttributeId]
+            readAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+                              clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
+                            attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
                                  params:params
                             clientQueue:callbackQueue
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
@@ -129,9 +129,9 @@ public:
             = mKeepSubscriptions.HasValue() ? [NSNumber numberWithBool:mKeepSubscriptions.Value()] : nil;
         params.autoResubscribe = mAutoResubscribe.HasValue() ? [NSNumber numberWithBool:mAutoResubscribe.Value()] : nil;
 
-        [device subscribeAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
-            clusterId:[NSNumber numberWithUnsignedInteger:mClusterId]
-            attributeId:[NSNumber numberWithUnsignedInteger:mAttributeId]
+        [device subscribeAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+            clusterID:[NSNumber numberWithUnsignedInteger:mClusterId]
+            attributeID:[NSNumber numberWithUnsignedInteger:mAttributeId]
             minInterval:[NSNumber numberWithUnsignedInteger:mMinInterval]
             maxInterval:[NSNumber numberWithUnsignedInteger:mMaxInterval]
             params:params

--- a/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
+++ b/examples/darwin-framework-tool/commands/clusters/WriteAttributeCommandBridge.h
@@ -74,9 +74,9 @@ public:
     {
         dispatch_queue_t callbackQueue = dispatch_queue_create("com.chip.command", DISPATCH_QUEUE_SERIAL);
         [device
-            writeAttributeWithEndpointId:[NSNumber numberWithUnsignedShort:endpointId]
-                               clusterId:[NSNumber numberWithUnsignedInteger:clusterId]
-                             attributeId:[NSNumber numberWithUnsignedInteger:attributeId]
+            writeAttributeWithEndpointID:[NSNumber numberWithUnsignedShort:endpointId]
+                               clusterID:[NSNumber numberWithUnsignedInteger:clusterId]
+                             attributeID:[NSNumber numberWithUnsignedInteger:attributeId]
                                    value:value
                        timedWriteTimeout:mTimedInteractionTimeoutMs.HasValue()
                            ? [NSNumber numberWithUnsignedShort:mTimedInteractionTimeoutMs.Value()]

--- a/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
+++ b/examples/darwin-framework-tool/commands/common/CHIPCommandBridge.mm
@@ -147,7 +147,7 @@ CHIP_ERROR CHIPCommandBridge::MaybeSetUpStack()
         auto controller = [factory startControllerOnExistingFabric:controllerParams];
         if (controller == nil) {
             // Maybe we didn't have this fabric yet.
-            controllerParams.vendorId = @(chip::VendorId::TestVendor1);
+            controllerParams.vendorID = @(chip::VendorId::TestVendor1);
             controller = [factory startControllerOnNewFabric:controllerParams];
         }
         if (controller == nil) {

--- a/src/darwin/Framework/CHIP/MTRAttributeCacheContainer+XPC.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeCacheContainer+XPC.h
@@ -23,8 +23,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRAttributeCacheContainer (XPC)
 - (void)setXPCConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
-            controllerId:(id<NSCopying>)controllerId
-                deviceId:(NSNumber *)deviceId;
+            controllerID:(id<NSCopying>)controllerID
+                deviceID:(NSNumber *)deviceID;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRAttributeCacheContainer.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeCacheContainer.h
@@ -29,19 +29,30 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * Reads an attribute with specific attribute path
  *
- * @param endpointId  endpoint ID of the attribute
- * @param clusterId  cluster ID of the attribute
- * @param attributeId  attribute ID of the attribute
+ * @param endpointID  endpoint ID of the attribute
+ * @param clusterID  cluster ID of the attribute
+ * @param attributeID  attribute ID of the attribute
  * @param clientQueue  client queue to dispatch the completion handler through
  * @param completion  block to receive the result.
  *                   "values" received by the block will have the same format of object as the one received by completion block
- *                   of CHIPDevice readAttributeWithEndpointId:clusterId:attributeId:clientQueue:completion method.
+ *                   of MTRBaseDevice readAttributeWithEndpointID:clusterID:attributeID:clientQueue:completion method.
  */
+- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
+
+@end
+
+@interface MTRAttributeCacheContainer (Deprecated)
+
 - (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
                           clusterId:(NSNumber * _Nullable)clusterId
                         attributeId:(NSNumber * _Nullable)attributeId
                         clientQueue:(dispatch_queue_t)clientQueue
-                         completion:(MTRDeviceResponseHandler)completion;
+                         completion:(MTRDeviceResponseHandler)completion
+    MTR_NEWLY_DEPRECATED("Please use readAttributeWithEndpointID:clusterID:attributeID:clientQueue:completion:");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRAttributeCacheContainer.mm
+++ b/src/darwin/Framework/CHIP/MTRAttributeCacheContainer.mm
@@ -43,12 +43,12 @@ using namespace chip;
 }
 
 - (void)setXPCConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
-            controllerId:(id<NSCopying>)controllerId
-                deviceId:(NSNumber *)deviceId
+            controllerID:(id<NSCopying>)controllerID
+                deviceID:(NSNumber *)deviceID
 {
     self.xpcConnection = xpcConnection;
-    self.xpcControllerId = controllerId;
-    self.deviceId = deviceId;
+    self.xpcControllerID = controllerID;
+    self.deviceID = deviceID;
     self.shouldUseXPC = YES;
 }
 
@@ -78,9 +78,9 @@ static CHIP_ERROR AppendAttibuteValueToArray(
     return err;
 }
 
-- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
 {
@@ -97,16 +97,16 @@ static CHIP_ERROR AppendAttibuteValueToArray(
             completion(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeGeneralError userInfo:nil]);
             return;
         }
-        __auto_type controllerId = self.xpcControllerId;
-        NSNumber * nodeId = self.deviceId;
+        __auto_type controllerId = self.xpcControllerID;
+        NSNumber * nodeId = self.deviceID;
         [xpcConnection
             getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
                 if (handle) {
                     [handle.proxy readAttributeCacheWithController:controllerId
                                                             nodeId:nodeId.unsignedLongLongValue
-                                                        endpointId:endpointId
-                                                         clusterId:clusterId
-                                                       attributeId:attributeId
+                                                        endpointId:endpointID
+                                                         clusterId:clusterID
+                                                       attributeId:attributeID
                                                         completion:^(id _Nullable values, NSError * _Nullable error) {
                                                             completion([MTRDeviceController decodeXPCResponseValues:values], error);
                                                             __auto_type handleRetainer = handle;
@@ -121,7 +121,7 @@ static CHIP_ERROR AppendAttibuteValueToArray(
     }
 
     dispatch_async(DeviceLayer::PlatformMgrImpl().GetWorkQueue(), ^{
-        if (endpointId == nil && clusterId == nil) {
+        if (endpointID == nil && clusterID == nil) {
             MTR_LOG_ERROR("Error: currently read from attribute cache does not support wildcards for both endpoint and cluster");
             completionHandler(nil, [NSError errorWithDomain:MTRErrorDomain code:MTRErrorCodeInvalidArgument userInfo:nil]);
             return;
@@ -135,39 +135,39 @@ static CHIP_ERROR AppendAttibuteValueToArray(
 
         NSMutableArray * result = [[NSMutableArray alloc] init];
         CHIP_ERROR err = CHIP_NO_ERROR;
-        if (endpointId == nil) {
+        if (endpointID == nil) {
             err = self.cppAttributeCache->ForEachAttribute(
-                static_cast<chip::ClusterId>([clusterId unsignedLongValue]), [&](const app::ConcreteAttributePath & path) {
-                    if (attributeId == nil
-                        || static_cast<chip::AttributeId>([attributeId unsignedLongValue]) == path.mAttributeId) {
+                static_cast<chip::ClusterId>([clusterID unsignedLongValue]), [&](const app::ConcreteAttributePath & path) {
+                    if (attributeID == nil
+                        || static_cast<chip::AttributeId>([attributeID unsignedLongValue]) == path.mAttributeId) {
                         (void) AppendAttibuteValueToArray(path, self.cppAttributeCache, result);
                     }
                     return CHIP_NO_ERROR;
                 });
-        } else if (clusterId == nil) {
+        } else if (clusterID == nil) {
             err = self.cppAttributeCache->ForEachCluster(
-                static_cast<chip::EndpointId>([endpointId unsignedShortValue]), [&](chip::ClusterId enumeratedClusterId) {
-                    (void) self.cppAttributeCache->ForEachAttribute(static_cast<chip::EndpointId>([endpointId unsignedShortValue]),
+                static_cast<chip::EndpointId>([endpointID unsignedShortValue]), [&](chip::ClusterId enumeratedClusterId) {
+                    (void) self.cppAttributeCache->ForEachAttribute(static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
                         enumeratedClusterId, [&](const app::ConcreteAttributePath & path) {
-                            if (attributeId == nil
-                                || static_cast<chip::AttributeId>([attributeId unsignedLongValue]) == path.mAttributeId) {
+                            if (attributeID == nil
+                                || static_cast<chip::AttributeId>([attributeID unsignedLongValue]) == path.mAttributeId) {
                                 (void) AppendAttibuteValueToArray(path, self.cppAttributeCache, result);
                             }
                             return CHIP_NO_ERROR;
                         });
                     return CHIP_NO_ERROR;
                 });
-        } else if (attributeId == nil) {
-            err = self.cppAttributeCache->ForEachAttribute(static_cast<chip::EndpointId>([endpointId unsignedShortValue]),
-                static_cast<chip::ClusterId>([clusterId unsignedLongValue]), [&](const app::ConcreteAttributePath & path) {
+        } else if (attributeID == nil) {
+            err = self.cppAttributeCache->ForEachAttribute(static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+                static_cast<chip::ClusterId>([clusterID unsignedLongValue]), [&](const app::ConcreteAttributePath & path) {
                     (void) AppendAttibuteValueToArray(path, self.cppAttributeCache, result);
                     return CHIP_NO_ERROR;
                 });
         } else {
             app::ConcreteAttributePath path;
-            path.mEndpointId = static_cast<chip::EndpointId>([endpointId unsignedShortValue]);
-            path.mClusterId = static_cast<chip::ClusterId>([clusterId unsignedLongValue]);
-            path.mAttributeId = static_cast<chip::AttributeId>([attributeId unsignedLongValue]);
+            path.mEndpointId = static_cast<chip::EndpointId>([endpointID unsignedShortValue]);
+            path.mClusterId = static_cast<chip::ClusterId>([clusterID unsignedLongValue]);
+            path.mAttributeId = static_cast<chip::AttributeId>([attributeID unsignedLongValue]);
             err = AppendAttibuteValueToArray(path, self.cppAttributeCache, result);
         }
         if (err == CHIP_NO_ERROR) {
@@ -176,6 +176,23 @@ static CHIP_ERROR AppendAttibuteValueToArray(
             completionHandler(nil, [NSError errorWithDomain:MTRErrorDomain code:err.AsInteger() userInfo:nil]);
         }
     });
+}
+
+@end
+
+@implementation MTRAttributeCacheContainer (Deprecated)
+
+- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                          clusterId:(NSNumber * _Nullable)clusterId
+                        attributeId:(NSNumber * _Nullable)attributeId
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(MTRDeviceResponseHandler)completion
+{
+    [self readAttributeWithEndpointID:endpointId
+                            clusterID:clusterId
+                          attributeID:attributeId
+                          clientQueue:clientQueue
+                           completion:completion];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRAttributeCacheContainer_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRAttributeCacheContainer_Internal.h
@@ -27,9 +27,9 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRAttributeCacheContainer ()
 
 @property (atomic, readwrite, nullable) chip::app::ClusterStateCache * cppAttributeCache;
-@property (nonatomic, readwrite, copy) NSNumber * deviceId;
+@property (nonatomic, readwrite, copy) NSNumber * deviceID;
 @property (nonatomic, readwrite, weak, nullable) MTRDeviceControllerXPCConnection * xpcConnection;
-@property (nonatomic, readwrite, strong, nullable) id<NSCopying> xpcControllerId;
+@property (nonatomic, readwrite, strong, nullable) id<NSCopying> xpcControllerID;
 @property (atomic, readwrite) BOOL shouldUseXPC;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -176,12 +176,12 @@ extern NSString * const MTRArrayValueType;
 /**
  * Read attribute in a designated attribute path
  */
-- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                              params:(MTRReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
-                         completion:(MTRDeviceResponseHandler)completion;
+                         completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
 
 /**
  * Write to attribute in a designated attribute path
@@ -194,15 +194,15 @@ extern NSString * const MTRArrayValueType;
  * @param completion  response handler will receive either values or error.
  *
  *                    Received values are an NSArray object with response-value element as described in
- *                    readAttributeWithEndpointId:clusterId:attributeId:clientQueue:completion:.
+ *                    readAttributeWithEndpointID:clusterID:attributeID:clientQueue:completion:.
  */
-- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+- (void)writeAttributeWithEndpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                          clientQueue:(dispatch_queue_t)clientQueue
-                          completion:(MTRDeviceResponseHandler)completion;
+                          completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
 
 /**
  * Invoke a command with a designated command path
@@ -216,26 +216,26 @@ extern NSString * const MTRArrayValueType;
  *
  * @param completion  response handler will receive either values or error.
  */
-- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+- (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                       commandFields:(id)commandFields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                         clientQueue:(dispatch_queue_t)clientQueue
-                         completion:(MTRDeviceResponseHandler)completion;
+                         completion:(MTRDeviceResponseHandler)completion MTR_NEWLY_AVAILABLE;
 
 /**
  * Subscribe an attribute in a designated attribute path
  */
-- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(MTRSubscribeParams * _Nullable)params
                              clientQueue:(dispatch_queue_t)clientQueue
                            reportHandler:(MTRDeviceResponseHandler)reportHandler
-                 subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler;
+                 subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler MTR_NEWLY_AVAILABLE;
 
 /**
  * Deregister all local report handlers for a remote device
@@ -288,6 +288,47 @@ extern NSString * const MTRArrayValueType;
                          "subscribeWithQueue:params:attributeCacheContainer:attributeReportHandler:eventReportHandler:errorHandler:"
                          "subscriptionEstablished:resubscriptionScheduled:");
 
+- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                          clusterId:(NSNumber * _Nullable)clusterId
+                        attributeId:(NSNumber * _Nullable)attributeId
+                             params:(MTRReadParams * _Nullable)params
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(MTRDeviceResponseHandler)completion
+    MTR_NEWLY_DEPRECATED("Please use readAttributeWithEndpointID:clusterID:attributeID:params:clientQueue:completion:");
+
+- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
+                           clusterId:(NSNumber *)clusterId
+                         attributeId:(NSNumber *)attributeId
+                               value:(id)value
+                   timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
+                         clientQueue:(dispatch_queue_t)clientQueue
+                          completion:(MTRDeviceResponseHandler)completion
+    MTR_NEWLY_DEPRECATED(
+        "Please use writeAttributeWithEndpointID:clusterID:attributeID:value:timedWriteTimeout:clientQueue:completion:");
+
+- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
+                          clusterId:(NSNumber *)clusterId
+                          commandId:(NSNumber *)commandId
+                      commandFields:(id)commandFields
+                 timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(MTRDeviceResponseHandler)completion
+    MTR_NEWLY_DEPRECATED(
+        "Please use invokeCommandWithEndpointID:clusterID:commandID:commandFields:timedInvokeTimeout:clientQueue:completion");
+
+- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                               clusterId:(NSNumber * _Nullable)clusterId
+                             attributeId:(NSNumber * _Nullable)attributeId
+                             minInterval:(NSNumber *)minInterval
+                             maxInterval:(NSNumber *)maxInterval
+                                  params:(MTRSubscribeParams * _Nullable)params
+                             clientQueue:(dispatch_queue_t)clientQueue
+                           reportHandler:(MTRDeviceResponseHandler)reportHandler
+                 subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler
+    MTR_NEWLY_DEPRECATED(
+        "Please use "
+        "subscribeAttributeWithEndpointID:clusterID:attributeID:params:minInterval:maxInterval:clientQueue:reportHandler:");
+
 @end
 
 @interface MTRAttributePath : NSObject <NSCopying>
@@ -295,12 +336,21 @@ extern NSString * const MTRArrayValueType;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * attribute;
 
-+ (instancetype)attributePathWithEndpointId:(NSNumber *)endpoint
-                                  clusterId:(NSNumber *)clusterId
-                                attributeId:(NSNumber *)attributeId;
++ (instancetype)attributePathWithEndpointID:(NSNumber *)endpointID
+                                  clusterID:(NSNumber *)clusterID
+                                attributeID:(NSNumber *)attributeID MTR_NEWLY_AVAILABLE;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface MTRAttributePath (Deprecated)
+
++ (instancetype)attributePathWithEndpointId:(NSNumber *)endpointId
+                                  clusterId:(NSNumber *)clusterId
+                                attributeId:(NSNumber *)attributeId
+    MTR_NEWLY_DEPRECATED("Please use attributePathWithEndpointID:clusterID:attributeID:");
+
 @end
 
 @interface MTREventPath : NSObject
@@ -308,10 +358,21 @@ extern NSString * const MTRArrayValueType;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * event;
 
-+ (instancetype)eventPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId eventId:(NSNumber *)eventId;
++ (instancetype)eventPathWithEndpointID:(NSNumber *)endpointID
+                              clusterID:(NSNumber *)clusterID
+                                eventID:(NSNumber *)eventID MTR_NEWLY_AVAILABLE;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface MTREventPath (Deprecated)
+
++ (instancetype)eventPathWithEndpointId:(NSNumber *)endpointId
+                              clusterId:(NSNumber *)clusterId
+                                eventId:(NSNumber *)eventId
+    MTR_NEWLY_DEPRECATED("Please use eventPathWithEndpointID:clusterID:eventID:");
+
 @end
 
 @interface MTRCommandPath : NSObject
@@ -319,10 +380,21 @@ extern NSString * const MTRArrayValueType;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
 @property (nonatomic, readonly, strong, nonnull) NSNumber * command;
 
-+ (instancetype)commandPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId commandId:(NSNumber *)commandId;
++ (instancetype)commandPathWithEndpointID:(NSNumber *)endpointID
+                                clusterID:(NSNumber *)clusterID
+                                commandID:(NSNumber *)commandID MTR_NEWLY_AVAILABLE;
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface MTRCommandPath (Deprecated)
+
++ (instancetype)commandPathWithEndpointId:(NSNumber *)endpointId
+                                clusterId:(NSNumber *)clusterId
+                                commandId:(NSNumber *)commandId
+    MTR_NEWLY_DEPRECATED("Please use commandPathWithEndpointID:clusterID:commandID:");
+
 @end
 
 @interface MTRAttributeReport : NSObject

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.mm
@@ -77,7 +77,7 @@ class MTRDataValueDictionaryCallbackBridge;
 @interface MTRReadClientContainer : NSObject
 @property (nonatomic, readwrite) app::ReadClient * readClientPtr;
 @property (nonatomic, readwrite) app::AttributePathParams * pathParams;
-@property (nonatomic, readwrite) uint64_t deviceId;
+@property (nonatomic, readwrite) uint64_t deviceID;
 - (void)onDone;
 @end
 
@@ -193,7 +193,7 @@ static void CauseReadClientFailure(uint64_t deviceId, dispatch_queue_t queue, vo
         Platform::Delete(_pathParams);
         _pathParams = nullptr;
     }
-    PurgeCompletedReadClientContainers(_deviceId);
+    PurgeCompletedReadClientContainers(_deviceID);
 }
 
 - (void)dealloc
@@ -773,16 +773,16 @@ private:
     Platform::UniquePtr<app::ReadClient> mReadClient;
 };
 
-- (void)readAttributeWithEndpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                        attributeId:(NSNumber *)attributeId
+- (void)readAttributeWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                        attributeID:(NSNumber *)attributeID
                              params:(MTRReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
 {
-    endpointId = (endpointId == nil) ? nil : [endpointId copy];
-    clusterId = (clusterId == nil) ? nil : [clusterId copy];
-    attributeId = (attributeId == nil) ? nil : [attributeId copy];
+    endpointID = (endpointID == nil) ? nil : [endpointID copy];
+    clusterID = (clusterID == nil) ? nil : [clusterID copy];
+    attributeID = (attributeID == nil) ? nil : [attributeID copy];
     params = (params == nil) ? nil : [params copy];
     new MTRDataValueDictionaryCallbackBridge(clientQueue, self, completion,
         ^(ExchangeManager & exchangeManager, const SessionHandle & session, chip::Callback::Cancelable * success,
@@ -818,14 +818,14 @@ private:
             };
 
             app::AttributePathParams attributePath;
-            if (endpointId) {
-                attributePath.mEndpointId = static_cast<chip::EndpointId>([endpointId unsignedShortValue]);
+            if (endpointID) {
+                attributePath.mEndpointId = static_cast<chip::EndpointId>([endpointID unsignedShortValue]);
             }
-            if (clusterId) {
-                attributePath.mClusterId = static_cast<chip::ClusterId>([clusterId unsignedLongValue]);
+            if (clusterID) {
+                attributePath.mClusterId = static_cast<chip::ClusterId>([clusterID unsignedLongValue]);
             }
-            if (attributeId) {
-                attributePath.mAttributeId = static_cast<chip::AttributeId>([attributeId unsignedLongValue]);
+            if (attributeID) {
+                attributePath.mAttributeId = static_cast<chip::AttributeId>([attributeID unsignedLongValue]);
             }
             app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
             CHIP_ERROR err = CHIP_NO_ERROR;
@@ -882,9 +882,9 @@ private:
         });
 }
 
-- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+- (void)writeAttributeWithEndpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                          clientQueue:(dispatch_queue_t)clientQueue
@@ -943,9 +943,9 @@ private:
                   };
 
             return chip::Controller::WriteAttribute<MTRDataValueDictionaryDecodableType>(session,
-                static_cast<chip::EndpointId>([endpointId unsignedShortValue]),
-                static_cast<chip::ClusterId>([clusterId unsignedLongValue]),
-                static_cast<chip::AttributeId>([attributeId unsignedLongValue]), MTRDataValueDictionaryDecodableType(value),
+                static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+                static_cast<chip::ClusterId>([clusterID unsignedLongValue]),
+                static_cast<chip::AttributeId>([attributeID unsignedLongValue]), MTRDataValueDictionaryDecodableType(value),
                 onSuccessCb, onFailureCb, (timeoutMs == nil) ? NullOptional : Optional<uint16_t>([timeoutMs unsignedShortValue]),
                 onDoneCb, NullOptional);
         });
@@ -1022,17 +1022,17 @@ exit:
     }
 }
 
-- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+- (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                       commandFields:(id)commandFields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
 {
-    endpointId = (endpointId == nil) ? nil : [endpointId copy];
-    clusterId = (clusterId == nil) ? nil : [clusterId copy];
-    commandId = (commandId == nil) ? nil : [commandId copy];
+    endpointID = (endpointID == nil) ? nil : [endpointID copy];
+    clusterID = (clusterID == nil) ? nil : [clusterID copy];
+    commandID = (commandID == nil) ? nil : [commandID copy];
     // TODO: This is not going to deep-copy the NSArray instances in
     // commandFields.  We need to do something smarter here.
     commandFields = (commandFields == nil) ? nil : [commandFields copy];
@@ -1070,9 +1070,9 @@ exit:
                 }
             };
 
-            app::CommandPathParams commandPath = { static_cast<chip::EndpointId>([endpointId unsignedShortValue]), 0,
-                static_cast<chip::ClusterId>([clusterId unsignedLongValue]),
-                static_cast<chip::CommandId>([commandId unsignedLongValue]), (app::CommandPathFlags::kEndpointIdValid) };
+            app::CommandPathParams commandPath = { static_cast<chip::EndpointId>([endpointID unsignedShortValue]), 0,
+                static_cast<chip::ClusterId>([clusterID unsignedLongValue]),
+                static_cast<chip::CommandId>([commandID unsignedLongValue]), (app::CommandPathFlags::kEndpointIdValid) };
 
             auto decoder = chip::Platform::MakeUnique<NSObjectCommandCallback>(
                 commandPath.mClusterId, commandPath.mCommandId, onSuccessCb, onFailureCb);
@@ -1116,9 +1116,9 @@ exit:
         });
 }
 
-- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(MTRSubscribeParams * _Nullable)params
@@ -1135,9 +1135,9 @@ exit:
     }
 
     // Copy params before going async.
-    endpointId = (endpointId == nil) ? nil : [endpointId copy];
-    clusterId = (clusterId == nil) ? nil : [clusterId copy];
-    attributeId = (attributeId == nil) ? nil : [attributeId copy];
+    endpointID = (endpointID == nil) ? nil : [endpointID copy];
+    clusterID = (clusterID == nil) ? nil : [clusterID copy];
+    attributeID = (attributeID == nil) ? nil : [attributeID copy];
     minInterval = (minInterval == nil) ? nil : [minInterval copy];
     maxInterval = (maxInterval == nil) ? nil : [maxInterval copy];
     params = (params == nil) ? nil : [params copy];
@@ -1193,16 +1193,16 @@ exit:
             };
 
             MTRReadClientContainer * container = [[MTRReadClientContainer alloc] init];
-            container.deviceId = self.nodeID;
+            container.deviceID = self.nodeID;
             container.pathParams = Platform::New<app::AttributePathParams>();
-            if (endpointId) {
-                container.pathParams->mEndpointId = static_cast<chip::EndpointId>([endpointId unsignedShortValue]);
+            if (endpointID) {
+                container.pathParams->mEndpointId = static_cast<chip::EndpointId>([endpointID unsignedShortValue]);
             }
-            if (clusterId) {
-                container.pathParams->mClusterId = static_cast<chip::ClusterId>([clusterId unsignedLongValue]);
+            if (clusterID) {
+                container.pathParams->mClusterId = static_cast<chip::ClusterId>([clusterID unsignedLongValue]);
             }
-            if (attributeId) {
-                container.pathParams->mAttributeId = static_cast<chip::AttributeId>([attributeId unsignedLongValue]);
+            if (attributeID) {
+                container.pathParams->mAttributeId = static_cast<chip::AttributeId>([attributeID unsignedLongValue]);
             }
 
             app::InteractionModelEngine * engine = app::InteractionModelEngine::GetInstance();
@@ -1251,7 +1251,7 @@ exit:
 
             // Read clients will be purged when deregistered.
             container.readClientPtr = readClient;
-            AddReadClientContainer(container.deviceId, container);
+            AddReadClientContainer(container.deviceID, container);
             callback.release();
         }];
 }
@@ -1477,6 +1477,76 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
         resubscriptionScheduled:resubscriptionScheduledHandler];
 }
 
+- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                          clusterId:(NSNumber * _Nullable)clusterId
+                        attributeId:(NSNumber * _Nullable)attributeId
+                             params:(MTRReadParams * _Nullable)params
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(MTRDeviceResponseHandler)completion
+{
+    [self readAttributeWithEndpointID:endpointId
+                            clusterID:clusterId
+                          attributeID:attributeId
+                               params:params
+                          clientQueue:clientQueue
+                           completion:completion];
+}
+
+- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
+                           clusterId:(NSNumber *)clusterId
+                         attributeId:(NSNumber *)attributeId
+                               value:(id)value
+                   timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
+                         clientQueue:(dispatch_queue_t)clientQueue
+                          completion:(MTRDeviceResponseHandler)completion
+{
+    [self writeAttributeWithEndpointID:endpointId
+                             clusterID:clusterId
+                           attributeID:attributeId
+                                 value:value
+                     timedWriteTimeout:timeoutMs
+                           clientQueue:clientQueue
+                            completion:completion];
+}
+
+- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
+                          clusterId:(NSNumber *)clusterId
+                          commandId:(NSNumber *)commandId
+                      commandFields:(id)commandFields
+                 timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
+                        clientQueue:(dispatch_queue_t)clientQueue
+                         completion:(MTRDeviceResponseHandler)completion
+{
+    [self invokeCommandWithEndpointID:endpointId
+                            clusterID:clusterId
+                            commandID:commandId
+                        commandFields:commandFields
+                   timedInvokeTimeout:timeoutMs
+                          clientQueue:clientQueue
+                           completion:completion];
+}
+
+- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
+                               clusterId:(NSNumber * _Nullable)clusterId
+                             attributeId:(NSNumber * _Nullable)attributeId
+                             minInterval:(NSNumber *)minInterval
+                             maxInterval:(NSNumber *)maxInterval
+                                  params:(MTRSubscribeParams * _Nullable)params
+                             clientQueue:(dispatch_queue_t)clientQueue
+                           reportHandler:(MTRDeviceResponseHandler)reportHandler
+                 subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler
+{
+    [self subscribeAttributeWithEndpointID:endpointId
+                                 clusterID:clusterId
+                               attributeID:attributeId
+                               minInterval:minInterval
+                               maxInterval:maxInterval
+                                    params:params
+                               clientQueue:clientQueue
+                             reportHandler:reportHandler
+                   subscriptionEstablished:subscriptionEstablishedHandler];
+}
+
 @end
 
 @implementation MTRAttributePath
@@ -1497,11 +1567,13 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
                      (uint32_t) _attribute.unsignedLongValue];
 }
 
-+ (instancetype)attributePathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId attributeId:(NSNumber *)attributeId
++ (instancetype)attributePathWithEndpointID:(NSNumber *)endpointID
+                                  clusterID:(NSNumber *)clusterID
+                                attributeID:(NSNumber *)attributeID
 {
-    ConcreteDataAttributePath path(static_cast<chip::EndpointId>([endpoint unsignedShortValue]),
-        static_cast<chip::ClusterId>([clusterId unsignedLongValue]),
-        static_cast<chip::AttributeId>([attributeId unsignedLongValue]));
+    ConcreteDataAttributePath path(static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+        static_cast<chip::ClusterId>([clusterID unsignedLongValue]),
+        static_cast<chip::AttributeId>([attributeID unsignedLongValue]));
 
     return [[MTRAttributePath alloc] initWithPath:path];
 }
@@ -1527,7 +1599,16 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
 
 - (id)copyWithZone:(NSZone *)zone
 {
-    return [MTRAttributePath attributePathWithEndpointId:_endpoint clusterId:_cluster attributeId:_attribute];
+    return [MTRAttributePath attributePathWithEndpointID:_endpoint clusterID:_cluster attributeID:_attribute];
+}
+@end
+
+@implementation MTRAttributePath (Deprecated)
++ (instancetype)attributePathWithEndpointId:(NSNumber *)endpointId
+                                  clusterId:(NSNumber *)clusterId
+                                attributeId:(NSNumber *)attributeId
+{
+    return [self attributePathWithEndpointID:endpointId clusterID:clusterId attributeID:attributeId];
 }
 @end
 
@@ -1542,12 +1623,19 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
     return self;
 }
 
-+ (instancetype)eventPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId eventId:(NSNumber *)eventId
++ (instancetype)eventPathWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID eventID:(NSNumber *)eventID
 {
-    ConcreteEventPath path(static_cast<chip::EndpointId>([endpoint unsignedShortValue]),
-        static_cast<chip::ClusterId>([clusterId unsignedLongValue]), static_cast<chip::EventId>([eventId unsignedLongValue]));
+    ConcreteEventPath path(static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+        static_cast<chip::ClusterId>([clusterID unsignedLongValue]), static_cast<chip::EventId>([eventID unsignedLongValue]));
 
     return [[MTREventPath alloc] initWithPath:path];
+}
+@end
+
+@implementation MTREventPath (Deprecated)
++ (instancetype)eventPathWithEndpointId:(NSNumber *)endpointId clusterId:(NSNumber *)clusterId eventId:(NSNumber *)eventId
+{
+    return [self eventPathWithEndpointID:endpointId clusterID:clusterId eventID:eventId];
 }
 @end
 
@@ -1562,12 +1650,19 @@ void OpenCommissioningWindowHelper::OnOpenCommissioningWindowResponse(
     return self;
 }
 
-+ (instancetype)commandPathWithEndpointId:(NSNumber *)endpoint clusterId:(NSNumber *)clusterId commandId:(NSNumber *)commandId
++ (instancetype)commandPathWithEndpointID:(NSNumber *)endpointID clusterID:(NSNumber *)clusterID commandID:(NSNumber *)commandID
 {
-    ConcreteCommandPath path(static_cast<chip::EndpointId>([endpoint unsignedShortValue]),
-        static_cast<chip::ClusterId>([clusterId unsignedLongValue]), static_cast<chip::CommandId>([commandId unsignedLongValue]));
+    ConcreteCommandPath path(static_cast<chip::EndpointId>([endpointID unsignedShortValue]),
+        static_cast<chip::ClusterId>([clusterID unsignedLongValue]), static_cast<chip::CommandId>([commandID unsignedLongValue]));
 
     return [[MTRCommandPath alloc] initWithPath:path];
+}
+@end
+
+@implementation MTRCommandPath (Deprecated)
++ (instancetype)commandPathWithEndpointId:(NSNumber *)endpointId clusterId:(NSNumber *)clusterId commandId:(NSNumber *)commandId
+{
+    return [self commandPathWithEndpointID:endpointId clusterID:clusterId commandID:commandId];
 }
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCertificates.h
+++ b/src/darwin/Framework/CHIP/MTRCertificates.h
@@ -30,28 +30,28 @@ NS_ASSUME_NONNULL_BEGIN
  * Generate a root (self-signed) X.509 DER encoded certificate that has the
  * right fields to be a valid Matter root certificate.
  *
- * If issuerId is nil, a random issuer id is generated.  Otherwise the provided
+ * If issuerID is nil, a random issuer id is generated.  Otherwise the provided
  * issuer id is used.
  *
- * If fabricId is not nil, it will be included in the subject DN of the
+ * If fabricID is not nil, it will be included in the subject DN of the
  * certificate.  In this case it must be a valid Matter fabric id.
  *
  * On failure returns nil and if "error" is not null sets *error to the relevant
  * error.
  */
 + (nullable NSData *)generateRootCertificate:(id<MTRKeypair>)keypair
-                                    issuerId:(nullable NSNumber *)issuerId
-                                    fabricId:(nullable NSNumber *)fabricId
-                                       error:(NSError * __autoreleasing _Nullable * _Nullable)error;
+                                    issuerID:(nullable NSNumber *)issuerID
+                                    fabricID:(nullable NSNumber *)fabricID
+                                       error:(NSError * __autoreleasing _Nullable * _Nullable)error MTR_NEWLY_AVAILABLE;
 
 /**
  * Generate an intermediate X.509 DER encoded certificate that has the
  * right fields to be a valid Matter intermediate certificate.
  *
- * If issuerId is nil, a random issuer id is generated.  Otherwise the provided
+ * If issuerID is nil, a random issuer id is generated.  Otherwise the provided
  * issuer id is used.
  *
- * If fabricId is not nil, it will be included in the subject DN of the
+ * If fabricID is not nil, it will be included in the subject DN of the
  * certificate.  In this case it must be a valid Matter fabric id.
  *
  * On failure returns nil and if "error" is not null sets *error to the relevant
@@ -60,9 +60,9 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
                                      rootCertificate:(NSData *)rootCertificate
                                intermediatePublicKey:(SecKeyRef)intermediatePublicKey
-                                            issuerId:(nullable NSNumber *)issuerId
-                                            fabricId:(nullable NSNumber *)fabricId
-                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error;
+                                            issuerID:(nullable NSNumber *)issuerID
+                                            fabricID:(nullable NSNumber *)fabricID
+                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error MTR_NEWLY_AVAILABLE;
 
 /**
  * Generate an X.509 DER encoded certificate that has the
@@ -71,11 +71,11 @@ NS_ASSUME_NONNULL_BEGIN
  * signingKeypair and signingCertificate are the root or intermediate that is
  * signing the operational certificate.
  *
- * nodeId and fabricId are expected to be 64-bit unsigned integers.
+ * nodeID and fabricID are expected to be 64-bit unsigned integers.
  *
- * nodeId must be a valid Matter operational node id.
+ * nodeID must be a valid Matter operational node id.
  *
- * fabricId must be a valid Matter fabric id.
+ * fabricID must be a valid Matter fabric id.
  *
  * caseAuthenticatedTags may be nil to indicate no CASE Authenticated Tags
  * should be used.  If caseAuthenticatedTags is not nil, it must have length at
@@ -88,10 +88,10 @@ NS_ASSUME_NONNULL_BEGIN
 + (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
                                  signingCertificate:(NSData *)signingCertificate
                                operationalPublicKey:(SecKeyRef)operationalPublicKey
-                                           fabricId:(NSNumber *)fabricId
-                                             nodeId:(NSNumber *)nodeId
+                                           fabricID:(NSNumber *)fabricID
+                                             nodeID:(NSNumber *)nodeID
                               caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
-                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error;
+                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error MTR_NEWLY_AVAILABLE;
 
 /**
  * Check whether the given keypair's public key matches the given certificate's
@@ -134,6 +134,36 @@ NS_ASSUME_NONNULL_BEGIN
  * represented in the Matter certificate format).
  */
 + (nullable NSData *)convertX509Certificate:(NSData *)x509Certificate;
+
+@end
+
+@interface MTRCertificates (Deprecated)
+
++ (nullable NSData *)generateRootCertificate:(id<MTRKeypair>)keypair
+                                    issuerId:(nullable NSNumber *)issuerId
+                                    fabricId:(nullable NSNumber *)fabricId
+                                       error:(NSError * __autoreleasing _Nullable * _Nullable)error
+    MTR_NEWLY_DEPRECATED("Please use generateRootCertificate:issuerId:fabricId:error:");
+
++ (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
+                                     rootCertificate:(NSData *)rootCertificate
+                               intermediatePublicKey:(SecKeyRef)intermediatePublicKey
+                                            issuerId:(nullable NSNumber *)issuerId
+                                            fabricId:(nullable NSNumber *)fabricId
+                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error
+    MTR_NEWLY_DEPRECATED(
+        "Please use generateIntermediateCertificate:rootCertificate:intermediatePublicKey:issuerID:fabricID:error:");
+
++ (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
+                                 signingCertificate:(NSData *)signingCertificate
+                               operationalPublicKey:(SecKeyRef)operationalPublicKey
+                                           fabricId:(NSNumber *)fabricId
+                                             nodeId:(NSNumber *)nodeId
+                              caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
+                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error
+    MTR_NEWLY_DEPRECATED(
+        "Plase use "
+        "generateOperationalCertificate:signingCertificate:operationalPublicKey:fabricID:nodeID:caseAuthenticatedTags:error:");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRCertificates.mm
+++ b/src/darwin/Framework/CHIP/MTRCertificates.mm
@@ -32,8 +32,8 @@ using namespace chip::Credentials;
 @implementation MTRCertificates
 
 + (nullable NSData *)generateRootCertificate:(id<MTRKeypair>)keypair
-                                    issuerId:(nullable NSNumber *)issuerId
-                                    fabricId:(nullable NSNumber *)fabricId
+                                    issuerID:(nullable NSNumber *)issuerID
+                                    fabricID:(nullable NSNumber *)fabricID
                                        error:(NSError * __autoreleasing *)error
 {
     NSLog(@"Generating root certificate");
@@ -41,7 +41,7 @@ using namespace chip::Credentials;
     [MTRMemory ensureInit];
 
     NSData * rootCert = nil;
-    CHIP_ERROR err = MTROperationalCredentialsDelegate::GenerateRootCertificate(keypair, issuerId, fabricId, &rootCert);
+    CHIP_ERROR err = MTROperationalCredentialsDelegate::GenerateRootCertificate(keypair, issuerID, fabricID, &rootCert);
     if (error) {
         *error = [MTRError errorForCHIPErrorCode:err];
     }
@@ -56,8 +56,8 @@ using namespace chip::Credentials;
 + (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
                                      rootCertificate:(NSData *)rootCertificate
                                intermediatePublicKey:(SecKeyRef)intermediatePublicKey
-                                            issuerId:(nullable NSNumber *)issuerId
-                                            fabricId:(nullable NSNumber *)fabricId
+                                            issuerID:(nullable NSNumber *)issuerID
+                                            fabricID:(nullable NSNumber *)fabricID
                                                error:(NSError * __autoreleasing *)error
 {
     NSLog(@"Generating intermediate certificate");
@@ -66,7 +66,7 @@ using namespace chip::Credentials;
 
     NSData * intermediate = nil;
     CHIP_ERROR err = MTROperationalCredentialsDelegate::GenerateIntermediateCertificate(
-        rootKeypair, rootCertificate, intermediatePublicKey, issuerId, fabricId, &intermediate);
+        rootKeypair, rootCertificate, intermediatePublicKey, issuerID, fabricID, &intermediate);
     if (error) {
         *error = [MTRError errorForCHIPErrorCode:err];
     }
@@ -81,8 +81,8 @@ using namespace chip::Credentials;
 + (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
                                  signingCertificate:(NSData *)signingCertificate
                                operationalPublicKey:(SecKeyRef)operationalPublicKey
-                                           fabricId:(NSNumber *)fabricId
-                                             nodeId:(NSNumber *)nodeId
+                                           fabricID:(NSNumber *)fabricID
+                                             nodeID:(NSNumber *)nodeID
                               caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error
 {
@@ -92,7 +92,7 @@ using namespace chip::Credentials;
 
     NSData * opcert = nil;
     CHIP_ERROR err = MTROperationalCredentialsDelegate::GenerateOperationalCertificate(
-        signingKeypair, signingCertificate, operationalPublicKey, fabricId, nodeId, caseAuthenticatedTags, &opcert);
+        signingKeypair, signingCertificate, operationalPublicKey, fabricID, nodeID, caseAuthenticatedTags, &opcert);
     if (error) {
         *error = [MTRError errorForCHIPErrorCode:err];
     }
@@ -212,6 +212,50 @@ using namespace chip::Credentials;
         return nil;
 
     return AsData(chipCertBytes);
+}
+
+@end
+
+@implementation MTRCertificates (Deprecated)
+
++ (nullable NSData *)generateRootCertificate:(id<MTRKeypair>)keypair
+                                    issuerId:(nullable NSNumber *)issuerId
+                                    fabricId:(nullable NSNumber *)fabricId
+                                       error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+    return [MTRCertificates generateRootCertificate:keypair issuerID:issuerId fabricID:fabricId error:error];
+}
+
++ (nullable NSData *)generateIntermediateCertificate:(id<MTRKeypair>)rootKeypair
+                                     rootCertificate:(NSData *)rootCertificate
+                               intermediatePublicKey:(SecKeyRef)intermediatePublicKey
+                                            issuerId:(nullable NSNumber *)issuerId
+                                            fabricId:(nullable NSNumber *)fabricId
+                                               error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+    return [MTRCertificates generateIntermediateCertificate:rootKeypair
+                                            rootCertificate:rootCertificate
+                                      intermediatePublicKey:intermediatePublicKey
+                                                   issuerID:issuerId
+                                                   fabricID:fabricId
+                                                      error:error];
+}
+
++ (nullable NSData *)generateOperationalCertificate:(id<MTRKeypair>)signingKeypair
+                                 signingCertificate:(NSData *)signingCertificate
+                               operationalPublicKey:(SecKeyRef)operationalPublicKey
+                                           fabricId:(NSNumber *)fabricId
+                                             nodeId:(NSNumber *)nodeId
+                              caseAuthenticatedTags:(NSArray<NSNumber *> * _Nullable)caseAuthenticatedTags
+                                              error:(NSError * __autoreleasing _Nullable * _Nullable)error
+{
+    return [MTRCertificates generateOperationalCertificate:signingKeypair
+                                        signingCertificate:signingCertificate
+                                      operationalPublicKey:operationalPublicKey
+                                                  fabricID:fabricId
+                                                    nodeID:nodeId
+                                     caseAuthenticatedTags:caseAuthenticatedTags
+                                                     error:error];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRControllerFactory.mm
+++ b/src/darwin/Framework/CHIP/MTRControllerFactory.mm
@@ -430,7 +430,7 @@ static NSString * const kErrorOtaProviderInit = @"Init failure while creating an
         return nil;
     }
 
-    if (startupParams.vendorId == nil) {
+    if (startupParams.vendorID == nil) {
         MTR_LOG_ERROR("Must provide vendor id when starting controller on new fabric");
         return nil;
     }

--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -393,9 +393,9 @@ private:
         MTRBaseDevice * baseDevice = [self newBaseDevice];
 
         [baseDevice
-            readAttributeWithEndpointId:endpointID
-                              clusterId:clusterID
-                            attributeId:attributeID
+            readAttributeWithEndpointID:endpointID
+                              clusterID:clusterID
+                            attributeID:attributeID
                                  params:params
                             clientQueue:self.queue
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
@@ -417,9 +417,9 @@ private:
     [_asyncCallbackWorkQueue enqueueWorkItem:workItem];
 
     // Return current known / expected value right away
-    MTRAttributePath * attributePath = [MTRAttributePath attributePathWithEndpointId:endpointID
-                                                                           clusterId:clusterID
-                                                                         attributeId:attributeID];
+    MTRAttributePath * attributePath = [MTRAttributePath attributePathWithEndpointID:endpointID
+                                                                           clusterID:clusterID
+                                                                         attributeID:attributeID];
     NSDictionary<NSString *, id> * attributeValueToReturn = [self _attributeValueDictionaryForAttributePath:attributePath];
 
     return attributeValueToReturn;
@@ -457,9 +457,9 @@ private:
     [_asyncCallbackWorkQueue enqueueWorkItem:workItem];
 
     // Commit change into expected value cache
-    MTRAttributePath * attributePath = [MTRAttributePath attributePathWithEndpointId:endpointID
-                                                                           clusterId:clusterID
-                                                                         attributeId:attributeID];
+    MTRAttributePath * attributePath = [MTRAttributePath attributePathWithEndpointID:endpointID
+                                                                           clusterID:clusterID
+                                                                         attributeID:attributeID];
     NSDictionary * newExpectedValueDictionary = @{ MTRAttributePathKey : attributePath, MTRDataKey : value };
 
     [self setExpectedValues:@[ newExpectedValueDictionary ] expectedValueInterval:expectedValueInterval];

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.h
@@ -36,12 +36,12 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
 /**
  * Returns a shared device controller proxy for the controller object over XPC connection.
  *
- * @param controllerId    an implementation specific id in case multiple shared device controllers are available over XPC connection
+ * @param controllerID    an implementation specific id in case multiple shared device controllers are available over XPC connection
  * @param xpcConnectBlock block to connect to an XPC listener serving the shared device controllers in an implementation specific
  * way
  */
-+ (MTRDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
-                                xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock;
++ (MTRDeviceController *)sharedControllerWithID:(id<NSCopying> _Nullable)controllerID
+                                xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock MTR_NEWLY_AVAILABLE;
 
 /**
  * Returns an encoded values object to send over XPC for read, write and command interactions
@@ -77,6 +77,14 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
 
 @end
 
+@interface MTRDeviceController (Deprecated_XPC)
+
++ (MTRDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerID
+                                xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock
+    MTR_NEWLY_DEPRECATED("Please use sharedControllerWithID:xpcConnectBlock:");
+
+@end
+
 /**
  * Protocol that remote object must support over XPC
  */
@@ -84,7 +92,7 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
 
 @optional
 /**
- * Gets device controller ID corresponding to a specific fabric Id
+ * Gets device controller ID corresponding to a specific fabric ID
  */
 - (void)getDeviceControllerWithFabricId:(uint64_t)fabricId
                              completion:(MTRDeviceControllerGetterHandler)completion MTR_NEWLY_DEPRECATED("This never called.");

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.m
@@ -48,7 +48,7 @@ static MTRAttributePath * _Nullable decodeAttributePath(NSArray * _Nullable path
     if (pathArray == nil || [pathArray count] != 3) {
         return nil;
     }
-    return [MTRAttributePath attributePathWithEndpointId:pathArray[0] clusterId:pathArray[1] attributeId:pathArray[2]];
+    return [MTRAttributePath attributePathWithEndpointID:pathArray[0] clusterID:pathArray[1] attributeID:pathArray[2]];
 }
 
 static MTRCommandPath * _Nullable decodeCommandPath(NSArray * _Nullable pathArray)
@@ -56,7 +56,7 @@ static MTRCommandPath * _Nullable decodeCommandPath(NSArray * _Nullable pathArra
     if (pathArray == nil || [pathArray count] != 3) {
         return nil;
     }
-    return [MTRCommandPath commandPathWithEndpointId:pathArray[0] clusterId:pathArray[1] commandId:pathArray[2]];
+    return [MTRCommandPath commandPathWithEndpointID:pathArray[0] clusterID:pathArray[1] commandID:pathArray[2]];
 }
 
 static void decodeReadParams(NSDictionary<NSString *, id> * inParams, MTRReadParams * outParams)
@@ -66,10 +66,10 @@ static void decodeReadParams(NSDictionary<NSString *, id> * inParams, MTRReadPar
 
 @implementation MTRDeviceController (XPC)
 
-+ (MTRDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
++ (MTRDeviceController *)sharedControllerWithID:(id<NSCopying> _Nullable)controllerID
                                 xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock
 {
-    return [MTRDeviceControllerOverXPC sharedControllerWithId:controllerId xpcConnectBlock:xpcConnectBlock];
+    return [MTRDeviceControllerOverXPC sharedControllerWithID:controllerID xpcConnectBlock:xpcConnectBlock];
 }
 
 + (NSArray<NSDictionary<NSString *, id> *> * _Nullable)encodeXPCResponseValues:
@@ -169,6 +169,16 @@ static void decodeReadParams(NSDictionary<NSString *, id> * inParams, MTRReadPar
     result.keepPreviousSubscriptions = params[kKeepPreviousSubscriptionsKey];
     result.autoResubscribe = params[kAutoResubscribeKey];
     return result;
+}
+
+@end
+
+@implementation MTRDeviceController (Deprecated_XPC)
+
++ (MTRDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerID
+                                xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock
+{
+    return [MTRDeviceController sharedControllerWithID:controllerID xpcConnectBlock:xpcConnectBlock];
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -34,10 +34,10 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
 @property (readonly, nonatomic) BOOL isRunning;
 
 /**
- * Return the Node Id assigned to the controller.  Will return nil if the
+ * Return the Node ID assigned to the controller.  Will return nil if the
  * controller is not running (and hence does not know its node id).
  */
-@property (readonly, nonatomic, nullable) NSNumber * controllerNodeId;
+@property (readonly, nonatomic, nullable) NSNumber * controllerNodeID MTR_NEWLY_AVAILABLE;
 
 /**
  * Set up a commissioning session for a device, using the provided setup payload
@@ -173,7 +173,7 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
  * Attempts to retrieve the attestation challenge for a commissionee with the given Device ID.
  * Returns nil if given Device ID does not match an active commissionee, or if a Secure Session is not availale.
  */
-- (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId;
+- (nullable NSData *)fetchAttestationChallengeForDeviceID:(uint64_t)deviceID MTR_NEWLY_AVAILABLE;
 
 /**
  * Compute a PASE verifier and passcode ID for the desired setup pincode.
@@ -191,6 +191,15 @@ typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NS
  * Shutdown the controller. Calls to shutdown after the first one are NO-OPs.
  */
 - (void)shutdown;
+
+@end
+
+@interface MTRDeviceController (Deprecated)
+
+@property (readonly, nonatomic, nullable) NSNumber * controllerNodeId MTR_NEWLY_DEPRECATED("Please use controllerNodeID");
+
+- (nullable NSData *)fetchAttestationChallengeForDeviceId:(uint64_t)deviceId
+    MTR_NEWLY_DEPRECATED("Please use fetchAttestationChallengeForDeviceID");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.h
@@ -32,7 +32,7 @@ typedef NSXPCConnection * _Nonnull (^MTRXPCConnectBlock)(void);
  * Returns a shared remote device controller associated with an implementation specific id and implementation specific way to
  * connect to an XPC listener.
  */
-+ (MTRDeviceControllerOverXPC *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
++ (MTRDeviceControllerOverXPC *)sharedControllerWithID:(id<NSCopying> _Nullable)controllerID
                                        xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC.m
@@ -37,11 +37,11 @@ static void SetupXPCQueue(void)
 
 @implementation MTRDeviceControllerOverXPC
 
-+ (MTRDeviceControllerOverXPC *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerId
++ (MTRDeviceControllerOverXPC *)sharedControllerWithID:(id<NSCopying> _Nullable)controllerID
                                        xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock
 {
     SetupXPCQueue();
-    return [[MTRDeviceControllerOverXPC alloc] initWithControllerId:controllerId
+    return [[MTRDeviceControllerOverXPC alloc] initWithControllerID:controllerID
                                                           workQueue:globalWorkQueue
                                                        connectBlock:xpcConnectBlock];
 }
@@ -83,7 +83,7 @@ static void SetupXPCQueue(void)
     return NO;
 }
 
-- (BOOL)commissionDevice:(uint64_t)deviceId
+- (BOOL)commissionDevice:(uint64_t)deviceID
      commissioningParams:(MTRCommissioningParameters *)commissioningParams
                    error:(NSError * __autoreleasing *)error
 {
@@ -102,7 +102,7 @@ static void SetupXPCQueue(void)
     return NO;
 }
 
-- (nullable MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceId error:(NSError * __autoreleasing *)error
+- (nullable MTRBaseDevice *)getDeviceBeingCommissioned:(uint64_t)deviceID error:(NSError * __autoreleasing *)error
 {
     MTR_LOG_ERROR("MTRDevice doesn't support getDeviceBeingCommissioned over XPC");
     return nil;
@@ -114,7 +114,7 @@ static void SetupXPCQueue(void)
 {
     dispatch_async(_workQueue, ^{
         dispatch_group_t group = dispatch_group_create();
-        if (!self.controllerId) {
+        if (!self.controllerID) {
             dispatch_group_enter(group);
             [self.xpcConnection getProxyHandleWithCompletion:^(
                 dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
@@ -123,7 +123,7 @@ static void SetupXPCQueue(void)
                         if (error) {
                             MTR_LOG_ERROR("Failed to fetch any shared remote controller");
                         } else {
-                            self.controllerId = controller;
+                            self.controllerID = controller;
                         }
                         dispatch_group_leave(group);
                         __auto_type handleRetainer = handle;
@@ -136,9 +136,9 @@ static void SetupXPCQueue(void)
             }];
         }
         dispatch_group_notify(group, queue, ^{
-            if (self.controllerId) {
-                MTRDeviceOverXPC * device = [[MTRDeviceOverXPC alloc] initWithController:self.controllerId
-                                                                                deviceId:@(deviceID)
+            if (self.controllerID) {
+                MTRDeviceOverXPC * device = [[MTRDeviceOverXPC alloc] initWithController:self.controllerID
+                                                                                deviceID:@(deviceID)
                                                                            xpcConnection:self.xpcConnection];
                 completionHandler(device, nil);
             } else {
@@ -165,22 +165,22 @@ static void SetupXPCQueue(void)
     return nil;
 }
 
-- (instancetype)initWithControllerId:(id)controllerId
+- (instancetype)initWithControllerID:(id)controllerID
                            workQueue:(dispatch_queue_t)queue
                        xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
 {
-    _controllerId = controllerId;
+    _controllerID = controllerID;
     _workQueue = queue;
     _xpcConnection = xpcConnection;
     return self;
 }
 
 // This is interface for unit testing
-- (instancetype)initWithControllerId:(id)controllerId
+- (instancetype)initWithControllerID:(id)controllerID
                            workQueue:(dispatch_queue_t)queue
                         connectBlock:(MTRXPCConnectBlock)connectBlock
 {
-    return [self initWithControllerId:controllerId
+    return [self initWithControllerID:controllerID
                             workQueue:queue
                         xpcConnection:[MTRDeviceControllerXPCConnection connectionWithWorkQueue:queue connectBlock:connectBlock]];
 }

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerOverXPC_Internal.h
@@ -22,7 +22,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface MTRDeviceControllerOverXPC ()
 
-@property (nonatomic, readwrite, strong) id<NSCopying> _Nullable controllerId;
+@property (nonatomic, readwrite, strong) id<NSCopying> _Nullable controllerID;
 @property (nonatomic, readonly, strong) dispatch_queue_t workQueue;
 @property (nonatomic, readonly, strong) MTRDeviceControllerXPCConnection * xpcConnection;
 

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.h
@@ -65,7 +65,7 @@ NS_ASSUME_NONNULL_BEGIN
  * * Will override existing value if not nil. Otherwise existing value will be
  *   used.
  */
-@property (nonatomic, copy, nullable) NSNumber * vendorId;
+@property (nonatomic, copy, nullable) NSNumber * vendorID MTR_NEWLY_AVAILABLE;
 
 /**
  * Node id for this controller.
@@ -75,27 +75,27 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * If not nil, must be a valid Matter operational node id.
  *
- * If operationalCertificate is nil, nodeId and operationalKeypair are used to
+ * If operationalCertificate is nil, nodeID and operationalKeypair are used to
  * determine an operational certificate, as follows:
  *
  * * When creating a new fabric:
  *
- * ** nodeId is allowed to be nil to indicate that a random node id should be
+ * ** nodeID is allowed to be nil to indicate that a random node id should be
  *    generated.
  *
  * * When using an existing fabric:
  *
- * ** nodeId is allowed to be nil to indicate that the existing operational node
+ * ** nodeID is allowed to be nil to indicate that the existing operational node
  *    id should be used.  The existing operational keys will also be used,
  *    unless operationalKeypair is provided.
  *
- * ** If nodeId is not nil, a new operational certificate will be generated for
+ * ** If nodeID is not nil, a new operational certificate will be generated for
  *    the provided node id (even if that matches the existing node id), using
  *    either the operationalKeypair if that is provided or a new randomly
  *    generated operational key.
  *
  */
-@property (nonatomic, copy, nullable) NSNumber * nodeId;
+@property (nonatomic, copy, nullable) NSNumber * nodeID MTR_NEWLY_AVAILABLE;
 
 // TODO: Add something here for CATs?
 
@@ -114,7 +114,7 @@ NS_ASSUME_NONNULL_BEGIN
  * * May be nil if nocSigner is not nil and an intermediate CA is not being
  *   used.  In that case the nocSigner keypair, which is the keypair for the
  *   root certificate, will be used to generate and sign a root certificate,
- *   with a random issuer id.  In this case, the fabricId will be included in
+ *   with a random issuer id.  In this case, the fabricID will be included in
  *   the root certificate's subject DN.
  *
  * When using an existing fabric:
@@ -171,7 +171,7 @@ NS_ASSUME_NONNULL_BEGIN
  * operationalKeypair must not be nil.
  *
  * If nil, an operational certificate will be determined as described in the
- * documentation for nodeId.
+ * documentation for nodeID.
  */
 @property (nonatomic, copy, readonly, nullable) NSData * operationalCertificate;
 
@@ -182,7 +182,7 @@ NS_ASSUME_NONNULL_BEGIN
  * If not nil, and if operationalCertificate is nil, a new operational
  * certificate will be generated for the given operationalKeypair.  The node id
  * will for that certificated will be determined as described in the
- * documentation for nodeId.
+ * documentation for nodeID.
  */
 @property (nonatomic, strong, nullable) id<MTRKeypair> operationalKeypair;
 
@@ -192,7 +192,7 @@ NS_ASSUME_NONNULL_BEGIN
  * Prepare to initialize a controller given a keypair to use for signing
  * operational certificates.
  *
- * fabricId must be set to a valid (i.e. nonzero) value.
+ * fabricID must be set to a valid (i.e. nonzero) value.
  *
  * ipk must be 16 bytes in length
  */
@@ -224,6 +224,8 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceControllerStartupParams (Deprecated)
 
 @property (nonatomic, assign, readonly) uint64_t fabricId MTR_NEWLY_DEPRECATED("Please use fabricID");
+@property (nonatomic, copy, nullable) NSNumber * vendorId MTR_NEWLY_DEPRECATED("Please use vendorID");
+@property (nonatomic, copy, nullable) NSNumber * nodeID MTR_NEWLY_DEPRECATED("Please use nodeID");
 
 - (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner
                               fabricId:(uint64_t)fabricId

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerStartupParams.mm
@@ -96,8 +96,8 @@ using namespace chip;
     _nocSigner = params.nocSigner;
     _fabricID = params.fabricID;
     _ipk = params.ipk;
-    _vendorId = params.vendorId;
-    _nodeId = params.nodeId;
+    _vendorID = params.vendorID;
+    _nodeID = params.nodeID;
     _rootCertificate = params.rootCertificate;
     _intermediateCertificate = params.intermediateCertificate;
     _operationalCertificate = params.operationalCertificate;
@@ -130,6 +130,26 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
     return self.fabricID.unsignedLongLongValue;
 }
 
+- (nullable NSNumber *)vendorId
+{
+    return self.vendorID;
+}
+
+- (void)setVendorId:(nullable NSNumber *)vendorId
+{
+    self.vendorID = vendorId;
+}
+
+- (nullable NSNumber *)nodeId
+{
+    return self.nodeID;
+}
+
+- (void)setNodeId:(nullable NSNumber *)nodeId
+{
+    self.nodeID = nodeId;
+}
+
 - (instancetype)initWithSigningKeypair:(id<MTRKeypair>)nocSigner fabricId:(uint64_t)fabricId ipk:(NSData *)ipk
 {
     return [self initWithSigningKeypair:nocSigner fabricID:@(fabricId) ipk:ipk];
@@ -150,8 +170,8 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
         return nil;
     }
 
-    if (self.operationalCertificate != nil && self.nodeId != nil) {
-        MTR_LOG_ERROR("nodeId must be nil if operationalCertificate is not nil");
+    if (self.operationalCertificate != nil && self.nodeID != nil) {
+        MTR_LOG_ERROR("nodeID must be nil if operationalCertificate is not nil");
         return nil;
     }
 
@@ -183,19 +203,19 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
         return nil;
     }
 
-    if (self.operationalCertificate == nil && self.nodeId == nil) {
+    if (self.operationalCertificate == nil && self.nodeID == nil) {
         // Just avoid setting the top bit, to avoid issues with node
         // ids outside the operational range.
         uint64_t nodeId = arc4random();
         nodeId = (nodeId << 31) | (arc4random() >> 1);
-        self.nodeId = @(nodeId);
+        self.nodeID = @(nodeId);
     }
 
     if (self.rootCertificate == nil) {
         NSError * error;
         self.rootCertificate = [MTRCertificates generateRootCertificate:self.nocSigner
-                                                               issuerId:nil
-                                                               fabricId:self.fabricID
+                                                               issuerID:nil
+                                                               fabricID:self.fabricID
                                                                   error:&error];
         if (error != nil || self.rootCertificate == nil) {
             MTR_LOG_ERROR("Failed to generate root certificate: %@", error);
@@ -220,13 +240,13 @@ static NSData * _Nullable MatterCertToX509Data(const ByteSpan & cert)
 
     const FabricInfo * fabric = fabricTable->FindFabricWithIndex(fabricIndex);
 
-    if (self.vendorId == nil) {
-        self.vendorId = @(fabric->GetVendorId());
+    if (self.vendorID == nil) {
+        self.vendorID = @(fabric->GetVendorId());
     }
 
     BOOL usingExistingNOC = NO;
-    if (self.operationalCertificate == nil && self.nodeId == nil) {
-        self.nodeId = @(fabric->GetNodeId());
+    if (self.operationalCertificate == nil && self.nodeID == nil) {
+        self.nodeID = @(fabric->GetNodeId());
 
         if (self.operationalKeypair == nil) {
             uint8_t nocBuf[Credentials::kMaxCHIPCertLength];

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.h
@@ -49,10 +49,10 @@ typedef void (^MTRGetProxyHandleHandler)(dispatch_queue_t queue, MTRDeviceContro
 
 - (void)getProxyHandleWithCompletion:(MTRGetProxyHandleHandler)completion;
 - (void)registerReportHandlerWithController:(id<NSCopying>)controller
-                                     nodeId:(NSNumber *)nodeId
+                                     nodeID:(NSNumber *)nodeID
                                     handler:(MTRXPCReportHandler)handler;
 - (void)deregisterReportHandlersWithController:(id<NSCopying>)controller
-                                        nodeId:(NSNumber *)nodeId
+                                        nodeID:(NSNumber *)nodeID
                                     completion:(dispatch_block_t)completion;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceControllerXPCConnection.m
@@ -118,7 +118,7 @@
     });
 }
 
-- (void)registerReportHandlerWithController:(id<NSCopying>)controller nodeId:(NSNumber *)nodeId handler:(MTRXPCReportHandler)handler
+- (void)registerReportHandlerWithController:(id<NSCopying>)controller nodeID:(NSNumber *)nodeID handler:(MTRXPCReportHandler)handler
 {
     dispatch_async(_workQueue, ^{
         BOOL shouldRetainProxyForReport = ([self.reportRegistry count] == 0);
@@ -127,10 +127,10 @@
             controllerDictionary = [[NSMutableDictionary alloc] init];
             [self.reportRegistry setObject:controllerDictionary forKey:controller];
         }
-        NSMutableArray * nodeArray = controllerDictionary[nodeId];
+        NSMutableArray * nodeArray = controllerDictionary[nodeID];
         if (!nodeArray) {
             nodeArray = [[NSMutableArray alloc] init];
-            [controllerDictionary setObject:nodeArray forKey:nodeId];
+            [controllerDictionary setObject:nodeArray forKey:nodeID];
         }
         [nodeArray addObject:handler];
         if (shouldRetainProxyForReport) {
@@ -140,7 +140,7 @@
 }
 
 - (void)deregisterReportHandlersWithController:(id<NSCopying>)controller
-                                        nodeId:(NSNumber *)nodeId
+                                        nodeID:(NSNumber *)nodeID
                                     completion:(dispatch_block_t)completion
 {
     dispatch_async(_workQueue, ^{
@@ -150,12 +150,12 @@
                 completion();
                 return;
             }
-            NSMutableArray * nodeArray = controllerDictionary[nodeId];
+            NSMutableArray * nodeArray = controllerDictionary[nodeID];
             if (!nodeArray) {
                 completion();
                 return;
             }
-            [controllerDictionary removeObjectForKey:nodeId];
+            [controllerDictionary removeObjectForKey:nodeID];
             if ([controllerDictionary count] == 0) {
                 // Dereference proxy retainer for reports so that XPC connection may be invalidated if no longer used.
                 self.proxyRetainerForReports = nil;
@@ -167,7 +167,7 @@
                 if (handle) {
                     MTR_LOG_DEBUG("CHIP XPC connection requests to stop reports");
                     [handle.proxy stopReportsWithController:controller
-                                                     nodeId:nodeId.unsignedLongLongValue
+                                                     nodeId:nodeID.unsignedLongLongValue
                                                  completion:^{
                                                      __auto_type handleRetainer = handle;
                                                      (void) handleRetainer;

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.h
@@ -31,7 +31,7 @@ NS_ASSUME_NONNULL_BEGIN
     subscriptionEstablished:(dispatch_block_t _Nullable)subscriptionEstablishedHandler NS_UNAVAILABLE;
 
 - (instancetype)initWithController:(id<NSCopying>)controller
-                          deviceId:(NSNumber *)deviceId
+                          deviceID:(NSNumber *)deviceID
                      xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection;
 
 @end

--- a/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
+++ b/src/darwin/Framework/CHIP/MTRDeviceOverXPC.m
@@ -29,7 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 @interface MTRDeviceOverXPC ()
 
 @property (nonatomic, strong, readonly) id<NSCopying> controller;
-@property (nonatomic, readonly) NSNumber * nodeId;
+@property (nonatomic, readonly) NSNumber * nodeID;
 @property (nonatomic, strong, readonly) MTRDeviceControllerXPCConnection * xpcConnection;
 
 @end
@@ -37,11 +37,11 @@ NS_ASSUME_NONNULL_BEGIN
 @implementation MTRDeviceOverXPC
 
 - (instancetype)initWithController:(id<NSCopying>)controller
-                          deviceId:(NSNumber *)deviceId
+                          deviceID:(NSNumber *)deviceID
                      xpcConnection:(MTRDeviceControllerXPCConnection *)xpcConnection
 {
     _controller = controller;
-    _nodeId = deviceId;
+    _nodeID = deviceID;
     _xpcConnection = xpcConnection;
     return self;
 }
@@ -60,13 +60,13 @@ NS_ASSUME_NONNULL_BEGIN
     MTR_LOG_DEBUG("Subscribing all attributes... Note that attributeReportHandler, eventReportHandler, and resubscriptionScheduled "
                   "are not supported.");
     if (attributeCacheContainer) {
-        [attributeCacheContainer setXPCConnection:_xpcConnection controllerId:self.controller deviceId:self.nodeId];
+        [attributeCacheContainer setXPCConnection:_xpcConnection controllerID:self.controller deviceID:self.nodeID];
     }
     [_xpcConnection
         getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull proxyQueue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
                 [handle.proxy subscribeWithController:self.controller
-                                               nodeId:self.nodeId.unsignedLongLongValue
+                                               nodeId:self.nodeID.unsignedLongLongValue
                                           minInterval:minInterval
                                           maxInterval:maxInterval
                                                params:[MTRDeviceController encodeXPCSubscribeParams:params]
@@ -91,9 +91,9 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)readAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                          clusterId:(NSNumber * _Nullable)clusterId
-                        attributeId:(NSNumber * _Nullable)attributeId
+- (void)readAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                          clusterID:(NSNumber * _Nullable)clusterID
+                        attributeID:(NSNumber * _Nullable)attributeID
                              params:(MTRReadParams * _Nullable)params
                         clientQueue:(dispatch_queue_t)clientQueue
                          completion:(MTRDeviceResponseHandler)completion
@@ -103,10 +103,10 @@ NS_ASSUME_NONNULL_BEGIN
         getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
                 [handle.proxy readAttributeWithController:self.controller
-                                                   nodeId:self.nodeId.unsignedLongLongValue
-                                               endpointId:endpointId
-                                                clusterId:clusterId
-                                              attributeId:attributeId
+                                                   nodeId:self.nodeID.unsignedLongLongValue
+                                               endpointId:endpointID
+                                                clusterId:clusterID
+                                              attributeId:attributeID
                                                    params:[MTRDeviceController encodeXPCReadParams:params]
                                                completion:^(id _Nullable values, NSError * _Nullable error) {
                                                    dispatch_async(clientQueue, ^{
@@ -127,9 +127,9 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)writeAttributeWithEndpointId:(NSNumber *)endpointId
-                           clusterId:(NSNumber *)clusterId
-                         attributeId:(NSNumber *)attributeId
+- (void)writeAttributeWithEndpointID:(NSNumber *)endpointID
+                           clusterID:(NSNumber *)clusterID
+                         attributeID:(NSNumber *)attributeID
                                value:(id)value
                    timedWriteTimeout:(NSNumber * _Nullable)timeoutMs
                          clientQueue:(dispatch_queue_t)clientQueue
@@ -140,10 +140,10 @@ NS_ASSUME_NONNULL_BEGIN
         getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
                 [handle.proxy writeAttributeWithController:self.controller
-                                                    nodeId:self.nodeId.unsignedLongLongValue
-                                                endpointId:endpointId
-                                                 clusterId:clusterId
-                                               attributeId:attributeId
+                                                    nodeId:self.nodeID.unsignedLongLongValue
+                                                endpointId:endpointID
+                                                 clusterId:clusterID
+                                               attributeId:attributeID
                                                      value:value
                                          timedWriteTimeout:timeoutMs
                                                 completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -165,9 +165,9 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)invokeCommandWithEndpointId:(NSNumber *)endpointId
-                          clusterId:(NSNumber *)clusterId
-                          commandId:(NSNumber *)commandId
+- (void)invokeCommandWithEndpointID:(NSNumber *)endpointID
+                          clusterID:(NSNumber *)clusterID
+                          commandID:(NSNumber *)commandID
                       commandFields:(id)commandFields
                  timedInvokeTimeout:(NSNumber * _Nullable)timeoutMs
                         clientQueue:(dispatch_queue_t)clientQueue
@@ -178,10 +178,10 @@ NS_ASSUME_NONNULL_BEGIN
         getProxyHandleWithCompletion:^(dispatch_queue_t _Nonnull queue, MTRDeviceControllerXPCProxyHandle * _Nullable handle) {
             if (handle) {
                 [handle.proxy invokeCommandWithController:self.controller
-                                                   nodeId:self.nodeId.unsignedLongLongValue
-                                               endpointId:endpointId
-                                                clusterId:clusterId
-                                                commandId:commandId
+                                                   nodeId:self.nodeID.unsignedLongLongValue
+                                               endpointId:endpointID
+                                                clusterId:clusterID
+                                                commandId:commandID
                                                    fields:commandFields
                                        timedInvokeTimeout:timeoutMs
                                                completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -203,9 +203,9 @@ NS_ASSUME_NONNULL_BEGIN
         }];
 }
 
-- (void)subscribeAttributeWithEndpointId:(NSNumber * _Nullable)endpointId
-                               clusterId:(NSNumber * _Nullable)clusterId
-                             attributeId:(NSNumber * _Nullable)attributeId
+- (void)subscribeAttributeWithEndpointID:(NSNumber * _Nullable)endpointID
+                               clusterID:(NSNumber * _Nullable)clusterID
+                             attributeID:(NSNumber * _Nullable)attributeID
                              minInterval:(NSNumber *)minInterval
                              maxInterval:(NSNumber *)maxInterval
                                   params:(MTRSubscribeParams * _Nullable)params
@@ -220,7 +220,7 @@ NS_ASSUME_NONNULL_BEGIN
             MTR_LOG_DEBUG("Setup report handler");
             [self.xpcConnection
                 registerReportHandlerWithController:self.controller
-                                             nodeId:self.nodeId
+                                             nodeID:self.nodeID
                                             handler:^(id _Nullable values, NSError * _Nullable error) {
                                                 if (values && ![values isKindOfClass:[NSArray class]]) {
                                                     MTR_LOG_ERROR("Unsupported report format");
@@ -238,10 +238,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                     [NSMutableArray arrayWithCapacity:[decodedValues count]];
                                                 for (NSDictionary<NSString *, id> * decodedValue in decodedValues) {
                                                     MTRAttributePath * attributePath = decodedValue[MTRAttributePathKey];
-                                                    if ((endpointId == nil || [attributePath.endpoint isEqualToNumber:endpointId])
-                                                        && (clusterId == nil || [attributePath.cluster isEqualToNumber:clusterId])
-                                                        && (attributeId == nil ||
-                                                            [attributePath.attribute isEqualToNumber:attributeId])) {
+                                                    if ((endpointID == nil || [attributePath.endpoint isEqualToNumber:endpointID])
+                                                        && (clusterID == nil || [attributePath.cluster isEqualToNumber:clusterID])
+                                                        && (attributeID == nil ||
+                                                            [attributePath.attribute isEqualToNumber:attributeID])) {
                                                         [filteredValues addObject:decodedValue];
                                                     }
                                                 }
@@ -253,10 +253,10 @@ NS_ASSUME_NONNULL_BEGIN
                                                 }
                                             }];
             [handle.proxy subscribeAttributeWithController:self.controller
-                                                    nodeId:self.nodeId.unsignedLongLongValue
-                                                endpointId:endpointId
-                                                 clusterId:clusterId
-                                               attributeId:attributeId
+                                                    nodeId:self.nodeID.unsignedLongLongValue
+                                                endpointId:endpointID
+                                                 clusterId:clusterID
+                                               attributeId:attributeID
                                                minInterval:minInterval
                                                maxInterval:maxInterval
                                                     params:[MTRDeviceController encodeXPCSubscribeParams:params]
@@ -284,7 +284,7 @@ NS_ASSUME_NONNULL_BEGIN
 {
     MTR_LOG_DEBUG("Deregistering report handlers");
     [_xpcConnection deregisterReportHandlersWithController:self.controller
-                                                    nodeId:self.nodeId
+                                                    nodeID:self.nodeID
                                                 completion:^{
                                                     dispatch_async(clientQueue, completion);
                                                 }];

--- a/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRCertificateTests.m
@@ -32,7 +32,7 @@
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:testKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:testKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 }
 
@@ -41,7 +41,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -50,8 +50,8 @@
     __auto_type * intermediateCert = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                       rootCertificate:rootCert
                                                                 intermediatePublicKey:intermediateKeys.publicKey
-                                                                             issuerId:nil
-                                                                             fabricId:nil
+                                                                             issuerID:nil
+                                                                             fabricID:nil
                                                                                 error:nil];
     XCTAssertNotNil(intermediateCert);
 }
@@ -61,7 +61,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -76,8 +76,8 @@
     __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                                  signingCertificate:rootCert
                                                                operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricId:@1
-                                                                             nodeId:@1
+                                                                           fabricID:@1
+                                                                             nodeID:@1
                                                               caseAuthenticatedTags:cats
                                                                               error:nil];
     XCTAssertNotNil(operationalCert);
@@ -88,7 +88,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -97,8 +97,8 @@
     __auto_type * intermediateCert = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                       rootCertificate:rootCert
                                                                 intermediatePublicKey:intermediateKeys.publicKey
-                                                                             issuerId:nil
-                                                                             fabricId:nil
+                                                                             issuerID:nil
+                                                                             fabricID:nil
                                                                                 error:nil];
     XCTAssertNotNil(intermediateCert);
 
@@ -108,8 +108,8 @@
     __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:intermediateKeys
                                                                  signingCertificate:intermediateCert
                                                                operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricId:@1
-                                                                             nodeId:@1
+                                                                           fabricID:@1
+                                                                             nodeID:@1
                                                               caseAuthenticatedTags:nil
                                                                               error:nil];
     XCTAssertNotNil(operationalCert);
@@ -120,7 +120,7 @@
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * rootCert = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(rootCert);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -153,8 +153,8 @@
     __auto_type * operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                                  signingCertificate:rootCert
                                                                operationalPublicKey:operationalKeys.publicKey
-                                                                           fabricId:@1
-                                                                             nodeId:@1
+                                                                           fabricID:@1
+                                                                             nodeID:@1
                                                               caseAuthenticatedTags:nil
                                                                               error:nil];
     XCTAssertNotNil(operationalCert);
@@ -163,8 +163,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:longCats
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -173,8 +173,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:catsWithSameIdentifier
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -183,8 +183,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:catsWithDuplicatedCAT
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -193,8 +193,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:catsWithInvalidVersion
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -203,8 +203,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:operationalKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@1
+                                                             fabricID:@1
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:nil
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -213,8 +213,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@0
-                                                               nodeId:@1
+                                                             fabricID:@0
+                                                               nodeID:@1
                                                 caseAuthenticatedTags:nil
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -223,8 +223,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@0
+                                                             fabricID:@1
+                                                               nodeID:@0
                                                 caseAuthenticatedTags:nil
                                                                 error:nil];
     XCTAssertNil(operationalCert);
@@ -233,8 +233,8 @@
     operationalCert = [MTRCertificates generateOperationalCertificate:rootKeys
                                                    signingCertificate:rootCert
                                                  operationalPublicKey:operationalKeys.publicKey
-                                                             fabricId:@1
-                                                               nodeId:@(0xFFFFFFFFFFFFFFFFLLU)
+                                                             fabricID:@1
+                                                               nodeID:@(0xFFFFFFFFFFFFFFFFLLU)
                                                 caseAuthenticatedTags:nil
                                                                 error:nil];
     XCTAssertNil(operationalCert);

--- a/src/darwin/Framework/CHIPTests/MTRControllerTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRControllerTests.m
@@ -75,7 +75,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -93,7 +93,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertFalse([controller isRunning]);
 
     // now try to restart the controller without providing a vendor id.
-    params.vendorId = nil;
+    params.vendorID = nil;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
@@ -123,7 +123,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -152,7 +152,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertTrue([controller isRunning]);
@@ -185,7 +185,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertTrue([controller isRunning]);
     [controller shutdown];
@@ -203,7 +203,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                          ipk:testKeys.ipk];
     XCTAssertNotNil(params2);
 
-    params2.vendorId = @(kTestVendorId);
+    params2.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller3 = [factory startControllerOnNewFabric:params2];
     XCTAssertTrue([controller3 isRunning]);
@@ -243,7 +243,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertTrue([controller isRunning]);
@@ -278,7 +278,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -315,7 +315,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -351,7 +351,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                          ipk:testKeys.ipk];
     XCTAssertNotNil(params1);
 
-    params1.vendorId = @(kTestVendorId);
+    params1.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller1 = [factory startControllerOnNewFabric:params1];
     XCTAssertNotNil(controller1);
@@ -364,7 +364,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                          ipk:testKeys.ipk];
     XCTAssertNotNil(params2);
 
-    params2.vendorId = @(kTestVendorId);
+    params2.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller2 = [factory startControllerOnNewFabric:params2];
     XCTAssertNotNil(controller2);
@@ -395,13 +395,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerId:@1 fabricId:@1 error:nil];
+    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root1);
 
-    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerId:@1 fabricId:@1 error:nil];
+    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root2);
 
-    __auto_type * root3 = [MTRCertificates generateRootCertificate:testKeys issuerId:@2 fabricId:@1 error:nil];
+    __auto_type * root3 = [MTRCertificates generateRootCertificate:testKeys issuerID:@2 fabricID:@1 error:nil];
     XCTAssertNotNil(root3);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
@@ -409,7 +409,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root1;
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
@@ -426,7 +426,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -444,7 +444,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     // operational certificate.  This should fail because our root of trust for
     // the fabric would change if we allowed this.
     params.rootCertificate = root3;
-    params.nodeId = nodeId;
+    params.nodeID = nodeId;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNil(controller);
 
@@ -465,10 +465,10 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * testKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(testKeys);
 
-    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerId:@1 fabricId:@1 error:nil];
+    __auto_type * root1 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@1 error:nil];
     XCTAssertNotNil(root1);
 
-    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerId:@1 fabricId:@2 error:nil];
+    __auto_type * root2 = [MTRCertificates generateRootCertificate:testKeys issuerID:@1 fabricID:@2 error:nil];
     XCTAssertNotNil(root2);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
@@ -476,7 +476,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:testKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Try to start controller when fabric id in root cert subject does not match provided fabric id.
     params.rootCertificate = root2;
@@ -526,7 +526,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * signerKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(signerKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:signerKeys
@@ -534,7 +534,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
 
     // Try to start controller when there is no ICA and root cert does not match signing key.
@@ -559,7 +559,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -568,8 +568,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
@@ -578,7 +578,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Try to start controller when there is an ICA and the ICA cert does not match signing key.
     params.rootCertificate = root;
@@ -588,7 +588,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
 
     // Now start controller with the signing key matching the intermediate cert.
     params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys fabricID:@(1) ipk:rootKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate;
     controller = [factory startControllerOnNewFabric:params];
@@ -644,7 +644,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(params);
 
     // Invalid vendor ID ("standard").
-    params.vendorId = @(0);
+    params.vendorID = @(0);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
@@ -671,13 +671,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -686,7 +686,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -713,37 +713,37 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Bring up with node id 17.
-    params.nodeId = @17;
+    params.nodeID = @17;
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @17);
+    XCTAssertEqualObjects([controller controllerNodeID], @17);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Bring up with a different node id (18).
-    params.nodeId = @18;
+    params.nodeID = @18;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @18);
+    XCTAssertEqualObjects([controller controllerNodeID], @18);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Verify the new node id has been stored.
-    params.nodeId = nil;
+    params.nodeID = nil;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @18);
+    XCTAssertEqualObjects([controller controllerNodeID], @18);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -770,25 +770,25 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Try to bring up with node id 0.
-    params.nodeId = @0;
+    params.nodeID = @0;
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
 
     // Try to bring up with node id that is outside of the operational range.
-    params.nodeId = @(0xFFFFFFFF00000000ULL);
+    params.nodeID = @(0xFFFFFFFF00000000ULL);
     controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
 
     // Verify that we can indeed bring up a controller for this fabric, with a valid node id.
-    params.nodeId = @17;
+    params.nodeID = @17;
     controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @17);
+    XCTAssertEqualObjects([controller controllerNodeID], @17);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -811,7 +811,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -820,8 +820,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
@@ -830,7 +830,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Create a new fabric without the ICA.
     params.rootCertificate = root;
@@ -838,21 +838,21 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but using the ICA.
     params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys fabricID:@(1) ipk:rootKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -875,7 +875,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -884,8 +884,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
@@ -894,7 +894,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Create a new fabric without the ICA.
     params.rootCertificate = root;
@@ -903,20 +903,20 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but without using the ICA.
     params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:rootKeys fabricID:@(1) ipk:rootKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -939,7 +939,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys1 = [[MTRTestKeys alloc] init];
@@ -948,8 +948,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate1 = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                    rootCertificate:root
                                                              intermediatePublicKey:intermediateKeys1.publicKey
-                                                                          issuerId:nil
-                                                                          fabricId:nil
+                                                                          issuerID:nil
+                                                                          fabricID:nil
                                                                              error:nil];
     XCTAssertNotNil(intermediate1);
 
@@ -959,8 +959,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate2 = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                    rootCertificate:root
                                                              intermediatePublicKey:intermediateKeys2.publicKey
-                                                                          issuerId:nil
-                                                                          fabricId:nil
+                                                                          issuerID:nil
+                                                                          fabricID:nil
                                                                              error:nil];
     XCTAssertNotNil(intermediate2);
 
@@ -969,7 +969,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Create a new fabric without the first ICA.
     params.rootCertificate = root;
@@ -978,21 +978,21 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    NSNumber * nodeId = [controller controllerNodeId];
+    NSNumber * nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
 
     // Now start controller on the same fabric but using the second ICA.
     params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:intermediateKeys2 fabricID:@(1) ipk:rootKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.rootCertificate = root;
     params.intermediateCertificate = intermediate2;
     controller = [factory startControllerOnExistingFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1014,7 +1014,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -1023,8 +1023,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
@@ -1033,7 +1033,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     // Pass in an intermediate but no root.  Should fail.
     params.intermediateCertificate = intermediate;
@@ -1057,7 +1057,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -1066,8 +1066,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:nil
+                                                                         issuerID:nil
+                                                                         fabricID:nil
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
@@ -1077,8 +1077,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operational = [MTRCertificates generateOperationalCertificate:intermediateKeys
                                                              signingCertificate:intermediate
                                                            operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricId:@123
-                                                                         nodeId:@456
+                                                                       fabricID:@123
+                                                                         nodeID:@456
                                                           caseAuthenticatedTags:nil
                                                                           error:nil];
     XCTAssertNotNil(operational);
@@ -1090,13 +1090,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                             ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @456);
+    XCTAssertEqualObjects([controller controllerNodeID], @456);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1110,7 +1110,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @456);
+    XCTAssertEqualObjects([controller controllerNodeID], @456);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1132,7 +1132,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:nil error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:nil error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -1141,8 +1141,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operational = [MTRCertificates generateOperationalCertificate:rootKeys
                                                              signingCertificate:root
                                                            operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricId:@123
-                                                                         nodeId:@456
+                                                                       fabricID:@123
+                                                                         nodeID:@456
                                                           caseAuthenticatedTags:nil
                                                                           error:nil];
     XCTAssertNotNil(operational);
@@ -1154,13 +1154,13 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                             ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], @456);
+    XCTAssertEqualObjects([controller controllerNodeID], @456);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1182,7 +1182,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:@111 error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:@111 error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * operationalKeys = [[MTRTestKeys alloc] init];
@@ -1191,8 +1191,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operational = [MTRCertificates generateOperationalCertificate:rootKeys
                                                              signingCertificate:root
                                                            operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricId:@123
-                                                                         nodeId:@456
+                                                                       fabricID:@123
+                                                                         nodeID:@456
                                                           caseAuthenticatedTags:nil
                                                                           error:nil];
     XCTAssertNotNil(operational);
@@ -1204,7 +1204,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                             ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
@@ -1226,7 +1226,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * rootKeys = [[MTRTestKeys alloc] init];
     XCTAssertNotNil(rootKeys);
 
-    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerId:nil fabricId:@123 error:nil];
+    __auto_type * root = [MTRCertificates generateRootCertificate:rootKeys issuerID:nil fabricID:@123 error:nil];
     XCTAssertNotNil(root);
 
     __auto_type * intermediateKeys = [[MTRTestKeys alloc] init];
@@ -1235,8 +1235,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * intermediate = [MTRCertificates generateIntermediateCertificate:rootKeys
                                                                   rootCertificate:root
                                                             intermediatePublicKey:intermediateKeys.publicKey
-                                                                         issuerId:nil
-                                                                         fabricId:@111
+                                                                         issuerID:nil
+                                                                         fabricID:@111
                                                                             error:nil];
     XCTAssertNotNil(intermediate);
 
@@ -1246,8 +1246,8 @@ static uint16_t kTestVendorId = 0xFFF1u;
     __auto_type * operational = [MTRCertificates generateOperationalCertificate:intermediateKeys
                                                              signingCertificate:intermediate
                                                            operationalPublicKey:operationalKeys.publicKey
-                                                                       fabricId:@123
-                                                                         nodeId:@456
+                                                                       fabricID:@123
+                                                                         nodeID:@456
                                                           caseAuthenticatedTags:nil
                                                                           error:nil];
     XCTAssertNotNil(operational);
@@ -1259,7 +1259,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                             ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNil(controller);
@@ -1289,14 +1289,14 @@ static uint16_t kTestVendorId = 0xFFF1u;
                                                                                         ipk:rootKeys.ipk];
     XCTAssertNotNil(params);
 
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
     params.operationalKeypair = operationalKeys;
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    __auto_type nodeId = [controller controllerNodeId];
+    __auto_type nodeId = [controller controllerNodeID];
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1315,7 +1315,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);
@@ -1330,7 +1330,7 @@ static uint16_t kTestVendorId = 0xFFF1u;
     XCTAssertNotNil(controller);
     XCTAssertTrue([controller isRunning]);
 
-    XCTAssertEqualObjects([controller controllerNodeId], nodeId);
+    XCTAssertEqualObjects([controller controllerNodeID], nodeId);
 
     [controller shutdown];
     XCTAssertFalse([controller isRunning]);

--- a/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRDeviceTests.m
@@ -165,7 +165,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
                                                                                    fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -237,9 +237,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:nil
-                              clusterId:@29
-                            attributeId:@0
+    [device readAttributeWithEndpointID:nil
+                              clusterID:@29
+                            attributeID:@0
                                  params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -279,9 +279,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@17
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
                                    value:writeValue
                        timedWriteTimeout:nil
                              clientQueue:queue
@@ -327,9 +327,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
             @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
         ]
     };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@8
-                              commandId:@4
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@8
+                              commandID:@4
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -372,9 +372,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
         @"type" : @"Structure",
         @"value" : @[],
     };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:@10000
                             clientQueue:queue
@@ -415,9 +415,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@1
         maxInterval:@10
         params:nil
@@ -459,9 +459,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : [NSArray array] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -509,9 +509,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -557,9 +557,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     dispatch_queue_t queue = dispatch_get_main_queue();
 
     [device
-        readAttributeWithEndpointId:@0
-                          clusterId:@10000
-                        attributeId:@0
+        readAttributeWithEndpointID:@0
+                          clusterID:@10000
+                        attributeID:@0
                              params:nil
                         clientQueue:queue
                          completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -588,9 +588,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
     [device
-        writeAttributeWithEndpointId:@1
-                           clusterId:@8
-                         attributeId:@10000
+        writeAttributeWithEndpointID:@1
+                           clusterID:@8
+                         attributeID:@10000
                                value:writeValue
                    timedWriteTimeout:nil
                          clientQueue:queue
@@ -625,9 +625,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
         ]
     };
     [device
-        invokeCommandWithEndpointId:@1
-                          clusterId:@8
-                          commandId:@40000
+        invokeCommandWithEndpointID:@1
+                          clusterID:@8
+                          commandID:@40000
                       commandFields:fields
                  timedInvokeTimeout:nil
                         clientQueue:queue
@@ -676,9 +676,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type * params = [[MTRSubscribeParams alloc] init];
     params.autoResubscribe = @(NO);
-    [device subscribeAttributeWithEndpointId:@10000
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@10000
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:params
@@ -713,9 +713,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:@1
-                              clusterId:@29
-                            attributeId:nil
+    [device readAttributeWithEndpointID:@1
+                              clusterID:@29
+                            attributeID:nil
                                  params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -904,9 +904,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using generic path...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:@1
-                          clusterId:@6
-                        attributeId:@0
+        readAttributeWithEndpointID:@1
+                          clusterID:@6
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -927,9 +927,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard endpoint...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:nil
-                          clusterId:@6
-                        attributeId:@0
+        readAttributeWithEndpointID:nil
+                          clusterID:@6
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -949,9 +949,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard cluster ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:@1
-                          clusterId:nil
-                        attributeId:@0
+        readAttributeWithEndpointID:@1
+                          clusterID:nil
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -970,9 +970,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard attribute ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:@1
-                          clusterId:@6
-                        attributeId:nil
+        readAttributeWithEndpointID:@1
+                          clusterID:@6
+                        attributeID:nil
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -992,9 +992,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from cache using wildcard endpoint ID and cluster ID...");
     cacheExpectation = [self expectationWithDescription:@"Attribute cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:nil
-                          clusterId:nil
-                        attributeId:@0
+        readAttributeWithEndpointID:nil
+                          clusterID:nil
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read attribute cache value: %@, error %@", values, error);
@@ -1023,9 +1023,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@1
         maxInterval:@10
         params:nil
@@ -1067,9 +1067,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : [NSArray array] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1180,9 +1180,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     };
     // KeySetReadAllIndices in the Group Key Management has id 4 and a data response with id 5
     [device
-        invokeCommandWithEndpointId:@0
-                          clusterId:@(0x003F)
-                          commandId:@4
+        invokeCommandWithEndpointID:@0
+                          clusterID:@(0x003F)
+                          commandID:@4
                       commandFields:fields
                  timedInvokeTimeout:nil
                         clientQueue:queue
@@ -1379,9 +1379,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     XCTestExpectation * expectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error) = nil;
 
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0xffffffff
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0xffffffff
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1423,9 +1423,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to set attribute state to a known state
     XCTestExpectation * commandExpectation = [self expectationWithDescription:@"command responded"];
     NSDictionary * fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1453,9 +1453,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send commands to trigger attribute change
     commandExpectation = [self expectationWithDescription:@"command responded"];
     fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1502,9 +1502,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // Send command to trigger attribute change
     commandExpectation = [self expectationWithDescription:@"command responded"];
     fields = @{ @"type" : @"Structure", @"value" : @[] };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue

--- a/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCListenerSampleTests.m
@@ -418,9 +418,9 @@ static NSString * const MTRDeviceControllerId = @"MTRController";
     MTRAttributeCacheContainer * attributeCacheContainer = _attributeCacheDictionary[[NSNumber numberWithUnsignedLongLong:nodeId]];
     if (attributeCacheContainer) {
         [attributeCacheContainer
-            readAttributeWithEndpointId:endpointId
-                              clusterId:clusterId
-                            attributeId:attributeId
+            readAttributeWithEndpointID:endpointId
+                              clusterID:clusterId
+                            attributeID:attributeId
                             clientQueue:dispatch_get_main_queue()
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                                  completion([MTRDeviceController encodeXPCResponseValues:values], error);
@@ -531,7 +531,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
     __auto_type * params = [[MTRDeviceControllerStartupParams alloc] initWithSigningKeypair:testKeys
                                                                                    fabricID:@(1)
                                                                                         ipk:testKeys.ipk];
-    params.vendorId = @(kTestVendorId);
+    params.vendorID = @(kTestVendorId);
 
     MTRDeviceController * controller = [factory startControllerOnNewFabric:params];
     XCTAssertNotNil(controller);
@@ -591,7 +591,7 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
     dispatch_queue_t queue = dispatch_get_main_queue();
     __auto_type remoteController = [MTRDeviceController
-        sharedControllerWithId:MTRDeviceControllerId
+        sharedControllerWithID:MTRDeviceControllerId
                xpcConnectBlock:^NSXPCConnection * _Nonnull {
                    if (mSampleListener.listenerEndpoint) {
                        return [[NSXPCConnection alloc] initWithListenerEndpoint:mSampleListener.listenerEndpoint];
@@ -629,9 +629,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:nil
-                              clusterId:@29
-                            attributeId:@0
+    [device readAttributeWithEndpointID:nil
+                              clusterID:@29
+                            attributeID:@0
                                  params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -671,9 +671,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
 
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@17
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
                                    value:writeValue
                        timedWriteTimeout:nil
                              clientQueue:queue
@@ -719,9 +719,9 @@ static MTRBaseDevice * GetConnectedDevice(void)
             @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
         ]
     };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@8
-                              commandId:@4
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@8
+                              commandID:@4
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -762,9 +762,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -806,9 +806,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -853,9 +853,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRBaseDevice * device = GetConnectedDevice();
     dispatch_queue_t queue = dispatch_get_main_queue();
 
-    [device readAttributeWithEndpointId:@0
-                              clusterId:@10000
-                            attributeId:@0
+    [device readAttributeWithEndpointID:@0
+                              clusterID:@10000
+                            attributeID:@0
                                  params:nil
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -886,9 +886,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@10000
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@10000
                                    value:writeValue
                        timedWriteTimeout:nil
                              clientQueue:queue
@@ -933,7 +933,7 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
                                             @"UnsignedInteger", @"type",
                                             [NSNumber numberWithUnsignedInteger:10], @"value", nil], @"value", nil],
                                           nil], @"value", nil];
-    [device invokeCommandWithEndpointId:@1 clusterId:@8 commandId:@40000 commandFields:fields clientQueue:queue
+    [device invokeCommandWithEndpointID:@1 clusterID:@8 commandID:@40000 commandFields:fields clientQueue:queue
             timedInvokeTimeout:nil
            completion:^(id _Nullable values, NSError * _Nullable error) {
                NSLog(@"invoke command: MoveToLevelWithOnOff values: %@, error: %@", values, error);
@@ -976,9 +976,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     __auto_type * params = [[MTRSubscribeParams alloc] init];
     params.autoResubscribe = @(NO);
-    [device subscribeAttributeWithEndpointId:@10000
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@10000
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:params
@@ -1015,9 +1015,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     MTRReadParams * readParams = [[MTRReadParams alloc] init];
     readParams.fabricFiltered = @NO;
-    [device readAttributeWithEndpointId:nil
-                              clusterId:@29
-                            attributeId:@0
+    [device readAttributeWithEndpointID:nil
+                              clusterID:@29
+                            attributeID:@0
                                  params:readParams
                             clientQueue:queue
                              completion:^(id _Nullable values, NSError * _Nullable error) {
@@ -1065,9 +1065,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1091,9 +1091,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Setup 2nd subscriber
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@8
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@8
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1118,9 +1118,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to clear attribute state
     XCTestExpectation * clearCommandExpectation = [self expectationWithDescription:@"Clearing command invoked"];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:@{ @"type" : @"Structure", @"value" : @[] }
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1187,9 +1187,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1244,9 +1244,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1272,9 +1272,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     MTRSubscribeParams * myParams = [[MTRSubscribeParams alloc] init];
     myParams.keepPreviousSubscriptions = @NO;
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@8
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@8
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:myParams
@@ -1299,9 +1299,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to clear attribute state
     XCTestExpectation * clearCommandExpectation = [self expectationWithDescription:@"Clearing command invoked"];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:@{ @"type" : @"Structure", @"value" : @[] }
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1368,9 +1368,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1432,9 +1432,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Subscribe
     XCTestExpectation * subscribeExpectation = [self expectationWithDescription:@"subscribe OnOff attribute"];
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@6
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@6
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:nil
@@ -1460,9 +1460,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     subscribeExpectation = [self expectationWithDescription:@"subscribe CurrentLevel attribute"];
     MTRSubscribeParams * myParams = [[MTRSubscribeParams alloc] init];
     myParams.keepPreviousSubscriptions = @YES;
-    [device subscribeAttributeWithEndpointId:@1
-        clusterId:@8
-        attributeId:@0
+    [device subscribeAttributeWithEndpointID:@1
+        clusterID:@8
+        attributeID:@0
         minInterval:@2
         maxInterval:@10
         params:myParams
@@ -1487,9 +1487,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to clear attribute state
     XCTestExpectation * clearCommandExpectation = [self expectationWithDescription:@"Clearing command invoked"];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:@{ @"type" : @"Structure", @"value" : @[] }
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1554,9 +1554,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Send command to trigger attribute change
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1603,9 +1603,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSDictionary * writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:200], @"value", nil];
     XCTestExpectation * expectation = [self expectationWithDescription:@"Wrote LevelControl Brightness attribute"];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@17
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
                                    value:writeValue
                        timedWriteTimeout:nil
                              clientQueue:queue
@@ -1635,9 +1635,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     writeValue = [NSDictionary
         dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithUnsignedInteger:100], @"value", nil];
     expectation = [self expectationWithDescription:@"Requested timed write on LevelControl Brightness attribute"];
-    [device writeAttributeWithEndpointId:@1
-                               clusterId:@8
-                             attributeId:@17
+    [device writeAttributeWithEndpointID:@1
+                               clusterID:@8
+                             attributeID:@17
                                    value:writeValue
                        timedWriteTimeout:@1000
                              clientQueue:queue
@@ -1667,9 +1667,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     // subscribe, which should get the new value at the timeout
     expectation = [self expectationWithDescription:@"Subscribed"];
     __block void (^reportHandler)(id _Nullable values, NSError * _Nullable error);
-    [device subscribeAttributeWithEndpointId:@1
-            clusterId:@8
-            attributeId:@17
+    [device subscribeAttributeWithEndpointID:@1
+            clusterID:@8
+            attributeID:@17
             minInterval:@2
             maxInterval:@10
             params:nil
@@ -1710,9 +1710,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
 
     // Read back to see if the timed write has taken effect
     expectation = [self expectationWithDescription:@"Read LevelControl Brightness attribute after pause"];
-    [device readAttributeWithEndpointId:@1
-                              clusterId:@8
-                            attributeId:@17
+    [device readAttributeWithEndpointID:@1
+                              clusterID:@8
+                            attributeID:@17
                                  params:nil
                             clientQueue:queue
                              completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
@@ -1749,9 +1749,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
             @{ @"contextTag" : @1, @"data" : @ { @"type" : @"UnsignedInteger", @"value" : @10 } }
         ]
     };
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@8
-                              commandId:@4
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@8
+                              commandID:@4
                           commandFields:fields
                      timedInvokeTimeout:@1000
                             clientQueue:queue
@@ -1818,9 +1818,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Invoking clearing command...");
     expectation = [self expectationWithDescription:@"Clearing command invoked"];
     NSDictionary * fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@0
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@0
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1849,9 +1849,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Invoking command to trigger report...");
     expectation = [self expectationWithDescription:@"Command invoked"];
     fields = [NSDictionary dictionaryWithObjectsAndKeys:@"Structure", @"type", [NSArray array], @"value", nil];
-    [device invokeCommandWithEndpointId:@1
-                              clusterId:@6
-                              commandId:@1
+    [device invokeCommandWithEndpointID:@1
+                              clusterID:@6
+                              commandID:@1
                           commandFields:fields
                      timedInvokeTimeout:nil
                             clientQueue:queue
@@ -1881,9 +1881,9 @@ static void (^globalReportHandler)(id _Nullable values, NSError * _Nullable erro
     NSLog(@"Reading from attribute cache...");
     expectation = [self expectationWithDescription:@"Cache read"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:@1
-                          clusterId:@6
-                        attributeId:@0
+        readAttributeWithEndpointID:@1
+                          clusterID:@6
+                        attributeID:@0
                         clientQueue:queue
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Cached attribute read: %@, error: %@", values, error);

--- a/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRXPCProtocolTests.m
@@ -79,7 +79,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 @interface MTRAttributeCacheContainer (Test)
 // Obsolete method is moved to this test suite to keep tests compatible
 - (void)subscribeWithDeviceController:(MTRDeviceController *)deviceController
-                             deviceId:(NSNumber *)deviceId
+                             deviceID:(NSNumber *)deviceID
                                params:(MTRSubscribeParams * _Nullable)params
                           clientQueue:(dispatch_queue_t)clientQueue
                            completion:(void (^)(NSError * _Nullable error))completion;
@@ -87,7 +87,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
 @implementation MTRAttributeCacheContainer (Test)
 - (void)subscribeWithDeviceController:(MTRDeviceController *)deviceController
-                             deviceId:(NSNumber *)deviceId
+                             deviceID:(NSNumber *)deviceID
                                params:(MTRSubscribeParams * _Nullable)params
                           clientQueue:clientQueue
                            completion:(void (^)(NSError * _Nullable error))completion
@@ -98,12 +98,12 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             completion(error);
         });
     };
-    [deviceController getBaseDevice:deviceId.unsignedLongLongValue
+    [deviceController getBaseDevice:deviceID.unsignedLongLongValue
                               queue:workQueue
                   completionHandler:^(MTRBaseDevice * _Nullable device, NSError * _Nullable error) {
                       if (error) {
                           NSLog(@"Error: Failed to get connected device (%llu) for attribute cache: %@",
-                              deviceId.unsignedLongLongValue, error);
+                              deviceID.unsignedLongLongValue, error);
                           completionHandler(error);
                           return;
                       }
@@ -126,7 +126,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                               }
                           }
                           subscriptionEstablished:^() {
-                              NSLog(@"Attribute cache subscription succeeded for device %llu", deviceId.unsignedLongLongValue);
+                              NSLog(@"Attribute cache subscription succeeded for device %llu", deviceID.unsignedLongLongValue);
                               if (![established[0] boolValue]) {
                                   established[0] = @YES;
                                   completionHandler(nil);
@@ -325,7 +325,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     [_xpcListener resume];
     _controllerUUID = [[NSUUID UUID] UUIDString];
     _remoteDeviceController =
-        [MTRDeviceController sharedControllerWithId:_controllerUUID
+        [MTRDeviceController sharedControllerWithID:_controllerUUID
                                     xpcConnectBlock:^NSXPCConnection * {
                                         return [[NSXPCConnection alloc] initWithListenerEndpoint:self.xpcListener.endpoint];
                                     }];
@@ -346,9 +346,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myClusterId = @200;
     NSNumber * myAttributeId = @300;
     NSArray * myValues = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
 
@@ -375,9 +375,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Reading...");
-                             [device readAttributeWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                     attributeId:myAttributeId
+                             [device readAttributeWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                     attributeID:myAttributeId
                                                           params:nil
                                                      clientQueue:dispatch_get_main_queue()
                                                       completion:^(id _Nullable value, NSError * _Nullable error) {
@@ -405,9 +405,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myClusterId = @200;
     NSNumber * myAttributeId = @300;
     NSArray * myValues = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     MTRReadParams * myParams = [[MTRReadParams alloc] init];
@@ -437,9 +437,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Reading...");
-                             [device readAttributeWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                     attributeId:myAttributeId
+                             [device readAttributeWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                     attributeID:myAttributeId
                                                           params:myParams
                                                      clientQueue:dispatch_get_main_queue()
                                                       completion:^(id _Nullable value, NSError * _Nullable error) {
@@ -490,9 +490,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Reading...");
-                             [device readAttributeWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                     attributeId:myAttributeId
+                             [device readAttributeWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                     attributeID:myAttributeId
                                                           params:nil
                                                      clientQueue:dispatch_get_main_queue()
                                                       completion:^(id _Nullable value, NSError * _Nullable error) {
@@ -521,9 +521,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSDictionary * myValue =
         [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
     NSArray * myResults = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId]
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId]
     } ];
 
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -549,9 +549,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Writing...");
-                             [device writeAttributeWithEndpointId:myEndpointId
-                                                        clusterId:myClusterId
-                                                      attributeId:myAttributeId
+                             [device writeAttributeWithEndpointID:myEndpointId
+                                                        clusterID:myClusterId
+                                                      attributeID:myAttributeId
                                                             value:myValue
                                                 timedWriteTimeout:nil
                                                       clientQueue:dispatch_get_main_queue()
@@ -583,9 +583,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         [NSDictionary dictionaryWithObjectsAndKeys:@"UnsignedInteger", @"type", [NSNumber numberWithInteger:654321], @"value", nil];
     NSNumber * myTimedWriteTimeout = @1234;
     NSArray * myResults = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId]
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId]
     } ];
 
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -612,9 +612,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Writing...");
-                             [device writeAttributeWithEndpointId:myEndpointId
-                                                        clusterId:myClusterId
-                                                      attributeId:myAttributeId
+                             [device writeAttributeWithEndpointID:myEndpointId
+                                                        clusterID:myClusterId
+                                                      attributeID:myAttributeId
                                                             value:myValue
                                                 timedWriteTimeout:myTimedWriteTimeout
                                                       clientQueue:dispatch_get_main_queue()
@@ -668,9 +668,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Writing...");
-                             [device writeAttributeWithEndpointId:myEndpointId
-                                                        clusterId:myClusterId
-                                                      attributeId:myAttributeId
+                             [device writeAttributeWithEndpointID:myEndpointId
+                                                        clusterID:myClusterId
+                                                      attributeID:myAttributeId
                                                             value:myValue
                                                 timedWriteTimeout:nil
                                                       clientQueue:dispatch_get_main_queue()
@@ -702,7 +702,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                                                    [NSNumber numberWithFloat:1.0], @"value", nil]],
                                             @"value", nil];
     NSArray * myResults = @[
-        @{ @"commandPath" : [MTRCommandPath commandPathWithEndpointId:myEndpointId clusterId:myClusterId commandId:myCommandId] }
+        @{ @"commandPath" : [MTRCommandPath commandPathWithEndpointID:myEndpointId clusterID:myClusterId commandID:myCommandId] }
     ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
@@ -728,9 +728,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Invoking command...");
-                             [device invokeCommandWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                       commandId:myCommandId
+                             [device invokeCommandWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                       commandID:myCommandId
                                                    commandFields:myFields
                                               timedInvokeTimeout:nil
                                                      clientQueue:dispatch_get_main_queue()
@@ -764,7 +764,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                                                                                    [NSNumber numberWithFloat:1.0], @"value", nil]],
                                             @"value", nil];
     NSArray * myResults = @[
-        @{ @"commandPath" : [MTRCommandPath commandPathWithEndpointId:myEndpointId clusterId:myClusterId commandId:myCommandId] }
+        @{ @"commandPath" : [MTRCommandPath commandPathWithEndpointID:myEndpointId clusterID:myClusterId commandID:myCommandId] }
     ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"XPC response received"];
@@ -791,9 +791,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Invoking command...");
-                             [device invokeCommandWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                       commandId:myCommandId
+                             [device invokeCommandWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                       commandID:myCommandId
                                                    commandFields:myFields
                                               timedInvokeTimeout:myTimedInvokeTimeout
                                                      clientQueue:dispatch_get_main_queue()
@@ -850,9 +850,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Invoking command...");
-                             [device invokeCommandWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                       commandId:myCommandId
+                             [device invokeCommandWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                       commandID:myCommandId
                                                    commandFields:myFields
                                               timedInvokeTimeout:nil
                                                      clientQueue:dispatch_get_main_queue()
@@ -882,9 +882,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -916,9 +916,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -950,9 +950,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1000,9 +1000,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     myParams.fabricFiltered = @NO;
     myParams.keepPreviousSubscriptions = @NO;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1036,9 +1036,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:myParams
@@ -1070,9 +1070,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1151,9 +1151,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1182,9 +1182,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"Report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1230,9 +1230,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:@([myEndpointId unsignedShortValue] + 1)
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:@([myEndpointId unsignedShortValue] + 1)
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1265,9 +1265,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1299,9 +1299,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1346,9 +1346,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:@([myClusterId unsignedLongValue] + 1)
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:@([myClusterId unsignedLongValue] + 1)
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1381,9 +1381,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1415,9 +1415,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1462,9 +1462,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:@([myAttributeId unsignedLongValue] + 1)],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:@([myAttributeId unsignedLongValue] + 1)],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1497,9 +1497,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1531,9 +1531,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1578,9 +1578,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1613,9 +1613,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1647,9 +1647,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1694,9 +1694,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1728,9 +1728,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:nil
-                clusterId:myClusterId
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:nil
+                clusterID:myClusterId
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1762,9 +1762,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1809,9 +1809,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1843,9 +1843,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:nil
-                attributeId:myAttributeId
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:nil
+                attributeID:myAttributeId
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1877,9 +1877,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -1924,9 +1924,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myMinInterval = @5;
     NSNumber * myMaxInterval = @60;
     __block NSArray * myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
     XCTestExpectation * callExpectation = [self expectationWithDescription:@"XPC call received"];
@@ -1958,9 +1958,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             XCTAssertNotNil(device);
             XCTAssertNil(error);
             NSLog(@"Device acquired. Subscribing...");
-            [device subscribeAttributeWithEndpointId:myEndpointId
-                clusterId:myClusterId
-                attributeId:nil
+            [device subscribeAttributeWithEndpointID:myEndpointId
+                clusterID:myClusterId
+                attributeID:nil
                 minInterval:myMinInterval
                 maxInterval:myMaxInterval
                 params:nil
@@ -1992,9 +1992,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     // Inject another report
     reportExpectation = [self expectationWithDescription:@"2nd report sent"];
     myReport = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @771234 }
     } ];
     [clientObject handleReportWithController:uuid
@@ -2084,9 +2084,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                 XCTAssertNotNil(device);
                 XCTAssertNil(error);
                 NSLog(@"Device acquired. Subscribing...");
-                [device subscribeAttributeWithEndpointId:myEndpointId
-                    clusterId:myClusterId
-                    attributeId:myAttributeId
+                [device subscribeAttributeWithEndpointID:myEndpointId
+                    clusterID:myClusterId
+                    attributeID:myAttributeId
                     minInterval:myMinInterval
                     maxInterval:myMaxInterval
                     params:nil
@@ -2116,15 +2116,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
             [self expectationWithDescription:[NSString stringWithFormat:@"Report(%d) for second subscriber sent", count]], nil];
         myReports = @[
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[0]
-                                                                       clusterId:clusterIds[0]
-                                                                     attributeId:attributeIds[0]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[0]
+                                                                       clusterID:clusterIds[0]
+                                                                     attributeID:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:123456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[1]
-                                                                       clusterId:clusterIds[1]
-                                                                     attributeId:attributeIds[1]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[1]
+                                                                       clusterID:clusterIds[1]
+                                                                     attributeID:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:123457 + count * 100] }
             } ]
         ];
@@ -2174,15 +2174,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         reportExpectations[0].inverted = YES;
         myReports = @[
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[0]
-                                                                       clusterId:clusterIds[0]
-                                                                     attributeId:attributeIds[0]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[0]
+                                                                       clusterID:clusterIds[0]
+                                                                     attributeID:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[1]
-                                                                       clusterId:clusterIds[1]
-                                                                     attributeId:attributeIds[1]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[1]
+                                                                       clusterID:clusterIds[1]
+                                                                     attributeID:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223457 + count * 100] }
             } ]
         ];
@@ -2236,15 +2236,15 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
         reportExpectations[1].inverted = YES;
         myReports = @[
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[0]
-                                                                       clusterId:clusterIds[0]
-                                                                     attributeId:attributeIds[0]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[0]
+                                                                       clusterID:clusterIds[0]
+                                                                     attributeID:attributeIds[0]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223456 + count * 100] }
             } ],
             @[ @{
-                @"attributePath" : [MTRAttributePath attributePathWithEndpointId:endpointIds[1]
-                                                                       clusterId:clusterIds[1]
-                                                                     attributeId:attributeIds[1]],
+                @"attributePath" : [MTRAttributePath attributePathWithEndpointID:endpointIds[1]
+                                                                       clusterID:clusterIds[1]
+                                                                     attributeID:attributeIds[1]],
                 @"data" : @ { @"type" : @"SignedInteger", @"value" : [NSNumber numberWithInteger:223457 + count * 100] }
             } ]
         ];
@@ -2267,7 +2267,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     uint64_t myNodeId = 9876543210;
 
     __auto_type unspecifiedRemoteDeviceController =
-        [MTRDeviceController sharedControllerWithId:nil
+        [MTRDeviceController sharedControllerWithID:nil
                                     xpcConnectBlock:^NSXPCConnection * {
                                         return [[NSXPCConnection alloc] initWithListenerEndpoint:self.xpcListener.endpoint];
                                     }];
@@ -2312,7 +2312,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2350,7 +2350,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:myParams
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2384,7 +2384,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2404,9 +2404,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     NSNumber * myClusterId = @200;
     NSNumber * myAttributeId = @300;
     NSArray * myValues = @[ @{
-        @"attributePath" : [MTRAttributePath attributePathWithEndpointId:myEndpointId
-                                                               clusterId:myClusterId
-                                                             attributeId:myAttributeId],
+        @"attributePath" : [MTRAttributePath attributePathWithEndpointID:myEndpointId
+                                                               clusterID:myClusterId
+                                                             attributeID:myAttributeId],
         @"data" : @ { @"type" : @"SignedInteger", @"value" : @123456 }
     } ];
 
@@ -2440,7 +2440,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
 
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2452,9 +2452,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:myEndpointId
-                          clusterId:myClusterId
-                        attributeId:myAttributeId
+        readAttributeWithEndpointID:myEndpointId
+                          clusterID:myClusterId
+                        attributeID:myAttributeId
                         clientQueue:dispatch_get_main_queue()
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read cached value: %@", values);
@@ -2502,7 +2502,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     };
 
     [attributeCacheContainer subscribeWithDeviceController:_remoteDeviceController
-                                                  deviceId:@(myNodeId)
+                                                  deviceID:@(myNodeId)
                                                     params:nil
                                                clientQueue:dispatch_get_main_queue()
                                                 completion:^(NSError * _Nullable error) {
@@ -2514,9 +2514,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
 
     _xpcDisconnectExpectation = [self expectationWithDescription:@"XPC Disconnected"];
     [attributeCacheContainer
-        readAttributeWithEndpointId:myEndpointId
-                          clusterId:myClusterId
-                        attributeId:myAttributeId
+        readAttributeWithEndpointID:myEndpointId
+                          clusterID:myClusterId
+                        attributeID:myAttributeId
                         clientQueue:dispatch_get_main_queue()
                          completion:^(NSArray<NSDictionary<NSString *, id> *> * _Nullable values, NSError * _Nullable error) {
                              NSLog(@"Read cached value: %@", values);
@@ -2537,7 +2537,7 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
     XCTestExpectation * responseExpectation = [self expectationWithDescription:@"Read response received"];
 
     // Test with a device controller which wouldn't connect to XPC listener successfully
-    __auto_type failingDeviceController = [MTRDeviceController sharedControllerWithId:_controllerUUID
+    __auto_type failingDeviceController = [MTRDeviceController sharedControllerWithID:_controllerUUID
                                                                       xpcConnectBlock:^NSXPCConnection * {
                                                                           return nil;
                                                                       }];
@@ -2548,9 +2548,9 @@ static const uint16_t kNegativeTimeoutInSeconds = 1;
                              XCTAssertNotNil(device);
                              XCTAssertNil(error);
                              NSLog(@"Device acquired. Reading...");
-                             [device readAttributeWithEndpointId:myEndpointId
-                                                       clusterId:myClusterId
-                                                     attributeId:myAttributeId
+                             [device readAttributeWithEndpointID:myEndpointId
+                                                       clusterID:myClusterId
+                                                     attributeID:myAttributeId
                                                           params:nil
                                                      clientQueue:dispatch_get_main_queue()
                                                       completion:^(id _Nullable value, NSError * _Nullable error) {


### PR DESCRIPTION
This is a re-landing of PR #22558 but modified to preserve the old APIs.

The header changes not accompanied by backwards-compat shims are OK for the following reasons:

* MTRAttributeCacheContainer+XPC.h is not public API.
* MTRAttributeCacheContainer_Internal.h is not public API.
* MTRDeviceOverXPC.h is not public API.
* MTRDeviceControllerXPCConnection.h is not public API.
* MTRDeviceControllerOverXPC.h is not public API.
* MTRDeviceControllerOverXPC_Internal.h is not public API.
