### PR TITLE
[ESP32] Enabled chip shell for lighting app

### DIFF
--- a/examples/lighting-app/esp32/sdkconfig.defaults
+++ b/examples/lighting-app/esp32/sdkconfig.defaults
@@ -32,6 +32,9 @@ CONFIG_BT_NIMBLE_ENABLED=y
 #enable lwip ipv6 autoconfig
 CONFIG_LWIP_IPV6_AUTOCONFIG=y
 
+#enable debug shell
+CONFIG_ENABLE_CHIP_SHELL=y
+
 # Use a custom partition table
 CONFIG_PARTITION_TABLE_CUSTOM=y
 CONFIG_PARTITION_TABLE_FILENAME="partitions.csv"


### PR DESCRIPTION
Problem

>  ENABLE_CHIP_SHELL config is disabled by default for lighting app
>  Fixes #23365

Testing
> Tested CLI for lighting app

