### PR TITLE
improve get last report data path api in cluster state cache

### DIFF
--- a/src/app/ClusterStateCache.cpp
+++ b/src/app/ClusterStateCache.cpp
@@ -534,8 +534,12 @@ exit:
 
 CHIP_ERROR ClusterStateCache::GetLastReportDataPath(ConcreteClusterPath & aPath)
 {
-    aPath = mLastReportDataPath;
-    return CHIP_NO_ERROR;
+    if (mLastReportDataPath.IsValidConcreteClusterPath())
+    {
+        aPath = mLastReportDataPath;
+        return CHIP_NO_ERROR;
+    }
+    return CHIP_ERROR_INCORRECT_STATE;
 }
 } // namespace app
 } // namespace chip

--- a/src/app/ClusterStateCache.h
+++ b/src/app/ClusterStateCache.h
@@ -483,6 +483,10 @@ public:
         mEventStatusCache.clear();
     }
 
+    /*
+     *  Get the last concrete report data path, if path is not concrete cluster path, return CHIP_ERROR_NOT_FOUND
+     *
+     */
     CHIP_ERROR GetLastReportDataPath(ConcreteClusterPath & aPath);
 
 private:


### PR DESCRIPTION
https://github.com/project-chip/connectedhomeip/pull/22851/files#diff-fa9b920825db40167f8aaa6d9a9f746b8e7c50823eefbc629b234e10f84b51c7R486 
Refactor GetLastReportDataPath a little bit so that it would fail when the path is not valid concrete cluster path, and update the corresponding logic in UpdateClusterDataVersion in AndroidCallback.

