### PR TITLE
Implement chip::Access::AccessControl::ResetAccessControl

### DIFF
--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -632,5 +632,10 @@ void SetAccessControl(AccessControl & accessControl)
     globalAccessControl = &accessControl;
 }
 
+void ResetAccessControl()
+{
+    globalAccessControl = &defaultAccessControl;
+}
+
 } // namespace Access
 } // namespace chip

--- a/src/access/AccessControl.cpp
+++ b/src/access/AccessControl.cpp
@@ -632,7 +632,7 @@ void SetAccessControl(AccessControl & accessControl)
     globalAccessControl = &accessControl;
 }
 
-void ResetAccessControl()
+void ResetAccessControlToDefault()
 {
     globalAccessControl = &defaultAccessControl;
 }

--- a/src/access/AccessControl.h
+++ b/src/access/AccessControl.h
@@ -683,7 +683,7 @@ void SetAccessControl(AccessControl & accessControl);
  *
  * Calls to this function must be synchronized externally.
  */
-void ResetAccessControl();
+void ResetAccessControlToDefault();
 
 } // namespace Access
 } // namespace chip

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -2173,6 +2173,7 @@ int Setup(void * inContext)
 int Teardown(void * inContext)
 {
     GetAccessControl().Finish();
+    ResetAccessControl();
     return SUCCESS;
 }
 

--- a/src/access/tests/TestAccessControl.cpp
+++ b/src/access/tests/TestAccessControl.cpp
@@ -2173,7 +2173,7 @@ int Setup(void * inContext)
 int Teardown(void * inContext)
 {
     GetAccessControl().Finish();
-    ResetAccessControl();
+    ResetAccessControlToDefault();
     return SUCCESS;
 }
 

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -430,6 +430,7 @@ void Server::Shutdown()
     mSessions.Shutdown();
     mTransports.Close();
     mAccessControl.Finish();
+    Access::ResetAccessControl();
     Credentials::SetGroupDataProvider(nullptr);
     mAttributePersister.Shutdown();
     // TODO(16969): Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code

--- a/src/app/server/Server.cpp
+++ b/src/app/server/Server.cpp
@@ -430,7 +430,7 @@ void Server::Shutdown()
     mSessions.Shutdown();
     mTransports.Close();
     mAccessControl.Finish();
-    Access::ResetAccessControl();
+    Access::ResetAccessControlToDefault();
     Credentials::SetGroupDataProvider(nullptr);
     mAttributePersister.Shutdown();
     // TODO(16969): Remove chip::Platform::MemoryInit() call from Server class, it belongs to outer code

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -52,6 +52,7 @@ CHIP_ERROR AppContext::Init()
 void AppContext::Shutdown()
 {
     Access::GetAccessControl().Finish();
+    Access::ResetAccessControl();
 
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
     Super::Shutdown();

--- a/src/app/tests/AppTestContext.cpp
+++ b/src/app/tests/AppTestContext.cpp
@@ -52,7 +52,7 @@ CHIP_ERROR AppContext::Init()
 void AppContext::Shutdown()
 {
     Access::GetAccessControl().Finish();
-    Access::ResetAccessControl();
+    Access::ResetAccessControlToDefault();
 
     chip::app::InteractionModelEngine::GetInstance()->Shutdown();
     Super::Shutdown();


### PR DESCRIPTION
It is not currently possible to release the injected AccessControl instance from the sdk's Access control singleton vendor because the symmetric reset method for Access::SetAccessControl isn't implemented. This commit adds the implementation.

Fixes #23415

