### PR TITLE
[Darwin] MTRDevice write expected value expiration should generate report properly

### DIFF
--- a/src/darwin/Framework/CHIP/MTRDevice.mm
+++ b/src/darwin/Framework/CHIP/MTRDevice.mm
@@ -570,7 +570,7 @@ private:
         NSDictionary * cachedAttributeDataValue = _readCache[attributePath];
         if (cachedAttributeDataValue
             && ![self _attributeDataValue:attributeDataValue isEqualToDataValue:cachedAttributeDataValue]) {
-            [attributesToReport addObject:cachedAttributeDataValue];
+            [attributesToReport addObject:@{ MTRAttributePathKey : attributePath, MTRDataKey : cachedAttributeDataValue }];
         }
 
         _expectedValueCache[attributePath] = nil;


### PR DESCRIPTION
Fixes #23440 

1. When MTRDevice writes fail, the expected value expiration would generate report to revert the value
2. The generated report is incorrectly formatted and missing the attribute path

The fix is to format it correctly on the expiration report generation path