### PR TITLE
Listen only on one of Ipv4&IPv6 address for minmdns

### DIFF
--- a/examples/minimal-mdns/client.cpp
+++ b/examples/minimal-mdns/client.cpp
@@ -269,19 +269,20 @@ void BroadcastPacket(mdns::Minimal::ServerBase * server)
         return;
     }
 
+    CHIP_ERROR err;
     if (gOptions.unicastAnswers)
     {
-        if (server->BroadcastUnicastQuery(builder.ReleasePacket(), gOptions.querySendPort) != CHIP_NO_ERROR)
+        if ((err = server->BroadcastUnicastQuery(builder.ReleasePacket(), gOptions.querySendPort)) != CHIP_NO_ERROR)
         {
-            printf("Error sending\n");
+            printf("Error sending: %" CHIP_ERROR_FORMAT "\n", err.Format());
             return;
         }
     }
     else
     {
-        if (server->BroadcastSend(builder.ReleasePacket(), gOptions.querySendPort) != CHIP_NO_ERROR)
+        if ((err = server->BroadcastSend(builder.ReleasePacket(), gOptions.querySendPort)) != CHIP_NO_ERROR)
         {
-            printf("Error sending\n");
+            printf("Error broadcast sending: %" CHIP_ERROR_FORMAT "\n", err.Format());
             return;
         }
     }

--- a/src/lib/dnssd/minimal_mdns/Server.cpp
+++ b/src/lib/dnssd/minimal_mdns/Server.cpp
@@ -298,7 +298,7 @@ CHIP_ERROR ServerBase::DirectSend(chip::System::PacketBufferHandle && data, cons
             return chip::Loop::Continue;
         }
 
-        err = info->mListenUdp->SendTo(addr, port, std::move(data));
+        err = info->mListenUdp->SendTo(addr, port, std::move(data), interface);
         return chip::Loop::Break;
     });
 


### PR DESCRIPTION
MinMdns creates too much traffic, as described in #23360:
  - By default we create a UDP endpoint on every single interface (and many developer machines may have at least ethernet and WiFi
  - broadcasts are sent on every interface, however it seems broadcasts do not take into account interfaceid when sent and as a result we multiply queries a lot
  - replies suffer from the same issue: any reply that is broadcasted (we do attempt unicast at first) will send a lot of traffic

Change in the PR:
  - default address logic will create just one of IPv4 and IPv6 listen address
  
Testing:
  - tested with linux minmdns, saw less traffic (but not perfect: a single query may arrive over different interfaces hence the same reply is sent many times .. this can be solved in a followup)
  - was able to manually commission a m5stack with chip-tool on linux, both using minmdns ipv6 only builds.

