### PR TITLE
Darwin API review fixes for MTRSetupPayload and MTROptionalQRCodeInfo.

### DIFF
--- a/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
+++ b/examples/darwin-framework-tool/commands/payload/SetupPayloadParseCommand.mm
@@ -61,7 +61,7 @@ CHIP_ERROR SetupPayloadParseCommand::Run()
     NSString * codeString = [NSString stringWithCString:mCode encoding:NSASCIIStringEncoding];
     NSError * error;
     MTRSetupPayload * payload;
-    payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:codeString error:&error];
+    payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:codeString error:&error];
     if (error) {
         LogNSError("Error: ", error);
         return CHIP_ERROR_INTERNAL;
@@ -78,37 +78,33 @@ CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
     NSLog(@"ProductID:     %@", payload.productID);
     NSLog(@"Custom flow:   %tu    (%@)", payload.commissioningFlow, CustomFlowString(payload.commissioningFlow));
     {
-        if (payload.rendezvousInformation == nil) {
+        if (payload.discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
             NSLog(@"Capabilities:  UNKNOWN");
         } else {
             NSMutableString * humanFlags = [[NSMutableString alloc] init];
 
-            auto value = [payload.rendezvousInformation unsignedLongValue];
-            if (value == MTRDiscoveryCapabilitiesNone) {
-                [humanFlags appendString:@"NONE"];
-            } else {
-                if (value & MTRDiscoveryCapabilitiesSoftAP) {
-                    [humanFlags appendString:@"SoftAP"];
+            auto value = payload.discoveryCapabilities;
+            if (value & MTRDiscoveryCapabilitiesSoftAP) {
+                [humanFlags appendString:@"SoftAP"];
+            }
+            if (value & MTRDiscoveryCapabilitiesBLE) {
+                if (!humanFlags) {
+                    [humanFlags appendString:@", "];
                 }
-                if (value & MTRDiscoveryCapabilitiesBLE) {
-                    if (!humanFlags) {
-                        [humanFlags appendString:@", "];
-                    }
-                    [humanFlags appendString:@"BLE"];
+                [humanFlags appendString:@"BLE"];
+            }
+            if (value & MTRDiscoveryCapabilitiesOnNetwork) {
+                if (!humanFlags) {
+                    [humanFlags appendString:@", "];
                 }
-                if (value & MTRDiscoveryCapabilitiesOnNetwork) {
-                    if (!humanFlags) {
-                        [humanFlags appendString:@", "];
-                    }
-                    [humanFlags appendString:@"ON NETWORK"];
-                }
+                [humanFlags appendString:@"ON NETWORK"];
             }
 
             NSLog(@"Capabilities:  0x%02lX (%@)", static_cast<long>(value), humanFlags);
         }
     }
     NSLog(@"Discriminator: %@", payload.discriminator);
-    NSLog(@"Passcode:      %@", payload.setUpPINCode);
+    NSLog(@"Passcode:      %@", payload.setupPasscode);
 
     if (payload.serialNumber) {
         NSLog(@"SerialNumber: %@", payload.serialNumber);
@@ -120,8 +116,8 @@ CHIP_ERROR SetupPayloadParseCommand::Print(MTRSetupPayload * payload)
         return CHIP_ERROR_INTERNAL;
     }
     for (const MTROptionalQRCodeInfo * info : optionalVendorData) {
-        bool isTypeString = [info.infoType isEqual:@(MTROptionalQRCodeInfoTypeString)];
-        bool isTypeInt32 = [info.infoType isEqual:@(MTROptionalQRCodeInfoTypeInt32)];
+        bool isTypeString = (info.type == MTROptionalQRCodeInfoTypeString);
+        bool isTypeInt32 = (info.type == MTROptionalQRCodeInfoTypeInt32);
         VerifyOrReturnError(isTypeString || isTypeInt32, CHIP_ERROR_INVALID_ARGUMENT);
 
         if (isTypeString) {

--- a/src/darwin/Framework/CHIP/MTRBaseDevice.h
+++ b/src/darwin/Framework/CHIP/MTRBaseDevice.h
@@ -269,6 +269,67 @@ extern NSString * const MTRArrayValueType;
 
 @end
 
+@interface MTRAttributePath : NSObject <NSCopying>
+@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * attribute;
+
++ (instancetype)attributePathWithEndpointID:(NSNumber *)endpointID
+                                  clusterID:(NSNumber *)clusterID
+                                attributeID:(NSNumber *)attributeID MTR_NEWLY_AVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface MTREventPath : NSObject
+@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * event;
+
++ (instancetype)eventPathWithEndpointID:(NSNumber *)endpointID
+                              clusterID:(NSNumber *)clusterID
+                                eventID:(NSNumber *)eventID MTR_NEWLY_AVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface MTRCommandPath : NSObject
+@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * command;
+
++ (instancetype)commandPathWithEndpointID:(NSNumber *)endpointID
+                                clusterID:(NSNumber *)clusterID
+                                commandID:(NSNumber *)commandID MTR_NEWLY_AVAILABLE;
+
+- (instancetype)init NS_UNAVAILABLE;
++ (instancetype)new NS_UNAVAILABLE;
+@end
+
+@interface MTRAttributeReport : NSObject
+@property (nonatomic, readonly, strong, nonnull) MTRAttributePath * path;
+// value is nullable because nullable attributes can have nil as value.
+@property (nonatomic, readonly, strong, nullable) id value;
+// If this specific path resulted in an error, the error (in the
+// MTRInteractionErrorDomain or MTRErrorDomain) that corresponds to this
+// path.
+@property (nonatomic, readonly, strong, nullable) NSError * error;
+@end
+
+@interface MTREventReport : NSObject
+@property (nonatomic, readonly, strong, nonnull) MTREventPath * path;
+@property (nonatomic, readonly, strong, nonnull) NSNumber * eventNumber; // chip::EventNumber type (uint64_t)
+@property (nonatomic, readonly, strong, nonnull) NSNumber * priority; // chip::app::PriorityLevel type (uint8_t)
+@property (nonatomic, readonly, strong, nonnull) NSNumber * timestamp; // chip::app::Timestamp.mValue type (uint64_t)
+@property (nonatomic, readonly, strong, nullable) id value;
+// If this specific path resulted in an error, the error (in the
+// MTRInteractionErrorDomain or MTRErrorDomain) that corresponds to this
+// path.
+@property (nonatomic, readonly, strong, nullable) NSError * error;
+@end
+
 @interface MTRBaseDevice (Deprecated)
 
 /**
@@ -331,19 +392,6 @@ extern NSString * const MTRArrayValueType;
 
 @end
 
-@interface MTRAttributePath : NSObject <NSCopying>
-@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * attribute;
-
-+ (instancetype)attributePathWithEndpointID:(NSNumber *)endpointID
-                                  clusterID:(NSNumber *)clusterID
-                                attributeID:(NSNumber *)attributeID MTR_NEWLY_AVAILABLE;
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-@end
-
 @interface MTRAttributePath (Deprecated)
 
 + (instancetype)attributePathWithEndpointId:(NSNumber *)endpointId
@@ -351,19 +399,6 @@ extern NSString * const MTRArrayValueType;
                                 attributeId:(NSNumber *)attributeId
     MTR_NEWLY_DEPRECATED("Please use attributePathWithEndpointID:clusterID:attributeID:");
 
-@end
-
-@interface MTREventPath : NSObject
-@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * event;
-
-+ (instancetype)eventPathWithEndpointID:(NSNumber *)endpointID
-                              clusterID:(NSNumber *)clusterID
-                                eventID:(NSNumber *)eventID MTR_NEWLY_AVAILABLE;
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
 @end
 
 @interface MTREventPath (Deprecated)
@@ -375,19 +410,6 @@ extern NSString * const MTRArrayValueType;
 
 @end
 
-@interface MTRCommandPath : NSObject
-@property (nonatomic, readonly, strong, nonnull) NSNumber * endpoint;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * cluster;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * command;
-
-+ (instancetype)commandPathWithEndpointID:(NSNumber *)endpointID
-                                clusterID:(NSNumber *)clusterID
-                                commandID:(NSNumber *)commandID MTR_NEWLY_AVAILABLE;
-
-- (instancetype)init NS_UNAVAILABLE;
-+ (instancetype)new NS_UNAVAILABLE;
-@end
-
 @interface MTRCommandPath (Deprecated)
 
 + (instancetype)commandPathWithEndpointId:(NSNumber *)endpointId
@@ -395,28 +417,6 @@ extern NSString * const MTRArrayValueType;
                                 commandId:(NSNumber *)commandId
     MTR_NEWLY_DEPRECATED("Please use commandPathWithEndpointID:clusterID:commandID:");
 
-@end
-
-@interface MTRAttributeReport : NSObject
-@property (nonatomic, readonly, strong, nonnull) MTRAttributePath * path;
-// value is nullable because nullable attributes can have nil as value.
-@property (nonatomic, readonly, strong, nullable) id value;
-// If this specific path resulted in an error, the error (in the
-// MTRInteractionErrorDomain or MTRErrorDomain) that corresponds to this
-// path.
-@property (nonatomic, readonly, strong, nullable) NSError * error;
-@end
-
-@interface MTREventReport : NSObject
-@property (nonatomic, readonly, strong, nonnull) MTREventPath * path;
-@property (nonatomic, readonly, strong, nonnull) NSNumber * eventNumber; // chip::EventNumber type (uint64_t)
-@property (nonatomic, readonly, strong, nonnull) NSNumber * priority; // chip::app::PriorityLevel type (uint8_t)
-@property (nonatomic, readonly, strong, nonnull) NSNumber * timestamp; // chip::app::Timestamp.mValue type (uint64_t)
-@property (nonatomic, readonly, strong, nullable) id value;
-// If this specific path resulted in an error, the error (in the
-// MTRInteractionErrorDomain or MTRErrorDomain) that corresponds to this
-// path.
-@property (nonatomic, readonly, strong, nullable) NSError * error;
 @end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/MTRDevice.h
+++ b/src/darwin/Framework/CHIP/MTRDevice.h
@@ -166,17 +166,6 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
 
 @end
 
-@interface MTRDevice (Deprecated)
-
-/**
- * Deprecated MTRDevice APIs.
- */
-+ (instancetype)deviceWithNodeID:(uint64_t)nodeID
-                deviceController:(MTRDeviceController *)deviceController
-    MTR_NEWLY_DEPRECATED("Please use deviceWithNodeID:controller:");
-
-@end
-
 @protocol MTRDeviceDelegate <NSObject>
 @required
 /**
@@ -203,6 +192,17 @@ typedef NS_ENUM(NSUInteger, MTRDeviceState) {
  * @param eventReport  An array of response-value objects as described in MTRDeviceResponseHandler
  */
 - (void)device:(MTRDevice *)device receivedEventReport:(NSArray<NSDictionary<NSString *, id> *> *)eventReport;
+
+@end
+
+@interface MTRDevice (Deprecated)
+
+/**
+ * Deprecated MTRDevice APIs.
+ */
++ (instancetype)deviceWithNodeID:(uint64_t)nodeID
+                deviceController:(MTRDeviceController *)deviceController
+    MTR_NEWLY_DEPRECATED("Please use deviceWithNodeID:controller:");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController+XPC.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController+XPC.h
@@ -77,14 +77,6 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
 
 @end
 
-@interface MTRDeviceController (Deprecated_XPC)
-
-+ (MTRDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerID
-                                xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock
-    MTR_NEWLY_DEPRECATED("Please use sharedControllerWithID:xpcConnectBlock:");
-
-@end
-
 /**
  * Protocol that remote object must support over XPC
  */
@@ -191,6 +183,14 @@ typedef void (^MTRValuesHandler)(id _Nullable values, NSError * _Nullable error)
                             nodeId:(uint64_t)nodeId
                             values:(id _Nullable)values
                              error:(NSError * _Nullable)error;
+
+@end
+
+@interface MTRDeviceController (Deprecated_XPC)
+
++ (MTRDeviceController *)sharedControllerWithId:(id<NSCopying> _Nullable)controllerID
+                                xpcConnectBlock:(MTRXPCConnectBlock)xpcConnectBlock
+    MTR_NEWLY_DEPRECATED("Please use sharedControllerWithID:xpcConnectBlock:");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRDeviceController.h
+++ b/src/darwin/Framework/CHIP/MTRDeviceController.h
@@ -18,7 +18,6 @@
 #import <Foundation/Foundation.h>
 
 #import <Matter/MTRNOCChainIssuer.h>
-#import <Matter/MTROnboardingPayloadParser.h>
 
 @class MTRBaseDevice;
 
@@ -27,6 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 typedef void (^MTRDeviceConnectionCallback)(MTRBaseDevice * _Nullable device, NSError * _Nullable error);
 
 @class MTRCommissioningParameters;
+@class MTRSetupPayload;
 @protocol MTRDevicePairingDelegate;
 
 @interface MTRDeviceController : NSObject

--- a/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRManualSetupPayloadParser.h
@@ -21,6 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+MTR_NEWLY_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload")
 @interface MTRManualSetupPayloadParser : NSObject
 - (instancetype)initWithDecimalStringRepresentation:(NSString *)decimalStringRepresentation;
 - (nullable MTRSetupPayload *)populatePayload:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.h
+++ b/src/darwin/Framework/CHIP/MTRQRCodeSetupPayloadParser.h
@@ -21,6 +21,7 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
+MTR_NEWLY_DEPRECATED("Please use [MTRSetupPayload setupPayloadWithOnboardingPayload")
 @interface MTRQRCodeSetupPayloadParser : NSObject
 - (instancetype)initWithBase38Representation:(NSString *)base38Representation;
 - (nullable MTRSetupPayload *)populatePayload:(NSError * __autoreleasing *)error;

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -19,8 +19,9 @@
 
 NS_ASSUME_NONNULL_BEGIN
 
-typedef NS_ENUM(NSUInteger, MTRDiscoveryCapabilities) {
-    MTRDiscoveryCapabilitiesNone = 0, // Device does not support any method for rendezvous
+typedef NS_OPTIONS(NSUInteger, MTRDiscoveryCapabilities) {
+    MTRDiscoveryCapabilitiesUnknown = 0, // Device capabilities are not known (e.g. all we have is a manual pairing code).
+    MTRDiscoveryCapabilitiesNone MTR_NEWLY_DEPRECATED("Please use MTRDiscoveryCapabilitiesUnknown") = 0,
     MTRDiscoveryCapabilitiesSoftAP = 1 << 0, // Device supports WiFi softAP
     MTRDiscoveryCapabilitiesBLE = 1 << 1, // Device supports BLE
     MTRDiscoveryCapabilitiesOnNetwork = 1 << 2, // Device supports On Network setup
@@ -37,13 +38,18 @@ typedef NS_ENUM(NSUInteger, MTRCommissioningFlow) {
 };
 
 typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
-    MTROptionalQRCodeInfoTypeUnknown,
+    MTROptionalQRCodeInfoTypeUnknown MTR_NEWLY_DEPRECATED("The type is never actually unknown"),
     MTROptionalQRCodeInfoTypeString,
-    MTROptionalQRCodeInfoTypeInt32
+    MTROptionalQRCodeInfoTypeInt32,
 };
 
+/**
+ * An optional information item present in the QR code the setup payload was
+ * initialized from.
+ */
 @interface MTROptionalQRCodeInfo : NSObject
-@property (nonatomic, copy) NSNumber * infoType;
+@property (nonatomic, assign) MTROptionalQRCodeInfoType type MTR_NEWLY_AVAILABLE;
+// The numeric value of the TLV tag for this information item.
 @property (nonatomic, copy) NSNumber * tag;
 // Exactly one of integerValue and stringValue will be non-nil, depending on the
 // the value of "infoType".
@@ -51,6 +57,16 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 @property (nonatomic, copy, nullable) NSString * stringValue;
 @end
 
+@interface MTROptionalQRCodeInfo (Deprecated)
+
+@property (nonatomic, copy) NSNumber * infoType MTR_NEWLY_DEPRECATED("Please use type");
+
+@end
+
+/**
+ * A setup payload that can be created from a pairing code and serialized to a
+ * pairing code.
+ */
 @interface MTRSetupPayload : NSObject <NSSecureCoding>
 
 @property (nonatomic, copy) NSNumber * version;
@@ -58,15 +74,20 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 @property (nonatomic, copy) NSNumber * productID;
 @property (nonatomic, assign) MTRCommissioningFlow commissioningFlow;
 /**
- * rendezvousInformation is nil when the discovery capabilities bitmask is
- * unknown.
- *
- * Otherwise its value is made up of the MTRDiscoveryCapabilities flags.
+ * The value of discoveryCapabilities is made up of the various
+ * MTRDiscoveryCapabilities flags.  If the discovery capabilities are not known,
+ * this will be set to MTRDiscoveryCapabilitiesUnknown.
  */
-@property (nonatomic, copy, nullable) NSNumber * rendezvousInformation;
+@property (nonatomic, assign) MTRDiscoveryCapabilities discoveryCapabilities MTR_NEWLY_AVAILABLE;
 @property (nonatomic, copy) NSNumber * discriminator;
+/**
+ * If hasShortDiscriminator is true, the discriminator value contains just the
+ * high 4 bits of the full discriminator.  For example, if
+ * hasShortDiscriminator is true and discriminator is 0xA, then the full
+ * discriminator can be anything in the range 0xA00 t0 0xAFF.
+ */
 @property (nonatomic, assign) BOOL hasShortDiscriminator;
-@property (nonatomic, copy) NSNumber * setUpPINCode;
+@property (nonatomic, copy) NSNumber * setupPasscode MTR_NEWLY_AVAILABLE;
 
 @property (nonatomic, copy, nullable) NSString * serialNumber;
 - (nullable NSArray<MTROptionalQRCodeInfo *> *)getAllOptionalVendorData:(NSError * __autoreleasing *)error;
@@ -108,6 +129,13 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
  */
 - (NSString * _Nullable)qrCodeString:(NSError * __autoreleasing *)error
     API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
+
+@end
+
+@interface MTRSetupPayload (Deprecated)
+
+@property (nonatomic, copy, nullable) NSNumber * rendezvousInformation MTR_NEWLY_DEPRECATED("Please use discoveryCapabilities");
+@property (nonatomic, copy) NSNumber * setUpPINCode MTR_NEWLY_DEPRECATED("Please use setupPasscode");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.h
@@ -57,12 +57,6 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
 @property (nonatomic, copy, nullable) NSString * stringValue;
 @end
 
-@interface MTROptionalQRCodeInfo (Deprecated)
-
-@property (nonatomic, copy) NSNumber * infoType MTR_NEWLY_DEPRECATED("Please use type");
-
-@end
-
 /**
  * A setup payload that can be created from a pairing code and serialized to a
  * pairing code.
@@ -129,6 +123,12 @@ typedef NS_ENUM(NSUInteger, MTROptionalQRCodeInfoType) {
  */
 - (NSString * _Nullable)qrCodeString:(NSError * __autoreleasing *)error
     API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2));
+
+@end
+
+@interface MTROptionalQRCodeInfo (Deprecated)
+
+@property (nonatomic, copy) NSNumber * infoType MTR_NEWLY_DEPRECATED("Please use type");
 
 @end
 

--- a/src/darwin/Framework/CHIP/MTRSetupPayload.mm
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload.mm
@@ -26,17 +26,31 @@
 @implementation MTROptionalQRCodeInfo
 @end
 
+@implementation MTROptionalQRCodeInfo (Deprecated)
+
+- (NSNumber *)infoType
+{
+    return @(self.type);
+}
+
+- (void)setInfoType:(NSNumber *)infoType
+{
+    self.type = static_cast<MTROptionalQRCodeInfoType>([infoType unsignedIntValue]);
+}
+
+@end
+
 @implementation MTRSetupPayload {
     chip::SetupPayload _chipSetupPayload;
 }
 
-- (NSNumber *)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value
+- (MTRDiscoveryCapabilities)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value
 {
     if (!value.HasValue()) {
-        return nil;
+        return MTRDiscoveryCapabilitiesUnknown;
     }
 
-    NSUInteger flags = MTRDiscoveryCapabilitiesNone;
+    NSUInteger flags = 0;
     if (value.Value().Has(chip::RendezvousInformationFlag::kBLE)) {
         flags |= MTRDiscoveryCapabilitiesBLE;
     }
@@ -46,7 +60,11 @@
     if (value.Value().Has(chip::RendezvousInformationFlag::kOnNetwork)) {
         flags |= MTRDiscoveryCapabilitiesOnNetwork;
     }
-    return [NSNumber numberWithUnsignedLong:flags];
+    if (flags == MTRDiscoveryCapabilitiesUnknown) {
+        // OnNetwork has to be supported!
+        flags = MTRDiscoveryCapabilitiesOnNetwork;
+    }
+    return flags;
 }
 
 + (chip::Optional<chip::RendezvousInformationFlags>)unconvertRendezvousFlags:(nullable NSNumber *)nullableValue
@@ -108,14 +126,14 @@
         _vendorID = [NSNumber numberWithUnsignedShort:setupPayload.vendorID];
         _productID = [NSNumber numberWithUnsignedShort:setupPayload.productID];
         _commissioningFlow = [self convertCommissioningFlow:setupPayload.commissioningFlow];
-        _rendezvousInformation = [self convertRendezvousFlags:setupPayload.rendezvousInformation];
+        _discoveryCapabilities = [self convertRendezvousFlags:setupPayload.rendezvousInformation];
         _hasShortDiscriminator = setupPayload.discriminator.IsShortDiscriminator();
         if (_hasShortDiscriminator) {
             _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator.GetShortValue()];
         } else {
             _discriminator = [NSNumber numberWithUnsignedShort:setupPayload.discriminator.GetLongValue()];
         }
-        _setUpPINCode = [NSNumber numberWithUnsignedInt:setupPayload.setUpPINCode];
+        _setupPasscode = [NSNumber numberWithUnsignedInt:setupPayload.setUpPINCode];
 
         [self getSerialNumber:setupPayload];
     }
@@ -129,10 +147,10 @@
         _vendorID = @(0); // Not available.
         _productID = @(0); // Not available.
         _commissioningFlow = MTRCommissioningFlowStandard;
-        _rendezvousInformation = nil;
+        _discoveryCapabilities = MTRDiscoveryCapabilitiesUnknown;
         _hasShortDiscriminator = NO;
         _discriminator = discriminator;
-        _setUpPINCode = setupPasscode;
+        _setupPasscode = setupPasscode;
         _serialNumber = nil;
     }
     return self;
@@ -156,11 +174,11 @@
         info.tag = [NSNumber numberWithUnsignedChar:chipInfo.tag];
         switch (chipInfo.type) {
         case chip::optionalQRCodeInfoTypeString:
-            info.infoType = [NSNumber numberWithInt:MTROptionalQRCodeInfoTypeString];
+            info.type = MTROptionalQRCodeInfoTypeString;
             info.stringValue = [NSString stringWithUTF8String:chipInfo.data.c_str()];
             break;
         case chip::optionalQRCodeInfoTypeInt32:
-            info.infoType = [NSNumber numberWithInt:MTROptionalQRCodeInfoTypeInt32];
+            info.type = MTROptionalQRCodeInfoTypeInt32;
             info.integerValue = [NSNumber numberWithInt:chipInfo.int32];
             break;
         default:
@@ -236,10 +254,10 @@ static NSString * const MTRSetupPayloadCodingKeyVersion = @"MTRSP.ck.version";
 static NSString * const MTRSetupPayloadCodingKeyVendorID = @"MTRSP.ck.vendorID";
 static NSString * const MTRSetupPayloadCodingKeyProductID = @"MTRSP.ck.productID";
 static NSString * const MTRSetupPayloadCodingKeyCommissioningFlow = @"MTRSP.ck.commissioningFlow";
-static NSString * const MTRSetupPayloadCodingKeyRendezvousFlags = @"MTRSP.ck.rendezvousFlags";
+static NSString * const MTRSetupPayloadCodingKeyDiscoveryCapabilities = @"MTRSP.ck.discoveryCapabilities";
 static NSString * const MTRSetupPayloadCodingKeyHasShortDiscriminator = @"MTRSP.ck.hasShortDiscriminator";
 static NSString * const MTRSetupPayloadCodingKeyDiscriminator = @"MTRSP.ck.discriminator";
-static NSString * const MTRSetupPayloadCodingKeySetupPINCode = @"MTRSP.ck.setupPINCode";
+static NSString * const MTRSetupPayloadCodingKeySetupPasscode = @"MTRSP.ck.setupPasscode";
 static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serialNumber";
 
 + (BOOL)supportsSecureCoding
@@ -252,13 +270,13 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     [coder encodeObject:self.version forKey:MTRSetupPayloadCodingKeyVersion];
     [coder encodeObject:self.vendorID forKey:MTRSetupPayloadCodingKeyVendorID];
     [coder encodeObject:self.productID forKey:MTRSetupPayloadCodingKeyProductID];
-    // Casts are safe because commissioning flow and hasShortDiscriminator
-    // values are both pretty small and non-negative.
+    // Casts are safe because commissioning flow, discoveryCapabilities, and
+    // hasShortDiscriminator values are all pretty small and non-negative.
     [coder encodeInteger:static_cast<NSInteger>(self.commissioningFlow) forKey:MTRSetupPayloadCodingKeyCommissioningFlow];
-    [coder encodeObject:self.rendezvousInformation forKey:MTRSetupPayloadCodingKeyRendezvousFlags];
+    [coder encodeInteger:static_cast<NSInteger>(self.discoveryCapabilities) forKey:MTRSetupPayloadCodingKeyDiscoveryCapabilities];
     [coder encodeInteger:static_cast<NSInteger>(self.hasShortDiscriminator) forKey:MTRSetupPayloadCodingKeyHasShortDiscriminator];
     [coder encodeObject:self.discriminator forKey:MTRSetupPayloadCodingKeyDiscriminator];
-    [coder encodeObject:self.setUpPINCode forKey:MTRSetupPayloadCodingKeySetupPINCode];
+    [coder encodeObject:self.setupPasscode forKey:MTRSetupPayloadCodingKeySetupPasscode];
     [coder encodeObject:self.serialNumber forKey:MTRSetupPayloadCodingKeySerialNumber];
 }
 
@@ -268,11 +286,10 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     NSNumber * vendorID = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyVendorID];
     NSNumber * productID = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyProductID];
     NSInteger commissioningFlow = [decoder decodeIntegerForKey:MTRSetupPayloadCodingKeyCommissioningFlow];
-    NSNumber * rendezvousInformation = [decoder decodeObjectOfClass:[NSNumber class]
-                                                             forKey:MTRSetupPayloadCodingKeyRendezvousFlags];
+    NSInteger discoveryCapabilities = [decoder decodeIntegerForKey:MTRSetupPayloadCodingKeyDiscoveryCapabilities];
     NSInteger hasShortDiscriminator = [decoder decodeIntegerForKey:MTRSetupPayloadCodingKeyHasShortDiscriminator];
     NSNumber * discriminator = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeyDiscriminator];
-    NSNumber * setUpPINCode = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeySetupPINCode];
+    NSNumber * setupPasscode = [decoder decodeObjectOfClass:[NSNumber class] forKey:MTRSetupPayloadCodingKeySetupPasscode];
     NSString * serialNumber = [decoder decodeObjectOfClass:[NSString class] forKey:MTRSetupPayloadCodingKeySerialNumber];
 
     MTRSetupPayload * payload = [[MTRSetupPayload alloc] init];
@@ -280,10 +297,10 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     payload.vendorID = vendorID;
     payload.productID = productID;
     payload.commissioningFlow = static_cast<MTRCommissioningFlow>(commissioningFlow);
-    payload.rendezvousInformation = rendezvousInformation;
+    payload.discoveryCapabilities = static_cast<MTRDiscoveryCapabilities>(discoveryCapabilities);
     payload.hasShortDiscriminator = static_cast<BOOL>(hasShortDiscriminator);
     payload.discriminator = discriminator;
-    payload.setUpPINCode = setUpPINCode;
+    payload.setupPasscode = setupPasscode;
     payload.serialNumber = serialNumber;
 
     return payload;
@@ -303,7 +320,7 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     } else {
         payload.discriminator.SetLongValue([self.discriminator unsignedShortValue]);
     }
-    payload.setUpPINCode = [self.setUpPINCode unsignedIntValue];
+    payload.setUpPINCode = [self.setupPasscode unsignedIntValue];
 
     err = chip::ManualSetupPayloadGenerator(payload).payloadDecimalStringRepresentation(outDecimalString);
 
@@ -361,6 +378,38 @@ static NSString * const MTRSetupPayloadCodingKeySerialNumber = @"MTRSP.ck.serial
     }
 
     return [NSString stringWithUTF8String:outDecimalString.c_str()];
+}
+
+@end
+
+@implementation MTRSetupPayload (Deprecated)
+
+- (nullable NSNumber *)rendezvousInformation
+{
+    if (self.discoveryCapabilities == MTRDiscoveryCapabilitiesUnknown) {
+        return nil;
+    }
+
+    return @(self.discoveryCapabilities);
+}
+
+- (void)setRendezvousInformation:(nullable NSNumber *)rendezvousInformation
+{
+    if (rendezvousInformation == nil) {
+        self.discoveryCapabilities = MTRDiscoveryCapabilitiesUnknown;
+    } else {
+        self.discoveryCapabilities = [rendezvousInformation unsignedIntValue];
+    }
+}
+
+- (NSNumber *)setUpPINCode
+{
+    return self.setupPasscode;
+}
+
+- (void)setSetUpPINCode:(NSNumber *)setUpPINCode
+{
+    self.setupPasscode = setUpPINCode;
 }
 
 @end

--- a/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
+++ b/src/darwin/Framework/CHIP/MTRSetupPayload_Internal.h
@@ -18,7 +18,7 @@
 
 #ifdef __cplusplus
 - (instancetype)initWithSetupPayload:(chip::SetupPayload)setupPayload;
-- (NSNumber *)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value;
+- (MTRDiscoveryCapabilities)convertRendezvousFlags:(const chip::Optional<chip::RendezvousInformationFlags> &)value;
 - (MTRCommissioningFlow)convertCommissioningFlow:(chip::CommissioningFlow)value;
 #endif
 

--- a/src/darwin/Framework/CHIP/Matter.h
+++ b/src/darwin/Framework/CHIP/Matter.h
@@ -50,6 +50,7 @@
 #import <Matter/MTRNOCChainIssuer.h>
 #import <Matter/MTROTAHeaderParser.h>
 #import <Matter/MTROTAProviderDelegate.h>
+#import <Matter/MTROnboardingPayloadParser.h>
 #import <Matter/MTRPersistentStorageDelegate.h>
 #import <Matter/MTRQRCodeSetupPayloadParser.h>
 #import <Matter/MTRSetupPayload.h>

--- a/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRBaseClusters.zapt
@@ -61,14 +61,6 @@ subscriptionEstablished:(SubscriptionEstablishedHandler _Nullable)subscriptionEs
 
 @end
 
-@interface MTRBaseCluster{{asUpperCamelCase name}} (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 {{/chip_client_clusters}}
 
 {{#zcl_clusters}}
@@ -101,5 +93,16 @@ API_AVAILABLE(ios(16.2), macos(13.1), watchos(9.2), tvos(16.2))
 
 {{/zcl_bitmaps}}
 {{/zcl_clusters}}
+
+{{#chip_client_clusters includeAll=true}}
+@interface MTRBaseCluster{{asUpperCamelCase name}} (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+{{/chip_client_clusters}}
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
+++ b/src/darwin/Framework/CHIP/templates/MTRClusters.zapt
@@ -47,6 +47,9 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+{{/chip_client_clusters}}
+
+{{#chip_client_clusters includeAll=true}}
 @interface MTRCluster{{asUpperCamelCase name}} (Deprecated)
 
 - (nullable instancetype)initWithDevice:(MTRDevice *)device

--- a/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRBaseClusters.h
@@ -174,14 +174,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterIdentify (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Groups
  *    Attributes and commands for group configuration and manipulation.
@@ -320,14 +312,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterGroups (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -571,14 +555,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterScenes (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster On/Off
  *    Attributes and commands for switching devices between 'On' and 'Off' states.
@@ -793,14 +769,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterOnOff (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster On/off Switch Configuration
  *    Attributes and commands for configuring On/Off switching devices.
@@ -943,14 +911,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterOnOffSwitchConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -1351,14 +1311,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterLevelControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Binary Input (Basic)
  *    An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
@@ -1645,14 +1597,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterBinaryInputBasic (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Descriptor
  *    The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its
@@ -1824,14 +1768,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterDescriptor (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Binding
  *    The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
@@ -1955,14 +1891,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterBinding (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -2172,14 +2100,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterAccessControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Actions
  *    This cluster provides a standardized way for a Node (typically a Bridge, but could be any Node) to expose action information.
@@ -2353,14 +2273,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterActions (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -2835,14 +2747,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterBasic (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster OTA Software Update Provider
  *    Provides an interface for providing OTA software updates
@@ -2955,14 +2859,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterOtaSoftwareUpdateProvider (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -3153,14 +3049,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterOtaSoftwareUpdateRequestor (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Localization Configuration
  *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
@@ -3307,14 +3195,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterLocalizationConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -3489,14 +3369,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterTimeFormatLocalization (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Unit Localization
  *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
@@ -3628,14 +3500,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterUnitLocalization (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Power Source Configuration
  *    This cluster is used to describe the configuration and capabilities of a Device's power system.
@@ -3754,14 +3618,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterPowerSourceConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -4432,14 +4288,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterPowerSource (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster General Commissioning
  *    This cluster is used to manage global aspects of the Commissioning flow.
@@ -4654,14 +4502,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterGeneralCommissioning (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -4937,14 +4777,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterNetworkCommissioning (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Diagnostic Logs
  *    The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
@@ -5052,14 +4884,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterDiagnosticLogs (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -5334,14 +5158,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterGeneralDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Software Diagnostics
  *    The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
@@ -5523,14 +5339,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterSoftwareDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -6786,14 +6594,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterThreadNetworkDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster WiFi Network Diagnostics
  *    The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
@@ -7136,14 +6936,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterWiFiNetworkDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Ethernet Network Diagnostics
  *    The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a
@@ -7410,14 +7202,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterEthernetNetworkDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -7794,14 +7578,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRBaseClusterBridgedDeviceBasic (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Switch
  *    This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
@@ -7964,14 +7740,6 @@ light or a window shade.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterSwitch (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -8140,14 +7908,6 @@ light or a window shade.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterAdministratorCommissioning (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -8388,14 +8148,6 @@ light or a window shade.
 
 @end
 
-@interface MTRBaseClusterOperationalCredentials (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Group Key Management
  *    The Group Key Management Cluster is the mechanism by which group keys are managed.
@@ -8587,14 +8339,6 @@ light or a window shade.
 
 @end
 
-@interface MTRBaseClusterGroupKeyManagement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Fixed Label
  *    The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
@@ -8715,14 +8459,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterFixedLabel (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -8852,14 +8588,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterUserLabel (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Boolean State
  *    This cluster provides an interface to a boolean state called StateValue.
@@ -8980,14 +8708,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterBooleanState (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -9207,14 +8927,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterModeSelect (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -10102,14 +9814,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterDoorLock (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Window Covering
  *    Provides an interface for controlling and adjusting automatic window coverings.
@@ -10644,14 +10348,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterWindowCovering (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Barrier Control
  *    This cluster provides control of a barrier (garage door).
@@ -10971,14 +10667,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterBarrierControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -11506,14 +11194,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterPumpConfigurationAndControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -12657,14 +12337,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterThermostat (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Fan Control
  *    An interface for controlling a fan in a heating/cooling system.
@@ -12985,14 +12657,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterFanControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Thermostat User Interface Configuration
  *    An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
@@ -13166,14 +12830,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterThermostatUserInterfaceConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -14284,14 +13940,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterColorControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Ballast Configuration
  *    Attributes and commands for configuring a lighting ballast.
@@ -14690,14 +14338,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterBallastConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Illuminance Measurement
  *    Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
@@ -14892,14 +14532,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterIlluminanceMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Temperature Measurement
  *    Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
@@ -15073,14 +14705,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterTemperatureMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -15346,14 +14970,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterPressureMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Flow Measurement
  *    Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
@@ -15530,14 +15146,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterFlowMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Relative Humidity Measurement
  *    Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
@@ -15711,14 +15319,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterRelativeHumidityMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -16102,14 +15702,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterOccupancySensing (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Wake on LAN
  *    This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
@@ -16230,14 +15822,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterWakeOnLan (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -16407,14 +15991,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterChannel (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Target Navigator
  *    This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
@@ -16556,14 +16132,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterTargetNavigator (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -16846,14 +16414,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterMediaPlayback (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Media Input
  *    This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
@@ -17003,14 +16563,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterMediaInput (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Low Power
  *    This cluster provides an interface for managing low power mode on a device.
@@ -17117,14 +16669,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterLowPower (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -17235,14 +16779,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterKeypadInput (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -17400,14 +16936,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterContentLauncher (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Audio Output
  *    This cluster provides an interface for controlling the Output on a media device such as a TV.
@@ -17550,14 +17078,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterAudioOutput (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -17714,14 +17234,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterApplicationLauncher (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -17970,14 +17482,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterApplicationBasic (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Account Login
  *    This cluster provides commands that facilitate user account login on a Content App or a node. For example, a Content App
@@ -18091,14 +17595,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRBaseClusterAccountLogin (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
 
 @end
 
@@ -20616,14 +20112,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterElectricalMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 /**
  * Cluster Test Cluster
  *    The Test Cluster is meant to validate the generated code
@@ -22561,14 +22049,6 @@ labels.
 
 @end
 
-@interface MTRBaseClusterTestCluster (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
-
-@end
-
 typedef NS_ENUM(uint8_t, MTRIdentifyEffectIdentifier) {
     MTRIdentifyEffectIdentifierBlink = 0x00,
     MTRIdentifyEffectIdentifierBreathe = 0x01,
@@ -24016,5 +23496,525 @@ typedef NS_ENUM(uint8_t, MTRFaultInjectionFaultType) {
     MTRFaultInjectionFaultTypeChipFault = 0x03,
     MTRFaultInjectionFaultTypeCertFault = 0x04,
 };
+
+@interface MTRBaseClusterIdentify (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterGroups (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterScenes (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterOnOff (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterOnOffSwitchConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterLevelControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterBinaryInputBasic (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterDescriptor (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterBinding (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterAccessControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterActions (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterBasic (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterOtaSoftwareUpdateProvider (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterOtaSoftwareUpdateRequestor (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterLocalizationConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterTimeFormatLocalization (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterUnitLocalization (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterPowerSourceConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterPowerSource (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterGeneralCommissioning (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterNetworkCommissioning (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterDiagnosticLogs (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterGeneralDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterSoftwareDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterThreadNetworkDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterWiFiNetworkDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterEthernetNetworkDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterBridgedDeviceBasic (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterSwitch (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterAdministratorCommissioning (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterOperationalCredentials (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterGroupKeyManagement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterFixedLabel (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterUserLabel (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterBooleanState (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterModeSelect (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterDoorLock (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterWindowCovering (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterBarrierControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterPumpConfigurationAndControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterThermostat (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterFanControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterThermostatUserInterfaceConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterColorControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterBallastConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterIlluminanceMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterTemperatureMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterPressureMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterFlowMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterRelativeHumidityMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterOccupancySensing (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterWakeOnLan (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterChannel (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterTargetNavigator (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterMediaPlayback (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterMediaInput (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterLowPower (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterKeypadInput (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterContentLauncher (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterAudioOutput (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterApplicationLauncher (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterApplicationBasic (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterAccountLogin (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterElectricalMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
+
+@interface MTRBaseClusterTestCluster (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRBaseDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpointID:queue:");
+
+@end
 
 NS_ASSUME_NONNULL_END

--- a/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
+++ b/src/darwin/Framework/CHIP/zap-generated/MTRClusters.h
@@ -69,14 +69,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterIdentify (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Groups
  *    Attributes and commands for group configuration and manipulation.
@@ -133,14 +125,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterGroups (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -231,14 +215,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterScenes (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster On/Off
  *    Attributes and commands for switching devices between 'On' and 'Off' states.
@@ -326,14 +302,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterOnOff (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster On/off Switch Configuration
  *    Attributes and commands for configuring On/Off switching devices.
@@ -365,14 +333,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterOnOffSwitchConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -501,14 +461,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterLevelControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Binary Input (Basic)
  *    An interface for reading the value of a binary measurement and accessing various characteristics of that measurement.
@@ -582,14 +534,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterBinaryInputBasic (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Descriptor
  *    The Descriptor Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for describing a node, its
@@ -624,14 +568,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterDescriptor (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Binding
  *    The Binding Cluster is meant to replace the support from the Zigbee Device Object (ZDO) for supporting the binding table.
@@ -661,14 +597,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterBinding (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -717,14 +645,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterAccessControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -805,14 +725,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterActions (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -906,14 +818,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterBasic (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster OTA Software Update Provider
  *    Provides an interface for providing OTA software updates
@@ -951,14 +855,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterOtaSoftwareUpdateProvider (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -1005,14 +901,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterOtaSoftwareUpdateRequestor (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Localization Configuration
  *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
@@ -1047,14 +935,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterLocalizationConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -1102,14 +982,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterTimeFormatLocalization (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Unit Localization
  *    Nodes should be expected to be deployed to any and all regions of the world. These global regions
@@ -1145,14 +1017,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterUnitLocalization (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Power Source Configuration
  *    This cluster is used to describe the configuration and capabilities of a Device's power system.
@@ -1177,14 +1041,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterPowerSourceConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -1276,14 +1132,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterPowerSource (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster General Commissioning
  *    This cluster is used to manage global aspects of the Commissioning flow.
@@ -1343,14 +1191,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterGeneralCommissioning (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -1431,14 +1271,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterNetworkCommissioning (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Diagnostic Logs
  *    The cluster provides commands for retrieving unstructured diagnostic logs from a Node that may be used to aid in diagnostics.
@@ -1467,14 +1299,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterDiagnosticLogs (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -1527,14 +1351,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterGeneralDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Software Diagnostics
  *    The Software Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node to
@@ -1574,14 +1390,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterSoftwareDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -1745,14 +1553,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterThreadNetworkDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster WiFi Network Diagnostics
  *    The Wi-Fi Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a Node
@@ -1813,14 +1613,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterWiFiNetworkDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Ethernet Network Diagnostics
  *    The Ethernet Network Diagnostics Cluster provides a means to acquire standardized diagnostics metrics that MAY be used by a
@@ -1870,14 +1662,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterEthernetNetworkDiagnostics (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -1944,14 +1728,6 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
-@interface MTRClusterBridgedDeviceBasic (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Switch
  *    This cluster exposes interactions with a switch device, for the purpose of using those interactions by other devices.
@@ -1985,14 +1761,6 @@ light or a window shade.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterSwitch (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -2040,14 +1808,6 @@ light or a window shade.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterAdministratorCommissioning (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -2129,14 +1889,6 @@ light or a window shade.
 
 @end
 
-@interface MTRClusterOperationalCredentials (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Group Key Management
  *    The Group Key Management Cluster is the mechanism by which group keys are managed.
@@ -2194,14 +1946,6 @@ light or a window shade.
 
 @end
 
-@interface MTRClusterGroupKeyManagement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Fixed Label
  *    The Fixed Label Cluster provides a feature for the device to tag an endpoint with zero or more read only
@@ -2227,14 +1971,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterFixedLabel (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -2270,14 +2006,6 @@ labels.
 
 @end
 
-@interface MTRClusterUserLabel (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Boolean State
  *    This cluster provides an interface to a boolean state called StateValue.
@@ -2302,14 +2030,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterBooleanState (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -2362,14 +2082,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterModeSelect (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -2639,14 +2351,6 @@ labels.
 
 @end
 
-@interface MTRClusterDoorLock (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Window Covering
  *    Provides an interface for controlling and adjusting automatic window coverings.
@@ -2759,14 +2463,6 @@ labels.
 
 @end
 
-@interface MTRClusterWindowCovering (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Barrier Control
  *    This cluster provides control of a barrier (garage door).
@@ -2851,14 +2547,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterBarrierControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -2950,14 +2638,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterPumpConfigurationAndControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -3240,14 +2920,6 @@ labels.
 
 @end
 
-@interface MTRClusterThermostat (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Fan Control
  *    An interface for controlling a fan in a heating/cooling system.
@@ -3325,14 +2997,6 @@ labels.
 
 @end
 
-@interface MTRClusterFanControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Thermostat User Interface Configuration
  *    An interface for configuring the user interface of a thermostat (which may be remote from the thermostat).
@@ -3376,14 +3040,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterThermostatUserInterfaceConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -3658,14 +3314,6 @@ labels.
 
 @end
 
-@interface MTRClusterColorControl (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Ballast Configuration
  *    Attributes and commands for configuring a lighting ballast.
@@ -3769,14 +3417,6 @@ labels.
 
 @end
 
-@interface MTRClusterBallastConfiguration (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Illuminance Measurement
  *    Attributes and commands for configuring the measurement of illuminance, and reporting illuminance measurements.
@@ -3812,14 +3452,6 @@ labels.
 
 @end
 
-@interface MTRClusterIlluminanceMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Temperature Measurement
  *    Attributes and commands for configuring the measurement of temperature, and reporting temperature measurements.
@@ -3850,14 +3482,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterTemperatureMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -3904,14 +3528,6 @@ labels.
 
 @end
 
-@interface MTRClusterPressureMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Flow Measurement
  *    Attributes and commands for configuring the measurement of flow, and reporting flow measurements.
@@ -3945,14 +3561,6 @@ labels.
 
 @end
 
-@interface MTRClusterFlowMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Relative Humidity Measurement
  *    Attributes and commands for configuring the measurement of relative humidity, and reporting relative humidity measurements.
@@ -3983,14 +3591,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterRelativeHumidityMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -4089,14 +3689,6 @@ labels.
 
 @end
 
-@interface MTRClusterOccupancySensing (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Wake on LAN
  *    This cluster provides an interface for managing low power mode on a device that supports the Wake On LAN protocol.
@@ -4121,14 +3713,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterWakeOnLan (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -4177,14 +3761,6 @@ labels.
 
 @end
 
-@interface MTRClusterChannel (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Target Navigator
  *    This cluster provides an interface for UX navigation within a set of targets on a device or endpoint.
@@ -4217,14 +3793,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterTargetNavigator (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -4356,14 +3924,6 @@ labels.
 
 @end
 
-@interface MTRClusterMediaPlayback (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Media Input
  *    This cluster provides an interface for controlling the Input Selector on a media device such as a TV.
@@ -4416,14 +3976,6 @@ labels.
 
 @end
 
-@interface MTRClusterMediaInput (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Low Power
  *    This cluster provides an interface for managing low power mode on a device.
@@ -4457,14 +4009,6 @@ labels.
 
 @end
 
-@interface MTRClusterLowPower (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Keypad Input
  *    This cluster provides an interface for controlling a device like a TV using action commands such as UP, DOWN, and SELECT.
@@ -4493,14 +4037,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterKeypadInput (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -4549,14 +4085,6 @@ labels.
 
 @end
 
-@interface MTRClusterContentLauncher (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Audio Output
  *    This cluster provides an interface for controlling the Output on a media device such as a TV.
@@ -4592,14 +4120,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterAudioOutput (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -4653,14 +4173,6 @@ labels.
 
 @end
 
-@interface MTRClusterApplicationLauncher (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
-
-@end
-
 /**
  * Cluster Application Basic
  *    This cluster provides information about an application running on a TV or media player device which is represented as an
@@ -4700,14 +4212,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterApplicationBasic (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -4752,14 +4256,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterAccountLogin (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -5094,14 +4590,6 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
-
-@end
-
-@interface MTRClusterElectricalMeasurement (Deprecated)
-
-- (nullable instancetype)initWithDevice:(MTRDevice *)device
-                               endpoint:(uint16_t)endpoint
-                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 
@@ -5836,6 +5324,518 @@ labels.
 
 - (instancetype)init NS_UNAVAILABLE;
 + (instancetype)new NS_UNAVAILABLE;
+
+@end
+
+@interface MTRClusterIdentify (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterGroups (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterScenes (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterOnOff (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterOnOffSwitchConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterLevelControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterBinaryInputBasic (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterDescriptor (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterBinding (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterAccessControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterActions (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterBasic (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterOtaSoftwareUpdateProvider (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterOtaSoftwareUpdateRequestor (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterLocalizationConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterTimeFormatLocalization (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterUnitLocalization (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterPowerSourceConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterPowerSource (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterGeneralCommissioning (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterNetworkCommissioning (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterDiagnosticLogs (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterGeneralDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterSoftwareDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterThreadNetworkDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterWiFiNetworkDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterEthernetNetworkDiagnostics (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterBridgedDeviceBasic (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterSwitch (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterAdministratorCommissioning (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterOperationalCredentials (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterGroupKeyManagement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterFixedLabel (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterUserLabel (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterBooleanState (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterModeSelect (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterDoorLock (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterWindowCovering (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterBarrierControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterPumpConfigurationAndControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterThermostat (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterFanControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterThermostatUserInterfaceConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterColorControl (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterBallastConfiguration (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterIlluminanceMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterTemperatureMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterPressureMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterFlowMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterRelativeHumidityMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterOccupancySensing (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterWakeOnLan (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterChannel (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterTargetNavigator (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterMediaPlayback (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterMediaInput (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterLowPower (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterKeypadInput (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterContentLauncher (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterAudioOutput (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterApplicationLauncher (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterApplicationBasic (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterAccountLogin (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
+
+@end
+
+@interface MTRClusterElectricalMeasurement (Deprecated)
+
+- (nullable instancetype)initWithDevice:(MTRDevice *)device
+                               endpoint:(uint16_t)endpoint
+                                  queue:(dispatch_queue_t)queue MTR_NEWLY_DEPRECATED("Please use initWithDevice:endpoindID:queue:");
 
 @end
 

--- a/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
+++ b/src/darwin/Framework/CHIPTests/MTRSetupPayloadParserTests.m
@@ -18,9 +18,6 @@
  *    limitations under the License.
  */
 // module headers
-#import "MTRManualSetupPayloadParser.h"
-#import "MTROnboardingPayloadParser.h"
-#import "MTRQRCodeSetupPayloadParser.h"
 #import "MTRSetupPayload.h"
 
 // additional includes
@@ -38,87 +35,91 @@
 - (void)testOnboardingPayloadParser_Manual_NoError
 {
     NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"636108753500001000015" error:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"641286075300001000016" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertTrue(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 12345670);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertNil(payload.rendezvousInformation);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
 }
 
 - (void)testOnboardingPayloadParser_QRCode_NoError
 {
     NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser setupPayloadForOnboardingPayload:@"MT:R5L90MP500K64J00000"
-                                                                                       error:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J00000" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
-    XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertNotNil(payload.rendezvousInformation);
-    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
+}
+
+- (void)testOnboardingPayloadParser_QRCode_WrongVersion
+{
+    // Same as testOnboardingPayloadParser_QRCode_NoError, but with version set to 5.
+    NSError * error;
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:R5L90MP500K64J00000" error:&error];
+
+    XCTAssertNil(payload);
+    XCTAssertNotNil(error);
 }
 
 - (void)testOnboardingPayloadParser_NFC_NoError
 {
     NSError * error;
-    MTRSetupPayload * payload = [MTROnboardingPayloadParser
-        setupPayloadForOnboardingPayload:@"MT:R5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
-                                   error:&error];
+    MTRSetupPayload * payload =
+        [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
+                                                     error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
-    XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertNotNil(payload.rendezvousInformation);
-    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
 }
 
 - (void)testManualParser
 {
     NSError * error;
-    MTRManualSetupPayloadParser * parser =
-        [[MTRManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:@"636108753500001000015"];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"641286075300001000016" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertTrue(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 10);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 123456780);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 12345670);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowCustom);
     XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
-    XCTAssertNil(payload.rendezvousInformation);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
 }
 
 - (void)testManualParser_Error
 {
     NSError * error;
-    MTRManualSetupPayloadParser * parser = [[MTRManualSetupPayloadParser alloc] initWithDecimalStringRepresentation:@""];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"" error:&error];
 
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, MTRErrorCodeInvalidStringLength);
@@ -127,9 +128,7 @@
 - (void)testQRCodeParser_Error
 {
     NSError * error;
-    MTRQRCodeSetupPayloadParser * parser =
-        [[MTRQRCodeSetupPayloadParser alloc] initWithBase38Representation:@"MT:R5L90MP500K64J0000."];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J0000." error:&error];
 
     XCTAssertNil(payload);
     XCTAssertEqual(error.code, MTRErrorCodeInvalidArgument);
@@ -138,43 +137,39 @@
 - (void)testQRCodeParser
 {
     NSError * error;
-    MTRQRCodeSetupPayloadParser * parser =
-        [[MTRQRCodeSetupPayloadParser alloc] initWithBase38Representation:@"MT:R5L90MP500K64J00000"];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J00000" error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
-    XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
-    XCTAssertNotNil(payload.rendezvousInformation);
-    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
 }
 
 - (void)testQRCodeParserWithOptionalData
 {
     NSError * error;
-    MTRQRCodeSetupPayloadParser * parser = [[MTRQRCodeSetupPayloadParser alloc]
-        initWithBase38Representation:@"MT:R5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"];
-    MTRSetupPayload * payload = [parser populatePayload:&error];
+    MTRSetupPayload * payload =
+        [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L90MP500K64J0A33P0SET70.QT52B.E23-WZE0WISA0DK5N1K8SQ1RYCU1O0"
+                                                     error:&error];
 
     XCTAssertNotNil(payload);
     XCTAssertNil(error);
 
-    XCTAssertEqual(payload.version.unsignedIntegerValue, 5);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
     XCTAssertFalse(payload.hasShortDiscriminator);
     XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
-    XCTAssertEqual(payload.setUpPINCode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
     XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
     XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
     XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
-    XCTAssertNotNil(payload.rendezvousInformation);
-    XCTAssertEqual([payload.rendezvousInformation unsignedLongValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
     XCTAssertTrue([payload.serialNumber isEqualToString:@"123456789"]);
 
     NSArray<MTROptionalQRCodeInfo *> * vendorOptionalInfo = [payload getAllOptionalVendorData:&error];
@@ -182,13 +177,77 @@
     XCTAssertEqual([vendorOptionalInfo count], 2);
     for (MTROptionalQRCodeInfo * info in vendorOptionalInfo) {
         if (info.tag.intValue == 130) {
-            XCTAssertEqual(info.infoType.intValue, MTROptionalQRCodeInfoTypeString);
+            XCTAssertEqual(info.type, MTROptionalQRCodeInfoTypeString);
+            XCTAssertEqual([info.infoType unsignedIntValue], MTROptionalQRCodeInfoTypeString);
             XCTAssertTrue([info.stringValue isEqualToString:@"myData"]);
         } else if (info.tag.intValue == 131) {
-            XCTAssertEqual(info.infoType.intValue, MTROptionalQRCodeInfoTypeInt32);
+            XCTAssertEqual(info.type, MTROptionalQRCodeInfoTypeInt32);
+            XCTAssertEqual([info.infoType unsignedIntValue], MTROptionalQRCodeInfoTypeInt32);
             XCTAssertEqual(info.integerValue.intValue, 12);
         }
     }
+}
+
+- (void)testQRCodeWithNoCapabilities
+{
+    NSError * error;
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L9000000K64J00000" error:&error];
+
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertFalse(payload.hasShortDiscriminator);
+    XCTAssertEqual(payload.discriminator.unsignedIntegerValue, 128);
+    XCTAssertEqual(payload.setupPasscode.unsignedIntegerValue, 2048);
+    XCTAssertEqual(payload.vendorID.unsignedIntegerValue, 12);
+    XCTAssertEqual(payload.productID.unsignedIntegerValue, 1);
+    XCTAssertEqual(payload.commissioningFlow, MTRCommissioningFlowStandard);
+    XCTAssertEqual(payload.version.unsignedIntegerValue, 0);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesOnNetwork);
+}
+
+- (void)testQRCodePropertyAliases
+{
+    NSError * error;
+    MTRSetupPayload * payload = [MTRSetupPayload setupPayloadWithOnboardingPayload:@"MT:M5L9000000K64J00000" error:&error];
+
+    XCTAssertNotNil(payload);
+    XCTAssertNil(error);
+
+    XCTAssertNotNil(payload.rendezvousInformation);
+    XCTAssertEqual([payload.rendezvousInformation unsignedIntValue], MTRDiscoveryCapabilitiesOnNetwork);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesOnNetwork);
+
+    // Check that writing to rendezvousInformation is reflected in
+    // discoveryCapabilities.
+    payload.rendezvousInformation = nil;
+    XCTAssertNil(payload.rendezvousInformation);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
+
+    payload.rendezvousInformation = @(MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertNotNil(payload.rendezvousInformation);
+    XCTAssertEqual([payload.rendezvousInformation unsignedIntValue], MTRDiscoveryCapabilitiesSoftAP);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesSoftAP);
+
+    // Check that writing to discoveryCapabilities is reflected in
+    // rendezvousInformation.
+    payload.discoveryCapabilities = MTRDiscoveryCapabilitiesBLE;
+    XCTAssertNotNil(payload.rendezvousInformation);
+    XCTAssertEqual([payload.rendezvousInformation unsignedIntValue], MTRDiscoveryCapabilitiesBLE);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesBLE);
+
+    payload.discoveryCapabilities = MTRDiscoveryCapabilitiesUnknown;
+    XCTAssertNil(payload.rendezvousInformation);
+    XCTAssertEqual(payload.discoveryCapabilities, MTRDiscoveryCapabilitiesUnknown);
+
+    // Check that setupPasscode and setUpPINCode alias each other.
+    payload.setupPasscode = @(1);
+    XCTAssertEqualObjects(payload.setupPasscode, @(1));
+    XCTAssertEqualObjects(payload.setUpPINCode, @(1));
+
+    payload.setUpPINCode = @(2);
+    XCTAssertEqualObjects(payload.setupPasscode, @(2));
+    XCTAssertEqualObjects(payload.setUpPINCode, @(2));
 }
 
 @end


### PR DESCRIPTION
This is a re-landing of PR 22566 but with some changes made for backwards compat.

* Add MTRDiscoveryCapabilitiesUnknown to indicate capabilities unknown (e.g. manual setup code).
* In MTROptionalQRCodeInfo add a "type" which is just MTROptionalQRCodeInfoType, not NSNumber.
* In MTRSetupPayload, add a discoveryCapabilities which is just a MTRDiscoveryCapabilities value, not nullable NSNumber, with MTRDiscoveryCapabilitiesUnknown meaning unknown. When parsing QR code, if the value ends up as 0, reset it to MTRDiscoveryCapabilitiesOnNetwork.
* Add setupPasscode as a better-named alias for setUpPINCode.
* Change some QR codes in the test that had version set to 5, since the new API we're using to parse them does not allow invalid (e.g. version != 0) payloads.
