### PR TITLE
[Zephyr] Allow to erase entire NVS on factory reset

### DIFF
--- a/config/nrfconnect/chip-module/Kconfig
+++ b/config/nrfconnect/chip-module/Kconfig
@@ -284,5 +284,9 @@ config CHIP_CERTIFiCATION_DECLARATION_OTA_IMAGE_ID
 
 endif
 
+# See config/zephyr/Kconfig for full definition
+config CHIP_FACTORY_RESET_ERASE_NVS
+	bool
+	default y if CHIP_FACTORY_DATA || CHIP_FACTORY_DATA_CUSTOM_BACKEND
 
 endif

--- a/config/zephyr/Kconfig
+++ b/config/zephyr/Kconfig
@@ -202,6 +202,17 @@ config CHIP_CRYPTO_PSA
 	  Use the backend for the Matter crypto layer that is based on PSA crypto
 	  API instead of the default, based on legacy mbedTLS APIs.
 
+config CHIP_FACTORY_RESET_ERASE_NVS
+	bool "Erase NVS flash pages on factory reset"
+	depends on SETTINGS_NVS
+	help
+	  When factory reset is requested, erase flash pages occupied by non-volatile storage
+	  instead of removing Matter-related settings only. This provides a more robust
+	  factory reset mechanism and allows to regain the original storage performance if any
+	  firmware issue has brought it to an unexpected state. For this reason, it is
+	  advisable to set this option if all configuration, including device-specific
+	  entries, is supposed to be cleared on a factory reset.
+
 config CHIP_MALLOC_SYS_HEAP
 	bool "Memory allocator based on Zephyr sys_heap"
 	imply SYS_HEAP_RUNTIME_STATS

--- a/docs/guides/nrfconnect_examples_configuration.md
+++ b/docs/guides/nrfconnect_examples_configuration.md
@@ -193,6 +193,15 @@ instead of using a QR code, which is the default configuration.
 To enable NFC for commissioning and share the onboarding payload in an NFC tag,
 set the `CONFIG_CHIP_NFC_COMMISSIONING` option.
 
+**Factory reset behavior**
+
+By default, the factory reset procedure implemented in the Matter stack removes
+Matter-related settings only. If your application does not depend on any
+device-lifelong data stored in the non-volatile storage, set the
+`CONFIG_CHIP_FACTORY_RESET_ERASE_NVS` option to fully erase the NVS partition at
+the factory reset. This approach is more robust and regains the original NVS
+performance in case it has been polluted with unwanted entries.
+
 **Logging**
 
 You can enable logging for both the stack and Zephyr’s


### PR DESCRIPTION
Currently, the default factory reset implementation simply removes Matter (and OpenThread) settings instead of formatting the non-volatile storage partition. The latter approach may be advisable in the cases where no settings need to survive a factory reset, as it is expected to work properly regardless of the state of the storage partition. Additionally, it will regain the original storage
performance if it has been loaded with a lot of stale data.
